### PR TITLE
Allows multi-line fields in LOAD CSV

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/CharSeekers.java
@@ -77,6 +77,12 @@ public class CharSeekers
             {
                 return bufferSize;
             }
+
+            @Override
+            public boolean multilineFields()
+            {
+                return true;
+            }
         }, readAhead );
     }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResourcesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResourcesTest.scala
@@ -190,4 +190,28 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     val e = intercept[IllegalStateException](resources.getCsvIterator(new URL(url)))
     e.getMessage() should include(url)
   }
+
+    test("should parse multiline fields") {
+    // given
+    val url = createCSVTempFileURL {
+      writer =>
+        writer.println("a\tb")
+        writer.println("1\t\"Bar\"")
+        writer.println("2\t\"Bar\n\nQuux\n\"")
+        writer.println("3\t\"Bar\n\nQuux\"")
+    }
+
+    //when
+    val result: List[Array[String]] = resources.getCsvIterator(new URL(url), Some("\t")).toList
+
+    (result zip List(
+      Array[String]("a", "b"),
+      Array[String]("1", "Bar"),
+      Array[String]("2", "Bar\n\nQuux\n"),
+      Array[String]("3", "Bar\n\nQuux")
+    )).foreach {
+      case (r, expected) =>
+        r should equal(expected)
+    }
+  }
 }


### PR DESCRIPTION
This was disabled by mistake in a recent feature addition where multi-line
fields could be enabled/disabled by the CSV parser.

Fixes #5028
