### PR TITLE
Changed cypher syntax used to create/drop mandatory property constraints

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MandatoryPropertyConstraintAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MandatoryPropertyConstraintAcceptanceTest.scala
@@ -27,7 +27,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should enforce constraints on creation") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert has(node.key1)")
 
     // WHEN
     val e = intercept[ConstraintValidationException](execute("create (node:Label1)"))
@@ -38,7 +38,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should enforce constraints on creation") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert has(rel.since)")
 
     // WHEN
     val e = intercept[ConstraintValidationException](execute("create (p1:Person)-[:KNOWS]->(p2:Person)"))
@@ -49,7 +49,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should enforce on removing property") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert has(node.key1)")
 
     // WHEN
     execute("create (node1:Label1 {key1:'value1'})")
@@ -60,7 +60,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should enforce on removing property") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert has(rel.since)")
 
     // WHEN
     execute("create (p1:Person)-[:KNOWS {since: 'yesterday'}]->(p2:Person)")
@@ -71,7 +71,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should enforce on setting property to null") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert has(node.key1)")
 
     // WHEN
     execute("create ( node1:Label1 {key1:'value1' } )")
@@ -82,7 +82,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should enforce on setting property to null") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert has(rel.since)")
 
     // WHEN
     execute("create (p1:Person)-[:KNOWS {since: 'yesterday'}]->(p2:Person)")
@@ -93,7 +93,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should allow to break constraint within statement") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert has(node.key1)")
 
     // WHEN
     val res = execute("create (node:Label1) set node.key1 = 'foo' return node")
@@ -104,7 +104,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should allow to break constraint within statement") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert has(rel.since)")
 
     // WHEN
     val res = execute("create (p1:Person)-[r:KNOWS]->(p2:Person) set r.since = 'yesterday' return r")
@@ -115,7 +115,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should allow creation of non-conflicting data") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert has(node.key1)")
 
     // WHEN
     execute("create (node {key1:'value1'} )")
@@ -129,7 +129,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should allow creation of non-conflicting data") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert has(rel.since)")
 
     // WHEN
     execute("create (p1:Person {name: 'foo'})-[r:KNOWS {since: 'today'}]->(p2:Person {name: 'bar'})")
@@ -145,7 +145,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
     execute("create (node:Label1)")
 
     // WHEN
-    val e = intercept[CypherExecutionException](execute("create constraint on (node:Label1) assert node.key1 is not null"))
+    val e = intercept[CypherExecutionException](execute("create constraint on (node:Label1) assert has(node.key1)"))
 
     //THEN
     e.status should equal(Status.Schema.ConstraintCreationFailure)
@@ -156,7 +156,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
     execute("create (p1:Person)-[:KNOWS]->(p2:Person)")
 
     // WHEN
-    val e = intercept[CypherExecutionException](execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null"))
+    val e = intercept[CypherExecutionException](execute("create constraint on ()-[rel:KNOWS]-() assert has(rel.since)"))
 
     //THEN
     e.status should equal(Status.Schema.ConstraintCreationFailure)
@@ -164,13 +164,13 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should drop constraint") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert has(node.key1)")
 
     intercept[ConstraintValidationException](execute("create (node:Label1)"))
     numberOfNodes shouldBe 0
 
     // WHEN
-    execute("drop constraint on (node:Label1) assert node.key1 is not null")
+    execute("drop constraint on (node:Label1) assert has(node.key1)")
     execute("create (node:Label1)")
 
     // THEN
@@ -179,13 +179,13 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should drop constraint") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert has(rel.since)")
 
     intercept[ConstraintValidationException](execute("create (p1:Person)-[:KNOWS]->(p2:Person)"))
     numberOfRelationships shouldBe 0
 
     // WHEN
