### PR TITLE
Reset closed transaction offset to first empty checkpoint in case of non forensic store copy

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -140,7 +140,7 @@ class BackupService
             StoreCopyClient storeCopier = new StoreCopyClient( targetDirectory, tuningConfiguration, loadKernelExtensions(),
                     logProvider,
                     new DefaultFileSystemAbstraction(), pageCache,
-                    monitors.newMonitor( StoreCopyClient.Monitor.class, getClass() ) );
+                    monitors.newMonitor( StoreCopyClient.Monitor.class, getClass() ), forensics );
             storeCopier.copyStore( new StoreCopyClient.StoreCopyRequester()
             {
                 private BackupClient client;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -452,7 +452,7 @@ public class SwitchToSlave
         // This will move the copied db to the graphdb location
         userLog.info( "Copying store from master" );
         new StoreCopyClient( storeDir, config, kernelExtensions, logService.getUserLogProvider(),
-                fileSystemAbstraction, pageCache, storeCopyMonitor ).copyStore(
+                fileSystemAbstraction, pageCache, storeCopyMonitor, false ).copyStore(
                 new StoreCopyClient.StoreCopyRequester()
                 {
                     @Override


### PR DESCRIPTION
Reset closed transaction offset to last created checkpoint on LOG_HEADER_SIZE to prevent checkpoint creation with non existing anymore _old_ closed transaction offset, since logs copy was skipped.

Keeping old offset will lead to creation of checkpoint based on last closed transaction with offset potentially bigger than new log. In such cases recovery procedure will not be able to restore store in case of failures.
