### PR TITLE
Load entity data on write after having acquired an exclusive lock

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -33,7 +33,6 @@ import org.neo4j.index.lucene.LuceneLabelScanStoreBuilder;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.direct.DirectStoreAccess;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -59,7 +58,6 @@ import org.neo4j.kernel.impl.store.record.SchemaRule;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
-import org.neo4j.kernel.impl.transaction.state.NeoStoreSupplier;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.test.PageCacheRule;
@@ -353,8 +351,6 @@ public abstract class GraphStoreFixture extends PageCacheRule implements TestRul
             TransactionRepresentationCommitProcess commitProcess =
                     new TransactionRepresentationCommitProcess(
                             dependencyResolver.resolveDependency( TransactionAppender.class ),
-                            dependencyResolver.resolveDependency( KernelHealth.class ),
-                            dependencyResolver.resolveDependency( NeoStoreSupplier.class ).get(),
                             dependencyResolver.resolveDependency( TransactionRepresentationStoreApplier.class ),
                             dependencyResolver.resolveDependency( IndexUpdatesValidator.class ) );
             TransactionIdStore transactionIdStore = database.getDependencyResolver().resolveDependency(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
@@ -59,8 +59,8 @@ public class GuardingStatementOperations implements
     @Override
     public long relationshipCreate( KernelStatement statement,
             int relationshipTypeId,
-            NodeItem startNodeId,
-            NodeItem endNodeId )
+            long startNodeId,
+            long endNodeId )
             throws EntityNotFoundException
     {
         guard.check();
@@ -75,49 +75,49 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public void nodeDelete( KernelStatement state, NodeItem node )
+    public void nodeDelete( KernelStatement state, long nodeId ) throws EntityNotFoundException
     {
         guard.check();
-        entityWriteDelegate.nodeDelete( state, node );
+        entityWriteDelegate.nodeDelete( state, nodeId );
     }
 
     @Override
-    public void relationshipDelete( KernelStatement state, RelationshipItem relationship )
+    public void relationshipDelete( KernelStatement state, long relationshipId ) throws EntityNotFoundException
     {
         guard.check();
-        entityWriteDelegate.relationshipDelete( state, relationship );
+        entityWriteDelegate.relationshipDelete( state, relationshipId );
     }
 
     @Override
-    public boolean nodeAddLabel( KernelStatement state, NodeItem node, int labelId )
-            throws ConstraintValidationKernelException
+    public boolean nodeAddLabel( KernelStatement state, long nodeId, int labelId )
+            throws ConstraintValidationKernelException, EntityNotFoundException
     {
         guard.check();
-        return entityWriteDelegate.nodeAddLabel( state, node, labelId );
+        return entityWriteDelegate.nodeAddLabel( state, nodeId, labelId );
     }
 
     @Override
-    public boolean nodeRemoveLabel( KernelStatement state, NodeItem node, int labelId )
+    public boolean nodeRemoveLabel( KernelStatement state, long nodeId, int labelId ) throws EntityNotFoundException
     {
         guard.check();
-        return entityWriteDelegate.nodeRemoveLabel( state, node, labelId );
+        return entityWriteDelegate.nodeRemoveLabel( state, nodeId, labelId );
     }
 
     @Override
-    public Property nodeSetProperty( KernelStatement state, NodeItem node, DefinedProperty property )
-            throws ConstraintValidationKernelException
+    public Property nodeSetProperty( KernelStatement state, long nodeId, DefinedProperty property )
+            throws ConstraintValidationKernelException, EntityNotFoundException
     {
         guard.check();
-        return entityWriteDelegate.nodeSetProperty( state, node, property );
+        return entityWriteDelegate.nodeSetProperty( state, nodeId, property );
     }
 
     @Override
     public Property relationshipSetProperty( KernelStatement state,
-            RelationshipItem relationship,
-            DefinedProperty property )
+            long relationshipId,
+            DefinedProperty property ) throws EntityNotFoundException
     {
         guard.check();
-        return entityWriteDelegate.relationshipSetProperty( state, relationship, property );
+        return entityWriteDelegate.relationshipSetProperty( state, relationshipId, property );
     }
 
     @Override
@@ -128,19 +128,20 @@ public class GuardingStatementOperations implements
     }
 
     @Override
-    public Property nodeRemoveProperty( KernelStatement state, NodeItem node, int propertyKeyId )
+    public Property nodeRemoveProperty( KernelStatement state, long nodeId, int propertyKeyId )
+            throws EntityNotFoundException
     {
         guard.check();
-        return entityWriteDelegate.nodeRemoveProperty( state, node, propertyKeyId );
+        return entityWriteDelegate.nodeRemoveProperty( state, nodeId, propertyKeyId );
     }
 
     @Override
     public Property relationshipRemoveProperty( KernelStatement state,
-            RelationshipItem relationship,
-            int propertyKeyId )
+            long relationshipId,
+            int propertyKeyId ) throws EntityNotFoundException
     {
         guard.check();
-        return entityWriteDelegate.relationshipRemoveProperty( state, relationship, propertyKeyId );
+        return entityWriteDelegate.relationshipRemoveProperty( state, relationshipId, propertyKeyId );
     }
 
     @Override
@@ -260,6 +261,13 @@ public class GuardingStatementOperations implements
     }
 
     @Override
+    public Cursor<NodeItem> nodeCursorById( KernelStatement statement, long nodeId ) throws EntityNotFoundException
+    {
+        guard.check();
+        return entityReadDelegate.nodeCursorById( statement, nodeId );
+    }
+
+    @Override
     public Cursor<NodeItem> nodeCursor( KernelStatement statement, long nodeId )
     {
         guard.check();
@@ -271,6 +279,14 @@ public class GuardingStatementOperations implements
     {
         guard.check();
         return entityReadDelegate.nodeCursor( txStateHolder, statement, nodeId );
+    }
+
+    @Override
+    public Cursor<RelationshipItem> relationshipCursorById( KernelStatement statement, long relId )
+            throws EntityNotFoundException
+    {
+        guard.check();
+        return entityReadDelegate.relationshipCursorById( statement, relId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -29,7 +29,6 @@ import org.neo4j.cursor.Cursor;
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.api.DataWriteOperations;
-import org.neo4j.kernel.api.EntityType;
 import org.neo4j.kernel.api.LegacyIndexHits;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
@@ -259,7 +258,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
             return false;
         }
 
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().hasLabel( labelId );
         }
@@ -269,7 +268,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public PrimitiveIntIterator nodeGetLabels( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().getLabels();
         }
@@ -283,7 +282,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
         {
             return false;
         }
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().hasProperty( propertyKeyId );
         }
