### PR TITLE
Fixed closing of compiled execution result

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompiledExecutionResultTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompiledExecutionResultTest.scala
@@ -21,11 +21,10 @@ package org.neo4j.cypher.internal.compiler.v2_3.executionplan
 
 import java.util
 
-import org.neo4j.cypher.internal.compiler.v2_3.{NormalMode, ExecutionMode}
-import org.neo4j.cypher.internal.compiler.v2_3.TaskCloser
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.ResultRowImpl
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.compiler.v2_3.{ExecutionMode, NormalMode, TaskCloser}
 import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
 import org.neo4j.helpers.collection.Iterables._
 
@@ -129,6 +128,23 @@ class CompiledExecutionResultTest extends CypherFunSuite {
 
     // also then
     intercept[IllegalStateException](result.javaIterator.hasNext)
+  }
+
+  test("close should work after result is consumed") {
+    // given
+    val result = newCompiledExecutionResult(javaMap("a" -> "1", "b" -> "2"))
+
+    // when
+    result.accept(new ResultVisitor[Exception] {
+      override def visit(row: ResultRow): Boolean = {
+        true
+      }
+    })
+
+    result.close()
+
+    // then
+    // call of close actually worked
   }
 
   private def newCompiledExecutionResult(row: util.Map[String, Any] = new util.HashMap(),

--- a/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/CypherAdapterStream.java
+++ b/community/ndp/runtime/src/main/java/org/neo4j/ndp/runtime/internal/CypherAdapterStream.java
@@ -28,7 +28,6 @@ public class CypherAdapterStream implements RecordStream
     private final Result delegate;
     private final String[] fieldNames;
     private CypherAdapterRecord currentRecord;
-    private boolean exhaustedResult = false;
 
     public CypherAdapterStream( Result delegate )
     {
@@ -40,11 +39,7 @@ public class CypherAdapterStream implements RecordStream
     @Override
     public void close()
     {
-        // TODO Temp workaround for bug in Cypher, only close if we've not exhausted the result, fix the root cause
-        if(!exhaustedResult)
-        {
-            delegate.close();
-        }
+        delegate.close();
     }
 
     @Override
@@ -64,8 +59,7 @@ public class CypherAdapterStream implements RecordStream
                 visitor.visit( currentRecord.reset( row ) );
                 return true;
             }
-        });
-        exhaustedResult = true;
+        } );
     }
 
     private static class CypherAdapterRecord implements Record


### PR DESCRIPTION
Problem occurred when closing ExecutionResult that had underlying result object from compiled runtime. Close method ensured that iterator over underlying result was initialized regardless whether it was consumed via iterator or visitor. For compiled execution result this caused visitor to be called twice - once for consumption and once for closing.

Issue fixed by always closing underlying execution result and closing iterator, obtained from underlying result, only if it is initialized.
