### PR TITLE
Cluster code no longer resolves hostnames into IPs.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/HostnamePort.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/HostnamePort.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.helpers;
 
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -98,18 +96,7 @@ public class HostnamePort
         {
             return defaultHost;
         }
-
-        try
-        {
-            InetAddress ip = InetAddress.getByName( host );
-            if ( ip == null )
-            {
-                return defaultHost;
-            }
-
-            return ip.getHostAddress();
-        }
-        catch ( UnknownHostException e )
+        else
         {
             return host;
         }

--- a/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
@@ -109,8 +109,8 @@ public class HostnamePortTest
     	assertThat( HostnamePort.getHostAddress( null, "default" ), equalTo( "default" ) );
     	
     	// should return host ip address when host is known
-    	assertThat( HostnamePort.getHostAddress( hostName, "default" ), equalTo( InetAddress.getByName( hostName ).getHostAddress() ) );
-    	
+        assertThat( HostnamePort.getHostAddress( hostName, "default" ), equalTo( hostName ) );
+
     }
     
     @Test
@@ -227,9 +227,9 @@ public class HostnamePortTest
         // When & Then
         
         // Should match, same host and port
-        assertTrue( hostnamePortSinglePort.matches( URI.create( "ha://" + host1 + ":1234" ) ) );
+        assertTrue( hostnamePortSinglePort.matches( URI.create( "ha://" + hostname1 + ":1234" ) ) );
         // Should fail, different host or port
-        assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + host1 + ":1235" ) ) );
+        assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + hostname1 + ":1235" ) ) );
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + host2 + ":1234" ) ) );
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + host2 + ":1235" ) ) );
         // Should fail, no port
@@ -237,17 +237,17 @@ public class HostnamePortTest
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + host2 ) ) );
 
         // Should match, port in range and host the same
-        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1234" ) ) );
-        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1235" ) ) );
-        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1236" ) ) );
+        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1234" ) ) );
+        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1235" ) ) );
+        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1236" ) ) );
         // Should not match, different host
         assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + host2 + ":1234" ) ) );
         assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + host2 + ":1235" ) ) );
         // Should not match, port outside of range
-        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1233" ) ) );
-        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1237" ) ) );
+        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1233" ) ) );
+        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1237" ) ) );
         // Should not match, no port
-        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + host1 ) ) );
+        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 ) ) );
         assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + host2 ) ) );
     }
 
@@ -278,27 +278,27 @@ public class HostnamePortTest
         // When & Then
         
         // Should match, same host and port
-        assertTrue( hostnamePortSinglePort.matches( URI.create( "ha://" + hostname1 + ":1234" ) ) );
+        assertTrue( hostnamePortSinglePort.matches( URI.create( "ha://" + host1 + ":1234" ) ) );
         // Should fail, different host or port
-        assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + hostname1 + ":1235" ) ) );
+        assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + host1 + ":1235" ) ) );
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + hostname2 + ":1234" ) ) );
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + hostname2 + ":1235" ) ) );
         // Should fail, no port
-        assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + hostname1 ) ) );
+        assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + host1 ) ) );
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + hostname2 ) ) );
 
         // Should match, port in range and host the same
-        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1234" ) ) );
-        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1235" ) ) );
-        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1236" ) ) );
+        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1234" ) ) );
+        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1235" ) ) );
+        assertTrue( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1236" ) ) );
         // Should not match, different host
         assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + hostname2 + ":1234" ) ) );
         assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + hostname2 + ":1235" ) ) );
         // Should not match, port outside of range
-        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1233" ) ) );
-        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 + ":1237" ) ) );
+        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1233" ) ) );
+        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + host1 + ":1237" ) ) );
         // Should not match, no port
-        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + hostname1 ) ) );
+        assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + host1 ) ) );
         assertFalse( hostnamePortWithRange.matches( URI.create( "ha://" + hostname2 ) ) );
  
     }
@@ -497,20 +497,11 @@ public class HostnamePortTest
     }
     
     @Test
-    public void testHostnameLookup() throws Exception
-    {
-        String hostName = InetAddress.getLocalHost().getHostName();
-        HostnamePort hostnamePort = new HostnamePort( hostName, 1234 );
-        
-        assertThat( hostnamePort.toString( null ), equalTo( InetAddress.getByName( hostName ).getHostAddress()+":1234" ) );
-    }
-
-    @Test
     public void testIPv6Address()
     {
         HostnamePort hostnamePort = new HostnamePort( "[2001:cdba:0:0:0:0:3257:9652]" );
 
-        assertThat( hostnamePort.getHost( null ), equalTo( resolveHost( "[2001:cdba:0:0:0:0:3257:9652]" ) ) );
+        assertThat( hostnamePort.getHost( null ), equalTo( "[2001:cdba:0:0:0:0:3257:9652]" ) );
         assertThat( hostnamePort.getPort(), equalTo( 0 ) );
         assertThat( hostnamePort.getPorts(), equalTo( new int[]{0, 0} ) );
     }
