### PR TITLE
Adds a thorough test for transaction event data

### DIFF
--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -90,7 +90,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into",          dbRule.getStoreDir().getAbsolutePath(),
+                "--into",          dbRule.getStoreDirAbsolutePath(),
                 "--nodes",         nodeData( true, config, nodeIds, alwaysTrue() ).getAbsolutePath(),
                 "--relationships", relationshipData( true, config, nodeIds, alwaysTrue(), true ).getAbsolutePath() );
 
@@ -107,7 +107,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into", dbRule.getStoreDir().getAbsolutePath(),
+                "--into", dbRule.getStoreDirAbsolutePath(),
                 "--delimiter", "TAB",
                 "--array-delimiter", String.valueOf( config.arrayDelimiter() ),
                 "--nodes",
@@ -130,7 +130,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into", dbRule.getStoreDir().getAbsolutePath(),
+                "--into", dbRule.getStoreDirAbsolutePath(),
                 "--nodes", // One group with one header file and one data file
                     nodeHeader( config ).getAbsolutePath() + MULTI_FILE_DELIMITER +
                     nodeData( false, config, nodeIds, lines( 0, NODE_COUNT/2 ) ).getAbsolutePath(),
@@ -159,7 +159,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into", dbRule.getStoreDir().getAbsolutePath(),
+                "--into", dbRule.getStoreDirAbsolutePath(),
                 "--nodes:" + join( firstLabels, ":" ),
                     nodeData( true, config, nodeIds, lines( 0, NODE_COUNT/2 ) ).getAbsolutePath(),
                 "--nodes:" + join( secondLabels, ":" ),
@@ -213,7 +213,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into",          dbRule.getStoreDir().getAbsolutePath(),
+                "--into",          dbRule.getStoreDirAbsolutePath(),
                 "--nodes",         nodeData( true, config, nodeIds, alwaysTrue() ).getAbsolutePath() );
                 // no relationships
 
@@ -249,7 +249,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into",  dbRule.getStoreDir().getAbsolutePath(),
+                "--into",  dbRule.getStoreDirAbsolutePath(),
                 "--nodes", nodeHeader( config, groupOne ) + MULTI_FILE_DELIMITER +
                            nodeData( false, config, groupOneNodeIds, alwaysTrue() ),
                 "--nodes", nodeHeader( config, groupTwo ) + MULTI_FILE_DELIMITER +
