### PR TITLE
Implement Positioned, Vectored IO in the Page Cache

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -414,10 +414,12 @@ public class ImportTool
     {
         return new org.neo4j.unsafe.impl.batchimport.Configuration.Default()
         {
+            private static final int WRITE_BUFFER_SIZE_FOR_TEST = 1024 * 1024 * 8; // 8 MiB
+
             @Override
             public int writeBufferSize()
             {
-                return defaultSettingsSuitableForTests? 1024 * 1024 * 8 : super.writeBufferSize();
+                return defaultSettingsSuitableForTests? WRITE_BUFFER_SIZE_FOR_TEST : super.writeBufferSize();
             }
 
             @Override

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -415,15 +415,15 @@ public class ImportTool
         return new org.neo4j.unsafe.impl.batchimport.Configuration.Default()
         {
             @Override
-            public int maxNumberOfProcessors()
+            public int writeBufferSize()
             {
-                return processors != null ? processors.intValue() : super.maxNumberOfProcessors();
+                return defaultSettingsSuitableForTests? 1024 * 1024 * 8 : super.writeBufferSize();
             }
 
             @Override
-            public int bigFileChannelBufferSizeMultiplier()
+            public int maxNumberOfProcessors()
             {
-                return defaultSettingsSuitableForTests ? 1 : super.bigFileChannelBufferSizeMultiplier();
+                return processors != null ? processors.intValue() : super.maxNumberOfProcessors();
             }
         };
     }

--- a/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannel.java
@@ -170,4 +170,10 @@ public class StoreFileChannel implements StoreChannel
     {
         force( false );
     }
+
+    public static FileChannel unwrap( StoreChannel channel )
+    {
+        StoreFileChannel sfc = (StoreFileChannel) channel;
+        return sfc.channel;
+    }
 }

--- a/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannel.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannel.java
@@ -171,7 +171,7 @@ public class StoreFileChannel implements StoreChannel
         force( false );
     }
 
