### PR TITLE
Restart DataSourceManager instead of DataSource

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DataSourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DataSourceManager.java
@@ -108,12 +108,12 @@ public class DataSourceManager implements Lifecycle, Provider<KernelAPI>
     public void init() throws Throwable
     {
         life = new LifeSupport();
+        life.add( dataSource );
     }
 
     @Override
     public void start() throws Throwable
     {
-        life.add( dataSource );
         life.start();
 
         for ( Listener listener : dsRegistrationListeners )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/DataSourceManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/DataSourceManagerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.state;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.NeoStoreDataSource;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class DataSourceManagerTest
+{
+    @Test
+    public void shouldCallListenersOnStart() throws Throwable
+    {
+        // given
+        DataSourceManager manager = new DataSourceManager();
+        DataSourceManager.Listener listener = mock( DataSourceManager.Listener.class );
+        manager.register( mock( NeoStoreDataSource.class ) );
+        manager.addListener( listener );
+
+        // when
+        manager.start();
+
+        // then
+        verify( listener ).registered( any( NeoStoreDataSource.class ) );
+    }
+
+    @Test
+    public void shouldCallListenersWhenAddedIfManagerAlreadyStarted() throws Throwable
+    {
+        // given
+        DataSourceManager manager = new DataSourceManager();
+        DataSourceManager.Listener listener = mock( DataSourceManager.Listener.class );
+        manager.register( mock( NeoStoreDataSource.class ) );
+        manager.start();
+
+        // when
+        manager.addListener( listener );
+
+        // then
+        verify( listener ).registered( any( NeoStoreDataSource.class ) );
+    }
+
+    @Test
+    public void shouldCallListenersOnDataSourceRegistrationIfManagerAlreadyStarted() throws Throwable
+    {
+        // given
+        DataSourceManager manager = new DataSourceManager();
+        DataSourceManager.Listener listener = mock( DataSourceManager.Listener.class );
+        manager.addListener( listener );
+        manager.start();
+
+        // when
+        manager.register( mock( NeoStoreDataSource.class ) );
+
+        // then
+        verify( listener ).registered( any( NeoStoreDataSource.class ) );
+    }
+
+    @Test
+    public void shouldSupportMultipleStartStopCycles() throws Throwable
+    {
+        // given
+        DataSourceManager manager = new DataSourceManager();
+        NeoStoreDataSource dataSource = mock( NeoStoreDataSource.class );
+        manager.register( dataSource );
+        manager.init();
+
+        // when
+        manager.start();
+        manager.stop();
+        manager.start();
+
+        // then
+        verify( dataSource, times( 2 ) ).start();
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -75,6 +75,7 @@ import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.log.MissingLogDataException;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -100,7 +101,7 @@ public class SwitchToSlave
     @SuppressWarnings("unchecked")
     private static final Class<? extends Lifecycle>[] SERVICES_TO_RESTART_FOR_STORE_COPY = new Class[]{
             StoreLockerLifecycleAdapter.class,
-            NeoStoreDataSource.class,
+            DataSourceManager.class,
             RequestContextFactory.class,
             TransactionCommittingResponseUnpacker.class,
             IndexConfigStore.class,

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
@@ -51,6 +51,7 @@ import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.DevNullLoggingService;
@@ -158,8 +159,8 @@ public class SwitchToSlaveTest
 
         when( resolver.resolveDependency( StoreLockerLifecycleAdapter.class ) ).thenReturn(
                 mockWithLifecycle( StoreLockerLifecycleAdapter.class ) );
-        when( resolver.resolveDependency( NeoStoreDataSource.class ) ).thenReturn(
-                mockWithLifecycle( NeoStoreDataSource.class ) );
+        when( resolver.resolveDependency( DataSourceManager.class ) ).thenReturn(
+                mockWithLifecycle( DataSourceManager.class ) );
         when( resolver.resolveDependency( RequestContextFactory.class ) ).thenReturn(
                 mockWithLifecycle( RequestContextFactory.class ) );
         when( resolver.resolveDependency( TransactionCommittingResponseUnpacker.class ) ).thenReturn(


### PR DESCRIPTION
- This fixes a bug where the StoreId exposed through JMX is stale when
  a store is first copied down from the master