@@ -285,7 +285,7 @@ public class ImportToolTest
         try
         {
             importTool(
-                    "--into",          dbRule.getStoreDir().getAbsolutePath(),
+                    "--into",          dbRule.getStoreDirAbsolutePath(),
                     "--nodes",         nodeHeader( config, "MyGroup" ).getAbsolutePath() + MULTI_FILE_DELIMITER +
                     nodeData( false, config, groupOneNodeIds, alwaysTrue() ).getAbsolutePath(),
                     "--nodes",         nodeHeader( config ).getAbsolutePath() + MULTI_FILE_DELIMITER +
@@ -308,7 +308,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into",          dbRule.getStoreDir().getAbsolutePath(),
+                "--into",          dbRule.getStoreDirAbsolutePath(),
                 "--nodes",         nodeData( true, config, nodeIds, alwaysTrue() ).getAbsolutePath(),
                                    // there will be no :TYPE specified in the header of the relationships below
                 "--relationships:" + type,
@@ -332,7 +332,7 @@ public class ImportToolTest
         try
         {
             importTool(
-                    "--into",  dbRule.getStoreDir().getAbsolutePath(),
+                    "--into",  dbRule.getStoreDirAbsolutePath(),
                     "--nodes", nodeHeaderFile.getAbsolutePath() + MULTI_FILE_DELIMITER +
                                nodeData1.getAbsolutePath() + MULTI_FILE_DELIMITER +
                                nodeData2.getAbsolutePath() );
@@ -358,7 +358,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into",  dbRule.getStoreDir().getAbsolutePath(),
+                "--into",  dbRule.getStoreDirAbsolutePath(),
                 "--skip-duplicate-nodes",
                 "--nodes", nodeHeaderFile.getAbsolutePath() + MULTI_FILE_DELIMITER +
                 nodeData1.getAbsolutePath() + MULTI_FILE_DELIMITER +
@@ -404,7 +404,7 @@ public class ImportToolTest
 
         // WHEN importing data where some relationships refer to missing nodes
         importTool(
-                "--into",          dbRule.getStoreDir().getAbsolutePath(),
+                "--into",          dbRule.getStoreDirAbsolutePath(),
                 "--nodes",         nodeData.getAbsolutePath(),
                 "--bad",           bad.getAbsolutePath(),
                 "--bad-tolerance", "2",
@@ -442,7 +442,7 @@ public class ImportToolTest
         try
         {
             importTool(
-                    "--into",          dbRule.getStoreDir().getAbsolutePath(),
+                    "--into",          dbRule.getStoreDirAbsolutePath(),
                     "--nodes",         nodeData.getAbsolutePath(),
                     "--bad",           bad.getAbsolutePath(),
                     "--bad-tolerance", "1",
@@ -477,7 +477,7 @@ public class ImportToolTest
         try
         {
             importTool(
-                    "--into",          dbRule.getStoreDir().getAbsolutePath(),
+                    "--into",          dbRule.getStoreDirAbsolutePath(),
                     "--nodes",         nodeData.getAbsolutePath(),
                     "--bad",           bad.getAbsolutePath(),
                     "--skip-bad-relationships", "false",
@@ -502,7 +502,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into", dbRule.getStoreDir().getAbsolutePath(),
+                "--into", dbRule.getStoreDirAbsolutePath(),
                 "--nodes:My First Label:My Other Label",
                         nodeData( true, config, nodeIds, alwaysTrue() ).getAbsolutePath(),
                 "--relationships", relationshipData( true, config, nodeIds, alwaysTrue(), true ).getAbsolutePath() );
@@ -529,7 +529,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into",           dbRule.getStoreDir().getAbsolutePath(),
+                "--into",           dbRule.getStoreDirAbsolutePath(),
                 "--input-encoding", charset.name(),
                 "--nodes",          nodeData( true, config, nodeIds, alwaysTrue(), charset ).getAbsolutePath(),
                 "--relationships",  relationshipData( true, config, nodeIds, alwaysTrue(), true, charset )
@@ -550,7 +550,7 @@ public class ImportToolTest
         try
         {
             importTool(
-                    "--into", dbRule.getStoreDir().getAbsolutePath(),
+                    "--into", dbRule.getStoreDirAbsolutePath(),
                     "--relationships", relationshipData( true, config, nodeIds, alwaysTrue(), true ).getAbsolutePath() );
             fail( "Should have failed" );
         }
@@ -571,7 +571,7 @@ public class ImportToolTest
 
         // WHEN
         importTool(
-                "--into",          dbRule.getStoreDir().getAbsolutePath(),
+                "--into",          dbRule.getStoreDirAbsolutePath(),
                 "--nodes",         nodeData( true, config, nodeIds, alwaysTrue() ).getAbsolutePath(),
                 "--relationships", relationshipData( true, config, relationshipData.iterator(),
                                    alwaysTrue(), true ).getAbsolutePath() );
@@ -608,7 +608,7 @@ public class ImportToolTest
         try
         {
             importTool(
-                    "--into",  dbRule.getStoreDir().getAbsolutePath(),
+                    "--into",  dbRule.getStoreDirAbsolutePath(),
                     "--nodes", data.getAbsolutePath() );
         }
         catch ( Exception e )
@@ -1046,7 +1046,7 @@ public class ImportToolTest
     private static final int NODE_COUNT = 100;
 
     @Rule
-    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() );
+    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
     public final @Rule RandomRule random = new RandomRule();
     public final @Rule Mute mute = Mute.mute( Mute.System.values() );
     private int dataIndex;

--- a/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
@@ -76,6 +76,63 @@ public abstract class ArrayUtil
         }
     };
 
+    public static final ArrayEquality BOXING_AWARE_ARRAY_EQUALITY = new ArrayEquality()
+    {
+        @Override
+        public boolean typeEquals( Class<?> firstType, Class<?> otherType )
+        {
+            return boxedType( firstType ) == boxedType( otherType );
+        }
+
+        private Class<?> boxedType( Class<?> type )
+        {
+            if ( !type.isPrimitive() )
+            {
+                return type;
+            }
+
+            if ( type.equals( Boolean.TYPE ) )
+            {
+                return Boolean.class;
+            }
+            if ( type.equals( Byte.TYPE ) )
+            {
+                return Byte.class;
+            }
+            if ( type.equals( Short.TYPE ) )
+            {
+                return Short.class;
+            }
+            if ( type.equals( Character.TYPE ) )
+            {
+                return Character.class;
+            }
+            if ( type.equals( Integer.TYPE ) )
+            {
+                return Integer.class;
+            }
+            if ( type.equals( Long.TYPE ) )
+            {
+                return Long.class;
+            }
+            if ( type.equals( Float.TYPE ) )
+            {
+                return Float.class;
+            }
+            if ( type.equals( Double.TYPE ) )
+            {
+                return Double.class;
+            }
+            throw new IllegalArgumentException( "Oops, forgot to include a primitive type " + type );
+        }
+
+        @Override
+        public boolean itemEquals( Object lhs, Object rhs )
+        {
+            return lhs == rhs || lhs != null && lhs.equals( rhs );
+        }
+    };
+
     public static boolean equals( Object firstArray, Object otherArray )
     {
         return equals( firstArray, otherArray, DEFAULT_ARRAY_EQUALITY );
@@ -97,7 +154,7 @@ public abstract class ArrayUtil
         assert otherArray.getClass().isArray() : otherArray + " is not an array";
 
         int length;
-        if ( equality.typeEquals( firstArray.getClass(), otherArray.getClass() )
+        if ( equality.typeEquals( firstArray.getClass().getComponentType(), otherArray.getClass().getComponentType() )
                 && (length = Array.getLength( firstArray )) == Array.getLength( otherArray ) )
         {
             for ( int i = 0; i < length; i++ )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/ExpectedTransactionData.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/ExpectedTransactionData.java
@@ -24,69 +24,214 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.event.LabelEntry;
 import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
+import org.neo4j.kernel.impl.util.AutoCreatingHashMap;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import static org.neo4j.kernel.impl.util.AutoCreatingHashMap.nested;
+
 class ExpectedTransactionData
 {
-    final Set<Node> expectedCreatedNodes = new HashSet<Node>();
-    final Set<Relationship> expectedCreatedRelationships = new HashSet<Relationship>();
-    final Set<Node> expectedDeletedNodes = new HashSet<Node>();
-    final Set<Relationship> expectedDeletedRelationships = new HashSet<Relationship>();
+    final Set<Node> expectedCreatedNodes = new HashSet<>();
+    final Set<Relationship> expectedCreatedRelationships = new HashSet<>();
+    final Set<Node> expectedDeletedNodes = new HashSet<>();
+    final Set<Relationship> expectedDeletedRelationships = new HashSet<>();
     final Map<Node, Map<String, PropertyEntryImpl<Node>>> expectedAssignedNodeProperties =
-            new HashMap<Node, Map<String, PropertyEntryImpl<Node>>>();
+            new AutoCreatingHashMap<>( nested( String.class, AutoCreatingHashMap.<PropertyEntryImpl<Node>>dontCreate() ) );
     final Map<Relationship, Map<String, PropertyEntryImpl<Relationship>>> expectedAssignedRelationshipProperties =
-            new HashMap<Relationship, Map<String, PropertyEntryImpl<Relationship>>>();
+            new AutoCreatingHashMap<>( nested( String.class, AutoCreatingHashMap.<PropertyEntryImpl<Relationship>>dontCreate() ) );
     final Map<Node, Map<String, PropertyEntryImpl<Node>>> expectedRemovedNodeProperties =
-            new HashMap<Node, Map<String, PropertyEntryImpl<Node>>>();
+            new AutoCreatingHashMap<>( nested( String.class, AutoCreatingHashMap.<PropertyEntryImpl<Node>>dontCreate() ) );
     final Map<Relationship, Map<String, PropertyEntryImpl<Relationship>>> expectedRemovedRelationshipProperties =
-            new HashMap<Relationship, Map<String, PropertyEntryImpl<Relationship>>>();
-    
+            new AutoCreatingHashMap<>( nested( String.class, AutoCreatingHashMap.<PropertyEntryImpl<Relationship>>dontCreate() ) );
+    final Map<Node, Set<String>> expectedAssignedLabels =
+            new AutoCreatingHashMap<>( AutoCreatingHashMap.<String>valuesOfTypeHashSet() );
+    final Map<Node, Set<String>> expectedRemovedLabels =
+            new AutoCreatingHashMap<>( AutoCreatingHashMap.<String>valuesOfTypeHashSet() );
+    private final boolean ignoreAdditionalData;
+
+    /**
+     * @param ignoreAdditionalData if {@code true} then only compare the expected data. If the transaction data
+     * contains data in addition to that, then ignore that data. The reason is that for some scenarios
+     * it's hard to anticipate the full extent of the transaction data. F.ex. deleting a node will
+     * have all its committed properties seen as removed as well. To tell this instance about that expectancy
+     * is difficult if there have been other property changes for that node within the same transaction
+     * before deleting that node. It's possible, it's just that it will require some tedious state keeping
+     * on the behalf of the test.
+     */
+    ExpectedTransactionData( boolean ignoreAdditionalData )
+    {
+        this.ignoreAdditionalData = ignoreAdditionalData;
+    }
+
+    ExpectedTransactionData()
+    {
+        this( false );
+    }
+
+    void clear()
+    {
+        expectedAssignedNodeProperties.clear();
+        expectedAssignedRelationshipProperties.clear();
+        expectedCreatedNodes.clear();
+        expectedCreatedRelationships.clear();
+        expectedDeletedNodes.clear();
+        expectedDeletedRelationships.clear();
+        expectedRemovedNodeProperties.clear();
+        expectedRemovedRelationshipProperties.clear();
+        expectedAssignedLabels.clear();
+        expectedRemovedLabels.clear();
+    }
+
+    void createdNode( Node node )
+    {
+        expectedCreatedNodes.add( node );
+    }
+
+    void deletedNode( Node node )
+    {
+        if ( !expectedCreatedNodes.remove( node ) )
+        {
+            expectedDeletedNodes.add( node );
+        }
+        expectedAssignedNodeProperties.remove( node );
+        expectedAssignedLabels.remove( node );
+        expectedRemovedNodeProperties.remove( node );
+        expectedRemovedLabels.remove( node );
+    }
+
+    void createdRelationship( Relationship relationship )
+    {
+        expectedCreatedRelationships.add( relationship );
+    }
+
+    void deletedRelationship( Relationship relationship )
+    {
+        if ( !expectedCreatedRelationships.remove( relationship ) )
+        {
+            expectedDeletedRelationships.add( relationship );
+        }
+        expectedAssignedRelationshipProperties.remove( relationship );
+        expectedRemovedRelationshipProperties.remove( relationship );
+    }
+
     void assignedProperty( Node node, String key, Object value, Object valueBeforeTx )
     {
-        putInMap( this.expectedAssignedNodeProperties, node, key, value, valueBeforeTx );
+        valueBeforeTx = removeProperty( expectedRemovedNodeProperties, node, key, valueBeforeTx );
+        Map<String,PropertyEntryImpl<Node>> map = expectedAssignedNodeProperties.get( node );
+        PropertyEntryImpl<Node> prev = map.get( key );
+        map.put( key, property( node, key, value, prev != null ? prev.previouslyCommitedValue() : valueBeforeTx ) );
     }
-    
+
     void assignedProperty( Relationship rel, String key, Object value, Object valueBeforeTx )
     {
-        putInMap( this.expectedAssignedRelationshipProperties, rel, key, value, valueBeforeTx );
+        valueBeforeTx = removeProperty( expectedRemovedRelationshipProperties, rel, key, valueBeforeTx );
+        Map<String,PropertyEntryImpl<Relationship>> map = expectedAssignedRelationshipProperties.get( rel );
+        PropertyEntryImpl<Relationship> prev = map.get( key );
+        map.put( key, property( rel, key, value, prev != null ? prev.previouslyCommitedValue() : valueBeforeTx ) );
     }
-    
-    void removedProperty( Node node, String key, Object value, Object valueBeforeTx )
+
+    void assignedLabel( Node node, Label label )
     {
-        putInMap( this.expectedRemovedNodeProperties, node, key, value, valueBeforeTx );
-    }
-    
-    void removedProperty( Relationship rel, String key, Object value, Object valueBeforeTx )
-    {
-        putInMap( this.expectedRemovedRelationshipProperties, rel, key, value, valueBeforeTx );
-    }
-    
-    <T extends PropertyContainer> void putInMap( Map<T, Map<String, PropertyEntryImpl<T>>> map,
-            T entity, String key, Object value, Object valueBeforeTx )
-    {
-        Map<String, PropertyEntryImpl<T>> innerMap = map.get( entity );
-        if ( innerMap == null )
+        if ( removeLabel( expectedRemovedLabels, node, label ) )
         {
-            innerMap = new HashMap<String, PropertyEntryImpl<T>>();
-            map.put( entity, innerMap );
+            expectedAssignedLabels.get( node ).add( label.name() );
         }
-        innerMap.put( key, new PropertyEntryImpl<T>( entity, key, value, valueBeforeTx ) );
     }
-    
+
+    void removedLabel( Node node, Label label )
+    {
+        if ( removeLabel( expectedAssignedLabels, node, label ) )
+        {
+            expectedRemovedLabels.get( node ).add( label.name() );
+        }
+    }
+
+    /**
+     * @return {@code true} if this property should be expected to come as removed property in the event
+     */
+    private boolean removeLabel( Map<Node,Set<String>> map, Node node, Label label )
+    {
+        if ( map.containsKey( node ) )
+        {
+            Set<String> set = map.get( node );
+            if ( !set.remove( label.name() ) )
+            {
+                return true;
+            }
+            if ( set.isEmpty() )
+            {
+                map.remove( node );
+            }
+        }
+        return false;
+    }
+
+    void removedProperty( Node node, String key, Object valueBeforeTx )
+    {
+        if ( (valueBeforeTx = removeProperty( expectedAssignedNodeProperties, node, key, valueBeforeTx )) != null )
+        {
+            expectedRemovedNodeProperties.get( node ).put( key, property( node, key, null, valueBeforeTx ) );
+        }
+    }
+
+    void removedProperty( Relationship rel, String key, Object valueBeforeTx )
+    {
+        if ( (valueBeforeTx = removeProperty( expectedAssignedRelationshipProperties, rel, key, valueBeforeTx )) != null )
+        {
+            expectedRemovedRelationshipProperties.get( rel ).put( key, property( rel, key, null, valueBeforeTx ) );
+        }
+    }
+
+    /**
+     * @return {@code non-null} if this property should be expected to come as removed property in the event
+     */
+    private <E extends PropertyContainer> Object removeProperty( Map<E,Map<String,PropertyEntryImpl<E>>> map,
+            E entity, String key, Object valueBeforeTx )
+    {
+        if ( map.containsKey( entity ) )
+        {
+            Map<String,PropertyEntryImpl<E>> inner = map.get( entity );
+            PropertyEntryImpl<E> entry = inner.remove( key );
+            if ( entry == null )
+            {   // this means that we've been called to remove an existing property
+                return valueBeforeTx;
+            }
+
+            if ( inner.isEmpty() )
+            {
+                map.remove( entity );
+            }
+            if ( entry.previouslyCommitedValue() != null )
+            {   // this means that we're removing a previously changed property, i.e. there's a value to remove
+                return entry.previouslyCommitedValue();
+            }
+            return null;
+        }
+        return valueBeforeTx;
+    }
+
+    private <E extends PropertyContainer> PropertyEntryImpl<E> property( E entity, String key, Object value,
+            Object valueBeforeTx )
+    {
+        return new PropertyEntryImpl<>( entity, key, value, valueBeforeTx );
+    }
+
     void compareTo( TransactionData data )
     {
-        Set<Node> expectedCreatedNodes = new HashSet<Node>( this.expectedCreatedNodes );
-        Set<Relationship> expectedCreatedRelationships = new HashSet<Relationship>( this.expectedCreatedRelationships );
+        Set<Node> expectedCreatedNodes = new HashSet<>( this.expectedCreatedNodes );
+        Set<Relationship> expectedCreatedRelationships = new HashSet<>( this.expectedCreatedRelationships );
         Set<Node> expectedDeletedNodes = new HashSet<Node>( this.expectedDeletedNodes );
-        Set<Relationship> expectedDeletedRelationships = new HashSet<Relationship>( this.expectedDeletedRelationships );
+        Set<Relationship> expectedDeletedRelationships = new HashSet<>( this.expectedDeletedRelationships );
         Map<Node, Map<String, PropertyEntryImpl<Node>>> expectedAssignedNodeProperties =
                 clone( this.expectedAssignedNodeProperties );
         Map<Relationship, Map<String, PropertyEntryImpl<Relationship>>> expectedAssignedRelationshipProperties =
@@ -95,7 +240,9 @@ class ExpectedTransactionData
                 clone( this.expectedRemovedNodeProperties );
         Map<Relationship, Map<String, PropertyEntryImpl<Relationship>>> expectedRemovedRelationshipProperties =
                 clone( this.expectedRemovedRelationshipProperties );
-        
+        Map<Node,Set<String>> expectedAssignedLabels = cloneLabelData( this.expectedAssignedLabels );
+        Map<Node,Set<String>> expectedRemovedLabels = cloneLabelData( this.expectedRemovedLabels );
+
         for ( Node node : data.createdNodes() )
         {
             assertTrue( expectedCreatedNodes.remove( node ) );
@@ -103,34 +250,36 @@ class ExpectedTransactionData
         }
         assertTrue( "Expected some created nodes that weren't seen: " + expectedCreatedNodes,
                 expectedCreatedNodes.isEmpty() );
-        
+
         for ( Relationship rel : data.createdRelationships() )
         {
             assertTrue( expectedCreatedRelationships.remove( rel ) );
             assertFalse( data.isDeleted( rel ) );
         }
-        assertTrue( expectedCreatedRelationships.isEmpty() );
-        
+        assertTrue( "Expected created relationships not encountered " + expectedCreatedRelationships,
+                expectedCreatedRelationships.isEmpty() );
+
         for ( Node node : data.deletedNodes() )
         {
             assertTrue( "Unexpected deleted node " + node, expectedDeletedNodes.remove( node ) );
             assertTrue( data.isDeleted( node ) );
         }
-        assertTrue( expectedDeletedNodes.isEmpty() );
-        
+        assertTrue( "Expected deleted nodes: " + expectedDeletedNodes, expectedDeletedNodes.isEmpty() );
+
         for ( Relationship rel : data.deletedRelationships() )
         {
             assertTrue( expectedDeletedRelationships.remove( rel ) );
             assertTrue( data.isDeleted( rel ) );
         }
-        assertTrue( expectedDeletedRelationships.isEmpty() );
-        
+        assertTrue( "Expected deleted relationships not encountered " + expectedDeletedRelationships,
+                expectedDeletedRelationships.isEmpty() );
+
         for ( PropertyEntry<Node> entry : data.assignedNodeProperties() )
         {
             checkAssigned( expectedAssignedNodeProperties, entry );
             assertFalse( data.isDeleted( entry.entity() ) );
         }
-        assertTrue( "Expected node properties not encountered " + expectedAssignedNodeProperties,
+        assertTrue( "Expected assigned node properties not encountered " + expectedAssignedNodeProperties,
                 expectedAssignedNodeProperties.isEmpty() );
 
         for ( PropertyEntry<Relationship> entry : data.assignedRelationshipProperties() )
@@ -138,21 +287,71 @@ class ExpectedTransactionData
             checkAssigned( expectedAssignedRelationshipProperties, entry );
             assertFalse( data.isDeleted( entry.entity() ) );
         }
-        assertTrue( expectedAssignedRelationshipProperties.isEmpty() );
+        assertTrue( "Expected assigned relationship properties not encountered " + expectedAssignedRelationshipProperties,
+                expectedAssignedRelationshipProperties.isEmpty() );
 
         for ( PropertyEntry<Node> entry : data.removedNodeProperties() )
         {
             checkRemoved( expectedRemovedNodeProperties, entry );
         }
-        assertTrue( expectedRemovedNodeProperties.isEmpty() );
+        assertTrue( "Expected removed node properties not encountered " + expectedRemovedNodeProperties,
+                expectedRemovedNodeProperties.isEmpty() );
 
         for ( PropertyEntry<Relationship> entry : data.removedRelationshipProperties() )
         {
             checkRemoved( expectedRemovedRelationshipProperties, entry );
         }
-        assertTrue( expectedRemovedRelationshipProperties.isEmpty() );
+        assertTrue( "Expected removed relationship properties not encountered " + expectedRemovedRelationshipProperties,
+                expectedRemovedRelationshipProperties.isEmpty() );
+
+        for ( LabelEntry entry : data.assignedLabels() )
+        {
+            check( expectedAssignedLabels, entry );
+        }
+        assertTrue( "Expected assigned labels not encountered " + expectedAssignedLabels,
+                expectedAssignedLabels.isEmpty() );
+
+        for ( LabelEntry entry : data.removedLabels() )
+        {
+            check( expectedRemovedLabels, entry );
+        }
+        assertTrue( "Expected removed labels not encountered " + expectedRemovedLabels,
+                expectedRemovedLabels.isEmpty() );
     }
-    
+
+    private Map<Node,Set<String>> cloneLabelData( Map<Node,Set<String>> map )
+    {
+        Map<Node,Set<String>> clone = new HashMap<>();
+        for ( Map.Entry<Node,Set<String>> entry : map.entrySet() )
+        {
+            clone.put( entry.getKey(), new HashSet<>( entry.getValue() ) );
+        }
+        return clone;
+    }
+
+    private void check( Map<Node,Set<String>> expected, LabelEntry entry )
+    {
+        Node node = entry.node();
+        String labelName = entry.label().name();
+        boolean hasEntity = expected.containsKey( node );
+        if ( !hasEntity && ignoreAdditionalData )
+        {
+            return;
+        }
+        assertTrue( "Unexpected node " + node, hasEntity );
+        Set<String> labels = expected.get( node );
+        boolean hasLabel = labels.remove( labelName );
+        if ( !hasLabel && ignoreAdditionalData )
+        {
+            return;
+        }
+        assertTrue( "Unexpected label " + labelName + " for " + node, hasLabel );
+        if ( labels.isEmpty() )
+        {
+            expected.remove( node );
+        }
+    }
+
     private <KEY extends PropertyContainer> Map<KEY, Map<String, PropertyEntryImpl<KEY>>> clone(
             Map<KEY, Map<String, PropertyEntryImpl<KEY>>> map )
     {
@@ -167,25 +366,43 @@ class ExpectedTransactionData
     <T extends PropertyContainer> void checkAssigned(
             Map<T, Map<String, PropertyEntryImpl<T>>> map, PropertyEntry<T> entry )
     {
-        fetchExpectedPropertyEntry( map, entry ).compareToAssigned( entry );
+        PropertyEntryImpl<T> expected = fetchExpectedPropertyEntry( map, entry );
+        if ( expected != null )
+        {   // To handle the ignore flag (read above)
+            expected.compareToAssigned( entry );
+        }
     }
 
     <T extends PropertyContainer> void checkRemoved(
             Map<T, Map<String, PropertyEntryImpl<T>>> map, PropertyEntry<T> entry )
     {
-        fetchExpectedPropertyEntry( map, entry ).compareToRemoved( entry );
+        PropertyEntryImpl<T> expected = fetchExpectedPropertyEntry( map, entry );
+        if ( expected != null )
+        {   // To handle the ignore flag (read above)
+            expected.compareToRemoved( entry );
+        }
     }
-    
+
     <T extends PropertyContainer> PropertyEntryImpl<T> fetchExpectedPropertyEntry(
             Map<T, Map<String, PropertyEntryImpl<T>>> map, PropertyEntry<T> entry )
     {
-        Map<String, PropertyEntryImpl<T>> innerMap = map.get( entry.entity() );
-        assertNotNull( "Unexpected entity " + entry, innerMap );
+        T entity = entry.entity();
+        boolean hasEntity = map.containsKey( entity );
+        if ( ignoreAdditionalData && !hasEntity )
+        {
+            return null;
+        }
+        assertTrue( "Unexpected entity " + entry, hasEntity );
+        Map<String, PropertyEntryImpl<T>> innerMap = map.get( entity );
         PropertyEntryImpl<T> expectedEntry = innerMap.remove( entry.key() );
-        assertNotNull( "Unexpacted property entry " + entry, expectedEntry );
+        if ( expectedEntry == null && ignoreAdditionalData )
+        {
+            return null;
+        }
+        assertNotNull( "Unexpected property entry " + entry, expectedEntry );
         if ( innerMap.isEmpty() )
         {
-            map.remove( entry.entity() );
+            map.remove( entity );
         }
         return expectedEntry;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
@@ -226,7 +226,7 @@ public class TestTransactionEvents
                 node3.setProperty( "name", "No name" );
                 node3.delete();
                 expectedData.expectedDeletedNodes.add( node3 );
-                expectedData.removedProperty( node3, "name", null, "Node 3" );
+                expectedData.removedProperty( node3, "name", "Node 3" );
 
                 node1.setProperty( "new name", "A name" );
                 node1.setProperty( "new name", "A better name" );
@@ -237,7 +237,7 @@ public class TestTransactionEvents
                 expectedData.assignedProperty( node1, "name", "Mattias Persson",
                         "Mattias" );
                 node1.removeProperty( "counter" );
-                expectedData.removedProperty( node1, "counter", null, 10 );
+                expectedData.removedProperty( node1, "counter", 10 );
                 node1.removeProperty( "last name" );
                 node1.setProperty( "last name", "Hi" );
                 expectedData.assignedProperty( node1, "last name", "Hi", "Persson" );
@@ -246,7 +246,7 @@ public class TestTransactionEvents
                 expectedData.expectedDeletedRelationships.add( rel2 );
 
                 rel1.removeProperty( "number" );
-                expectedData.removedProperty( rel1, "number", null, 4.5D );
+                expectedData.removedProperty( rel1, "number", 4.5D );
                 rel1.setProperty( "description", "Ignored" );
                 rel1.setProperty( "description", "New" );
                 expectedData.assignedProperty( rel1, "description", "New",

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.event;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.event.TransactionEventHandler;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.RandomRule;
+
+/**
+ * Test for randomly creating data and verifying transaction data seen in transaction event handlers.
+ */
+public class TransactionEventsIT
+{
+    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
+    public final @Rule RandomRule random = new RandomRule();
+
+    @Test
+    public void shouldSeeExpectedTransactionData() throws Exception
+    {
+        // GIVEN
+        final Graph state = new Graph( db, random );
+        final ExpectedTransactionData expected = new ExpectedTransactionData( true );
+        final TransactionEventHandler<Object> handler = new VerifyingTransactionEventHandler( expected );
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < 100; i++ )
+            {
+                Operation.createNode.perform( state, expected );
+            }
+            for ( int i = 0; i < 20; i++ )
+            {
+                Operation.createRelationship.perform( state, expected );
+            }
+            tx.success();
+        }
+
+        db.registerTransactionEventHandler( handler );
+
+        // WHEN
+        Operation[] operations = Operation.values();
+        for ( int i = 0; i < 1_000; i++ )
+        {
+            expected.clear();
+            try ( Transaction tx = db.beginTx() )
+            {
+                int transactionSize = random.intBetween( 1, 20 );
+                for ( int j = 0; j < transactionSize; j++ )
+                {
+                    random.among( operations ).perform( state, expected );
+                }
+                tx.success();
+            }
+        }
+
+        // THEN the verifications all happen inside the transaction event handler
+    }
+
+    enum Operation
+    {
+        createNode
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                Node node = graph.createNode();
+                expectations.createdNode( node );
+                debug( node );
+            }
+        },
+        deleteNode
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                Node node = graph.randomNode();
+                if ( node != null )
+                {
+                    for ( Relationship relationship : node.getRelationships() )
+                    {
+                        graph.deleteRelationship( relationship );
+                        expectations.deletedRelationship( relationship );
+                        debug( relationship );
+                    }
+                    graph.deleteNode( node );
+                    expectations.deletedNode( node );
+                    debug( node );
+                }
+            }
+        },
+        assignLabel
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                Node node = graph.randomNode();
+                if ( node != null )
+                {
+                    Label label = graph.randomLabel();
+                    if ( !node.hasLabel( label ) )
+                    {
+                        node.addLabel( label );
+                        expectations.assignedLabel( node, label );
+                        debug( node + " " + label );
+                    }
+                }
+            }
+        },
+        removeLabel
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                Node node = graph.randomNode();
+                if ( node != null )
+                {
+                    Label label = graph.randomLabel();
+                    if ( node.hasLabel( label ) )
+                    {
+                        node.removeLabel( label );
+                        expectations.removedLabel( node, label );
+                        debug( node + " " + label );
+                    }
+                }
+            }
+        },
+        setNodeProperty
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                Node node = graph.randomNode();
+                if ( node != null )
+                {
+                    String key = graph.randomPropertyKey();
+                    Object valueBefore = node.getProperty( key, null );
+                    Object value = graph.randomPropertyValue();
+                    node.setProperty( key, value );
+                    expectations.assignedProperty( node, key, value, valueBefore );
+                    debug( node + " " + key + "=" + value + " prev " + valueBefore );
+                }
+            }
+        },
+        removeNodeProperty
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                Node node = graph.randomNode();
+                if ( node != null )
+                {
+                    String key = graph.randomPropertyKey();
+                    if ( node.hasProperty( key ) )
+                    {
+                        Object valueBefore = node.removeProperty( key );
+                        expectations.removedProperty( node, key, valueBefore );
+                        debug( node + " " + key + "=" + valueBefore );
+                    }
+                }
+            }
+        },
+        setRelationshipProperty
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                Relationship relationship = graph.randomRelationship();
+                if ( relationship != null )
+                {
+                    String key = graph.randomPropertyKey();
+                    Object valueBefore = relationship.getProperty( key, null );
+                    Object value = graph.randomPropertyValue();
+                    relationship.setProperty( key, value );
+                    expectations.assignedProperty( relationship, key, value, valueBefore );
+                    debug( relationship + " " + key + "=" + value + " prev " + valueBefore );
+                }
+            }
+        },
+        removeRelationshipProperty
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                Relationship relationship = graph.randomRelationship();
+                if ( relationship != null )
+                {
+                    String key = graph.randomPropertyKey();
+                    if ( relationship.hasProperty( key ) )
+                    {
+                        Object valueBefore = relationship.removeProperty( key );
+                        expectations.removedProperty( relationship, key, valueBefore );
+                        debug( relationship + " " + key + "=" + valueBefore );
+                    }
+                }
+            }
+        },
+        createRelationship
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                while ( graph.nodeCount() < 2 )
+                {
+                    createNode.perform( graph, expectations );
+                }
+                Node node1 = graph.randomNode();
+                Node node2 = graph.randomNode();
+                Relationship relationship = graph.createRelationship( node1, node2, graph.randomRelationshipType() );
+                expectations.createdRelationship( relationship );
+                debug( relationship );
+            }
+        },
+        deleteRelationship
+        {
+            @Override
+            void perform( Graph graph, ExpectedTransactionData expectations )
+            {
+                Relationship relationship = graph.randomRelationship();
+                if ( relationship != null )
+                {
+                    graph.deleteRelationship( relationship );
+                    expectations.deletedRelationship( relationship );
+                    debug( relationship );
+                }
+            }
+        };
+
+        abstract void perform( Graph graph, ExpectedTransactionData expectations );
+
+        void debug( Object value )
+        {   // Add a system.out here if you need to debug this case a bit easier
+        }
+    }
+
+    private static class Graph
+    {
+        private static final String[] TOKENS = {"A", "B", "C", "D", "E"};
+
+        private final GraphDatabaseService db;
+        private final RandomRule random;
+        private final List<Node> nodes = new ArrayList<>();
+        private final List<Relationship> relationships = new ArrayList<>();
+
+        Graph( GraphDatabaseService db, RandomRule random )
+        {
+            this.db = db;
+            this.random = random;
+        }
+
+        private <E extends PropertyContainer> E random( List<E> entities )
+        {
+            return entities.isEmpty() ? null : entities.get( random.nextInt( entities.size() ) );
+        }
+
+        Node randomNode()
+        {
+            return random( nodes );
+        }
+
+        Relationship randomRelationship()
+        {
+            return random( relationships );
+        }
+
+        Node createNode()
+        {
+            Node node = db.createNode();
+            nodes.add( node );
+            return node;
+        }
+
+        void deleteRelationship( Relationship relationship )
+        {
+            relationship.delete();
+            relationships.remove( relationship );
+        }
+
+        void deleteNode( Node node )
+        {
+            node.delete();
+            nodes.remove( node );
+        }
+
+        private String randomToken()
+        {
+            return random.among( TOKENS );
+        }
+
+        Label randomLabel()
+        {
+            return DynamicLabel.label( randomToken() );
+        }
+
+        RelationshipType randomRelationshipType()
+        {
+            return DynamicRelationshipType.withName( randomToken() );
+        }
+
+        String randomPropertyKey()
+        {
+            return randomToken();
+        }
+
+        Object randomPropertyValue()
+        {
+            return random.propertyValue();
+        }
+
+        int nodeCount()
+        {
+            return nodes.size();
+        }
+
+        Relationship createRelationship( Node node1, Node node2, RelationshipType type )
+        {
+            Relationship relationship = node1.createRelationshipTo( node2, type );
+            relationships.add( relationship );
+            return relationship;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/AutoCreatingHashMap.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/AutoCreatingHashMap.java
@@ -20,7 +20,9 @@
 package org.neo4j.kernel.impl.util;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.neo4j.function.Factory;
 
@@ -145,6 +147,30 @@ public class AutoCreatingHashMap<K,V> extends HashMap<K,V>
             public Map<K,V> newInstance()
             {
                 return new AutoCreatingHashMap<>( nested );
+            }
+        };
+    }
+
+    public static <V> Factory<V> dontCreate()
+    {
+        return new Factory<V>()
+        {
+            @Override
+            public V newInstance()
+            {
+                return null;
+            }
+        };
+    }
+
+    public static <V> Factory<Set<V>> valuesOfTypeHashSet()
+    {
+        return new Factory<Set<V>>()
+        {
+            @Override
+            public Set<V> newInstance()
+            {
+                return new HashSet<>();
             }
         };
     }

