### PR TITLE
Profiling and referential identity

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenerator.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenerator.scala
@@ -34,7 +34,6 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.{CantCompileQueryExceptio
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{InstrumentedGraphStatistics, PlanContext}
 import org.neo4j.cypher.internal.compiler.v2_3.{ExecutionMode, PlannerName, TaskCloser}
 import org.neo4j.function.Supplier
-import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.helpers.Clock
 import org.neo4j.kernel.api.Statement
 import org.neo4j.kernel.impl.core.NodeManager

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/GreedyQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/GreedyQueryGraphSolver.scala
@@ -64,7 +64,7 @@ class GreedyQueryGraphSolver(planCombiner: CandidateGenerator[GreedyPlanTable],
                 acc + (ids -> candidates)
             }
 
-          val best: Iterable[LogicalPlan] = candidatesPerIds.values.map(kit.pickBest(_)).flatten
+          val best: Iterable[LogicalPlan] = candidatesPerIds.values.flatMap(kit.pickBest(_))
 
           //          println(s"best: ${best.map(_.availableSymbols)}")
           val result = best.foldLeft(planTable)(_ + _)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Argument.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Argument.scala
@@ -31,6 +31,9 @@ case class Argument(argumentIds: Set[IdName])(val solved: PlannerQuery with Card
   def availableSymbols = argumentIds
 
 
+  override def updateSolved(newSolved: PlannerQuery with CardinalityEstimation) =
+    copy(argumentIds)(newSolved)(typeInfo)
+
   override def copyPlan(): LogicalPlan = this.copy(argumentIds)(solved)(typeInfo).asInstanceOf[this.type]
 
   override def dup(children: Seq[AnyRef]) = children.size match {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Argument.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Argument.scala
@@ -30,6 +30,9 @@ case class Argument(argumentIds: Set[IdName])(val solved: PlannerQuery with Card
 
   def availableSymbols = argumentIds
 
+
+  override def copyPlan(): LogicalPlan = this.copy(argumentIds)(solved)(typeInfo).asInstanceOf[this.type]
+
   override def dup(children: Seq[AnyRef]) = children.size match {
     case 1 =>
       copy(children.head.asInstanceOf[Set[IdName]])(solved)(typeInfo).asInstanceOf[this.type]

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/LogicalPlan.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/LogicalPlan.scala
@@ -68,6 +68,16 @@ abstract class LogicalPlan
     }
   }
 
+  def copyPlan(): LogicalPlan = {
+    try {
+      val arguments = this.children.toList :+ solved
+      copyConstructor.invoke(this, arguments: _*).asInstanceOf[this.type]
+    } catch {
+      case e: IllegalArgumentException if e.getMessage.startsWith("wrong number of arguments") =>
+        throw new InternalException("Logical plans need to be case classes, and have the PlannerQuery in a separate constructor", e)
+    }
+  }
+
   lazy val copyConstructor: Method = this.getClass.getMethods.find(_.getName == "copy").get
 
   def updateSolved(f: PlannerQuery with CardinalityEstimation => PlannerQuery with CardinalityEstimation): LogicalPlan =

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/rewriter/removeIdenticalPlans.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/rewriter/removeIdenticalPlans.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.rewriter
+
+import org.neo4j.cypher.internal.compiler.v2_3.Foldable._
+import org.neo4j.cypher.internal.compiler.v2_3._
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
+
+
+/**
+ * Runs through LogicalPlan and copies duplicate plans to make sure the
+ * plan doesn't contain elements that are referentially identical.
+ */
+case object removeIdenticalPlans extends Rewriter {
+
+  def apply(input: AnyRef) = {
+    val rewrite = findDuplicates(input)
+
+    bottomUp(Rewriter.lift {
+      case plan: LogicalPlan if rewrite(plan) => plan.copyPlan()
+    }).apply(input)
+  }
+
+  private def findDuplicates(input: AnyRef) =
+    input.treeFold((IdentitySet.empty[LogicalPlan], IdentitySet.empty[LogicalPlan])) {
+      case plan: LogicalPlan =>
+        (acc, children) =>
+          val (seen, duplicates) = acc
+          if (seen(plan)) children((seen, duplicates + plan)) else children((seen + plan, duplicates))
+    }._2
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/LogicalPlanTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/LogicalPlanTest.scala
@@ -65,4 +65,11 @@ class LogicalPlanTest extends CypherFunSuite with LogicalPlanningTestSupport  {
 
     metaApply.leafs should equal(Seq(singleRow1, singleRow2, singleRow3, singleRow4))
   }
+
+  test("calling updateSolved on argument should work") {
+    val argument = Argument(Set(IdName("a")))(solved)()
+    val updatedPlannerQuery = CardinalityEstimation.lift(PlannerQuery.empty.updateGraph(_.addPatternNodes(IdName("a"))), 0.0)
+    val newPlan = argument.updateSolved(updatedPlannerQuery)
+    newPlan.solved should equal(updatedPlannerQuery)
+  }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/rewriter/removeIdenticalTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/rewriter/removeIdenticalTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.rewriter
+
+import org.neo4j.cypher.internal.compiler.v2_3.planner.LogicalPlanningTestSupport
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+
+class removeIdenticalTest extends CypherFunSuite with LogicalPlanningTestSupport {
+  test("should not contain copies") {
+    val scan = AllNodesScan(IdName("a"), Set.empty)(solved)
+    val join = NodeHashJoin(Set(IdName("a")), scan, scan)(solved)
+
+    val rewritten = join.endoRewrite(removeIdenticalPlans)
+
+    rewritten should equal(join)
+    rewritten shouldNot be theSameInstanceAs join
+    rewritten.left shouldNot be theSameInstanceAs rewritten.right
+  }
+
+  test("should not rewrite when not needed") {
+    val scan1 = AllNodesScan(IdName("a"), Set.empty)(solved)
+    val scan2 = AllNodesScan(IdName("a"), Set.empty)(solved)
+    val join = NodeHashJoin(Set(IdName("a")), scan1, scan2)(solved)
+
+    val rewritten = join.endoRewrite(removeIdenticalPlans)
+
+    rewritten should equal(join)
+    rewritten.left should be theSameInstanceAs join.left
+    rewritten.right should be theSameInstanceAs join.right
+  }
+}


### PR DESCRIPTION
Having plans in the logical plan that are referentially equal causes problem with
profiling since the profiling id is mapped by an identity map. For example a hashjoin
with an identical label scan on both left and right was seen as the same plan and the
profiling statistics was thus counted twice. 

Also fixed a bug that caused an exception to be thrown when `updateSolved` on was called on `Argument` 
