### PR TITLE
Fixed batch endpoint with http logging turned on

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/preflight/EnsurePreparedForHttpLoggingTest.java
+++ b/community/server/src/test/java/org/neo4j/server/preflight/EnsurePreparedForHttpLoggingTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.preflight;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ServerSettings;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class EnsurePreparedForHttpLoggingTest
+{
+    @Test
+    public void shouldNotRunIfLoggingIsEnabledButConfigFileIsNull()
+    {
+        // Given
+        Config config = new Config( singletonMap( ServerSettings.http_logging_enabled.name(), "true" ) );
+        EnsurePreparedForHttpLogging task = new EnsurePreparedForHttpLogging( config );
+
+        // When
+        boolean run = task.run();
+
+        // Then
+        assertFalse( run );
+        assertEquals( "HTTP logging configuration file is not specified", task.getFailureMessage() );
+    }
+}

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -104,8 +104,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.neo4j.app</groupId>
+      <artifactId>neo4j-server</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-ha</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j.test</groupId>
+      <artifactId>neo4j-harness</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
+++ b/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.neo4j.harness.junit.Neo4jRule;
+import org.neo4j.server.configuration.ServerSettings;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
+import static org.neo4j.test.server.HTTP.Response;
+import static org.neo4j.test.server.HTTP.withBaseUri;
+
+public class BatchEndpointIT
+{
+    @Rule
+    public final Neo4jRule neo4j = new Neo4jRule()
+            .withConfig( ServerSettings.http_logging_enabled, "true" )
+            .withConfig( ServerSettings.http_log_config_File, createDummyLogbackConfigFile() )
+            .withConfig( ServerSettings.auth_enabled, "false" );
+
+    @Test
+    public void requestsShouldNotFailWhenHttpLoggingIsOn()
+    {
+        // Given
+        String body = "[" +
+                      "{'method': 'POST', 'to': '/node', 'body': {'age': 1}, 'id': 1}," +
+                      "{'method': 'POST', 'to': '/node', 'body': {'age': 2}, 'id': 2}" +
+                      "]";
+
+        // When
+        Response response = withBaseUri( neo4j.httpURI().toString() )
+                .withHeaders( "Content-Type", "application/json" )
+                .POST( "db/data/batch", quotedJson( body ) );
+
+        // Then
+        assertEquals( 200, response.status() );
+    }
+
+    private static String createDummyLogbackConfigFile()
+    {
+        try
+        {
+            Path file = Files.createTempFile( "logback", ".xml" );
+            Files.write( file, "<configuration></configuration>".getBytes() );
+            return file.toAbsolutePath().toString();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( "Unable to create dummy logback configuration file", e );
+        }
+    }
+}


### PR DESCRIPTION
Also fixed NPE when config file for HTTP logging not specified.

This is a tentative fix for batch endpoint issue.
I'm not sure that returning a dummy `HttpChannelState` is a pretty thing to do but it does seem like the only option at the moment.