--- a/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
@@ -23,18 +23,27 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.event.KernelEventHandler;
+import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilderTestTools;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.graphdb.schema.Schema;
+import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
+import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.Provider;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -43,13 +52,25 @@ import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.store.StoreId;
 
-public abstract class DatabaseRule extends ExternalResource
+public abstract class DatabaseRule extends ExternalResource implements GraphDatabaseAPI
 {
     GraphDatabaseBuilder databaseBuilder;
     GraphDatabaseAPI database;
     private String storeDir;
     private Provider<Statement> statementProvider;
+    private boolean startEagerly = true;
+
+    /**
+     * Means the database will be started on first {@link #getGraphDatabaseAPI()}, {@link #getGraphDatabaseService()}
+     * or {@link #ensureStarted()} call.
+     */
+    public DatabaseRule startLazily()
+    {
+        startEagerly = false;
+        return this;
+    }
 
     public <T> T when( Function<GraphDatabaseService, T> function )
     {
@@ -100,36 +121,43 @@ public abstract class DatabaseRule extends ExternalResource
         }
     }
 
+    @Override
     public Result execute( String query ) throws QueryExecutionException
     {
         return getGraphDatabaseAPI().execute( query );
     }
 
+    @Override
     public Result execute( String query, Map<String, Object> parameters ) throws QueryExecutionException
     {
         return getGraphDatabaseAPI().execute( query, parameters );
     }
 
