### PR TITLE
Cypher part of NOT NULL constraints for relationships

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/StatementConverters.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/StatementConverters.scala
@@ -51,16 +51,28 @@ object StatementConverters {
           label = s.label.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
           propertyKey = s.property.propertyKey.name)
-      case s: ast.CreateMandatoryPropertyConstraint =>
-        commands.CreateMandatoryPropertyConstraint(
+      case s: ast.CreateNodeMandatoryPropertyConstraint =>
+        commands.CreateNodeMandatoryPropertyConstraint(
           id = s.identifier.name,
           label = s.label.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
           propertyKey = s.property.propertyKey.name)
-      case s: ast.DropMandatoryPropertyConstraint =>
-        commands.DropMandatoryPropertyConstraint(
+      case s: ast.DropNodeMandatoryPropertyConstraint =>
+        commands.DropNodeMandatoryPropertyConstraint(
           id = s.identifier.name,
           label = s.label.name,
+          idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
+          propertyKey = s.property.propertyKey.name)
+      case s: ast.CreateRelationshipMandatoryPropertyConstraint =>
+        commands.CreateRelationshipMandatoryPropertyConstraint(
+          id = s.identifier.name,
+          relType = s.relType.name,
+          idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
+          propertyKey = s.property.propertyKey.name)
+      case s: ast.DropRelationshipMandatoryPropertyConstraint =>
+        commands.DropRelationshipMandatoryPropertyConstraint(
+          id = s.identifier.name,
+          relType = s.relType.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
           propertyKey = s.property.propertyKey.name)
       case _ =>

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/IndexOperation.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/IndexOperation.scala
@@ -32,30 +32,46 @@ final case class DropIndex(label: String, propertyKeys: Seq[String], queryString
   def setQueryText(t: String): DropIndex = copy(queryString = QueryString(t))
 }
 
-sealed abstract class PropertyConstraintOperation(_id: String, _label: String, _idForProperty: String, _propertyKey: String,
-    _queryString: QueryString = QueryString.empty) extends AbstractQuery {
-  def id:String
-  def label: String
+sealed abstract class PropertyConstraintOperation extends AbstractQuery {
+  def id: String
   def idForProperty: String
   def propertyKey: String
 }
 
+sealed abstract class NodePropertyConstraintOperation extends PropertyConstraintOperation {
+  def label: String
+}
+
+sealed abstract class RelationshipPropertyConstraintOperation extends PropertyConstraintOperation {
+  def relType: String
+}
+
 final case class CreateUniqueConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
-    queryString: QueryString = QueryString.empty) extends PropertyConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
+                                        queryString: QueryString = QueryString.empty) extends NodePropertyConstraintOperation {
   def setQueryText(t: String): CreateUniqueConstraint = copy(queryString = QueryString(t))
 }
 
 final case class DropUniqueConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
-    queryString: QueryString = QueryString.empty) extends PropertyConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
+                                      queryString: QueryString = QueryString.empty) extends NodePropertyConstraintOperation {
   def setQueryText(t: String): DropUniqueConstraint = copy(queryString = QueryString(t))
 }
 
-final case class CreateMandatoryPropertyConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
-                                        queryString: QueryString = QueryString.empty) extends PropertyConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
-  def setQueryText(t: String): CreateMandatoryPropertyConstraint = copy(queryString = QueryString(t))
+final case class CreateNodeMandatoryPropertyConstraint(id: String, label: String, idForProperty: String,
+                                                       propertyKey: String, queryString: QueryString = QueryString.empty) extends NodePropertyConstraintOperation {
+  def setQueryText(t: String): CreateNodeMandatoryPropertyConstraint = copy(queryString = QueryString(t))
 }
 