@@ -297,7 +296,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
         {
             return null;
         }
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().getProperty( propertyKeyId );
         }
@@ -308,7 +307,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
             throws EntityNotFoundException
     {
         statement.assertOpen();
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().getRelationships( direction, relTypes );
         }
@@ -319,7 +318,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
             throws EntityNotFoundException
     {
         statement.assertOpen();
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().getRelationships( direction );
         }
@@ -329,7 +328,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public int nodeGetDegree( long nodeId, Direction direction, int relType ) throws EntityNotFoundException
     {
         statement.assertOpen();
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().degree( direction, relType );
         }
@@ -339,7 +338,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public int nodeGetDegree( long nodeId, Direction direction ) throws EntityNotFoundException
     {
         statement.assertOpen();
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().degree( direction );
         }
@@ -349,7 +348,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public PrimitiveIntIterator nodeGetRelationshipTypes( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().getRelationshipTypes();
         }
@@ -363,7 +362,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
         {
             return false;
         }
-        try ( Cursor<RelationshipItem> relationship = getRelationshipCursor( relationshipId ) )
+        try ( Cursor<RelationshipItem> relationship = dataRead().relationshipCursorById( statement, relationshipId ) )
         {
             return relationship.get().hasProperty( propertyKeyId );
         }
@@ -377,7 +376,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
         {
             return null;
         }
-        try ( Cursor<RelationshipItem> relationship = getRelationshipCursor( relationshipId ) )
+        try ( Cursor<RelationshipItem> relationship = dataRead().relationshipCursorById( statement, relationshipId ) )
         {
             return relationship.get().getProperty( propertyKeyId );
         }
