### PR TITLE
Fixes input id iterator stopping on null values

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
 
@@ -582,11 +583,17 @@ public class StoreMigrator implements StoreMigrationParticipant
                 return new SourceInputIterator<InputRelationship, RelationshipRecord>( traceability )
                 {
                     @Override
-                    protected InputRelationship fetchNextOrNull()
+                    public boolean hasNext()
                     {
-                        if ( !source.hasNext() )
+                        return source.hasNext();
+                    }
+
+                    @Override
+                    public InputRelationship next()
+                    {
+                        if ( !hasNext() )
                         {
-                            return null;
+                            throw new NoSuchElementException();
                         }
 
                         RelationshipRecord record = source.next();
@@ -637,11 +644,17 @@ public class StoreMigrator implements StoreMigrationParticipant
                 return new SourceInputIterator<InputNode, NodeRecord>( traceability )
                 {
                     @Override
-                    protected InputNode fetchNextOrNull()
+                    public boolean hasNext()
                     {
-                        if ( !source.hasNext() )
+                        return source.hasNext();
+                    }
+
+                    @Override
+                    public InputNode next()
+                    {
+                        if ( !hasNext() )
                         {
-                            return null;
+                            throw new NoSuchElementException();
                         }
 
                         NodeRecord record = source.next();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
+import java.util.NoSuchElementException;
+
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.SourceInputIterator;
 
@@ -116,9 +118,19 @@ public class Utils
                     }
 
                     @Override
-                    protected Object fetchNextOrNull()
+                    public boolean hasNext()
                     {
-                        return iterator.hasNext() ? iterator.next().id() : null;
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public Object next()
+                    {
+                        if ( !hasNext() )
+                        {
+                            throw new NoSuchElementException();
+                        }
+                        return iterator.next().id();
                     }
                 };
             }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/SourceInputIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/SourceInputIterator.java
@@ -20,18 +20,19 @@
 package org.neo4j.unsafe.impl.batchimport.input;
 
 import org.neo4j.csv.reader.SourceTraceability;
-import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.kernel.impl.storemigration.StoreMigrator;
 import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
 
 /**
  * Used by {@link StoreMigrator} for providing {@link RelationshipRecord} and {@link NodeRecord}
  * data to {@link BatchImporter}.
+ * @param <T> Type of items in this iterator
+ * @param <U> Type of underlying item to convert from
  */
 public abstract class SourceInputIterator<T,U>
-        extends PrefetchingIterator<T>
         implements InputIterator<T>
 {
     private final SourceTraceability source;
@@ -57,5 +58,11 @@ public abstract class SourceInputIterator<T,U>
     public long position()
     {
         return source.position();
+    }
+
+    @Override
+    public void remove()
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
@@ -22,13 +22,22 @@ package org.neo4j.unsafe.impl.batchimport;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.unsafe.impl.batchimport.input.InputNode;
+import org.neo4j.unsafe.impl.batchimport.input.SimpleInputIteratorWrapper;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_LABELS;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
 
 public class UtilsTest
 {
@@ -117,6 +126,26 @@ public class UtilsTest
             Utils.mergeSortedInto( values, into, batchSize );
             assertArrayEquals( expectedMergedArray, into );
         }
+    }
+
+    @Test
+    public void shouldContinueIdIteratorThroughNulls() throws Exception
+    {
+        // GIVEN
+        Collection<InputNode> inputs = Arrays.asList(
+                new InputNode( "Source", 1, 1, "1", NO_PROPERTIES, null, NO_LABELS, null ),
+                new InputNode( "Source", 2, 2, null, NO_PROPERTIES, null, NO_LABELS, null ),
+                new InputNode( "Source", 3, 3, "3", NO_PROPERTIES, null, NO_LABELS, null ) );
+        InputIterable<InputNode> input = SimpleInputIteratorWrapper.wrap( "Source", inputs );
+
+        // WHEN
+        Iterator<Object> ids = Utils.idsOf( input ).iterator();
+
+        // THEN
+        assertEquals( "1", ids.next() );
+        assertNull( ids.next() );
+        assertEquals( "3", ids.next() );
+        assertFalse( ids.hasNext() );
     }
 
     private long[] manuallyMerge( long[] values, long[] into )


### PR DESCRIPTION
During id collision resolving phase in batch importer, preparing the
IdMapper, the passed in ID iterator would have a flaw in that it stopped
its iteration on the first null ID encountered. This would mess up the
collision resolving in that not all IDs marked as collisions would be
added to the list to be sorted, although the sorting algorithm thought it
was and so there would potentially be some data entries in the end that
wouldn't have been initialized and eventially break the sorting algo.
