### PR TITLE
GC-free property cursors

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompiledExecutionResult.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompiledExecutionResult.scala
@@ -25,7 +25,8 @@ import java.util.Collections
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken
-import org.neo4j.cypher.internal.compiler.v2_3.helpers.{Eagerly, IsCollection}
+import org.neo4j.cypher.internal.compiler.v2_3.helpers.JavaConversionSupport.asScala
+import org.neo4j.cypher.internal.compiler.v2_3.helpers.{JavaConversionSupport, Eagerly, IsCollection}
 import org.neo4j.cypher.internal.compiler.v2_3.notification.InternalNotification
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{Planner, Runtime}
@@ -174,12 +175,12 @@ class CompiledExecutionResult(taskCloser: TaskCloser,
   private def props(x: PropertyContainer): String = {
     val readOperations = statement.readOperations()
     val (properties, propFcn, id) = x match {
-      case n: Node => (readOperations.nodeGetAllProperties(n.getId).asScala.map(_.propertyKeyId()), readOperations.nodeGetProperty _, n.getId )
-      case r: Relationship => (readOperations.relationshipGetAllProperties(r.getId).asScala.map(_.propertyKeyId()), readOperations.relationshipGetProperty _, r.getId)
+      case n: Node => (asScala(readOperations.nodeGetPropertyKeys(n.getId)), readOperations.nodeGetProperty _, n.getId )
+      case r: Relationship => (asScala(readOperations.relationshipGetPropertyKeys(r.getId)), readOperations.relationshipGetProperty _, r.getId)
     }
 
     val keyValStrings = properties.
-      map(pkId => readOperations.propertyKeyGetName(pkId) + ":" + text(propFcn(id, pkId).value(null)))
+      map(pkId => readOperations.propertyKeyGetName(pkId) + ":" + text(propFcn(id, pkId)))
 
     keyValStrings.mkString("{", ",", "}")
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
@@ -111,10 +111,10 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     JavaConversionSupport.asScala(statement.readOperations().nodeGetLabels(node))
 
   def getPropertiesForNode(node: Long) =
-    JavaConversionSupport.mapToScala(statement.readOperations().nodeGetAllPropertiesKeys(node))(_.toLong)
+    JavaConversionSupport.mapToScala(statement.readOperations().nodeGetPropertyKeys(node))(_.toLong)
 
   def getPropertiesForRelationship(relId: Long) =
-    JavaConversionSupport.mapToScala(statement.readOperations().relationshipGetAllPropertiesKeys(relId))(_.toLong)
+    JavaConversionSupport.mapToScala(statement.readOperations().relationshipGetPropertyKeys(relId))(_.toLong)
 
   override def isLabelSetOnNode(label: Int, node: Long) =
     statement.readOperations().nodeHasLabel(node, label)
@@ -159,14 +159,14 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     }
 
     def propertyKeyIds(id: Long): Iterator[Int] =
-      statement.readOperations().nodeGetAllProperties(id).asScala.map(_.propertyKeyId())
+      asScala(statement.readOperations().nodeGetPropertyKeys(id))
 
     def getProperty(id: Long, propertyKeyId: Int): Any = {
-      statement.readOperations().nodeGetProperty(id, propertyKeyId).value(null)
+      statement.readOperations().nodeGetProperty(id, propertyKeyId)
     }
 
     def hasProperty(id: Long, propertyKey: Int) =
-      statement.readOperations().nodeGetProperty(id, propertyKey).isDefined
+      statement.readOperations().nodeHasProperty(id, propertyKey)
 
     def removeProperty(id: Long, propertyKeyId: Int) {
       statement.dataWriteOperations().nodeRemoveProperty(id, propertyKeyId)
@@ -200,13 +200,13 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     }
 
     def propertyKeyIds(id: Long): Iterator[Int] =
-      statement.readOperations().relationshipGetAllProperties(id).asScala.map(_.propertyKeyId())
+      asScala(statement.readOperations().relationshipGetPropertyKeys(id))
 
     def getProperty(id: Long, propertyKeyId: Int): Any =
-      statement.readOperations().relationshipGetProperty(id, propertyKeyId).value(null)
+      statement.readOperations().relationshipGetProperty(id, propertyKeyId)
 
     def hasProperty(id: Long, propertyKey: Int) =
-      statement.readOperations().relationshipGetProperty(id, propertyKey).isDefined
+      statement.readOperations().relationshipHasProperty(id, propertyKey)
 
     def removeProperty(id: Long, propertyKeyId: Int) {
       statement.dataWriteOperations().relationshipRemoveProperty(id, propertyKeyId)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/GeneratedQueryStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/GeneratedQueryStructure.scala
@@ -678,9 +678,7 @@ private case class Method(fields: Fields, generator: CodeBlock, aux:AuxGenerator
     val local = locals(propValueVar)
     Templates.handleExceptions(generator, fields.ro) { body =>
 
-      body.assign(local, Expression.invoke(
-        Expression.invoke(readOperations, Methods.nodeGetProperty, body.load(nodeIdVar), body.load(propIdVar)),
-        Methods.value, Expression.constant(null)))
+      body.assign(local, Expression.invoke(readOperations, Methods.nodeGetProperty, body.load(nodeIdVar), body.load(propIdVar)))
 
     }
   }
@@ -688,27 +686,21 @@ private case class Method(fields: Fields, generator: CodeBlock, aux:AuxGenerator
   override def nodeGetPropertyById(nodeIdVar: String, propId: Int, propValueVar: String) = {
     val local = locals(propValueVar)
     Templates.handleExceptions(generator, fields.ro) { body =>
-      body.assign(local, Expression.invoke(
-        Expression.invoke(readOperations, Methods.nodeGetProperty, body.load(nodeIdVar), Expression.constant(propId)),
-        Methods.value, Expression.constant(null)))
+      body.assign(local, Expression.invoke(readOperations, Methods.nodeGetProperty, body.load(nodeIdVar), Expression.constant(propId)))
     }
   }
 
   override def relationshipGetPropertyForVar(relIdVar: String, propIdVar: String, propValueVar: String) = {
     val local = locals(propValueVar)
     Templates.handleExceptions(generator, fields.ro) { body =>
-      body.assign(local, Expression.invoke(
-        Expression.invoke(readOperations, Methods.relationshipGetProperty, body.load(relIdVar), body.load(propIdVar)),
-        Methods.value, Expression.constant(null)))
+      body.assign(local, Expression.invoke(readOperations, Methods.relationshipGetProperty, body.load(relIdVar), body.load(propIdVar)))
     }
   }
 
   override def relationshipGetPropertyById(relIdVar: String, propId: Int, propValueVar: String) = {
     val local = locals(propValueVar)
     Templates.handleExceptions(generator, fields.ro) { body =>
-      body.assign(local, Expression.invoke(
-        Expression.invoke(readOperations, Methods.relationshipGetProperty, body.load(relIdVar), Expression.constant(propId)),
-        Methods.value, Expression.constant(null)))
+      body.assign(local, Expression.invoke(readOperations, Methods.relationshipGetProperty, body.load(relIdVar), Expression.constant(propId)))
     }
   }
 
@@ -803,7 +795,6 @@ private object Methods {
   val executeOperator = method[QueryExecutionTracer, QueryExecutionEvent]("executeOperator", typeRef[Id])
   val dbHit = method[QueryExecutionEvent, Unit]("dbHit")
   val row = method[QueryExecutionEvent, Unit]("row")
-  val value = method[Property, Object]("value", typeRef[Object])
 }
 
 private object Templates {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -114,10 +114,10 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     JavaConversionSupport.asScala(statement.readOperations().nodeGetLabels(node))
 
   def getPropertiesForNode(node: Long) =
-    JavaConversionSupport.asScala(statement.readOperations().nodeGetAllPropertiesKeys(node))
+    JavaConversionSupport.asScala(statement.readOperations().nodeGetPropertyKeys(node))
 
   def getPropertiesForRelationship(relId: Long) =
-    JavaConversionSupport.asScala(statement.readOperations().relationshipGetAllPropertiesKeys(relId))
+    JavaConversionSupport.asScala(statement.readOperations().relationshipGetPropertyKeys(relId))
 
   override def isLabelSetOnNode(label: Int, node: Long) =
     statement.readOperations().nodeHasLabel(node, label)
@@ -173,16 +173,16 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     }
 
     def propertyKeyIds(id: Long): Iterator[Int] =
-      JavaConversionSupport.asScala(statement.readOperations().nodeGetAllPropertiesKeys(id))
+      JavaConversionSupport.asScala(statement.readOperations().nodeGetPropertyKeys(id))
 
     def getProperty(id: Long, propertyKeyId: Int): Any = try {
-      statement.readOperations().nodeGetProperty(id, propertyKeyId).value(null)
+      statement.readOperations().nodeGetProperty(id, propertyKeyId)
     } catch {
       case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => null
     }
 
     def hasProperty(id: Long, propertyKey: Int) =
-      statement.readOperations().nodeGetProperty(id, propertyKey).isDefined
+      statement.readOperations().nodeHasProperty(id, propertyKey)
 
     def removeProperty(id: Long, propertyKeyId: Int) {
       statement.dataWriteOperations().nodeRemoveProperty(id, propertyKeyId)
@@ -216,13 +216,13 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     }
 
     def propertyKeyIds(id: Long): Iterator[Int] =
-      statement.readOperations().relationshipGetAllProperties(id).asScala.map(_.propertyKeyId())
+      asScala(statement.readOperations().relationshipGetPropertyKeys(id))
 
     def getProperty(id: Long, propertyKeyId: Int): Any =
-      statement.readOperations().relationshipGetProperty(id, propertyKeyId).value(null)
+      statement.readOperations().relationshipGetProperty(id, propertyKeyId)
 
     def hasProperty(id: Long, propertyKey: Int) =
-      statement.readOperations().relationshipGetProperty(id, propertyKey).isDefined
+      statement.readOperations().relationshipHasProperty(id, propertyKey)
 
     def removeProperty(id: Long, propertyKeyId: Int) {
       statement.dataWriteOperations().relationshipRemoveProperty(id, propertyKeyId)

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/DataRead.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/DataRead.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.api;
 
-import java.util.Iterator;
-
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Direction;
@@ -28,8 +26,6 @@ import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
-import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 
@@ -116,24 +112,25 @@ interface DataRead
      */
     PrimitiveIntIterator nodeGetLabels( long nodeId ) throws EntityNotFoundException;
 
-    PrimitiveIntIterator nodeGetAllPropertiesKeys( long nodeId ) throws EntityNotFoundException;
+    PrimitiveIntIterator nodeGetPropertyKeys( long nodeId ) throws EntityNotFoundException;
 
-    PrimitiveIntIterator relationshipGetAllPropertiesKeys( long relationshipId ) throws EntityNotFoundException;
+    PrimitiveIntIterator relationshipGetPropertyKeys( long relationshipId ) throws EntityNotFoundException;
+
+    PrimitiveIntIterator graphGetPropertyKeys();
 
     PrimitiveIntIterator nodeGetRelationshipTypes( long nodeId ) throws EntityNotFoundException;
 
-    Property nodeGetProperty( long nodeId, int propertyKeyId ) throws EntityNotFoundException;
+    boolean nodeHasProperty( long nodeId, int propertyKeyId ) throws EntityNotFoundException;
 
-    Property relationshipGetProperty( long relationshipId, int propertyKeyId ) throws EntityNotFoundException;
+    Object nodeGetProperty( long nodeId, int propertyKeyId ) throws EntityNotFoundException;
 
-    Property graphGetProperty( int propertyKeyId );
+    boolean relationshipHasProperty( long relationshipId, int propertyKeyId ) throws EntityNotFoundException;
 
-    Iterator<DefinedProperty> nodeGetAllProperties( long nodeId ) throws EntityNotFoundException;
+    Object relationshipGetProperty( long relationshipId, int propertyKeyId ) throws EntityNotFoundException;
 
-    Iterator<DefinedProperty> relationshipGetAllProperties( long relationshipId )
-            throws EntityNotFoundException;
+    boolean graphHasProperty( int propertyKeyId );
 
-    Iterator<DefinedProperty> graphGetAllProperties();
+    Object graphGetProperty( int propertyKeyId );
 
     <EXCEPTION extends Exception> void relationshipVisit( long relId, RelationshipVisitor<EXCEPTION> visitor )
             throws EntityNotFoundException, EXCEPTION;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/EntityCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/EntityCursor.java
@@ -19,29 +19,23 @@
  */
 package org.neo4j.kernel.api.cursor;
 
-import org.neo4j.graphdb.Direction;
+import org.neo4j.cursor.Cursor;
 
 /**
- * Cursor for iterating over a set of nodes.
+ * Cursor for iterating over a set of entities (nodes or relationships).
  */
-public interface NodeCursor
-    extends EntityCursor
+public interface EntityCursor
+    extends Cursor
 {
     /**
-     * @return label cursor for current node
-     * @throws IllegalStateException if no current node is selected
+     * @return id of current entity
+     * @throws IllegalStateException if no current entity is selected
      */
-    LabelCursor labels();
+    long getId();
 
     /**
-     * @return relationship cursor for current node
-     * @throws IllegalStateException if no current node is selected
+     * @return cursor for properties of current entity
+     * @throws IllegalStateException if no current entity is selected
      */
-    RelationshipCursor relationships( Direction direction, int... relTypes );
-
-    /**
-     * @return relationship cursor for current node
-     * @throws IllegalStateException if no current node is selected
-     */
-    RelationshipCursor relationships( Direction direction );
+    PropertyCursor properties();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/LabelCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/LabelCursor.java
@@ -72,5 +72,8 @@ public interface LabelCursor
      */
     boolean seek( int labelId );
 
+    /**
+     * @return id of current label
+     */
     int getLabel();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/PropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/PropertyCursor.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.kernel.api.cursor;
 
+import java.nio.channels.WritableByteChannel;
+
 import org.neo4j.cursor.Cursor;
-import org.neo4j.function.Function;
 import org.neo4j.function.ToIntFunction;
-import org.neo4j.kernel.api.properties.DefinedProperty;
 
 /**
  * Cursor for iterating over the properties of a node or relationship.
@@ -30,21 +30,12 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 public interface PropertyCursor
         extends Cursor
 {
-    Function<PropertyCursor, DefinedProperty> GET_PROPERTY = new Function<PropertyCursor, DefinedProperty>()
-    {
-        @Override
-        public DefinedProperty apply( PropertyCursor propertyCursor )
-        {
-            return propertyCursor.getProperty();
-        }
-    };
-
     ToIntFunction<PropertyCursor> GET_KEY_INDEX_ID = new ToIntFunction<PropertyCursor>()
     {
         @Override
-        public int apply( PropertyCursor value )
+        public int apply( PropertyCursor cursor )
         {
-            return value.getProperty().propertyKeyId();
+            return cursor.propertyKeyId();
         }
     };
 
@@ -57,7 +48,43 @@ public interface PropertyCursor
         }
 
         @Override
-        public DefinedProperty getProperty()
+        public int propertyKeyId()
+        {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public Object value()
+        {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public boolean booleanValue()
+        {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public long longValue()
+        {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public double doubleValue()
+        {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public String stringValue()
+        {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void propertyData( WritableByteChannel channel )
         {
             throw new IllegalStateException();
         }
@@ -75,14 +102,19 @@ public interface PropertyCursor
         }
     };
 
-
-    /**
-     * Move the cursor to a particular property.
-     *
-     * @param keyId of the property to find
-     * @return true if found
-     */
     boolean seek( int keyId );
 
-    DefinedProperty getProperty();
+    int propertyKeyId();
+
+    Object value();
+
+    boolean booleanValue();
+
+    long longValue();
+
+    double doubleValue();
+
+    String stringValue();
+
+    void propertyData( WritableByteChannel channel );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/PropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/PropertyCursor.java
@@ -26,6 +26,9 @@ import org.neo4j.function.ToIntFunction;
 
 /**
  * Cursor for iterating over the properties of a node or relationship.
+ *
+ * If the cursor is not in a valid state ({@link #next()} or {@link #seek(int)} returns false,
+ * then accessor calls will result in IllegalStateException being thrown.
  */
 public interface PropertyCursor
         extends Cursor
@@ -102,19 +105,54 @@ public interface PropertyCursor
         }
     };
 
+    /**
+      * Move the cursor to a particular property.
+      *
+      * @param keyId of the property to find
+      * @return true if found
+      */
     boolean seek( int keyId );
 
+    /**
+     * @return the key id of the current property.
+     */
     int propertyKeyId();
 
+    /**
+     * @return the value of the current property.
+     */
     Object value();
 
+    /**
+     * @return the boolean value of the current property
+     * @throws IllegalStateException if current property is not a boolean
+     */
     boolean booleanValue();
 
+    /**
+     * @return the integer value of the current property
+     * @throws IllegalStateException if current property is not an integer number
+     */
     long longValue();
 
+    /**
+     * @return the real value of the current property
+     * @throws IllegalStateException if current property is not a real number
+     */
     double doubleValue();
 
+    /**
+     * @return the string value of the current property
+     */
     String stringValue();
 
+    /**
+     * The byte representation of the current value.
+     *
+     * NOTE: this is currently less than useful as it will return
+     * the internal formats for e.g. strings, rather than UTF-8.
+     *
+     * @param channel to write the data into
+     */
     void propertyData( WritableByteChannel channel );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/RelationshipCursor.java
@@ -19,36 +19,40 @@
  */
 package org.neo4j.kernel.api.cursor;
 
-import org.neo4j.cursor.Cursor;
-
 /**
  * Cursor for iterating over a set of relationships.
  */
 public interface RelationshipCursor
-        extends Cursor
+        extends EntityCursor
 {
     RelationshipCursor EMPTY = new RelationshipCursor()
     {
         @Override
         public long getId()
         {
-            throw new IllegalStateException(  );
+            throw new IllegalStateException();
         }
 
         @Override
         public int getType()
         {
-            throw new IllegalStateException(  );
+            throw new IllegalStateException();
         }
 
         @Override
         public long getStartNode()
         {
-            throw new IllegalStateException(  );
+            throw new IllegalStateException();
         }
 
         @Override
         public long getEndNode()
+        {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public long getOtherNode( long nodeId )
         {
             throw new IllegalStateException(  );
         }
@@ -56,7 +60,7 @@ public interface RelationshipCursor
         @Override
         public PropertyCursor properties()
         {
-            throw new IllegalStateException(  );
+            throw new IllegalStateException();
         }
 
         @Override
@@ -72,13 +76,14 @@ public interface RelationshipCursor
         }
     };
 
-    long getId();
-
+    /**
+     * @return relationship type for current relationship
+     */
     int getType();
 
     long getStartNode();
 
     long getEndNode();
 
-    PropertyCursor properties();
+    long getOtherNode( long nodeId );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -88,10 +88,11 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         {
             PropertyConstraint constraint = constraints.next();
             int propertyKeyId = constraint.propertyKeyId();
-            Property property = entityReadOperations.nodeGetProperty( state, nodeId, propertyKeyId );
-            if ( property.isDefined() )
+            Object value = entityReadOperations.nodeGetProperty( state, nodeId, propertyKeyId );
+            if ( value != null )
             {
-                validateNoExistingNodeWithLabelAndProperty( state, labelId, (DefinedProperty) property, nodeId );
+                DefinedProperty property = Property.property( propertyKeyId, value );
+                validateNoExistingNodeWithLabelAndProperty( state, labelId, property, nodeId );
             }
         }
         return entityWriteOperations.nodeAddLabel( state, nodeId, labelId );
@@ -321,7 +322,15 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public Property nodeGetProperty( KernelStatement state,
+    public boolean nodeHasProperty( KernelStatement statement,
+            long nodeId,
+            int propertyKeyId ) throws EntityNotFoundException
+    {
+        return entityReadOperations.nodeHasProperty( statement, nodeId, propertyKeyId );
+    }
+
+    @Override
+    public Object nodeGetProperty( KernelStatement state,
             long nodeId,
             int propertyKeyId ) throws EntityNotFoundException
     {
@@ -329,14 +338,28 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public Property relationshipGetProperty( KernelStatement state, long relationshipId, int propertyKeyId ) throws
+    public boolean relationshipHasProperty( KernelStatement state,
+            long relationshipId,
+            int propertyKeyId ) throws EntityNotFoundException
+    {
+        return entityReadOperations.relationshipHasProperty( state, relationshipId, propertyKeyId );
+    }
+
+    @Override
+    public Object relationshipGetProperty( KernelStatement state, long relationshipId, int propertyKeyId ) throws
             EntityNotFoundException
     {
         return entityReadOperations.relationshipGetProperty( state, relationshipId, propertyKeyId );
     }
 
     @Override
-    public Property graphGetProperty( KernelStatement state, int propertyKeyId )
+    public boolean graphHasProperty( KernelStatement state, int propertyKeyId )
+    {
+        return entityReadOperations.graphHasProperty( state, propertyKeyId );
+    }
+
+    @Override
+    public Object graphGetProperty( KernelStatement state, int propertyKeyId )
     {
         return entityReadOperations.graphGetProperty( state, propertyKeyId );
     }
@@ -348,13 +371,6 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public Iterator<DefinedProperty> nodeGetAllProperties( KernelStatement state,
-            long nodeId ) throws EntityNotFoundException
-    {
-        return entityReadOperations.nodeGetAllProperties( state, nodeId );
-    }
-
-    @Override
     public PrimitiveIntIterator relationshipGetPropertyKeys( KernelStatement state, long relationshipId ) throws
             EntityNotFoundException
     {
@@ -362,22 +378,9 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public Iterator<DefinedProperty> relationshipGetAllProperties( KernelStatement state, long relationshipId ) throws
-            EntityNotFoundException
-    {
-        return entityReadOperations.relationshipGetAllProperties( state, relationshipId );
-    }
-
-    @Override
     public PrimitiveIntIterator graphGetPropertyKeys( KernelStatement state )
     {
         return entityReadOperations.graphGetPropertyKeys( state );
-    }
-
-    @Override
-    public Iterator<DefinedProperty> graphGetAllProperties( KernelStatement state )
-    {
-        return entityReadOperations.graphGetAllProperties( state );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import java.util.Iterator;
-
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Direction;
@@ -215,7 +213,16 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public Property nodeGetProperty( KernelStatement state, long nodeId, int propertyKeyId )
+    public boolean nodeHasProperty( KernelStatement statement,
+            long nodeId,
+            int propertyKeyId ) throws EntityNotFoundException
+    {
+        guard.check();
+        return entityReadDelegate.nodeHasProperty( statement, nodeId, propertyKeyId );
+    }
+
+    @Override
+    public Object nodeGetProperty( KernelStatement state, long nodeId, int propertyKeyId )
             throws EntityNotFoundException
     {
         guard.check();
@@ -223,7 +230,16 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public Property relationshipGetProperty( KernelStatement state, long relationshipId, int propertyKeyId )
+    public boolean relationshipHasProperty( KernelStatement state,
+            long relationshipId,
+            int propertyKeyId ) throws EntityNotFoundException
+    {
+        guard.check();
+        return entityReadDelegate.relationshipHasProperty( state, relationshipId, propertyKeyId );
+    }
+
+    @Override
+    public Object relationshipGetProperty( KernelStatement state, long relationshipId, int propertyKeyId )
             throws EntityNotFoundException
     {
         guard.check();
@@ -231,7 +247,14 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public Property graphGetProperty( KernelStatement state, int propertyKeyId )
+    public boolean graphHasProperty( KernelStatement state, int propertyKeyId )
+    {
+        guard.check();
+        return entityReadDelegate.graphHasProperty( state, propertyKeyId );
+    }
+
+    @Override
+    public Object graphGetProperty( KernelStatement state, int propertyKeyId )
     {
         guard.check();
         return entityReadDelegate.graphGetProperty( state, propertyKeyId );
@@ -246,14 +269,6 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public Iterator<DefinedProperty> nodeGetAllProperties( KernelStatement state, long nodeId )
-            throws EntityNotFoundException
-    {
-        guard.check();
-        return entityReadDelegate.nodeGetAllProperties( state, nodeId );
-    }
-
-    @Override
     public PrimitiveIntIterator relationshipGetPropertyKeys( KernelStatement state, long relationshipId )
             throws EntityNotFoundException
     {
@@ -262,25 +277,10 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public Iterator<DefinedProperty> relationshipGetAllProperties( KernelStatement state, long relationshipId )
-            throws EntityNotFoundException
-    {
-        guard.check();
-        return entityReadDelegate.relationshipGetAllProperties( state, relationshipId );
-    }
-
-    @Override
     public PrimitiveIntIterator graphGetPropertyKeys( KernelStatement state )
     {
         guard.check();
         return entityReadDelegate.graphGetPropertyKeys( state );
-    }
-
-    @Override
-    public Iterator<DefinedProperty> graphGetAllProperties( KernelStatement state )
-    {
-        guard.check();
-        return entityReadDelegate.graphGetAllProperties( state );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
@@ -31,10 +31,12 @@ import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.api.txstate.TxStateHolder;
 import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+import org.neo4j.kernel.impl.api.store.StoreStatement;
 
 public class GuardingStatementOperations implements
         EntityWriteOperations,
@@ -213,12 +215,31 @@ public class GuardingStatementOperations implements
     }
 
     @Override
+    public PrimitiveIntIterator nodeGetLabels( TxStateHolder txStateHolder,
+            StoreStatement storeStatement,
+            long nodeId ) throws EntityNotFoundException
+    {
+        guard.check();
+        return entityReadDelegate.nodeGetLabels( txStateHolder, storeStatement, nodeId );
+    }
+
+    @Override
     public boolean nodeHasProperty( KernelStatement statement,
             long nodeId,
             int propertyKeyId ) throws EntityNotFoundException
     {
         guard.check();
         return entityReadDelegate.nodeHasProperty( statement, nodeId, propertyKeyId );
+    }
+
+    @Override
+    public boolean nodeHasProperty( TxStateHolder txStateHolder,
+            StoreStatement storeStatement,
+            long nodeId,
+            int propertyKeyId ) throws EntityNotFoundException
+    {
+        guard.check();
+        return entityReadDelegate.nodeHasProperty( txStateHolder, storeStatement, nodeId, propertyKeyId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
@@ -110,7 +110,8 @@ public class LookupFilter
         @Override
         Property nodeProperty( long nodeId, int propertyKeyId ) throws EntityNotFoundException
         {
-            return readOperations.nodeGetProperty( state, nodeId, propertyKeyId );
+            Object value = readOperations.nodeGetProperty( state, nodeId, propertyKeyId );
+            return value == null ? Property.noNodeProperty( nodeId, propertyKeyId ) : Property.property( propertyKeyId, value );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -222,7 +222,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public PrimitiveIntIterator nodeGetLabels( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-        return dataRead().nodeGetLabels( statement, nodeId );
+        return dataRead().nodeGetLabels( statement, statement.getStoreStatement(), nodeId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -226,12 +226,23 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public Property nodeGetProperty( long nodeId, int propertyKeyId ) throws EntityNotFoundException
+    public boolean nodeHasProperty( long nodeId, int propertyKeyId ) throws EntityNotFoundException
     {
         statement.assertOpen();
         if ( propertyKeyId == StatementConstants.NO_SUCH_PROPERTY_KEY )
         {
-            return Property.noNodeProperty( nodeId, propertyKeyId );
+            return false;
+        }
+        return dataRead().nodeHasProperty(statement, nodeId, propertyKeyId);
+    }
+
+    @Override
+    public Object nodeGetProperty( long nodeId, int propertyKeyId ) throws EntityNotFoundException
+    {
+        statement.assertOpen();
+        if ( propertyKeyId == StatementConstants.NO_SUCH_PROPERTY_KEY )
+        {
+            return null;
         }
         return dataRead().nodeGetProperty( statement, nodeId, propertyKeyId );
     }
@@ -274,23 +285,45 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public Property relationshipGetProperty( long relationshipId, int propertyKeyId ) throws EntityNotFoundException
+    public boolean relationshipHasProperty( long relationshipId, int propertyKeyId ) throws EntityNotFoundException
     {
         statement.assertOpen();
         if ( propertyKeyId == StatementConstants.NO_SUCH_PROPERTY_KEY )
         {
-            return Property.noRelationshipProperty( relationshipId, propertyKeyId );
+            return false;
+        }
+        return dataRead().relationshipHasProperty( statement, relationshipId, propertyKeyId );
+    }
+
+    @Override
+    public Object relationshipGetProperty( long relationshipId, int propertyKeyId ) throws EntityNotFoundException
+    {
+        statement.assertOpen();
+        if ( propertyKeyId == StatementConstants.NO_SUCH_PROPERTY_KEY )
+        {
+            return null;
         }
         return dataRead().relationshipGetProperty( statement, relationshipId, propertyKeyId );
     }
 
     @Override
-    public Property graphGetProperty( int propertyKeyId )
+    public boolean graphHasProperty( int propertyKeyId )
     {
         statement.assertOpen();
         if ( propertyKeyId == StatementConstants.NO_SUCH_PROPERTY_KEY )
         {
-            return Property.noGraphProperty( propertyKeyId );
+            return false;
+        }
+        return dataRead().graphHasProperty(statement, propertyKeyId);
+    }
+
+    @Override
+    public Object graphGetProperty( int propertyKeyId )
+    {
+        statement.assertOpen();
+        if ( propertyKeyId == StatementConstants.NO_SUCH_PROPERTY_KEY )
+        {
+            return null;
         }
         return dataRead().graphGetProperty( statement, propertyKeyId );
     }
@@ -303,32 +336,17 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public Iterator<DefinedProperty> nodeGetAllProperties( long nodeId ) throws EntityNotFoundException
-    {
-        statement.assertOpen();
-        return dataRead().nodeGetAllProperties( statement, nodeId );
-    }
-
-    @Override
     public PrimitiveIntIterator relationshipGetAllPropertiesKeys( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-        return dataRead().relationshipGetPropertyKeys( statement, nodeId );
+        return dataRead().relationshipGetPropertyKeys(statement, nodeId);
     }
 
     @Override
-    public Iterator<DefinedProperty> relationshipGetAllProperties( long relationshipId )
-            throws EntityNotFoundException
+    public PrimitiveIntIterator graphGetAllPropertiesKeys()
     {
         statement.assertOpen();
-        return dataRead().relationshipGetAllProperties( statement, relationshipId );
-    }
-
-    @Override
-    public Iterator<DefinedProperty> graphGetAllProperties()
-    {
-        statement.assertOpen();
-        return dataRead().graphGetAllProperties( statement );
+        return dataRead().graphGetPropertyKeys( statement );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -233,7 +233,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
         {
             return false;
         }
-        return dataRead().nodeHasProperty(statement, nodeId, propertyKeyId);
+        return dataRead().nodeHasProperty( statement, nodeId, propertyKeyId );
     }
 
     @Override
@@ -314,7 +314,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
         {
             return false;
         }
-        return dataRead().graphHasProperty(statement, propertyKeyId);
+        return dataRead().graphHasProperty( statement, propertyKeyId );
     }
 
     @Override
@@ -329,21 +329,21 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public PrimitiveIntIterator nodeGetAllPropertiesKeys( long nodeId ) throws EntityNotFoundException
+    public PrimitiveIntIterator nodeGetPropertyKeys( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
         return dataRead().nodeGetPropertyKeys( statement, nodeId );
     }
 
     @Override
-    public PrimitiveIntIterator relationshipGetAllPropertiesKeys( long nodeId ) throws EntityNotFoundException
+    public PrimitiveIntIterator relationshipGetPropertyKeys( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-        return dataRead().relationshipGetPropertyKeys(statement, nodeId);
+        return dataRead().relationshipGetPropertyKeys( statement, nodeId );
     }
 
     @Override
-    public PrimitiveIntIterator graphGetAllPropertiesKeys()
+    public PrimitiveIntIterator graphGetPropertyKeys()
     {
         statement.assertOpen();
         return dataRead().graphGetPropertyKeys( statement );
@@ -364,25 +364,25 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public NodeCursor nodeCursor( long nodeId )
     {
         statement.assertOpen();
-        return dataRead().nodeCursor(statement, nodeId);
+        return dataRead().nodeCursor( statement, nodeId );
     }
 
     @Override
     public RelationshipCursor relationshipCursor( long relId )
     {
         statement.assertOpen();
-        return dataRead().relationshipCursor(statement, relId);
+        return dataRead().relationshipCursor( statement, relId );
     }
 
     @Override
-    public NodeCursor nodeCursorGetAll( )
+    public NodeCursor nodeCursorGetAll()
     {
         statement.assertOpen();
-        return dataRead().nodeCursorGetAll(statement);
+        return dataRead().nodeCursorGetAll( statement );
     }
 
     @Override
-    public RelationshipCursor relationshipCursorGetAll(  )
+    public RelationshipCursor relationshipCursorGetAll()
     {
         statement.assertOpen();
         return dataRead().relationshipCursorGetAll( statement );
@@ -396,7 +396,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public NodeCursor nodeCursorGetFromIndexSeek(  IndexDescriptor index,
+    public NodeCursor nodeCursorGetFromIndexSeek( IndexDescriptor index,
             Object value ) throws IndexNotFoundKernelException
     {
         statement.assertOpen();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAbstractRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxAbstractRelationshipCursor.java
@@ -94,6 +94,12 @@ public abstract class TxAbstractRelationshipCursor implements RelationshipCursor
     }
 
     @Override
+    public long getOtherNode( long nodeId )
+    {
+        return startNodeId == nodeId ? endNodeId : startNodeId;
+    }
+
+    @Override
     public PropertyCursor properties()
     {
         return state.augmentPropertyCursor(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxPropertyCursor.java
@@ -208,11 +208,15 @@ public class TxPropertyCursor implements PropertyCursor
 
     private void check()
     {
-        if (property == null && !seekFoundIt)
-            throw new IllegalStateException(  );
+        if ( property == null && !seekFoundIt )
+        {
+            throw new IllegalStateException();
+        }
 
-        if (seekFoundIt)
+        if ( seekFoundIt )
+        {
             property = Property.property( cursor.propertyKeyId(), cursor.value() );
+        }
         seekFoundIt = false;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxPropertyCursor.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.cursor;
 
+import java.nio.channels.WritableByteChannel;
 import java.util.Iterator;
 
 import org.neo4j.function.Consumer;
@@ -41,6 +42,7 @@ public class TxPropertyCursor implements PropertyCursor
 
     private DefinedProperty property;
     private Iterator<DefinedProperty> added;
+    private boolean seekFoundIt;
 
 
     public TxPropertyCursor( Consumer<TxPropertyCursor> instanceCache )
@@ -70,7 +72,7 @@ public class TxPropertyCursor implements PropertyCursor
             {
                 if ( changedProperties != null )
                 {
-                    Property property = changedProperties.get( cursor.getProperty().propertyKeyId() );
+                    Property property = changedProperties.get( cursor.propertyKeyId() );
 
                     if ( property != null )
                     {
@@ -79,10 +81,9 @@ public class TxPropertyCursor implements PropertyCursor
                     }
                 }
 
-                if ( removedProperties == null || !removedProperties.containsKey(
-                        cursor.getProperty().propertyKeyId() ) )
+                if ( removedProperties == null || !removedProperties.containsKey( cursor.propertyKeyId() ) )
                 {
-                    this.property = cursor.getProperty();
+                    this.property = Property.property( cursor.propertyKeyId(), cursor.value() );
                     return true;
                 }
             }
@@ -109,6 +110,7 @@ public class TxPropertyCursor implements PropertyCursor
     @Override
     public boolean seek( int keyId )
     {
+        seekFoundIt = false;
         if ( changedProperties != null )
         {
             Property property = changedProperties.get( keyId );
@@ -139,8 +141,8 @@ public class TxPropertyCursor implements PropertyCursor
 
         if ( cursor.seek( keyId ) )
         {
-            this.property = cursor.getProperty();
-            return true;
+            this.property = null;
+            return seekFoundIt = true;
         }
         else
         {
@@ -150,12 +152,47 @@ public class TxPropertyCursor implements PropertyCursor
     }
 
     @Override
-    public DefinedProperty getProperty()
+    public int propertyKeyId()
     {
-        if (property == null)
-            throw new IllegalStateException(  );
+        check();
+        return property.propertyKeyId();
+    }
 
-        return property;
+    @Override
+    public Object value()
+    {
+        check();
+        return property.value();
+    }
+
+    @Override
+    public boolean booleanValue()
+    {
+        return (Boolean) value();
+    }
+
+    @Override
+    public long longValue()
+    {
+        return ((Number) value()).longValue();
+    }
+
+    @Override
+    public double doubleValue()
+    {
+        return ((Number) value()).doubleValue();
+    }
+
+    @Override
+    public String stringValue()
+    {
+        return value().toString();
+    }
+
+    @Override
+    public void propertyData( WritableByteChannel channel )
+    {
+        throw new UnsupportedOperationException( "NYI" );
     }
 
     @Override
@@ -163,7 +200,19 @@ public class TxPropertyCursor implements PropertyCursor
     {
         cursor.close();
         cursor = null;
+        property = null;
         this.added = null;
         instanceCache.accept( this );
+    }
+
+
+    private void check()
+    {
+        if (property == null && !seekFoundIt)
+            throw new IllegalStateException(  );
+
+        if (seekFoundIt)
+            property = Property.property( cursor.propertyKeyId(), cursor.value() );
+        seekFoundIt = false;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.api.operations;
 
-import java.util.Iterator;
-
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Direction;
@@ -30,8 +28,6 @@ import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
-import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
@@ -97,23 +93,24 @@ public interface EntityReadOperations
      */
     PrimitiveIntIterator nodeGetLabels( KernelStatement state, long nodeId ) throws EntityNotFoundException;
 
-    Property nodeGetProperty( KernelStatement state, long nodeId, int propertyKeyId ) throws EntityNotFoundException;
+    boolean nodeHasProperty( KernelStatement statement, long nodeId, int propertyKeyId ) throws EntityNotFoundException;
 
-    Property relationshipGetProperty( KernelStatement state, long relationshipId, int propertyKeyId )
+    Object nodeGetProperty( KernelStatement state, long nodeId, int propertyKeyId ) throws EntityNotFoundException;
+
+    boolean relationshipHasProperty( KernelStatement state, long relationshipId, int propertyKeyId )
             throws EntityNotFoundException;
 
-    Property graphGetProperty( KernelStatement state, int propertyKeyId );
+    Object relationshipGetProperty( KernelStatement state, long relationshipId, int propertyKeyId )
+            throws EntityNotFoundException;
 
-    // TODO: decide if this should be replaced by nodeGetAllProperties()
+    boolean graphHasProperty( KernelStatement state, int propertyKeyId );
+
+    Object graphGetProperty( KernelStatement state, int propertyKeyId );
 
     /**
      * Return all property keys associated with a node.
      */
     PrimitiveIntIterator nodeGetPropertyKeys( KernelStatement state, long nodeId ) throws EntityNotFoundException;
-
-    Iterator<DefinedProperty> nodeGetAllProperties( KernelStatement state, long nodeId ) throws EntityNotFoundException;
-
-    // TODO: decide if this should be replaced by relationshipGetAllProperties()
 
     /**
      * Return all property keys associated with a relationship.
@@ -121,17 +118,10 @@ public interface EntityReadOperations
     PrimitiveIntIterator relationshipGetPropertyKeys( KernelStatement state, long relationshipId ) throws
             EntityNotFoundException;
 
-    Iterator<DefinedProperty> relationshipGetAllProperties( KernelStatement state,
-            long relationshipId ) throws EntityNotFoundException;
-
-    // TODO: decide if this should be replaced by relationshipGetAllProperties()
-
     /**
      * Return all property keys associated with a relationship.
      */
     PrimitiveIntIterator graphGetPropertyKeys( KernelStatement state );
-
-    Iterator<DefinedProperty> graphGetAllProperties( KernelStatement state );
 
     RelationshipIterator nodeGetRelationships( KernelStatement statement, long nodeId, Direction direction,
             int[] relTypes ) throws EntityNotFoundException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
@@ -28,9 +28,11 @@ import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.txstate.TxStateHolder;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+import org.neo4j.kernel.impl.api.store.StoreStatement;
 
 public interface EntityReadOperations
 {
@@ -93,7 +95,13 @@ public interface EntityReadOperations
      */
     PrimitiveIntIterator nodeGetLabels( KernelStatement state, long nodeId ) throws EntityNotFoundException;
 
+    public PrimitiveIntIterator nodeGetLabels( TxStateHolder txStateHolder, StoreStatement storeStatement, long nodeId )
+            throws EntityNotFoundException;
+
     boolean nodeHasProperty( KernelStatement statement, long nodeId, int propertyKeyId ) throws EntityNotFoundException;
+
+    public boolean nodeHasProperty( TxStateHolder txStateHolder, StoreStatement storeStatement,
+            long nodeId, int propertyKeyId ) throws EntityNotFoundException;
 
     Object nodeGetProperty( KernelStatement state, long nodeId, int propertyKeyId ) throws EntityNotFoundException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -59,7 +59,6 @@ import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.DegreeVisitor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
@@ -107,18 +106,6 @@ public class CacheLayer implements StoreReadLayer
     public StoreStatement acquireStatement()
     {
         return diskLayer.acquireStatement();
-    }
-
-    @Override
-    public boolean nodeExists( long nodeId )
-    {
-        return diskLayer.nodeExists( nodeId );
-    }
-
-    @Override
-    public boolean nodeHasLabel( StoreStatement statement, long nodeId, int labelId ) throws EntityNotFoundException
-    {
-        return diskLayer.nodeHasLabel( statement, nodeId, labelId );
     }
 
     @Override
@@ -208,56 +195,13 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveIntIterator nodeGetPropertyKeys( StoreStatement statement,
-            long nodeId ) throws EntityNotFoundException
-    {
-        return diskLayer.nodeGetPropertyKeys( statement, nodeId );
-    }
-
-    @Override
-    public Property nodeGetProperty( StoreStatement statement,
-            long nodeId,
-            int propertyKeyId ) throws EntityNotFoundException
-    {
-        return diskLayer.nodeGetProperty( statement, nodeId, propertyKeyId );
-    }
-
-    @Override
-    public Iterator<DefinedProperty> nodeGetAllProperties( StoreStatement statement,
-            long nodeId ) throws EntityNotFoundException
-    {
-        return diskLayer.nodeGetAllProperties( statement, nodeId );
-    }
-
-    @Override
-    public PrimitiveIntIterator relationshipGetPropertyKeys( StoreStatement statement, long relationshipId )
-            throws EntityNotFoundException
-    {
-        return diskLayer.relationshipGetPropertyKeys( statement, relationshipId );
-    }
-
-    @Override
-    public Property relationshipGetProperty( StoreStatement statement, long relationshipId, int propertyKeyId )
-            throws EntityNotFoundException
-    {
-        return diskLayer.relationshipGetProperty( acquireStatement(), relationshipId, propertyKeyId );
-    }
-
-    @Override
-    public Iterator<DefinedProperty> relationshipGetAllProperties( StoreStatement statement, long relationshipId )
-            throws EntityNotFoundException
-    {
-        return diskLayer.relationshipGetAllProperties( statement, relationshipId );
-    }
-
-    @Override
     public PrimitiveIntIterator graphGetPropertyKeys( KernelStatement state )
     {
         return diskLayer.graphGetPropertyKeys( state );
     }
 
     @Override
-    public Property graphGetProperty( int propertyKeyId )
+    public Object graphGetProperty( int propertyKeyId )
     {
         return diskLayer.graphGetProperty( propertyKeyId );
     }
@@ -516,12 +460,6 @@ public class CacheLayer implements StoreReadLayer
     public RelationshipIterator relationshipsGetAll()
     {
         return diskLayer.relationshipsGetAll();
-    }
-
-    @Override
-    public boolean relationshipExists( long relationshipId )
-    {
-        return diskLayer.relationshipExists( relationshipId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/LegacyStorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/LegacyStorePropertyCursor.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import java.nio.channels.WritableByteChannel;
+
+import org.neo4j.kernel.api.cursor.PropertyCursor;
+import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.util.InstanceCache;
+
+/**
+ * Cursor for all properties on a node or relationship.
+ *
+ * This implementation uses the old PropertyBlock loading, which eager loads
+ * all data on init.
+ */
+public class LegacyStorePropertyCursor implements PropertyCursor
+{
+    private PropertyStore propertyStore;
+    private InstanceCache<LegacyStorePropertyCursor> instanceCache;
+    private PropertyRecordCursor propertyRecordCursor;
+    private PropertyBlockCursor propertyBlockCursor;
+
+    public LegacyStorePropertyCursor( PropertyStore propertyStore,
+            InstanceCache<LegacyStorePropertyCursor> instanceCache )
+    {
+        this.propertyStore = propertyStore;
+        this.instanceCache = instanceCache;
+    }
+
+    public LegacyStorePropertyCursor init( long firstPropertyId )
+    {
+        propertyRecordCursor = propertyStore.getPropertyRecordCursor( propertyRecordCursor, firstPropertyId );
+        propertyBlockCursor = null;
+        return this;
+    }
+
+    @Override
+    public boolean next()
+    {
+        if ( propertyBlockCursor != null && propertyBlockCursor.next() )
+        {
+            return true;
+        }
+        else if ( propertyRecordCursor.next() )
+        {
+            propertyBlockCursor = propertyRecordCursor.getPropertyBlockCursor( propertyBlockCursor );
+
+            return propertyBlockCursor.next();
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean seek( int keyId )
+    {
+        while ( next() )
+        {
+            if ( propertyBlockCursor.getPropertyBlock().getKeyIndexId() == keyId )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public int propertyKeyId()
+    {
+        return propertyBlockCursor.getPropertyBlock().getKeyIndexId();
+    }
+
+    @Override
+    public Object value()
+    {
+        return propertyBlockCursor.getProperty().value();
+    }
+
+    @Override
+    public boolean booleanValue()
+    {
+        return (Boolean) value();
+    }
+
+    @Override
+    public long longValue()
+    {
+        return ((Number)value()).longValue();
+    }
+
+    @Override
+    public double doubleValue()
+    {
+        return ((Number)value()).doubleValue();
+    }
+
+    @Override
+    public String stringValue()
+    {
+        return value().toString();
+    }
+
+    @Override
+    public void propertyData( WritableByteChannel channel )
+    {
+        throw new UnsupportedOperationException(  );
+    }
+
+    @Override
+    public void close()
+    {
+        instanceCache.accept( this );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PropertyBlockCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PropertyBlockCursor.java
@@ -28,7 +28,7 @@ import org.neo4j.kernel.impl.store.record.PropertyBlock;
 /**
  * Cursor over a set of {@link PropertyBlock} instances.
  *
- * This is used by the {@link StorePropertyCursor} to find
+ * This is used by the {@link LegacyStorePropertyCursor} to find
  * all properties of a node.
  */
 public class PropertyBlockCursor

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PropertyRecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/PropertyRecordCursor.java
@@ -26,7 +26,7 @@ import org.neo4j.kernel.impl.store.record.Record;
 /**
  * Cursor over {@link PropertyRecord} instances.
  *
- * Used by {@link StorePropertyCursor} to find all properties of a node or relationship.
+ * Used by {@link LegacyStorePropertyCursor} to find all properties of a node or relationship.
  *
  */
 public class PropertyRecordCursor

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
@@ -68,6 +68,13 @@ public abstract class StoreAbstractRelationshipCursor implements RelationshipCur
     }
 
     @Override
+    public long getOtherNode( long nodeId )
+    {
+        return relationshipRecord.getFirstNode() == nodeId ?
+                relationshipRecord.getSecondNode() : relationshipRecord.getFirstNode();
+    }
+
+    @Override
     public PropertyCursor properties()
     {
         return storeStatement.acquirePropertyCursor( relationshipRecord.getNextProp() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
@@ -76,7 +76,7 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
         this.direction = direction;
         this.relTypes = relTypes;
 
-        if ( isDense )
+        if ( isDense && firstRelId != Record.NO_NEXT_RELATIONSHIP.intValue())
         {
             groupRecord = groupStore.getRecord( firstRelId, groupRecordInstance );
             relationshipId = nextChainStart();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
@@ -19,9 +19,28 @@
  */
 package org.neo4j.kernel.impl.api.store;
 
+import java.io.IOException;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+
+import org.neo4j.cursor.GenericCursor;
+import org.neo4j.helpers.UTF8;
+import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.api.cursor.PropertyCursor;
-import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.impl.store.AbstractDynamicStore;
+import org.neo4j.kernel.impl.store.DynamicArrayStore;
+import org.neo4j.kernel.impl.store.DynamicStringStore;
+import org.neo4j.kernel.impl.store.LongerShortString;
 import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.PropertyType;
+import org.neo4j.kernel.impl.store.ShortArray;
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.util.Bits;
 import org.neo4j.kernel.impl.util.InstanceCache;
 
 /**
@@ -29,43 +48,66 @@ import org.neo4j.kernel.impl.util.InstanceCache;
  */
 public class StorePropertyCursor implements PropertyCursor
 {
-    private PropertyStore propertyStore;
-    private StoreStatement storeStatement;
-    private InstanceCache<StorePropertyCursor> instanceCache;
-    private PropertyRecordCursor propertyRecordCursor;
-    private PropertyBlockCursor propertyBlockCursor;
+    private static final long KEY_BITMASK = 0xFFFFFFL;
+
+    private final PropertyStore propertyStore;
+    private final DynamicStringStore stringStore;
+    private final DynamicArrayStore arrayStore;
+    private final InstanceCache<StorePropertyCursor> instanceCache;
+
+    private long nextPropertyRecordId;
+    private PageCursor cursor;
+
+    private int offsetAtBeginning;
+    private int remainingBlocksToRead;
+    private long header;
+    private PropertyType type;
+    private int keyId;
+
+    private byte[] bytes = new byte[4096];
+    private ByteBuffer buffer = ByteBuffer.wrap( bytes ).order( ByteOrder.LITTLE_ENDIAN );
+    private Bits bits = Bits.bits( 32 );
+
+    private AbstractDynamicStore.DynamicRecordCursor stringRecordCursor;
+    private AbstractDynamicStore.DynamicRecordCursor arrayRecordCursor;
+    private long currentRecordId;
+    private long originalHeader;
 
     public StorePropertyCursor( PropertyStore propertyStore,
-            StoreStatement storeStatement,
             InstanceCache<StorePropertyCursor> instanceCache )
     {
         this.propertyStore = propertyStore;
-        this.storeStatement = storeStatement;
+        this.stringStore = propertyStore.getStringStore();
+        this.arrayStore = propertyStore.getArrayStore();
         this.instanceCache = instanceCache;
     }
 
     public StorePropertyCursor init( long firstPropertyId )
     {
-        propertyRecordCursor = propertyStore.getPropertyRecordCursor( propertyRecordCursor, firstPropertyId );
-        propertyBlockCursor = null;
+        nextPropertyRecordId = firstPropertyId;
+        cursor = null;
+        remainingBlocksToRead = 0;
         return this;
     }
 
     @Override
     public boolean next()
     {
-        if ( propertyBlockCursor != null && propertyBlockCursor.next() )
+        do
         {
-            return true;
-        }
-        else if ( propertyRecordCursor.next() )
-        {
-            propertyBlockCursor = propertyRecordCursor.getPropertyBlockCursor( propertyBlockCursor );
+            if ( cursor == null )
+            {
+                if ( nextPropertyRecordId == Record.NO_NEXT_PROPERTY.intValue() )
+                {
+                    return false;
+                }
 
-            return propertyBlockCursor.next();
-        }
+                nextRecord();
+            }
 
-        return false;
+        } while ( !nextBlock() );
+
+        return true;
     }
 
     @Override
@@ -73,7 +115,7 @@ public class StorePropertyCursor implements PropertyCursor
     {
         while ( next() )
         {
-            if ( propertyBlockCursor.getPropertyBlock().getKeyIndexId() == keyId )
+            if ( propertyKeyId() == keyId )
             {
                 return true;
             }
@@ -82,15 +124,521 @@ public class StorePropertyCursor implements PropertyCursor
         return false;
     }
 
-    @Override
-    public DefinedProperty getProperty()
+    public int propertyKeyId()
     {
-        return propertyBlockCursor.getProperty();
+        return keyId;
+    }
+
+    @Override
+    public Object value()
+    {
+        if (type == null)
+            throw new IllegalStateException(  );
+
+        switch ( type )
+        {
+            case BOOL:
+            {
+                return header == 1;
+            }
+
+            case BYTE:
+            {
+                return (byte) header;
+            }
+
+            case SHORT:
+            {
+                return (short)header;
+            }
+
+            case CHAR:
+            {
+                return (char)header;
+            }
+
+            case INT:
+            {
+                return (int)header;
+            }
+
+            case LONG:
+            {
+                if ( (header & 0x1L) > 0 )
+                {
+                   return header >>> 1;
+                }
+                else
+                {
+                    remainingBlocksToRead--;
+                    return cursor.getLong();
+                }
+            }
+
+            case FLOAT:
+            {
+                return Float.intBitsToFloat( (int) header );
+            }
+
+            case DOUBLE:
+            {
+                remainingBlocksToRead--;
+                return Double.longBitsToDouble( cursor.getLong());
+            }
+
+            case STRING:
+            {
+                try
+                {
+                    readPropertyData();
+                    return UTF8.decode( bytes, 0, buffer.limit() );
+                }
+                catch ( IOException e )
+                {
+                    throw new UnderlyingStorageException( e );
+                }
+            }
+
+            case ARRAY:
+            {
+                try
+                {
+                    readPropertyData();
+                    return getRightArray();
+                }
+                catch ( IOException e )
+                {
+                    throw new UnderlyingStorageException( e );
+                }
+            }
+
+            case SHORT_STRING:
+            {
+                try
+                {
+                    readPropertyData();
+                    bits.clear( true );
+                    bits.put(bytes, 0, buffer.limit());
+                    return LongerShortString.decode( bits );
+                } catch ( IOException e )
+                {
+                    throw new UnderlyingStorageException( e );
+                }
+            }
+
+            case SHORT_ARRAY:
+            {
+                try
+                {
+                    readPropertyData();
+                    bits.clear( true );
+                    bits.put( bytes, 0, buffer.limit() );
+                    return ShortArray.decode( bits );
+                } catch ( IOException e )
+                {
+                    throw new UnderlyingStorageException( e );
+                }
+            }
+
+            default:
+            {
+                throw new IllegalStateException( "No such type:"+type );
+            }
+        }
+    }
+
+    @Override
+    public boolean booleanValue()
+    {
+        return ((Boolean)value());
+    }
+
+    @Override
+    public long longValue()
+    {
+        if (type == null)
+            throw new IllegalStateException(  );
+
+        switch ( type )
+        {
+            case BOOL:
+            case BYTE:
+            case SHORT:
+            case CHAR:
+            case INT:
+            {
+                return header;
+            }
+
+            case LONG:
+            {
+                if ( (header & 0x1L) > 0 )
+                {
+                   return header >>> 1;
+                }
+                else
+                {
+                    remainingBlocksToRead--;
+                    return cursor.getLong();
+                }
+            }
+
+
+            default:
+            {
+                throw new IllegalStateException( "Not an integral type:"+type );
+            }
+        }
+    }
+
+    @Override
+    public double doubleValue()
+    {
+        if (type == null)
+            throw new IllegalStateException(  );
+
+        switch ( type )
+        {
+            case FLOAT:
+            {
+                return Float.intBitsToFloat( (int) header );
+            }
+
+            case DOUBLE:
+            {
+                remainingBlocksToRead--;
+                return Double.longBitsToDouble( cursor.getLong());
+            }
+
+            default:
+            {
+                throw new IllegalStateException( "Not a real number type:"+type );
+            }
+        }
+    }
+
+    @Override
+    public String stringValue()
+    {
+        return value().toString();
+    }
+
+    public void propertyData( WritableByteChannel channel )
+    {
+        try
+        {
+            readPropertyData();
+
+            channel.write( buffer );
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
+    }
+
+    private void readPropertyData() throws IOException
+    {
+        buffer.clear();
+
+        switch ( type )
+        {
+            case BOOL:
+            case BYTE:
+            {
+                buffer.put( (byte) header );
+                break;
+            }
+
+            case SHORT:
+            {
+                buffer.putShort( (short) header );
+                break;
+            }
+
+            case CHAR:
+            {
+                buffer.putChar( (char) header );
+                break;
+            }
+
+            case INT:
+            {
+                buffer.putInt( (int) header );
+                break;
+            }
+
+            case LONG:
+            {
+                if ( (header & 0x1L) > 0 )
+                {
+                    buffer.putLong( header >>> 1 );
+                }
+                else
+                {
+                    buffer.putLong( cursor.getLong() );
+                    remainingBlocksToRead--;
+                }
+                break;
+            }
+
+            case FLOAT:
+            {
+                buffer.putInt( (int) header);
+                break;
+            }
+
+            case DOUBLE:
+            {
+                buffer.putLong( cursor.getLong() );
+                remainingBlocksToRead--;
+                break;
+            }
+
+            case STRING:
+            {
+                int storeOffset = cursor.getOffset();
+                cursor.close();
+
+                if ( stringRecordCursor == null )
+                {
+                    stringRecordCursor = stringStore.newDynamicRecordCursor();
+                }
+
+                try ( GenericCursor<DynamicRecord> stringRecords = stringStore.getRecordsCursor( header, true,
+                        stringRecordCursor ) )
+                {
+                    while ( stringRecords.next() )
+                    {
+                        DynamicRecord dynamicRecord = stringRecords.get();
+
+                        buffer.put( dynamicRecord.getData(), 0, dynamicRecord.getData().length );
+                    }
+                }
+
+                cursor = propertyStore.newReadCursor( currentRecordId );
+                cursor.setOffset( storeOffset );
+                break;
+            }
+
+            case ARRAY:
+            {
+                int storeOffset = cursor.getOffset();
+                cursor.close();
+
+                if ( arrayRecordCursor == null )
+                {
+                    arrayRecordCursor = arrayStore.newDynamicRecordCursor();
+                }
+
+                try ( GenericCursor<DynamicRecord> arrayRecords = arrayStore.getRecordsCursor( header, true,
+                        arrayRecordCursor ) )
+                {
+                    while ( arrayRecords.next() )
+                    {
+                        DynamicRecord dynamicRecord = arrayRecords.get();
+
+                        while (true)
+                        {
+                            try
+                            {
+                                buffer.put( dynamicRecord.getData(), 0, dynamicRecord.getData().length );
+                                break;
+                            }
+                            catch ( BufferOverflowException e )
+                            {
+                                buffer.flip();
+                                bytes = new byte[bytes.length * 2];
+                                ByteBuffer newBuffer = ByteBuffer.wrap( bytes ).order( ByteOrder.LITTLE_ENDIAN );
+                                newBuffer.put( buffer );
+                                buffer = newBuffer;
+                            }
+                        }
+                    }
+                }
+
+                cursor = propertyStore.newReadCursor( currentRecordId );
+                cursor.setOffset( storeOffset );
+                break;
+            }
+
+            case SHORT_STRING:
+            case SHORT_ARRAY:
+            {
+                buffer.putLong(originalHeader);
+                while (remainingBlocksToRead-->0)
+                {
+                    buffer.putLong( cursor.getLong() );
+                }
+                break;
+            }
+
+            default:
+            {
+                throw new IllegalStateException();
+            }
+        }
+
+        buffer.flip();
     }
 
     @Override
     public void close()
     {
+        if ( cursor != null )
+        {
+            cursor.close();
+            cursor = null;
+        }
+
         instanceCache.accept( this );
+    }
+
+
+    private void nextRecord()
+    {
+        try
+        {
+            cursor = propertyStore.newReadCursor( nextPropertyRecordId );
+            currentRecordId = nextPropertyRecordId;
+
+            offsetAtBeginning = cursor.getOffset();
+
+            byte modifiers = cursor.getByte();
+            long nextMod = (modifiers & 0x0FL) << 32;
+            cursor.getUnsignedInt(); // We don't care about previous pointer
+            long nextProp = cursor.getUnsignedInt();
+            nextPropertyRecordId = longFromIntAndMod( nextProp, nextMod );
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
+    }
+
+    private boolean nextBlock()
+    {
+        // Read remaining data from previous property (if it was not read)
+        while ( remainingBlocksToRead-- > 0 )
+        {
+            cursor.getLong();
+        }
+
+        if ( cursor.getOffset() - offsetAtBeginning < PropertyStore.RECORD_SIZE )
+        {
+            header = cursor.getLong();
+
+            type = getPropertyType( header );
+            if ( type != null )
+            {
+                keyId = (int) (header & KEY_BITMASK);
+
+                remainingBlocksToRead = type.calculateNumberOfBlocksUsed( header ) - 1;
+
+                originalHeader = header;
+                header = header >>> 28;
+
+                return true;
+            }
+        }
+
+        cursor.close();
+        cursor = null;
+
+        return false;
+    }
+
+    private long longFromIntAndMod( long base, long modifier )
+    {
+        return modifier == 0 && base == IdGeneratorImpl.INTEGER_MINUS_ONE ? -1 : base | modifier;
+    }
+
+    private PropertyType getPropertyType( long propBlock )
+    {
+        // [][][][][    ,tttt][kkkk,kkkk][kkkk,kkkk][kkkk,kkkk]
+        int type = (int) ((propBlock & 0x000000000F000000L) >> 24);
+        switch ( type )
+        {
+            case 1:
+                return PropertyType.BOOL;
+            case 2:
+                return PropertyType.BYTE;
+            case 3:
+                return PropertyType.SHORT;
+            case 4:
+                return PropertyType.CHAR;
+            case 5:
+                return PropertyType.INT;
+            case 6:
+                return PropertyType.LONG;
+            case 7:
+                return PropertyType.FLOAT;
+            case 8:
+                return PropertyType.DOUBLE;
+            case 9:
+                return PropertyType.STRING;
+            case 10:
+                return PropertyType.ARRAY;
+            case 11:
+                return PropertyType.SHORT_STRING;
+            case 12:
+                return PropertyType.SHORT_ARRAY;
+            default:
+            {
+                return null;
+            }
+        }
+    }
+
+    private Object getRightArray()
+    {
+       // byte[] header = data.first();
+       // byte[] bArray = data.other();
+        byte typeId = buffer.get();
+        buffer.order(ByteOrder.BIG_ENDIAN);
+        try
+        {
+            if ( typeId == PropertyType.STRING.intValue() )
+            {
+                int arrayLength = buffer.getInt();
+                String[] result = new String[arrayLength];
+
+                for ( int i = 0; i < arrayLength; i++ )
+                {
+                    int byteLength = buffer.getInt();
+                    result[i] = UTF8.decode( bytes, buffer.position(), byteLength );
+                    buffer.position( buffer.position() + byteLength );
+                }
+                return result;
+            }
+            else
+            {
+                ShortArray type = ShortArray.typeOf( typeId );
+                int bitsUsedInLastByte = buffer.get();
+                int requiredBits = buffer.get();
+                if ( requiredBits == 0 )
+                {
+                    return type.createEmptyArray();
+                }
+                Object result;
+                if ( type == ShortArray.BYTE && requiredBits == Byte.SIZE )
+                {   // Optimization for byte arrays (probably large ones)
+                    byte[] byteArray = new byte[buffer.limit()-buffer.position()];
+                    buffer.get( byteArray );
+                    result = byteArray;
+                }
+                else
+                {   // Fallback to the generic approach, which is a slower
+                    Bits bits = Bits.bitsFromBytes( bytes, buffer.position() );
+                    int length = ((buffer.limit()-buffer.position())*8-(8-bitsUsedInLastByte))/requiredBits;
+                    result = type.createArray(length, bits, requiredBits);
+                }
+                return result;
+            }
+        }
+        finally
+        {
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -38,7 +38,6 @@ import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.properties.DefinedProperty;
-import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.DegreeVisitor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
@@ -54,10 +53,6 @@ public interface StoreReadLayer
 {
     // Cursor
     StoreStatement acquireStatement();
-
-    boolean nodeHasLabel( StoreStatement statement, long nodeId, int labelId ) throws EntityNotFoundException;
-
-    boolean nodeExists( long nodeId );
 
     PrimitiveIntIterator nodeGetLabels( StoreStatement statement, long nodeId ) throws EntityNotFoundException;
 
@@ -98,27 +93,9 @@ public interface StoreReadLayer
 
     IndexRule indexRule( IndexDescriptor index, SchemaStorage.IndexRuleKind kind );
 
-    PrimitiveIntIterator nodeGetPropertyKeys( StoreStatement statement, long nodeId ) throws EntityNotFoundException;
-
-    Property nodeGetProperty( StoreStatement statement, long nodeId, int propertyKeyId ) throws EntityNotFoundException;
-
-    Iterator<DefinedProperty> nodeGetAllProperties( StoreStatement statement,
-            long nodeId ) throws EntityNotFoundException;
-
-    boolean relationshipExists( long relationshipId );
-
-    PrimitiveIntIterator relationshipGetPropertyKeys( StoreStatement statement, long relationshipId )
-            throws EntityNotFoundException;
-
-    Property relationshipGetProperty( StoreStatement statement, long relationshipId, int propertyKeyId )
-            throws EntityNotFoundException;
-
-    Iterator<DefinedProperty> relationshipGetAllProperties( StoreStatement statement, long nodeId )
-            throws EntityNotFoundException;
-
     PrimitiveIntIterator graphGetPropertyKeys( KernelStatement state );
 
-    Property graphGetProperty( int propertyKeyId );
+    Object graphGetProperty( int propertyKeyId );
 
     Iterator<DefinedProperty> graphGetAllProperties();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
@@ -79,8 +79,7 @@ public class StoreStatement
             @Override
             protected StorePropertyCursor create()
             {
-                return new StorePropertyCursor( StoreStatement.this.neoStore.getPropertyStore(),
-                        StoreStatement.this, this );
+                return new StorePropertyCursor( StoreStatement.this.neoStore.getPropertyStore(), this );
             }
         };
         labelCursor = new InstanceCache<StoreLabelCursor>()
@@ -135,10 +134,10 @@ public class StoreStatement
         return iteratorNodeCursor.get().init( nodeIdIterator );
     }
 
-    public PropertyCursor acquirePropertyCursor( long firstPropertyId )
+    public PropertyCursor acquirePropertyCursor( long firstPropertyRecordId )
     {
         neoStore.assertOpen();
-        return propertyCursor.get().init( firstPropertyId );
+        return propertyCursor.get().init( firstPropertyRecordId );
     }
 
     public LabelCursor acquireLabelCursor( long[] labels )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesProxy.java
@@ -182,7 +182,7 @@ public class GraphPropertiesProxy implements GraphProperties
         try ( Statement statement = actions.statement() )
         {
             List<String> keys = new ArrayList<>();
-            PrimitiveIntIterator properties = statement.readOperations().graphGetAllPropertiesKeys( );
+            PrimitiveIntIterator properties = statement.readOperations().graphGetPropertyKeys();
             while ( properties.hasNext() )
             {
                 keys.add( statement.readOperations().propertyKeyGetName( properties.next() ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/GraphPropertiesProxy.java
@@ -20,20 +20,20 @@
 package org.neo4j.kernel.impl.core;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
+import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.helpers.ThisShouldNotHappenError;
+import org.neo4j.kernel.api.EntityType;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
-import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 
@@ -76,7 +76,7 @@ public class GraphPropertiesProxy implements GraphProperties
         try ( Statement statement = actions.statement() )
         {
             int propertyKeyId = statement.readOperations().propertyKeyGetForName( key );
-            return statement.readOperations().graphGetProperty( propertyKeyId ).isDefined();
+            return statement.readOperations().graphHasProperty( propertyKeyId );
         }
     }
 
@@ -97,7 +97,15 @@ public class GraphPropertiesProxy implements GraphProperties
                 {
                     throw new NotFoundException( format( "No such property, '%s'.", key ) );
                 }
-                return statement.readOperations().graphGetProperty( propertyKeyId ).value();
+
+                Object value = statement.readOperations().graphGetProperty( propertyKeyId );
+
+                if (value == null)
+                {
+                    throw new PropertyNotFoundException( propertyKeyId, EntityType.GRAPH, -1 );
+                }
+
+                return value;
             }
             catch ( PropertyNotFoundException e )
             {
@@ -118,7 +126,8 @@ public class GraphPropertiesProxy implements GraphProperties
         try ( Statement statement = actions.statement() )
         {
             int propertyKeyId = statement.readOperations().propertyKeyGetForName( key );
-            return statement.readOperations().graphGetProperty( propertyKeyId ).value( defaultValue );
+            Object value = statement.readOperations().graphGetProperty( propertyKeyId );
+            return value == null ? defaultValue : value;
         }
     }
 
@@ -173,10 +182,10 @@ public class GraphPropertiesProxy implements GraphProperties
         try ( Statement statement = actions.statement() )
         {
             List<String> keys = new ArrayList<>();
-            Iterator<DefinedProperty> properties = statement.readOperations().graphGetAllProperties();
+            PrimitiveIntIterator properties = statement.readOperations().graphGetAllPropertiesKeys( );
             while ( properties.hasNext() )
             {
-                keys.add( statement.readOperations().propertyKeyGetName( properties.next().propertyKeyId() ) );
+                keys.add( statement.readOperations().propertyKeyGetName( properties.next() ) );
             }
             return keys;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -358,7 +358,7 @@ public class NodeProxy implements Node
         try ( Statement statement = actions.statement() )
         {
             List<String> keys = new ArrayList<>();
-            PrimitiveIntIterator properties = statement.readOperations().nodeGetAllPropertiesKeys( getId() );
+            PrimitiveIntIterator properties = statement.readOperations().nodeGetPropertyKeys( getId() );
             while ( properties.hasNext() )
             {
                 keys.add( statement.readOperations().propertyKeyGetName( properties.next() ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.core;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
@@ -42,6 +41,7 @@ import org.neo4j.graphdb.StopEvaluator;
 import org.neo4j.graphdb.Traverser;
 import org.neo4j.graphdb.Traverser.Order;
 import org.neo4j.helpers.ThisShouldNotHappenError;
+import org.neo4j.kernel.api.EntityType;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
@@ -54,7 +54,6 @@ import org.neo4j.kernel.api.exceptions.RelationshipTypeIdNotFoundKernelException
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
-import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 import org.neo4j.kernel.impl.traversal.OldTraverserWrapper;
@@ -344,7 +343,8 @@ public class NodeProxy implements Node
         try ( Statement statement = actions.statement() )
         {
             int propertyKeyId = statement.readOperations().propertyKeyGetForName( key );
-            return statement.readOperations().nodeGetProperty( nodeId, propertyKeyId ).value( defaultValue );
+            Object value =  statement.readOperations().nodeGetProperty( nodeId, propertyKeyId );
+            return value == null ? defaultValue : value;
         }
         catch ( EntityNotFoundException e )
         {
@@ -358,10 +358,10 @@ public class NodeProxy implements Node
         try ( Statement statement = actions.statement() )
         {
             List<String> keys = new ArrayList<>();
-            Iterator<DefinedProperty> properties = statement.readOperations().nodeGetAllProperties( getId() );
+            PrimitiveIntIterator properties = statement.readOperations().nodeGetAllPropertiesKeys( getId() );
             while ( properties.hasNext() )
             {
-                keys.add( statement.readOperations().propertyKeyGetName( properties.next().propertyKeyId() ) );
+                keys.add( statement.readOperations().propertyKeyGetName( properties.next() ) );
             }
             return keys;
         }
@@ -393,7 +393,14 @@ public class NodeProxy implements Node
                 {
                     throw new NotFoundException( format( "No such property, '%s'.", key ) );
                 }
-                return statement.readOperations().nodeGetProperty( nodeId, propertyKeyId ).value();
+
+                Object value = statement.readOperations().nodeGetProperty( nodeId, propertyKeyId );
+
+                if (value == null)
+                    throw new PropertyNotFoundException( propertyKeyId, EntityType.NODE, nodeId );
+
+                return value;
+
             }
             catch ( EntityNotFoundException | PropertyNotFoundException e )
             {
@@ -414,7 +421,7 @@ public class NodeProxy implements Node
         try ( Statement statement = actions.statement() )
         {
             int propertyKeyId = statement.readOperations().propertyKeyGetForName( key );
-            return statement.readOperations().nodeGetProperty( nodeId, propertyKeyId ).isDefined();
+            return statement.readOperations().nodeHasProperty( nodeId, propertyKeyId );
         }
         catch ( EntityNotFoundException e )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -217,7 +217,7 @@ public class RelationshipProxy implements Relationship, RelationshipVisitor<Runt
         try ( Statement statement = actions.statement() )
         {
             List<String> keys = new ArrayList<>();
-            PrimitiveIntIterator properties = statement.readOperations().relationshipGetAllPropertiesKeys( getId() );
+            PrimitiveIntIterator properties = statement.readOperations().relationshipGetPropertyKeys( getId() );
             while ( properties.hasNext() )
             {
                 keys.add( statement.readOperations().propertyKeyGetName( properties.next() ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -72,7 +72,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
     public TxStateTransactionDataSnapshot(
             ReadableTxState state,
             NodeProxy.NodeActions nodeActions, RelationshipProxy.RelationshipActions relationshipActions,
-            StoreReadLayer storeReadLayer)
+            StoreReadLayer storeReadLayer )
     {
         this.state = state;
         this.nodeActions = nodeActions;
@@ -164,24 +164,26 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         {
             for ( Long nodeId : state.addedAndRemovedNodes().getRemoved() )
             {
-                try (NodeCursor node = storeStatement.acquireSingleNodeCursor( nodeId ))
+                try ( NodeCursor node = storeStatement.acquireSingleNodeCursor( nodeId ) )
                 {
-                    if (node.next())
+                    if ( node.next() )
                     {
-                        try (PropertyCursor properties = node.properties())
+                        try ( PropertyCursor properties = node.properties() )
                         {
-                            while (properties.next())
+                            while ( properties.next() )
                             {
                                 removedNodeProperties.add( new NodePropertyEntryView( nodeId,
-                                        storeReadLayer.propertyKeyGetName( properties.propertyKeyId()), null, properties.value() ) );
+                                        storeReadLayer.propertyKeyGetName( properties.propertyKeyId() ), null,
+                                        properties.value() ) );
                             }
                         }
 
-                        try (LabelCursor labels = node.labels())
+                        try ( LabelCursor labels = node.labels() )
                         {
-                            while (labels.next())
+                            while ( labels.next() )
                             {
-                                removedLabels.add( new LabelEntryView( nodeId, storeReadLayer.labelGetName( labels.getLabel() ) ) );
+                                removedLabels.add( new LabelEntryView( nodeId,
+                                        storeReadLayer.labelGetName( labels.getLabel() ) ) );
                             }
                         }
                     }
@@ -190,16 +192,17 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             for ( Long relId : state.addedAndRemovedRelationships().getRemoved() )
             {
                 Relationship relationshipProxy = relationship( relId );
-                try (RelationshipCursor relationship = storeStatement.acquireSingleRelationshipCursor( relId ))
+                try ( RelationshipCursor relationship = storeStatement.acquireSingleRelationshipCursor( relId ) )
                 {
-                    if (relationship.next())
+                    if ( relationship.next() )
                     {
-                        try (PropertyCursor properties = relationship.properties())
+                        try ( PropertyCursor properties = relationship.properties() )
                         {
-                            while (properties.next())
+                            while ( properties.next() )
                             {
                                 removedRelationshipProperties.add( new RelationshipPropertyEntryView( relationshipProxy,
-                                        storeReadLayer.propertyKeyGetName( properties.propertyKeyId() ), null, properties.value() ) );
+                                        storeReadLayer.propertyKeyGetName( properties.propertyKeyId() ), null,
+                                        properties.value() ) );
                             }
                         }
 
@@ -270,7 +273,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
 
     private Iterable<Node> map2Nodes( Iterable<Long> added )
     {
-        return new IterableWrapper<Node,Long>( added )
+        return new IterableWrapper<Node, Long>( added )
         {
             @Override
             protected Node underlyingObjectToObject( Long id )
@@ -282,7 +285,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
 
     private Iterable<Relationship> map2Rels( Iterable<Long> ids )
     {
-        return new IterableWrapper<Relationship,Long>( ids )
+        return new IterableWrapper<Relationship, Long>( ids )
         {
             @Override
             protected Relationship underlyingObjectToObject( Long id )
@@ -299,15 +302,19 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             return null;
         }
 
-        try (NodeCursor node = storeStatement.acquireSingleNodeCursor( nodeState.getId() ))
+        try ( NodeCursor node = storeStatement.acquireSingleNodeCursor( nodeState.getId() ) )
         {
-            if (!node.next())
-                return null;
-
-            try (PropertyCursor properties = node.properties())
+            if ( !node.next() )
             {
-                if (properties.seek( property ))
+                return null;
+            }
+
+            try ( PropertyCursor properties = node.properties() )
+            {
+                if ( properties.seek( property ) )
+                {
                     return properties.value();
+                }
             }
         }
 
@@ -321,15 +328,19 @@ public class TxStateTransactionDataSnapshot implements TransactionData
             return null;
         }
 
-        try (RelationshipCursor relationship = storeStatement.acquireSingleRelationshipCursor( relState.getId() ))
+        try ( RelationshipCursor relationship = storeStatement.acquireSingleRelationshipCursor( relState.getId() ) )
         {
-            if (!relationship.next())
-                return null;
-
-            try (PropertyCursor properties = relationship.properties())
+            if ( !relationship.next() )
             {
-                if (properties.seek( property ))
+                return null;
+            }
+
+            try ( PropertyCursor properties = relationship.properties() )
+            {
+                if ( properties.seek( property ) )
+                {
                     return properties.value();
+                }
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataSnapshot.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -33,10 +32,12 @@ import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.helpers.collection.IterableWrapper;
-import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.api.cursor.LabelCursor;
+import org.neo4j.kernel.api.cursor.NodeCursor;
+import org.neo4j.kernel.api.cursor.PropertyCursor;
+import org.neo4j.kernel.api.cursor.RelationshipCursor;
 import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
-import org.neo4j.kernel.api.exceptions.PropertyNotFoundException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.txstate.ReadableTxState;
 import org.neo4j.kernel.impl.api.RelationshipDataExtractor;
@@ -163,30 +164,46 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         {
             for ( Long nodeId : state.addedAndRemovedNodes().getRemoved() )
             {
-                Iterator<DefinedProperty> props = storeReadLayer.nodeGetAllProperties( storeStatement, nodeId );
-                while ( props.hasNext() )
+                try (NodeCursor node = storeStatement.acquireSingleNodeCursor( nodeId ))
                 {
-                    DefinedProperty prop = props.next();
-                    removedNodeProperties.add( new NodePropertyEntryView( nodeId,
-                            storeReadLayer.propertyKeyGetName( prop.propertyKeyId() ), null, prop.value() ) );
-                }
+                    if (node.next())
+                    {
+                        try (PropertyCursor properties = node.properties())
+                        {
+                            while (properties.next())
+                            {
+                                removedNodeProperties.add( new NodePropertyEntryView( nodeId,
+                                        storeReadLayer.propertyKeyGetName( properties.propertyKeyId()), null, properties.value() ) );
+                            }
+                        }
 
-                PrimitiveIntIterator labels = storeReadLayer.nodeGetLabels( storeStatement, nodeId );
-                while ( labels.hasNext() )
-                {
-                    removedLabels.add( new LabelEntryView( nodeId, storeReadLayer.labelGetName( labels.next() ) ) );
+                        try (LabelCursor labels = node.labels())
+                        {
+                            while (labels.next())
+                            {
+                                removedLabels.add( new LabelEntryView( nodeId, storeReadLayer.labelGetName( labels.getLabel() ) ) );
+                            }
+                        }
+                    }
                 }
-
             }
             for ( Long relId : state.addedAndRemovedRelationships().getRemoved() )
             {
-                Relationship relationship = relationship( relId );
-                Iterator<DefinedProperty> props = storeReadLayer.relationshipGetAllProperties(storeStatement , relId );
-                while(props.hasNext())
+                Relationship relationshipProxy = relationship( relId );
+                try (RelationshipCursor relationship = storeStatement.acquireSingleRelationshipCursor( relId ))
                 {
-                    DefinedProperty prop = props.next();
-                    removedRelationshipProperties.add( new RelationshipPropertyEntryView( relationship,
-                            storeReadLayer.propertyKeyGetName( prop.propertyKeyId() ), null, prop.value() ) );
+                    if (relationship.next())
+                    {
+                        try (PropertyCursor properties = relationship.properties())
+                        {
+                            while (properties.next())
+                            {
+                                removedRelationshipProperties.add( new RelationshipPropertyEntryView( relationshipProxy,
+                                        storeReadLayer.propertyKeyGetName( properties.propertyKeyId() ), null, properties.value() ) );
+                            }
+                        }
+
+                    }
                 }
             }
             for ( NodeState nodeState : state.modifiedNodes() )
@@ -197,7 +214,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
                     DefinedProperty property = added.next();
                     assignedNodeProperties.add( new NodePropertyEntryView( nodeState.getId(),
                             storeReadLayer.propertyKeyGetName( property.propertyKeyId() ), property.value(),
-                            committedValue( storeReadLayer, nodeState, property.propertyKeyId() ) ) );
+                            committedValue( nodeState, property.propertyKeyId() ) ) );
                 }
                 Iterator<Integer> removed = nodeState.removedProperties();
                 while ( removed.hasNext() )
@@ -205,7 +222,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
                     Integer property = removed.next();
                     removedNodeProperties.add( new NodePropertyEntryView( nodeState.getId(),
                             storeReadLayer.propertyKeyGetName( property ), null,
-                            committedValue( storeReadLayer, nodeState, property ) ) );
+                            committedValue( nodeState, property ) ) );
                 }
                 ReadableDiffSets<Integer> labels = nodeState.labelDiffSets();
                 for ( Integer label : labels.getAdded() )
@@ -238,7 +255,7 @@ public class TxStateTransactionDataSnapshot implements TransactionData
                 }
             }
         }
-        catch ( EntityNotFoundException | PropertyKeyIdNotFoundKernelException | LabelNotFoundKernelException e )
+        catch ( PropertyKeyIdNotFoundKernelException | LabelNotFoundKernelException e )
         {
             throw new ThisShouldNotHappenError( "Jake", "An entity that does not exist was modified.", e );
         }
@@ -275,36 +292,48 @@ public class TxStateTransactionDataSnapshot implements TransactionData
         };
     }
 
-    private Object committedValue( StoreReadLayer storeReadLayer, NodeState nodeState, int property )
+    private Object committedValue( NodeState nodeState, int property )
     {
-        try
-        {
-            if ( state.nodeIsAddedInThisTx( nodeState.getId() ) )
-            {
-                return null;
-            }
-            return storeReadLayer.nodeGetProperty( storeStatement, nodeState.getId(), property ).value();
-        }
-        catch ( EntityNotFoundException | PropertyNotFoundException e )
+        if ( state.nodeIsAddedInThisTx( nodeState.getId() ) )
         {
             return null;
         }
+
+        try (NodeCursor node = storeStatement.acquireSingleNodeCursor( nodeState.getId() ))
+        {
+            if (!node.next())
+                return null;
+
+            try (PropertyCursor properties = node.properties())
+            {
+                if (properties.seek( property ))
+                    return properties.value();
+            }
+        }
+
+        return null;
     }
 
     private Object committedValue( StoreReadLayer storeReadLayer, RelationshipState relState, int property )
     {
-        try
-        {
-            if ( state.relationshipIsAddedInThisTx( relState.getId() ) )
-            {
-                return null;
-            }
-            return storeReadLayer.relationshipGetProperty( storeStatement, relState.getId(), property ).value();
-        }
-        catch ( EntityNotFoundException | PropertyNotFoundException e )
+        if ( state.relationshipIsAddedInThisTx( relState.getId() ) )
         {
             return null;
         }
+
+        try (RelationshipCursor relationship = storeStatement.acquireSingleRelationshipCursor( relState.getId() ))
+        {
+            if (!relationship.next())
+                return null;
+
+            try (PropertyCursor properties = relationship.properties())
+            {
+                if (properties.seek( property ))
+                    return properties.value();
+            }
+        }
+
+        return null;
     }
 
     private class NodePropertyEntryView implements PropertyEntry<Node>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -587,9 +587,13 @@ public class GraphDatabaseFacade
                 long nextValue = nodesWithLabel.next();
                 try
                 {
-                    if ( Property.property(propertyKeyId, statement.nodeGetProperty( nextValue, propertyKeyId )).valueEquals( value ) )
+                    Object propertyValue = statement.nodeGetProperty( nextValue, propertyKeyId );
+                    if ( propertyValue != null )
                     {
-                        return next( nextValue );
+                        if ( Property.property( propertyKeyId, propertyValue ).valueEquals( value ) )
+                        {
+                            return next( nextValue );
+                        }
                     }
                 }
                 catch ( EntityNotFoundException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -69,6 +69,7 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
@@ -586,7 +587,7 @@ public class GraphDatabaseFacade
                 long nextValue = nodesWithLabel.next();
                 try
                 {
-                    if ( statement.nodeGetProperty( nextValue, propertyKeyId ).valueEquals( value ) )
+                    if ( Property.property(propertyKeyId, statement.nodeGetProperty( nextValue, propertyKeyId )).valueEquals( value ) )
                     {
                         return next( nextValue );
                     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
@@ -25,8 +25,6 @@ import java.util.Arrays;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.util.Bits;
 
-import static java.util.Arrays.copyOf;
-
 /**
  * Supports encoding alphanumerical and <code>SP . - + , ' : / _</code>
  *
@@ -764,15 +762,19 @@ public enum LongerShortString
      */
     public static String decode( PropertyBlock block )
     {
-        Bits bits = Bits.bitsFromLongs( copyOf( block.getValueBlocks(),
-                block.getValueBlocks().length ) );
+        Bits bits = Bits.bitsFromLongs( block.getValueBlocks());
+        return decode(bits);
+    }
+
+    public static String decode(Bits bits)
+    {
         long firstLong = bits.getLongs()[0];
         if ( ( firstLong & 0xFFFFFF0FFFFFFFFFL ) == 0 ) return "";
         bits.getInt( 24 ); // Get rid of the key
         bits.getByte( 4 ); // Get rid of the type
         int encoding = bits.getByte( 5 ); //(int) ( ( firstLong & 0xF00000000L ) >>> 32 );
         int stringLength = bits.getByte( 6 ); //(int) ( ( firstLong & 0xFC000000L ) >>> 26 );
-        if ( encoding == ENCODING_UTF8 ) return decodeUTF8( bits, stringLength );
+        if ( encoding == LongerShortString.ENCODING_UTF8 ) return decodeUTF8( bits, stringLength );
         if ( encoding == ENCODING_LATIN1 ) return decodeLatin1( bits, stringLength );
 
         LongerShortString table = getEncodingTable( encoding );
@@ -786,6 +788,7 @@ public enum LongerShortString
         }
         return String.valueOf(result);
     }
+
 
     // lookup table by encoding header
     // +2 because of ENCODING_LATIN1 gap and one based index

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
@@ -762,8 +762,8 @@ public enum LongerShortString
      */
     public static String decode( PropertyBlock block )
     {
-        Bits bits = Bits.bitsFromLongs( block.getValueBlocks());
-        return decode(bits);
+        Bits bits = Bits.bitsFromLongs( block.getValueBlocks() );
+        return decode( bits );
     }
 
     public static String decode(Bits bits)

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -301,7 +301,7 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord>
                     while ( stringRecords.next() )
                     {
                         stringRecords.get().setType( PropertyType.STRING.intValue() );
-                        block.addValueRecord( stringRecords.get() );
+                        block.addValueRecord( stringRecords.get().clone() );
                     }
                 }
             }
@@ -361,9 +361,13 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord>
         }
     }
 
-    public PageCursor newPageCursor( int mode ) throws IOException
+    public PageCursor newReadCursor( long recordId ) throws IOException
     {
-        return storeFile.io( 0, mode );
+        PageCursor cursor =  storeFile.io( pageIdForRecord( recordId ), PF_SHARED_LOCK );
+        if (!cursor.next())
+            throw new IOException( "Record not found: "+recordId );
+        cursor.setOffset( (int) (recordId * RECORD_SIZE % storeFile.pageSize()) );
+        return cursor;
     }
 
     public PropertyRecord getRecord( PropertyRecord record, PageCursor cursor )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -363,9 +363,11 @@ public class PropertyStore extends AbstractRecordStore<PropertyRecord>
 
     public PageCursor newReadCursor( long recordId ) throws IOException
     {
-        PageCursor cursor =  storeFile.io( pageIdForRecord( recordId ), PF_SHARED_LOCK );
-        if (!cursor.next())
-            throw new IOException( "Record not found: "+recordId );
+        PageCursor cursor = storeFile.io( pageIdForRecord( recordId ), PF_SHARED_LOCK );
+        if ( !cursor.next() )
+        {
+            throw new IOException( "Record not found: " + recordId );
+        }
         cursor.setOffset( (int) (recordId * RECORD_SIZE % storeFile.pageSize()) );
         return cursor;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
@@ -710,8 +710,8 @@ public enum ShortArray
 
     public static Object decode( PropertyBlock block )
     {
-        Bits bits = Bits.bitsFromLongs(Arrays.copyOf(block.getValueBlocks(), block.getValueBlocks().length));
-        return decode(bits);
+        Bits bits = Bits.bitsFromLongs( Arrays.copyOf( block.getValueBlocks(), block.getValueBlocks().length) );
+        return decode( bits );
     }
 
     public static Object decode( Bits bits )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
@@ -711,6 +711,11 @@ public enum ShortArray
     public static Object decode( PropertyBlock block )
     {
         Bits bits = Bits.bitsFromLongs(Arrays.copyOf(block.getValueBlocks(), block.getValueBlocks().length));
+        return decode(bits);
+    }
+
+    public static Object decode( Bits bits )
+    {
         // [][][    ,bbbb][bbll,llll][yyyy,tttt][kkkk,kkkk][kkkk,kkkk][kkkk,kkkk]
         bits.getInt( 24 ); // Get rid of key
         bits.getByte( 4 ); // Get rid of short array type

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ByteBufferWritableByteChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ByteBufferWritableByteChannel.java
@@ -28,12 +28,12 @@ import java.nio.channels.WritableByteChannel;
 /**
  * WritableByteChannel which is backed by a ByteBuffer. If data cannot fit
  * the buffer will be expanded on the fly.
- *
+ * <p>
  * Instances can be reused by calling {@link #reset()}. The internal buffer will not be reset
  * to the initial size, but will retain whatever size it had before resetting.
  */
 public class ByteBufferWritableByteChannel
-    implements WritableByteChannel
+        implements WritableByteChannel
 {
     private boolean closed = false;
 
@@ -41,10 +41,10 @@ public class ByteBufferWritableByteChannel
 
     public ByteBufferWritableByteChannel()
     {
-        this(1024);
+        this( 1024 );
     }
 
-    public ByteBufferWritableByteChannel(int initialSize)
+    public ByteBufferWritableByteChannel( int initialSize )
     {
         buffer = ByteBuffer.allocate( initialSize );
     }
@@ -64,8 +64,10 @@ public class ByteBufferWritableByteChannel
     @Override
     public int write( ByteBuffer src ) throws IOException
     {
-        if (closed)
+        if ( closed )
+        {
             throw new ClosedChannelException();
+        }
 
         int remaining = src.remaining();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ByteBufferWritableByteChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ByteBufferWritableByteChannel.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.io.IOException;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * WritableByteChannel which is backed by a ByteBuffer. If data cannot fit
+ * the buffer will be expanded on the fly.
+ *
+ * Instances can be reused by calling {@link #reset()}. The internal buffer will not be reset
+ * to the initial size, but will retain whatever size it had before resetting.
+ */
+public class ByteBufferWritableByteChannel
+    implements WritableByteChannel
+{
+    private boolean closed = false;
+
+    private ByteBuffer buffer;
+
+    public ByteBufferWritableByteChannel()
+    {
+        this(1024);
+    }
+
+    public ByteBufferWritableByteChannel(int initialSize)
+    {
+        buffer = ByteBuffer.allocate( initialSize );
+    }
+
+    public void reset()
+    {
+        buffer.clear();
+        closed = false;
+    }
+
+    public ByteBuffer getBuffer()
+    {
+        buffer.flip();
+        return buffer;
+    }
+
+    @Override
+    public int write( ByteBuffer src ) throws IOException
+    {
+        if (closed)
+            throw new ClosedChannelException();
+
+        int remaining = src.remaining();
+
+        try
+        {
+            buffer.put( src );
+        }
+        catch ( BufferOverflowException e )
+        {
+            // Increase internal buffer size and try again
+            ByteBuffer newBuffer = ByteBuffer.allocate( buffer.capacity() + src.remaining() );
+            newBuffer.put( buffer );
+            return write( src );
+        }
+
+        return remaining;
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return !closed;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        closed = true;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.kernel.api;
 
+import java.util.Collection;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import java.util.Collection;
 
 import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.FakeClock;
@@ -35,6 +35,8 @@ import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionHooks;
+import org.neo4j.kernel.impl.api.store.StoreReadLayer;
+import org.neo4j.kernel.impl.api.store.StoreStatement;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.store.NeoStore;
@@ -47,6 +49,8 @@ import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.test.DoubleLatch;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyListOf;
@@ -56,8 +60,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class KernelTransactionImplementationTest
 {
@@ -373,9 +375,12 @@ public class KernelTransactionImplementationTest
 
     private KernelTransactionImplementation newTransaction()
     {
+        StoreReadLayer readLayer = mock(StoreReadLayer.class);
+        when(readLayer.acquireStatement()).thenReturn( mock(StoreStatement.class) );
+
         KernelTransactionImplementation transaction = new KernelTransactionImplementation(
                 null, null, null, null, null, recordState, null, neoStore, new NoOpClient(),
-                hooks, null, headerInformationFactory, commitProcess, transactionMonitor, null, legacyIndexState,
+                hooks, null, headerInformationFactory, commitProcess, transactionMonitor, readLayer, legacyIndexState,
                 mock( Pool.class ), clock, TransactionTracer.NULL );
         transaction.initialize( 0 );
         return transaction;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataStatementArgumentVerificationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataStatementArgumentVerificationTest.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.StatementConstants;
-import org.neo4j.kernel.api.properties.Property;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 public class DataStatementArgumentVerificationTest
@@ -39,10 +39,10 @@ public class DataStatementArgumentVerificationTest
         DataWriteOperations statement = stubStatement();
 
         // when
-        Property property = statement.nodeGetProperty( 17, StatementConstants.NO_SUCH_PROPERTY_KEY );
+        Object value = statement.nodeGetProperty( 17, StatementConstants.NO_SUCH_PROPERTY_KEY );
 
         // then
-        assertFalse( "should return NoProperty", property.isDefined() );
+        assertNull( "should return NoProperty", value );
     }
 
     @Test
@@ -53,10 +53,10 @@ public class DataStatementArgumentVerificationTest
         DataWriteOperations statement = stubStatement();
 
         // when
-        Property property = statement.relationshipGetProperty( 17, StatementConstants.NO_SUCH_PROPERTY_KEY );
+        Object value = statement.relationshipGetProperty( 17, StatementConstants.NO_SUCH_PROPERTY_KEY );
 
         // then
-        assertFalse( "should return NoProperty", property.isDefined() );
+        assertNull( "should return NoProperty", value );
     }
 
     @Test
@@ -67,10 +67,10 @@ public class DataStatementArgumentVerificationTest
         DataWriteOperations statement = stubStatement();
 
         // when
-        Property property = statement.graphGetProperty( StatementConstants.NO_SUCH_PROPERTY_KEY );
+        Object value = statement.graphGetProperty( StatementConstants.NO_SUCH_PROPERTY_KEY );
 
         // then
-        assertFalse( "should return NoProperty", property.isDefined() );
+        assertNull( "should return NoProperty", value );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -73,8 +73,6 @@ public class PropertyIT extends KernelIntegrationTest
 
             // THEN
             Object value = statement.nodeGetProperty( nodeId, propertyKeyId );
-
-            System.out.println( value );
         }
     }
 
@@ -91,9 +89,7 @@ public class PropertyIT extends KernelIntegrationTest
 
             // WHEN
             propertyKeyId = statement.propertyKeyGetOrCreateForName( "clown" );
-            statement.nodeSetProperty( nodeId,
-                    stringProperty( propertyKeyId, value ) );
-//            statement.nodeSetProperty( nodeId, byteProperty( propertyKeyId, (byte)42 ) );
+            statement.nodeSetProperty( nodeId, stringProperty( propertyKeyId, value ) );
 
             // THEN
             assertEquals( value, statement.nodeGetProperty(
@@ -209,7 +205,7 @@ public class PropertyIT extends KernelIntegrationTest
         {
             DataWriteOperations statement = dataWriteOperationsInNewTransaction();
             assertThat( statement.nodeGetProperty( nodeId, propertyKeyId ), equalTo( newProperty.value() ) );
-            assertThat( IteratorUtil.asList( statement.nodeGetAllPropertiesKeys( nodeId ) ), equalTo( Arrays.asList(
+            assertThat( IteratorUtil.asList( statement.nodeGetPropertyKeys( nodeId ) ), equalTo( Arrays.asList(
                     newProperty.propertyKeyId() ) ) );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -49,7 +49,6 @@ import static java.util.Arrays.asList;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -332,7 +331,6 @@ public class IndexQueryTransactionStateTest
                 .<IndexDescriptor>emptyList() ) );
         when( store.indexesGetAll() ).then( answerAsIteratorFrom( Collections.<IndexDescriptor>emptyList() ) );
         when( store.constraintsGetForLabel( labelId ) ).thenReturn( Collections.<PropertyConstraint>emptyIterator() );
-        when( store.nodeExists( anyLong() ) ).thenReturn( true );
         when( store.indexesGetForLabelAndPropertyKey( labelId, propertyKeyId ) )
                 .thenReturn( new IndexDescriptor( labelId, propertyKeyId ) );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
@@ -237,8 +237,6 @@ public class LabelTransactionStateTest
         when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337, PropertyCursor.EMPTY,
                 asLabelCursor( 12 ) ) );
 
-//        when( store.nodeHasLabel( storeStatement, 1337, 12 ) ).thenReturn( true );
-
         // WHEN and THEN
         assertFalse( "Label should have been added", txContext.nodeAddLabel( state, 1337, 12 ) );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
@@ -28,12 +28,10 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.cursor.LabelCursor;
 import org.neo4j.kernel.api.cursor.PropertyCursor;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
-import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.LegacyPropertyTrackers;
@@ -46,14 +44,11 @@ import org.neo4j.kernel.impl.index.LegacyIndexStore;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import static org.neo4j.graphdb.Neo4jMockitoHelpers.answerAsIteratorFrom;
 import static org.neo4j.graphdb.Neo4jMockitoHelpers.answerAsPrimitiveLongIteratorFrom;
-import static org.neo4j.helpers.collection.IteratorUtil.asResourceIterator;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asLabelCursor;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asNodeCursor;
@@ -242,7 +237,7 @@ public class LabelTransactionStateTest
         when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337, PropertyCursor.EMPTY,
                 asLabelCursor( 12 ) ) );
 
-        when( store.nodeHasLabel( storeStatement, 1337, 12 ) ).thenReturn( true );
+//        when( store.nodeHasLabel( storeStatement, 1337, 12 ) ).thenReturn( true );
 
         // WHEN and THEN
         assertFalse( "Label should have been added", txContext.nodeAddLabel( state, 1337, 12 ) );
@@ -291,8 +286,6 @@ public class LabelTransactionStateTest
         when( store.indexesGetForLabel( labelId2 ) ).then( answerAsIteratorFrom( Collections
                 .<IndexDescriptor>emptyList() ) );
         when( store.indexesGetAll() ).then( answerAsIteratorFrom( Collections.<IndexDescriptor>emptyList() ) );
-        when( store.nodeGetAllProperties( isA( StoreStatement.class ), anyLong() ) )
-                .thenReturn( asResourceIterator( IteratorUtil.<DefinedProperty>emptyIterator() ) );
 
         txState = new TxState();
         state = StatementOperationsTestHelper.mockedState( txState );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -292,7 +292,6 @@ public class SchemaTransactionStateTest
                     asAnswer( Arrays.<Integer>asList( nodeLabels.labelIds ) ) );
             for ( int label : nodeLabels.labelIds )
             {
-                when( store.nodeHasLabel(storeStatement , nodeLabels.nodeId, label ) ).thenReturn( true );
 
                 Collection<Long> nodes = allLabels.get( label );
                 if ( nodes == null )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -98,7 +98,7 @@ public class StateHandlingStatementOperationsTest
         // ctx.getOrCreateLabelId("0");
         // ctx.getOrCreatePropertyKeyId("0");
 
-        verify( storeStatement, times( 3 ) ).acquireSingleNodeCursor( 0 );
+        verify( storeStatement, times( 2 ) ).acquireSingleNodeCursor( 0 );
         verifyNoMoreInteractions( storeStatement );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
@@ -115,6 +115,12 @@ public class StubCursors
             }
 
             @Override
+            public long getOtherNode( long nodeId )
+            {
+                return startNode == nodeId ? endNode : startNode;
+            }
+
+            @Override
             public PropertyCursor properties()
             {
                 return propertyCursor;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.state;
 
+import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
 import java.util.List;
 
@@ -212,9 +213,45 @@ public class StubCursors
             }
 
             @Override
-            public DefinedProperty getProperty()
+            public int propertyKeyId()
             {
-                return property;
+                return property.propertyKeyId();
+            }
+
+            @Override
+            public Object value()
+            {
+                return property.value();
+            }
+
+            @Override
+            public boolean booleanValue()
+            {
+                return ((Boolean)value());
+            }
+
+            @Override
+            public long longValue()
+            {
+                return ((Number)value()).longValue();
+            }
+
+            @Override
+            public double doubleValue()
+            {
+                return ((Number)value()).doubleValue();
+            }
+
+            @Override
+            public String stringValue()
+            {
+                return value().toString();
+            }
+
+            @Override
+            public void propertyData( WritableByteChannel channel )
+            {
+
             }
 
             @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
@@ -20,10 +20,14 @@
 package org.neo4j.kernel.impl.api.store;
 
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.cursor.NodeCursor;
+import org.neo4j.kernel.api.cursor.RelationshipCursor;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.collection.MapUtil.map;
 
@@ -47,9 +51,9 @@ public class DiskLayerNodeAndRelTest extends DiskLayerTest
         }
 
         // When & then
-        assertTrue(  disk.nodeExists( created ));
-        assertFalse( disk.nodeExists( createdAndRemoved ) );
-        assertFalse( disk.nodeExists( neverExisted ) );
+        assertTrue(  nodeExists( created ));
+        assertFalse( nodeExists( createdAndRemoved ) );
+        assertFalse( nodeExists( neverExisted ) );
     }
 
     @Test
@@ -75,9 +79,31 @@ public class DiskLayerNodeAndRelTest extends DiskLayerTest
         neverExisted = created + 99;
 
         // When & then
-        assertTrue(  disk.relationshipExists( node ));
-        assertFalse( disk.relationshipExists( createdAndRemoved ) );
-        assertFalse( disk.relationshipExists( neverExisted ) );
+        assertTrue(  relationshipExists( node ));
+        assertFalse( relationshipExists( createdAndRemoved ) );
+        assertFalse( relationshipExists( neverExisted ) );
+    }
+
+    private boolean nodeExists( long id )
+    {
+        try (StoreStatement statement = disk.acquireStatement())
+        {
+            try (NodeCursor node = statement.acquireSingleNodeCursor( id ))
+            {
+                return node.next();
+            }
+        }
+    }
+
+    private boolean relationshipExists( long id )
+    {
+        try (StoreStatement statement = disk.acquireStatement())
+        {
+            try (RelationshipCursor relationship = statement.acquireSingleRelationshipCursor( id ))
+            {
+                return relationship.next();
+            }
+        }
     }
 
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerPropertyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerPropertyTest.java
@@ -46,7 +46,7 @@ public class DiskLayerPropertyTest extends DiskLayerTest
         String longString =
                 "AlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalongAlalalalalong";
         Object[] properties = {
-/*                longString,
+                longString,
                 createNew( String.class ),
                 createNew( long.class ),
                 createNew( int.class ),
@@ -73,9 +73,8 @@ public class DiskLayerPropertyTest extends DiskLayerTest
                 array( 1, boolean.class ),
                 array( 1, char.class ),
                 array( 1, float.class ),
-                array( 1, double.class ),*/
+                array( 1, double.class ),
                 array( 256, String.class ),
-/*
                 array( 256, long.class ),
                 array( 256, int.class ),
                 array( 256, byte.class ),
@@ -84,7 +83,6 @@ public class DiskLayerPropertyTest extends DiskLayerTest
                 array( 256, char.class ),
                 array( 256, float.class ),
                 array( 256, double.class ),
-*/
         };
 
         int propKey = disk.propertyKeyGetOrCreateForName( "prop" );
@@ -96,18 +94,19 @@ public class DiskLayerPropertyTest extends DiskLayerTest
             long nodeId = createLabeledNode( db, singletonMap( "prop", value ), label1 ).getId();
 
             // when
-            try (NodeCursor node = statement.acquireSingleNodeCursor( nodeId ))
+            try ( NodeCursor node = statement.acquireSingleNodeCursor( nodeId ) )
             {
                 node.next();
 
-                try (PropertyCursor props = node.properties())
+                try ( PropertyCursor props = node.properties() )
                 {
-                    if (props.seek( propKey ))
+                    if ( props.seek( propKey ) )
                     {
                         Object propVal = props.value();
 
                         //then
-                        assertTrue( propVal + ".valueEquals(" + value + ")", Property.property(propKey, propVal).valueEquals( value ) );
+                        assertTrue( propVal + ".valueEquals(" + value + ")",
+                                Property.property( propKey, propVal ).valueEquals( value ) );
                     }
                     else
                     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestBits.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestBits.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
@@ -80,5 +83,18 @@ public class TestBits
             bits.put( value );
             assertEquals( value, bits.getByte() );
         }
+    }
+
+    @Test
+    public void writeAndReadByteBuffer()
+    {
+        byte[] bytes = new byte[512];
+        ByteBuffer buffer = ByteBuffer.wrap(bytes).order( ByteOrder.LITTLE_ENDIAN );
+        buffer.putLong( 123456789L );
+        buffer.flip();
+        Bits bits = Bits.bitsFromBytes( bytes, 0, buffer.limit() );
+
+        assertEquals( 123456789L, bits.getLong());
+
     }
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntStack.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntStack.java
@@ -62,7 +62,22 @@ public class PrimitiveIntStack implements PrimitiveIntCollection
     @Override
     public PrimitiveIntIterator iterator()
     {
-        throw new UnsupportedOperationException( "Please implement" );
+        return new PrimitiveIntIterator()
+        {
+            int idx = 0;
+
+            @Override
+            public boolean hasNext()
+            {
+                return idx <= cursor;
+            }
+
+            @Override
+            public int next()
+            {
+                return array[idx++];
+            }
+        };
     }
 
     @Override

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntStack.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveIntStack.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.collection.primitive;
 
+import java.util.NoSuchElementException;
+
 import static java.util.Arrays.copyOf;
 
 /**
@@ -75,6 +77,8 @@ public class PrimitiveIntStack implements PrimitiveIntCollection
             @Override
             public int next()
             {
+                if( !hasNext() ) throw new NoSuchElementException();
+
                 return array[idx++];
             }
         };


### PR DESCRIPTION
This PR primarily provides support for GC-free property cursors. Current usage through standard Kernel API will still cause minor GC (e.g. boxing and String deserialization), but has been minimized as much as possible. One major change is that Kernel API reads no longer expose Property objects, but instead returns value or null.

As transactional layer now uses cursors only the old StoreReadLayer methods for reading data have been removed.

Cypher Kernel API layer and code generator has been updated.