-final case class DropMandatoryPropertyConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
-                                      queryString: QueryString = QueryString.empty) extends PropertyConstraintOperation(id, label, idForProperty, propertyKey, queryString) {
-  def setQueryText(t: String): DropMandatoryPropertyConstraint = copy(queryString = QueryString(t))
+final case class DropNodeMandatoryPropertyConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
+                                                     queryString: QueryString = QueryString.empty) extends NodePropertyConstraintOperation {
+  def setQueryText(t: String): DropNodeMandatoryPropertyConstraint = copy(queryString = QueryString(t))
+}
+
+final case class CreateRelationshipMandatoryPropertyConstraint(id: String, relType: String, idForProperty: String,
+                                                               propertyKey: String, queryString: QueryString = QueryString.empty) extends RelationshipPropertyConstraintOperation {
+  def setQueryText(t: String): CreateRelationshipMandatoryPropertyConstraint = copy(queryString = QueryString(t))
+}
+
+final case class DropRelationshipMandatoryPropertyConstraint(id: String, relType: String, idForProperty: String, propertyKey: String,
+                                                             queryString: QueryString = QueryString.empty) extends RelationshipPropertyConstraintOperation {
+  def setQueryText(t: String): DropRelationshipMandatoryPropertyConstraint = copy(queryString = QueryString(t))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/LegacyExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/LegacyExecutablePlanBuilder.scala
@@ -71,7 +71,10 @@ class LegacyExecutablePlanBuilder(monitors: Monitors, rewriterSequencer: (String
   private def buildIndexQuery(op: IndexOperation): PipeInfo = PipeInfo(new IndexOperationPipe(op), updating = true, plannerUsed = RulePlannerName)
 
   private def buildConstraintQuery(op: PropertyConstraintOperation): PipeInfo = {
-    val label = KeyToken.Unresolved(op.label, TokenType.Label)
+    val label = op match {
+      case n: NodePropertyConstraintOperation => KeyToken.Unresolved(n.label, TokenType.Label)
+      case r: RelationshipPropertyConstraintOperation => KeyToken.Unresolved(r.relType, TokenType.RelType)
+    }
     val propertyKey = KeyToken.Unresolved(op.propertyKey, TokenType.PropertyKey)
 
     PipeInfo(new ConstraintOperationPipe(op, label, propertyKey), updating = true, plannerUsed = RulePlannerName)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
@@ -29,10 +29,12 @@ trait Command extends Parser
 
   def Command: Rule1[ast.Command] = rule(
     CreateUniqueConstraint
-      | CreateMandatoryConstraint
+      | CreateNodeMandatoryConstraint
+      | CreateRelMandatoryConstraint
       | CreateIndex
       | DropUniqueConstraint
-      | DropMandatoryConstraint
+      | DropNodeMandatoryConstraint
+      | DropRelMandatoryConstraint
       | DropIndex
   )
 
@@ -48,21 +50,32 @@ trait Command extends Parser
     group(keyword("CREATE") ~~ UniqueConstraintSyntax) ~~>> (ast.CreateUniquePropertyConstraint(_, _, _))
   }
 
-  def CreateMandatoryConstraint: Rule1[ast.CreateMandatoryPropertyConstraint] = rule {
-    group(keyword("CREATE") ~~ MandatoryConstraintSyntax) ~~>> (ast.CreateMandatoryPropertyConstraint(_, _, _))
+  def CreateNodeMandatoryConstraint: Rule1[ast.CreateNodeMandatoryPropertyConstraint] = rule {
+    group(keyword("CREATE") ~~ NodeMandatoryConstraintSyntax) ~~>> (ast.CreateNodeMandatoryPropertyConstraint(_, _, _))
+  }
+
+  def CreateRelMandatoryConstraint: Rule1[ast.CreateRelationshipMandatoryPropertyConstraint] = rule {
+    group(keyword("CREATE") ~~ RelationshipMandatoryConstraintSyntax) ~~>> (ast.CreateRelationshipMandatoryPropertyConstraint(_, _, _))
   }
 
   def DropUniqueConstraint: Rule1[ast.DropUniquePropertyConstraint] = rule {
     group(keyword("DROP") ~~ UniqueConstraintSyntax) ~~>> (ast.DropUniquePropertyConstraint(_, _, _))
   }
 
-  def DropMandatoryConstraint: Rule1[ast.DropMandatoryPropertyConstraint] = rule {
-    group(keyword("DROP") ~~ MandatoryConstraintSyntax) ~~>> (ast.DropMandatoryPropertyConstraint(_, _, _))
+  def DropNodeMandatoryConstraint: Rule1[ast.DropNodeMandatoryPropertyConstraint] = rule {
+    group(keyword("DROP") ~~ NodeMandatoryConstraintSyntax) ~~>> (ast.DropNodeMandatoryPropertyConstraint(_, _, _))
+  }
+
+  def DropRelMandatoryConstraint: Rule1[ast.DropRelationshipMandatoryPropertyConstraint] = rule {
+    group(keyword("DROP") ~~ RelationshipMandatoryConstraintSyntax) ~~>> (ast.DropRelationshipMandatoryPropertyConstraint(_, _, _))
   }
 
   private def UniqueConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
     optional(keyword("ASSERT")) ~~ PropertyExpression ~~ keyword("IS UNIQUE")
 
-  private def MandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
+  private def NodeMandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
+    optional(keyword("ASSERT")) ~~ PropertyExpression ~~ keyword("IS NOT NULL")
+
+  private def RelationshipMandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ "[" ~~ Identifier ~~ RelType ~~ "]" ~~
     optional(keyword("ASSERT")) ~~ PropertyExpression ~~ keyword("IS NOT NULL")
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Literals.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Literals.scala
@@ -97,6 +97,10 @@ trait Literals extends Parser
     ((operator(":") ~~ LabelName) memoMismatches).suppressSubnodes
   }
 
+  def RelType: Rule1[ast.RelTypeName] = rule {
+    ((operator(":") ~~ RelTypeName) memoMismatches).suppressSubnodes
+  }
+
   def StringLiteral: Rule1[ast.StringLiteral] = rule("\"...string...\"") {
     (((
        ch('\'') ~ StringCharacters('\'') ~ ch('\'')

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ConstraintOperationPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ConstraintOperationPipe.scala
@@ -26,17 +26,19 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols._
 
-class ConstraintOperationPipe(op: PropertyConstraintOperation, label: KeyToken, propertyKey: KeyToken)
+class ConstraintOperationPipe(op: PropertyConstraintOperation, keyToken: KeyToken, propertyKey: KeyToken)
                              (implicit val monitor: PipeMonitor) extends Pipe {
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
-    val labelId = label.getOrCreateId(state.query)
+    val keyTokenId = keyToken.getOrCreateId(state.query)
     val propertyKeyId = propertyKey.getOrCreateId(state.query)
 
     op match {
-      case _: CreateUniqueConstraint => state.query.createUniqueConstraint(labelId, propertyKeyId)
-      case _: DropUniqueConstraint   => state.query.dropUniqueConstraint(labelId, propertyKeyId)
-      case _: CreateMandatoryPropertyConstraint => state.query.createMandatoryConstraint(labelId, propertyKeyId)
-      case _: DropMandatoryPropertyConstraint => state.query.dropMandatoryConstraint(labelId, propertyKeyId)
+      case _: CreateUniqueConstraint => state.query.createUniqueConstraint(keyTokenId, propertyKeyId)
+      case _: DropUniqueConstraint   => state.query.dropUniqueConstraint(keyTokenId, propertyKeyId)
+      case _: CreateNodeMandatoryPropertyConstraint => state.query.createNodeMandatoryConstraint(keyTokenId, propertyKeyId)
+      case _: DropNodeMandatoryPropertyConstraint => state.query.dropNodeMandatoryConstraint(keyTokenId, propertyKeyId)
+      case _: CreateRelationshipMandatoryPropertyConstraint => state.query.createRelationshipMandatoryConstraint(keyTokenId, propertyKeyId)
+      case _: DropRelationshipMandatoryPropertyConstraint => state.query.dropRelationshipMandatoryConstraint(keyTokenId, propertyKeyId)
     }
 
     Iterator.empty

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
@@ -95,9 +95,13 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
 
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.dropUniqueConstraint(labelId, propertyKeyId))
 
-  def createMandatoryConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.createMandatoryConstraint(labelId, propertyKeyId))
+  def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.createNodeMandatoryConstraint(labelId, propertyKeyId))
 
-  def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.dropMandatoryConstraint(labelId, propertyKeyId))
+  def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.dropNodeMandatoryConstraint(labelId, propertyKeyId))
+
+  def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = singleDbHit(inner.createRelationshipMandatoryConstraint(relTypeId, propertyKeyId))
+
+  def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = singleDbHit(inner.dropRelationshipMandatoryConstraint(relTypeId, propertyKeyId))
 
   def withAnyOpenQueryContext[T](work: (QueryContext) => T): T = inner.withAnyOpenQueryContext(work)
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
@@ -95,9 +95,13 @@ trait QueryContext extends TokenContext {
 
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int)
 
-  def createMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[MandatoryPropertyConstraint]
+  def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[MandatoryPropertyConstraint]
 
-  def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int)
+  def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int)
+
+  def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int): IdempotentResult[MandatoryPropertyConstraint]
+
+  def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int)
 
   def getOptStatistics: Option[InternalQueryStatistics] = None
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContext.scala
@@ -105,14 +105,25 @@ class UpdateCountingQueryContext(inner: QueryContext) extends DelegatingQueryCon
     uniqueConstraintsRemoved.increase()
   }
 
