### PR TITLE
Ensure that we flush the same log channel as the one we wrote the buffer to

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/fs/AbstractStoreChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/AbstractStoreChannel.java
@@ -132,4 +132,10 @@ public class AbstractStoreChannel implements StoreChannel
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void flush() throws IOException
+    {
+        force( false );
+    }
 }

--- a/community/io/src/main/java/org/neo4j/io/fs/StoreChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/StoreChannel.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.io.fs;
 
+import java.io.Flushable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileLock;
@@ -28,7 +29,7 @@ import java.nio.channels.ScatteringByteChannel;
 import java.nio.channels.SeekableByteChannel;
 
 public interface StoreChannel
-        extends SeekableByteChannel, GatheringByteChannel, ScatteringByteChannel, InterruptibleChannel
+        extends Flushable, SeekableByteChannel, GatheringByteChannel, ScatteringByteChannel, InterruptibleChannel
 {
     /**
      * Attempts to acquire an exclusive lock on this channel's file.

--- a/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannel.java
@@ -164,4 +164,10 @@ public class StoreFileChannel implements StoreChannel
     {
         return channel.size();
     }
+
+    @Override
+    public void flush() throws IOException
+    {
+        force( false );
+    }
 }

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileChannel.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileChannel.java
@@ -197,4 +197,10 @@ public class AdversarialFileChannel implements StoreChannel
         adversary.injectFailure( IOException.class );
         return delegate.size();
     }
+
+    @Override
+    public void flush() throws IOException
+    {
+        force( false );
+    }
 }

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingStoreChannel.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingStoreChannel.java
@@ -125,4 +125,10 @@ public class DelegatingStoreChannel implements StoreChannel
         delegate.position( newPosition );
         return this;
     }
+
+    @Override
+    public void flush() throws IOException
+    {
+        delegate.flush();
+    }
 }

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileChannel.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/LimitedFileChannel.java
@@ -148,4 +148,10 @@ public class LimitedFileChannel implements StoreChannel
     {
         inner.close();
     }
+
+    @Override
+    public void flush() throws IOException
+    {
+        inner.flush();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
@@ -140,6 +140,7 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
          * current log file and replay everything. That's unnecessary but totally ok.
          */
         long newLogVersion = logVersionRepository.incrementAndGetVersion();
+        currentLog.flush();
         /*
          * The log version is now in the store, flushed and persistent. If we crash
          * now, on recovery we'll attempt to open the version we're about to create

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogVersionedStoreChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogVersionedStoreChannel.java
@@ -205,4 +205,10 @@ public class PhysicalLogVersionedStoreChannel implements LogVersionedStoreChanne
         result = 31 * result + (int) (version ^ (version >>> 32));
         return result;
     }
+
+    @Override
+    public void flush() throws IOException
+    {
+        force( false );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/WritableLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/WritableLogChannel.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.transaction.log;
 
 import java.io.Closeable;
+import java.io.Flushable;
 import java.io.IOException;
 
 public interface WritableLogChannel extends PositionAwareChannel, Closeable
@@ -27,13 +28,7 @@ public interface WritableLogChannel extends PositionAwareChannel, Closeable
     /**
     * Writes any changes not present in the channel yet and clears the buffer.
     */
-    void emptyBufferIntoChannelAndClearIt() throws IOException;
-
-    /**
-     * Forces the data that has already been written to the underlying channel, down to disk.
-     * Must not write any data to the channel.
-     */
-    void force() throws IOException;
+    Flushable emptyBufferIntoChannelAndClearIt() throws IOException;
 
     WritableLogChannel put( byte value ) throws IOException;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/InMemoryLogChannel.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/InMemoryLogChannel.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.transaction.log;
 
+import java.io.Flushable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -27,6 +28,13 @@ import org.neo4j.io.fs.StoreChannel;
 
 public class InMemoryLogChannel implements WritableLogChannel, ReadableLogChannel
 {
+    private static final Flushable NO_OP_FLUSHABLE = new Flushable()
+    {
+        @Override
+        public void flush() throws IOException
+        {
+        }
+    };
     private final byte[] bytes = new byte[1000];
     private final ByteBuffer asWriter = ByteBuffer.wrap( bytes );
     private final ByteBuffer asReader = ByteBuffer.wrap( bytes );
@@ -87,11 +95,6 @@ public class InMemoryLogChannel implements WritableLogChannel, ReadableLogChanne
         return this;
     }
 
-    @Override
-    public void force() throws IOException
-    {
-    }
-
     public StoreChannel getFileChannel()
     {
         throw new UnsupportedOperationException();
@@ -108,8 +111,9 @@ public class InMemoryLogChannel implements WritableLogChannel, ReadableLogChanne
     }
 
     @Override
-    public void emptyBufferIntoChannelAndClearIt()
+    public Flushable emptyBufferIntoChannelAndClearIt()
     {
+        return NO_OP_FLUSHABLE;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileTest.java
@@ -96,8 +96,7 @@ public class PhysicalLogFileTest
             long longValue = 4854587;
             writer.putInt( intValue );
             writer.putLong( longValue );
-            writer.emptyBufferIntoChannelAndClearIt();
-            writer.force();
+            writer.emptyBufferIntoChannelAndClearIt().flush();
 
             // THEN
             try ( ReadableLogChannel reader = logFile.getReader( positionMarker.newPosition() ) )
@@ -138,15 +137,13 @@ public class PhysicalLogFileTest
             writer.putInt( intValue );
             writer.putLong( longValue );
             writer.put( someBytes, someBytes.length );
-            writer.emptyBufferIntoChannelAndClearIt();
-            writer.force();
+            writer.emptyBufferIntoChannelAndClearIt().flush();
             writer.getCurrentPosition( positionMarker );
             LogPosition position2 = positionMarker.newPosition();
             long longValue2 = 123456789L;
             writer.putLong( longValue2 );
             writer.put( someBytes, someBytes.length );
-            writer.emptyBufferIntoChannelAndClearIt();
-            writer.force();
+            writer.emptyBufferIntoChannelAndClearIt().flush();
 
             // THEN
             try ( ReadableLogChannel reader = logFile.getReader( position1 ) )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalWritableLogChannelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalWritableLogChannelTest.java
@@ -140,8 +140,7 @@ public class PhysicalWritableLogChannelTest
         channel.putShort( shortValue );
         channel.putInt( intValue );
         channel.putLong( longValue );
-        channel.emptyBufferIntoChannelAndClearIt();
-        channel.force();
+        channel.emptyBufferIntoChannelAndClearIt().flush();
 
         // "Rotate" and continue
         storeChannel = fs.open( secondFile, "rw" );
@@ -207,16 +206,6 @@ public class PhysicalWritableLogChannelTest
         try
         {
             channel.emptyBufferIntoChannelAndClearIt();
-            fail( "Should have thrown exception" );
-        }
-        catch ( IllegalStateException e )
-        {
-            // THEN we should get an IllegalStateException, not a ClosedChannelException
-        }
-
-        try
-        {
-            channel.force();
             fail( "Should have thrown exception" );
         }
         catch ( IllegalStateException e )

--- a/enterprise/com/src/main/java/org/neo4j/com/NetworkWritableLogChannel.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/NetworkWritableLogChannel.java
@@ -19,14 +19,15 @@
  */
 package org.neo4j.com;
 
-import java.io.IOException;
-
 import org.jboss.netty.buffer.ChannelBuffer;
+
+import java.io.Flushable;
+import java.io.IOException;
 
 import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
 import org.neo4j.kernel.impl.transaction.log.WritableLogChannel;
 
-public class NetworkWritableLogChannel implements WritableLogChannel
+public class NetworkWritableLogChannel implements Flushable, WritableLogChannel
 {
     private final ChannelBuffer delegate;
 
@@ -36,7 +37,7 @@ public class NetworkWritableLogChannel implements WritableLogChannel
     }
 
     @Override
-    public void force() throws IOException
+    public void flush() throws IOException
     {
     }
 
@@ -102,7 +103,8 @@ public class NetworkWritableLogChannel implements WritableLogChannel
     }
 
     @Override
-    public void emptyBufferIntoChannelAndClearIt()
+    public Flushable emptyBufferIntoChannelAndClearIt()
     {
+        return this;
     }
 }


### PR DESCRIPTION
Also ensure that we force the log before we close it during rotation.
