### PR TITLE
Cleanup around index seeks and scan

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/IndexReaderFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/IndexReaderFactory.java
@@ -23,21 +23,22 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.impl.api.index.IndexProxy;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 
 public interface IndexReaderFactory
 {
-    IndexReader newReader( long indexId ) throws IndexNotFoundKernelException;
+    IndexReader newReader( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
-    IndexReader newUnCachedReader( long indexId ) throws IndexNotFoundKernelException;
+    IndexReader newUnCachedReader( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     void close();
 
     class Caching implements IndexReaderFactory
     {
-        private Map<Long,IndexReader> indexReaders = null;
+        private Map<IndexDescriptor,IndexReader> indexReaders;
         private final IndexingService indexingService;
 
         public Caching( IndexingService indexingService )
@@ -46,25 +47,25 @@ public interface IndexReaderFactory
         }
 
         @Override
-        public IndexReader newReader( long indexId ) throws IndexNotFoundKernelException
+        public IndexReader newReader( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
         {
             if( indexReaders == null )
             {
                 indexReaders = new HashMap<>();
             }
 
-            IndexReader reader = indexReaders.get( indexId );
+            IndexReader reader = indexReaders.get( descriptor );
             if ( reader == null )
             {
-                reader = newUnCachedReader( indexId );
-                indexReaders.put( indexId, reader );
+                reader = newUnCachedReader( descriptor );
+                indexReaders.put( descriptor, reader );
             }
             return reader;
         }
 
-        public IndexReader newUnCachedReader( long indexId ) throws IndexNotFoundKernelException
+        public IndexReader newUnCachedReader( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
         {
-            IndexProxy index = indexingService.getIndexProxy( indexId );
+            IndexProxy index = indexingService.getIndexProxy( descriptor );
             return index.newReader();
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.labelscan.LabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
@@ -136,14 +137,14 @@ public class KernelStatement implements TxStateHolder, Statement
         return locks;
     }
 
-    public IndexReader getIndexReader( long indexId ) throws IndexNotFoundKernelException
+    public IndexReader getIndexReader( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return indexReaderFactory.newReader( indexId );
+        return indexReaderFactory.newReader( descriptor );
     }
 
-    public IndexReader getFreshIndexReader( long indexId ) throws IndexNotFoundKernelException
+    public IndexReader getFreshIndexReader( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return indexReaderFactory.newUnCachedReader( indexId );
+        return indexReaderFactory.newUnCachedReader( descriptor );
     }
 
     public LabelScanReader getLabelScanReader()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -688,35 +688,32 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, IndexDescriptor index,
-            Object value ) throws IndexNotFoundKernelException
+    public PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, IndexDescriptor index, Object value )
+            throws IndexNotFoundKernelException
     {
-        PrimitiveLongResourceIterator committed = storeLayer.nodesGetFromIndexSeek( state, index, value );
+        PrimitiveLongIterator committed = storeLayer.nodesGetFromIndexSeek( state, index, value );
         PrimitiveLongIterator exactMatches = filterExactIndexMatches( state, index, value, committed );
-        PrimitiveLongIterator changesFiltered = filterIndexStateChanges( state, index, value, exactMatches );
-        return resourceIterator( changesFiltered, committed );
+        return filterIndexStateChanges( state, index, value, exactMatches );
     }
 
     @Override
     public PrimitiveLongIterator nodesGetFromIndexSeekByPrefix( KernelStatement state, IndexDescriptor index,
             String prefix ) throws IndexNotFoundKernelException
     {
-        PrimitiveLongResourceIterator committed = storeLayer.nodesGetFromIndexSeekByPrefix( state, index, prefix );
-        PrimitiveLongIterator changesFiltered = filterIndexStateChangesForPrefix( state, index, prefix, committed );
-        return resourceIterator( changesFiltered, committed );
+        PrimitiveLongIterator committed = storeLayer.nodesGetFromIndexSeekByPrefix( state, index, prefix );
+        return filterIndexStateChangesForPrefix( state, index, prefix, committed );
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index ) throws
-            IndexNotFoundKernelException
+    public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index )
+            throws IndexNotFoundKernelException
     {
-        PrimitiveLongResourceIterator committed = storeLayer.nodesGetFromIndexScan( state, index );
-        PrimitiveLongIterator changesFiltered = filterIndexStateChanges( state, index, null, committed );
-        return resourceIterator( changesFiltered, committed );
+        PrimitiveLongIterator committed = storeLayer.nodesGetFromIndexScan( state, index );
+        return filterIndexStateChanges( state, index, null, committed );
     }
 
     private PrimitiveLongIterator filterExactIndexMatches( final KernelStatement state, IndexDescriptor index,
-            Object value, PrimitiveLongResourceIterator committed )
+            Object value, PrimitiveLongIterator committed )
     {
         return LookupFilter.exactIndexMatches( this, state, committed, index.getPropertyKeyId(), value );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapReference.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.api.index;
 
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 
 public class IndexMapReference implements IndexMapSnapshotProvider
 {
@@ -41,16 +42,26 @@ public class IndexMapReference implements IndexMapSnapshotProvider
         return proxy;
     }
 
-    public IndexProxy getOnlineIndexProxy( long indexId ) throws IndexNotFoundKernelException
+    public IndexProxy getIndexProxy( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        IndexProxy proxy = getIndexProxy( indexId );
+        IndexProxy proxy = indexMap.getIndexProxy( descriptor );
+        if ( proxy == null )
+        {
+            throw new IndexNotFoundKernelException( "No index for " + descriptor + " exists." );
+        }
+        return proxy;
+    }
+
+    public IndexProxy getOnlineIndexProxy( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    {
+        IndexProxy proxy = getIndexProxy( descriptor );
         switch ( proxy.getState() )
         {
             case ONLINE:
                 return proxy;
 
             default:
-                throw new IndexNotFoundKernelException( "Expected index with id " + indexId + " to be online.");
+                throw new IndexNotFoundKernelException( "Expected index on " + descriptor + " to be online.");
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -319,25 +319,25 @@ public class IndexingService extends LifecycleAdapter
         closeAllIndexes();
     }
 
-    public DoubleLongRegister indexUpdatesAndSize( long indexId ) throws IndexNotFoundKernelException
+    public DoubleLongRegister indexUpdatesAndSize( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        final IndexProxy indexProxy = indexMapRef.getOnlineIndexProxy( indexId );
+        final IndexProxy indexProxy = indexMapRef.getOnlineIndexProxy( descriptor );
         final DoubleLongRegister output = Registers.newDoubleLongRegister();
         storeView.indexUpdatesAndSize( indexProxy.getDescriptor(), output );
         return output;
     }
 
-    public long indexSize( long indexId ) throws IndexNotFoundKernelException
+    public long indexSize( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        final IndexProxy indexProxy = indexMapRef.getOnlineIndexProxy( indexId );
+        final IndexProxy indexProxy = indexMapRef.getOnlineIndexProxy( descriptor );
         final DoubleLongRegister output = Registers.newDoubleLongRegister();
         storeView.indexSample( indexProxy.getDescriptor(), output );
         return output.readSecond();
     }
 
-    public double indexUniqueValuesPercentage( long indexId ) throws IndexNotFoundKernelException
+    public double indexUniqueValuesPercentage( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        final IndexProxy indexProxy = indexMapRef.getOnlineIndexProxy( indexId );
+        final IndexProxy indexProxy = indexMapRef.getOnlineIndexProxy( descriptor );
         final DoubleLongRegister output = Registers.newDoubleLongRegister();
         storeView.indexSample( indexProxy.getDescriptor(), output );
         long unique = output.readFirst();
@@ -749,6 +749,11 @@ public class IndexingService extends LifecycleAdapter
     public IndexProxy getIndexProxy( long indexId ) throws IndexNotFoundKernelException
     {
         return indexMapRef.getIndexProxy( indexId );
+    }
+
+    public IndexProxy getIndexProxy( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    {
+        return indexMapRef.getIndexProxy( descriptor );
     }
 
     public void validateIndex( long indexId ) throws IndexNotFoundKernelException, ConstraintVerificationFailedKernelException, IndexPopulationFailedKernelException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -96,15 +96,10 @@ public class CacheLayer implements StoreReadLayer
 
     private final SchemaCache schemaCache;
     private final DiskLayer diskLayer;
-    private final IndexingService indexingService;
 
-    public CacheLayer(
-            DiskLayer diskLayer,
-            IndexingService indexingService,
-            SchemaCache schemaCache )
+    public CacheLayer( DiskLayer diskLayer, SchemaCache schemaCache )
     {
         this.diskLayer = diskLayer;
-        this.indexingService = indexingService;
         this.schemaCache = schemaCache;
     }
 
@@ -298,7 +293,7 @@ public class CacheLayer implements StoreReadLayer
             Object value )
             throws IndexNotFoundKernelException, IndexBrokenKernelException
     {
-        return diskLayer.nodeGetFromUniqueIndexSeek( state, schemaCache.indexId( index ), value );
+        return diskLayer.nodeGetFromUniqueIndexSeek( state, index, value );
     }
 
     @Override
@@ -313,7 +308,7 @@ public class CacheLayer implements StoreReadLayer
             Object value )
             throws IndexNotFoundKernelException
     {
-        return diskLayer.nodesGetFromIndexSeek( state, schemaCache.indexId( index ), value );
+        return diskLayer.nodesGetFromIndexSeek( state, index, value );
     }
 
     @Override
@@ -322,14 +317,14 @@ public class CacheLayer implements StoreReadLayer
             String prefix )
             throws IndexNotFoundKernelException
     {
-        return diskLayer.nodesGetFromIndexSeekByPrefix( state, schemaCache.indexId( index ), prefix );
+        return diskLayer.nodesGetFromIndexSeekByPrefix( state, index, prefix );
     }
 
     @Override
     public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index )
             throws IndexNotFoundKernelException
     {
-        return diskLayer.nodesGetFromIndexScan( state, schemaCache.indexId( index ) );
+        return diskLayer.nodesGetFromIndexScan( state, index );
     }
 
     @Override
@@ -342,19 +337,19 @@ public class CacheLayer implements StoreReadLayer
     public InternalIndexState indexGetState( IndexDescriptor descriptor )
             throws IndexNotFoundKernelException
     {
-        return indexingService.getIndexProxy( schemaCache.indexId( descriptor ) ).getState();
+        return diskLayer.indexGetState( descriptor );
     }
 
     @Override
     public long indexSize( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return indexingService.indexSize( schemaCache.indexId( descriptor ) );
+        return diskLayer.indexSize( descriptor );
     }
 
     @Override
     public double indexUniqueValuesPercentage( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
-        return indexingService.indexUniqueValuesPercentage( schemaCache.indexId( descriptor ) );
+        return diskLayer.indexUniqueValuesPercentage( descriptor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -308,7 +308,7 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongResourceIterator nodesGetFromIndexSeek( KernelStatement state,
+    public PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state,
             IndexDescriptor index,
             Object value )
             throws IndexNotFoundKernelException
@@ -317,7 +317,7 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongResourceIterator nodesGetFromIndexSeekByPrefix( KernelStatement state,
+    public PrimitiveLongIterator nodesGetFromIndexSeekByPrefix( KernelStatement state,
             IndexDescriptor index,
             String prefix )
             throws IndexNotFoundKernelException
@@ -326,7 +326,7 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongResourceIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index )
+    public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index )
             throws IndexNotFoundKernelException
     {
         return diskLayer.nodesGetFromIndexScan( state, schemaCache.indexId( index ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
@@ -493,14 +493,14 @@ public class DiskLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongResourceIterator nodesGetFromIndexSeek( KernelStatement state, IndexDescriptor index,
+    public PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, IndexDescriptor index,
             Object value ) throws IndexNotFoundKernelException
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public PrimitiveLongResourceIterator nodesGetFromIndexSeekByPrefix( KernelStatement state,
+    public PrimitiveLongIterator nodesGetFromIndexSeekByPrefix( KernelStatement state,
             IndexDescriptor index,
             String prefix )
             throws IndexNotFoundKernelException
@@ -509,7 +509,7 @@ public class DiskLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongResourceIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index ) throws
+    public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index ) throws
             IndexNotFoundKernelException
     {
         throw new UnsupportedOperationException();
@@ -872,26 +872,25 @@ public class DiskLayer implements StoreReadLayer
         return resourceIterator( reader.indexSeek( value ), reader );
     }
 
-    public PrimitiveLongResourceIterator nodesGetFromIndexSeek( KernelStatement state, long index, Object value )
+    public PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, long index, Object value )
             throws IndexNotFoundKernelException
     {
         IndexReader reader = state.getIndexReader( index );
-        return resourceIterator( reader.indexSeek( value ), reader );
+        return reader.indexSeek( value );
     }
 
-    public PrimitiveLongResourceIterator nodesGetFromIndexSeekByPrefix( KernelStatement state, long index,
-            String prefix )
+    public PrimitiveLongIterator nodesGetFromIndexSeekByPrefix( KernelStatement state, long index, String prefix )
             throws IndexNotFoundKernelException
     {
         IndexReader reader = state.getIndexReader( index );
-        return resourceIterator( reader.indexSeekByPrefix( prefix ), reader );
+        return reader.indexSeekByPrefix( prefix );
     }
 
-    public PrimitiveLongResourceIterator nodesGetFromIndexScan( KernelStatement state, long index )
+    public PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, long index )
             throws IndexNotFoundKernelException
     {
         IndexReader reader = state.getIndexReader( index );
-        return resourceIterator( reader.scan(), reader );
+        return reader.scan();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -135,14 +135,13 @@ public interface StoreReadLayer
 
     PrimitiveLongIterator nodesGetForLabel( KernelStatement state, int labelId );
 
-    PrimitiveLongResourceIterator nodesGetFromIndexSeek( KernelStatement state, IndexDescriptor index, Object value )
+    PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, IndexDescriptor index, Object value )
             throws IndexNotFoundKernelException;
 
-    PrimitiveLongResourceIterator nodesGetFromIndexSeekByPrefix( KernelStatement state, IndexDescriptor index,
-            String prefix )
+    PrimitiveLongIterator nodesGetFromIndexSeekByPrefix( KernelStatement state, IndexDescriptor index, String prefix )
             throws IndexNotFoundKernelException;
 
-    PrimitiveLongResourceIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index )
+    PrimitiveLongIterator nodesGetFromIndexScan( KernelStatement state, IndexDescriptor index )
             throws IndexNotFoundKernelException;
 
     IndexDescriptor indexesGetForLabelAndPropertyKey( int labelId, int propertyKey );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
@@ -24,6 +24,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexReader;
@@ -40,7 +41,6 @@ import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
 import org.neo4j.kernel.impl.locking.Locks;
 
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -75,7 +75,7 @@ public abstract class StatementOperationsTestHelper
         {
             IndexReader indexReader = mock( IndexReader.class );
             when( indexReader.indexSeek( Matchers.any() ) ).thenReturn( PrimitiveLongCollections.emptyIterator() );
-            when( state.getIndexReader( anyLong() ) ).thenReturn( indexReader );
+            when( state.getIndexReader( Matchers.<IndexDescriptor>any() ) ).thenReturn( indexReader );
         }
         catch ( IndexNotFoundKernelException e )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -55,8 +55,6 @@ import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.store.NeoStore;
-import org.neo4j.kernel.impl.store.SchemaStorage;
-import org.neo4j.kernel.impl.store.SchemaStore;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.register.Register.DoubleLongRegister;
@@ -384,7 +382,7 @@ public class IndexStatisticsTest
         return ((GraphDatabaseAPI) db).getDependencyResolver()
                                       .resolveDependency( NeoStoreDataSource.class )
                                       .getIndexService()
-                                      .indexUpdatesAndSize( indexId( descriptor ) ).readSecond();
+                                      .indexUpdatesAndSize( descriptor ).readSecond();
     }
 
     private long indexUpdates( IndexDescriptor descriptor ) throws KernelException
@@ -392,16 +390,7 @@ public class IndexStatisticsTest
         return ((GraphDatabaseAPI) db).getDependencyResolver()
                                       .resolveDependency( NeoStoreDataSource.class )
                                       .getIndexService()
-                                      .indexUpdatesAndSize( indexId( descriptor ) ).readFirst();
-    }
-
-    private long indexId( IndexDescriptor descriptor )
-    {
-        SchemaStore schemaStore = ((GraphDatabaseAPI) db).getDependencyResolver()
-                                                         .resolveDependency( NeoStore.class )
-                                                         .getSchemaStore();
-        SchemaStorage schemaStorage = new SchemaStorage( schemaStore );
-        return schemaStorage.indexRule( descriptor.getLabelId(), descriptor.getPropertyKeyId() ).getId();
+                                      .indexUpdatesAndSize( descriptor ).readFirst();
     }
 
     private double indexSelectivity( IndexDescriptor descriptor ) throws KernelException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CacheLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CacheLayerTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import java.util.Set;
 
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
-import org.neo4j.kernel.impl.api.index.IndexingService;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -37,8 +36,7 @@ public class CacheLayerTest
 {
     private final DiskLayer diskLayer = mock( DiskLayer.class );
     private final SchemaCache schemaCache = mock( SchemaCache.class );
-    private final IndexingService indexingService = mock( IndexingService.class );
-    private final CacheLayer context = new CacheLayer( diskLayer, indexingService, schemaCache );
+    private final CacheLayer context = new CacheLayer( diskLayer, schemaCache );
 
     @Test
     public void shouldLoadAllConstraintsFromCache() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerIndexTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerIndexTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.index.IndexDescriptor;
 
 import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
@@ -39,6 +40,7 @@ public class DiskLayerIndexTest extends DiskLayerTest
     public void should_find_nodes_with_given_label_and_property_via_index() throws Exception
     {
         // GIVEN
+        IndexDescriptor descriptor = new IndexDescriptor( 0, 0 );
         createIndexAndAwaitOnline( label1, propertyKey );
 
         String name = "Mr. Taylor";
@@ -46,7 +48,7 @@ public class DiskLayerIndexTest extends DiskLayerTest
         try ( Transaction ignored = db.beginTx() )
         {
             // WHEN
-            Set<Long> foundNodes = asUniqueSet( disk.nodesGetFromIndexSeek( state, 1l, name ) );
+            Set<Long> foundNodes = asUniqueSet( disk.nodesGetFromIndexSeek( state, descriptor, name ) );
 
             // THEN
             assertEquals( asSet( mrTaylor.getId() ), foundNodes );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
@@ -19,12 +19,11 @@
  */
 package org.neo4j.kernel.impl.api.store;
 
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 
-import org.neo4j.function.Suppliers;
+import java.util.Map;
+
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -46,7 +45,6 @@ import org.neo4j.kernel.impl.transaction.state.NeoStoreSupplier;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.neo4j.graphdb.DynamicLabel.label;
 
 /**
@@ -73,7 +71,7 @@ public class DiskLayerTest
                 resolver.resolveDependency( LabelTokenHolder.class ),
                 resolver.resolveDependency( RelationshipTypeTokenHolder.class ),
                 new SchemaStorage( neoStore.getSchemaStore() ),
-                Suppliers.singleton( neoStore ),
+                neoStore,
                 indexingService );
         this.state = new KernelStatement( null, new IndexReaderFactory.Caching( indexingService ),
                 resolver.resolveDependency( LabelScanStore.class ), null,


### PR DESCRIPTION
This PR removes closing of lucene index readers used for seeks/scan and makes it possible to lookup index by `IndexDescriptor` instead of `indexId` to avoid unnecessary resolving. 