-  override def createMandatoryConstraint(labelId: Int, propertyKeyId: Int) = {
-    val result = inner.createMandatoryConstraint(labelId, propertyKeyId)
+  override def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) = {
+    val result = inner.createNodeMandatoryConstraint(labelId, propertyKeyId)
     result.ifCreated { mandatoryConstraintsAdded.increase() }
     result
   }
 
-  override def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) {
-    inner.dropMandatoryConstraint(labelId, propertyKeyId)
+  override def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) {
+    inner.dropNodeMandatoryConstraint(labelId, propertyKeyId)
+    mandatoryConstraintsRemoved.increase()
+  }
+
+  override def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = {
+    val result = inner.createRelationshipMandatoryConstraint(relTypeId, propertyKeyId)
+    result.ifCreated { mandatoryConstraintsAdded.increase() }
+    result
+  }
+
+  override def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) {
+    inner.dropRelationshipMandatoryConstraint(relTypeId, propertyKeyId)
     mandatoryConstraintsRemoved.increase()
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
@@ -2895,17 +2895,31 @@ class CypherParserTest extends CypherFunSuite {
     )
   }
 
-  test("mandatory property constraint creation") {
+  test("node mandatory property constraint creation") {
     expectQuery(
       "CREATE CONSTRAINT ON (id:Label) ASSERT id.property IS NOT NULL",
-      CreateMandatoryPropertyConstraint("id", "Label", "id", "property")
+      CreateNodeMandatoryPropertyConstraint("id", "Label", "id", "property")
     )
   }
 
-  test("mandatory property constraint deletion") {
+  test("node mandatory property constraint deletion") {
     expectQuery(
       "DROP CONSTRAINT ON (id:Label) ASSERT id.property IS NOT NULL",
-      DropMandatoryPropertyConstraint("id", "Label", "id", "property")
+      DropNodeMandatoryPropertyConstraint("id", "Label", "id", "property")
+    )
+  }
+
+  test("relationship mandatory property constraint creation") {
+    expectQuery(
+      "CREATE CONSTRAINT ON [id:RelType] ASSERT id.property IS NOT NULL",
+      CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
+    )
+  }
+
+  test("relationship mandatory property constraint deletion") {
+    expectQuery(
+      "DROP CONSTRAINT ON [id:RelType] ASSERT id.property IS NOT NULL",
+      DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContextTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContextTest.scala
@@ -60,7 +60,10 @@ class UpdateCountingQueryContextTest extends CypherFunSuite {
   when( inner.createUniqueConstraint(anyInt(), anyInt()) )
     .thenReturn(IdempotentResult(mock[UniquenessConstraint]))
 
-  when( inner.createMandatoryConstraint(anyInt(), anyInt()) )
+  when( inner.createNodeMandatoryConstraint(anyInt(), anyInt()) )
+    .thenReturn(IdempotentResult(mock[MandatoryPropertyConstraint]))
+
+  when( inner.createRelationshipMandatoryConstraint(anyInt(), anyInt()) )
     .thenReturn(IdempotentResult(mock[MandatoryPropertyConstraint]))
 
   when( inner.addIndexRule(anyInt(), anyInt()) )
@@ -157,14 +160,26 @@ class UpdateCountingQueryContextTest extends CypherFunSuite {
     context.getStatistics should equal(InternalQueryStatistics(uniqueConstraintsRemoved = 1))
   }
 
-  test("create mandatory constraint") {
-    context.createMandatoryConstraint(0, 1)
+  test("create node mandatory constraint") {
+    context.createNodeMandatoryConstraint(0, 1)
 
     context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsAdded = 1))
   }
 
-  test("drop mandatory constraint") {
-    context.dropMandatoryConstraint(0, 42)
+  test("drop node mandatory constraint") {
+    context.dropNodeMandatoryConstraint(0, 42)
+
+    context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsRemoved = 1))
+  }
+
+  test("create rel mandatory constraint") {
+    context.createRelationshipMandatoryConstraint(0, 42)
+
+    context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsAdded = 1))
+  }
+
+  test("drop rel mandatory constraint") {
+    context.dropRelationshipMandatoryConstraint(0, 1)
 
     context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsRemoved = 1))
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
@@ -112,11 +112,17 @@ class ExceptionTranslatingQueryContextFor2_3(inner: QueryContext) extends Delega
   override def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) =
     translateException(super.dropUniqueConstraint(labelId, propertyKeyId))
 
