### PR TITLE
Make FOREACH cypher queries return empty result

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/EmptyResultBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/EmptyResultBuilder.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.executionplan.builders
 
-import org.neo4j.cypher.internal.compiler.v2_2.executionplan.{PlanBuilder, ExecutionPlanInProgress}
-import org.neo4j.cypher.internal.compiler.v2_2.pipes.{PipeMonitor, EmptyResultPipe}
+import org.neo4j.cypher.internal.compiler.v2_2.executionplan.{ExecutionPlanInProgress, PlanBuilder}
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.{EmptyResultPipe, PipeMonitor}
 import org.neo4j.cypher.internal.compiler.v2_2.spi.PlanContext
 
 /**
@@ -36,14 +36,19 @@ class EmptyResultBuilder extends PlanBuilder {
   def canWorkWith(plan: ExecutionPlanInProgress, ctx: PlanContext)(implicit pipeMonitor: PipeMonitor) = {
     val q = plan.query
 
+    val emptyResultPipeWasNotAlreadyPlanned = plan.pipe match {
+      case _: EmptyResultPipe => false
+      case _ => true
+    }
     val noSortingLeftToDo = q.sort.isEmpty
     val noSkipOrLimitLeftToDo = q.slice.isEmpty
-    val nothingToReturnButPipeNotEmpty = q.returns.size == 0 && plan.pipe.symbols.size > 0
+    val nothingToReturn = q.returns.isEmpty
     val isLastPipe = q.tail.isEmpty
 
+    emptyResultPipeWasNotAlreadyPlanned &&
       noSortingLeftToDo &&
       noSkipOrLimitLeftToDo &&
       isLastPipe &&
-      nothingToReturnButPipeNotEmpty
+      nothingToReturn
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExecuteUpdateCommandsPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/ExecuteUpdateCommandsPipe.scala
@@ -36,8 +36,6 @@ case class ExecuteUpdateCommandsPipe(source: Pipe, commands: Seq[UpdateAction])(
     case ctx => executeMutationCommands(ctx, state, commands.size == 1)
   }
 
-  val allKeys = commands.flatMap( c => c.identifiers.map(_._1) )
-
   private def executeMutationCommands(ctx: ExecutionContext,
                                       state: QueryState,
                                       singleCommand: Boolean): Iterator[ExecutionContext] =

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/BuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/BuilderTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 
 trait BuilderTest extends CypherFunSuite {
 
-  private implicit val monitor = mock[PipeMonitor]
+  implicit val monitor = mock[PipeMonitor]
 
   def createPipe(nodes: Seq[String] = Seq(), relationships: Seq[String] = Seq()): FakePipe = {
     val nodeIdentifiers = nodes.map(x => x -> CTNode)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/DeleteAndPropertySetBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/DeleteAndPropertySetBuilderTest.scala
@@ -22,12 +22,9 @@ package org.neo4j.cypher.internal.compiler.v2_2.executionplan.builders
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Identifier
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.PartiallySolvedQuery
 import org.neo4j.cypher.internal.compiler.v2_2.mutation.DeleteEntityAction
-import org.neo4j.cypher.internal.compiler.v2_2.pipes.PipeMonitor
 import org.neo4j.cypher.internal.compiler.v2_2.spi.PlanContext
 
 class DeleteAndPropertySetBuilderTest extends BuilderTest {
-
-  private implicit val monitor = mock[PipeMonitor]
 
   val builder = new UpdateActionBuilder
   val planContext = mock[PlanContext]

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/EmptyResultBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/EmptyResultBuilderTest.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_2.executionplan.builders
+
+import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Identifier, Literal, Property, RangeFunction}
+import org.neo4j.cypher.internal.compiler.v2_2.commands.values.TokenType._
+import org.neo4j.cypher.internal.compiler.v2_2.commands.{ReturnItem, Slice, SortItem}
+import org.neo4j.cypher.internal.compiler.v2_2.executionplan.{ExecutionPlanInProgress, PartiallySolvedQuery}
+import org.neo4j.cypher.internal.compiler.v2_2.mutation.{CreateNode, ForeachAction}
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.{EmptyResultPipe, SingleRowPipe}
+
+class EmptyResultBuilderTest extends BuilderTest {
+
+  def builder = new EmptyResultBuilder
+
+  test("should add empty result pipe") {
+    // Given
+    val query = PartiallySolvedQuery().copy(
+      updates = Seq(Unsolved(ForeachAction(RangeFunction(Literal(0), Literal(1), Literal(1)), "n", List(CreateNode("p", Map(), List())))))
+    )
+
+    // When
+    val plan = assertAccepts(query)
+
+    // Then
+    plan.pipe shouldBe an[EmptyResultPipe]
+  }
+
+  test("should reject when empty result pipe already planned") {
+    // Given
+    val query = PartiallySolvedQuery().copy(
+      updates = Seq(Unsolved(ForeachAction(RangeFunction(Literal(0), Literal(1), Literal(1)), "n", List(CreateNode("p", Map(), List())))))
+    )
+    val pipe = EmptyResultPipe(SingleRowPipe())
+    val planInProgress = ExecutionPlanInProgress(query, pipe, isUpdating = true)
+
+    // When / Then
+    assertRejects(planInProgress)
+  }
+
+  test("should reject when sorting should be done") {
+    // Given
+    val query = PartiallySolvedQuery().copy(
+      sort = Seq(Unsolved(SortItem(Property(Identifier("x"), PropertyKey("y")), ascending = true))),
+      extracted = true
+    )
+
+    // When / Then
+    assertRejects(query)
+  }
+
+  test("should reject when skip should be done") {
+    // Given
+    val query = PartiallySolvedQuery().copy(
+      slice = Some(Unsolved(Slice(Some(Literal(10)), None)))
+    )
+
+    // When / Then
+    assertRejects(query)
+  }
+
+  test("should reject when limit should be done") {
+    // Given
+    val query = PartiallySolvedQuery().copy(
+      slice = Some(Unsolved(Slice(None, Some(Literal(10)))))
+    )
+
+    // When / Then
+    assertRejects(query)
+  }
+
+  test("should reject when both skip and limit should be done") {
+    // Given
+    val query = PartiallySolvedQuery().copy(
+      slice = Some(Unsolved(Slice(Some(Literal(42)), Some(Literal(42)))))
+    )
+
+    // When / Then
+    assertRejects(query)
+  }
+
+  test("should reject when query has something to return") {
+    // Given
+    val query = PartiallySolvedQuery().copy(
+      returns = Seq(Unsolved(ReturnItem(Literal("foo"), "foo")))
+    )
+
+    // When / Then
+    assertRejects(query)
+  }
+
+  test("should reject when query has tail") {
+    // Given
+    val query = PartiallySolvedQuery().copy(
+      tail = Some(PartiallySolvedQuery())
+    )
+
+    // When / Then
+    assertRejects(query)
+  }
+}

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/ExtractBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/ExtractBuilderTest.scala
@@ -22,12 +22,11 @@ package org.neo4j.cypher.internal.compiler.v2_2.executionplan.builders
 import org.neo4j.cypher.internal.compiler.v2_2.commands.ReturnItem
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions._
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan._
-import org.neo4j.cypher.internal.compiler.v2_2.pipes.{ExtractPipe, PipeMonitor}
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.ExtractPipe
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 
 class ExtractBuilderTest extends BuilderTest {
 
-  private implicit val monitor = mock[PipeMonitor]
   val builder = new ExtractBuilder
 
   test("should_solve_the_predicates_that_are_possible_to_solve") {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/FilterBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/FilterBuilderTest.scala
@@ -25,11 +25,9 @@ import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Identifier,
 import org.neo4j.cypher.internal.compiler.v2_2.commands.values.TokenType._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.{Equals, Predicate, SingleNode}
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.PartiallySolvedQuery
-import org.neo4j.cypher.internal.compiler.v2_2.pipes.PipeMonitor
 
 class FilterBuilderTest extends BuilderTest {
 
-  private implicit val monitor: PipeMonitor = mock[PipeMonitor]
   val builder = new FilterBuilder
 
   test("does_not_offer_to_solve_queries_without_start_items") {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/NamedPathBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/NamedPathBuilderTest.scala
@@ -22,11 +22,11 @@ package org.neo4j.cypher.internal.compiler.v2_2.executionplan.builders
 import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.{NamedPath, NodeById, RelatedTo, SingleNode}
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.PartiallySolvedQuery
-import org.neo4j.cypher.internal.compiler.v2_2.pipes.{NamedPathPipe, PipeMonitor}
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.NamedPathPipe
 import org.neo4j.graphdb.Direction
 
 class NamedPathBuilderTest extends BuilderTest {
-  private implicit val monitor = mock[PipeMonitor]
+
   val builder = new NamedPathBuilder
 
   test("should_not_accept_if_pattern_is_not_yet_solved") {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/PredicateRewriterTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/PredicateRewriterTest.scala
@@ -23,12 +23,9 @@ import org.neo4j.cypher.internal.compiler.v2_2.commands._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Identifier, Literal, Property}
 import org.neo4j.cypher.internal.compiler.v2_2.commands.values.{UnresolvedLabel, UnresolvedProperty}
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.{ExecutionPlanInProgress, Namer, PlanBuilder}
-import org.neo4j.cypher.internal.compiler.v2_2.pipes.PipeMonitor
 import org.neo4j.graphdb.Direction
 
 class PredicateRewriterTest extends BuilderTest {
-
-  private implicit val monitor = mock[PipeMonitor]
 
   def builder: PlanBuilder = new PredicateRewriter(new Namer {
     var count = 0

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ForeachAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ForeachAcceptanceTest.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import org.neo4j.cypher.{NewPlannerTestSupport, QueryStatisticsTestSupport, ExecutionEngineFunSuite}
+package org.neo4j.cypher
 
 class ForeachAcceptanceTest extends ExecutionEngineFunSuite {
 
@@ -39,5 +39,16 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite {
     rows should equal(10)
     val ids = execute("MATCH (:root)-[:PARENT*]->(c:child) RETURN c.id AS id ORDER BY c.id").toList
     ids should equal((1 to 110).map(i => Map("id" -> i)))
+  }
+
+  test("foreach should return no results") {
+    // given
+    val query = "FOREACH( n in range( 0, 1 ) | CREATE (p:Person) )"
+
+    // when
+    val result = execute(query).toList
+
+    // then
+    result shouldBe empty
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/TraversalMatcherBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/TraversalMatcherBuilderTest.scala
@@ -19,17 +19,16 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2
 
-import org.junit.Assert._
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.ast.Statement
 import org.neo4j.cypher.internal.compiler.v2_2.ast.convert.commands.StatementConverters
-import StatementConverters._
+import org.neo4j.cypher.internal.compiler.v2_2.ast.convert.commands.StatementConverters._
 import org.neo4j.cypher.internal.compiler.v2_2.commands._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions._
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.builders.{BuilderTest, Solved, TraversalMatcherBuilder, Unsolved}
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.{ExecutionPlanInProgress, PartiallySolvedQuery}
 import org.neo4j.cypher.internal.compiler.v2_2.parser.{CypherParser, ParserMonitor}
-import org.neo4j.cypher.internal.compiler.v2_2.pipes.{ArgumentPipe, SingleRowPipe, PipeMonitor}
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.{ArgumentPipe, SingleRowPipe}
 import org.neo4j.cypher.internal.compiler.v2_2.spi.PlanContext
 import org.neo4j.cypher.internal.spi.v2_2.TransactionBoundPlanContext
 import org.neo4j.graphdb.Transaction
@@ -41,7 +40,6 @@ class TraversalMatcherBuilderTest extends GraphDatabaseFunSuite with BuilderTest
   var builder: TraversalMatcherBuilder = null
   var ctx: PlanContext = null
   var tx: Transaction = null
-  private implicit val monitor = mock[PipeMonitor]
 
   override def beforeEach() {
     super.beforeEach()


### PR DESCRIPTION
Previously result of `FOREACH( n in range( 0, 1 ) | CREATE (p:Person) )` query
would be `Iterator(Map())` which is incorrect. Empty iterator is the correct and expected result.

This was so because `EmptyResultPipe` was not planned on top of foreach and dummy empty execution context, created by `SingleRowPipe`, was passed all the way up to the user.

PR fixes the problem by forcing `EmptyResultPipe` on top of any pipe that has nothing to return. To avoid infinite planning of `EmptyResultPipe` it's presence is checked in `EmptyResultBuilder#canWorkWith`.
