### PR TITLE
Graceful close of forseti client from other thread. Clean up hanging holder references.

### DIFF
--- a/advanced/management/src/main/java/org/neo4j/management/impl/LockManagerBean.java
+++ b/advanced/management/src/main/java/org/neo4j/management/impl/LockManagerBean.java
@@ -95,7 +95,8 @@ public final class LockManagerBean extends ManagementBeanProvider
             lockManager.accept( new Locks.Visitor()
             {
                 @Override
-                public void visit( Locks.ResourceType resourceType, long resourceId, String description, long waitTime )
+                public void visit( Locks.ResourceType resourceType, long resourceId, String description, long waitTime,
+                        long lockIdentityHashCode )
                 {
                     locks.add( new LockInfo( resourceType.toString(), String.valueOf( resourceId ), description ) );
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/DumpLocksVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/DumpLocksVisitor.java
@@ -31,8 +31,10 @@ public class DumpLocksVisitor implements Locks.Visitor
     }
 
     @Override
-    public void visit( Locks.ResourceType resourceType, long resourceId, String description, long estimatedWaitTime )
+    public void visit( Locks.ResourceType resourceType, long resourceId, String description, long estimatedWaitTime,
+            long lockIdentityHashCode )
     {
-        log.info( "%s{id=%d, waitTime=%d, description=%s}", resourceType, resourceId, estimatedWaitTime, description );
+        log.info( "%s{id=%d, waitTime=%d, description=%s, lockHash=%d}", resourceType, resourceId, estimatedWaitTime,
+                description, lockIdentityHashCode );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockCountVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/LockCountVisitor.java
@@ -19,14 +19,19 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-/**
- * Exception that will be thrown in case when closed {@link org.neo4j.kernel.impl.locking.Locks.Client}
- * will be used to acquire shared/exclusive lock
- */
-public class LockClientAlreadyClosedException extends RuntimeException
+public class LockCountVisitor implements  Locks.Visitor
 {
-    public LockClientAlreadyClosedException( String message )
+    private int lockCount = 0;
+
+    @Override
+    public void visit( Locks.ResourceType resourceType, long resourceId, String description, long estimatedWaitTime,
+            long lockIdentityHashCode )
     {
-        super( message );
+        lockCount++;
+    }
+
+    public int getLockCount()
+    {
+        return lockCount;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -58,7 +58,8 @@ public interface Locks extends Lifecycle
     interface Visitor
     {
         /** Visit the description of a lock held by at least one client. */
-        void visit( ResourceType resourceType, long resourceId, String description, long estimatedWaitTime );
+        void visit( ResourceType resourceType, long resourceId, String description, long estimatedWaitTime,
+                long lockIdentityHashCode );
     }
 
     /** Locks are split by resource types. It is up to the implementation to define the contract for these. */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockManger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockManger.java
@@ -45,7 +45,7 @@ public class CommunityLockManger extends LifecycleAdapter implements Locks
                 {
                     LockResource lockResource = (LockResource)resource;
                     visitor.visit( lockResource.type(), lockResource.resourceId(),
-                            element.describe(), element.maxWaitTime() );
+                            element.describe(), element.maxWaitTime(), System.identityHashCode( lockResource ) );
                 }
                 return false;
             }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseShutdownTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseShutdownTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Future;
 import org.junit.Test;
 
 import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.locking.LockCountVisitor;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -138,17 +139,8 @@ public class GraphDatabaseShutdownTest
 
     private static int lockCount( Locks locks )
     {
-        final int[] counter = new int[1];
-
-        locks.accept( new Locks.Visitor()
-        {
-            @Override
-            public void visit( Locks.ResourceType resourceType, long resourceId, String description, long waitTime )
-            {
-                counter[0]++;
-            }
-        } );
-
-        return counter[0];
+        LockCountVisitor lockCountVisitor = new LockCountVisitor();
+        locks.accept( lockCountVisitor );
+        return lockCountVisitor.getLockCount();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
@@ -20,12 +20,10 @@
 package org.neo4j.kernel.impl.locking;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.neo4j.kernel.impl.locking.ResourceTypes.NODE;
 
-@Ignore("Not a test. This is a compatibility suite, run from LockingCompatibilityTestSuite.")
 public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibility
 {
     public CloseCompatibility( LockingCompatibilityTestSuite suite )
@@ -34,7 +32,6 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
     }
 
     @Test
-    @Ignore("Will be merged and enabled when both lock managers will support it")
     public void closeShouldWaitAllOperationToFinish()
     {
         // given
@@ -54,37 +51,27 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
         // reader/writer waiter in any threads
         // those should be gracefully finish and client should be closed
 
-        final int[] counters = new int[1];
-        locks.accept( new Locks.Visitor()
-        {
-            @Override
-            public void visit( Locks.ResourceType resourceType, long resourceId, String description,
-                    long estimatedWaitTime )
-            {
-                counters[0] ++;
-            }
-        } );
-        Assert.assertEquals( 0, counters[0] );
+        LockCountVisitor lockCountVisitor = new LockCountVisitor();
+        locks.accept( lockCountVisitor );
+        Assert.assertEquals( 0, lockCountVisitor.getLockCount() );
+
     }
 
-    @Test(expected = LockClientAlreadyClosedException.class)
-    @Ignore("Will be enabled when both clients support it.")
+    @Test( expected = LockClientAlreadyClosedException.class )
     public void shouldNotBeAbleToAcquireSharedLockFromClosedClient()
     {
         clientA.close();
-        clientA.acquireShared( NODE, 1l);
+        clientA.acquireShared( NODE, 1l );
     }
 
-    @Test(expected = LockClientAlreadyClosedException.class)
-    @Ignore("Will be enabled when both clients support it.")
+    @Test( expected = LockClientAlreadyClosedException.class )
     public void shouldNotBeAbleToAcquireExclusiveLockFromClosedClient()
     {
         clientA.close();
-        clientA.acquireExclusive( NODE, 1l);
+        clientA.acquireExclusive( NODE, 1l );
     }
 
     @Test
-    @Ignore("Will be enabled when both clients support it.")
     public void shouldNotBeAbleToAcquireLocksUsingTryFromClosedClient()
     {
         clientA.close();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockReentrancyCompatibility.java
@@ -19,11 +19,12 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import java.util.concurrent.Future;
-
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.NODE;
 
 @Ignore("Not a test. This is a compatibility suite, run from LockingCompatibilityTestSuite.")
@@ -199,5 +200,67 @@ public class LockReentrancyCompatibility extends LockingCompatibilityTestSuite.C
 
         // Then
         assertNotWaiting( clientB, clientBLock );
+    }
+
+    @Test
+    public void shouldUpgradeAndDowngradeSameSharedLock() throws InterruptedException
+    {
+        // when
+        clientA.acquireShared( NODE, 1L );
+        clientB.acquireShared( NODE, 1L );
+
+
+        LockIdentityExplorer sharedLockExplorer = new LockIdentityExplorer( NODE, 1L );
+        locks.accept( sharedLockExplorer );
+
+        // then xclusive should wait for shared from other client to be released
+        Future<Object> exclusiveLockFuture = acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
+
+        // and when
+        clientA.releaseAll();
+
+        // exclusive lock should be received
+        assertNotWaiting( clientB, exclusiveLockFuture );
+
+        // and when releasing exclusive
+        clientB.releaseExclusive( NODE, 1L );
+
+        // we still should have same read lock
+        LockIdentityExplorer releasedLockExplorer = new LockIdentityExplorer( NODE, 1L );
+        locks.accept( releasedLockExplorer );
+
+        // we still hold same lock as before
+        assertEquals( sharedLockExplorer.getLockIdentityHashCode(),
+                releasedLockExplorer.getLockIdentityHashCode() );
+    }
+
+    private static class LockIdentityExplorer implements Locks.Visitor
+    {
+
+        private Locks.ResourceType resourceType;
+        private long resourceId;
+        private long lockIdentityHashCode;
+
+        public LockIdentityExplorer( Locks.ResourceType resourceType, long resourceId )
+        {
+            this.resourceType = resourceType;
+            this.resourceId = resourceId;
+        }
+
+        @Override
+        public void visit( Locks.ResourceType resourceType, long resourceId, String description,
+                long estimatedWaitTime,
+                long lockIdentityHashCode )
+        {
+            if ( this.resourceType.equals( resourceType ) && this.resourceId == resourceId )
+            {
+                this.lockIdentityHashCode = lockIdentityHashCode;
+            }
+        }
+
+        public long getLockIdentityHashCode()
+        {
+            return lockIdentityHashCode;
+        }
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiLockManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiLockManager.java
@@ -147,7 +147,9 @@ public class ForsetiLockManager extends LifecycleAdapter implements Locks
     @Override
     public Client newClient()
     {
-        return clientPool.acquire();
+        ForsetiClient forsetiClient = clientPool.acquire();
+        forsetiClient.reset();
+        return forsetiClient;
     }
 
     @Override
@@ -161,7 +163,7 @@ public class ForsetiLockManager extends LifecycleAdapter implements Locks
                 for ( Map.Entry<Long, Lock> entry : lockMaps[i].entrySet() )
                 {
                     Lock lock = entry.getValue();
-                    out.visit( type, entry.getKey(), lock.describeWaitList(), 0 );
+                    out.visit( type, entry.getKey(), lock.describeWaitList(), 0, System.identityHashCode( lock ) );
                 }
             }
         }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/forseti/SharedLockTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/forseti/SharedLockTest.java
@@ -28,12 +28,13 @@ import static org.mockito.Mockito.mock;
 
 public class SharedLockTest
 {
+
     @Test
     public void shouldUpgradeToUpdateLock() throws Exception
     {
         // Given
-        ForsetiClient clientA = mock(ForsetiClient.class);
-        ForsetiClient clientB = mock(ForsetiClient.class);
+        ForsetiClient clientA = mock( ForsetiClient.class );
+        ForsetiClient clientB = mock( ForsetiClient.class );
 
         SharedLock lock = new SharedLock( clientA );
         lock.acquire( clientB );
@@ -42,15 +43,15 @@ public class SharedLockTest
         assertTrue( lock.tryAcquireUpdateLock( clientA ) );
 
         // Then
-        assertThat( lock.numberOfHolders(), equalTo(2));
-        assertThat( lock.isUpdateLock(), equalTo(true));
+        assertThat( lock.numberOfHolders(), equalTo( 2 ) );
+        assertThat( lock.isUpdateLock(), equalTo( true ) );
     }
 
     @Test
     public void shouldReleaseSharedLock() throws Exception
     {
         // Given
-        ForsetiClient clientA = mock(ForsetiClient.class);
+        ForsetiClient clientA = mock( ForsetiClient.class );
         SharedLock lock = new SharedLock( clientA );
 
         // When
@@ -58,7 +59,7 @@ public class SharedLockTest
 
         // Then
         assertThat( lock.numberOfHolders(), equalTo( 0 ) );
-        assertThat( lock.isUpdateLock(), equalTo(false));
+        assertThat( lock.isUpdateLock(), equalTo( false ) );
     }
 
 }


### PR DESCRIPTION
Introduce way of graceful close of forseti client from another thread by tracking status and number of active operations. Clear updateHolder reference to allow SharedLock be garbage collected. More gentle way of handling duplicate references during lock acquisition. Downgrading update lock to shared on exclusive lock release to keep common lifecycle of shared locks.
