### PR TITLE
Fix an integer overflow bug in the expected max memory allocation

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -236,7 +236,8 @@ public class MuninnPageCache implements PageCache
         this.printExceptionsOnClose = true;
 
         long alignment = swapperFactory.getRequiredBufferAlignment();
-        MemoryManager memoryManager = new MemoryManager( maxPages * cachePageSize, alignment );
+        long expectedMaxMemory = ((long) maxPages) * cachePageSize; // cast to long prevents overflow
+        MemoryManager memoryManager = new MemoryManager( expectedMaxMemory, alignment );
         Object pageList = null;
         int pageIndex = maxPages;
         while ( pageIndex --> 0 )


### PR DESCRIPTION
The MuninnPageCache constructor was calling the MemoryManager constructor, giving it an estimate of how much memory we might need.
This estimate was computed by multiplying the maxPages and the cachePageSize values together.
The problem was that both of these variables were 32 bit signed integers, and thus could easily overflow with just a moderate page cache memory allocation.
The effect of this bug, is that the MemoryManager would get a really bad estimate of how much memory would be needed, and thus end up producing many more Slab objects than expected.
In the worst case, this could lead to an OutOfMemoryError: Heap space, when the increased number of Slab objects put too much memory pressure on the Java heap.

The fix is to first cast one the variables to a `long` before doing the multiplication.