@@ -409,7 +408,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public PrimitiveIntIterator nodeGetPropertyKeys( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
+        try ( Cursor<NodeItem> node = dataRead().nodeCursorById( statement, nodeId ) )
         {
             return node.get().getPropertyKeys();
         }
@@ -419,7 +418,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public PrimitiveIntIterator relationshipGetPropertyKeys( long relationshipId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-        try ( Cursor<RelationshipItem> relationship = getRelationshipCursor( relationshipId ) )
+        try ( Cursor<RelationshipItem> relationship = dataRead().relationshipCursorById( statement, relationshipId ) )
         {
             return relationship.get().getPropertyKeys();
         }
@@ -542,7 +541,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
         IndexDescriptor descriptor = schemaRead().indexesGetForLabelAndPropertyKey( statement, labelId, propertyKeyId );
         if ( descriptor == null )
         {
-            throw new IndexSchemaRuleNotFoundException( labelId, propertyKeyId);
+            throw new IndexSchemaRuleNotFoundException( labelId, propertyKeyId );
         }
         return descriptor;
     }
@@ -586,7 +585,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
 
         if ( null == result )
         {
-            throw new IndexSchemaRuleNotFoundException( labelId, propertyKeyId, true);
+            throw new IndexSchemaRuleNotFoundException( labelId, propertyKeyId, true );
         }
 
         return result;
@@ -791,7 +790,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
 
     // <SchemaState>
     @Override
-    public <K, V> V schemaStateGetOrCreate( K key, Function<K, V> creator )
+    public <K, V> V schemaStateGetOrCreate( K key, Function<K,V> creator )
     {
         return schemaState().schemaStateGetOrCreate( statement, key, creator );
     }
@@ -816,11 +815,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public void nodeDelete( long nodeId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
-        {
-            dataWrite().nodeDelete( statement, node.get() );
-        }
+        dataWrite().nodeDelete( statement, nodeId );
     }
 
     @Override
@@ -828,26 +823,14 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
             throws RelationshipTypeIdNotFoundKernelException, EntityNotFoundException
     {
         statement.assertOpen();
-
-        try ( Cursor<NodeItem> startNode = getNodeCursor( startNodeId ) )
-        {
-            try ( Cursor<NodeItem> endNode = getNodeCursor( endNodeId ) )
-            {
-                return dataWrite().relationshipCreate( statement, relationshipTypeId, startNode.get(), endNode.get() );
-            }
-        }
-
+        return dataWrite().relationshipCreate( statement, relationshipTypeId, startNodeId, endNodeId );
     }
 
     @Override
     public void relationshipDelete( long relationshipId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-
-        try ( Cursor<RelationshipItem> relationship = getRelationshipCursor( relationshipId ) )
-        {
-            dataWrite().relationshipDelete( statement, relationship.get() );
-        }
+        dataWrite().relationshipDelete( statement, relationshipId );
     }
 
     @Override
@@ -855,22 +838,14 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
             throws EntityNotFoundException, ConstraintValidationKernelException
     {
         statement.assertOpen();
-
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
-        {
-            return dataWrite().nodeAddLabel( statement, node.get(), labelId );
-        }
+        return dataWrite().nodeAddLabel( statement, nodeId, labelId );
     }
 
     @Override
     public boolean nodeRemoveLabel( long nodeId, int labelId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
-        {
-            return dataWrite().nodeRemoveLabel( statement, node.get(), labelId );
-        }
+        return dataWrite().nodeRemoveLabel( statement, nodeId, labelId );
     }
 
     @Override
@@ -878,11 +853,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
             throws EntityNotFoundException, ConstraintValidationKernelException
     {
         statement.assertOpen();
-
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
-        {
-            return dataWrite().nodeSetProperty( statement, node.get(), property );
-        }
+        return dataWrite().nodeSetProperty( statement, nodeId, property );
     }
 
     @Override
@@ -890,11 +861,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
             throws EntityNotFoundException
     {
         statement.assertOpen();
-
-        try ( Cursor<RelationshipItem> relationship = getRelationshipCursor( relationshipId ) )
-        {
-            return dataWrite().relationshipSetProperty( statement, relationship.get(), property );
-        }
+            return dataWrite().relationshipSetProperty( statement, relationshipId, property );
     }
 
     @Override
@@ -908,22 +875,14 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public Property nodeRemoveProperty( long nodeId, int propertyKeyId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-
-        try ( Cursor<NodeItem> node = getNodeCursor( nodeId ) )
-        {
-            return dataWrite().nodeRemoveProperty( statement, node.get(), propertyKeyId );
-        }
+        return dataWrite().nodeRemoveProperty( statement, nodeId, propertyKeyId );
     }
 
     @Override
     public Property relationshipRemoveProperty( long relationshipId, int propertyKeyId ) throws EntityNotFoundException
     {
         statement.assertOpen();
-
-        try ( Cursor<RelationshipItem> relationship = getRelationshipCursor( relationshipId ) )
-        {
-            return dataWrite().relationshipRemoveProperty( statement, relationship.get(), propertyKeyId );
-        }
+        return dataWrite().relationshipRemoveProperty( statement, relationshipId, propertyKeyId );
     }
 
     @Override
@@ -1080,14 +1039,14 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public void nodeLegacyIndexCreateLazily( String indexName, Map<String, String> customConfig )
+    public void nodeLegacyIndexCreateLazily( String indexName, Map<String,String> customConfig )
     {
         statement.assertOpen();
         legacyIndexWrite().nodeLegacyIndexCreateLazily( statement, indexName, customConfig );
     }
 
     @Override
-    public void nodeLegacyIndexCreate( String indexName, Map<String, String> customConfig )
+    public void nodeLegacyIndexCreate( String indexName, Map<String,String> customConfig )
     {
         statement.assertOpen();
 
@@ -1095,14 +1054,14 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public void relationshipLegacyIndexCreateLazily( String indexName, Map<String, String> customConfig )
+    public void relationshipLegacyIndexCreateLazily( String indexName, Map<String,String> customConfig )
     {
         statement.assertOpen();
         legacyIndexWrite().relationshipLegacyIndexCreateLazily( statement, indexName, customConfig );
     }
 
     @Override
-    public void relationshipLegacyIndexCreate( String indexName, Map<String, String> customConfig )
+    public void relationshipLegacyIndexCreate( String indexName, Map<String,String> customConfig )
     {
         statement.assertOpen();
 
@@ -1187,7 +1146,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public Map<String, String> nodeLegacyIndexGetConfiguration( String indexName )
+    public Map<String,String> nodeLegacyIndexGetConfiguration( String indexName )
             throws LegacyIndexNotFoundKernelException
     {
         statement.assertOpen();
@@ -1195,7 +1154,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public Map<String, String> relationshipLegacyIndexGetConfiguration( String indexName )
+    public Map<String,String> relationshipLegacyIndexGetConfiguration( String indexName )
             throws LegacyIndexNotFoundKernelException
     {
         statement.assertOpen();
@@ -1266,34 +1225,4 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     // </Counts>
-
-    private Cursor<NodeItem> getNodeCursor( long nodeId ) throws EntityNotFoundException
-    {
-        Cursor<NodeItem> node = dataRead().nodeCursor( statement, nodeId );
-
-        if ( !node.next() )
-        {
-            node.close();
-            throw new EntityNotFoundException( EntityType.NODE, nodeId );
-        }
-        else
-        {
-            return node;
-        }
-    }
-
-    private Cursor<RelationshipItem> getRelationshipCursor( long relationshipId ) throws EntityNotFoundException
-    {
-        Cursor<RelationshipItem> relationship = dataRead().relationshipCursor( statement, relationshipId );
-
-        if ( !relationship.next() )
-        {
-            relationship.close();
-            throw new EntityNotFoundException( EntityType.RELATIONSHIP, relationshipId );
-        }
-        else
-        {
-            return relationship;
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
@@ -27,7 +26,6 @@ import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.Commitment;
 import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
-import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
 import org.neo4j.kernel.impl.transaction.tracing.StoreApplyEvent;
@@ -39,25 +37,20 @@ import static org.neo4j.kernel.api.exceptions.Status.Transaction.ValidationFaile
 public class TransactionRepresentationCommitProcess implements TransactionCommitProcess
 {
     private final TransactionAppender appender;
-    private final KernelHealth kernelHealth;
-    private final TransactionIdStore transactionIdStore;
     private final TransactionRepresentationStoreApplier storeApplier;
     private final IndexUpdatesValidator indexUpdatesValidator;
 
-    public TransactionRepresentationCommitProcess(TransactionAppender appender, KernelHealth kernelHealth,
-            TransactionIdStore transactionIdStore, TransactionRepresentationStoreApplier storeApplier,
-            IndexUpdatesValidator indexUpdatesValidator )
+    public TransactionRepresentationCommitProcess( TransactionAppender appender,
+            TransactionRepresentationStoreApplier storeApplier, IndexUpdatesValidator indexUpdatesValidator )
     {
         this.appender = appender;
-        this.transactionIdStore = transactionIdStore;
-        this.kernelHealth = kernelHealth;
         this.storeApplier = storeApplier;
         this.indexUpdatesValidator = indexUpdatesValidator;
     }
 
     @Override
     public long commit( TransactionRepresentation transaction, LockGroup locks, CommitEvent commitEvent,
-                        TransactionApplicationMode mode ) throws TransactionFailureException
+            TransactionApplicationMode mode ) throws TransactionFailureException
     {
         try ( ValidatedIndexUpdates indexUpdates = validateIndexUpdates( transaction, mode ) )
         {
@@ -68,8 +61,7 @@ public class TransactionRepresentationCommitProcess implements TransactionCommit
     }
 
     private ValidatedIndexUpdates validateIndexUpdates( TransactionRepresentation transaction,
-                                                        TransactionApplicationMode mode)
-            throws TransactionFailureException
+            TransactionApplicationMode mode ) throws TransactionFailureException
     {
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
@@ -118,9 +118,14 @@ public interface EntityReadOperations
     <EXCEPTION extends Exception> void relationshipVisit( KernelStatement statement, long relId,
             RelationshipVisitor<EXCEPTION> visitor ) throws EntityNotFoundException, EXCEPTION;
 
+    Cursor<NodeItem> nodeCursorById( KernelStatement statement, long nodeId ) throws EntityNotFoundException;
+
     Cursor<NodeItem> nodeCursor( KernelStatement statement, long nodeId );
 
     Cursor<NodeItem> nodeCursor( TxStateHolder txStateHolder, StoreStatement statement, long nodeId );
+
+    Cursor<RelationshipItem> relationshipCursorById( KernelStatement statement, long relId )
+            throws EntityNotFoundException;
 
     Cursor<RelationshipItem> relationshipCursor( KernelStatement statement, long relId );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityWriteOperations.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.api.operations;
 
-import org.neo4j.kernel.api.cursor.NodeItem;
-import org.neo4j.kernel.api.cursor.RelationshipItem;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.properties.DefinedProperty;
@@ -33,14 +31,14 @@ public interface EntityWriteOperations
 
     long relationshipCreate( KernelStatement statement,
             int relationshipTypeId,
-            NodeItem startNodeId,
-            NodeItem endNodeId ) throws EntityNotFoundException;
+            long startNodeId,
+            long endNodeId ) throws EntityNotFoundException;
 
     long nodeCreate( KernelStatement statement );
 
-    void nodeDelete( KernelStatement state, NodeItem node );
+    void nodeDelete( KernelStatement state, long nodeId ) throws EntityNotFoundException;
 
-    void relationshipDelete( KernelStatement state, RelationshipItem relationship );
+    void relationshipDelete( KernelStatement state, long relationshipId ) throws EntityNotFoundException;
 
     /**
      * Labels a node with the label corresponding to the given label id.
@@ -49,8 +47,8 @@ public interface EntityWriteOperations
      * or {@link
      * KeyReadOperations#labelGetForName(org.neo4j.kernel.api.Statement, String)}.
      */
-    boolean nodeAddLabel( KernelStatement state, NodeItem node, int labelId )
-            throws ConstraintValidationKernelException;
+    boolean nodeAddLabel( KernelStatement state, long nodeId, int labelId )
+            throws ConstraintValidationKernelException, EntityNotFoundException;
 
     /**
      * Removes a label with the corresponding id from a node.
@@ -59,12 +57,12 @@ public interface EntityWriteOperations
      * or {@link
      * KeyReadOperations#labelGetForName(org.neo4j.kernel.api.Statement, String)}.
      */
-    boolean nodeRemoveLabel( KernelStatement state, NodeItem node, int labelId );
+    boolean nodeRemoveLabel( KernelStatement state, long nodeId, int labelId ) throws EntityNotFoundException;
 
-    Property nodeSetProperty( KernelStatement state, NodeItem node, DefinedProperty property )
-            throws ConstraintValidationKernelException;
+    Property nodeSetProperty( KernelStatement state, long nodeId, DefinedProperty property )
+            throws ConstraintValidationKernelException, EntityNotFoundException;
 
-    Property relationshipSetProperty( KernelStatement state, RelationshipItem relationship, DefinedProperty property );
+    Property relationshipSetProperty( KernelStatement state, long relationshipId, DefinedProperty property ) throws EntityNotFoundException;
 
     Property graphSetProperty( KernelStatement state, DefinedProperty property );
 
@@ -72,9 +70,9 @@ public interface EntityWriteOperations
      * Remove a node's property given the node's id and the property key id and return the value to which
      * it was set or null if it was not set on the node
      */
-    Property nodeRemoveProperty( KernelStatement state, NodeItem node, int propertyKeyId );
+    Property nodeRemoveProperty( KernelStatement state, long nodeId, int propertyKeyId ) throws EntityNotFoundException;
 
-    Property relationshipRemoveProperty( KernelStatement state, RelationshipItem relationship, int propertyKeyId );
+    Property relationshipRemoveProperty( KernelStatement state, long relationshipId, int propertyKeyId ) throws EntityNotFoundException;
 
     Property graphRemoveProperty( KernelStatement state, int propertyKeyId );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -166,8 +166,7 @@ public class CommunityEditionModule
                 }
                 else
                 {
-                    return new TransactionRepresentationCommitProcess( appender, kernelHealth,
-                            neoStore, storeApplier, indexUpdatesValidator );
+                    return new TransactionRepresentationCommitProcess( appender, storeApplier, indexUpdatesValidator );
                 }
             }
         };

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChanges.java
@@ -53,6 +53,14 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
     }
 
     @Override
+    public String toString()
+    {
+        return "RecordChanges{" +
+               "recordChanges=" + recordChanges +
+               '}';
+    }
+
+    @Override
     public RecordProxy<KEY, RECORD, ADDITIONAL> getIfLoaded( KEY key )
     {
         return recordChanges.get( key );
@@ -155,6 +163,16 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
             this.manageBeforeState = manageBeforeState;
             this.created = created;
             this.additionalData = additionalData;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "RecordChange{" +
+                   "record=" + record +
+                   "key=" + key +
+                   "created=" + created +
+                   '}';
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -136,7 +136,7 @@ public class TransactionRecordState implements RecordState
         for ( RecordProxy<Integer, LabelTokenRecord, Void> record : context.getLabelTokenRecords().changes() )
         {
             Command.LabelTokenCommand command = new Command.LabelTokenCommand();
-            command.init(  record.forReadingLinkage()  );
+            command.init( record.forReadingLinkage() );
             commands.add( command );
         }
         for ( RecordProxy<Integer, RelationshipTypeTokenRecord, Void> record : context.getRelationshipTypeTokenRecords().changes() )
@@ -147,8 +147,7 @@ public class TransactionRecordState implements RecordState
         }
         for ( RecordProxy<Integer, PropertyKeyTokenRecord, Void> record : context.getPropertyKeyTokenRecords().changes() )
         {
-            Command.PropertyKeyTokenCommand command =
-                    new Command.PropertyKeyTokenCommand();
+            Command.PropertyKeyTokenCommand command = new Command.PropertyKeyTokenCommand();
             command.init( record.forReadingLinkage() );
             commands.add( command );
         }
@@ -169,7 +168,7 @@ public class TransactionRecordState implements RecordState
         for ( RecordProxy<Long, RelationshipRecord, Void> record : context.getRelRecords().changes() )
         {
             Command.RelationshipCommand command = new Command.RelationshipCommand();
-            command.init(  record.forReadingLinkage()  );
+            command.init( record.forReadingLinkage() );
             relCommands.add( command );
         }
         Collections.sort( relCommands, COMMAND_SORTER );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ArrayCollection.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/ArrayCollection.java
@@ -211,4 +211,12 @@ public class ArrayCollection<T> implements Collection<T>
         }
         size = 0;
     }
+
+    @Override
+    public String toString()
+    {
+        return "ArrayCollection{" +
+               "array=" + Arrays.toString( array ) +
+               '}';
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestGuard.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestGuard.java
@@ -96,7 +96,7 @@ public class TestGuard
             getGuard( db ).startOperationsCount( MAX_VALUE );
             n0.createRelationshipTo( n1, withName( "REL" ) );
             Guard.OperationsCount ops3 = getGuard( db ).stop();
-            assertEquals( 3, ops3.getOpsCount() );
+            assertEquals( 1, ops3.getOpsCount() );
 
             getGuard( db ).startOperationsCount( MAX_VALUE );
             for ( Path position : Traversal.description().breadthFirst().relationships( withName( "REL" ) ).

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -19,17 +19,16 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import java.util.Collections;
-import java.util.Iterator;
-
 import org.junit.Test;
 import org.mockito.InOrder;
+
+import java.util.Collections;
+import java.util.Iterator;
 
 import org.neo4j.function.Function;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
-import org.neo4j.kernel.api.cursor.NodeItem;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
@@ -39,7 +38,6 @@ import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaReadOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
-import org.neo4j.kernel.impl.api.state.StubCursors;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 
@@ -47,9 +45,7 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.function.Functions.constant;
-import static org.neo4j.kernel.impl.api.state.StubCursors.asNode;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.schemaResource;
 
 public class LockingStatementOperationsTest
@@ -85,38 +81,34 @@ public class LockingStatementOperationsTest
     public void shouldAcquireEntityWriteLockCreatingRelationship() throws Exception
     {
         // when
-        NodeItem node1 = StubCursors.asNode( 2 );
-        NodeItem node2 = StubCursors.asNode( 3 );
-        lockingOps.relationshipCreate( state, 1, node1, node2 );
+        lockingOps.relationshipCreate( state, 1, 2, 3 );
 
         // then
         order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 2 );
         order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 3 );
-        order.verify( entityWriteOps ).relationshipCreate( state, 1, node1, node2 );
+        order.verify( entityWriteOps ).relationshipCreate( state, 1, 2, 3 );
     }
 
     @Test
     public void shouldAcquireEntityWriteLockBeforeAddingLabelToNode() throws Exception
     {
         // when
-        NodeItem nodeCursor = asNode( 123 );
-        lockingOps.nodeAddLabel( state, nodeCursor, 456 );
+        lockingOps.nodeAddLabel( state, 123, 456 );
 
         // then
         order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 123 );
-        order.verify( entityWriteOps ).nodeAddLabel( state, nodeCursor, 456 );
+        order.verify( entityWriteOps ).nodeAddLabel( state, 123, 456 );
     }
 
     @Test
     public void shouldAcquireSchemaReadLockBeforeAddingLabelToNode() throws Exception
     {
         // when
-        NodeItem nodeCursor = asNode( 123 );
-        lockingOps.nodeAddLabel( state, nodeCursor, 456 );
+        lockingOps.nodeAddLabel( state, 123, 456 );
 
         // then
         order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
-        order.verify( entityWriteOps ).nodeAddLabel( state, nodeCursor, 456 );
+        order.verify( entityWriteOps ).nodeAddLabel( state, 123, 456 );
     }
 
     @Test
