### PR TITLE
Use NotFoundException only for deleted nodes/rels

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/Node.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Node.java
@@ -76,7 +76,7 @@ public interface Node extends PropertyContainer
      * <code>delete()</code> is invoked on a node with relationships, an
      * unchecked exception will be raised when the transaction is committing.
      * Invoking any methods on this node after <code>delete()</code> has
-     * returned is invalid and will lead to unspecified behavior.
+     * returned is invalid and will lead to {@link NotFoundException} being thrown.
      */
     void delete();
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/NotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/NotFoundException.java
@@ -26,14 +26,12 @@ package org.neo4j.graphdb;
  * will cause this exception to be thrown.
  * {@link PropertyContainer#getProperty(String)} will also throw this exception
  * if the given key does not exist.
- * <p>
- * Another scenario when this exception will be thrown is if one or more
- * transactions keep a reference to a node or relationship that gets deleted in
- * some other transaction. If the deleting transaction commits all other
- * transactions having a reference to the deleted node or relationship will
- * throw this exception when invoking any of the methods on the node or
- * relationship.
- * 
+ * <p/>
+ * Another scenario involves multiple concurrent transactions which obtain a reference to the same node or
+ * relationship, which is then deleted by one of the transactions. If the deleting transaction commits, then invoking
+ * any node or relationship methods within any of the remaining open transactions will cause this exception to be
+ * thrown.
+ *
  * @see GraphDatabaseService
  */
 public class NotFoundException extends RuntimeException

--- a/community/kernel/src/main/java/org/neo4j/graphdb/Relationship.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Relationship.java
@@ -83,7 +83,7 @@ public interface Relationship extends PropertyContainer
     /**
      * Deletes this relationship. Invoking any methods on this relationship
      * after <code>delete()</code> has returned is invalid and will lead to
-     * unspecified behavior.
+     * {@link NotFoundException} being thrown.
      */
      void delete();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -985,12 +985,16 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         }
     }
 
-    private PrimitiveIntIterator labelsOf( long nodeId ) throws EntityNotFoundException
+    private PrimitiveIntIterator labelsOf( long nodeId )
     {
         try ( StoreStatement statement = storeLayer.acquireStatement() )
         {
             return StateHandlingStatementOperations.nodeGetLabels( storeLayer, statement,
                     txState, nodeId );
+        }
+        catch ( EntityNotFoundException ex )
+        {
+            return PrimitiveIntCollections.emptyIterator();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -321,15 +321,7 @@ public class StateHandlingStatementOperations implements
     {
         try ( NodeCursor cursor = nodeCursor( state, nodeId ) )
         {
-            try
-            {
-                return cursor.next();
-            }
-            catch ( IllegalStateException e )
-            {
-                // Deleted in this transaction
-                return false;
-            }
+            return cursor.next();
         }
     }
 
@@ -338,15 +330,7 @@ public class StateHandlingStatementOperations implements
     {
         try ( RelationshipCursor cursor = relationshipCursor( state, relId ) )
         {
-            try
-            {
-                return cursor.next();
-            }
-            catch ( IllegalStateException e )
-            {
-                // Deleted in this transaction
-                return false;
-            }
+            return cursor.next();
         }
     }
 
@@ -388,7 +372,7 @@ public class StateHandlingStatementOperations implements
             }
             else
             {
-                return PrimitiveIntCollections.emptyIterator();
+                throw new EntityNotFoundException( EntityType.NODE, nodeId );
             }
         }
     }
@@ -401,7 +385,7 @@ public class StateHandlingStatementOperations implements
     {
         if ( txState.nodeIsDeletedInThisTx( nodeId ) )
         {
-            return PrimitiveIntCollections.emptyIterator();
+            throw new EntityNotFoundException( EntityType.NODE, nodeId );
         }
         if ( txState.nodeIsAddedInThisTx( nodeId ) )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSingleNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSingleNodeCursor.java
@@ -49,14 +49,8 @@ public class TxSingleNodeCursor
 
         if ( state.nodeIsDeletedInThisTx( id ) )
         {
-            try
-            {
-                throw new IllegalStateException("Node " + id + " has been deleted");
-            }
-            finally
-            {
-                this.id = 0;
-            }
+            this.id = -1;
+            return false;
         }
 
         this.nodeIsAddedInThisTx = state.nodeIsAddedInThisTx( id );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSingleRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/cursor/TxSingleRelationshipCursor.java
@@ -50,7 +50,7 @@ public class TxSingleRelationshipCursor
         if ( state.relationshipIsDeletedInThisTx( id ) )
         {
             visit( -1, -1, -1, -1 );
-            throw new IllegalStateException("Relationship " + id + " has been deleted");
+            return false;
         }
 
         this.relationshipIsAddedInThisTx = state.relationshipIsAddedInThisTx( id );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -119,7 +119,7 @@ public class NodeProxy implements Node
         }
         catch ( EntityNotFoundException e )
         {
-            throw new IllegalStateException( "Unable to delete Node[" + nodeId +
+            throw new NotFoundException( "Unable to delete Node[" + nodeId +
                                              "] since it has already been deleted." );
         }
     }