-    public static FileChannel unwrap( StoreChannel channel )
+    static FileChannel unwrap( StoreChannel channel )
     {
         StoreFileChannel sfc = (StoreFileChannel) channel;
         return sfc.channel;

--- a/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannelUnwrapper.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/StoreFileChannelUnwrapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.fs;
+
+import java.nio.channels.FileChannel;
+
+/**
+ * This class exist to circumvent the encapsulation of the StoreChannel interface and the StoreFileChannel wrapper.
+ * This way, access can be obtained to the underlying FileChannel contained in StoreFileChannels, allowing special
+ * optimisations. Use with care.
+ */
+public final class StoreFileChannelUnwrapper
+{
+    public static FileChannel unwrap( StoreChannel channel )
+    {
+        return StoreFileChannel.unwrap( channel );
+    }
+}

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
@@ -43,8 +43,7 @@ public interface PageSwapper
      * interrupted. If this happens, then the implementation must reopen the
      * channel and the operation must be retried.
      */
-    // TODO all these read and write methods should return long instead of int
-    int read( long filePageId, Page page ) throws IOException;
+    long read( long filePageId, Page page ) throws IOException;
 
     /**
      * Read pages from the file into the given pages, starting from the given startFilePageId.
@@ -62,7 +61,7 @@ public interface PageSwapper
      * interrupted. If this happens, then the implementation must reopen the
      * channel and the operation must be retried.
      */
-    int read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException;
+    long read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException;
 
     /**
      * Write the contents of the given page, to the concrete file on the file
@@ -75,7 +74,7 @@ public interface PageSwapper
      * interrupted. If this happens, then implementation must reopen the
      * channel and the operation must be retried.
      */
-    int write( long filePageId, Page page ) throws IOException;
+    long write( long filePageId, Page page ) throws IOException;
 
     /**
      * Write the contents of the given pages, to the concrete file on the file system,
@@ -93,7 +92,7 @@ public interface PageSwapper
      * interrupted. If this happens, then implementation must reopen the
      * channel and the operation must be retried.
      */
-    int write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException;
+    long write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException;
 
     /**
      * Notification that a page has been evicted, used to clean up state in structures

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
@@ -43,6 +43,7 @@ public interface PageSwapper
      * interrupted. If this happens, then the implementation must reopen the
      * channel and the operation must be retried.
      */
+    // TODO all these read and write methods should return long instead of int
     int read( long filePageId, Page page ) throws IOException;
 
     /**
@@ -54,7 +55,7 @@ public interface PageSwapper
      * filled with zero bytes.
      *
      * The contents of the pages should be considered to be garbage if the operation throws an exception,
-     * since the constiuent reads can be reordered, and no zeroing will take place.
+     * since the constituent reads can be reordered, and no zeroing will take place.
      *
      * Note: It is possible for the channel to be asynchronously closed while
      * this operation is taking place. For instance, if the current thread is

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
@@ -46,6 +46,24 @@ public interface PageSwapper
     int read( long filePageId, Page page ) throws IOException;
 
     /**
+     * Read pages from the file into the given pages, starting from the given startFilePageId.
+     *
+     * Returns the number of bytes read in from the file. May be zero if the
+     * requested startFilePageId was beyond the end of the file. If the file does not have enough data
+     * to fill up all the buffer space represented by the pages, then the remaining buffer space will be
+     * filled with zero bytes.
+     *
+     * The contents of the pages should be considered to be garbage if the operation throws an exception,
+     * since the constiuent reads can be reordered, and no zeroing will take place.
+     *
+     * Note: It is possible for the channel to be asynchronously closed while
+     * this operation is taking place. For instance, if the current thread is
+     * interrupted. If this happens, then the implementation must reopen the
+     * channel and the operation must be retried.
+     */
+    int read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException;
+
+    /**
      * Write the contents of the given page, to the concrete file on the file
      * system, at the located indicated by the given filePageId.
      *
@@ -57,6 +75,24 @@ public interface PageSwapper
      * channel and the operation must be retried.
      */
     int write( long filePageId, Page page ) throws IOException;
+
+    /**
+     * Write the contents of the given pages, to the concrete file on the file system,
+     * starting at the location of the given startFilePageId.
+     *
+     * If an exception is thrown, then some of the data may have been written, and some might not.
+     * The writes may reorder and tear, so no guarantee can be made about what has been written and what has not, if
+     * an exception is thrown. Therefor, the entire write operation should be retried, in the case of failure, or the
+     * data should be rewritten through other means.
+     *
+     * Returns the number of bytes written to the file.
+     *
+     * Note: It is possible for the channel to be asynchronously closed while
+     * this operation is taking place. For instance, if the current thread is
+     * interrupted. If this happens, then implementation must reopen the
+     * channel and the operation must be retried.
+     */
+    int write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException;
 
     /**
      * Notification that a page has been evicted, used to clean up state in structures

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
@@ -36,6 +36,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.fs.StoreFileChannel;
+import org.neo4j.io.fs.StoreFileChannelUnwrapper;
 import org.neo4j.io.pagecache.Page;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PageEvictionCallback;
@@ -163,7 +164,7 @@ public class SingleFilePageSwapper implements PageSwapper
             closeAndCollectExceptions( 0, e );
         }
         hasPositionLock = channels[0].getClass() == StoreFileChannel.class
-                && StoreFileChannel.unwrap( channels[0] ).getClass() == sun.nio.ch.FileChannelImpl.class;
+                && StoreFileChannelUnwrapper.unwrap( channels[0] ).getClass() == sun.nio.ch.FileChannelImpl.class;
     }
 
     private void increaseFileSizeTo( long newFileSize )
@@ -488,7 +489,7 @@ public class SingleFilePageSwapper implements PageSwapper
     private FileChannel unwrappedChannel( long startFilePageId )
     {
         StoreChannel storeChannel = channel( startFilePageId );
-        return StoreFileChannel.unwrap( storeChannel );
+        return StoreFileChannelUnwrapper.unwrap( storeChannel );
     }
 
     private long lockPositionWriteVector(

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
@@ -28,9 +28,9 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
-import java.nio.channels.FileChannel;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
@@ -236,9 +236,10 @@ public class SingleFilePageSwapper implements PageSwapper
 
     private int swapOut( Page page, long fileOffset, StoreChannel channel ) throws IOException
     {
+        long address = page.address();
         try
         {
-            ByteBuffer bufferProxy = proxy( page.address(), filePageSize );
+            ByteBuffer bufferProxy = proxy( address, filePageSize );
             channel.writeAll( bufferProxy, fileOffset );
         }
         catch ( IOException e )
@@ -291,6 +292,17 @@ public class SingleFilePageSwapper implements PageSwapper
     }
 
     @Override
+    public int read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    {
+        int bytes = 0;
+        for ( int i = 0; i < length; i++ )
+        {
+            bytes += read( startFilePageId + i, pages[arrayOffset + i] );
+        }
+        return bytes;
+    }
+
+    @Override
     public int write( long filePageId, Page page ) throws IOException
     {
         long fileOffset = pageIdToPosition( filePageId );
@@ -315,6 +327,17 @@ public class SingleFilePageSwapper implements PageSwapper
             }
             return bytesWritten;
         }
+    }
+
+    @Override
+    public int write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    {
+        int bytes = 0;
+        for ( int i = 0; i < length; i++ )
+        {
+            bytes += write( startFilePageId + i, pages[arrayOffset + i] );
+        }
+        return bytes;
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperFactory.java
@@ -73,7 +73,7 @@ public class SingleFilePageSwapperFactory implements PageSwapperFactory
     @Override
     public String implementationName()
     {
-        return "striped";
+        return "single";
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
@@ -341,7 +341,7 @@ final class MuninnPage extends StampedLock implements Page
         FlushEvent event = flushOpportunity.beginFlush( filePageId, getCachePageId(), swapper );
         try
         {
-            int bytesWritten = swapper.write( filePageId, this );
+            long bytesWritten = swapper.write( filePageId, this );
             markAsClean();
             event.addBytesWritten( bytesWritten );
             event.done();
@@ -380,7 +380,7 @@ final class MuninnPage extends StampedLock implements Page
         // the file page, so any subsequent thread that finds the page in their
         // translation table will re-do the page fault.
         this.filePageId = filePageId; // Page now considered isLoaded()
-        int bytesRead = swapper.read( filePageId, this );
+        long bytesRead = swapper.read( filePageId, this );
         faultEvent.addBytesRead( bytesRead );
         faultEvent.setCachePageId( getCachePageId() );
         this.swapper = swapper; // Page now considered isBoundTo( swapper, filePageId )

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
@@ -317,21 +317,6 @@ final class MuninnPage extends StampedLock implements Page
         }
     }
 
-    /**
-     * NOTE: This method must be called while holding a pessimistic lock on the page.
-     */
-    public void flush(
-            PageSwapper swapper,
-            long filePageId,
-            FlushEventOpportunity flushOpportunity ) throws IOException
-    {
-        if ( isDirty() && this.swapper == swapper && this.filePageId == filePageId )
-        {
-            // The page is bound to the given swapper and has stuff to flush
-            doFlush( swapper, filePageId, flushOpportunity );
-        }
-    }
-
     private void doFlush(
             PageSwapper swapper,
             long filePageId,
@@ -431,11 +416,6 @@ final class MuninnPage extends StampedLock implements Page
             pointer = memoryManager.allocateAligned( size() );
             UnsafeUtil.setMemory( pointer, size(), MuninnPageCache.ZERO_BYTE );
         }
-    }
-
-    public PageSwapper getSwapper()
-    {
-        return swapper;
     }
 
     public long getFilePageId()

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
@@ -107,7 +107,7 @@ final class MuninnPage extends StampedLock implements Page
         cachePageHeader |= ~0x7F;
     }
 
