### PR TITLE
Removes post commit check for uniqueness constraint

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UniquePropertyIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/UniquePropertyIndexUpdater.java
@@ -24,16 +24,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.neo4j.kernel.api.index.DuplicateIndexEntryConflictException;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
-import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.impl.util.diffsets.DiffSets;
-
-import static org.neo4j.helpers.collection.IteratorUtil.asSet;
-import static org.neo4j.helpers.collection.IteratorUtil.single;
 
 /**
  * This IndexUpdater ensures that updated properties abide by uniqueness constraints. Updates are grouped up in
@@ -42,19 +37,8 @@ import static org.neo4j.helpers.collection.IteratorUtil.single;
  */
 public abstract class UniquePropertyIndexUpdater implements IndexUpdater
 {
-    public interface Lookup
-    {
-        Long currentlyIndexedNode( Object value ) throws IOException;
-    }
-
     private final Map<Object, DiffSets<Long>> referenceCount = new HashMap<>();
     private final ArrayList<NodePropertyUpdate> updates = new ArrayList<>();
-    private final Lookup lookup;
-
-    public UniquePropertyIndexUpdater( Lookup lookup )
-    {
-        this.lookup = lookup;
-    }
 
     @Override
     public void process( NodePropertyUpdate update )
@@ -83,27 +67,6 @@ public abstract class UniquePropertyIndexUpdater implements IndexUpdater
     @Override
     public void close() throws IOException, IndexEntryConflictException, IndexCapacityExceededException
     {
-        // verify uniqueness
-        for ( Map.Entry<Object, DiffSets<Long>> entry : referenceCount.entrySet() )
-        {
-            Object value = entry.getKey();
-            int delta = entry.getValue().delta();
-            if ( delta > 1 )
-            {
-                throw new DuplicateIndexEntryConflictException( value, asSet( entry.getValue().getAdded() ) );
-            }
-            if ( delta == 1 )
-            {
-                Long addedNode = single( entry.getValue().getAdded() );
-                Long existingNode = lookup.currentlyIndexedNode( value );
-
-                if ( existingNode != null && !addedNode.equals( existingNode ) )
-                {
-                    throw new PreexistingIndexEntryConflictException( value, existingNode, addedNode );
-                }
-            }
-        }
-
         // flush updates
         flushUpdates( updates );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 import org.neo4j.kernel.api.index.IndexEntryConflictException;
@@ -37,7 +36,7 @@ import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.UniquePropertyIndexUpdater;
 
-class UniqueInMemoryIndex extends InMemoryIndex implements UniquePropertyIndexUpdater.Lookup
+class UniqueInMemoryIndex extends InMemoryIndex
 {
     private final int propertyKeyId;
 
@@ -59,7 +58,7 @@ class UniqueInMemoryIndex extends InMemoryIndex implements UniquePropertyIndexUp
     @Override
     protected IndexUpdater newUpdater( final IndexUpdateMode mode, final boolean populating )
     {
-        return new UniquePropertyIndexUpdater( this )
+        return new UniquePropertyIndexUpdater()
         {
             @Override
             protected void flushUpdates( Iterable<NodePropertyUpdate> updates )
@@ -97,13 +96,6 @@ class UniqueInMemoryIndex extends InMemoryIndex implements UniquePropertyIndexUp
                 nodeIds.visitKeys( removeFromIndex );
             }
         };
-    }
-
-    @Override
-    public Long currentlyIndexedNode( Object value ) throws IOException
-    {
-        PrimitiveLongIterator nodes = lookup( value );
-        return nodes.hasNext() ? nodes.next() : null;
     }
 
     @Override

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/UniqueLuceneIndexAccessor.java
@@ -23,9 +23,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.lucene.document.Document;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.TopDocs;
 
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.helpers.CancellationRequest;
@@ -41,7 +39,7 @@ import org.neo4j.kernel.impl.api.index.UniquePropertyIndexUpdater;
 /**
  * Variant of {@link LuceneIndexAccessor} that also verifies uniqueness constraints.
  */
-class UniqueLuceneIndexAccessor extends LuceneIndexAccessor implements UniquePropertyIndexUpdater.Lookup
+class UniqueLuceneIndexAccessor extends LuceneIndexAccessor
 {
     public UniqueLuceneIndexAccessor( LuceneDocumentStructure documentStructure,
                                       IndexWriterFactory<ReservingLuceneIndexWriter> indexWriterFactory,
@@ -69,26 +67,6 @@ class UniqueLuceneIndexAccessor extends LuceneIndexAccessor implements UniquePro
     protected IndexReader makeNewReader( IndexSearcher searcher, Closeable closeable, CancellationRequest cancellation )
     {
         return new LuceneUniqueIndexAccessorReader( searcher, documentStructure, closeable, cancellation );
-    }
-
-    @Override
-    public Long currentlyIndexedNode( Object value ) throws IOException
-    {
-        IndexSearcher searcher = searcherManager.acquire();
-        try
-        {
-            TopDocs docs = searcher.search( documentStructure.newQuery( value ), 1 );
-            if ( docs.scoreDocs.length > 0 )
-            {
-                Document doc = searcher.getIndexReader().document( docs.scoreDocs[0].doc );
-                return documentStructure.getNodeId( doc );
-            }
-        }
-        finally
-        {
-            searcherManager.release( searcher );
-        }
-        return null;
     }
 
     /* The fact that this is here is a sign of a design error, and we should revisit and
@@ -126,7 +104,6 @@ class UniqueLuceneIndexAccessor extends LuceneIndexAccessor implements UniquePro
 
         public LuceneUniquePropertyIndexUpdater( IndexUpdater delegate )
         {
-            super( UniqueLuceneIndexAccessor.this );
             this.delegate = delegate;
         }
 


### PR DESCRIPTION
This commit removes a check that happened on uniqueness indexes
 after commit had already occured. This check would ensure that
 values added to an index were indeed unique. Given that
 locks ensure this invariant before commit begins, it is
 not clear why it would be necessary to do so. Moreover,
 having exceptions interrupt the transaction application
 process can lead to unexpected behaviour.
The commit also adds a test cases that reproduces the scenario
 which made this problem obvious. Since lucene indexes
 store only double values, there are some rounding errors
 that we have to deal with when storing long values. The
 check that was removed would not deal properly with this
 case and would lead to exceptions during transaction
 application while no constraint was actually being
 violated.

Undoes part of 2b7c813f71e901e8fc7ec3290211ceaecdba75f9
