### PR TITLE
Fix PriorityMap not returning entries in correct order

### DIFF
--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PriorityMap.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PriorityMap.java
@@ -167,15 +167,16 @@ public class PriorityMap<E, K, P>
                 else if ( order.compare( priority, node.head.priority ) < 0 )
                 {   // ...with lower (better) priority => this new one replaces any existing
                     queue.remove( node );
-                    put( entity, priority, key );
+                    putNew( entity, priority, key );
                     result = true;
                 }
             }
             else
             {   // put in the appropriate place in the node linked list
                 if ( order.compare( priority, node.head.priority ) < 0 )
-                {   // ...first in chain
+                {   // ...first in chain and re-insert to queue
                     node.head = new Link<E,P>( entity, priority, node.head );
+                    reinsert( node );
                     result = true;
                 }
                 else
@@ -205,16 +206,22 @@ public class PriorityMap<E, K, P>
         }
         else
         {   // Didn't exist, just put
-            put( entity, priority, key );
+            putNew( entity, priority, key );
             result = true;
         }
         return result;
     }
 
-    private void put( E entity, P priority, K key )
+    private void putNew( E entity, P priority, K key )
     {
         Node<E, P> node = new Node<E, P>( new Link<E,P>( entity, priority, null ) );
         map.put( key, node );
+        queue.add( node );
+    }
+
+    private void reinsert( Node<E,P> node )
+    {
+        queue.remove( node );
         queue.add( node );
     }
 
@@ -241,10 +248,13 @@ public class PriorityMap<E, K, P>
         Entry<E, P> result = null;
         if ( node == null )
         {
+            // Queue is empty
             return null;
         }
         else if ( node.head.next == null )
         {
+            // There are no more entries attached to this key
+            // Poll from queue and remove from map.
             node = queue.poll();
             map.remove( keyFunction.convert( node.head.entity ) );
             result = new Entry<E, P>( node );
@@ -253,6 +263,17 @@ public class PriorityMap<E, K, P>
         {
             result = new Entry<E, P>( node );
             node.head = node.head.next;
+            if ( order.compare( result.priority, node.head.priority ) == 0 )
+            {
+                // Can leave at front of queue as priority is the same
+                // Do nothing
+            }
+            else
+            {
+                // node needs to be reinserted into queue
+                reinsert( node );
+            }
+
         }
         return result;
     }

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestPriorityMap.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/TestPriorityMap.java
@@ -107,6 +107,46 @@ public class TestPriorityMap
         assertEntry( map.pop(), entity, 5d );
     }
 
+    @Test
+    public void inCaseSaveAllPrioritiesShouldHandleNewEntryWithWorsePrio()
+    {
+        // GIVEN
+        int first = 1;
+        int second = 2;
+        PriorityMap<Integer, Integer, Double> map = PriorityMap.<Integer, Double>withSelfKeyNaturalOrder( false, false);
+
+        // WHEN
+        assertTrue( map.put( first, 1d) );
+        assertTrue( map.put( second, 2d) );
+        assertTrue( map.put( first, 3d ) );
+
+        // THEN
+        assertEntry( map.pop(), first, 1d );
+        assertEntry( map.pop(), second, 2d );
+        assertEntry( map.pop(), first, 3d );
+        assertNull( map.peek() );
+    }
+
+    @Test
+    public void inCaseSaveAllPrioritiesShouldHandleNewEntryWithBetterPrio()
+    {
+        // GIVEN
+        int first = 1;
+        int second = 2;
+        PriorityMap<Integer, Integer, Double> map = PriorityMap.<Integer, Double>withSelfKeyNaturalOrder( false, false);
+
+        // WHEN
+        assertTrue( map.put( first, 3d) );
+        assertTrue( map.put( second, 2d) );
+        assertTrue( map.put( first, 1d ) );
+
+        // THEN
+        assertEntry( map.pop(), first, 1d );
+        assertEntry( map.pop(), second, 2d );
+        assertEntry( map.pop(), first, 3d );
+        assertNull( map.peek() );
+    }
+
     private void assertEntry( Entry<Integer, Double> entry, Integer entity, Double priority )
     {
         assertNotNull( entry );


### PR DESCRIPTION
When using functionallity to not only save best priority for each key in PriorityMap entries could be returned in incorrect order.
This should be fixed now.