+    @Override
     public Transaction beginTx()
     {
         return getGraphDatabaseAPI().beginTx();
     }
 
+    @Override
     public Node createNode( Label... labels )
     {
         return getGraphDatabaseAPI().createNode( labels );
     }
 
+    @Override
     public Node getNodeById( long id )
     {
         return getGraphDatabaseService().getNodeById( id );
     }
 
+    @Override
     public IndexManager index()
     {
         return getGraphDatabaseService().index();
     }
 
+    @Override
     public Schema schema()
     {
         return getGraphDatabaseAPI().schema();
@@ -139,6 +167,10 @@ public abstract class DatabaseRule extends ExternalResource
     protected void before() throws Throwable
     {
         create();
+        if ( startEagerly )
+        {
+            ensureStarted();
+        }
     }
 
     @Override
@@ -147,7 +179,6 @@ public abstract class DatabaseRule extends ExternalResource
         shutdown( success );
     }
 
-    @SuppressWarnings("deprecation")
     private void create() throws IOException
     {
         createResources();
@@ -204,18 +235,27 @@ public abstract class DatabaseRule extends ExternalResource
         GraphDatabaseBuilderTestTools.clearConfig( databaseBuilder );
     }
 
+    /**
+     * {@link DatabaseRule} now implements {@link GraphDatabaseAPI} directly, so no need. Also for ensuring
+     * a lazily started database is created, use {@link #ensureStarted()} instead.
+     */
+    @Deprecated
     public GraphDatabaseService getGraphDatabaseService()
     {
         return getGraphDatabaseAPI();
     }
 
