### PR TITLE
Prevents read-only transactions from trigger tx events

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/event/TransactionEventHandler.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/event/TransactionEventHandler.java
@@ -54,10 +54,10 @@ import org.neo4j.graphdb.TransactionFailureException;
  * {@link Transaction#close()}. All handlers which at this point have had its
  * {@link #beforeCommit(TransactionData)} method executed successfully will
  * receive a call to {@link #afterRollback(TransactionData, Object)}.
- * 
+ *
  * @author Tobias Ivarsson
  * @author Mattias Persson
- * 
+ *
  * @param <T> The type of a state object that the transaction handler can use to
  *            pass information from the {@link #beforeCommit(TransactionData)}
  *            event dispatch method to the
@@ -89,7 +89,9 @@ public interface TransactionEventHandler<T>
 
     /**
      * Invoked after the transaction has been committed successfully.
-     * 
+     * Any {@link TransactionData} being passed in to this method is guaranteed
+     * to first be have been called with {@link #beforeCommit(TransactionData)}.
+     *
      * @param data the changes that were committed in this transaction.
      * @param state the object returned by
      *            {@link #beforeCommit(TransactionData)}.
@@ -99,6 +101,8 @@ public interface TransactionEventHandler<T>
     /**
      * Invoked after the transaction has been rolled back if committing the
      * transaction failed for some reason.
+     * Any {@link TransactionData} being passed in to this method is guaranteed
+     * to first be have been called with {@link #beforeCommit(TransactionData)}.
      *
      * @param data the changes that were committed in this transaction.
      * @param state the object returned by
@@ -106,7 +110,7 @@ public interface TransactionEventHandler<T>
      */
     // TODO: should this method take a parameter describing WHY the tx failed?
     void afterRollback( TransactionData data, T state );
-    
+
     /**
      * Adapter for a {@link TransactionEventHandler}
      *

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/ReadableTxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/ReadableTxState.java
@@ -134,4 +134,13 @@ public interface ReadableTxState
     Long indexCreatedForConstraint( UniquenessConstraint constraint );
 
     ReadableDiffSets<Long> indexUpdates( IndexDescriptor index, Object value );
+
+    /**
+     * The way tokens are created is that the first time a token is needed it gets created in its own little
+     * token mini-transaction, separate from the surrounding transaction that creates or modifies data that need it.
+     * From the kernel POV it's interesting to know whether or not any tokens have been created in this tx state,
+     * because then we know it's a mini-transaction like this and won't have to let transaction event handlers
+     * know about it, for example.
+     */
+    boolean hasTokenChanges();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -147,6 +147,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     private LegacyIndexTransactionState legacyIndexTransactionState;
     private TransactionType transactionType = TransactionType.ANY;
     private TransactionHooks.TransactionHooksState hooksState;
+    private boolean beforeHookInvoked;
     private Locks.Client locks;
     private boolean closing, closed;
     private boolean failure, success;
@@ -210,6 +211,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.terminated = closing = closed = failure = success = false;
         this.transactionType = TransactionType.ANY;
         this.hooksState = null;
+        this.beforeHookInvoked = false;
         this.txState = null; // TODO: Implement txState.clear() instead, to re-use data structures
         this.legacyIndexTransactionState.initialize();
         this.recordState.initialize( lastCommittedTx );
@@ -458,10 +460,20 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
 
         try ( CommitEvent commitEvent = transactionEvent.beginCommitEvent() )
         {
-            // Trigger transaction "before" hooks
-            if ( (hooksState = hooks.beforeCommit( txState, this, storeLayer )) != null && hooksState.failed() )
+            // Trigger transaction "before" hooks.
+            if ( hasChanges() )
             {
-                throw new TransactionFailureException( Status.Transaction.HookFailed, hooksState.failure(), "" );
+                try
+                {
+                    if ( (hooksState = hooks.beforeCommit( txState, this, storeLayer )) != null && hooksState.failed() )
+                    {
+                        throw new TransactionFailureException( Status.Transaction.HookFailed, hooksState.failure(), "" );
+                    }
+                }
+                finally
+                {
+                    beforeHookInvoked = true;
+                }
             }
 
             prepareRecordChangesFromTransactionState();
@@ -572,7 +584,10 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         try
         {
             closeTransaction();
-            hooks.afterCommit( txState, this, hooksState );
+            if ( beforeHookInvoked )
+            {
+                hooks.afterCommit( txState, this, hooksState );
+            }
         }
         finally
         {
@@ -585,7 +600,10 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         try
         {
             closeTransaction();
-            hooks.afterRollback( txState, this, hooksState );
+            if ( beforeHookInvoked )
+            {
+                hooks.afterRollback( txState, this, hooksState );
+            }
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -388,6 +388,11 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                counts.hasChanges();
     }
 
+    private boolean hasAnyTokenChanges()
+    {
+        return hasTxStateWithChanges() ? txState.hasTokenChanges() : false;
+    }
+
     public TransactionRecordState getTransactionRecordState()
     {
         return recordState;
@@ -461,7 +466,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         try ( CommitEvent commitEvent = transactionEvent.beginCommitEvent() )
         {
             // Trigger transaction "before" hooks.
-            if ( hasChanges() )
+            if ( hasChanges() && !hasAnyTokenChanges() )
             {
                 try
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -29,8 +29,8 @@ import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
-import org.neo4j.graphdb.Direction;
 import org.neo4j.function.Function;
+import org.neo4j.graphdb.Direction;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
@@ -39,9 +39,9 @@ import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.txstate.ReadableTxState;
 import org.neo4j.kernel.api.txstate.RelationshipChangeVisitorAdapter;
+import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.api.txstate.TxStateVisitor;
 import org.neo4j.kernel.api.txstate.UpdateTriState;
-import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.util.diffsets.DiffSets;
 import org.neo4j.kernel.impl.util.diffsets.DiffSetsVisitor;
@@ -1134,5 +1134,11 @@ public final class TxState implements TransactionState
         createdRelationshipLegacyIndexes.put(indexName, customConfig);
 
         hasChanges = true;
+    }
+
+    @Override
+    public boolean hasTokenChanges()
+    {
+        return createdLabelTokens != null || createdPropertyKeyTokens != null || createdRelationshipTypeTokens != null;
     }
 }


### PR DESCRIPTION
This was a behaviour change introduced in 2.2 by mistake.

Additionally (in a second commit):
Prevents token mini-transactions from triggering tx events

since that causes confusion and the TransactionData cannot access
information about created tokens anyway.