-  override def createMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
-    translateException(super.createMandatoryConstraint(labelId, propertyKeyId))
+  override def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
+    translateException(super.createNodeMandatoryConstraint(labelId, propertyKeyId))
 
-  override def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
-    translateException(super.dropMandatoryConstraint(labelId, propertyKeyId))
+  override def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
+    translateException(super.dropNodeMandatoryConstraint(labelId, propertyKeyId))
+
+  override def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) =
+    translateException(super.createRelationshipMandatoryConstraint(relTypeId, propertyKeyId))
+
+  override def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) =
+    translateException(super.dropRelationshipMandatoryConstraint(relTypeId, propertyKeyId))
 
   override def withAnyOpenQueryContext[T](work: (QueryContext) => T): T =
     super.withAnyOpenQueryContext(qc =>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -305,15 +305,22 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) =
     statement.schemaWriteOperations().constraintDrop(new UniquenessConstraint(labelId, propertyKeyId))
 
-  def createMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[MandatoryPropertyConstraint] = try {
-    IdempotentResult(statement.schemaWriteOperations().mandatoryPropertyConstraintCreate(labelId, propertyKeyId))
-  } catch {
-    case existing: AlreadyConstrainedException =>
-      IdempotentResult(existing.constraint().asInstanceOf[MandatoryPropertyConstraint], wasCreated = false)
-  }
+  def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[MandatoryPropertyConstraint] =
+    try {
+      IdempotentResult(statement.schemaWriteOperations().mandatoryPropertyConstraintCreate(labelId, propertyKeyId))
+    } catch {
+      case existing: AlreadyConstrainedException =>
+        IdempotentResult(existing.constraint().asInstanceOf[MandatoryPropertyConstraint], wasCreated = false)
+    }
 
