### PR TITLE
Change abstract stores to use the page cache

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
@@ -30,7 +30,6 @@ import java.util.List;
 
 import org.neo4j.cursor.GenericCursor;
 import org.neo4j.helpers.Pair;
-import org.neo4j.helpers.UTF8;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -230,12 +229,6 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     }
 
     @Override
-    protected int getEffectiveRecordSize()
-    {
-        return getBlockSize();
-    }
-
-    @Override
     public int getRecordSize()
     {
         return getBlockSize();
@@ -256,23 +249,6 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     public int getNumberOfReservedLowIds()
     {
         return 1;
-    }
-
-    @Override
-    protected void verifyFileSizeAndTruncate() throws IOException
-    {
-        int expectedVersionLength = UTF8.encode( buildTypeDescriptorAndVersion( getTypeDescriptor() ) ).length;
-        long fileSize = getFileChannel().size();
-        if ( (fileSize - expectedVersionLength) % blockSize != 0 )
-        {
-            setStoreNotOk( new IllegalStateException(
-                    "Misaligned file size " + fileSize + " for " + this + ", expected version length " +
-                            expectedVersionLength ) );
-        }
-        if ( getStoreOk() )
-        {
-            getFileChannel().truncate( fileSize - expectedVersionLength );
-        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractStore.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store;
 import java.io.File;
 import java.io.IOException;
 
-import org.neo4j.helpers.UTF8;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.IdGeneratorFactory;
@@ -65,33 +64,9 @@ public abstract class AbstractStore extends CommonAbstractStore
     public abstract int getRecordSize();
 
     @Override
-    protected int getEffectiveRecordSize()
-    {
-        return getRecordSize();
-    }
-
-    @Override
     protected void readAndVerifyBlockSize() throws IOException
     {
         // record size is fixed for non-dynamic stores, so nothing to do here
-    }
-
-    @Override
-    protected void verifyFileSizeAndTruncate() throws IOException
-    {
-        int expectedVersionLength = UTF8.encode( buildTypeDescriptorAndVersion( getTypeDescriptor() ) ).length;
-        long fileSize = getFileChannel().size();
-        if ( getRecordSize() != 0
-             && (fileSize - expectedVersionLength) % getRecordSize() != 0 )
-        {
-            setStoreNotOk( new IllegalStateException(
-                    "Misaligned file size " + fileSize + " for " + this + ", expected version length:" +
-                    expectedVersionLength ) );
-        }
-        if ( getStoreOk() )
-        {
-            getFileChannel().truncate( fileSize - expectedVersionLength );
-        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreVersionTrailerUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreVersionTrailerUtil.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store;
+
+import java.io.IOException;
+
+import org.neo4j.helpers.UTF8;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.impl.util.Charsets;
+
+public abstract class StoreVersionTrailerUtil
+{
+    /**
+     * Get the offset of the store trailer, from the beginning of the file.
+     *
+     * @param pagedFile The paged file that to find the trailer offset of
+     * @param expectedTrailer The trailer is expected to be found in the file
+     * @return The offset of the trailer, or -1 if no trailer was found
+     * @throws IOException
+     */
+    public static long getTrailerOffset( PagedFile pagedFile, String expectedTrailer ) throws IOException
+    {
+        int trailerPositionRelativeToFirstPageTrailerMightBeIn;
+        int pageSize = pagedFile.pageSize();
+        int expectedTrailerLength = UTF8.encode( expectedTrailer ).length;
+        long lastPageId = pagedFile.getLastPageId();
+
+        long firstPageThatTrailerMightBeIn =
+                getFirstPageThatTrailerMightBeIn( lastPageId, pageSize, expectedTrailerLength );
+
+        try ( PageCursor pageCursor = pagedFile.io( firstPageThatTrailerMightBeIn, PagedFile.PF_SHARED_LOCK ) )
+        {
+            byte[] allData = getTheBytesThatWillContainTheTrailer( pageSize, firstPageThatTrailerMightBeIn, lastPageId,
+                    pageCursor );
+            trailerPositionRelativeToFirstPageTrailerMightBeIn =
+                    findTrailerPositionInArray( allData, UTF8.encode( expectedTrailer.split( " " )[0] ) );
+        }
+        if ( trailerPositionRelativeToFirstPageTrailerMightBeIn == -1 )
+        {
+            return trailerPositionRelativeToFirstPageTrailerMightBeIn;
+        }
+        return trailerPositionRelativeToFirstPageTrailerMightBeIn + firstPageThatTrailerMightBeIn * pageSize;
+    }
+
+    /**
+     * Read the trailer present in the given file.
+     *
+     * @param pagedFile The paged file to look in
+     * @param expectedTrailer The trailer is expected to be found in the file
+     * @return The found trailer, or null if no trailer was found
+     * @throws IOException
+     */
+    public static String readTrailer( PagedFile pagedFile, String expectedTrailer ) throws IOException
+    {
+        String version = null;
+        int pageSize = pagedFile.pageSize();
+        int encodedExpectedTrailerLength = UTF8.encode( expectedTrailer ).length;
+        long lastPageId = pagedFile.getLastPageId();
+        long firstPageThatTrailerMightBeIn =
+                getFirstPageThatTrailerMightBeIn( lastPageId, pageSize, encodedExpectedTrailerLength );
+
+        try ( PageCursor pageCursor = pagedFile.io( firstPageThatTrailerMightBeIn, PagedFile.PF_SHARED_LOCK ) )
+        {
+            byte[] allData = getTheBytesThatWillContainTheTrailer( pageSize, firstPageThatTrailerMightBeIn, lastPageId,
+                    pageCursor );
+            int trailerPositionRelativeToFirstPageTrailerMightBeIn =
+                    findTrailerPositionInArray( allData, UTF8.encode( expectedTrailer.split( " " )[0] ) );
+            if ( trailerPositionRelativeToFirstPageTrailerMightBeIn != -1 )
+            {
+                version = new String( allData, trailerPositionRelativeToFirstPageTrailerMightBeIn,
+                        encodedExpectedTrailerLength, Charsets.UTF_8 );
+            }
+        }
+        return version;
+    }
+
+    /**
+     * Write the given trailer att the given offset into the file.
+     *
+     * @param pagedFile The paged file to write the trailer into
+     * @param trailer The trailer to be written, encoded in UTF-8
+     * @param trailerOffset The position to write the trailer at, from the beginning of the file.
+     * @throws IOException
+     */
+    public static void writeTrailer( PagedFile pagedFile, byte[] trailer, long trailerOffset ) throws IOException
+    {
+        int pageSize = pagedFile.pageSize();
+        long pageIdTrailerStartsIn = trailerOffset / pageSize;
+
+        try ( PageCursor pageCursor = pagedFile.io( pageIdTrailerStartsIn, PagedFile.PF_EXCLUSIVE_LOCK ) )
+        {
+            int writtenOffset = 0;
+            while ( writtenOffset < trailer.length )
+            {
+                pageCursor.next();
+                pageCursor.setOffset( (int) ((writtenOffset + trailerOffset) % pageSize) );
+                do
+                {
+                    do
+                    {
+                        pageCursor.putByte( trailer[writtenOffset] );
+                    }
+                    while ( pageCursor.shouldRetry() );
+                    writtenOffset++;
+                }
+                while ( (writtenOffset + trailerOffset) % pageSize != 0 && writtenOffset < trailer.length );
+            }
+        }
+    }
+
+    private static long getFirstPageThatTrailerMightBeIn( long lastPageId, int pageSize, int expectedTrailerLength )
+            throws IOException
+    {
+        int maximumNumberOfPagesVersionSpans = getMaximumNumberOfPagesVersionSpans( expectedTrailerLength, pageSize );
+        return Math.max( lastPageId + 1 - maximumNumberOfPagesVersionSpans, 0 );
+    }
+
+    private static int findTrailerPositionInArray( byte[] dataThatShouldContailTrailer, byte[] trailer )
+    {
+        for ( int i = dataThatShouldContailTrailer.length - trailer.length; i >= 0; i-- )
+        {
+            int pos = 0;
+            while ( pos < trailer.length && dataThatShouldContailTrailer[i + pos] == trailer[pos] )
+            {
+                pos++;
+            }
+            if ( pos == trailer.length )
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int getMaximumNumberOfPagesVersionSpans( int trailerLength, int pageSize )
+    {
+        return trailerLength / pageSize + 2;
+    }
+
+    private static byte[] getTheBytesThatWillContainTheTrailer( int pageSize, long firstPageThatTrailerMightBeIn,
+            long lastPageId, PageCursor pageCursor ) throws IOException
+    {
+        byte[] allData = new byte[(int) (pageSize * (lastPageId - firstPageThatTrailerMightBeIn + 1))];
+        byte[] data = new byte[pageSize];
+        int currentPage = 0;
+        while ( pageCursor.next() )
+        {
+            do
+            {
+                pageCursor.getBytes( data );
+            }
+            while ( pageCursor.shouldRetry() );
+            System.arraycopy( data, 0, allData, currentPage * data.length, data.length );
+            currentPage++;
+        }
+        return allData;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -441,7 +441,7 @@ public class StoreMigrator implements StoreMigrationParticipant
         StoreFile.fileOperation( COPY, fileSystem, storeDir, migrationDir, storeFiles,
                 true, // OK if it's not there (1.9)
                 false, StoreFileType.values() );
-        StoreFile.ensureStoreVersion( fileSystem, pageCache, migrationDir, storeFiles );
+        StoreFile.ensureStoreVersion( pageCache, migrationDir, storeFiles );
     }
 
     private AdditionalInitialIds readAdditionalIds( File storeDir, final long lastTxId, final long lastTxChecksum,
@@ -842,7 +842,7 @@ public class StoreMigrator implements StoreMigrationParticipant
     private void ensureStoreVersions( File dir ) throws IOException
     {
         final Iterable<StoreFile> versionedStores = iterable( allExcept() );
-        StoreFile.ensureStoreVersion( fileSystem, pageCache, dir, versionedStores );
+        StoreFile.ensureStoreVersion( pageCache, dir, versionedStores );
     }
 
     private void updateOrAddNeoStoreFieldsAsPartOfMigration( File migrationDir, File storeDir ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyStoreTest.java
@@ -19,20 +19,19 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.internal.InOrderImpl;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.File;
+import java.io.IOException;
 
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.JumpingIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
@@ -42,11 +41,10 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 public class PropertyStoreTest
 {
@@ -72,50 +70,50 @@ public class PropertyStoreTest
     public void shouldWriteOutTheDynamicChainBeforeUpdatingThePropertyRecord() throws IOException
     {
         // given
-        PageCache pageCache = mock( PageCache.class );
-
-        PagedFile storeFile = mock( PagedFile.class );
-        when( pageCache.map( any( File.class ), anyInt() ) ).thenReturn( storeFile );
+        PageCache pageCache = pageCacheRule.getPageCache( fileSystemAbstraction );
+        Config config = new Config();
+        config.setProperty( PropertyStore.Configuration.rebuild_idgenerators_fast.name(), "true" );
 
         DynamicStringStore stringPropertyStore = mock( DynamicStringStore.class );
 
-        PageCursor cursor = mock( PageCursor.class );
-        when( cursor.next() ).thenReturn( true );
-
-        when( storeFile.io( anyInt(), anyInt() ) ).thenReturn( cursor );
-        when( storeFile.pageSize() ).thenReturn( 8 );
-
-        org.neo4j.kernel.configuration.Config config = mock( org.neo4j.kernel.configuration.Config.class );
-        when( config.get( PropertyStore.Configuration.rebuild_idgenerators_fast ) ).thenReturn( true );
-
-
-        PropertyStore store = new PropertyStore( path, config, new JumpingIdGeneratorFactory( 1 ), pageCache,
+        final PropertyStore store = new PropertyStore( path, config, new JumpingIdGeneratorFactory( 1 ), pageCache,
                 fileSystemAbstraction, NullLogProvider.getInstance(),
                 stringPropertyStore, mock( PropertyKeyTokenStore.class ), mock( DynamicArrayStore.class ),
-                null, null );
+                StoreVersionMismatchHandler.FORCE_CURRENT_VERSION, null );
 
-        store.makeStoreOk();
-        long l = store.nextId();
+        try
+        {
+            store.makeStoreOk();
+            final long propertyRecordId = store.nextId();
 
-        PropertyRecord record = new PropertyRecord( l );
-        record.setInUse( true );
+            PropertyRecord record = new PropertyRecord( propertyRecordId );
+            record.setInUse( true );
 
-        DynamicRecord dynamicRecord = dynamicRecord();
-        PropertyBlock propertyBlock = propertyBlockWith( dynamicRecord );
-        record.setPropertyBlock( propertyBlock );
+            DynamicRecord dynamicRecord = dynamicRecord();
+            PropertyBlock propertyBlock = propertyBlockWith( dynamicRecord );
+            record.setPropertyBlock( propertyBlock );
 
-        // when
-        store.updateRecord( record );
+            doAnswer( new Answer()
+            {
+                @Override
+                public Object answer( InvocationOnMock invocation ) throws Throwable
+                {
+                    PropertyRecord recordBeforeWrite = store.forceGetRecord( propertyRecordId );
+                    assertFalse( recordBeforeWrite.inUse() );
+                    return null;
+                }
+            } ).when( stringPropertyStore ).updateRecord( dynamicRecord );
 
-        // then
-        InOrderImpl inOrder = new InOrderImpl( Arrays.<Object>asList(stringPropertyStore, cursor) );
+            // when
+            store.updateRecord( record );
 
-        inOrder.verify( stringPropertyStore ).updateRecord( dynamicRecord );
-
-        inOrder.verify( cursor ).putByte( (byte) 0 );
-        inOrder.verify( cursor, times( 2 ) ).putInt( -1 );
-        inOrder.verify( cursor ).putLong( propertyBlock.getValueBlocks()[0] );
-        inOrder.verify( cursor ).putLong( 0 );
+            // then verify that our mocked method above, with the assert, was actually called
+            verify( stringPropertyStore ).updateRecord( dynamicRecord );
+        }
+        finally
+        {
+            store.close();
+        }
     }
 
     private DynamicRecord dynamicRecord()
@@ -138,6 +136,4 @@ public class PropertyStoreTest
 
         return propertyBlock;
     }
-
-
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreVersionTrailerUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreVersionTrailerUtilTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.UTF8;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.PageCacheRule;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.kernel.impl.store.CommonAbstractStore.buildTypeDescriptorAndVersion;
+
+public class StoreVersionTrailerUtilTest
+{
+
+    @Rule
+    public PageCacheRule pageCacheRule = new PageCacheRule();
+    @Rule
+    public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+    @Rule
+    public TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTestWithEphemeralFS( fs.get(), getClass() );
+
+    private PageCache pageCache;
+    private File neoStoreFile;
+
+    @Before
+    public void setUpNeoStore() throws Exception
+    {
+        Config config = new Config( new HashMap<String,String>(), GraphDatabaseSettings.class );
+        Monitors monitors = new Monitors();
+        pageCache = pageCacheRule.getPageCache( fs.get() );
+        StoreFactory sf =
+                new StoreFactory( dir.graphDbDir(), config, new DefaultIdGeneratorFactory( fs.get() ), pageCache,
+                        fs.get(), NullLogProvider.getInstance(), monitors );
+        sf.createNeoStore().close();
+        neoStoreFile = new File( dir.graphDbDir(), NeoStore.DEFAULT_NAME );
+    }
+
+    @Test
+    public void testGetTrailerOffset() throws Exception
+    {
+        long trailerOffset;
+        String expectedTrailer = buildTypeDescriptorAndVersion( NeoStore.TYPE_DESCRIPTOR );
+        try ( PagedFile pagedFile = pageCache.map( neoStoreFile, pageCache.pageSize() ) )
+        {
+            trailerOffset = StoreVersionTrailerUtil.getTrailerOffset( pagedFile, expectedTrailer );
+        }
+        int expectedOffset = NeoStore.Position.values().length * NeoStore.RECORD_SIZE;
+        assertEquals( expectedOffset, trailerOffset );
+
+    }
+
+    @Test
+    public void testReadTrailer() throws Exception
+    {
+        String trailer;
+        String expectedTrailer = buildTypeDescriptorAndVersion( NeoStore.TYPE_DESCRIPTOR );
+        try ( PagedFile pagedFile = pageCache.map( neoStoreFile, pageCache.pageSize() ) )
+        {
+            trailer = StoreVersionTrailerUtil.readTrailer( pagedFile, expectedTrailer );
+        }
+        assertEquals( expectedTrailer, trailer );
+    }
+
+    @Test
+    public void testWriteTrailer() throws Exception
+    {
+        String expectedTrailer = buildTypeDescriptorAndVersion( NeoStore.TYPE_DESCRIPTOR );
+        byte[] encocdedTrailer = UTF8.encode( expectedTrailer );
+        try ( PagedFile pagedFile = pageCache.map( neoStoreFile, pageCache.pageSize() ) )
+        {
+            long trailerOffset;
+            trailerOffset = StoreVersionTrailerUtil.getTrailerOffset( pagedFile, expectedTrailer );
+            StoreVersionTrailerUtil.writeTrailer( pagedFile, new byte[encocdedTrailer.length], trailerOffset );
+
+            assertEquals( -1, StoreVersionTrailerUtil.getTrailerOffset( pagedFile, expectedTrailer ) );
+
+            StoreVersionTrailerUtil.writeTrailer( pagedFile, encocdedTrailer, trailerOffset );
+            assertEquals( trailerOffset, StoreVersionTrailerUtil.getTrailerOffset( pagedFile, expectedTrailer ) );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -27,12 +33,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
@@ -84,16 +84,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class TestNeoStore
 {
-    private File storeDir;
-    private PropertyStore pStore;
-    private RelationshipTypeTokenStore rtStore;
-    private NeoStoreDataSource ds;
-
     @Rule
     public PageCacheRule pageCacheRule = new PageCacheRule();
     @Rule
@@ -104,6 +98,10 @@ public class TestNeoStore
     public NeoStoreDataSourceRule dsRule = new NeoStoreDataSourceRule();
 
     private PageCache pageCache;
+    private File storeDir;
+    private PropertyStore pStore;
+    private RelationshipTypeTokenStore rtStore;
+    private NeoStoreDataSource ds;
 
     @Before
     public void setUpNeoStore() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.impl.storemigration.legacystore.v19.Legacy19Store;
 import org.neo4j.kernel.impl.storemigration.legacystore.v20.Legacy20Store;
 import org.neo4j.kernel.impl.storemigration.legacystore.v21.Legacy21Store;
 import org.neo4j.kernel.impl.storemigration.legacystore.v22.Legacy22Store;
+import org.neo4j.kernel.impl.store.StoreVersionTrailerUtil;
 import org.neo4j.test.Unzip;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -197,7 +198,7 @@ public class MigrationTestUtils
             try ( PagedFile pagedFile = pageCache
                     .map( new File( workingDirectory, storeFile.storeFileName() ), pageCache.pageSize() ) )
             {
-                foundVersion = StoreVersionCheck.readVersion( pagedFile, version );
+                foundVersion = StoreVersionTrailerUtil.readTrailer( pagedFile, version );
             }
             if ( !version.equals( foundVersion ) )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigratorTest.java
@@ -52,6 +52,11 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class StoreMigratorTest
 {
+    @Rule
+    public final TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+    @Rule
+    public final PageCacheRule pageCacheRule = new PageCacheRule();
+    public final FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
     private final SchemaIndexProvider schemaIndexProvider = new InMemoryIndexProvider();
 
     @Parameterized.Parameter(0)
@@ -99,10 +104,4 @@ public class StoreMigratorTest
                 logService.getInternalLogProvider(), new Monitors() );
         storeFactory.newNeoStore( false ).close();
     }
-
-    @Rule
-    public final TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
-    public final FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
-    @Rule
-    public final PageCacheRule pageCacheRule = new PageCacheRule();
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -294,7 +294,8 @@ public class StoreCopyClient
                 // last closed transaction offset will not overcome old one. Till that happens it will be
                 // impossible for recovery process to restore the store
                 File neoStore = new File( tempStoreDir, NeoStore.DEFAULT_NAME );
-                NeoStore.setRecord( pageCache, neoStore, NeoStore.Position.LAST_CLOSED_TRANSACTION_LOG_BYTE_OFFSET, LOG_HEADER_SIZE );
+                NeoStore.setRecord( pageCache, neoStore, NeoStore.Position.LAST_CLOSED_TRANSACTION_LOG_BYTE_OFFSET,
+                        LOG_HEADER_SIZE );
             }
         }
         finally


### PR DESCRIPTION
Also introduces StoreVersionTrailerUtil for store version trailer handling with the page cache.
This is a step towards making the stores independent of the FilesystemAbstraction, which will help with supporting block devices.
