### PR TITLE
Add pageCache to lifecycle of BatchInserterImpl

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -90,6 +90,7 @@ import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.locking.ReentrantLockService;
 import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
+import org.neo4j.kernel.impl.pagecache.PageCacheLifecycle;
 import org.neo4j.kernel.impl.store.CountsComputer;
 import org.neo4j.kernel.impl.store.LabelTokenStore;
 import org.neo4j.kernel.impl.store.NeoStore;
@@ -234,6 +235,7 @@ public class BatchInserterImpl implements BatchInserter
         ConfiguringPageCacheFactory pageCacheFactory = new ConfiguringPageCacheFactory(
                 fileSystem, config, PageCacheTracer.NULL );
         PageCache pageCache = pageCacheFactory.getOrCreatePageCache();
+        life.add( new PageCacheLifecycle( pageCache ) );
 
         msgLog = StringLogger.loggerDirectory( fileSystem, this.storeDir );
         logging = new SingleLoggingService( msgLog );


### PR DESCRIPTION
Background MunninPageCache threads are not part of the lifecycle and therefore not shutdown. Fixes  https://github.com/neo4j/neo4j/issues/5019
