### PR TITLE
Add missing CEIL function to user manual

### DIFF
--- a/community/cypher/docs/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/ql/functions/index.asciidoc
@@ -126,6 +126,8 @@ include::atan.asciidoc[]
 
 include::atan2.asciidoc[]
 
+include::ceil.asciidoc[]
+
 include::cos.asciidoc[]
 
 include::cot.asciidoc[]


### PR DESCRIPTION
The reference to the CEIL function was missing in the manual, so this has now been added. The actual text for CEIL was already in place.