@@ -126,12 +118,11 @@ public class LockingStatementOperationsTest
         DefinedProperty property = Property.property( 8, 9 );
 
         // when
-        NodeItem nodeCursor = asNode( 123 );
-        lockingOps.nodeSetProperty( state, nodeCursor, property );
+        lockingOps.nodeSetProperty( state, 123, property );
 
         // then
         order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 123 );
-        order.verify( entityWriteOps ).nodeSetProperty( state, nodeCursor, property );
+        order.verify( entityWriteOps ).nodeSetProperty( state, 123, property );
     }
 
     @Test
@@ -141,24 +132,22 @@ public class LockingStatementOperationsTest
         DefinedProperty property = Property.property( 8, 9 );
 
         // when
-        NodeItem nodeCursor = asNode( 123 );
-        lockingOps.nodeSetProperty( state, nodeCursor, property );
+        lockingOps.nodeSetProperty( state, 123, property );
 
         // then
         order.verify( locks ).acquireShared( ResourceTypes.SCHEMA, schemaResource() );
-        order.verify( entityWriteOps ).nodeSetProperty( state, nodeCursor, property );
+        order.verify( entityWriteOps ).nodeSetProperty( state, 123, property );
     }
 
     @Test
     public void shouldAcquireEntityWriteLockBeforeDeletingNode() throws EntityNotFoundException
     {
         // WHEN
-        NodeItem nodeCursor = asNode( 123 );
-        lockingOps.nodeDelete( state, nodeCursor );
+        lockingOps.nodeDelete( state, 123 );
 
         //THEN
         order.verify( locks ).acquireExclusive( ResourceTypes.NODE, 123 );
-        order.verify( entityWriteOps ).nodeDelete( state, nodeCursor );
+        order.verify( entityWriteOps ).nodeDelete( state, 123 );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
@@ -52,7 +51,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.Exceptions.contains;
 import static org.neo4j.kernel.impl.api.TransactionApplicationMode.INTERNAL;
 
@@ -69,11 +67,10 @@ public class TransactionRepresentationCommitProcessTest
         IOException rootCause = new IOException( "Mock exception" );
         doThrow( new IOException( rootCause ) ).when( appender ).append( any( TransactionRepresentation.class ),
                 any( LogAppendEvent.class ) );
-        KernelHealth kernelHealth = mock( KernelHealth.class );
         TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
         TransactionRepresentationStoreApplier storeApplier = mock( TransactionRepresentationStoreApplier.class );
-        TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( appender,
-                kernelHealth, transactionIdStore, storeApplier, mockedIndexUpdatesValidator() );
+        TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( appender, storeApplier,
+                mockedIndexUpdatesValidator() );
 
         // WHEN
         try ( LockGroup locks = new LockGroup() )
@@ -100,12 +97,11 @@ public class TransactionRepresentationCommitProcessTest
         when( appender.append( any( TransactionRepresentation.class ), any( LogAppendEvent.class ) ) )
                 .thenReturn( new FakeCommitment( txId, transactionIdStore ) );
         IOException rootCause = new IOException( "Mock exception" );
-        KernelHealth kernelHealth = mock( KernelHealth.class );
         TransactionRepresentationStoreApplier storeApplier = mock( TransactionRepresentationStoreApplier.class );
         doThrow( new IOException( rootCause ) ).when( storeApplier ).apply( any( TransactionRepresentation.class ),
                 any( ValidatedIndexUpdates.class ), any( LockGroup.class ), eq( txId ), eq( INTERNAL ) );
-        TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( appender,
-                kernelHealth, transactionIdStore, storeApplier, mockedIndexUpdatesValidator() );
+        TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( appender, storeApplier,
+                mockedIndexUpdatesValidator() );
         TransactionRepresentation transaction = mockedTransaction();
 
         // WHEN
@@ -135,8 +131,8 @@ public class TransactionRepresentationCommitProcessTest
                 .thenThrow( error );
 
         TransactionRepresentationCommitProcess commitProcess = new TransactionRepresentationCommitProcess(
-                mock( TransactionAppender.class ), mock( KernelHealth.class ), mock( TransactionIdStore.class ),
-                mock( TransactionRepresentationStoreApplier.class ), indexUpdatesValidator );
+                mock( TransactionAppender.class ), mock( TransactionRepresentationStoreApplier.class ),
+                indexUpdatesValidator );
 
         try ( LockGroup lockGroup = new LockGroup() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LabelTransactionStateTest.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.kernel.impl.api.state;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Test;
 
 import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.api.cursor.NodeItem;
@@ -46,12 +46,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.graphdb.Neo4jMockitoHelpers.answerAsIteratorFrom;
 import static org.neo4j.graphdb.Neo4jMockitoHelpers.answerAsPrimitiveLongIteratorFrom;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asLabelCursor;
-import static org.neo4j.kernel.impl.api.state.StubCursors.asNode;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asNodeCursor;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asPropertyCursor;
 
@@ -83,13 +81,7 @@ public class LabelTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeAddLabel( state, cursor.get(), labelId1 );
-            }
-        }
+        txContext.nodeAddLabel( state, nodeId, labelId1 );
 
         // THEN
         assertLabels( labelId1 );
