### PR TITLE
Provide more specific exceptions for missing, duplicated indexes and constraints

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundPlanContext.scala
@@ -26,7 +26,7 @@ import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.Statement
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.kernel.api.exceptions.KernelException
-import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException
+import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore
 
@@ -49,7 +49,7 @@ class TransactionBoundPlanContext(someStatement: Statement, val gdb: GraphDataba
   }
 
   private def evalOrNone[T](f: => Option[T]): Option[T] =
-    try { f } catch { case _: SchemaRuleNotFoundException => None }
+    try { f } catch { case _: SchemaKernelException => None }
 
   private def getOnlineIndex(descriptor: IndexDescriptor): Option[IndexDescriptor] =
     statement.readOperations().indexGetState(descriptor) match {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
@@ -26,7 +26,7 @@ import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.Statement
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.kernel.api.exceptions.KernelException
-import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException
+import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore
 
@@ -49,7 +49,7 @@ class TransactionBoundPlanContext(initialStatement: Statement, val gdb: GraphDat
   }
 
   private def evalOrNone[T](f: => Option[T]): Option[T] =
-    try { f } catch { case _: SchemaRuleNotFoundException => None }
+    try { f } catch { case _: SchemaKernelException => None }
 
   private def getOnlineIndex(descriptor: IndexDescriptor): Option[IndexDescriptor] =
     statement.readOperations().indexGetState(descriptor) match {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaRead.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaRead.java
@@ -25,6 +25,7 @@ import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.exceptions.schema.DuplicateIndexSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
@@ -43,7 +44,7 @@ interface SchemaRead
 
     /** Returns the constraint index for the given labelId and propertyKey. */
     IndexDescriptor uniqueIndexGetForLabelAndPropertyKey( int labelId, int propertyKeyId )
-        throws SchemaRuleNotFoundException;
+            throws SchemaRuleNotFoundException, DuplicateIndexSchemaRuleException;
 
     /** Get all constraint indexes for a label. */
     Iterator<IndexDescriptor> uniqueIndexesGetForLabel( int labelId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -209,6 +209,7 @@ public interface Status
         NoSuchPropertyKey( DatabaseError, "The request accessed a property that does not exist." ),
         NoSuchRelationshipType( DatabaseError, "The request accessed a relationship type that does not exist." ),
         NoSuchSchemaRule( DatabaseError, "The request referred to a schema rule that does not exist." ),
+        DuplicateSchemaRule( DatabaseError, "The request referred to a schema rule that defined multiple times." ),
 
         LabelLimitReached( ClientError, "The maximum number of labels supported has been reached, no more labels can be created." ),
         IndexLimitReached( ClientError, "The maximum number of index entries supported has been reached, no more entities can be indexed." ),

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DuplicateEntitySchemaRuleException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DuplicateEntitySchemaRuleException.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.schema;
+
+import org.neo4j.kernel.api.EntityType;
+import org.neo4j.kernel.api.TokenNameLookup;
+
+import static java.lang.String.format;
+
+public class DuplicateEntitySchemaRuleException extends DuplicateSchemaRuleException
+{
+    private static final String DUPLICATE_NODE_RULE_MESSAGE_TEMPLATE =
+            "Multiple %s found for label '%s' and property '%s'.";
+    private static final String DUPLICATED_RELATIONSHIP_RULE_MESSAGE_TEMPLATE =
+            "Multiple %s found for relationship type '%s' and property '%s'.";
+
+    private EntityType entityType;
+
+    public DuplicateEntitySchemaRuleException( EntityType entityType, int entityId, int propertyKeyId )
+    {
+        this( entityType, entityId, propertyKeyId, false );
+    }
+
+    public DuplicateEntitySchemaRuleException( EntityType entityType, int ruleEntityId, int propertyKeyId,
+            boolean unique )
+    {
+        super( getMessageTemplate( entityType ), ruleEntityId, propertyKeyId,
+                unique ? UNIQUE_CONSTRAINT_PREFIX : CONSTRAINT_PREFIX );
+        this.entityType = entityType;
+    }
+
+
+    @Override
+    public String getUserMessage( TokenNameLookup tokenNameLookup )
+    {
+        String entityName = EntityType.NODE == entityType ? tokenNameLookup.labelGetName( ruleEntityId ) :
+                            tokenNameLookup.relationshipTypeGetName( ruleEntityId );
+        return format( messageTemplate, messagePrefix, entityName,
+                tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
+    }
+
+    private static String getMessageTemplate( EntityType entityType )
+    {
+        switch ( entityType )
+        {
+        case NODE:
+            return DUPLICATE_NODE_RULE_MESSAGE_TEMPLATE;
+        case RELATIONSHIP:
+            return DUPLICATED_RELATIONSHIP_RULE_MESSAGE_TEMPLATE;
+        default:
+            throw new IllegalArgumentException( "Schema rules for specified entityType not supported." );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DuplicateIndexSchemaRuleException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DuplicateIndexSchemaRuleException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.schema;
+
+import org.neo4j.kernel.api.TokenNameLookup;
+
+import static java.lang.String.format;
+
+public class DuplicateIndexSchemaRuleException extends DuplicateSchemaRuleException
+{
+    private static final String UNIQUE_INDEX_PREFIX = "uniqueness indexes";
+    private static final String INDEX_PREFIX = "indexes";
+
+    private static final String DUPLICATE_INDEX_RULE_MESSAGE_TEMPLATE =
+            "Multiple %s found for label '%s' and property '%s'.";
+
+    public DuplicateIndexSchemaRuleException( int ruleEntityId, int propertyKeyId,
+            boolean unique )
+    {
+        super( DUPLICATE_INDEX_RULE_MESSAGE_TEMPLATE, ruleEntityId, propertyKeyId,
+                unique ? UNIQUE_INDEX_PREFIX : INDEX_PREFIX );
+    }
+
+    @Override
+    public String getUserMessage( TokenNameLookup tokenNameLookup )
+    {
+        return format( messageTemplate, messagePrefix,
+                tokenNameLookup.labelGetName( ruleEntityId ),
+                tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DuplicateSchemaRuleException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/DuplicateSchemaRuleException.java
@@ -21,15 +21,14 @@ package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.exceptions.Status;
 
-public abstract class SchemaRuleNotFoundException extends SchemaRuleException
+public abstract class DuplicateSchemaRuleException extends SchemaRuleException
 {
-    protected static final String UNIQUE_CONSTRAINT_PREFIX = "Uniqueness constraint";
-    protected static final String CONSTRAINT_PREFIX = "Constraint";
+    protected static final String UNIQUE_CONSTRAINT_PREFIX = "uniqueness constraints";
+    protected static final String CONSTRAINT_PREFIX = "constraints";
 
-    protected SchemaRuleNotFoundException( String messageTemplate, int ruleEntityId, int propertyKeyId, String messagePrefix)
+    protected DuplicateSchemaRuleException( String messageTemplate, int ruleEntityId, int propertyKeyId, String
+            messagePrefix )
     {
-        super( Status.Schema.NoSuchSchemaRule, messageTemplate, ruleEntityId, propertyKeyId, messagePrefix );
-
+        super( Status.Schema.DuplicateSchemaRule, messageTemplate, ruleEntityId, propertyKeyId, messagePrefix );
     }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/EntitySchemaRuleNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/EntitySchemaRuleNotFoundException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.schema;
+
+import org.neo4j.kernel.api.EntityType;
+import org.neo4j.kernel.api.TokenNameLookup;
+
+public class EntitySchemaRuleNotFoundException extends SchemaRuleNotFoundException
+{
+    private static final String NODE_RULE_NOT_FOUND_MESSAGE_TEMPLATE =
+            "%s for label '%s' and property '%s' not found.";
+    private static final String RELATIONSHIP_RULE_NOT_FOUND_MESSAGE_TEMPLATE =
+            "%s for relationship type '%s' and property '%s' not found.";
+    private EntityType entityType;
+
+    public EntitySchemaRuleNotFoundException( EntityType entityType, int labelId, int propertyKeyId )
+    {
+        this( entityType, labelId, propertyKeyId, false );
+    }
+
+    public EntitySchemaRuleNotFoundException( EntityType entityType, int entityId, int propertyKeyId, boolean unique )
+    {
+        super( getMessageTemplate( entityType ), entityId, propertyKeyId,
+                unique ? UNIQUE_CONSTRAINT_PREFIX : CONSTRAINT_PREFIX );
+        this.entityType = entityType;
+    }
+
+    @Override
+    public String getUserMessage( TokenNameLookup tokenNameLookup )
+    {
+        String entityName = EntityType.NODE == entityType ? tokenNameLookup.labelGetName( ruleEntityId ) :
+                            tokenNameLookup.relationshipTypeGetName( ruleEntityId );
+        return String.format( messageTemplate, messagePrefix, entityName,
+                tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
+    }
+
+    private static String getMessageTemplate( EntityType entityType )
+    {
+        switch ( entityType )
+        {
+        case NODE:
+            return NODE_RULE_NOT_FOUND_MESSAGE_TEMPLATE;
+        case RELATIONSHIP:
+            return RELATIONSHIP_RULE_NOT_FOUND_MESSAGE_TEMPLATE;
+        default:
+            throw new IllegalArgumentException( "Schema rules for specified entityType not supported." );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexSchemaRuleNotFoundException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/IndexSchemaRuleNotFoundException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.exceptions.schema;
+
+import org.neo4j.kernel.api.TokenNameLookup;
+
+public class IndexSchemaRuleNotFoundException extends SchemaRuleNotFoundException
+{
+    private static final String UNIQUE_INDEX_PREFIX = "Uniqueness index";
+    private static final String INDEX_PREFIX = "Index";
+    private static final String INDEX_RULE_NOT_FOUND_MESSAGE_TEMPLATE =
+            "%s for label '%s' and property '%s' not found.";
+
+    public IndexSchemaRuleNotFoundException( int labelId, int propertyKeyId )
+    {
+        this( labelId, propertyKeyId, false );
+    }
+
+    public IndexSchemaRuleNotFoundException( int labelId, int propertyKeyId, boolean unique )
+    {
+        super( INDEX_RULE_NOT_FOUND_MESSAGE_TEMPLATE, labelId, propertyKeyId,
+                unique ? UNIQUE_INDEX_PREFIX : INDEX_PREFIX );
+    }
+
+    @Override
+    public String getUserMessage( TokenNameLookup tokenNameLookup )
+    {
+        return String.format( messageTemplate, messagePrefix,
+                tokenNameLookup.labelGetName( ruleEntityId ),
+                tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/SchemaRuleException.java
@@ -21,15 +21,23 @@ package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.exceptions.Status;
 
-public abstract class SchemaRuleNotFoundException extends SchemaRuleException
+import static java.lang.String.format;
+
+public class SchemaRuleException extends SchemaKernelException
 {
-    protected static final String UNIQUE_CONSTRAINT_PREFIX = "Uniqueness constraint";
-    protected static final String CONSTRAINT_PREFIX = "Constraint";
 
-    protected SchemaRuleNotFoundException( String messageTemplate, int ruleEntityId, int propertyKeyId, String messagePrefix)
+    protected final int ruleEntityId;
+    protected final int propertyKeyId;
+    protected final String messageTemplate;
+    protected final String messagePrefix;
+
+    protected SchemaRuleException( Status status, String messageTemplate, int ruleEntityId, int propertyKeyId,
+            String messagePrefix)
     {
-        super( Status.Schema.NoSuchSchemaRule, messageTemplate, ruleEntityId, propertyKeyId, messagePrefix );
-
+        super( status, format( messageTemplate, messagePrefix, ruleEntityId, propertyKeyId ) );
+        this.ruleEntityId = ruleEntityId;
+        this.propertyKeyId = propertyKeyId;
+        this.messageTemplate = messageTemplate;
+        this.messagePrefix = messagePrefix;
     }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -47,6 +47,7 @@ import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
+import org.neo4j.kernel.api.exceptions.schema.DuplicateSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
@@ -951,6 +952,10 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                         "Constraint to be removed should exist, since its existence should " +
                                 "have been validated earlier and the schema should have been locked." );
             }
+            catch ( DuplicateSchemaRuleException de )
+            {
+                throw new IllegalStateException( "Multiple constraints found for specified label and property." );
+            }
             // Remove the index for the constraint as well
             visitRemovedIndex( new IndexDescriptor( element.label(), element.propertyKey() ), true );
         }
@@ -977,6 +982,11 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                 throw new IllegalStateException(
                         "Mandatory node property constraint to be removed should exist, since its existence should " +
                                 "have been validated earlier and the schema should have been locked." );
+            }
+            catch ( DuplicateSchemaRuleException de )
+            {
+                throw new IllegalStateException( "Multiple node property constraints found for specified label and " +
+                                                 "property." );
             }
         }
 
@@ -1005,6 +1015,11 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                 throw new IllegalStateException(
                         "Mandatory relationship property constraint to be removed should exist, since its existence " +
                                 "should have been validated earlier and the schema should have been locked." );
+            }
+            catch ( DuplicateSchemaRuleException re )
+            {
+                throw new IllegalStateException( "Multiple relationship property constraints found for specified " +
+                                                 "property and relationship type." );
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -54,8 +54,10 @@ import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelExceptio
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
+import org.neo4j.kernel.api.exceptions.schema.DuplicateIndexSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
+import org.neo4j.kernel.api.exceptions.schema.IndexSchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -540,7 +542,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
         IndexDescriptor descriptor = schemaRead().indexesGetForLabelAndPropertyKey( statement, labelId, propertyKeyId );
         if ( descriptor == null )
         {
-            throw SchemaRuleNotFoundException.forNode( labelId, propertyKeyId, "not found" );
+            throw new IndexSchemaRuleNotFoundException( labelId, propertyKeyId);
         }
         return descriptor;
     }
@@ -561,7 +563,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
 
     @Override
     public IndexDescriptor uniqueIndexGetForLabelAndPropertyKey( int labelId, int propertyKeyId )
-            throws SchemaRuleNotFoundException
+            throws SchemaRuleNotFoundException, DuplicateIndexSchemaRuleException
 
     {
         IndexDescriptor result = null;
@@ -577,14 +579,14 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
                 }
                 else
                 {
-                    throw SchemaRuleNotFoundException.forNode( labelId, propertyKeyId, "duplicate uniqueness index" );
+                    throw new DuplicateIndexSchemaRuleException( labelId, propertyKeyId, true );
                 }
             }
         }
 
         if ( null == result )
         {
-            throw SchemaRuleNotFoundException.forNode( labelId, propertyKeyId, "uniqueness index not found" );
+            throw new IndexSchemaRuleNotFoundException( labelId, propertyKeyId, true);
         }
 
         return result;

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -222,8 +222,8 @@ public class SchemaAcceptanceTest
             }
             catch ( ConstraintViolationException e )
             {
-                assertThat( e.getMessage(), containsString( "Index rule(s) for label 'MY_LABEL' and property " +
-                                                            "'my_property_key': not found." ) );
+                assertThat( e.getMessage(), containsString( "Index for label 'MY_LABEL' and property " +
+                                                            "'my_property_key' not found." ) );
             }
             tx.success();
         }
@@ -247,8 +247,8 @@ public class SchemaAcceptanceTest
         }
         catch ( ConstraintViolationException e )
         {
-            assertThat( e.getMessage(), containsString( "Index rule(s) for label 'MY_LABEL' and property " +
-                                                        "'my_property_key': not found." ) );
+            assertThat( e.getMessage(), containsString( "Index for label 'MY_LABEL' and property " +
+                                                        "'my_property_key' not found." ) );
         }
 
         // THEN

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/OperationsFacadeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/OperationsFacadeTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.schema.DuplicateIndexSchemaRuleException;
+import org.neo4j.kernel.api.exceptions.schema.IndexSchemaRuleNotFoundException;
+import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
+import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
+import org.neo4j.test.KernelExceptionUserMessageMatcher;
+
+@RunWith( MockitoJUnitRunner.class )
+public class OperationsFacadeTest
+{
+    private final String LABEL1 = "Label1";
+    private final String PROP1 = "Prop1";
+    private final int LABEL1_ID = 1;
+    private final int PROP1_ID = 2;
+
+    @Mock
+    private KernelStatement kernelStatement;
+    @Mock
+    private StatementOperationParts statementOperationParts;
+    @Mock
+    private SchemaReadOperations schemaReadOperations;
+    @InjectMocks
+    private OperationsFacade operationsFacade;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testThrowExceptionWhenIndexNotFoundByLabelAndProperty() throws SchemaRuleNotFoundException
+    {
+        setupSchemaReadOperations();
+
+        TokenNameLookup tokenNameLookup = getDefaultTokenNameLookup();
+
+        expectedException.expect( IndexSchemaRuleNotFoundException.class );
+        expectedException.expect( new KernelExceptionUserMessageMatcher<>( tokenNameLookup,
+                "Index for label 'Label1' and property 'Prop1' not found." ) );
+
+        operationsFacade.indexesGetForLabelAndPropertyKey( LABEL1_ID, PROP1_ID );
+    }
+
+    @Test
+    public void testThrowExceptionWhenDuplicateUniqueIndexFound()
+            throws SchemaRuleNotFoundException, DuplicateIndexSchemaRuleException
+    {
+        SchemaReadOperations readOperations = setupSchemaReadOperations();
+        Mockito.when( readOperations
+                .uniqueIndexesGetForLabel( Mockito.any( KernelStatement.class ), Mockito.eq( LABEL1_ID ) ) )
+                .thenReturn( IteratorUtil.iterator( new IndexDescriptor( LABEL1_ID, PROP1_ID ),
+                        new IndexDescriptor( LABEL1_ID, PROP1_ID ) ) );
+        TokenNameLookup tokenNameLookup = getDefaultTokenNameLookup();
+
+        expectedException.expect( DuplicateIndexSchemaRuleException.class );
+        expectedException.expect( new KernelExceptionUserMessageMatcher<>( tokenNameLookup,
+                "Multiple uniqueness indexes found for label 'Label1' and property 'Prop1'." ) );
+
+        operationsFacade.uniqueIndexGetForLabelAndPropertyKey( LABEL1_ID, PROP1_ID );
+    }
+
+    @Test
+    public void testThrowExceptionWhenUniqueIndexNotFound()
+            throws SchemaRuleNotFoundException, DuplicateIndexSchemaRuleException
+    {
+        SchemaReadOperations readOperations = setupSchemaReadOperations();
+        TokenNameLookup tokenNameLookup = getDefaultTokenNameLookup();
+        Mockito.when( readOperations
+                .uniqueIndexesGetForLabel( Mockito.any( KernelStatement.class ), Mockito.eq( LABEL1_ID ) ) )
+                .thenReturn( IteratorUtil.<IndexDescriptor>emptyIterator() );
+
+        expectedException.expect( IndexSchemaRuleNotFoundException.class );
+        expectedException.expect( new KernelExceptionUserMessageMatcher<>( tokenNameLookup,
+                "Uniqueness index for label 'Label1' and property 'Prop1' not found." ) );
+
+        operationsFacade.uniqueIndexGetForLabelAndPropertyKey( LABEL1_ID, PROP1_ID );
+    }
+
+    private SchemaReadOperations setupSchemaReadOperations()
+    {
+        SchemaReadOperations readOperations = Mockito.mock(SchemaReadOperations.class);
+        Mockito.when( statementOperationParts.schemaReadOperations() ).thenReturn( readOperations );
+        return readOperations;
+    }
+
+    private TokenNameLookup getDefaultTokenNameLookup()
+    {
+        TokenNameLookup tokenNameLookup = Mockito.mock( TokenNameLookup.class );
+        Mockito.when( tokenNameLookup.labelGetName( LABEL1_ID ) ).thenReturn( LABEL1 );
+        Mockito.when( tokenNameLookup.propertyKeyGetName( PROP1_ID ) ).thenReturn( PROP1 );
+        return tokenNameLookup;
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/test/KernelExceptionUserMessageMatcher.java
+++ b/community/kernel/src/test/java/org/neo4j/test/KernelExceptionUserMessageMatcher.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException;
+
+public class KernelExceptionUserMessageMatcher<T extends SchemaKernelException> extends BaseMatcher<T>
+{
+    private TokenNameLookup tokenNameLookup;
+    private String expectedMessage;
+    private String actualMessage;
+
+    public KernelExceptionUserMessageMatcher( TokenNameLookup tokenNameLookup, String expectedMessage )
+    {
+        this.tokenNameLookup = tokenNameLookup;
+        this.expectedMessage = expectedMessage;
+    }
+
+    @Override
+    public boolean matches( Object item )
+    {
+        if ( item instanceof SchemaKernelException )
+        {
+            actualMessage = ((SchemaKernelException) item).getUserMessage( tokenNameLookup );
+            return expectedMessage.equals( actualMessage );
+        }
+        return false;
+    }
+
+    @Override
+    public void describeTo( Description description )
+    {
+        description.appendText( " expected message: '" ).appendText( expectedMessage )
+                .appendText( "', but was: '" ).appendText( actualMessage ).appendText( "'" );
+    }
+}


### PR DESCRIPTION
- split SchemaRuleNotFoundException to more specific exceptions
- introduce hierarchy of exceptions for duplicate schema rules 
- provide tests for expected user messages.