@@ -491,7 +491,7 @@ public class NodeProxy implements Node
         }
         catch ( EntityNotFoundException e )
         {
-            throw new IllegalStateException( "Node[" + e.entityId() +
+            throw new NotFoundException( "Node[" + e.entityId() +
                                              "] is deleted and cannot be used to create a relationship" );
         }
         catch ( InvalidTransactionTypeKernelException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -160,7 +160,7 @@ public class RelationshipProxy implements Relationship, RelationshipVisitor<Runt
         }
         catch ( EntityNotFoundException e )
         {
-            throw new IllegalStateException( "Unable to delete relationship[" +
+            throw new NotFoundException( "Unable to delete relationship[" +
                                              getId() + "] since it is already deleted." );
         }
     }
@@ -286,7 +286,7 @@ public class RelationshipProxy implements Relationship, RelationshipVisitor<Runt
         }
         catch ( EntityNotFoundException e )
         {
-            throw new IllegalStateException( e );
+            throw new NotFoundException( e );
         }
     }
 
@@ -306,7 +306,7 @@ public class RelationshipProxy implements Relationship, RelationshipVisitor<Runt
         }
         catch ( EntityNotFoundException e )
         {
-            throw new IllegalStateException( e );
+            throw new NotFoundException( e );
         }
     }
 
@@ -326,7 +326,7 @@ public class RelationshipProxy implements Relationship, RelationshipVisitor<Runt
         }
         catch ( EntityNotFoundException e )
         {
-            throw new IllegalStateException( e );
+            throw new NotFoundException( e );
         }
         catch ( IllegalTokenNameException e )
         {
@@ -349,7 +349,7 @@ public class RelationshipProxy implements Relationship, RelationshipVisitor<Runt
         }
         catch ( EntityNotFoundException e )
         {
-            throw new IllegalStateException( e );
+            throw new NotFoundException( e );
         }
         catch ( IllegalTokenNameException e )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -436,7 +436,7 @@ public class KernelIT extends KernelIntegrationTest
             statement.readOperations().nodeGetLabels( node.getId() );
             fail();
         }
-        catch ( IllegalStateException e )
+        catch ( EntityNotFoundException e )
         {
             // Ok
         }
@@ -446,7 +446,7 @@ public class KernelIT extends KernelIntegrationTest
             statement.readOperations().nodeHasLabel( node.getId(), labelId );
             fail();
         }
-        catch ( IllegalStateException e )
+        catch ( EntityNotFoundException e )
         {
             // Ok
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.core.Token;
@@ -402,10 +403,10 @@ public class PropertyIT extends KernelIntegrationTest
                 statement.nodeRemoveProperty( node, prop1 );
                 fail( "Should have failed." );
             }
-            catch ( IllegalStateException e )
+            catch ( EntityNotFoundException e )
             {
                 assertThat( e.getMessage(),
-                        equalTo( "Node " + node + " has been deleted" ) );
+                            equalTo( "Unable to load NODE with id " + node + "." ) );
             }
         }
     }
@@ -431,10 +432,10 @@ public class PropertyIT extends KernelIntegrationTest
                 statement.relationshipRemoveProperty( rel, prop1 );
                 fail( "Should have failed." );
             }
-            catch ( IllegalStateException e )
+            catch ( EntityNotFoundException e )
             {
                 assertThat( e.getMessage(),
-                        equalTo( "Relationship " + rel + " has been deleted" ) );
+                            equalTo( "Unable to load RELATIONSHIP with id " + rel + "." ) );
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/Neo4jConstraintsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/Neo4jConstraintsTest.java
@@ -416,7 +416,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             node1.getProperty( "key1" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -424,7 +424,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             node1.setProperty( "key1", "value2" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -432,7 +432,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             node1.removeProperty( "key1" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         node2.delete();
@@ -441,7 +441,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             node2.delete();
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -449,7 +449,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             node1.getProperty( "key1" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -457,7 +457,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             node1.setProperty( "key1", "value2" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -465,7 +465,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             node1.removeProperty( "key1" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         assertEquals( "value1", rel1.getProperty( "key1" ) );
@@ -475,7 +475,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             rel1.delete();
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -483,7 +483,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             rel1.getProperty( "key1" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -491,7 +491,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             rel1.setProperty( "key1", "value2" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -499,7 +499,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             rel1.removeProperty( "key1" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -507,7 +507,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             rel1.getProperty( "key1" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -515,7 +515,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             rel1.setProperty( "key1", "value2" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -523,7 +523,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             rel1.removeProperty( "key1" );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -531,7 +531,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             node2.createRelationshipTo( node1, MyRelTypes.TEST );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
         try
@@ -539,7 +539,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
             node2.createRelationshipTo( node1, MyRelTypes.TEST );
             fail( "Should throw exception" );
         }
-        catch ( IllegalStateException e )
+        catch ( NotFoundException e )
         { // good
         }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
@@ -116,7 +116,7 @@ public class NodeProxyTest
         }
 
         // Then
-        assertThat( exceptionThrownBySecondDelete, instanceOf( IllegalStateException.class ) );
+        assertThat( exceptionThrownBySecondDelete, instanceOf( NotFoundException.class ) );
 
         try ( Transaction tx = db.beginTx() )
         {
@@ -125,7 +125,7 @@ public class NodeProxyTest
         }
     }
 
-    @Test( expected = IllegalStateException.class )
+    @Test( expected = NotFoundException.class )
     public void deletionOfAlreadyDeletedNodeShouldThrow()
     {
         // Given
@@ -144,7 +144,7 @@ public class NodeProxyTest
         // When
         try ( Transaction tx = db.beginTx() )
         {
-            node.delete(); // should throw IllegalStateException as this node is already deleted
+            node.delete(); // should throw NotFoundException as this node is already deleted
             tx.success();
         }
     }


### PR DESCRIPTION
Previously we use NotFoundException and IllegalStateException to indicate deleted nodes/rels. This PR changes so that only NotFoundException is used.