@@ -102,13 +94,7 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeAddLabel( state, cursor.get(), labelId2 );
-            }
-        }
+        txContext.nodeAddLabel( state, nodeId, labelId2 );
 
         // THEN
         assertLabels( labelId1, labelId2 );
@@ -121,13 +107,7 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeAddLabel( state, cursor.get(), labelId1 );
-            }
-        }
+        txContext.nodeAddLabel( state, nodeId, labelId1 );
 
         // THEN
         assertLabels( labelId1 );
@@ -140,13 +120,8 @@ public class LabelTransactionStateTest
         commitLabels( labelId1, labelId2 );
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeRemoveLabel( state, cursor.get(), labelId1 );
-            }
-        }
+        txContext.nodeRemoveLabel( state, nodeId, labelId1 );
+
         // THEN
         assertLabels( labelId2 );
     }
@@ -158,21 +133,8 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeAddLabel( state, cursor.get(), labelId2 );
-            }
-        }
-
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeRemoveLabel( state, cursor.get(), labelId2 );
-            }
-        }
+        txContext.nodeAddLabel( state, nodeId, labelId2 );
+        txContext.nodeRemoveLabel( state, nodeId, labelId2 );
 
         // THEN
         assertLabels( labelId1 );
@@ -185,21 +147,8 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeRemoveLabel( state, cursor.get(), labelId1 );
-            }
-        }
-
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeAddLabel( state, cursor.get(), labelId1 );
-            }
-        }
+        txContext.nodeRemoveLabel( state, nodeId, labelId1 );
+        txContext.nodeAddLabel( state, nodeId, labelId1 );
 
         // THEN
         assertLabels( labelId1 );