-  def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
+  def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
     statement.schemaWriteOperations().constraintDrop(new MandatoryPropertyConstraint(labelId, propertyKeyId))
+
+  //TODO implement
+  def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int): IdempotentResult[MandatoryPropertyConstraint] = ???
+
+  //TODO implement
+  def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = ???
 
   override def hasLocalFileAccess: Boolean = graph match {
     case db: GraphDatabaseAPI => db.getDependencyResolver.resolveDependency(classOf[Config]).get(GraphDatabaseSettings.allow_file_urls)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
@@ -139,11 +139,15 @@ class SnitchingQueryContext extends QueryContext {
 
   def createUniqueConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[UniquenessConstraint] = ???
 
-  def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) {???}
+  def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) = ???
 
-  def createMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[MandatoryPropertyConstraint] = ???
+  def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[MandatoryPropertyConstraint] = ???
 
-  def dropMandatoryConstraint(labelId: Int, propertyKeyId: Int) {???}
+  def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) = ???
+
+  def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = ???
+
+  def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = ???
 
   def getLabelId(labelName: String): Int = ???
 


### PR DESCRIPTION
Syntax additions include:
    `CREATE CONSTRAINT ON [id:RelType] ASSERT id.property IS NOT NULL`
    `DROP CONSTRAINT ON [id:RelType] ASSERT id.property IS NOT NULL`
