### PR TITLE
Fix unnecessary predicate exceptions

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/FilterBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/FilterBuilder.scala
@@ -32,7 +32,7 @@ class FilterBuilder extends PlanBuilder {
 
     val onlyDeterministic = !allPatternsSolved(plan)
     val item = q.where.filter(pred => yesOrNo(pred, p, onlyDeterministic))
-    val pred: Predicate = item.map(_.token).reduce(_ ++ _)
+    val pred: Predicate = item.map(_.token).reduce(_ andWith _)
 
     val newPipe = if (pred == True()) {
       p

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -92,7 +92,7 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
           NodeIndexSeekPipe(id, label, propertyKey, valueExpr.map(buildExpression), unique = true)()
 
         case Selection(predicates, left) =>
-          FilterPipe(buildPipe(left), predicates.map(buildPredicate).reduce(_ ++ _))()
+          FilterPipe(buildPipe(left), predicates.map(buildPredicate).reduce(_ andWith _))()
 
         case CartesianProduct(left, right) =>
           CartesianProductPipe(buildPipe(left), buildPipe(right))()
@@ -104,11 +104,11 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
           ExpandIntoPipe(buildPipe(left), fromName, relName, toName, dir, LazyTypes(types))()
 
         case OptionalExpand(left, IdName(fromName), dir, types, IdName(toName), IdName(relName), ExpandAll, predicates) =>
-          val predicate = predicates.map(buildPredicate).reduceOption(_ ++ _).getOrElse(True())
+          val predicate = predicates.map(buildPredicate).reduceOption(_ andWith _).getOrElse(True())
           OptionalExpandAllPipe(buildPipe(left), fromName, relName, toName, dir, LazyTypes(types), predicate)()
 
         case OptionalExpand(left, IdName(fromName), dir, types, IdName(toName), IdName(relName), ExpandInto, predicates) =>
-          val predicate = predicates.map(buildPredicate).reduceOption(_ ++ _).getOrElse(True())
+          val predicate = predicates.map(buildPredicate).reduceOption(_ andWith _).getOrElse(True())
           OptionalExpandIntoPipe(buildPipe(left), fromName, relName, toName, dir, LazyTypes(types), predicate)()
 
         case VarExpand(left, IdName(fromName), dir, projectedDir, types, IdName(toName), IdName(relName), VarPatternLength(min, max), expansionMode, predicates) =>

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -31,7 +31,20 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val n2 = createNode()
     val r = relate(n1, n2)
     val result = executeWithAllPlanners("MATCH (n)-[r]->() RETURN n, r")
-    a [NotFoundException] should be thrownBy result.columnAs("m")
+    a[NotFoundException] should be thrownBy result.columnAs("m")
+  }
+
+  test("predicates that throw exceptions should not matter if other predicates return false") {
+    val root = createLabeledNode(Map("name" -> "x"), "Root")
+    val child1 = createLabeledNode(Map("id" -> "text"), "TextNode")
+    val child2 = createLabeledNode(Map("id" -> 0), "IntNode")
+    relate(root, child1)
+    relate(root, child2)
+
+    val query = "MATCH (:Root {name:'x'})-->(i:TextNode) WHERE i.id =~ 'te.*' RETURN i"
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("i" -> child1)))
   }
 
   test("combines aggregation and named path") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -52,12 +52,22 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     result.columnAs("i").toSet[Node] should equal(Set(child1, child2))
   }
 
-  test("exceptions should be thrown if rows are kept") {
+  test("exceptions should be thrown if rows are kept through AND'd predicates") {
     val root = createLabeledNode(Map("name" -> "x"), "Root")
-    val child = createLabeledNode(Map("id" -> 0), "TextNode")
+    val child = createLabeledNode(Map("id" -> 0), "Child")
     relate(root, child)
 
-    val query = "MATCH (:Root {name:'x'})-->(i:TextNode) WHERE i.id =~ 'te.*' RETURN i"
+    val query = "MATCH (:Root {name:'x'})-->(i:Child) WHERE i.id =~ 'te.*' RETURN i"
+
+    a [CypherTypeException] should be thrownBy executeWithAllPlanners(query)
+  }
+
+  test("exceptions should be thrown if rows are kept through OR'd predicates") {
+    val root = createLabeledNode(Map("name" -> "x"), "Root")
+    val child = createLabeledNode(Map("id" -> 0), "Child")
+    relate(root, child)
+
+    val query = "MATCH (:Root {name:'x'})-->(i) WHERE NOT has(i.id) OR i.id =~ 'te.*' RETURN i"
 
     a [CypherTypeException] should be thrownBy executeWithAllPlanners(query)
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -34,7 +34,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     a[NotFoundException] should be thrownBy result.columnAs("m")
   }
 
-  test("predicates that throw exceptions should not matter if other predicates return false") {
+  test("AND'd predicates that throw exceptions should not matter if other predicates return false") {
     val root = createLabeledNode(Map("name" -> "x"), "Root")
     val child1 = createLabeledNode(Map("id" -> "text"), "TextNode")
     val child2 = createLabeledNode(Map("id" -> 0), "IntNode")
@@ -45,6 +45,29 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val result = executeWithAllPlanners(query)
 
     result.toList should equal(List(Map("i" -> child1)))
+  }
+
+  test("OR'd predicates that throw exceptions should not matter if other predicates return true") {
+    val root = createLabeledNode(Map("name" -> "x"), "Root")
+    val child1 = createLabeledNode(Map("id" -> "text"), "TextNode")
+    val child2 = createLabeledNode(Map("id" -> 0), "IntNode")
+    relate(root, child1)
+    relate(root, child2)
+
+    val query = "MATCH (:Root {name:'x'})-->(i) WHERE has(i.id) OR i.id =~ 'te.*' RETURN i"
+    val result = executeWithAllPlanners(query)
+
+    result.columnAs("i").toSet[Node] should equal(Set(child1, child2))
+  }
+
+  test("exceptions should be thrown if rows are kept") {
+    val root = createLabeledNode(Map("name" -> "x"), "Root")
+    val child = createLabeledNode(Map("id" -> 0), "TextNode")
+    relate(root, child)
+
+    val query = "MATCH (:Root {name:'x'})-->(i:TextNode) WHERE i.id =~ 'te.*' RETURN i"
+
+    a [CypherTypeException] should be thrownBy executeWithAllPlanners(query)
   }
 
   test("combines aggregation and named path") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -26,6 +26,19 @@ import scala.collection.JavaConverters._
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
+  test("predicates that throw exceptions should not matter if other predicates return false") {
+    val root = createLabeledNode(Map("name" -> "x"), "Root")
+    val child1 = createLabeledNode(Map("id" -> "text"), "TextNode")
+    val child2 = createLabeledNode(Map("id" -> 0), "IntNode")
+    relate(root, child1)
+    relate(root, child2)
+
+    val query = "MATCH (:Root {name:'x'})-->(i:TextNode) WHERE i.id =~ 'te.*' RETURN i"
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("i" -> child1)))
+  }
+
   test("combines aggregation and named path") {
     val node1 = createNode("num" -> 1)
     val node2 = createNode("num" -> 2)


### PR DESCRIPTION
When we have multiple predicates AND'd together, if one evaluates to false
and another throws an exception, the exception is of no use, since the
entire row should not be returned. We evaluate these cases to false,
effectively ignoring the exception. If the other predicate was true, the
exception would of course be thrown as normal.