@@ -215,7 +164,7 @@ public class LabelTransactionStateTest
                 labels( 2, 1, 3 ) );
 
         // WHEN
-        txContext.nodeAddLabel( state, asNode( 2 ), 2 );
+        txContext.nodeAddLabel( state, 2, 2 );
 
         // THEN
         assertEquals( asSet( 0L, 1L, 2L ), asSet( txContext.nodesGetForLabel( state, 2 ) ) );
@@ -231,13 +180,7 @@ public class LabelTransactionStateTest
                 labels( 2, 1, 3 ) );
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, 1 ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeRemoveLabel( state, cursor.get(), 2 );
-            }
-        }
+        txContext.nodeRemoveLabel( state, 1, 2 );
 
         // THEN
         assertEquals( asSet( 0L ), asSet( txContext.nodesGetForLabel( state, 2 ) ) );
@@ -250,16 +193,10 @@ public class LabelTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                boolean added = txContext.nodeAddLabel( state, cursor.get(), labelId1 );
+        boolean added = txContext.nodeAddLabel( state, nodeId, labelId1 );
 
-                // THEN
-                assertTrue( "Should have been added now", added );
-            }
-        }
+        // THEN
+        assertTrue( "Should have been added now", added );
     }
 
     @Test
@@ -269,16 +206,10 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                boolean added = txContext.nodeAddLabel( state, cursor.get(), labelId1 );
+        boolean added = txContext.nodeAddLabel( state, nodeId, labelId1 );
 
-                // THEN
-                assertFalse( "Shouldn't have been added now", added );
-            }
-        }
+        // THEN
+        assertFalse( "Shouldn't have been added now", added );
     }
 
     @Test
@@ -288,17 +219,10 @@ public class LabelTransactionStateTest
         commitLabels( labelId1 );
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                boolean removed = txContext.nodeRemoveLabel( state, cursor.get(), labelId1 );
+        boolean removed = txContext.nodeRemoveLabel( state, nodeId, labelId1 );
 
-                // THEN
-                assertTrue( "Should have been removed now", removed );
-            }
-
-        }
+        // THEN
+        assertTrue( "Should have been removed now", removed );
     }
 
     @Test
@@ -308,13 +232,7 @@ public class LabelTransactionStateTest
         commitNoLabels();
 
         // WHEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, nodeId ) )
-        {
-            if ( cursor.next() )
-            {
-                txContext.nodeAddLabel( state, cursor.get(), labelId1 );
-            }
-        }
+        txContext.nodeAddLabel( state, nodeId, labelId1 );
 
         // THEN
         assertLabels( labelId1 );
@@ -326,14 +244,11 @@ public class LabelTransactionStateTest
         // GIVEN
         when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337 ) );
 
-        // WHEN and THEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, 1337 ) )
-        {
-            if ( cursor.next() )
-            {
-                assertTrue( "Label should have been added", txContext.nodeAddLabel( state, cursor.get(), 12 ) );
-            }
-        }
+        // WHEN
+        boolean added = txContext.nodeAddLabel( state, 1337, 12 );
+
+        // THEN
+        assertTrue( "Label should have been added", added );
     }
 
     @Test
@@ -343,14 +258,11 @@ public class LabelTransactionStateTest
         when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337, asPropertyCursor(),
                 asLabelCursor( 12 ) ) );
 
