### PR TITLE
Resolve index-out-of-bounds error and several exception issues in GAP

### DIFF
--- a/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/MessageBoundaryHook.java
+++ b/community/ndp/messaging-v1/src/main/java/org/neo4j/ndp/messaging/v1/MessageBoundaryHook.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ndp.messaging.v1;
+
+import java.io.IOException;
+
+public interface MessageBoundaryHook
+{
+    void onMessageComplete() throws IOException;
+}

--- a/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/ChunkedInput.java
+++ b/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/ChunkedInput.java
@@ -193,7 +193,7 @@ public class ChunkedInput implements PackInput
 
     private void ensureChunkAvailable() throws IOException
     {
-        if ( currentChunk == null || currentChunk.readableBytes() == 0 )
+        while ( currentChunk == null || currentChunk.readableBytes() == 0 )
         {
             currentChunkIndex++;
             if ( currentChunkIndex < chunks.size() )

--- a/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketTransportHandler.java
+++ b/community/ndp/transport-socket/src/main/java/org/neo4j/ndp/transport/socket/SocketTransportHandler.java
@@ -89,8 +89,8 @@ public class SocketTransportHandler extends ChannelInboundHandlerAdapter
     @Override
     public void exceptionCaught( ChannelHandlerContext ctx, Throwable cause ) throws Exception
     {
-        close();
         log.error( "Fatal error occurred when handling a client connection: " + cause.getMessage(), cause );
+        close();
     }
 
     private void close()

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/ChunkedInputTest.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/ChunkedInputTest.java
@@ -99,4 +99,22 @@ public class ChunkedInputTest
         // Then
         assertThat( bytes, equalTo( new byte[]{1, 2, 3, 4, 5} ) );
     }
+
+    @Test
+    public void shouldHandleEmptyBuffer() throws Throwable
+    {
+        // Given the user sent an empty network frame
+        ChunkedInput ch = new ChunkedInput();
+
+        ch.append( wrappedBuffer( new byte[]{1, 2} ) );
+        ch.append( wrappedBuffer( new byte[0] ) );
+        ch.append( wrappedBuffer( new byte[]{3} ) );
+
+        // When
+        byte[] bytes = new byte[3];
+        ch.readBytes( bytes, 0, 3 );
+
+        // Then
+        assertThat( bytes, equalTo( new byte[]{1, 2, 3} ) );
+    }
 }

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/ChunkedOutputTest.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/ChunkedOutputTest.java
@@ -51,7 +51,7 @@ public class ChunkedOutputTest
     {
         // When
         out.writeByte( (byte) 1 ).writeShort( (short) 2 );
-        out.messageBoundaryHook().run();
+        out.onMessageComplete();
         out.flush();
 
         // Then
@@ -65,7 +65,7 @@ public class ChunkedOutputTest
     {
         // When
         out.writeLong( 1 ).writeLong( 2 ).writeLong( 3 );
-        out.messageBoundaryHook().run();
+        out.onMessageComplete();
         out.flush();
 
         // Then
@@ -80,7 +80,7 @@ public class ChunkedOutputTest
     {
         // Given 2 bytes left in buffer + chunk is closed
         out.writeBytes( new byte[10], 0, 10 );  // 2 (header) + 10
-        out.messageBoundaryHook().run();        // 2 (ending)
+        out.onMessageComplete();                // 2 (ending)
 
         // When write 2 bytes
         out.writeShort( (short) 33 );           // 2 (header) + 2
@@ -96,7 +96,7 @@ public class ChunkedOutputTest
     {
         // Given
         out.writeBytes( new byte[16], 0, 16 ); // 2 + 16 is greater than the default max size 16
-        out.messageBoundaryHook().run();
+        out.onMessageComplete();
         out.flush();
 
         // When & Then

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/Chunker.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/Chunker.java
@@ -59,7 +59,7 @@ public class Chunker
         for ( byte[] message : messages )
         {
             out.writeBytes( message, 0, message.length );
-            out.messageBoundaryHook().run();
+            out.onMessageComplete();
         }
         out.flush();
 

--- a/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/client/SecureWebSocketConnection.java
+++ b/community/ndp/transport-socket/src/test/java/org/neo4j/ndp/transport/socket/client/SecureWebSocketConnection.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.helpers.HostnamePort;
@@ -41,7 +41,7 @@ public class SecureWebSocketConnection implements Connection, WebSocketListener
     private RemoteEndpoint server;
 
     // Incoming data goes on this queue
-    private final ArrayBlockingQueue<byte[]> received = new ArrayBlockingQueue<>( 4 );
+    private final LinkedBlockingQueue<byte[]> received = new LinkedBlockingQueue<>();
 
     // Current input data being handled, poppoed off of 'recieved' queue
     private byte[] currentRecieveBuffer = null;


### PR DESCRIPTION
- IOB was caused by a race between IO thread and worker thread on flushing.
  Flushing is now only ordered from the worker thread. The general behavior
  is covered by existing tests, the race condition convered by larger scale
  integration tests in quality tooling.
- Be more careful in several exception paths to log the exception before doing
  anything else
- Handle empty buffers in the input chunking
