### PR TITLE
Ensures INSTANCE_ID header is passed in Learner catchUp messages

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
@@ -136,12 +136,17 @@ public enum HeartbeatState
                                 long lastLearned = Long.parseLong( message.getHeader( "last-learned" ) );
                                 if ( lastLearned > context.getLastKnownLearnedInstanceInCluster() )
                                 {
-                                    // Need to pass the FROM header to catchUp state,
-                                    // as the instance in catchUp state should be aware of at least one
-                                    // alive member of the cluster (can use FROM as such instance)
+                                    /*
+                                     * Need to pass the INSTANCE_ID header to catchUp state,
+                                     * as the instance in catchUp state should be aware of at least one
+                                     * alive member of the cluster. FROM used to be abused for this reason
+                                     * previously, so we leave it here for legacy reasons - should really have
+                                     * no use within the current codebase but mixed version clusters may
+                                     * make use of it.
+                                     */
                                     Message<LearnerMessage> catchUpMessage = message.copyHeadersTo(
                                             internal( LearnerMessage.catchUp, lastLearned ),
-                                            Message.FROM );
+                                            Message.FROM, Message.INSTANCE_ID );
                                     outgoing.offer( catchUpMessage );
                                 }
                             }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
@@ -32,10 +32,12 @@ import org.neo4j.cluster.com.message.MessageHolder;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AcceptorInstanceStore;
+import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.LearnerMessage;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context.MultiPaxosContext;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.ElectionRole;
+import org.neo4j.cluster.protocol.omega.MessageArgumentMatcher;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -44,6 +46,8 @@ import org.neo4j.kernel.logging.Logging;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class HeartbeatStateTest
@@ -114,5 +118,47 @@ public class HeartbeatStateTest
         // Then
         assertThat( heartbeatContext.getSuspicionsOf( myId ).size(), equalTo( 0 ) );
         assertThat( heartbeatContext.getSuspicionsOf( foreignId ).size(), equalTo( 1 ) );
+    }
+
+    @Test
+    public void shouldAddInstanceIdHeaderInCatchUpMessages() throws Throwable
+    {
+        // Given
+        InstanceId instanceId = new InstanceId( 1 );
+        HeartbeatState heartbeat= HeartbeatState.heartbeat;
+        ClusterConfiguration configuration = new ClusterConfiguration("whatever", StringLogger.DEV_NULL,
+                "cluster://1", "cluster://2" );
+        configuration.joined( instanceId, URI.create("cluster://1" ) );
+        InstanceId otherInstance = new InstanceId( 2 );
+        configuration.joined( otherInstance, URI.create("cluster://2" ));
+
+        Logging logging = mock( Logging.class );
+        when( logging.getMessagesLog( Matchers.<Class>any() ) ).thenReturn( mock( StringLogger.class ) );
+
+        MultiPaxosContext context = new MultiPaxosContext( instanceId, Iterables.<ElectionRole, ElectionRole>iterable(
+                new ElectionRole( "coordinator" ) ), configuration,
+                Mockito.mock( Executor.class ), logging,
+                Mockito.mock( ObjectInputStreamFactory.class), Mockito.mock( ObjectOutputStreamFactory.class),
+                Mockito.mock( AcceptorInstanceStore.class), Mockito.mock( Timeouts.class),
+                mock( ElectionCredentialsProvider.class) );
+
+        int lastDeliveredInstanceId = 100;
+        context.getLearnerContext().setLastDeliveredInstanceId( lastDeliveredInstanceId );
+        // This gap will trigger the catchUp message that we'll test against
+        lastDeliveredInstanceId += 20;
+
+        HeartbeatContext heartbeatContext = context.getHeartbeatContext();
+        Message received = Message.internal( HeartbeatMessage.i_am_alive,
+                new HeartbeatMessage.IAmAliveState( otherInstance ) );
+        received.setHeader( Message.FROM, "cluster://2" ).setHeader( Message.INSTANCE_ID, "2" )
+                .setHeader( "last-learned", Integer.toString( lastDeliveredInstanceId ) );
+
+        // When
+        MessageHolder holder = mock( MessageHolder.class );
+        heartbeat.handle( heartbeatContext, received, holder );
+
+        // Then
+        verify( holder, times( 1 ) ).offer( Matchers.argThat( new MessageArgumentMatcher<LearnerMessage>()
+                .onMessageType( LearnerMessage.catchUp ).withHeader( Message.INSTANCE_ID, "2" ) ) );
     }
 }


### PR DESCRIPTION
When a received heartbeat message contains a last learned header with
 a value larger than what we already know, this triggers a request
 for catching up with the current cluster state. The instance that
 delivered the triggering heartbeat is marked as the last known
 alive instance to be at that state. It used to be that the
 FROM header was used for that purpose but that changed to be
 the INSTANCE_ID header. The change however was not done all
 the way through so a bug was present. This commit fixes the
 issue.
It also adds the ability to MessageArgumentMatchers to match on
 headers and their values.