-    execute("drop constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("drop constraint on ()-[rel:KNOWS]-() assert has(rel.since)")
     execute("create (p1:Person)-[:KNOWS]->(p2:Person)")
 
     // THEN

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
@@ -74,10 +74,10 @@ trait Command extends Parser
     keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS UNIQUE")
 
   private def NodeMandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
-    keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS NOT NULL")
+    keyword("ASSERT HAS") ~~ "(" ~~ PropertyExpression ~~ ")"
 
   private def RelationshipMandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ RelationshipPatternSyntax ~~
-    keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS NOT NULL")
+    keyword("ASSERT HAS") ~~ "(" ~~ PropertyExpression ~~ ")"
 
   private def RelationshipPatternSyntax = rule(
     ("()-[" ~~ Identifier ~~ RelType ~~ "]-()")

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
@@ -2897,44 +2897,44 @@ class CypherParserTest extends CypherFunSuite {
 
   test("node mandatory property constraint creation") {
     expectQuery(
-      "CREATE CONSTRAINT ON (id:Label) ASSERT id.property IS NOT NULL",
+      "CREATE CONSTRAINT ON (id:Label) ASSERT has(id.property)",
       CreateNodeMandatoryPropertyConstraint("id", "Label", "id", "property")
     )
   }
 
   test("node mandatory property constraint deletion") {
     expectQuery(
-      "DROP CONSTRAINT ON (id:Label) ASSERT id.property IS NOT NULL",
+      "DROP CONSTRAINT ON (id:Label) ASSERT has(id.property)",
       DropNodeMandatoryPropertyConstraint("id", "Label", "id", "property")
     )
   }
 
   test("relationship mandatory property constraint creation") {
     expectQuery(
-      "CREATE CONSTRAINT ON ()-[id:RelType]-() ASSERT id.property IS NOT NULL",
+      "CREATE CONSTRAINT ON ()-[id:RelType]-() ASSERT has(id.property)",
       CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
-      "CREATE CONSTRAINT ON ()-[id:RelType]->() ASSERT id.property IS NOT NULL",
+      "CREATE CONSTRAINT ON ()-[id:RelType]->() ASSERT has(id.property)",
       CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
-      "CREATE CONSTRAINT ON ()<-[id:RelType]-() ASSERT id.property IS NOT NULL",
+      "CREATE CONSTRAINT ON ()<-[id:RelType]-() ASSERT has(id.property)",
       CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
   }
 
   test("relationship mandatory property constraint deletion") {
     expectQuery(
-      "DROP CONSTRAINT ON ()-[id:RelType]-() ASSERT id.property IS NOT NULL",
+      "DROP CONSTRAINT ON ()-[id:RelType]-() ASSERT has(id.property)",
       DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
-      "DROP CONSTRAINT ON ()-[id:RelType]->() ASSERT id.property IS NOT NULL",
+      "DROP CONSTRAINT ON ()-[id:RelType]->() ASSERT has(id.property)",
       DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
-      "DROP CONSTRAINT ON ()<-[id:RelType]-() ASSERT id.property IS NOT NULL",
+      "DROP CONSTRAINT ON ()<-[id:RelType]-() ASSERT has(id.property)",
       DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
@@ -134,7 +134,7 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory node property constraint added") {
-    val result = execute("create constraint on (n:Person) assert n.name is not null")
+    val result = execute("create constraint on (n:Person) assert has(n.name)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 1)
@@ -142,8 +142,8 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory node property constraint added twice") {
-    execute("create constraint on (n:Person) assert n.name is not null")
-    val result = execute("create constraint on (n:Person) assert n.name is not null")
+    execute("create constraint on (n:Person) assert has(n.name)")
+    val result = execute("create constraint on (n:Person) assert has(n.name)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 0)
@@ -151,8 +151,8 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory node property constraint dropped") {
-    execute("create constraint on (n:Person) assert n.name is not null")
-    val result = execute("drop constraint on (n:Person) assert n.name is not null")
+    execute("create constraint on (n:Person) assert has(n.name)")
+    val result = execute("drop constraint on (n:Person) assert has(n.name)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 0)
@@ -160,7 +160,7 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory relationship property constraint added") {
-    val result = execute("create constraint on ()-[r:KNOWS]-() assert r.since is not null")
+    val result = execute("create constraint on ()-[r:KNOWS]-() assert has(r.since)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 1)
@@ -168,8 +168,8 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory relationship property constraint added twice") {
-    execute("create constraint on ()-[r:KNOWS]-() assert r.since is not null")
-    val result = execute("create constraint on ()-[r:KNOWS]-() assert r.since is not null")
+    execute("create constraint on ()-[r:KNOWS]-() assert has(r.since)")
+    val result = execute("create constraint on ()-[r:KNOWS]-() assert has(r.since)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 0)
@@ -177,8 +177,8 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory relationship property constraint dropped") {
-    execute("create constraint on ()-[r:KNOWS]-() assert r.since is not null")
-    val result = execute("drop constraint on ()-[r:KNOWS]-() assert r.since is not null")
+    execute("create constraint on ()-[r:KNOWS]-() assert has(r.since)")
+    val result = execute("drop constraint on ()-[r:KNOWS]-() assert has(r.since)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 0)

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -99,7 +99,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     testQuery(
       title = "Create mandatory node property constraint",
       text = "To create a constraint that makes sure that all nodes with a certain label have a certain property, use the +IS+ +NOT+ +NULL+ syntax.",
-      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL",
+      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT has(book.isbn)",
       optionalResultExplanation = "",
       assertions = (p) => assertNodeConstraintExist("Book", "isbn")
     )
@@ -111,9 +111,9 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     prepareAndTestQuery(
       title = "Drop mandatory node property constraint",
       text = "By using +DROP+ +CONSTRAINT+, you remove a constraint from the database.",
-      queryText = "DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL",
+      queryText = "DROP CONSTRAINT ON (book:Book) ASSERT has(book.isbn)",
       optionalResultExplanation = "",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL")),
+      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON (book:Book) ASSERT has(book.isbn)")),
       assertions = (p) => assertNodeConstraintDoesNotExist("Book", "isbn")
     )
   }
@@ -126,14 +126,14 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       text = "Create a `Book` node with an existing `isbn` property.",
       queryText = "CREATE (book:Book {isbn: '1449356265', title: 'Graph Databases'})",
       optionalResultExplanation = "",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL")),
+      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON (book:Book) ASSERT has(book.isbn)")),
       assertions = (p) => assertNodeConstraintExist("Book", "isbn")
     )
   }
 
   @Test def break_mandatory_node_property_constraint() {
     generateConsole = false
-    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL")
+    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT has(book.isbn)")
     testFailingQuery[ConstraintValidationException](
       title = "Create a node that breaks a mandatory property constraint",
       text = "Create a `Book` node without an `isbn`.",
@@ -144,7 +144,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
 
   @Test def break_mandatory_node_property_constraint_by_removing_property() {
     generateConsole = false
-    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL")
+    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT has(book.isbn)")
     engine.execute("CREATE (book:Book {isbn: '1449356265', title: 'Graph Databases'})")
     testFailingQuery[ConstraintValidationException](
       title = "Removing a mandatory node property",
@@ -162,7 +162,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       title = "Failure to create a mandatory node property constraint due to existing node",
       text = "Create a constraint on the property `isbn` on nodes with the `Book` label when there already exists " +
         " a node without an `isbn`.",
-      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL",
+      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT has(book.isbn)",
       optionalResultExplanation = "In this case the constraint can't be created because it is violated by existing " +
         "data. We may choose to remove the offending nodes and then re-apply the constraint."
     )
@@ -172,7 +172,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     testQuery(
       title = "Create mandatory relationship property constraint",
       text = "To create a constraint that makes sure that all relationships with a certain type have a certain property, use the +IS+ +NOT+ +NULL+ syntax.",
-      queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL",
+      queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT has(like.day)",
       optionalResultExplanation = "",
       assertions = (p) => assertRelationshipConstraintExist("LIKED", "day")
     )
@@ -184,9 +184,9 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     prepareAndTestQuery(
       title = "Drop mandatory relationship property constraint",
       text = "By using +DROP+ +CONSTRAINT+, you remove a constraint from the database.",
-      queryText = "DROP CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL",
+      queryText = "DROP CONSTRAINT ON ()-[like:LIKED]-() ASSERT has(like.day)",
       optionalResultExplanation = "",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL")),
+      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT has(like.day)")),
       assertions = (p) => assertRelationshipConstraintDoesNotExist("LIKED", "day")
     )
   }
@@ -199,14 +199,14 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       text = "Create a `LIKED` relationship with an existing `day` property.",
       queryText = "CREATE (user:User)-[like:LIKED {day: 'yesterday'}]->(book:Book)",
       optionalResultExplanation = "",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL")),
+      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT has(like.day)")),
       assertions = (p) => assertRelationshipConstraintExist("LIKED", "day")
     )
   }
 
   @Test def break_mandatory_relationship_property_constraint() {
     generateConsole = false
-    engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL")
+    engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT has(like.day)")
     testFailingQuery[ConstraintValidationException](
       title = "Create a relationship that breaks a mandatory property constraint",
       text = "Create a `LIKED` relationship without an existing `day` property.",
@@ -217,7 +217,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
 
   @Test def break_mandatory_relationship_property_constraint_by_removing_property() {
     generateConsole = false
-    engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL")
+    engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT has(like.day)")
     engine.execute("CREATE (user:User)-[like:LIKED {day: 'today'}]->(book:Book)")
     testFailingQuery[ConstraintValidationException](
       title = "Removing a mandatory relationship property",
@@ -235,7 +235,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       title = "Failure to create a mandatory relationship property constraint due to existing relationship",
       text = "Create a constraint on the property `day` on relationships with the `LIKED` type when there already " +
         "exists a relationship without an `day`.",
-      queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL",
+      queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT has(like.day)",
       optionalResultExplanation = "In this case the constraint can't be created because it is violated by existing " +
         "data. We may choose to remove the offending relationships and then re-apply the constraint."
     )

--- a/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
+++ b/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
@@ -93,7 +93,7 @@ Drop the unique constraint and index on the label `Person` and property `name`.
 //
 
 CREATE CONSTRAINT ON (p:Person)
-       ASSERT p.name IS NOT NULL
+       ASSERT has(p.name)
 ###
 
 Create a mandatory node property constraint on the label `Person` and property `name`.
@@ -104,7 +104,7 @@ removed from an existing node with the `Person` label, the write operation will 
 //
 
 DROP CONSTRAINT ON (p:Person)
-     ASSERT p.name IS NOT NULL
+     ASSERT has(p.name)
 ###
 
 Drop the mandatory node property constraint on the label `Person` and property `name`.
@@ -113,7 +113,7 @@ Drop the mandatory node property constraint on the label `Person` and property `
 //
 
 CREATE CONSTRAINT ON ()-[l:LIKED]-()
-       ASSERT l.when IS NOT NULL
+       ASSERT has(l.when)
 ###
 
 Create a mandatory relationship property constraint on the type `LIKED` and property `when`.
@@ -124,7 +124,7 @@ removed from an existing relationship with the `LIKED` type, the write operation
 //
 
 DROP CONSTRAINT ON ()-[l:LIKED]-()
-     ASSERT l.when IS NOT NULL
+     ASSERT has(l.when)
 ###
 
 Drop the mandatory relationship property constraint on the type `LIKED` and property `when`.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/MandatoryRelationshipPropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/MandatoryRelationshipPropertyConstraint.java
@@ -19,9 +19,12 @@
  */
 package org.neo4j.kernel.api.constraints;
 
+import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.StatementTokenNameLookup;
+import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.impl.coreapi.schema.InternalSchemaActions;
 import org.neo4j.kernel.impl.coreapi.schema.MandatoryRelationshipPropertyConstraintDefinition;
 
@@ -51,15 +54,27 @@ public class MandatoryRelationshipPropertyConstraint extends RelationshipPropert
     }
 
     @Override
-    String constraintString()
+    public ConstraintDefinition asConstraintDefinition( InternalSchemaActions schemaActions, ReadOperations readOps )
     {
-        return "NOT NULL";
+        StatementTokenNameLookup lookup = new StatementTokenNameLookup( readOps );
+        return new MandatoryRelationshipPropertyConstraintDefinition( schemaActions,
+                DynamicRelationshipType.withName( lookup.relationshipTypeGetName( relationshipTypeId ) ),
+                lookup.propertyKeyGetName( propertyKeyId ) );
     }
 
     @Override
-    public ConstraintDefinition asConstraintDefinition( InternalSchemaActions schemaActions, ReadOperations readOps )
+    public String userDescription( TokenNameLookup tokenNameLookup )
     {
-        return new MandatoryRelationshipPropertyConstraintDefinition( schemaActions,
-                relTypeById( relationshipType(), readOps ), propertyKeyById( propertyKeyId, readOps ) );
+        String typeName = tokenNameLookup.relationshipTypeGetName( relationshipTypeId );
+        String boundIdentifier = typeName.toLowerCase();
+        return String.format( "CONSTRAINT ON ()-[ %s:%s ]-() ASSERT has(%s.%s)",
+                boundIdentifier, typeName, boundIdentifier, tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "CONSTRAINT ON ()-[ n:relationshipType[%s] ]-() ASSERT hs(n.property[%s])",
+                relationshipTypeId, propertyKeyId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyConstraint.java
@@ -19,11 +19,9 @@
  */
 package org.neo4j.kernel.api.constraints;
 
-import org.neo4j.kernel.api.TokenNameLookup;
-
 public abstract class NodePropertyConstraint extends PropertyConstraint
 {
-    private final int labelId;
+    protected final int labelId;
 
     public NodePropertyConstraint( int labelId, int propertyKeyId )
     {
@@ -31,18 +29,9 @@ public abstract class NodePropertyConstraint extends PropertyConstraint
         this.labelId = labelId;
     }
 
-    public int label()
+    public final int label()
     {
         return labelId;
-    }
-
-    @Override
-    public String userDescription( TokenNameLookup tokenNameLookup )
-    {
-        String labelName = tokenNameLookup.labelGetName( labelId );
-        String boundIdentifier = labelName.toLowerCase();
-        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s.%s IS %s", boundIdentifier, labelName,
-                boundIdentifier, tokenNameLookup.propertyKeyGetName( propertyKeyId ), constraintString() );
     }
 
     @Override
@@ -65,12 +54,5 @@ public abstract class NodePropertyConstraint extends PropertyConstraint
     public int hashCode()
     {
         return 31 * propertyKeyId + labelId;
-    }
-
-    @Override
-    public String toString()
-    {
-        return String.format( "CONSTRAINT ON ( n:label[%s] ) ASSERT n.property[%s] IS %s",
-                labelId, propertyKeyId, constraintString() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
@@ -19,17 +19,10 @@
  */
 package org.neo4j.kernel.api.constraints;
 
-import org.neo4j.graphdb.DynamicLabel;
-import org.neo4j.graphdb.DynamicRelationshipType;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.TokenNameLookup;
-import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
-import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
-import org.neo4j.kernel.api.exceptions.RelationshipTypeIdNotFoundKernelException;
 import org.neo4j.kernel.impl.coreapi.schema.InternalSchemaActions;
 
 public abstract class PropertyConstraint
@@ -67,8 +60,6 @@ public abstract class PropertyConstraint
 
     public abstract ConstraintType type();
 
-    abstract String constraintString();
-
     public abstract String userDescription( TokenNameLookup tokenNameLookup );
 
     public abstract ConstraintDefinition asConstraintDefinition( InternalSchemaActions schemaActions,
@@ -82,40 +73,4 @@ public abstract class PropertyConstraint
 
     @Override
     public abstract String toString();
-
-    protected static Label labelById( int id, ReadOperations readOps )
-    {
-        try
-        {
-            return DynamicLabel.label( readOps.labelGetName( id ) );
-        }
-        catch ( LabelNotFoundKernelException e )
-        {
-            throw new IllegalStateException( "Couldn't find label name for id: " + id );
-        }
-    }
-
-    protected static String propertyKeyById( int id, ReadOperations readOps )
-    {
-        try
-        {
-            return readOps.propertyKeyGetName( id );
-        }
-        catch ( PropertyKeyIdNotFoundKernelException e )
-        {
-            throw new IllegalStateException( "Couldn't find property for id: " + id );
-        }
-    }
-
-    protected static RelationshipType relTypeById( int id, ReadOperations readOps )
-    {
-        try
-        {
-            return DynamicRelationshipType.withName( readOps.relationshipTypeGetName( id ) );
-        }
-        catch ( RelationshipTypeIdNotFoundKernelException e )
-        {
-            throw new IllegalStateException( "Couldn't find relationship type name for id: " + id );
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/RelationshipPropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/RelationshipPropertyConstraint.java
@@ -19,11 +19,9 @@
  */
 package org.neo4j.kernel.api.constraints;
 
-import org.neo4j.kernel.api.TokenNameLookup;
-
 public abstract class RelationshipPropertyConstraint extends PropertyConstraint
 {
-    private final int relationshipTypeId;
+    protected final int relationshipTypeId;
 
     public RelationshipPropertyConstraint( int relationshipTypeId, int propertyKeyId )
     {
@@ -31,18 +29,9 @@ public abstract class RelationshipPropertyConstraint extends PropertyConstraint
         this.relationshipTypeId = relationshipTypeId;
     }
 
-    public int relationshipType()
+    public final int relationshipType()
     {
         return relationshipTypeId;
-    }
-
-    @Override
-    public String userDescription( TokenNameLookup tokenNameLookup )
-    {
-        String typeName = tokenNameLookup.relationshipTypeGetName( relationshipTypeId );
-        String boundIdentifier = typeName.toLowerCase();
-        return String.format( "CONSTRAINT ON ()-[ %s:%s ]-() ASSERT %s.%s IS %s", boundIdentifier, typeName,
-                boundIdentifier, tokenNameLookup.propertyKeyGetName( propertyKeyId ), constraintString() );
     }
 
     @Override
@@ -65,12 +54,5 @@ public abstract class RelationshipPropertyConstraint extends PropertyConstraint
     public int hashCode()
     {
         return 31 * propertyKeyId + relationshipTypeId;
-    }
-
-    @Override
-    public String toString()
-    {
-        return String.format( "CONSTRAINT ON ()-[ n:relationshipType[%s] ]-() ASSERT n.property[%s] IS %s",
-                relationshipTypeId, propertyKeyId, constraintString() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MandatoryNodePropertyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MandatoryNodePropertyConstraintDefinition.java
@@ -48,7 +48,7 @@ public class MandatoryNodePropertyConstraintDefinition extends NodeConstraintDef
     @Override
     public String toString()
     {
-        return format( "ON (%1$s:%2$s) ASSERT %1$s.%3$s IS NOT NULL",
+        return format( "ON (%1$s:%2$s) ASSERT has(%1$s.%3$s)",
                 label.name().toLowerCase(), label.name(), propertyKey );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MandatoryRelationshipPropertyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MandatoryRelationshipPropertyConstraintDefinition.java
@@ -48,7 +48,7 @@ public class MandatoryRelationshipPropertyConstraintDefinition extends Relations
     @Override
     public String toString()
     {
-        return format( "ON ()-[%1$s:%2$s]-() ASSERT %1$s.%3$s IS NOT NULL",
+        return format( "ON ()-[%1$s:%2$s]-() ASSERT has(%1$s.%3$s)",
                 relationshipType.name().toLowerCase(), relationshipType.name(), propertyKey );
     }
 }

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -879,7 +879,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls", "ON \\(person:Person\\) ASSERT person.name IS NOT NULL" );
+        executeCommand( "schema ls", "ON \\(person:Person\\) ASSERT has\\(person.name\\)" );
     }
 
     @Test
@@ -892,7 +892,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+        executeCommand( "schema ls", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT has\\(knows.since\\)" );
     }
 
     @Test
@@ -918,7 +918,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls -l :Person", "ON \\(person:Person\\) ASSERT person.name IS NOT NULL" );
+        executeCommand( "schema ls -l :Person", "ON \\(person:Person\\) ASSERT has\\(person.name\\)" );
     }
 
     @Test
@@ -931,7 +931,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls -r :KNOWS", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+        executeCommand( "schema ls -r :KNOWS", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT has\\(knows.since\\)" );
     }
 
     @Test
@@ -944,7 +944,8 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls -r :KNOWS -p since", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+        executeCommand( "schema ls -r :KNOWS -p since",
+                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT has\\(knows.since\\)" );
     }
 
     @Test
@@ -965,8 +966,8 @@ public class TestApps extends AbstractShellTest
 
         // THEN
         executeCommand( "schema ls",
-                "ON \\(person:Person\\) ASSERT person.name IS NOT NULL",
-                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+                "ON \\(person:Person\\) ASSERT has\\(person.name\\)",
+                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT has\\(knows.since\\)" );
     }
 
     @Test
@@ -987,8 +988,8 @@ public class TestApps extends AbstractShellTest
 
         // THEN
         executeCommand( "schema ls -l :Person -r :KNOWS",
-                "ON \\(person:Person\\) ASSERT person.name IS NOT NULL",
-                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+                "ON \\(person:Person\\) ASSERT has\\(person.name\\)",
+                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT has\\(knows.since\\)" );
     }
 
     @Test
@@ -1017,8 +1018,8 @@ public class TestApps extends AbstractShellTest
                 "  ON :Person\\(name\\) ONLINE \\(for uniqueness constraint\\)",
                 "Constraints",
                 "  ON \\(person:Person\\) ASSERT person.name IS UNIQUE",
-                "  ON \\(person:Person\\) ASSERT person.name IS NOT NULL",
-                "  ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+                "  ON \\(person:Person\\) ASSERT has\\(person.name\\)",
+                "  ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT has\\(knows.since\\)" );
     }
 
     @Test
@@ -1044,7 +1045,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls -l :Person -p name", "ON \\(person:Person\\) ASSERT person.name IS NOT NULL" );
+        executeCommand( "schema ls -l :Person -p name", "ON \\(person:Person\\) ASSERT has\\(person.name\\)" );
     }
 
     @Test


### PR DESCRIPTION
Commit changes:
- `CREATE CONSTRAINT ON (node:Label1) ASSERT node.key1 IS NOT NULL`
  to
  `CREATE CONSTRAINT ON (node:Label1) ASSERT has(node.key1)`
- `DROP CONSTRAINT ON (node:Label1) ASSERT node.key1 IS NOT NULL`
  to
  `DROP CONSTRAINT ON (node:Label1) ASSERT has(node.key1)`
- `CREATE CONSTRAINT ON ()-[rel:KNOWS]-() ASSERT rel.since IS NOT NULL`
  to
  `CREATE CONSTRAINT ON ()-[rel:KNOWS]-() ASSERT has(rel.since)`
- `DROP CONSTRAINT ON ()-[rel:KNOWS]-() ASSERT rel.since IS NOT NULL`
  to
  `DROP CONSTRAINT ON ()-[rel:KNOWS]-() ASSERT has(rel.since)`

This syntax change is made to emphasize the fact that mandatory property
constraint is about node/relationship having particular property defined and
not about them having property with value different from null.
