### PR TITLE
Fix the version of the maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
           <version>2.5.4</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.10.3</version>
+        </plugin>
+        <plugin>
           <groupId>com.voltvoodoo</groupId>
           <artifactId>brew</artifactId>
           <version>0.2.10</version>


### PR DESCRIPTION
We get sporadic build failures where Maven tries to download a
non-existent version of one of the depdencies of the assembly
plugin. Since we weren't enforcing a consistent version of the plugin,
there is hope that this will fix the problem.