+    /**
+     * {@link DatabaseRule} now implements {@link GraphDatabaseAPI} directly, so no need. Also for ensuring
+     * a lazily started database is created, use {@link #ensureStarted()} instead.
+     */
     public GraphDatabaseAPI getGraphDatabaseAPI()
     {
         ensureStarted();
         return database;
     }
 
-    private synchronized void ensureStarted()
+    public synchronized void ensureStarted()
     {
         if ( database == null )
         {
@@ -253,6 +293,7 @@ public abstract class DatabaseRule extends ExternalResource
         return getGraphDatabaseAPI();
     }
 
+    @Override
     public void shutdown()
     {
         shutdown( true );
@@ -306,5 +347,118 @@ public abstract class DatabaseRule extends ExternalResource
     {
         ensureStarted();
         return statementProvider.instance();
+    }
+
+    @Override
+    public DependencyResolver getDependencyResolver()
+    {
+        return database.getDependencyResolver();
+    }
+
+    @Override
+    public StoreId storeId()
+    {
+        return database.storeId();
+    }
+
+    @Override
+    public String getStoreDir()
+    {
+        return database.getStoreDir();
+    }
+
+    public String getStoreDirAbsolutePath()
+    {
+        return new File( getStoreDir() ).getAbsolutePath();
+    }
+
+    @Override
+    public Node createNode()
+    {
+        return database.createNode();
+    }
+
+    @Override
+    public Relationship getRelationshipById( long id )
+    {
+        return database.getRelationshipById( id );
+    }
+
+    @Override
+    public Iterable<Node> getAllNodes()
+    {
+        return database.getAllNodes();
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label, String key, Object value )
+    {
+        return database.findNodes( label, key, value );
+    }
+
+    @Override
+    public Node findNode( Label label, String key, Object value )
+    {
+        return database.findNode( label, key, value );
+    }
+
+    @Override
+    public ResourceIterator<Node> findNodes( Label label )
+    {
+        return database.findNodes( label );
+    }
+
+    @Override
+    public ResourceIterable<Node> findNodesByLabelAndProperty( Label label, String key, Object value )
+    {
+        return database.findNodesByLabelAndProperty( label, key, value );
+    }
+
+    @Override
+    public Iterable<RelationshipType> getRelationshipTypes()
+    {
+        return database.getRelationshipTypes();
+    }
+
+    @Override
+    public boolean isAvailable( long timeout )
+    {
+        return database.isAvailable( timeout );
+    }
+
+    @Override
+    public <T> TransactionEventHandler<T> registerTransactionEventHandler( TransactionEventHandler<T> handler )
+    {
+        return database.registerTransactionEventHandler( handler );
+    }
+
+    @Override
+    public <T> TransactionEventHandler<T> unregisterTransactionEventHandler( TransactionEventHandler<T> handler )
+    {
+        return database.unregisterTransactionEventHandler( handler );
+    }
+
+    @Override
+    public KernelEventHandler registerKernelEventHandler( KernelEventHandler handler )
+    {
+        return database.registerKernelEventHandler( handler );
+    }
+
+    @Override
+    public KernelEventHandler unregisterKernelEventHandler( KernelEventHandler handler )
+    {
+        return database.unregisterKernelEventHandler( handler );
+    }
+
+    @Override
+    public TraversalDescription traversalDescription()
+    {
+        return database.traversalDescription();
+    }
+
+    @Override
+    public BidirectionalTraversalDescription bidirectionalTraversalDescription()
+    {
+        return database.bidirectionalTraversalDescription();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/EmbeddedDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/EmbeddedDatabaseRule.java
@@ -37,25 +37,25 @@ import org.neo4j.io.fs.FileUtils;
 public class EmbeddedDatabaseRule extends DatabaseRule
 {
     private final TempDirectory temp;
-    
+
     public EmbeddedDatabaseRule()
     {
         this.temp = new TempDirectory()
         {
             private final TemporaryFolder folder = new TemporaryFolder();
-            
+
             @Override
             public File root()
             {
                 return folder.getRoot();
             }
-            
+
             @Override
             public void delete()
             {
                 folder.delete();
             }
-            
+
             @Override
             public void create() throws IOException
             {
@@ -63,7 +63,7 @@ public class EmbeddedDatabaseRule extends DatabaseRule
             }
         };
     }
-    
+
     public EmbeddedDatabaseRule( final Class<?> testClass )
     {
         this.temp = new TempDirectory()
@@ -76,13 +76,13 @@ public class EmbeddedDatabaseRule extends DatabaseRule
             {
                 return dbDir;
             }
-            
+
             @Override
             public void delete() throws IOException
             {
                 targetDirectory.cleanup();
             }
-            
+
             @Override
             public void create()
             {
@@ -117,13 +117,31 @@ public class EmbeddedDatabaseRule extends DatabaseRule
             }
         };
     }
-    
+
+    @Override
+    public EmbeddedDatabaseRule startLazily()
+    {
+        return (EmbeddedDatabaseRule) super.startLazily();
+    }
+
+    @Override
+    public String getStoreDir()
+    {
+        return temp.root().getPath();
+    }
+
+    @Override
+    public String getStoreDirAbsolutePath()
+    {
+        return temp.root().getAbsolutePath();
+    }
+
     @Override
     protected GraphDatabaseFactory newFactory()
     {
         return new TestGraphDatabaseFactory();
     }
-    
+
     @Override
     protected GraphDatabaseBuilder newBuilder(GraphDatabaseFactory factory )
     {
@@ -135,7 +153,7 @@ public class EmbeddedDatabaseRule extends DatabaseRule
     {
         temp.create();
     }
-    
+
     @Override
     protected void deleteResources()
     {
@@ -149,17 +167,12 @@ public class EmbeddedDatabaseRule extends DatabaseRule
         }
     }
 
-    public File getStoreDir()
-    {
-        return temp.root();
-    }
-    
     private interface TempDirectory
     {
         File root();
-        
+
         void create() throws IOException;
-        
+
         void delete() throws IOException;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentDatabaseRule.java
@@ -40,6 +40,12 @@ public class ImpermanentDatabaseRule extends DatabaseRule
     }
 
     @Override
+    public ImpermanentDatabaseRule startLazily()
+    {
+        return (ImpermanentDatabaseRule) super.startLazily();
+    }
+
+    @Override
     protected GraphDatabaseFactory newFactory()
     {
         return new TestGraphDatabaseFactory( logging );

--- a/community/kernel/src/test/java/org/neo4j/test/RandomRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/RandomRule.java
@@ -135,12 +135,6 @@ public class RandomRule implements TestRule
         return randoms.string( minLength, maxLength, characterSets );
     }
 
-    @Override
-    public boolean equals( Object obj )
-    {
-        return randoms.equals( obj );
-    }
-
     public char character( int characterSets )
     {
         return randoms.character( characterSets );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/BatchInsertionIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/BatchInsertionIT.java
@@ -36,9 +36,11 @@ import org.neo4j.unsafe.batchinsert.BatchInserterIndex;
 import org.neo4j.unsafe.batchinsert.BatchInserterIndexProvider;
 import org.neo4j.unsafe.batchinsert.BatchInserters;
 
-import static java.lang.System.currentTimeMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+
+import static java.lang.System.currentTimeMillis;
+
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 import static org.neo4j.helpers.collection.MapUtil.map;
@@ -47,13 +49,13 @@ import static org.neo4j.index.impl.lucene.LuceneIndexImplementation.EXACT_CONFIG
 public class BatchInsertionIT
 {
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( BatchInsertionIT.class );
+    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( BatchInsertionIT.class ).startLazily();
 
     @Test
     public void shouldIndexNodesWithMultipleLabels() throws Exception
     {
         // Given
-        String path = dbRule.getStoreDir().getAbsolutePath();
+        String path = dbRule.getStoreDirAbsolutePath();
         BatchInserter inserter = BatchInserters.inserter( path );
 
         inserter.createNode( map( "name", "Bob" ), label( "User" ), label( "Admin" ) );
@@ -82,7 +84,7 @@ public class BatchInsertionIT
     public void shouldNotIndexNodesWithWrongLabel() throws Exception
     {
         // Given
-        BatchInserter inserter = BatchInserters.inserter( dbRule.getStoreDir().getAbsolutePath() );
+        BatchInserter inserter = BatchInserters.inserter( dbRule.getStoreDirAbsolutePath() );
 
         inserter.createNode( map("name", "Bob"), label( "User" ), label("Admin"));
 
@@ -107,7 +109,7 @@ public class BatchInsertionIT
     @Test
     public void shouldBeAbleToMakeRepeatedCallsToSetNodeProperty() throws Exception
     {
-        BatchInserter inserter = BatchInserters.inserter( dbRule.getStoreDir().getAbsolutePath() );
+        BatchInserter inserter = BatchInserters.inserter( dbRule.getStoreDirAbsolutePath() );
         long nodeId = inserter.createNode( Collections.<String, Object>emptyMap() );
 
         final Object finalValue = 87;
@@ -132,7 +134,7 @@ public class BatchInsertionIT
     @Test
     public void shouldBeAbleToMakeRepeatedCallsToSetNodePropertyWithMultiplePropertiesPerBlock() throws Exception
     {
-        BatchInserter inserter = BatchInserters.inserter( dbRule.getStoreDir().getAbsolutePath() );
+        BatchInserter inserter = BatchInserters.inserter( dbRule.getStoreDirAbsolutePath() );
         long nodeId = inserter.createNode( Collections.<String, Object>emptyMap() );
 
         final Object finalValue1 = 87;
@@ -161,7 +163,7 @@ public class BatchInsertionIT
     @Test
     public void testInsertionSpeed()
     {
-        BatchInserter inserter = BatchInserters.inserter( dbRule.getStoreDir().getAbsolutePath() );
+        BatchInserter inserter = BatchInserters.inserter( dbRule.getStoreDirAbsolutePath() );
         BatchInserterIndexProvider provider = new LuceneBatchInserterIndexProvider( inserter );
         BatchInserterIndex index = provider.nodeIndex( "yeah", EXACT_CONFIG );
         index.setCacheCapacity( "key", 1000000 );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
@@ -40,6 +40,7 @@ import org.neo4j.test.EmbeddedDatabaseRule;
 import org.neo4j.test.ProcessStreamHandler;
 
 import static org.junit.Assert.assertEquals;
+
 import static org.neo4j.helpers.Settings.osIsWindows;
 import static org.neo4j.test.TargetDirectory.forTest;
 
@@ -49,8 +50,7 @@ public class BackupEmbeddedIT
     public static final File BACKUP_PATH = forTest( BackupEmbeddedIT.class ).cleanDirectory( "backup-db" );
 
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( PATH );
-    private GraphDatabaseService db;
+    public EmbeddedDatabaseRule db = new EmbeddedDatabaseRule( PATH ).startLazily();
     private String ip;
 
     @Before
@@ -120,12 +120,12 @@ public class BackupEmbeddedIT
 
     private void startDb( String backupPort )
     {
-        dbRule.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE );
+        db.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE );
         if(backupPort != null)
         {
-            dbRule.setConfig( OnlineBackupSettings.online_backup_server, ip +":" + backupPort );
+            db.setConfig( OnlineBackupSettings.online_backup_server, ip +":" + backupPort );
         }
-        db = dbRule.getGraphDatabaseService();
+        db.ensureStarted();
         createSomeData( db );
     }
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.backup;
 
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -26,12 +32,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
 import org.neo4j.com.storecopy.StoreCopyServer;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -77,8 +77,6 @@ import org.neo4j.test.EmbeddedDatabaseRule;
 import org.neo4j.test.Mute;
 import org.neo4j.test.TargetDirectory;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -89,6 +87,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static org.neo4j.backup.BackupServiceStressTestingBuilder.untilTimeExpired;
 
@@ -126,7 +126,7 @@ public class BackupServiceIT
     public int backupPort = 8200;
 
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( storeDir );
+    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( storeDir ).startLazily();
     @Rule
     public Mute mute = Mute.muteAll();
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/forseti/ForsetiServiceLoadingTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/forseti/ForsetiServiceLoadingTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 public class ForsetiServiceLoadingTest
 {
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() );
+    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
 
     @Test
     public void shouldUseForsetiAsDefaultLockManager() throws Exception


### PR DESCRIPTION
also makes DatabaseRule implement GraphDatabaseAPI so that
dbRule.getGraphDatabaseService()/getGraphDatabaseAPI() gets deprecated,
since a DatabaseRule can be used as a
GraphDatabaseAPI/GraphDatabaseService directly.
Also changes the default behaviour so that the db is started as part of
the before section of the rule instead of on the first call to
getGDS()/getGDAPI() to behave more like rules usually do. Although there's
the option of having the old behaviour to start lazily. This is done by
calling startLazily() on the DatabaseRule, f.ex:

DatabaseRule db = new EmbeddedDatabaseRule( getClass() ).startLazily()

although very few tests need that functionality.