-        // WHEN and THEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, 1337 ) )
-        {
-            if ( cursor.next() )
-            {
-                assertFalse( "Label should have been added", txContext.nodeAddLabel( state, cursor.get(), 12 ) );
-            }
-        }
+        // WHEN
+        boolean added = txContext.nodeAddLabel( state, 1337, 12 );
+
+        // THEN
+        assertFalse( "Label should have been added", added );
     }
 
     @Test
@@ -360,14 +272,11 @@ public class LabelTransactionStateTest
         when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337, asPropertyCursor(),
                 asLabelCursor( 12 ) ) );
 
-        // WHEN and THEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, 1337 ) )
-        {
-            if ( cursor.next() )
-            {
-                assertTrue( "Label should have been removed", txContext.nodeRemoveLabel( state, cursor.get(), 12 ) );
-            }
-        }
+        // WHEN
+        boolean added = txContext.nodeRemoveLabel( state, 1337, 12 );
+
+        // THEN
+        assertTrue( "Label should have been removed", added );
     }
 
     @Test
@@ -376,15 +285,11 @@ public class LabelTransactionStateTest
         // GIVEN
         when( storeStatement.acquireSingleNodeCursor( 1337 ) ).thenReturn( asNodeCursor( 1337 ) );
 
-        // WHEN and THEN
-        try ( Cursor<NodeItem> cursor = txContext.nodeCursor( state, 1337 ) )
-        {
-            if ( cursor.next() )
-            {
-                assertFalse( "Label should have been removed",
-                        txContext.nodeRemoveLabel( state, cursor.get(), 12 ) );
-            }
-        }
+        // WHEN
+        boolean removed = txContext.nodeRemoveLabel( state, 1337, 12 );
+
+        // THEN
+        assertFalse( "Label should have been removed", removed );
     }
 
     // exists
