### PR TITLE
Make the constraint syntax require ASSERT

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/Command.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/Command.scala
@@ -51,5 +51,5 @@ trait Command extends Parser
   }
 
   private def ConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
-    optional(keyword("ASSERT")) ~~ PropertyExpression ~~ keyword("IS UNIQUE")
+    keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS UNIQUE")
 }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/ConstraintTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/parser/ConstraintTest.scala
@@ -22,14 +22,12 @@ package org.neo4j.cypher.internal.compiler.v2_1.parser
 import org.neo4j.cypher.internal.compiler.v2_1.ast.convert.StatementConverters._
 import org.neo4j.cypher.internal.compiler.v2_1.{commands => legacyCommands, _}
 import org.parboiled.scala._
-import org.parboiled.scala.rules.Rule1
 
 class ConstraintTest extends ParserTest[ast.Command, legacyCommands.AbstractQuery] with Command {
   implicit val parserToTest = Command ~ EOI
 
   test("create_uniqueness_constraint") {
     parsing("CREATE CONSTRAINT ON (foo:Foo) ASSERT foo.name IS UNIQUE") or
-      parsing("CREATE CONSTRAINT ON (foo:Foo) foo.name IS UNIQUE") or
       parsing("create constraint on (foo:Foo) assert foo.name is unique") shouldGive
       legacyCommands.CreateUniqueConstraint("foo", "Foo", "foo", "name")
 
@@ -39,12 +37,16 @@ class ConstraintTest extends ParserTest[ast.Command, legacyCommands.AbstractQuer
 
   test("drop_uniqueness_constraint") {
     parsing("DROP CONSTRAINT ON (foo:Foo) ASSERT foo.name IS UNIQUE") or
-      parsing("DROP CONSTRAINT ON (foo:Foo) foo.name IS UNIQUE") or
       parsing("drop constraint on (foo:Foo) assert foo.name is unique") shouldGive
       legacyCommands.DropUniqueConstraint("foo", "Foo", "foo", "name")
 
     parsing("DROP CONSTRAINT ON (foo:Foo) ASSERT bar.name IS UNIQUE") shouldGive
       legacyCommands.DropUniqueConstraint("foo", "Foo", "bar", "name")
+  }
+
+  test("ASSERT is a required part of the constraint syntax") {
+    assertFails("CREATE CONSTRAINT ON (foo:Foo) foo.name IS UNIQUE")
+    assertFails("DROP CONSTRAINT ON (foo:Foo) foo.name IS UNIQUE")
   }
 
   def convert(astNode: ast.Command): legacyCommands.AbstractQuery = astNode.asQuery

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -159,29 +159,29 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
 
   test("should be semantically incorrect to refer to unknown identifier in create constraint") {
     executeAndEnsureError(
-      "create constraint on (foo:Foo) bar.name is unique",
-      "bar not defined (line 1, column 32)"
+      "create constraint on (foo:Foo) assert bar.name is unique",
+      "bar not defined (line 1, column 39)"
     )
   }
 
   test("should be semantically incorrect to refer to nexted property in create constraint") {
     executeAndEnsureError(
-      "create constraint on (foo:Foo) foo.bar.name is unique",
-      "Cannot index nested properties (line 1, column 40)"
+      "create constraint on (foo:Foo) assert foo.bar.name is unique",
+      "Cannot index nested properties (line 1, column 47)"
     )
   }
 
   test("should be semantically incorrect to refer to unknown identifier in drop constraint") {
     executeAndEnsureError(
-      "drop constraint on (foo:Foo) bar.name is unique",
-      "bar not defined (line 1, column 30)"
+      "drop constraint on (foo:Foo) assert bar.name is unique",
+      "bar not defined (line 1, column 37)"
     )
   }
 
   test("should be semantically incorrect to refer to nested property in drop constraint") {
     executeAndEnsureError(
-      "drop constraint on (foo:Foo) foo.bar.name is unique",
-      "Cannot index nested properties (line 1, column 38)"
+      "drop constraint on (foo:Foo) assert foo.bar.name is unique",
+      "Cannot index nested properties (line 1, column 45)"
     )
   }
 


### PR DESCRIPTION
For some reason the `ASSERT` in the constraint syntax was optional. This was not intentional.
