### PR TITLE
Introducing TransientFailureException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ out
 .java-version
 community/server/data
 enterprise/server-enterprise/data
+.cache-main
+.cache-tests
+Thumbs.db

--- a/community/kernel/src/main/java/org/neo4j/graphdb/TransientDatabaseFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/TransientDatabaseFailureException.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+/**
+ * Indicates that the database is in, or meanwhile a unit of work was executing, got into an intermediate state
+ * where the unit of work, and potentially other units of work as well, couldn't complete successfully.
+ *
+ * A proper response to a caught exception of this type is to cancel the unit of work that produced
+ * this exception, check for database availability and retry the unit of work again, as a whole.
+ */
+public class TransientDatabaseFailureException extends TransientFailureException
+{
+    public TransientDatabaseFailureException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+
+    public TransientDatabaseFailureException( String message )
+    {
+        super( message );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/graphdb/TransientFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/TransientFailureException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+/**
+ * Indicates a type of failure that is intermediate and, in a way benign.
+ *
+ * A proper response to a caught exception of this type is to cancel the unit of work that produced
+ * this exception and retry the unit of work again, as a whole.
+ */
+public abstract class TransientFailureException extends RuntimeException
+{
+    protected TransientFailureException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+
+    protected TransientFailureException( String message )
+    {
+        super( message );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/graphdb/TransientTransactionFailureException.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/TransientTransactionFailureException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+/**
+ * Indicates that a transaction couldn't complete successfully due to an intermediate failure.
+ *
+ * A proper response to a caught exception of this type is to cancel the unit of work that produced
+ * this exception and retry the unit of work again, as a whole.
+ */
+public class TransientTransactionFailureException extends TransientFailureException
+{
+    public TransientTransactionFailureException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+
+    public TransientTransactionFailureException( String message )
+    {
+        super( message );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/DeadlockDetectedException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DeadlockDetectedException.java
@@ -19,10 +19,12 @@
  */
 package org.neo4j.kernel;
 
+import org.neo4j.graphdb.TransientTransactionFailureException;
+
 /**
  * Signals that a deadlock between two or more transactions has been detected.
  */
-public class DeadlockDetectedException extends RuntimeException
+public class DeadlockDetectedException extends TransientTransactionFailureException
 {
     public DeadlockDetectedException( String message )
     {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
+import org.neo4j.graphdb.TransientDatabaseFailureException;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.kernel.impl.util.LazySingleReference;
 
@@ -152,7 +153,7 @@ public class DelegateInvocationHandler<T> implements InvocationHandler
         {
             if ( delegate == null )
             {
-                throw new IllegalStateException( "Transaction state is not valid. Perhaps a state change of the database has happened while this transaction was running?" );
+                throw new TransientDatabaseFailureException( "Transaction state is not valid. Perhaps a state change of the database has happened while this transaction was running?" );
             }
             
             return proxyInvoke( delegate, method, args );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DelegateInvocationHandlerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DelegateInvocationHandlerTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.ha;
 
+import org.neo4j.graphdb.TransientFailureException;
+
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -38,7 +40,7 @@ public class DelegateInvocationHandlerTest
             value.get();
             fail( "Should fail" );
         }
-        catch ( IllegalStateException e )
+        catch ( TransientFailureException e )
         {   // THEN
         }
     }


### PR DESCRIPTION
for user code to catch as a point of retry. One example is
DeadlockDetectedException, which is a common exception to catch and retry
ethe transaction that deadlocked. These new exceptions are a
broader net for catching these conditions.
