### PR TITLE
Avoid multiple open muninnPage cursors during constraint validation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -99,15 +99,12 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
         {
             PropertyConstraint constraint = constraints.next();
             int propertyKeyId = constraint.propertyKey();
-
-            try ( Cursor<PropertyItem> properties = node.property( propertyKeyId ) )
+            Object propertyValue = node.getProperty( propertyKeyId );
+            if ( propertyValue != null )
             {
-                if ( properties.next() )
-                {
-                    validateNoExistingNodeWithLabelAndProperty( state, labelId, propertyKeyId, properties.get().value(),
-                            node.id() );
-                }
+                validateNoExistingNodeWithLabelAndProperty( state, labelId, propertyKeyId, propertyValue, node.id() );
             }
+
         }
         return entityWriteOperations.nodeAddLabel( state, node, labelId );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -90,7 +90,32 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
     }
 
     @Test
-    public void shouldEnforceUniquenessConstraintOnAddLabel() throws Exception
+    public void shouldEnforceUniquenessConstraintOnAddLabelForNumberPropertyOnNodeNotFromTransaction() throws Exception
+    {
+        // given
+        constrainedNode( "Label1", "key1", 1 );
+
+        // when
+        DataWriteOperations statement = dataWriteOperationsInNewTransaction();
+        long node = createNode( statement, "key1", 1 );
+        commit();
+
+        statement = dataWriteOperationsInNewTransaction();
+        try
+        {
+            statement.nodeAddLabel( node, statement.labelGetOrCreateForName( "Label1" ) );
+
+            fail( "should have thrown exception" );
+        }
+        // then
+        catch ( UniquePropertyConstraintViolationKernelException e )
+        {
+            assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "\"key1\"=[1]" ) );
+        }
+    }
+
+    @Test
+    public void shouldEnforceUniquenessConstraintOnAddLabelForStringProperty() throws Exception
     {
         // given
         constrainedNode( "Label1", "key1", "value1" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersionTest.java
@@ -33,7 +33,6 @@ public class LogEntryVersionTest
             // GIVEN
             byte code = version.byteCode();
             byte logHeaderFormatVersion = version.logHeaderFormatVersion();
-            System.out.println( "trying " + code +  ", " + logHeaderFormatVersion );
 
             // WHEN
             LogEntryVersion selectedVersion = LogEntryVersion.byVersion( code, logHeaderFormatVersion );


### PR DESCRIPTION
Conflicting usage of page cursor by property and node cursors. Fix will allow LookupFilter to load NodeItem for property value comparisons. 
