### PR TITLE
Fixed indentation of constraints in 'schema' shell command

### DIFF
--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
@@ -52,6 +52,8 @@ import static org.neo4j.shell.Continuation.INPUT_COMPLETE;
 
 public class Schema extends TransactionProvidingApp
 {
+    private static final String INDENT = "  ";
+
     private static final Function<IndexDefinition, String> LABEL_COMPARE_FUNCTION =
             new Function<IndexDefinition, String>()
             {
@@ -292,7 +294,7 @@ public class Schema extends TransactionProvidingApp
                 out.println( "Constraints" );
             }
 
-            out.println( constraint.toString() );
+            out.println( indent( constraint.toString() ) );
             j++;
 
         }
@@ -306,7 +308,7 @@ public class Schema extends TransactionProvidingApp
     private void reportNodeIndexes( Output out, org.neo4j.graphdb.schema.Schema schema, Label[] labels, String property,
             boolean verbose ) throws RemoteException
     {
-        ColumnPrinter printer = new ColumnPrinter( "  ON ", "", "" );
+        ColumnPrinter printer = new ColumnPrinter( indent( "ON " ), "", "" );
         Iterable<IndexDefinition> indexes = indexesByLabelAndProperty( schema, labels, property );
         
         int i = 0;
@@ -481,5 +483,10 @@ public class Schema extends TransactionProvidingApp
             }, indexes );
         }
         return indexes;
+    }
+
+    private static String indent( String str )
+    {
+        return INDENT + str;
     }
 }

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -992,6 +992,36 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
+    public void shouldHaveCorrectIndentationsInSchemaListing() throws Exception
+    {
+        // GIVEN
+        Label label = DynamicLabel.label( "Person" );
+        RelationshipType relType = DynamicRelationshipType.withName( "KNOWS" );
+
+        // WHEN
+        beginTx();
+        db.schema().constraintFor( label ).assertPropertyIsUnique( "name" ).create();
+        finishTx();
+
+        beginTx();
+        db.schema().constraintFor( label ).assertPropertyExists( "name" ).create();
+        finishTx();
+
+        beginTx();
+        db.schema().constraintFor( relType ).assertPropertyExists( "since" ).create();
+        finishTx();
+
+        // THEN
+        executeCommand( "schema",
+                "Indexes",
+                "  ON :Person\\(name\\) ONLINE \\(for uniqueness constraint\\)",
+                "Constraints",
+                "  ON \\(person:Person\\) ASSERT person.name IS UNIQUE",
+                "  ON \\(person:Person\\) ASSERT person.name IS NOT NULL",
+                "  ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+    }
+
+    @Test
     public void canListUniquePropertyConstraintsByLabelAndProperty() throws Exception
     {
         // GIVEN


### PR DESCRIPTION
Fixes broken indentation:

```
Indexes
  ON :Person(name) ONLINE (for uniqueness constraint) 

Constraints
ON (person:Person) ASSERT person.name IS NOT NULL
ON (person:Person) ASSERT person.name IS UNIQUE
ON ()-[knows:KNOWS]-() ASSERT knows.since IS NOT NULL
```

to be:

```
Indexes
  ON :Person(name) ONLINE (for uniqueness constraint) 

Constraints
  ON (person:Person) ASSERT person.name IS NOT NULL
  ON (person:Person) ASSERT person.name IS UNIQUE
  ON ()-[knows:KNOWS]-() ASSERT knows.since IS NOT NULL
```