-    private void markAsClean()
+    public void markAsClean()
     {
         cachePageHeader &= 0x7F;
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -382,7 +382,7 @@ public class MuninnPageCache implements PageCache
         try
         {
             backgroundThreadExecutor.execute( new EvictionTask( this ) );
-            backgroundThreadExecutor.execute( new FlushTask( this ) );
+            backgroundThreadExecutor.execute( new FlushTask( this ) ); // TODO disable background flushing
         }
         catch ( Exception e )
         {

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCursor.java
@@ -250,10 +250,7 @@ abstract class MuninnPageCursor implements PageCursor
 
     protected void assertPagedFileStillMapped()
     {
-        if ( pagedFile.getRefCount() == 0 )
-        {
-            throw new IllegalStateException( "File has been unmapped" );
-        }
+        pagedFile.assertStillMapped();
     }
 
     protected abstract void unpinCurrentPage();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -244,7 +244,7 @@ final class MuninnPagedFile implements PagedFile
             MuninnPage firstPage = pages[0];
             long startFilePageId = firstPage.getFilePageId();
             flush = flushOpportunity.beginFlush( startFilePageId, firstPage.getCachePageId(), swapper );
-            int bytesWritten = swapper.write( startFilePageId, pages, 0, pagesGrabbed );
+            long bytesWritten = swapper.write( startFilePageId, pages, 0, pagesGrabbed );
             flush.addBytesWritten( bytesWritten );
             flush.addPagesFlushed( pagesGrabbed );
             flush.done();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
@@ -94,7 +94,7 @@ public class DefaultPageCacheTracer implements PageCacheTracer
     private final FlushEvent flushEvent = new FlushEvent()
     {
         @Override
-        public void addBytesWritten( int bytes )
+        public void addBytesWritten( long bytes )
         {
             bytesWritten.getAndAdd( bytes );
         }
@@ -179,7 +179,7 @@ public class DefaultPageCacheTracer implements PageCacheTracer
     private final PageFaultEvent pageFaultEvent = new PageFaultEvent()
     {
         @Override
-        public void addBytesRead( int bytes )
+        public void addBytesRead( long bytes )
         {
             bytesRead.getAndAdd( bytes );
         }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
@@ -110,6 +110,11 @@ public class DefaultPageCacheTracer implements PageCacheTracer
         {
             done();
         }
+
+        @Override
+        public void addPagesFlushed( int pageCount )
+        {
+        }
     };
 
     private final FlushEventOpportunity flushEventOpportunity = new FlushEventOpportunity()

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/FlushEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/FlushEvent.java
@@ -45,20 +45,27 @@ public interface FlushEvent
         public void done( IOException exception )
         {
         }
+
+        @Override
+        public void addPagesFlushed( int pageCount )
+        {
+        }
     };
 
     /**
      * Add up a number of bytes that has been written to the file.
      */
-    public void addBytesWritten( int bytes );
+    void addBytesWritten( int bytes );
 
     /**
      * The page flush has completed successfully.
      */
-    public void done();
+    void done();
 
     /**
      * The page flush did not complete successfully, but threw the given exception.
      */
-    public void done( IOException exception );
+    void done( IOException exception );
+
+    void addPagesFlushed( int pageCount );
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/FlushEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/FlushEvent.java
@@ -32,7 +32,7 @@ public interface FlushEvent
     FlushEvent NULL = new FlushEvent()
     {
         @Override
-        public void addBytesWritten( int bytes )
+        public void addBytesWritten( long bytes )
         {
         }
 
@@ -55,7 +55,7 @@ public interface FlushEvent
     /**
      * Add up a number of bytes that has been written to the file.
      */
-    void addBytesWritten( int bytes );
+    void addBytesWritten( long bytes );
 
     /**
      * The page flush has completed successfully.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageFaultEvent.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageFaultEvent.java
@@ -30,7 +30,7 @@ public interface PageFaultEvent
     PageFaultEvent NULL = new PageFaultEvent()
     {
         @Override
-        public void addBytesRead( int bytes )
+        public void addBytesRead( long bytes )
         {
         }
 
@@ -59,7 +59,7 @@ public interface PageFaultEvent
     /**
      * Add up a number of bytes that has been read from the backing file into the free page being bound.
      */
-    void addBytesRead( int bytes );
+    void addBytesRead( long bytes );
 
     /**
      * The id of the cache page that is being faulted into.

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -818,8 +818,9 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         int read( Positionable fc, ByteBuffer dst )
         {
             int wanted = dst.limit() - dst.position();
-            int available = min( wanted, (int) (size() - fc.pos()) );
-            if ( available == 0 )
+            long size = size();
+            int available = min( wanted, (int) (size - fc.pos()) );
+            if ( available <= 0 )
             {
                 return -1; // EOF
             }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
@@ -36,7 +36,7 @@ public class DelegatingPageSwapper implements PageSwapper
         this.delegate = delegate;
     }
 
-    public int read( long filePageId, Page page ) throws IOException
+    public long read( long filePageId, Page page ) throws IOException
     {
         return delegate.read( filePageId, page );
     }
@@ -61,7 +61,7 @@ public class DelegatingPageSwapper implements PageSwapper
         return delegate.file();
     }
 
-    public int write( long filePageId, Page page ) throws IOException
+    public long write( long filePageId, Page page ) throws IOException
     {
         return delegate.write( filePageId, page );
     }
@@ -76,12 +76,12 @@ public class DelegatingPageSwapper implements PageSwapper
         delegate.truncate();
     }
 
-    public int read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    public long read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
     {
         return delegate.read( startFilePageId, pages, arrayOffset, length );
     }
 
-    public int write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    public long write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
     {
         return delegate.write( startFilePageId, pages, arrayOffset, length );
     }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
@@ -75,4 +75,14 @@ public class DelegatingPageSwapper implements PageSwapper
     {
         delegate.truncate();
     }
+
+    public int read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    {
+        return delegate.read( startFilePageId, pages, arrayOffset, length );
+    }
+
+    public int write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    {
+        return delegate.write( startFilePageId, pages, arrayOffset, length );
+    }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -3797,7 +3797,7 @@ public abstract class PageCacheTest<T extends PageCache>
                 return new DelegatingPageSwapper( delegate )
                 {
                     @Override
-                    public int write( long filePageId, Page page ) throws IOException
+                    public long write( long filePageId, Page page ) throws IOException
                     {
                         try
                         {

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageSwapperTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageSwapperTest.java
@@ -121,17 +121,22 @@ public abstract class PageSwapperTest
         PageSwapperFactory swapperFactory = swapperFactory();
         PageSwapper swapper = swapperFactory.createPageSwapper( file, cachePageSize(), NO_CALLBACK, true );
 
-        assertThat( swapper.write( 0, page ), is( page.size() ) );
+        assertThat( swapper.write( 0, page ), is( sizeOf( page ) ) );
                 page.putInt( 0, 0 );
         Thread.currentThread().interrupt();
 
-        assertThat( swapper.read( 0, page ), is( page.size() ) );
+        assertThat( swapper.read( 0, page ), is( sizeOf( page ) ) );
         assertTrue( Thread.currentThread().isInterrupted() );
         assertThat( page.getInt( 0 ), is( 1 ) );
 
-        assertThat( swapper.read( 0, page ), is( page.size() ) );
+        assertThat( swapper.read( 0, page ), is( sizeOf( page ) ) );
         assertTrue( Thread.currentThread().isInterrupted() );
         assertThat( page.getInt( 0 ), is( 1 ) );
+    }
+
+    private long sizeOf( ByteBufferPage page )
+    {
+        return page.size();
     }
 
     @Test
@@ -144,15 +149,15 @@ public abstract class PageSwapperTest
         PageSwapperFactory swapperFactory = swapperFactory();
         PageSwapper swapper = swapperFactory.createPageSwapper( file, cachePageSize(), NO_CALLBACK, true );
 
-        assertThat( swapper.write( 0, page ), is( page.size() ) );
+        assertThat( swapper.write( 0, page ), is( sizeOf( page ) ) );
                 page.putInt( 0, 0 );
         Thread.currentThread().interrupt();
 
-        assertThat( swapper.read( 0, new Page[]{page}, 0, 1 ), is( page.size() ) );
+        assertThat( swapper.read( 0, new Page[]{page}, 0, 1 ), is( sizeOf( page ) ) );
         assertTrue( Thread.currentThread().isInterrupted() );
         assertThat( page.getInt( 0 ), is( 1 ) );
 
-        assertThat( swapper.read( 0, new Page[] {page}, 0, 1 ), is( page.size() ) );
+        assertThat( swapper.read( 0, new Page[] {page}, 0, 1 ), is( sizeOf( page ) ) );
         assertTrue( Thread.currentThread().isInterrupted() );
         assertThat( page.getInt( 0 ), is( 1 ) );
     }
@@ -169,18 +174,18 @@ public abstract class PageSwapperTest
 
         Thread.currentThread().interrupt();
 
-        assertThat( swapper.write( 0, page ), is( page.size() ) );
+        assertThat( swapper.write( 0, page ), is( sizeOf( page ) ) );
         assertTrue( Thread.currentThread().isInterrupted() );
 
         page.putInt( 0, 0 );
-        assertThat( swapper.read( 0, page ), is( page.size() ) );
+        assertThat( swapper.read( 0, page ), is( sizeOf( page ) ) );
         assertThat( page.getInt( 0 ), is( 1 ) );
 
-        assertThat( swapper.write( 0, page ), is( page.size() ) );
+        assertThat( swapper.write( 0, page ), is( sizeOf( page ) ) );
         assertTrue( Thread.currentThread().isInterrupted() );
 
         page.putInt( 0, 0 );
-        assertThat( swapper.read( 0, page ), is( page.size() ) );
+        assertThat( swapper.read( 0, page ), is( sizeOf( page ) ) );
         assertThat( page.getInt( 0 ), is( 1 ) );
     }
 
@@ -196,18 +201,18 @@ public abstract class PageSwapperTest
 
         Thread.currentThread().interrupt();
 
-        assertThat( swapper.write( 0, new Page[] {page}, 0, 1 ), is( page.size() ) );
+        assertThat( swapper.write( 0, new Page[] {page}, 0, 1 ), is( sizeOf( page ) ) );
         assertTrue( Thread.currentThread().isInterrupted() );
 
         page.putInt( 0, 0 );
-        assertThat( swapper.read( 0, page ), is( page.size() ) );
+        assertThat( swapper.read( 0, page ), is( sizeOf( page ) ) );
         assertThat( page.getInt( 0 ), is( 1 ) );
 
-        assertThat( swapper.write( 0, new Page[] {page}, 0, 1 ), is( page.size() ) );
+        assertThat( swapper.write( 0, new Page[] {page}, 0, 1 ), is( sizeOf( page ) ) );
         assertTrue( Thread.currentThread().isInterrupted() );
 
         page.putInt( 0, 0 );
-        assertThat( swapper.read( 0, page ), is( page.size() ) );
+        assertThat( swapper.read( 0, page ), is( sizeOf( page ) ) );
         assertThat( page.getInt( 0 ), is( 1 ) );
     }
 
@@ -623,19 +628,19 @@ public abstract class PageSwapperTest
         swapper.read( 0, result );
         assertThat( result.getInt( 0 ), is( 0 ) );
         result.putInt( 0, 0 );
-        assertThat( swapper.read( 1, result ), is( 4 ) );
+        assertThat( swapper.read( 1, result ), is( 4L ) );
         assertThat( result.getInt( 0 ), is( 2 ) );
         result.putInt( 0, 0 );
-        assertThat( swapper.read( 2, result ), is( 4 ) );
+        assertThat( swapper.read( 2, result ), is( 4L ) );
         assertThat( result.getInt( 0 ), is( 3 ) );
         result.putInt( 0, 0 );
-        assertThat( swapper.read( 3, result ), is( 4 ) );
+        assertThat( swapper.read( 3, result ), is( 4L ) );
         assertThat( result.getInt( 0 ), is( 4 ) );
         result.putInt( 0, 0 );
-        assertThat( swapper.read( 4, result ), is( 4 ) );
+        assertThat( swapper.read( 4, result ), is( 4L ) );
         assertThat( result.getInt( 0 ), is( 5 ) );
         result.putInt( 0, 0 );
-        assertThat( swapper.read( 5, result ), is( 0 ) );
+        assertThat( swapper.read( 5, result ), is( 0L ) );
         assertThat( result.getInt( 0 ), is( 0 ) );
     }
 
@@ -663,7 +668,7 @@ public abstract class PageSwapperTest
         ByteBufferPage pageD = createPage( 4 );
 
         // Read 4 pages of 4 bytes each
-        assertThat( swapper.read( 1, new Page[]{pageA, pageB, pageC, pageD}, 0, 4 ), is( 4 * 4 ) );
+        assertThat( swapper.read( 1, new Page[]{pageA, pageB, pageC, pageD}, 0, 4 ), is( 4 * 4L ) );
 
         assertThat( pageA.getInt( 0 ), is( 2 ) );
         assertThat( pageB.getInt( 0 ), is( 3 ) );
@@ -680,7 +685,7 @@ public abstract class PageSwapperTest
 
         ByteBufferPage page = createPage( 4 );
         page.putInt( 1, 0 );
-        assertThat( swapper.read( 0, new Page[]{page}, 0, 1 ), is( 0 ) );
+        assertThat( swapper.read( 0, new Page[]{page}, 0, 1 ), is( 0L ) );
         assertThat( page.getInt( 0 ), is( 0 ) );
     }
 
@@ -699,7 +704,7 @@ public abstract class PageSwapperTest
         ByteBufferPage pageB = createPage( 4 );
         pageA.putInt( -1, 0 );
         pageB.putInt( -1, 0 );
-        assertThat( swapper.read( 3, new Page[]{pageA, pageB}, 0, 2 ), is( 0 ) );
+        assertThat( swapper.read( 3, new Page[]{pageA, pageB}, 0, 2 ), is( 0L ) );
         assertThat( pageA.getInt( 0 ), is( 0 ) );
         assertThat( pageB.getInt( 0 ), is( 0 ) );
     }
@@ -721,7 +726,7 @@ public abstract class PageSwapperTest
         ByteBufferPage pageB = createPage( 8 );
         pageA.putLong( X, 0 );
         pageB.putLong( Y, 0 );
-        assertThat( swapper.read( 1, new Page[]{pageA, pageB}, 0, 2 ), is( 12 ) );
+        assertThat( swapper.read( 1, new Page[]{pageA, pageB}, 0, 2 ), is( 12L ) );
         assertThat( pageA.getLong( 0 ), is( 0xFFFF_FFFF_FFFF_FFFFL ) );
         assertThat( pageB.getLong( 0 ), is( 0xFFFF_FFFF_0000_0000L ) );
     }
@@ -749,7 +754,7 @@ public abstract class PageSwapperTest
         pageA.putInt( -1, 0 );
         pageB.putInt( -1, 0 );
         pageC.putInt( -1, 0 );
-        assertThat( swapper.read( 0, new Page[]{pageA, pageB, pageC}, 0, 3 ), is( 12 ) );
+        assertThat( swapper.read( 0, new Page[]{pageA, pageB, pageC}, 0, 3 ), is( 12L ) );
         assertThat( pageA.getInt( 0 ), is( 1 ) );
         assertThat( pageA.getInt( 4 ), is( 2 ) );
         assertThat( pageB.getInt( 0 ), is( 3 ) );
@@ -792,8 +797,8 @@ public abstract class PageSwapperTest
                     if ( rng.nextBoolean() )
                     {
                         // Do read
-                        int bytesRead = swapper.read( startFilePageId, pages, 0, pages.length );
-                        assertThat( bytesRead, is( pages.length * 4 ) );
+                        long bytesRead = swapper.read( startFilePageId, pages, 0, pages.length );
+                        assertThat( bytesRead, is( pages.length * 4L ) );
                         for ( int j = 0; j < pages.length; j++ )
                         {
                             int expectedValue = (int) (1 + j + startFilePageId);
@@ -809,7 +814,7 @@ public abstract class PageSwapperTest
                             int value = (int) (1 + j + startFilePageId);
                             pages[j].putInt( value, 0 );
                         }
-                        assertThat( swapper.write( startFilePageId, pages, 0, pages.length ), is( pages.length * 4 ) );
+                        assertThat( swapper.write( startFilePageId, pages, 0, pages.length ), is( pages.length * 4L ) );
                     }
                 }
                 return null;
@@ -849,16 +854,16 @@ public abstract class PageSwapperTest
         pageD.putInt( 4, 0 );
 
         Page[] pages = {pageA, pageB, pageC, pageD};
-        int bytesWritten = swapper.write( 0, pages, 0, 4 );
-        assertThat( bytesWritten, is( 16 ) );
+        long bytesWritten = swapper.write( 0, pages, 0, 4 );
+        assertThat( bytesWritten, is( 16L ) );
 
         pageA.putInt( 5, 0 );
         pageB.putInt( 6, 0 );
         pageC.putInt( 7, 0 );
         pageD.putInt( 8, 0 );
 
-        int bytesRead = swapper.read( 1, pages, 1, 2 );
-        assertThat( bytesRead, is( 8 ) );
+        long bytesRead = swapper.read( 1, pages, 1, 2 );
+        assertThat( bytesRead, is( 8L ) );
 
         int[] actualValues = {pageA.getInt( 0 ), pageB.getInt( 0 ), pageC.getInt( 0 ), pageD.getInt( 0 )};
         int[] expectedValues = {5, 2, 3, 8};
@@ -883,22 +888,22 @@ public abstract class PageSwapperTest
         pageD.putInt( 4, 0 );
 
         Page[] pages = {pageA, pageB, pageC, pageD};
-        int bytesWritten = swapper.write( 0, pages, 0, 4 );
-        assertThat( bytesWritten, is( 16 ) );
+        long bytesWritten = swapper.write( 0, pages, 0, 4 );
+        assertThat( bytesWritten, is( 16L ) );
 
         pageB.putInt( 6, 0 );
         pageC.putInt( 7, 0 );
 
         bytesWritten = swapper.write( 1, pages, 1, 2 );
-        assertThat( bytesWritten, is( 8 ) );
+        assertThat( bytesWritten, is( 8L ) );
 
         pageA.putInt( 0, 0 );
         pageB.putInt( 0, 0 );
         pageC.putInt( 0, 0 );
         pageD.putInt( 0, 0 );
 
-        int bytesRead = swapper.read( 0, pages, 0, 4 );
-        assertThat( bytesRead, is( 16 ) );
+        long bytesRead = swapper.read( 0, pages, 0, 4 );
+        assertThat( bytesRead, is( 16L ) );
 
         int[] actualValues = {pageA.getInt( 0 ), pageB.getInt( 0 ), pageC.getInt( 0 ), pageD.getInt( 0 )};
         int[] expectedValues = {1, 6, 7, 4};

--- a/community/io/src/test/java/org/neo4j/io/pagecache/RecordingPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/RecordingPageCacheTracer.java
@@ -101,7 +101,7 @@ public class RecordingPageCacheTracer implements PageCacheTracer
                 return new PageFaultEvent()
                 {
                     @Override
-                    public void addBytesRead( int bytes )
+                    public void addBytesRead( long bytes )
                     {
                     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperWithRealFileSystemTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapperWithRealFileSystemTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.impl;
+
+import java.io.File;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+public class SingleFilePageSwapperWithRealFileSystemTest extends SingleFilePageSwapperTest
+{
+    private final DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
+
+    @Override
+    public void tearDown()
+    {
+        // Do nothing
+    }
+
+    @Override
+    protected File getFile()
+    {
+        return testDir.file( super.getFile().getName() );
+    }
+
+    @Override
+    protected FileSystemAbstraction getFs()
+    {
+        return fs;
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RandomPageCacheTestHarness.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RandomPageCacheTestHarness.java
@@ -398,10 +398,7 @@ public class RandomPageCacheTestHarness
                 }
                 future.get( deadlineMillis - now, TimeUnit.MILLISECONDS );
             }
-            if ( verification != null )
-            {
-                verification.run( cache, this.fs, plan.getFilesTouched() );
-            }
+            runVerificationPhase( cache );
         }
         finally
         {
@@ -416,6 +413,14 @@ public class RandomPageCacheTestHarness
             plan.close();
             cache.close();
             this.fs.shutdown();
+        }
+    }
+
+    private void runVerificationPhase( MuninnPageCache cache ) throws Exception
+    {
+        if ( verification != null )
+        {
+            verification.run( cache, this.fs, plan.getFilesTouched() );
         }
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RecordFormat.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/randomharness/RecordFormat.java
@@ -27,6 +27,7 @@ import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.StubPageCursor;
 
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertThat;
 
@@ -76,19 +77,34 @@ public abstract class RecordFormat
 
     public final void assertRecordsWrittenCorrectly( PageCursor cursor ) throws IOException
     {
-        int recordsPerPage = cursor.getCurrentPageSize() / getRecordSize();
+        int currentPageSize = cursor.getCurrentPageSize();
+        int recordSize = getRecordSize();
+        int recordsPerPage = currentPageSize / recordSize;
         for ( int pageRecordId = 0; pageRecordId < recordsPerPage; pageRecordId++ )
         {
-            int recordId = (int) (cursor.getCurrentPageId() * recordsPerPage + pageRecordId);
+            long currentPageId = cursor.getCurrentPageId();
+            int recordId = (int) (currentPageId * recordsPerPage + pageRecordId);
             Record expectedRecord = createRecord( cursor.getCurrentFile(), recordId );
             Record actualRecord;
-            int offset = cursor.getOffset();
-            do
-            {
-                cursor.setOffset( offset );
-                actualRecord = readRecord( cursor );
-            }
-            while ( cursor.shouldRetry() );
+            actualRecord = readRecord( cursor );
+            assertThat( actualRecord, isOneOf( expectedRecord, zeroRecord() ) );
+        }
+    }
+
+    public final void assertRecordsWrittenCorrectly( File file, StoreChannel channel ) throws IOException
+    {
+        int recordSize = getRecordSize();
+        long recordsInFile = channel.size() / recordSize;
+        ByteBuffer buffer = ByteBuffer.allocateDirect( recordSize );
+        StubPageCursor cursor = new StubPageCursor( 0, buffer );
+        for ( int i = 0; i < recordsInFile; i++ )
+        {
+            assertThat( "reading record id " + i, channel.read( buffer ), is( recordSize ) );
+            buffer.flip();
+            Record expectedRecord = createRecord( file, i );
+            cursor.setOffset( 0 );
+            Record actualRecord = readRecord( cursor );
+            buffer.clear();
             assertThat( actualRecord, isOneOf( expectedRecord, zeroRecord() ) );
         }
     }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
@@ -49,7 +49,6 @@ public class DummyPageSwapper implements PageSwapper
     @Override
     public void evicted( long pageId, Page page )
     {
-
     }
 
     @Override
@@ -77,5 +76,17 @@ public class DummyPageSwapper implements PageSwapper
     @Override
     public void truncate() throws IOException
     {
+    }
+
+    @Override
+    public int read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    {
+        return 0;
+    }
+
+    @Override
+    public int write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    {
+        return 0;
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
@@ -35,13 +35,13 @@ public class DummyPageSwapper implements PageSwapper
     }
 
     @Override
-    public int read( long filePageId, Page page ) throws IOException
+    public long read( long filePageId, Page page ) throws IOException
     {
         return 0;
     }
 
     @Override
-    public int write( long filePageId, Page page ) throws IOException
+    public long write( long filePageId, Page page ) throws IOException
     {
         return 0;
     }
@@ -79,13 +79,13 @@ public class DummyPageSwapper implements PageSwapper
     }
 
     @Override
-    public int read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    public long read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
     {
         return 0;
     }
 
     @Override
-    public int write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
+    public long write( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
     {
         return 0;
     }

--- a/community/io/src/test/java/org/neo4j/test/LinearHistoryPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/test/LinearHistoryPageCacheTracer.java
@@ -68,6 +68,7 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
 
         public SwitchableBufferedOutputStream()
         {
+            //noinspection ConstantConditions
             super( null ); // No output target by default. This is changed in printHistory.
         }
 
@@ -298,6 +299,7 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
     {
         private long filePageId;
         private int cachePageId;
+        private int pageCount;
         private File file;
         private int bytesWritten;
         private IOException exception;
@@ -306,6 +308,7 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
         {
             this.filePageId = filePageId;
             this.cachePageId = cachePageId;
+            this.pageCount = 1;
             this.file = swapper.file();
         }
 
@@ -329,12 +332,20 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
         }
 
         @Override
+        public void addPagesFlushed( int pageCount )
+        {
+            this.pageCount = pageCount;
+        }
+
+        @Override
         void printBody( PrintStream out, String exceptionLinePrefix )
         {
             out.print( ", filePageId:" );
             out.print( filePageId );
             out.print( ", cachePageId:" );
             out.print( cachePageId );
+            out.print( ", pageCount:" );
+            out.print( pageCount );
             print( out, file );
             out.print( ", bytesWritten:" );
             out.print( bytesWritten );

--- a/community/io/src/test/java/org/neo4j/test/LinearHistoryPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/test/LinearHistoryPageCacheTracer.java
@@ -313,7 +313,7 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
         }
 
         @Override
-        public void addBytesWritten( int bytes )
+        public void addBytesWritten( long bytes )
         {
             bytesWritten += bytes;
         }
@@ -406,7 +406,7 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
         private Throwable exception;
 
         @Override
-        public void addBytesRead( int bytes )
+        public void addBytesRead( long bytes )
         {
             bytesRead += bytes;
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityStoreUpdaterStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityStoreUpdaterStep.java
@@ -138,6 +138,10 @@ public class EntityStoreUpdaterStep<RECORD extends PrimitiveRecord,INPUT extends
             propertyStore.updateRecord( propertyRecord );
         }
 
+        // Flush after each batch.
+        // We get vectored, sequential IO when we write with flush, plus it makes future page faulting faster.
+        propertyStore.flush();
+        entityStore.flush();
         monitor.entitiesWritten( records[0].getClass(), records.length-skipped );
         monitor.propertiesWritten( propertyBlockCursor );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStore.java
@@ -62,6 +62,7 @@ import org.neo4j.unsafe.impl.batchimport.store.io.IoTracer;
 import static java.lang.String.valueOf;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_threshold;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 /**
@@ -92,14 +93,16 @@ public class BatchingNeoStore implements AutoCloseable, NeoStoreSupplier
         this.monitors = monitors;
         this.logProvider = logService.getInternalLogProvider();
         this.storeDir = storeDir;
-        this.neo4jConfig = new Config( stringMap( dense_node_threshold.name(), valueOf( config.denseNodeThreshold() ) ),
-                        GraphDatabaseSettings.class );
+        this.neo4jConfig = new Config( stringMap(
+                dense_node_threshold.name(), valueOf( config.denseNodeThreshold() ),
+                pagecache_memory.name(), valueOf( config.writeBufferSize() ) ),
+                GraphDatabaseSettings.class );
         final PageCacheTracer tracer = new DefaultPageCacheTracer();
         this.pageCache = createPageCache( fileSystem, neo4jConfig, logProvider, tracer );
         this.ioTracer = new IoTracer()
         {
             @Override
-            public long countBytesWrittem()
+            public long countBytesWritten()
             {
                 return tracer.countBytesWritten();
             }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoMonitor.java
@@ -47,7 +47,7 @@ public class IoMonitor implements StatsProvider
     {
         startTime = currentTimeMillis();
         endTime = 0;
-        resetPoint = tracer.countBytesWrittem();
+        resetPoint = tracer.countBytesWritten();
     }
 
     public void stop()
@@ -62,7 +62,7 @@ public class IoMonitor implements StatsProvider
 
     public long totalBytesWritten()
     {
-        return tracer.countBytesWrittem() - resetPoint;
+        return tracer.countBytesWritten() - resetPoint;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoTracer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/io/IoTracer.java
@@ -24,12 +24,12 @@ package org.neo4j.unsafe.impl.batchimport.store.io;
  */
 public interface IoTracer
 {
-    long countBytesWrittem();
+    long countBytesWritten();
 
     public static final IoTracer NONE = new IoTracer()
     {
         @Override
-        public long countBytesWrittem()
+        public long countBytesWritten()
         {
             return 0;
         }


### PR DESCRIPTION
This significantly speeds up the store flushing. Especially on fast storage devices.
The reason vectored IO speeds up our writes, is our odd-sized file pages.
Because the file pages are not sized as a multiple of the OS pages, the OS needs to read in the last block in a page, so that most of the data can be overwritten by the write, and then the whole block - included the last few unchanged bytes - can be written back to the device.
It is this read which slows us down, because we cannot make any progress until it completes.
This defeats many buffering and asynchronisity optimisations on many layers down to the device.
With the vectored IO methods, the last bytes of those blocks can now be found in the next page of the vector, which eliminates all but one read.
This allows us to stream data to the storage device in chunks of up to 32 MiB at a time, easily saturating all write buffers of the system, with the exception of the OS page cache.
The net effect is that we now stand a good chance of writing at the maximum speed of the underlying storage subsystem.
