### PR TITLE
Do not verify tx checksum when there are no transactions in the db

### DIFF
--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.com;
 
+import org.jboss.netty.buffer.ChannelBuffer;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
-
-import org.jboss.netty.buffer.ChannelBuffer;
 
 import org.neo4j.com.MadeUpServer.MadeUpRequestType;
 import org.neo4j.com.monitor.RequestMonitor;
@@ -90,7 +90,7 @@ public class MadeUpClient extends Client<MadeUpCommunicationInterface> implement
 
     private RequestContext getRequestContext()
     {
-        return new RequestContext( EMPTY.getEpoch(), EMPTY.machineId(), EMPTY.getEventIdentifier(), 1,
+        return new RequestContext( EMPTY.getEpoch(), EMPTY.machineId(), EMPTY.getEventIdentifier(), 2,
                 EMPTY.getChecksum() );
     }
 

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServerImplementation.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServerImplementation.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
 import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
 
@@ -84,9 +85,10 @@ public class MadeUpServerImplementation implements MadeUpCommunicationInterface
             @Override
             public void accept( Visitor<CommittedTransactionRepresentation, IOException> visitor ) throws IOException
             {
-                for ( int i = 0; i < txCount; i++ )
+                for ( int i = 1; i <= txCount; i++ )
                 {
-                    CommittedTransactionRepresentation transaction = createTransaction( i );
+                    CommittedTransactionRepresentation transaction =
+                            createTransaction( TransactionIdStore.BASE_TX_ID + i );
                     visitor.visit( transaction );
                 }
             }

--- a/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
@@ -19,17 +19,19 @@
  */
 package org.neo4j.com;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-
 import org.jboss.netty.buffer.ByteBufferBackedChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
 import org.neo4j.com.monitor.RequestMonitor;
+import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.TickingClock;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.logging.DevNullLoggingService;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 
@@ -39,8 +41,8 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.com.Protocol.EMPTY_SERIALIZER;
 import static org.neo4j.com.Protocol.VOID_DESERIALIZER;
 
@@ -52,21 +54,21 @@ public class ServerTest
     private final RecordingChannel channel = new RecordingChannel();
 
     @Test
-    public void shouldSendExceptionBackToClientOnInvalidChecksum() throws Exception
+    public void shouldSendExceptionBackToClientOnInvalidChecksum() throws Throwable
     {
         // Given
-        Server<Object, Object> server = newServer( checksumVerifier );
-        RequestContext ctx = new RequestContext( 0, 1, 0, 1, 12 );
+        Server<Object,Object> server = newServer( checksumVerifier );
+        RequestContext ctx = new RequestContext( 0, 1, 0, 2, 12 );
 
-        doThrow(new IllegalStateException("123")).when(checksumVerifier).assertMatch( anyLong(), anyLong() );
+        doThrow( new IllegalStateException( "123" ) ).when( checksumVerifier ).assertMatch( anyLong(), anyLong() );
 
         // When
         try
         {
             server.messageReceived( channelCtx( channel ), message( reqType, ctx, channel, EMPTY_SERIALIZER ) );
-            fail("Should have failed.");
+            fail( "Should have failed." );
         }
-        catch(IllegalStateException e)
+        catch ( IllegalStateException e )
         {
             // Expected
         }
@@ -76,17 +78,31 @@ public class ServerTest
         {
             protocol.deserializeResponse( channel.asBlockingReadHandler(), ByteBuffer.allocateDirect( 1024 ), 1,
                     VOID_DESERIALIZER, mock( ResourceReleaser.class ) );
-            fail("Should have failed.");
+            fail( "Should have failed." );
         }
-        catch(IllegalStateException e)
+        catch ( IllegalStateException e )
         {
-            assertThat(e.getMessage(), equalTo("123"));
+            assertThat( e.getMessage(), equalTo( "123" ) );
         }
+    }
 
+    @Test
+    public void shouldNotSendExceptionBackToClientOnInvalidChecksumIfThereAreNoTransactions() throws Throwable
+    {
+        // Given
+        Server<Object,Object> server = newServer( checksumVerifier );
+        RequestContext ctx =
+                new RequestContext( 0, 1, 0, TransactionIdStore.BASE_TX_ID, TransactionIdStore.BASE_TX_CHECKSUM );
+
+        // When
+        server.messageReceived( channelCtx( channel ), message( reqType, ctx, channel, EMPTY_SERIALIZER ) );
+
+        // Then
+        verifyZeroInteractions( checksumVerifier );
     }
 
     private MessageEvent message( RequestType reqType, RequestContext ctx,
-                                  Channel serverToClientChannel, Serializer payloadSerializer ) throws IOException
+            Channel serverToClientChannel, Serializer payloadSerializer ) throws IOException
     {
         ByteBuffer backingBuffer = ByteBuffer.allocate( 1024 );
 
@@ -94,9 +110,9 @@ public class ServerTest
                 reqType, ctx,
                 payloadSerializer );
 
-        MessageEvent event = mock(MessageEvent.class);
-        when(event.getMessage()).thenReturn( new ByteBufferBackedChannelBuffer( backingBuffer ) );
-        when(event.getChannel()).thenReturn( serverToClientChannel );
+        MessageEvent event = mock( MessageEvent.class );
+        when( event.getMessage() ).thenReturn( new ByteBufferBackedChannelBuffer( backingBuffer ) );
+        when( event.getChannel() ).thenReturn( serverToClientChannel );
 
         return event;
     }
@@ -104,13 +120,16 @@ public class ServerTest
     private ChannelHandlerContext channelCtx( Channel channel )
     {
         ChannelHandlerContext ctx = mock( ChannelHandlerContext.class );
-        when(ctx.getChannel()).thenReturn( channel );
+        when( ctx.getChannel() ).thenReturn( channel );
         return ctx;
     }
 
-    private Server<Object, Object> newServer( final TxChecksumVerifier checksumVerifier )
+    private Server<Object,Object> newServer( final TxChecksumVerifier checksumVerifier ) throws Throwable
     {
-        return new Server<Object, Object>( null, mock( Server.Configuration.class ), new DevNullLoggingService(),
+        Server.Configuration conf = mock( Server.Configuration.class );
+        when( conf.getServerAddress() ).thenReturn( new HostnamePort( "aa", -1667 ) );
+        Server<Object,Object> server = new Server<Object,Object>( null, conf, new
+                DevNullLoggingService(),
                 Protocol.DEFAULT_FRAME_LENGTH,
                 new ProtocolVersion( ((byte) 0), ProtocolVersion.INTERNAL_PROTOCOL_VERSION ),
                 checksumVerifier, new TickingClock( 0, 1 ),
@@ -127,5 +146,7 @@ public class ServerTest
             {
             }
         };
+        server.init();
+        return server;
     }
 }


### PR DESCRIPTION
This was causing issues in cluster synchronization and branch data on empty stores.