@@ -418,7 +323,7 @@ public class LabelTransactionStateTest
 
     private void commitLabels( Labels... labels ) throws Exception
     {
-        Map<Integer, Collection<Long>> allLabels = new HashMap<>();
+        Map<Integer,Collection<Long>> allLabels = new HashMap<>();
         for ( Labels nodeLabels : labels )
         {
             when( storeStatement.acquireSingleNodeCursor( nodeLabels.nodeId ) ).thenReturn( StubCursors.asNodeCursor(
@@ -436,7 +341,7 @@ public class LabelTransactionStateTest
             }
         }
 
-        for ( Map.Entry<Integer, Collection<Long>> entry : allLabels.entrySet() )
+        for ( Map.Entry<Integer,Collection<Long>> entry : allLabels.entrySet() )
         {
             when( store.nodesGetForLabel( state, entry.getKey() ) ).then( answerAsPrimitiveLongIteratorFrom( entry
                     .getValue() ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.kernel.impl.api.state;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.Set;
-
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -44,7 +44,6 @@ import org.neo4j.kernel.impl.index.LegacyIndexStore;
 import org.neo4j.kernel.impl.util.diffsets.DiffSets;
 
 import static java.util.Arrays.asList;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -54,11 +53,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.kernel.impl.api.StatementOperationsTestHelper.mockedState;
-import static org.neo4j.kernel.impl.api.state.StubCursors.asNode;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asNodeCursor;
 
 public class StateHandlingStatementOperationsTest
@@ -85,18 +82,12 @@ public class StateHandlingStatementOperationsTest
 
         // When
         ctx.indexCreate( state, 0, 0 );
-        ctx.nodeAddLabel( state, asNode( 0 ), 0 );
+        ctx.nodeAddLabel( state, 0, 0 );
         ctx.indexDrop( state, new IndexDescriptor( 0, 0 ) );
-        ctx.nodeRemoveLabel( state, asNode( 0 ), 0 );
+        ctx.nodeRemoveLabel( state, 0, 0 );
 
-        // These are kind of in between.. property key ids are created in
-        // micro-transactions, so these methods
-        // circumvent the normal state of affairs. We may want to rub the
-        // genius-bumps over this at some point.
-        // ctx.getOrCreateLabelId("0");
-        // ctx.getOrCreatePropertyKeyId("0");
-
-        verify( storeStatement, times( 0 ) ).acquireSingleNodeCursor( 0 );
+        // one for add and one for remove
+        verify( storeStatement, times( 2 ) ).acquireSingleNodeCursor( 0 );
         verifyNoMoreInteractions( storeStatement );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.kernel.impl.core;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.junit.Test;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -41,7 +41,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
@@ -994,7 +993,7 @@ public class TestRelationship extends AbstractNeo4jTestCase
         // When
         try ( Transaction tx = db.beginTx() )
         {
-            relationship.delete(); // should throw IllegalStateException as this relationship is already deleted
+            relationship.delete();
             tx.success();
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
@@ -50,7 +50,6 @@ import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.IdType;
-import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
@@ -108,6 +107,7 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
+import static java.lang.Integer.parseInt;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -126,9 +126,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
-import static java.lang.Integer.parseInt;
-
 import static org.neo4j.graphdb.Direction.INCOMING;
 import static org.neo4j.graphdb.Direction.OUTGOING;
 import static org.neo4j.helpers.collection.Iterables.count;
@@ -144,8 +141,8 @@ import static org.neo4j.kernel.api.index.NodePropertyUpdate.remove;
 import static org.neo4j.kernel.api.index.SchemaIndexProvider.NO_INDEX_PROVIDER;
 import static org.neo4j.kernel.impl.api.TransactionApplicationMode.INTERNAL;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
-import static org.neo4j.kernel.impl.store.record.UniquePropertyConstraintRule.uniquenessConstraintRule;
 import static org.neo4j.kernel.impl.store.record.IndexRule.indexRule;
+import static org.neo4j.kernel.impl.store.record.UniquePropertyConstraintRule.uniquenessConstraintRule;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 
 public class NeoStoreTransactionTest
@@ -1497,8 +1494,8 @@ public class NeoStoreTransactionTest
 
         PropertyLoader propertyLoader = new PropertyLoader( neoStore );
 
-        return new TransactionRepresentationCommitProcess( appenderMock, mock( KernelHealth.class ),
-                neoStore, applier, new IndexUpdatesValidator( neoStore, null, propertyLoader, indexing ) );
+        return new TransactionRepresentationCommitProcess( appenderMock, applier,
+                new IndexUpdatesValidator( neoStore, null, propertyLoader, indexing ) );
     }
 
     @After

--- a/community/neo4j/src/test/java/ConcurrentChangesOnEntitiesTest.java
+++ b/community/neo4j/src/test/java/ConcurrentChangesOnEntitiesTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.neo4j.consistency.ConsistencyCheckService;
+import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.function.Consumer;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.helpers.progress.ProgressMonitorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.FormattedLogProvider;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ConcurrentChangesOnEntitiesTest
+{
+    @Rule
+    public TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+    private final CyclicBarrier barrier = new CyclicBarrier( 2 );
+    private final AtomicReference<Exception> ex = new AtomicReference<>();
+    private GraphDatabaseService db;
+
+    @Before
+    public void setup()
+    {
+        db = new GraphDatabaseFactory().newEmbeddedDatabase( testDirectory.graphDbDir() );
+    }
+
+    @Test
+    public void addConcurrentlySameLabelToANode() throws Throwable
+    {
+
+        final long nodeId = initWithNode( db );
+
+        Thread t1 = newThreadForNodeAction( nodeId, new Consumer<Node>()
+        {
+            @Override
+            public void accept( Node node )
+            {
+                node.addLabel( DynamicLabel.label( "A" ) );
+            }
+        } );
+
+        Thread t2 = newThreadForNodeAction( nodeId, new Consumer<Node>()
+        {
+            @Override
+            public void accept( Node node )
+            {
+                node.addLabel( DynamicLabel.label( "A" ) );
+            }
+        } );
+
+        startAndWait( t1, t2 );
+
+        db.shutdown();
+
+        assertDatabaseConsistent();
+    }
+
+    @Test
+    public void setConcurrentlySamePropertyWithDifferentValuesOnANode() throws Throwable
+    {
+        final long nodeId = initWithNode( db );
+
+        Thread t1 = newThreadForNodeAction( nodeId, new Consumer<Node>()
+        {
+            @Override
+            public void accept( Node node )
+            {
+                node.setProperty( "a", 0.788 );
+            }
+        } );
+
+        Thread t2 = newThreadForNodeAction( nodeId, new Consumer<Node>()
+        {
+            @Override
+            public void accept( Node node )
+            {
+                node.setProperty( "a", new double[]{0.999, 0.77} );
+            }
+        } );
+
+        startAndWait( t1, t2 );
+
+        db.shutdown();
+
+        assertDatabaseConsistent();
+    }
+
+    @Test
+    public void setConcurrentlySamePropertyWithDifferentValuesOnARelationship() throws Throwable
+    {
+        final long relId = initWithRel( db );
+
+        Thread t1 = newThreadForRelationshipAction( relId, new Consumer<Relationship>()
+        {
+            @Override
+            public void accept( Relationship relationship )
+            {
+                relationship.setProperty( "a", 0.788 );
+            }
+        } );
+
+        Thread t2 = newThreadForRelationshipAction( relId, new Consumer<Relationship>()
+        {
+            @Override
+            public void accept( Relationship relationship )
+            {
+                relationship.setProperty( "a", new double[]{0.999, 0.77} );
+            }
+        } );
+
+        startAndWait( t1, t2 );
+
+        db.shutdown();
+
+        assertDatabaseConsistent();
+    }
+
+    private long initWithNode( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node theNode = db.createNode();
+            long id = theNode.getId();
+            tx.success();
+            return id;
+        }
+
+    }
+
+    private long initWithRel( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            node.setProperty( "a", "prop" );
+            Relationship rel = node.createRelationshipTo( db.createNode(), DynamicRelationshipType.withName( "T" ) );
+            long id = rel.getId();
+            tx.success();
+            return id;
+        }
+    }
+
+    private Thread newThreadForNodeAction( final long nodeId, final Consumer<Node> nodeConsumer )
+    {
+        return new Thread()
+        {
+            @Override
+            public void run()
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    Node node = db.getNodeById( nodeId );
+                    barrier.await();
+                    nodeConsumer.accept( node );
+                    tx.success();
+                }
+                catch ( Exception e )
+                {
+                    ex.set( e );
+                }
+            }
+        };
+    }
+
+    private Thread newThreadForRelationshipAction( final long relationshipId, final Consumer<Relationship> relConsumer )
+    {
+        return new Thread()
+        {
+            @Override
+            public void run()
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    Relationship relationship = db.getRelationshipById( relationshipId );
+                    barrier.await();
+                    relConsumer.accept( relationship );
+                    tx.success();
+                }
+                catch ( Exception e )
+                {
+                    ex.set( e );
+                }
+            }
+        };
+    }
+
+    private void startAndWait( Thread t1, Thread t2 ) throws Exception
+    {
+        t1.start();
+        t2.start();
+
+        t1.join();
+        t2.join();
+
+        if ( ex.get() != null )
+        {
+            throw ex.get();
+        }
+    }
+
+    private void assertDatabaseConsistent() throws IOException
+    {
+        LogProvider logProvider = FormattedLogProvider.toOutputStream( System.out );
+        try
+        {
+            ConsistencyCheckService.Result result = new ConsistencyCheckService().runFullConsistencyCheck(
+                    testDirectory.graphDbDir(), new Config(), ProgressMonitorFactory.textual( System.err ),
+                    logProvider );
+            assertTrue( result.isSuccessful() );
+        }
+        catch ( ConsistencyCheckIncompleteException e )
+        {
+            fail( e.getMessage() );
+        }
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/EnterpriseEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/EnterpriseEditionModule.java
@@ -612,8 +612,8 @@ public class EnterpriseEditionModule
                 }
                 else
                 {
-                    TransactionCommitProcess inner = new TransactionRepresentationCommitProcess( appender, kernelHealth,
-                                                neoStore, storeApplier, indexUpdatesValidator );
+                    TransactionCommitProcess inner = new TransactionRepresentationCommitProcess( appender, storeApplier,
+                            indexUpdatesValidator );
                     new CommitProcessSwitcher( pusher, master, commitProcessDelegate, requestContextFactory,
                             memberStateMachine, txValidator, inner );
 


### PR DESCRIPTION
The problem was that multiple threads modifying the same entity could corrupt the data.

As an example consider the following case with 2 threads:
- both threads load the same node record from disk (having no properties)
- first thread grabs the lock first and add a property "a" with value 42
- second thread waiting on the lock
- first thread release the lock
- second thread add a property "a" with vale 33 to the same node since the second thread thinks there are no properties on the node it adds a new property instead modifying the one already there
- there are duplicated properties in the property chain

Similar problems happened for writing properties on relationships and adding same labels on nodes.