@@ -520,7 +511,7 @@ public class HostnamePortTest
     {
         HostnamePort hostnamePort = new HostnamePort( "foo://[ff02::1:1]:9191" );
 
-        assertThat( hostnamePort.getHost( null ), equalTo( resolveHost( "[ff02::1:1]" ) ) );
+        assertThat( hostnamePort.getHost( null ), equalTo( "[ff02::1:1]" ) );
         assertThat( hostnamePort.getPort(), equalTo( 9191 ) );
         assertThat( hostnamePort.getPorts(), equalTo( new int[]{9191, 9191} ) );
     }
@@ -530,7 +521,7 @@ public class HostnamePortTest
     {
         HostnamePort hostnamePort = new HostnamePort( "[::1]" );
 
-        assertThat( hostnamePort.getHost( null ), equalTo( resolveHost( "[::1]" ) ) );
+        assertThat( hostnamePort.getHost( null ), equalTo( "[::1]" ) );
         assertThat( hostnamePort.getPort(), equalTo( 0 ) );
         assertThat( hostnamePort.getPorts(), equalTo( new int[]{0, 0} ) );
     }
@@ -540,20 +531,8 @@ public class HostnamePortTest
     {
         HostnamePort hostnamePort = new HostnamePort( "foo://[::1]:6362" );
 
-        assertThat( hostnamePort.getHost( null ), equalTo( resolveHost( "[::1]" ) ) );
+        assertThat( hostnamePort.getHost( null ), equalTo( "[::1]" ) );
         assertThat( hostnamePort.getPort(), equalTo( 6362 ) );
         assertThat( hostnamePort.getPorts(), equalTo( new int[]{6362, 6362} ) );
-    }
-
-    private static String resolveHost( String address )
-    {
-        try
-        {
-            return InetAddress.getByName( address ).getHostAddress();
-        }
-        catch ( UnknownHostException e )
-        {
-            throw new RuntimeException( "Unable to resolve host for '" + address + "'", e );
-        }
     }
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkReceiver.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkReceiver.java
@@ -20,7 +20,6 @@
 package org.neo4j.cluster.com;
 
 import java.net.ConnectException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -181,7 +180,6 @@ public class NetworkReceiver
         {
             try
             {
-                InetAddress host;
                 String address = config.clusterServer().getHost();
                 InetSocketAddress localAddress;
                 if ( address == null || address.equals( INADDR_ANY ))
@@ -190,8 +188,7 @@ public class NetworkReceiver
                 }
                 else
                 {
-                    host = InetAddress.getByName( address );
-                    localAddress = new InetSocketAddress( host, checkPort );
+                    localAddress = new InetSocketAddress( address, checkPort );
                 }
 
                 Channel listenChannel = serverBootstrap.bind( localAddress );

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterTest.java
@@ -59,7 +59,7 @@ public class ClusterTest
     {
         ClusterManager clusterManager = new ClusterManager( fromXml( getClass().getResource( "/threeinstances.xml" ).toURI() ),
                 testDirectory.directory(  "testCluster" ),
-                MapUtil.stringMap(HaSettings.ha_server.name(), ":6001-6005",
+                MapUtil.stringMap( HaSettings.ha_server.name(), "localhost:6001-6005",
                                   HaSettings.tx_push_factor.name(), "2"));
         try
         {

--- a/enterprise/ha/src/test/resources/fourinstances.xml
+++ b/enterprise/ha/src/test/resources/fourinstances.xml
@@ -21,9 +21,9 @@
 -->
 <clusters>
   <cluster name="neo4j.ha">
-    <member>127.0.0.1:5001</member>
-    <member>127.0.0.1:5002</member>
-    <member>127.0.0.1:5003</member>
-    <member>127.0.0.1:5004</member>
+    <member>localhost:5001</member>
+    <member>localhost:5002</member>
+    <member>localhost:5003</member>
+    <member>localhost:5004</member>
   </cluster>
 </clusters>

--- a/enterprise/ha/src/test/resources/threeinstances.xml
+++ b/enterprise/ha/src/test/resources/threeinstances.xml
@@ -21,8 +21,8 @@
 -->
 <clusters>
   <cluster name="neo4j.ha">
-    <member>127.0.0.1:5001</member>
-    <member>127.0.0.1:5002</member>
-    <member>127.0.0.1:5003</member>
+    <member>localhost:5001</member>
+    <member>localhost:5002</member>
+    <member>localhost:5003</member>
   </cluster>
 </clusters>


### PR DESCRIPTION
This should help in data center installations where a hostname might resolve into different IPs depending on which center the server is running in. Each center should see its own version of the world.
