### PR TITLE
Align indexes and constraints exception handling

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -391,23 +391,27 @@ public class SchemaImpl implements Schema
         {
             try ( Statement statement = ctxSupplier.get() )
             {
-                int labelId = statement.readOperations().labelGetForName( label.name() );
-                int propertyKeyId = statement.readOperations().propertyKeyGetForName( propertyKey );
-
-                if ( labelId != KeyReadOperations.NO_SUCH_LABEL && propertyKeyId != KeyReadOperations
-                        .NO_SUCH_PROPERTY_KEY )
+                try
                 {
-                    statement.schemaWriteOperations().indexDrop( statement.readOperations().indexesGetForLabelAndPropertyKey( labelId, propertyKeyId ) );
+                    int labelId = statement.readOperations().labelGetForName( label.name() );
+                    int propertyKeyId = statement.readOperations().propertyKeyGetForName( propertyKey );
+
+                    if ( labelId != KeyReadOperations.NO_SUCH_LABEL && propertyKeyId != KeyReadOperations
+                            .NO_SUCH_PROPERTY_KEY )
+                    {
+                        statement.schemaWriteOperations().indexDrop(
+                                statement.readOperations().indexesGetForLabelAndPropertyKey( labelId, propertyKeyId ) );
+                    }
                 }
-            }
-            catch ( SchemaRuleNotFoundException | DropIndexFailureException e )
-            {
-                throw new ConstraintViolationException( String.format(
-                        "Unable to drop index on label `%s` for property %s.", label.name(), propertyKey ), e );
-            }
-            catch ( InvalidTransactionTypeKernelException e )
-            {
-                throw new ConstraintViolationException( e.getMessage(), e );
+                catch ( SchemaRuleNotFoundException | DropIndexFailureException e )
+                {
+                    throw new ConstraintViolationException(
+                            e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
+                }
+                catch ( InvalidTransactionTypeKernelException e )
+                {
+                    throw new ConstraintViolationException( e.getMessage(), e );
+                }
             }
         }
 

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -214,7 +214,7 @@ public class SchemaAcceptanceTest
             }
             catch ( ConstraintViolationException e )
             {
-                assertThat( e.getMessage(), containsString( "Unable to drop index" ) );
+                assertThat( e.getMessage(), containsString( "Index rule for label:0 and property:0 not found" ) );
             }
             tx.success();
         }
@@ -238,7 +238,7 @@ public class SchemaAcceptanceTest
         }
         catch ( ConstraintViolationException e )
         {
-            assertThat( e.getMessage(), containsString( "Unable to drop index" ) );
+            assertThat( e.getMessage(), containsString( "Index rule for label:0 and property:0 not found" ) );
         }
 
         // THEN

--- a/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseActionsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseActionsTest.java
@@ -31,7 +31,9 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.ConstraintViolationException;
@@ -95,6 +97,9 @@ public class DatabaseActionsTest
     private static Database database;
     private static GraphDatabaseAPI graph;
     private static DatabaseActions actions;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void createDb() throws IOException
@@ -1527,20 +1532,24 @@ public class DatabaseActionsTest
                 asSet( graphdbHelper.getPropertyUniquenessConstraints( labelName, propertyKey ) ).contains( index ) );
     }
 
+
     @Test
-    public void shouldDropPropertyExistencesConstraint() throws Exception
+    public void dropNonExistentConstraint() throws Exception
     {
         // GIVEN
         String labelName = "user", propertyKey = "login";
-        ConstraintDefinition index = graphdbHelper.createPropertyExistenceConstraint( labelName,
+        ConstraintDefinition constraint = graphdbHelper.createPropertyUniquenessConstraint( labelName,
                 asList( propertyKey ) );
 
-        // WHEN
-        actions.dropPropertyExistenceConstraint( labelName, asList( propertyKey ) );
+        // EXPECT
+        expectedException.expect( ConstraintViolationException.class );
 
-        // THEN
-        assertFalse( "Constraint should have been dropped",
-                asSet( graphdbHelper.getPropertyExistenceConstraints( labelName, propertyKey ) ).contains( index ) );
+        // WHEN
+        try ( Transaction tx = graph.beginTx() )
+        {
+            constraint.drop();
+            constraint.drop();
+        }
     }
 
     @Test


### PR DESCRIPTION
Update handling of index creating exception to match common way oh handling, additional test to what already been fixed as part of mandatory properties work.
Corresponding github issue: #4925  
