### PR TITLE
Renamed mandatory property constraints to property existence constraints

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/SchemaRecordCheck.java
@@ -30,9 +30,9 @@ import org.neo4j.kernel.impl.store.SchemaRuleAccess;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
-import org.neo4j.kernel.impl.store.record.MandatoryNodePropertyConstraintRule;
-import org.neo4j.kernel.impl.store.record.MandatoryRelationshipPropertyConstraintRule;
+import org.neo4j.kernel.impl.store.record.NodePropertyExistenceConstraintRule;
 import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipPropertyExistenceConstraintRule;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
 import org.neo4j.kernel.impl.store.record.UniquePropertyConstraintRule;
@@ -113,12 +113,12 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
                     strategy.checkUniquenessConstraintRule( (UniquePropertyConstraintRule) rule, record, records,
                             engine );
                     break;
-                case MANDATORY_NODE_PROPERTY_CONSTRAINT:
-                    strategy.checkMandatoryNodePropertyRule( (MandatoryNodePropertyConstraintRule) rule, record,
+                case NODE_PROPERTY_EXISTENCE_CONSTRAINT:
+                    strategy.checkNodePropertyExistenceRule( (NodePropertyExistenceConstraintRule) rule, record,
                             records, engine );
                     break;
-                case MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT:
-                    strategy.checkMandatoryRelationshipPropertyRule( (MandatoryRelationshipPropertyConstraintRule) rule,
+                case RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT:
+                    strategy.checkRelationshipPropertyExistenceRule( (RelationshipPropertyExistenceConstraintRule) rule,
                             record, records, engine );
                     break;
                 default:
@@ -142,10 +142,10 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
         void checkUniquenessConstraintRule( UniquePropertyConstraintRule rule, DynamicRecord record,
                 RecordAccess records, CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine );
 
-        void checkMandatoryNodePropertyRule( MandatoryNodePropertyConstraintRule rule, DynamicRecord record,
+        void checkNodePropertyExistenceRule( NodePropertyExistenceConstraintRule rule, DynamicRecord record,
                 RecordAccess records, CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine );
 
-        void checkMandatoryRelationshipPropertyRule( MandatoryRelationshipPropertyConstraintRule rule,
+        void checkRelationshipPropertyExistenceRule( RelationshipPropertyExistenceConstraintRule rule,
                 DynamicRecord record, RecordAccess records,
                 CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine );
     }
@@ -187,14 +187,14 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
         }
 
         @Override
-        public void checkMandatoryNodePropertyRule( MandatoryNodePropertyConstraintRule rule, DynamicRecord record,
+        public void checkNodePropertyExistenceRule( NodePropertyExistenceConstraintRule rule, DynamicRecord record,
                 RecordAccess records, CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine )
         {
             checkLabelAndPropertyRule( rule, rule.getPropertyKey(), record, records, engine );
         }
 
         @Override
-        public void checkMandatoryRelationshipPropertyRule( MandatoryRelationshipPropertyConstraintRule rule,
+        public void checkRelationshipPropertyExistenceRule( RelationshipPropertyExistenceConstraintRule rule,
                 DynamicRecord record, RecordAccess records,
                 CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine )
         {
@@ -251,13 +251,13 @@ public class SchemaRecordCheck implements RecordCheck<DynamicRecord, Consistency
         }
 
         @Override
-        public void checkMandatoryNodePropertyRule( MandatoryNodePropertyConstraintRule rule, DynamicRecord record,
+        public void checkNodePropertyExistenceRule( NodePropertyExistenceConstraintRule rule, DynamicRecord record,
                 RecordAccess records, CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine )
         {
         }
 
         @Override
-        public void checkMandatoryRelationshipPropertyRule( MandatoryRelationshipPropertyConstraintRule rule,
+        public void checkRelationshipPropertyExistenceRule( RelationshipPropertyExistenceConstraintRule rule,
                 DynamicRecord record, RecordAccess records,
                 CheckerEngine<DynamicRecord,ConsistencyReport.SchemaConsistencyReport> engine )
         {

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
@@ -79,7 +79,7 @@ public class FullCheck
         OwnerCheck ownerCheck = new OwnerCheck( checkPropertyOwners );
         CountsBuilderDecorator countsBuilder =
                 new CountsBuilderDecorator( stores.nativeStores().getRawNeoStore().getNodeStore() );
-        MandatoryPropertyChecker mpc = new MandatoryPropertyChecker( stores.nativeStores().getSchemaStore() );
+        PropertyExistenceChecker mpc = new PropertyExistenceChecker( stores.nativeStores().getSchemaStore() );
         CheckDecorator decorator = new CheckDecorator.ChainCheckDecorator( ownerCheck, countsBuilder, mpc );
         DiffRecordAccess records = recordAccess( stores.nativeStores() );
         execute( stores, decorator, records, report );

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyExistenceChecker.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyExistenceChecker.java
@@ -35,8 +35,8 @@ import org.neo4j.consistency.checking.OwningRecordCheck;
 import org.neo4j.consistency.report.ConsistencyReport;
 import org.neo4j.consistency.store.DiffRecordAccess;
 import org.neo4j.consistency.store.RecordAccess;
-import org.neo4j.kernel.impl.store.record.MandatoryNodePropertyConstraintRule;
-import org.neo4j.kernel.impl.store.record.MandatoryRelationshipPropertyConstraintRule;
+import org.neo4j.kernel.impl.store.record.NodePropertyExistenceConstraintRule;
+import org.neo4j.kernel.impl.store.record.RelationshipPropertyExistenceConstraintRule;
 import org.neo4j.kernel.impl.store.record.PropertyConstraintRule;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.SchemaStorage;
@@ -50,14 +50,14 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
 import static org.neo4j.consistency.checking.full.NodeLabelReader.getListOfLabels;
 
-public class MandatoryPropertyChecker extends CheckDecorator.Adapter
+public class PropertyExistenceChecker extends CheckDecorator.Adapter
 {
     private static final Class<PropertyConstraintRule> BASE_RULE = PropertyConstraintRule.class;
 
     private final PrimitiveIntObjectMap<int[]> nodes = Primitive.intObjectMap();
     private final PrimitiveIntObjectMap<int[]> relationships = Primitive.intObjectMap();
 
-    public MandatoryPropertyChecker( RecordStore<DynamicRecord> schemaStore )
+    public PropertyExistenceChecker( RecordStore<DynamicRecord> schemaStore )
     {
         SchemaStorage schemaStorage = new SchemaStorage( schemaStore );
         for ( Iterator<PropertyConstraintRule> rules = schemaStorage.schemaRules( BASE_RULE ); safeHasNext( rules ); )
@@ -70,16 +70,16 @@ public class MandatoryPropertyChecker extends CheckDecorator.Adapter
 
             switch ( rule.getKind() )
             {
-            case MANDATORY_NODE_PROPERTY_CONSTRAINT:
+            case NODE_PROPERTY_EXISTENCE_CONSTRAINT:
                 storage = nodes;
-                MandatoryNodePropertyConstraintRule nodeRule = (MandatoryNodePropertyConstraintRule) rule;
+                NodePropertyExistenceConstraintRule nodeRule = (NodePropertyExistenceConstraintRule) rule;
                 labelOrRelType = nodeRule.getLabel();
                 propertyKey = nodeRule.getPropertyKey();
                 break;
 
-            case MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT:
+            case RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT:
                 storage = relationships;
-                MandatoryRelationshipPropertyConstraintRule relRule = (MandatoryRelationshipPropertyConstraintRule) rule;
+                RelationshipPropertyExistenceConstraintRule relRule = (RelationshipPropertyExistenceConstraintRule) rule;
                 labelOrRelType = relRule.getRelationshipType();
                 propertyKey = relRule.getPropertyKey();
                 break;

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -81,14 +81,14 @@ import org.neo4j.kernel.impl.store.StoreAccess;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
-import org.neo4j.kernel.impl.store.record.MandatoryNodePropertyConstraintRule;
-import org.neo4j.kernel.impl.store.record.MandatoryRelationshipPropertyConstraintRule;
 import org.neo4j.kernel.impl.store.record.NeoStoreRecord;
+import org.neo4j.kernel.impl.store.record.NodePropertyExistenceConstraintRule;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.RecordSerializer;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipPropertyExistenceConstraintRule;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
@@ -120,12 +120,12 @@ import static org.neo4j.kernel.impl.store.DynamicArrayStore.getRightArray;
 import static org.neo4j.kernel.impl.store.DynamicNodeLabels.dynamicPointer;
 import static org.neo4j.kernel.impl.store.LabelIdArray.prependNodeId;
 import static org.neo4j.kernel.impl.store.PropertyType.ARRAY;
-import static org.neo4j.kernel.impl.store.record.MandatoryNodePropertyConstraintRule.*;
-import static org.neo4j.kernel.impl.store.record.MandatoryRelationshipPropertyConstraintRule.*;
+import static org.neo4j.kernel.impl.store.record.NodePropertyExistenceConstraintRule.*;
 import static org.neo4j.kernel.impl.store.record.Record.NO_LABELS_FIELD;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_PROPERTY;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
 import static org.neo4j.kernel.impl.store.record.Record.NO_PREV_RELATIONSHIP;
+import static org.neo4j.kernel.impl.store.record.RelationshipPropertyExistenceConstraintRule.*;
 import static org.neo4j.kernel.impl.util.Bits.bits;
 import static org.neo4j.test.Property.property;
 import static org.neo4j.test.Property.set;
@@ -2044,7 +2044,7 @@ public class FullCheckIntegrationTest
                 DynamicRecord recordBefore = new DynamicRecord( id );
                 DynamicRecord recordAfter = recordBefore.clone();
 
-                MandatoryNodePropertyConstraintRule rule = mandatoryNodePropertyConstraintRule( id, labelId,
+                NodePropertyExistenceConstraintRule rule = nodePropertyExistenceConstraintRule( id, labelId,
                         propertyKeyId );
                 Collection<DynamicRecord> records = serializeRule( rule, recordAfter );
 
@@ -2067,7 +2067,7 @@ public class FullCheckIntegrationTest
                 DynamicRecord recordBefore = new DynamicRecord( id );
                 DynamicRecord recordAfter = recordBefore.clone();
 
-                MandatoryRelationshipPropertyConstraintRule rule = mandatoryRelPropertyConstraintRule( id, relTypeId,
+                RelationshipPropertyExistenceConstraintRule rule = relPropertyExistenceConstraintRule( id, relTypeId,
                         propertyKeyId );
                 Collection<DynamicRecord> records = serializeRule( rule, recordAfter );
 

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MandatoryPropertyConstraintAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MandatoryPropertyConstraintAcceptanceTest.scala
@@ -27,7 +27,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should enforce constraints on creation") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert exists(node.key1)")
 
     // WHEN
     val e = intercept[ConstraintValidationException](execute("create (node:Label1)"))
@@ -38,7 +38,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should enforce constraints on creation") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert exists(rel.since)")
 
     // WHEN
     val e = intercept[ConstraintValidationException](execute("create (p1:Person)-[:KNOWS]->(p2:Person)"))
@@ -49,7 +49,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should enforce on removing property") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert exists(node.key1)")
 
     // WHEN
     execute("create (node1:Label1 {key1:'value1'})")
@@ -60,7 +60,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should enforce on removing property") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert exists(rel.since)")
 
     // WHEN
     execute("create (p1:Person)-[:KNOWS {since: 'yesterday'}]->(p2:Person)")
@@ -71,7 +71,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should enforce on setting property to null") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert exists(node.key1)")
 
     // WHEN
     execute("create ( node1:Label1 {key1:'value1' } )")
@@ -82,7 +82,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should enforce on setting property to null") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert exists(rel.since)")
 
     // WHEN
     execute("create (p1:Person)-[:KNOWS {since: 'yesterday'}]->(p2:Person)")
@@ -93,7 +93,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should allow to break constraint within statement") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert exists(node.key1)")
 
     // WHEN
     val res = execute("create (node:Label1) set node.key1 = 'foo' return node")
@@ -104,7 +104,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should allow to break constraint within statement") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert exists(rel.since)")
 
     // WHEN
     val res = execute("create (p1:Person)-[r:KNOWS]->(p2:Person) set r.since = 'yesterday' return r")
@@ -115,7 +115,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should allow creation of non-conflicting data") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert exists(node.key1)")
 
     // WHEN
     execute("create (node {key1:'value1'} )")
@@ -129,7 +129,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should allow creation of non-conflicting data") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert exists(rel.since)")
 
     // WHEN
     execute("create (p1:Person {name: 'foo'})-[r:KNOWS {since: 'today'}]->(p2:Person {name: 'bar'})")
@@ -145,7 +145,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
     execute("create (node:Label1)")
 
     // WHEN
-    val e = intercept[CypherExecutionException](execute("create constraint on (node:Label1) assert node.key1 is not null"))
+    val e = intercept[CypherExecutionException](execute("create constraint on (node:Label1) assert exists(node.key1)"))
 
     //THEN
     e.status should equal(Status.Schema.ConstraintCreationFailure)
@@ -156,7 +156,7 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
     execute("create (p1:Person)-[:KNOWS]->(p2:Person)")
 
     // WHEN
-    val e = intercept[CypherExecutionException](execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null"))
+    val e = intercept[CypherExecutionException](execute("create constraint on ()-[rel:KNOWS]-() assert exists(rel.since)"))
 
     //THEN
     e.status should equal(Status.Schema.ConstraintCreationFailure)
@@ -164,13 +164,13 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("node: should drop constraint") {
     // GIVEN
-    execute("create constraint on (node:Label1) assert node.key1 is not null")
+    execute("create constraint on (node:Label1) assert exists(node.key1)")
 
     intercept[ConstraintValidationException](execute("create (node:Label1)"))
     numberOfNodes shouldBe 0
 
     // WHEN
-    execute("drop constraint on (node:Label1) assert node.key1 is not null")
+    execute("drop constraint on (node:Label1) assert exists(node.key1)")
     execute("create (node:Label1)")
 
     // THEN
@@ -179,13 +179,13 @@ class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite 
 
   test("relationship: should drop constraint") {
     // GIVEN
-    execute("create constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("create constraint on ()-[rel:KNOWS]-() assert exists(rel.since)")
 
     intercept[ConstraintValidationException](execute("create (p1:Person)-[:KNOWS]->(p2:Person)"))
     numberOfRelationships shouldBe 0
 
     // WHEN
-    execute("drop constraint on ()-[rel:KNOWS]-() assert rel.since is not null")
+    execute("drop constraint on ()-[rel:KNOWS]-() assert exists(rel.since)")
     execute("create (p1:Person)-[:KNOWS]->(p2:Person)")
 
     // THEN

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PropertyExistenceConstraintAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PropertyExistenceConstraintAcceptanceTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.helpers.CollectionSupport
 import org.neo4j.cypher.{ConstraintValidationException, CypherExecutionException, ExecutionEngineFunSuite, QueryStatisticsTestSupport}
 import org.neo4j.kernel.api.exceptions.Status
 
-class MandatoryPropertyConstraintAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CollectionSupport {
+class PropertyExistenceConstraintAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CollectionSupport {
 
   test("node: should enforce constraints on creation") {
     // GIVEN

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/InternalQueryStatistics.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/InternalQueryStatistics.scala
@@ -30,8 +30,8 @@ case class InternalQueryStatistics(nodesCreated: Int = 0,
                            indexesRemoved: Int = 0,
                            uniqueConstraintsAdded: Int = 0,
                            uniqueConstraintsRemoved: Int = 0,
-                           mandatoryConstraintsAdded: Int = 0,
-                           mandatoryConstraintsRemoved: Int = 0) {
+                           existenceConstraintsAdded: Int = 0,
+                           existenceConstraintsRemoved: Int = 0) {
   def containsUpdates =
     nodesCreated > 0 ||
       relationshipsCreated > 0 ||
@@ -44,8 +44,8 @@ case class InternalQueryStatistics(nodesCreated: Int = 0,
       indexesRemoved > 0 ||
       uniqueConstraintsAdded > 0 ||
       uniqueConstraintsRemoved > 0||
-      mandatoryConstraintsAdded > 0 ||
-      mandatoryConstraintsRemoved > 0
+      existenceConstraintsAdded > 0 ||
+      existenceConstraintsRemoved > 0
 
   override def toString = {
     val builder = new StringBuilder
@@ -61,8 +61,8 @@ case class InternalQueryStatistics(nodesCreated: Int = 0,
     includeIfNonZero(builder, "Indexes removed: ", indexesRemoved)
     includeIfNonZero(builder, "Unique constraints added: ", uniqueConstraintsAdded)
     includeIfNonZero(builder, "Unique constraints removed: ", uniqueConstraintsRemoved)
-    includeIfNonZero(builder, "Mandatory property constraints added: ", mandatoryConstraintsAdded)
-    includeIfNonZero(builder, "Mandatory property constraints removed: ", mandatoryConstraintsRemoved)
+    includeIfNonZero(builder, "Property existence constraints added: ", existenceConstraintsAdded)
+    includeIfNonZero(builder, "Property existence constraints removed: ", existenceConstraintsRemoved)
 
     val result = builder.toString()
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/Command.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/Command.scala
@@ -65,10 +65,10 @@ case class CreateUniquePropertyConstraint(identifier: Identifier, label: LabelNa
 
 case class DropUniquePropertyConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
 
-case class CreateNodeMandatoryPropertyConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
+case class CreateNodePropertyExistenceConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
 
-case class DropNodeMandatoryPropertyConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
+case class DropNodePropertyExistenceConstraint(identifier: Identifier, label: LabelName, property: Property)(val position: InputPosition) extends NodePropertyConstraintCommand
 
-case class CreateRelationshipMandatoryPropertyConstraint(identifier: Identifier, relType: RelTypeName, property: Property)(val position: InputPosition) extends RelationshipPropertyConstraintCommand
+case class CreateRelationshipPropertyExistenceConstraint(identifier: Identifier, relType: RelTypeName, property: Property)(val position: InputPosition) extends RelationshipPropertyConstraintCommand
 
-case class DropRelationshipMandatoryPropertyConstraint(identifier: Identifier, relType: RelTypeName, property: Property)(val position: InputPosition) extends RelationshipPropertyConstraintCommand
+case class DropRelationshipPropertyExistenceConstraint(identifier: Identifier, relType: RelTypeName, property: Property)(val position: InputPosition) extends RelationshipPropertyConstraintCommand

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/StatementConverters.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/StatementConverters.scala
@@ -52,26 +52,26 @@ object StatementConverters {
           label = s.label.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
           propertyKey = s.property.propertyKey.name)
-      case s: ast.CreateNodeMandatoryPropertyConstraint =>
-        commands.CreateNodeMandatoryPropertyConstraint(
+      case s: ast.CreateNodePropertyExistenceConstraint =>
+        commands.CreateNodePropertyExistenceConstraint(
           id = s.identifier.name,
           label = s.label.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
           propertyKey = s.property.propertyKey.name)
-      case s: ast.DropNodeMandatoryPropertyConstraint =>
-        commands.DropNodeMandatoryPropertyConstraint(
+      case s: ast.DropNodePropertyExistenceConstraint =>
+        commands.DropNodePropertyExistenceConstraint(
           id = s.identifier.name,
           label = s.label.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
           propertyKey = s.property.propertyKey.name)
-      case s: ast.CreateRelationshipMandatoryPropertyConstraint =>
-        commands.CreateRelationshipMandatoryPropertyConstraint(
+      case s: ast.CreateRelationshipPropertyExistenceConstraint =>
+        commands.CreateRelationshipPropertyExistenceConstraint(
           id = s.identifier.name,
           relType = s.relType.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,
           propertyKey = s.property.propertyKey.name)
-      case s: ast.DropRelationshipMandatoryPropertyConstraint =>
-        commands.DropRelationshipMandatoryPropertyConstraint(
+      case s: ast.DropRelationshipPropertyExistenceConstraint =>
+        commands.DropRelationshipPropertyExistenceConstraint(
           id = s.identifier.name,
           relType = s.relType.name,
           idForProperty = s.property.map.asInstanceOf[ast.Identifier].name,

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/IndexOperation.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/IndexOperation.scala
@@ -56,22 +56,22 @@ final case class DropUniqueConstraint(id: String, label: String, idForProperty: 
   def setQueryText(t: String): DropUniqueConstraint = copy(queryString = QueryString(t))
 }
 
-final case class CreateNodeMandatoryPropertyConstraint(id: String, label: String, idForProperty: String,
+final case class CreateNodePropertyExistenceConstraint(id: String, label: String, idForProperty: String,
                                                        propertyKey: String, queryString: QueryString = QueryString.empty) extends NodePropertyConstraintOperation {
-  def setQueryText(t: String): CreateNodeMandatoryPropertyConstraint = copy(queryString = QueryString(t))
+  def setQueryText(t: String): CreateNodePropertyExistenceConstraint = copy(queryString = QueryString(t))
 }
 
-final case class DropNodeMandatoryPropertyConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
+final case class DropNodePropertyExistenceConstraint(id: String, label: String, idForProperty: String, propertyKey: String,
                                                      queryString: QueryString = QueryString.empty) extends NodePropertyConstraintOperation {
-  def setQueryText(t: String): DropNodeMandatoryPropertyConstraint = copy(queryString = QueryString(t))
+  def setQueryText(t: String): DropNodePropertyExistenceConstraint = copy(queryString = QueryString(t))
 }
 
-final case class CreateRelationshipMandatoryPropertyConstraint(id: String, relType: String, idForProperty: String,
+final case class CreateRelationshipPropertyExistenceConstraint(id: String, relType: String, idForProperty: String,
                                                                propertyKey: String, queryString: QueryString = QueryString.empty) extends RelationshipPropertyConstraintOperation {
-  def setQueryText(t: String): CreateRelationshipMandatoryPropertyConstraint = copy(queryString = QueryString(t))
+  def setQueryText(t: String): CreateRelationshipPropertyExistenceConstraint = copy(queryString = QueryString(t))
 }
 
-final case class DropRelationshipMandatoryPropertyConstraint(id: String, relType: String, idForProperty: String, propertyKey: String,
+final case class DropRelationshipPropertyExistenceConstraint(id: String, relType: String, idForProperty: String, propertyKey: String,
                                                              queryString: QueryString = QueryString.empty) extends RelationshipPropertyConstraintOperation {
-  def setQueryText(t: String): DropRelationshipMandatoryPropertyConstraint = copy(queryString = QueryString(t))
+  def setQueryText(t: String): DropRelationshipPropertyExistenceConstraint = copy(queryString = QueryString(t))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
@@ -74,10 +74,10 @@ trait Command extends Parser
     keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS UNIQUE")
 
   private def NodeMandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
-    keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS NOT NULL")
+    keyword("ASSERT EXISTS") ~~ "(" ~~ PropertyExpression ~~ ")"
 
   private def RelationshipMandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ RelationshipPatternSyntax ~~
-    keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS NOT NULL")
+    keyword("ASSERT EXISTS") ~~ "(" ~~ PropertyExpression ~~ ")"
 
   private def RelationshipPatternSyntax = rule(
     ("()-[" ~~ Identifier ~~ RelType ~~ "]-()")

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/Command.scala
@@ -29,12 +29,12 @@ trait Command extends Parser
 
   def Command: Rule1[ast.Command] = rule(
     CreateUniqueConstraint
-      | CreateNodeMandatoryConstraint
-      | CreateRelMandatoryConstraint
+      | CreateNodePropertyExistenceConstraint
+      | CreateRelationshipPropertyExistenceConstraint
       | CreateIndex
       | DropUniqueConstraint
-      | DropNodeMandatoryConstraint
-      | DropRelMandatoryConstraint
+      | DropNodePropertyExistenceConstraint
+      | DropRelationshipPropertyExistenceConstraint
       | DropIndex
   )
 
@@ -50,33 +50,33 @@ trait Command extends Parser
     group(keyword("CREATE") ~~ UniqueConstraintSyntax) ~~>> (ast.CreateUniquePropertyConstraint(_, _, _))
   }
 
-  def CreateNodeMandatoryConstraint: Rule1[ast.CreateNodeMandatoryPropertyConstraint] = rule {
-    group(keyword("CREATE") ~~ NodeMandatoryConstraintSyntax) ~~>> (ast.CreateNodeMandatoryPropertyConstraint(_, _, _))
+  def CreateNodePropertyExistenceConstraint: Rule1[ast.CreateNodePropertyExistenceConstraint] = rule {
+    group(keyword("CREATE") ~~ NodePropertyExistenceConstraintSyntax) ~~>> (ast.CreateNodePropertyExistenceConstraint(_, _, _))
   }
 
-  def CreateRelMandatoryConstraint: Rule1[ast.CreateRelationshipMandatoryPropertyConstraint] = rule {
-    group(keyword("CREATE") ~~ RelationshipMandatoryConstraintSyntax) ~~>> (ast.CreateRelationshipMandatoryPropertyConstraint(_, _, _))
+  def CreateRelationshipPropertyExistenceConstraint: Rule1[ast.CreateRelationshipPropertyExistenceConstraint] = rule {
+    group(keyword("CREATE") ~~ RelationshipPropertyExistenceConstraintSyntax) ~~>> (ast.CreateRelationshipPropertyExistenceConstraint(_, _, _))
   }
 
   def DropUniqueConstraint: Rule1[ast.DropUniquePropertyConstraint] = rule {
     group(keyword("DROP") ~~ UniqueConstraintSyntax) ~~>> (ast.DropUniquePropertyConstraint(_, _, _))
   }
 
-  def DropNodeMandatoryConstraint: Rule1[ast.DropNodeMandatoryPropertyConstraint] = rule {
-    group(keyword("DROP") ~~ NodeMandatoryConstraintSyntax) ~~>> (ast.DropNodeMandatoryPropertyConstraint(_, _, _))
+  def DropNodePropertyExistenceConstraint: Rule1[ast.DropNodePropertyExistenceConstraint] = rule {
+    group(keyword("DROP") ~~ NodePropertyExistenceConstraintSyntax) ~~>> (ast.DropNodePropertyExistenceConstraint(_, _, _))
   }
 
-  def DropRelMandatoryConstraint: Rule1[ast.DropRelationshipMandatoryPropertyConstraint] = rule {
-    group(keyword("DROP") ~~ RelationshipMandatoryConstraintSyntax) ~~>> (ast.DropRelationshipMandatoryPropertyConstraint(_, _, _))
+  def DropRelationshipPropertyExistenceConstraint: Rule1[ast.DropRelationshipPropertyExistenceConstraint] = rule {
+    group(keyword("DROP") ~~ RelationshipPropertyExistenceConstraintSyntax) ~~>> (ast.DropRelationshipPropertyExistenceConstraint(_, _, _))
   }
 
   private def UniqueConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
     keyword("ASSERT") ~~ PropertyExpression ~~ keyword("IS UNIQUE")
 
-  private def NodeMandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
+  private def NodePropertyExistenceConstraintSyntax = keyword("CONSTRAINT ON") ~~ "(" ~~ Identifier ~~ NodeLabel ~~ ")" ~~
     keyword("ASSERT EXISTS") ~~ "(" ~~ PropertyExpression ~~ ")"
 
-  private def RelationshipMandatoryConstraintSyntax = keyword("CONSTRAINT ON") ~~ RelationshipPatternSyntax ~~
+  private def RelationshipPropertyExistenceConstraintSyntax = keyword("CONSTRAINT ON") ~~ RelationshipPatternSyntax ~~
     keyword("ASSERT EXISTS") ~~ "(" ~~ PropertyExpression ~~ ")"
 
   private def RelationshipPatternSyntax = rule(

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ConstraintOperationPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ConstraintOperationPipe.scala
@@ -35,10 +35,10 @@ class ConstraintOperationPipe(op: PropertyConstraintOperation, keyToken: KeyToke
     op match {
       case _: CreateUniqueConstraint => state.query.createUniqueConstraint(keyTokenId, propertyKeyId)
       case _: DropUniqueConstraint   => state.query.dropUniqueConstraint(keyTokenId, propertyKeyId)
-      case _: CreateNodeMandatoryPropertyConstraint => state.query.createNodeMandatoryConstraint(keyTokenId, propertyKeyId)
-      case _: DropNodeMandatoryPropertyConstraint => state.query.dropNodeMandatoryConstraint(keyTokenId, propertyKeyId)
-      case _: CreateRelationshipMandatoryPropertyConstraint => state.query.createRelationshipMandatoryConstraint(keyTokenId, propertyKeyId)
-      case _: DropRelationshipMandatoryPropertyConstraint => state.query.dropRelationshipMandatoryConstraint(keyTokenId, propertyKeyId)
+      case _: CreateNodePropertyExistenceConstraint => state.query.createNodePropertyExistenceConstraint(keyTokenId, propertyKeyId)
+      case _: DropNodePropertyExistenceConstraint => state.query.dropNodePropertyExistenceConstraint(keyTokenId, propertyKeyId)
+      case _: CreateRelationshipPropertyExistenceConstraint => state.query.createRelationshipPropertyExistenceConstraint(keyTokenId, propertyKeyId)
+      case _: DropRelationshipPropertyExistenceConstraint => state.query.dropRelationshipPropertyExistenceConstraint(keyTokenId, propertyKeyId)
     }
 
     Iterator.empty

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
@@ -95,13 +95,13 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
 
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.dropUniqueConstraint(labelId, propertyKeyId))
 
-  def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.createNodeMandatoryConstraint(labelId, propertyKeyId))
+  def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.createNodePropertyExistenceConstraint(labelId, propertyKeyId))
 
-  def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.dropNodeMandatoryConstraint(labelId, propertyKeyId))
+  def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) = singleDbHit(inner.dropNodePropertyExistenceConstraint(labelId, propertyKeyId))
 
-  def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = singleDbHit(inner.createRelationshipMandatoryConstraint(relTypeId, propertyKeyId))
+  def createRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) = singleDbHit(inner.createRelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
 
-  def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = singleDbHit(inner.dropRelationshipMandatoryConstraint(relTypeId, propertyKeyId))
+  def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) = singleDbHit(inner.dropRelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
 
   def withAnyOpenQueryContext[T](work: (QueryContext) => T): T = inner.withAnyOpenQueryContext(work)
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.spi
 
 import org.neo4j.cypher.internal.compiler.v2_3.InternalQueryStatistics
 import org.neo4j.graphdb._
-import org.neo4j.kernel.api.constraints.{MandatoryNodePropertyConstraint, MandatoryRelationshipPropertyConstraint, UniquenessConstraint}
+import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
 /*
@@ -95,13 +95,13 @@ trait QueryContext extends TokenContext {
 
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int)
 
-  def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[MandatoryNodePropertyConstraint]
+  def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[NodePropertyExistenceConstraint]
 
-  def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int)
+  def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int)
 
-  def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int): IdempotentResult[MandatoryRelationshipPropertyConstraint]
+  def createRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int): IdempotentResult[RelationshipPropertyExistenceConstraint]
 
-  def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int)
+  def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int)
 
   def getOptStatistics: Option[InternalQueryStatistics] = None
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContext.scala
@@ -36,8 +36,8 @@ class UpdateCountingQueryContext(inner: QueryContext) extends DelegatingQueryCon
   private val indexesRemoved = new Counter
   private val uniqueConstraintsAdded = new Counter
   private val uniqueConstraintsRemoved = new Counter
-  private val mandatoryConstraintsAdded = new Counter
-  private val mandatoryConstraintsRemoved = new Counter
+  private val propertyExistenceConstraintsAdded = new Counter
+  private val propertyExistenceConstraintsRemoved = new Counter
 
   def getStatistics = InternalQueryStatistics(
     nodesCreated = nodesCreated.count,
@@ -51,8 +51,8 @@ class UpdateCountingQueryContext(inner: QueryContext) extends DelegatingQueryCon
     indexesRemoved = indexesRemoved.count,
     uniqueConstraintsAdded = uniqueConstraintsAdded.count,
     uniqueConstraintsRemoved = uniqueConstraintsRemoved.count,
-    mandatoryConstraintsAdded = mandatoryConstraintsAdded.count,
-    mandatoryConstraintsRemoved = mandatoryConstraintsRemoved.count)
+    existenceConstraintsAdded = propertyExistenceConstraintsAdded.count,
+    existenceConstraintsRemoved = propertyExistenceConstraintsRemoved.count)
 
   override def getOptStatistics = Some(getStatistics)
 
@@ -105,26 +105,26 @@ class UpdateCountingQueryContext(inner: QueryContext) extends DelegatingQueryCon
     uniqueConstraintsRemoved.increase()
   }
 
-  override def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) = {
-    val result = inner.createNodeMandatoryConstraint(labelId, propertyKeyId)
-    result.ifCreated { mandatoryConstraintsAdded.increase() }
+  override def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) = {
+    val result = inner.createNodePropertyExistenceConstraint(labelId, propertyKeyId)
+    result.ifCreated { propertyExistenceConstraintsAdded.increase() }
     result
   }
 
-  override def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) {
-    inner.dropNodeMandatoryConstraint(labelId, propertyKeyId)
-    mandatoryConstraintsRemoved.increase()
+  override def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) {
+    inner.dropNodePropertyExistenceConstraint(labelId, propertyKeyId)
+    propertyExistenceConstraintsRemoved.increase()
   }
 
-  override def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = {
-    val result = inner.createRelationshipMandatoryConstraint(relTypeId, propertyKeyId)
-    result.ifCreated { mandatoryConstraintsAdded.increase() }
+  override def createRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) = {
+    val result = inner.createRelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId)
+    result.ifCreated { propertyExistenceConstraintsAdded.increase() }
     result
   }
 
-  override def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) {
-    inner.dropRelationshipMandatoryConstraint(relTypeId, propertyKeyId)
-    mandatoryConstraintsRemoved.increase()
+  override def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) {
+    inner.dropRelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId)
+    propertyExistenceConstraintsRemoved.increase()
   }
 
   override def nodeGetDegree(node: Long, dir: Direction): Int = super.nodeGetDegree(node, dir)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
@@ -2895,47 +2895,47 @@ class CypherParserTest extends CypherFunSuite {
     )
   }
 
-  test("node mandatory property constraint creation") {
+  test("node property existence constraint creation") {
     expectQuery(
       "CREATE CONSTRAINT ON (id:Label) ASSERT exists(id.property)",
-      CreateNodeMandatoryPropertyConstraint("id", "Label", "id", "property")
+      CreateNodePropertyExistenceConstraint("id", "Label", "id", "property")
     )
   }
 
-  test("node mandatory property constraint deletion") {
+  test("node property existence constraint deletion") {
     expectQuery(
       "DROP CONSTRAINT ON (id:Label) ASSERT exists(id.property)",
-      DropNodeMandatoryPropertyConstraint("id", "Label", "id", "property")
+      DropNodePropertyExistenceConstraint("id", "Label", "id", "property")
     )
   }
 
-  test("relationship mandatory property constraint creation") {
+  test("relationship property existence constraint creation") {
     expectQuery(
       "CREATE CONSTRAINT ON ()-[id:RelType]-() ASSERT exists(id.property)",
-      CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
+      CreateRelationshipPropertyExistenceConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
       "CREATE CONSTRAINT ON ()-[id:RelType]->() ASSERT exists(id.property)",
-      CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
+      CreateRelationshipPropertyExistenceConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
       "CREATE CONSTRAINT ON ()<-[id:RelType]-() ASSERT exists(id.property)",
-      CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
+      CreateRelationshipPropertyExistenceConstraint("id", "RelType", "id", "property")
     )
   }
 
-  test("relationship mandatory property constraint deletion") {
+  test("relationship property existence constraint deletion") {
     expectQuery(
       "DROP CONSTRAINT ON ()-[id:RelType]-() ASSERT exists(id.property)",
-      DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
+      DropRelationshipPropertyExistenceConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
       "DROP CONSTRAINT ON ()-[id:RelType]->() ASSERT exists(id.property)",
-      DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
+      DropRelationshipPropertyExistenceConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
       "DROP CONSTRAINT ON ()<-[id:RelType]-() ASSERT exists(id.property)",
-      DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
+      DropRelationshipPropertyExistenceConstraint("id", "RelType", "id", "property")
     )
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
@@ -2897,44 +2897,44 @@ class CypherParserTest extends CypherFunSuite {
 
   test("node mandatory property constraint creation") {
     expectQuery(
-      "CREATE CONSTRAINT ON (id:Label) ASSERT id.property IS NOT NULL",
+      "CREATE CONSTRAINT ON (id:Label) ASSERT exists(id.property)",
       CreateNodeMandatoryPropertyConstraint("id", "Label", "id", "property")
     )
   }
 
   test("node mandatory property constraint deletion") {
     expectQuery(
-      "DROP CONSTRAINT ON (id:Label) ASSERT id.property IS NOT NULL",
+      "DROP CONSTRAINT ON (id:Label) ASSERT exists(id.property)",
       DropNodeMandatoryPropertyConstraint("id", "Label", "id", "property")
     )
   }
 
   test("relationship mandatory property constraint creation") {
     expectQuery(
-      "CREATE CONSTRAINT ON ()-[id:RelType]-() ASSERT id.property IS NOT NULL",
+      "CREATE CONSTRAINT ON ()-[id:RelType]-() ASSERT exists(id.property)",
       CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
-      "CREATE CONSTRAINT ON ()-[id:RelType]->() ASSERT id.property IS NOT NULL",
+      "CREATE CONSTRAINT ON ()-[id:RelType]->() ASSERT exists(id.property)",
       CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
-      "CREATE CONSTRAINT ON ()<-[id:RelType]-() ASSERT id.property IS NOT NULL",
+      "CREATE CONSTRAINT ON ()<-[id:RelType]-() ASSERT exists(id.property)",
       CreateRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
   }
 
   test("relationship mandatory property constraint deletion") {
     expectQuery(
-      "DROP CONSTRAINT ON ()-[id:RelType]-() ASSERT id.property IS NOT NULL",
+      "DROP CONSTRAINT ON ()-[id:RelType]-() ASSERT exists(id.property)",
       DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
-      "DROP CONSTRAINT ON ()-[id:RelType]->() ASSERT id.property IS NOT NULL",
+      "DROP CONSTRAINT ON ()-[id:RelType]->() ASSERT exists(id.property)",
       DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
     expectQuery(
-      "DROP CONSTRAINT ON ()<-[id:RelType]-() ASSERT id.property IS NOT NULL",
+      "DROP CONSTRAINT ON ()<-[id:RelType]-() ASSERT exists(id.property)",
       DropRelationshipMandatoryPropertyConstraint("id", "RelType", "id", "property")
     )
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContextTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContextTest.scala
@@ -26,7 +26,7 @@ import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compiler.v2_3.InternalQueryStatistics
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.{Node, Relationship}
-import org.neo4j.kernel.api.constraints.{MandatoryNodePropertyConstraint, MandatoryRelationshipPropertyConstraint, UniquenessConstraint}
+import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
 class UpdateCountingQueryContextTest extends CypherFunSuite {
@@ -60,11 +60,11 @@ class UpdateCountingQueryContextTest extends CypherFunSuite {
   when( inner.createUniqueConstraint(anyInt(), anyInt()) )
     .thenReturn(IdempotentResult(mock[UniquenessConstraint]))
 
-  when( inner.createNodeMandatoryConstraint(anyInt(), anyInt()) )
-    .thenReturn(IdempotentResult(mock[MandatoryNodePropertyConstraint]))
+  when( inner.createNodePropertyExistenceConstraint(anyInt(), anyInt()) )
+    .thenReturn(IdempotentResult(mock[NodePropertyExistenceConstraint]))
 
-  when( inner.createRelationshipMandatoryConstraint(anyInt(), anyInt()) )
-    .thenReturn(IdempotentResult(mock[MandatoryRelationshipPropertyConstraint]))
+  when( inner.createRelationshipPropertyExistenceConstraint(anyInt(), anyInt()) )
+    .thenReturn(IdempotentResult(mock[RelationshipPropertyExistenceConstraint]))
 
   when( inner.addIndexRule(anyInt(), anyInt()) )
     .thenReturn(IdempotentResult(mock[IndexDescriptor]))
@@ -160,27 +160,27 @@ class UpdateCountingQueryContextTest extends CypherFunSuite {
     context.getStatistics should equal(InternalQueryStatistics(uniqueConstraintsRemoved = 1))
   }
 
-  test("create node mandatory constraint") {
-    context.createNodeMandatoryConstraint(0, 1)
+  test("create node property existence constraint") {
+    context.createNodePropertyExistenceConstraint(0, 1)
 
-    context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsAdded = 1))
+    context.getStatistics should equal(InternalQueryStatistics(existenceConstraintsAdded = 1))
   }
 
-  test("drop node mandatory constraint") {
-    context.dropNodeMandatoryConstraint(0, 42)
+  test("drop node property existence constraint") {
+    context.dropNodePropertyExistenceConstraint(0, 42)
 
-    context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsRemoved = 1))
+    context.getStatistics should equal(InternalQueryStatistics(existenceConstraintsRemoved = 1))
   }
 
-  test("create rel mandatory constraint") {
-    context.createRelationshipMandatoryConstraint(0, 42)
+  test("create rel property existence constraint") {
+    context.createRelationshipPropertyExistenceConstraint(0, 42)
 
-    context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsAdded = 1))
+    context.getStatistics should equal(InternalQueryStatistics(existenceConstraintsAdded = 1))
   }
 
-  test("drop rel mandatory constraint") {
-    context.dropRelationshipMandatoryConstraint(0, 1)
+  test("drop rel property existence constraint") {
+    context.dropRelationshipPropertyExistenceConstraint(0, 1)
 
-    context.getStatistics should equal(InternalQueryStatistics(mandatoryConstraintsRemoved = 1))
+    context.getStatistics should equal(InternalQueryStatistics(existenceConstraintsRemoved = 1))
   }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -247,8 +247,8 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
       labelsRemoved = i.labelsRemoved,
       indexesAdded = i.indexesAdded,
       indexesRemoved = i.indexesRemoved,
-      constraintsAdded = i.uniqueConstraintsAdded + i.mandatoryConstraintsAdded,
-      constraintsRemoved = i.uniqueConstraintsRemoved + i.mandatoryConstraintsRemoved
+      constraintsAdded = i.uniqueConstraintsAdded + i.existenceConstraintsAdded,
+      constraintsRemoved = i.uniqueConstraintsRemoved + i.existenceConstraintsRemoved
     )
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
@@ -112,17 +112,17 @@ class ExceptionTranslatingQueryContextFor2_3(inner: QueryContext) extends Delega
   override def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) =
     translateException(super.dropUniqueConstraint(labelId, propertyKeyId))
 
-  override def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
-    translateException(super.createNodeMandatoryConstraint(labelId, propertyKeyId))
+  override def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) =
+    translateException(super.createNodePropertyExistenceConstraint(labelId, propertyKeyId))
 
-  override def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
-    translateException(super.dropNodeMandatoryConstraint(labelId, propertyKeyId))
+  override def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) =
+    translateException(super.dropNodePropertyExistenceConstraint(labelId, propertyKeyId))
 
-  override def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) =
-    translateException(super.createRelationshipMandatoryConstraint(relTypeId, propertyKeyId))
+  override def createRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) =
+    translateException(super.createRelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
 
-  override def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) =
-    translateException(super.dropRelationshipMandatoryConstraint(relTypeId, propertyKeyId))
+  override def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) =
+    translateException(super.dropRelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
 
   override def withAnyOpenQueryContext[T](work: (QueryContext) => T): T =
     super.withAnyOpenQueryContext(qc =>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -33,7 +33,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.helpers.ThisShouldNotHappenError
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api._
-import org.neo4j.kernel.api.constraints.{MandatoryNodePropertyConstraint, MandatoryRelationshipPropertyConstraint, UniquenessConstraint}
+import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, AlreadyIndexedException}
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
 import org.neo4j.kernel.configuration.Config
@@ -417,27 +417,27 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) =
     statement.schemaWriteOperations().constraintDrop(new UniquenessConstraint(labelId, propertyKeyId))
 
-  def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[MandatoryNodePropertyConstraint] =
+  def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[NodePropertyExistenceConstraint] =
     try {
-      IdempotentResult(statement.schemaWriteOperations().mandatoryNodePropertyConstraintCreate(labelId, propertyKeyId))
+      IdempotentResult(statement.schemaWriteOperations().nodePropertyExistenceConstraintCreate(labelId, propertyKeyId))
     } catch {
       case existing: AlreadyConstrainedException =>
-        IdempotentResult(existing.constraint().asInstanceOf[MandatoryNodePropertyConstraint], wasCreated = false)
+        IdempotentResult(existing.constraint().asInstanceOf[NodePropertyExistenceConstraint], wasCreated = false)
     }
 
-  def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) =
-    statement.schemaWriteOperations().constraintDrop(new MandatoryNodePropertyConstraint(labelId, propertyKeyId))
+  def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) =
+    statement.schemaWriteOperations().constraintDrop(new NodePropertyExistenceConstraint(labelId, propertyKeyId))
 
-  def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int): IdempotentResult[MandatoryRelationshipPropertyConstraint] =
+  def createRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int): IdempotentResult[RelationshipPropertyExistenceConstraint] =
     try {
-      IdempotentResult(statement.schemaWriteOperations().mandatoryRelationshipPropertyConstraintCreate(relTypeId, propertyKeyId))
+      IdempotentResult(statement.schemaWriteOperations().relationshipPropertyExistenceConstraintCreate(relTypeId, propertyKeyId))
     } catch {
       case existing: AlreadyConstrainedException =>
-        IdempotentResult(existing.constraint().asInstanceOf[MandatoryRelationshipPropertyConstraint], wasCreated = false)
+        IdempotentResult(existing.constraint().asInstanceOf[RelationshipPropertyExistenceConstraint], wasCreated = false)
     }
 
-  def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) =
-    statement.schemaWriteOperations().constraintDrop(new MandatoryRelationshipPropertyConstraint(relTypeId, propertyKeyId))
+  def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) =
+    statement.schemaWriteOperations().constraintDrop(new RelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
 
   override def hasLocalFileAccess: Boolean = graph match {
     case db: GraphDatabaseAPI => db.getDependencyResolver.resolveDependency(classOf[Config]).get(GraphDatabaseSettings.allow_file_urls)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
@@ -133,55 +133,55 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
     assert(stats.uniqueConstraintsRemoved === 0)
   }
 
-  test("correct statistics for mandatory node property constraint added") {
+  test("correct statistics for added node property existence constraint") {
     val result = execute("create constraint on (n:Person) assert exists(n.name)")
     val stats  = result.queryStatistics()
 
-    assert(stats.mandatoryConstraintsAdded === 1)
-    assert(stats.mandatoryConstraintsRemoved === 0)
+    assert(stats.existenceConstraintsAdded === 1)
+    assert(stats.existenceConstraintsRemoved === 0)
   }
 
-  test("correct statistics for mandatory node property constraint added twice") {
+  test("correct statistics for node property existence constraint added twice") {
     execute("create constraint on (n:Person) assert exists(n.name)")
     val result = execute("create constraint on (n:Person) assert exists(n.name)")
     val stats  = result.queryStatistics()
 
-    assert(stats.mandatoryConstraintsAdded === 0)
-    assert(stats.mandatoryConstraintsRemoved === 0)
+    assert(stats.existenceConstraintsAdded === 0)
+    assert(stats.existenceConstraintsRemoved === 0)
   }
 
-  test("correct statistics for mandatory node property constraint dropped") {
+  test("correct statistics for dropped node property existence constraint") {
     execute("create constraint on (n:Person) assert exists(n.name)")
     val result = execute("drop constraint on (n:Person) assert exists(n.name)")
     val stats  = result.queryStatistics()
 
-    assert(stats.mandatoryConstraintsAdded === 0)
-    assert(stats.mandatoryConstraintsRemoved === 1)
+    assert(stats.existenceConstraintsAdded === 0)
+    assert(stats.existenceConstraintsRemoved === 1)
   }
 
-  test("correct statistics for mandatory relationship property constraint added") {
+  test("correct statistics for added relationship property existence constraint") {
     val result = execute("create constraint on ()-[r:KNOWS]-() assert exists(r.since)")
     val stats  = result.queryStatistics()
 
-    assert(stats.mandatoryConstraintsAdded === 1)
-    assert(stats.mandatoryConstraintsRemoved === 0)
+    assert(stats.existenceConstraintsAdded === 1)
+    assert(stats.existenceConstraintsRemoved === 0)
   }
 
-  test("correct statistics for mandatory relationship property constraint added twice") {
+  test("correct statistics for relationship property existence constraint added twice") {
     execute("create constraint on ()-[r:KNOWS]-() assert exists(r.since)")
     val result = execute("create constraint on ()-[r:KNOWS]-() assert exists(r.since)")
     val stats  = result.queryStatistics()
 
-    assert(stats.mandatoryConstraintsAdded === 0)
-    assert(stats.mandatoryConstraintsRemoved === 0)
+    assert(stats.existenceConstraintsAdded === 0)
+    assert(stats.existenceConstraintsRemoved === 0)
   }
 
-  test("correct statistics for mandatory relationship property constraint dropped") {
+  test("correct statistics for dropped relationship property existence constraint") {
     execute("create constraint on ()-[r:KNOWS]-() assert exists(r.since)")
     val result = execute("drop constraint on ()-[r:KNOWS]-() assert exists(r.since)")
     val stats  = result.queryStatistics()
 
-    assert(stats.mandatoryConstraintsAdded === 0)
-    assert(stats.mandatoryConstraintsRemoved === 1)
+    assert(stats.existenceConstraintsAdded === 0)
+    assert(stats.existenceConstraintsRemoved === 1)
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionResultTest.scala
@@ -134,7 +134,7 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory node property constraint added") {
-    val result = execute("create constraint on (n:Person) assert n.name is not null")
+    val result = execute("create constraint on (n:Person) assert exists(n.name)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 1)
@@ -142,8 +142,8 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory node property constraint added twice") {
-    execute("create constraint on (n:Person) assert n.name is not null")
-    val result = execute("create constraint on (n:Person) assert n.name is not null")
+    execute("create constraint on (n:Person) assert exists(n.name)")
+    val result = execute("create constraint on (n:Person) assert exists(n.name)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 0)
@@ -151,8 +151,8 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory node property constraint dropped") {
-    execute("create constraint on (n:Person) assert n.name is not null")
-    val result = execute("drop constraint on (n:Person) assert n.name is not null")
+    execute("create constraint on (n:Person) assert exists(n.name)")
+    val result = execute("drop constraint on (n:Person) assert exists(n.name)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 0)
@@ -160,7 +160,7 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory relationship property constraint added") {
-    val result = execute("create constraint on ()-[r:KNOWS]-() assert r.since is not null")
+    val result = execute("create constraint on ()-[r:KNOWS]-() assert exists(r.since)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 1)
@@ -168,8 +168,8 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory relationship property constraint added twice") {
-    execute("create constraint on ()-[r:KNOWS]-() assert r.since is not null")
-    val result = execute("create constraint on ()-[r:KNOWS]-() assert r.since is not null")
+    execute("create constraint on ()-[r:KNOWS]-() assert exists(r.since)")
+    val result = execute("create constraint on ()-[r:KNOWS]-() assert exists(r.since)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 0)
@@ -177,8 +177,8 @@ class ExecutionResultTest extends ExecutionEngineFunSuite {
   }
 
   test("correct statistics for mandatory relationship property constraint dropped") {
-    execute("create constraint on ()-[r:KNOWS]-() assert r.since is not null")
-    val result = execute("drop constraint on ()-[r:KNOWS]-() assert r.since is not null")
+    execute("create constraint on ()-[r:KNOWS]-() assert exists(r.since)")
+    val result = execute("drop constraint on ()-[r:KNOWS]-() assert exists(r.since)")
     val stats  = result.queryStatistics()
 
     assert(stats.mandatoryConstraintsAdded === 0)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{KeyToken, TokenT
 import org.neo4j.cypher.internal.compiler.v2_3.commands.{LabelAction, LabelSetOp}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{IdempotentResult, LockingQueryContext, QueryContext}
 import org.neo4j.graphdb.{Direction, Node, Relationship}
-import org.neo4j.kernel.api.constraints.{MandatoryNodePropertyConstraint, UniquenessConstraint}
+import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
 class LabelActionTest extends GraphDatabaseFunSuite {
@@ -141,13 +141,13 @@ class SnitchingQueryContext extends QueryContext {
 
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) = ???
 
-  def createNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[MandatoryNodePropertyConstraint] = ???
+  def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[NodePropertyExistenceConstraint] = ???
 
-  def dropNodeMandatoryConstraint(labelId: Int, propertyKeyId: Int) = ???
+  def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) = ???
 
-  def createRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = ???
+  def createRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) = ???
 
-  def dropRelationshipMandatoryConstraint(relTypeId: Int, propertyKeyId: Int) = ???
+  def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) = ???
 
   def getLabelId(labelName: String): Int = ???
 

--- a/community/cypher/docs/cypher-docs/src/docs/dev/ql/constraints/index.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/ql/constraints/index.asciidoc
@@ -4,16 +4,16 @@
 [abstract]
 Neo4j helps enforce data integrity with the use of constraints.
 Constraints can be applied to either nodes or relationships.
-There exits unique node property constraints, mandatory node  relationship property constraints.
+There exit unique node property constraints, node and relationship property existence constraints.
 
 You can use unique property constraints to ensure that property values are unique for all nodes with a specific label.
 Unique constraints do not mean that all nodes have to have a unique value for the properties -- nodes without the property are not subject to this rule.
 
-You can use mandatory property constraints to ensure that a property exists for all nodes with a specific label or relationship with specific type.
+You can use property existence constraints to ensure that a property exists for all nodes with a specific label or relationship with specific type.
 All queries that try to create new nodes or relationships without the property, or queries that try to remove the mandatory property will now fail.
 
 
-You can have multiple constraints for a given label and you can also combine unique and mandatory property constraints on the same property.
+You can have multiple constraints for a given label and you can also combine unique and property existence constraints on the same property.
 
 Remember that adding constraints is an atomic operation that can take a while -- all existing data has to be scanned before Neo4j can turn the constraint ``on''.
 
@@ -31,28 +31,28 @@ include::create-a-node-that-breaks-a-unique-property-constraint.asciidoc[]
 
 include::failure-to-create-a-unique-property-constraint-due-to-conflicting-nodes.asciidoc[]
 
-include::create-mandatory-node-property-constraint.asciidoc[]
+include::create-node-property-existence-constraint.asciidoc[]
 
-include::drop-mandatory-node-property-constraint.asciidoc[]
+include::drop-node-property-existence-constraint.asciidoc[]
 
-include::create-a-node-that-complies-with-mandatory-property-constraints.asciidoc[]
+include::create-a-node-that-complies-with-property-existence-constraints.asciidoc[]
 
-include::create-a-node-that-breaks-a-mandatory-property-constraint.asciidoc[]
+include::create-a-node-that-breaks-a-property-existence-constraint.asciidoc[]
 
 include::removing-a-mandatory-node-property.asciidoc[]
 
-include::failure-to-create-a-mandatory-node-property-constraint-due-to-existing-node.asciidoc[]
+include::failure-to-create-a-node-property-existence-constraint-due-to-existing-node.asciidoc[]
 
-include::create-mandatory-relationship-property-constraint.asciidoc[]
+include::create-relationship-property-existence-constraint.asciidoc[]
 
-include::drop-mandatory-relationship-property-constraint.asciidoc[]
+include::drop-relationship-property-existence-constraint.asciidoc[]
 
-include::create-a-relationship-that-complies-with-mandatory-property-constraints.asciidoc[]
+include::create-a-relationship-that-complies-with-property-existence-constraints.asciidoc[]
 
-include::create-a-relationship-that-breaks-a-mandatory-property-constraint.asciidoc[]
+include::create-a-relationship-that-breaks-a-property-existence-constraint.asciidoc[]
 
 include::removing-a-mandatory-relationship-property.asciidoc[]
 
-include::failure-to-create-a-mandatory-relationship-property-constraint-due-to-existing-relationship.asciidoc[]
+include::failure-to-create-a-relationship-property-existence-constraint-due-to-existing-relationship.asciidoc[]
 
 

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -95,9 +95,9 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def create_mandatory_node_property_constraint() {
+  @Test def create_node_property_existence_constraint() {
     testQuery(
-      title = "Create mandatory node property constraint",
+      title = "Create node property existence constraint",
       text = "To create a constraint that makes sure that all nodes with a certain label have a certain property, use the +IS+ +NOT+ +NULL+ syntax.",
       queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)",
       optionalResultExplanation = "",
@@ -105,11 +105,11 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def drop_mandatory_node_property_constraint() {
+  @Test def drop_node_property_existence_constraint() {
     generateConsole = false
 
     prepareAndTestQuery(
-      title = "Drop mandatory node property constraint",
+      title = "Drop node property existence constraint",
       text = "By using +DROP+ +CONSTRAINT+, you remove a constraint from the database.",
       queryText = "DROP CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)",
       optionalResultExplanation = "",
@@ -118,11 +118,11 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def play_nice_with_mandatory_node_property_constraint() {
+  @Test def play_nice_with_node_property_existence_constraint() {
     generateConsole = false
 
     prepareAndTestQuery(
-      title = "Create a node that complies with mandatory property constraints",
+      title = "Create a node that complies with property existence constraints",
       text = "Create a `Book` node with an existing `isbn` property.",
       queryText = "CREATE (book:Book {isbn: '1449356265', title: 'Graph Databases'})",
       optionalResultExplanation = "",
@@ -131,18 +131,18 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def break_mandatory_node_property_constraint() {
+  @Test def break_node_property_existence_constraint() {
     generateConsole = false
     engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)")
     testFailingQuery[ConstraintValidationException](
-      title = "Create a node that breaks a mandatory property constraint",
+      title = "Create a node that breaks a property existence constraint",
       text = "Create a `Book` node without an `isbn`.",
       queryText = "CREATE (book:Book {title: 'Graph Databases'})",
       optionalResultExplanation = "In this case the node isn't created in the graph."
     )
   }
 
-  @Test def break_mandatory_node_property_constraint_by_removing_property() {
+  @Test def break_node_property_existence_constraint_by_removing_property() {
     generateConsole = false
     engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)")
     engine.execute("CREATE (book:Book {isbn: '1449356265', title: 'Graph Databases'})")
@@ -154,12 +154,12 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def fail_to_create_mandatory_node_property_constraint() {
+  @Test def fail_to_create_node_property_existence_constraint() {
     generateConsole = false
     engine.execute("CREATE (book:Book {title: 'Graph Databases'})")
 
     testFailingQuery[CypherExecutionException](
-      title = "Failure to create a mandatory node property constraint due to existing node",
+      title = "Failure to create a node property existence constraint due to existing node",
       text = "Create a constraint on the property `isbn` on nodes with the `Book` label when there already exists " +
         " a node without an `isbn`.",
       queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)",
@@ -168,9 +168,9 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def create_mandatory_relationship_property_constraint() {
+  @Test def create_relationship_property_existence_constraint() {
     testQuery(
-      title = "Create mandatory relationship property constraint",
+      title = "Create relationship property existence constraint",
       text = "To create a constraint that makes sure that all relationships with a certain type have a certain property, use the +IS+ +NOT+ +NULL+ syntax.",
       queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)",
       optionalResultExplanation = "",
@@ -178,11 +178,11 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def drop_mandatory_relationship_property_constraint() {
+  @Test def drop_relationship_property_existence_constraint() {
     generateConsole = false
 
     prepareAndTestQuery(
-      title = "Drop mandatory relationship property constraint",
+      title = "Drop relationship property existence constraint",
       text = "By using +DROP+ +CONSTRAINT+, you remove a constraint from the database.",
       queryText = "DROP CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)",
       optionalResultExplanation = "",
@@ -191,11 +191,11 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def play_nice_with_mandatory_relationship_property_constraint() {
+  @Test def play_nice_with_relationship_property_existence_constraint() {
     generateConsole = false
 
     prepareAndTestQuery(
-      title = "Create a relationship that complies with mandatory property constraints",
+      title = "Create a relationship that complies with property existence constraints",
       text = "Create a `LIKED` relationship with an existing `day` property.",
       queryText = "CREATE (user:User)-[like:LIKED {day: 'yesterday'}]->(book:Book)",
       optionalResultExplanation = "",
@@ -204,18 +204,18 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def break_mandatory_relationship_property_constraint() {
+  @Test def break_relationship_property_existence_constraint() {
     generateConsole = false
     engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)")
     testFailingQuery[ConstraintValidationException](
-      title = "Create a relationship that breaks a mandatory property constraint",
+      title = "Create a relationship that breaks a property existence constraint",
       text = "Create a `LIKED` relationship without an existing `day` property.",
       queryText = "CREATE (user:User)-[like:LIKED]->(book:Book)",
       optionalResultExplanation = "In this case the relationship isn't created in the graph."
     )
   }
 
-  @Test def break_mandatory_relationship_property_constraint_by_removing_property() {
+  @Test def break_relationship_property_existence_constraint_by_removing_property() {
     generateConsole = false
     engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)")
     engine.execute("CREATE (user:User)-[like:LIKED {day: 'today'}]->(book:Book)")
@@ -227,12 +227,12 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     )
   }
 
-  @Test def fail_to_create_mandatory_relationship_property_constraint() {
+  @Test def fail_to_create_relationship_property_existence_constraint() {
     generateConsole = false
     engine.execute("CREATE (user:User)-[like:LIKED]->(book:Book)")
 
     testFailingQuery[CypherExecutionException](
-      title = "Failure to create a mandatory relationship property constraint due to existing relationship",
+      title = "Failure to create a relationship property existence constraint due to existing relationship",
       text = "Create a constraint on the property `day` on relationships with the `LIKED` type when there already " +
         "exists a relationship without an `day`.",
       queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)",

--- a/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
+++ b/community/cypher/docs/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ConstraintsTest.scala
@@ -99,7 +99,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     testQuery(
       title = "Create mandatory node property constraint",
       text = "To create a constraint that makes sure that all nodes with a certain label have a certain property, use the +IS+ +NOT+ +NULL+ syntax.",
-      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL",
+      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)",
       optionalResultExplanation = "",
       assertions = (p) => assertNodeConstraintExist("Book", "isbn")
     )
@@ -111,9 +111,9 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     prepareAndTestQuery(
       title = "Drop mandatory node property constraint",
       text = "By using +DROP+ +CONSTRAINT+, you remove a constraint from the database.",
-      queryText = "DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL",
+      queryText = "DROP CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)",
       optionalResultExplanation = "",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL")),
+      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)")),
       assertions = (p) => assertNodeConstraintDoesNotExist("Book", "isbn")
     )
   }
@@ -126,14 +126,14 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       text = "Create a `Book` node with an existing `isbn` property.",
       queryText = "CREATE (book:Book {isbn: '1449356265', title: 'Graph Databases'})",
       optionalResultExplanation = "",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL")),
+      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)")),
       assertions = (p) => assertNodeConstraintExist("Book", "isbn")
     )
   }
 
   @Test def break_mandatory_node_property_constraint() {
     generateConsole = false
-    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL")
+    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)")
     testFailingQuery[ConstraintValidationException](
       title = "Create a node that breaks a mandatory property constraint",
       text = "Create a `Book` node without an `isbn`.",
@@ -144,7 +144,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
 
   @Test def break_mandatory_node_property_constraint_by_removing_property() {
     generateConsole = false
-    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL")
+    engine.execute("CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)")
     engine.execute("CREATE (book:Book {isbn: '1449356265', title: 'Graph Databases'})")
     testFailingQuery[ConstraintValidationException](
       title = "Removing a mandatory node property",
@@ -162,7 +162,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       title = "Failure to create a mandatory node property constraint due to existing node",
       text = "Create a constraint on the property `isbn` on nodes with the `Book` label when there already exists " +
         " a node without an `isbn`.",
-      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS NOT NULL",
+      queryText = "CREATE CONSTRAINT ON (book:Book) ASSERT exists(book.isbn)",
       optionalResultExplanation = "In this case the constraint can't be created because it is violated by existing " +
         "data. We may choose to remove the offending nodes and then re-apply the constraint."
     )
@@ -172,7 +172,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     testQuery(
       title = "Create mandatory relationship property constraint",
       text = "To create a constraint that makes sure that all relationships with a certain type have a certain property, use the +IS+ +NOT+ +NULL+ syntax.",
-      queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL",
+      queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)",
       optionalResultExplanation = "",
       assertions = (p) => assertRelationshipConstraintExist("LIKED", "day")
     )
@@ -184,9 +184,9 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
     prepareAndTestQuery(
       title = "Drop mandatory relationship property constraint",
       text = "By using +DROP+ +CONSTRAINT+, you remove a constraint from the database.",
-      queryText = "DROP CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL",
+      queryText = "DROP CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)",
       optionalResultExplanation = "",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL")),
+      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)")),
       assertions = (p) => assertRelationshipConstraintDoesNotExist("LIKED", "day")
     )
   }
@@ -199,14 +199,14 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       text = "Create a `LIKED` relationship with an existing `day` property.",
       queryText = "CREATE (user:User)-[like:LIKED {day: 'yesterday'}]->(book:Book)",
       optionalResultExplanation = "",
-      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL")),
+      prepare = _ => executePreparationQueries(List("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)")),
       assertions = (p) => assertRelationshipConstraintExist("LIKED", "day")
     )
   }
 
   @Test def break_mandatory_relationship_property_constraint() {
     generateConsole = false
-    engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL")
+    engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)")
     testFailingQuery[ConstraintValidationException](
       title = "Create a relationship that breaks a mandatory property constraint",
       text = "Create a `LIKED` relationship without an existing `day` property.",
@@ -217,7 +217,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
 
   @Test def break_mandatory_relationship_property_constraint_by_removing_property() {
     generateConsole = false
-    engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL")
+    engine.execute("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)")
     engine.execute("CREATE (user:User)-[like:LIKED {day: 'today'}]->(book:Book)")
     testFailingQuery[ConstraintValidationException](
       title = "Removing a mandatory relationship property",
@@ -235,7 +235,7 @@ class ConstraintsTest extends DocumentingTestBase with SoftReset {
       title = "Failure to create a mandatory relationship property constraint due to existing relationship",
       text = "Create a constraint on the property `day` on relationships with the `LIKED` type when there already " +
         "exists a relationship without an `day`.",
-      queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT like.day IS NOT NULL",
+      queryText = "CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)",
       optionalResultExplanation = "In this case the constraint can't be created because it is violated by existing " +
         "data. We may choose to remove the offending relationships and then re-apply the constraint."
     )

--- a/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
+++ b/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
@@ -93,7 +93,7 @@ Drop the unique constraint and index on the label `Person` and property `name`.
 //
 
 CREATE CONSTRAINT ON (p:Person)
-       ASSERT p.name IS NOT NULL
+       ASSERT exists(p.name)
 ###
 
 Create a mandatory node property constraint on the label `Person` and property `name`.
@@ -104,7 +104,7 @@ removed from an existing node with the `Person` label, the write operation will 
 //
 
 DROP CONSTRAINT ON (p:Person)
-     ASSERT p.name IS NOT NULL
+     ASSERT exists(p.name)
 ###
 
 Drop the mandatory node property constraint on the label `Person` and property `name`.
@@ -113,7 +113,7 @@ Drop the mandatory node property constraint on the label `Person` and property `
 //
 
 CREATE CONSTRAINT ON ()-[l:LIKED]-()
-       ASSERT l.when IS NOT NULL
+       ASSERT exists(l.when)
 ###
 
 Create a mandatory relationship property constraint on the type `LIKED` and property `when`.
@@ -124,7 +124,7 @@ removed from an existing relationship with the `LIKED` type, the write operation
 //
 
 DROP CONSTRAINT ON ()-[l:LIKED]-()
-     ASSERT l.when IS NOT NULL
+     ASSERT exists(l.when)
 ###
 
 Drop the mandatory relationship property constraint on the type `LIKED` and property `when`.

--- a/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
+++ b/community/cypher/docs/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
@@ -37,16 +37,16 @@ class ConstraintTest extends RefcardTest with QueryStatisticsTestSupport {
       case "drop-unique-property-constraint" =>
         assertStats(result, constraintsRemoved = 1)
         assert(result.toList.size === 0)
-      case "create-mandatory-node-property-constraint" =>
+      case "create-node-property-existence-constraint" =>
         assertStats(result, constraintsAdded = 1)
         assert(result.toList.size === 0)
-      case "drop-mandatory-node-property-constraint" =>
+      case "drop-node-property-existence-constraint" =>
         assertStats(result, constraintsRemoved = 1)
         assert(result.toList.size === 0)
-      case "create-mandatory-relationship-property-constraint" =>
+      case "create-relationship-property-existence-constraint" =>
         assertStats(result, constraintsAdded = 1)
         assert(result.toList.size === 0)
-      case "drop-mandatory-relationship-property-constraint" =>
+      case "drop-relationship-property-existence-constraint" =>
         assertStats(result, constraintsRemoved = 1)
         assert(result.toList.size === 0)
       case "match" =>
@@ -89,44 +89,44 @@ DROP CONSTRAINT ON (p:Person)
 
 Drop the unique constraint and index on the label `Person` and property `name`.
 
-###assertion=create-mandatory-node-property-constraint
+###assertion=create-node-property-existence-constraint
 //
 
 CREATE CONSTRAINT ON (p:Person)
        ASSERT exists(p.name)
 ###
 
-Create a mandatory node property constraint on the label `Person` and property `name`.
+Create a node property existence constraint on the label `Person` and property `name`.
 If a node with that label is created without a `name`, or if the `name` property is
 removed from an existing node with the `Person` label, the write operation will fail.
 
-###assertion=drop-mandatory-node-property-constraint
+###assertion=drop-node-property-existence-constraint
 //
 
 DROP CONSTRAINT ON (p:Person)
      ASSERT exists(p.name)
 ###
 
-Drop the mandatory node property constraint on the label `Person` and property `name`.
+Drop the node property existence constraint on the label `Person` and property `name`.
 
-###assertion=create-mandatory-relationship-property-constraint
+###assertion=create-relationship-property-existence-constraint
 //
 
 CREATE CONSTRAINT ON ()-[l:LIKED]-()
        ASSERT exists(l.when)
 ###
 
-Create a mandatory relationship property constraint on the type `LIKED` and property `when`.
+Create a relationship property existence constraint on the type `LIKED` and property `when`.
 If a relationship with that type is created without a `when`, or if the `when` property is
 removed from an existing relationship with the `LIKED` type, the write operation will fail.
 
-###assertion=drop-mandatory-relationship-property-constraint
+###assertion=drop-relationship-property-existence-constraint
 //
 
 DROP CONSTRAINT ON ()-[l:LIKED]-()
      ASSERT exists(l.when)
 ###
 
-Drop the mandatory relationship property constraint on the type `LIKED` and property `when`.
+Drop the relationship property existence constraint on the type `LIKED` and property `when`.
 """
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/schema/ConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/schema/ConstraintDefinition.java
@@ -32,7 +32,7 @@ public interface ConstraintDefinition
 {
     /**
      * This accessor method returns a label which this constraint is associated with if this constraint has type
-     * {@link ConstraintType#UNIQUENESS} or {@link ConstraintType#MANDATORY_NODE_PROPERTY}.
+     * {@link ConstraintType#UNIQUENESS} or {@link ConstraintType#NODE_PROPERTY_EXISTENCE}.
      * Type of the constraint can be examined by calling {@link #getConstraintType()} or
      * {@link #isConstraintType(ConstraintType)} methods.
      *
@@ -43,7 +43,7 @@ public interface ConstraintDefinition
 
     /**
      * This accessor method returns a relationship type which this constraint is associated with if this constraint
-     * has type {@link ConstraintType#UNIQUENESS} or {@link ConstraintType#MANDATORY_NODE_PROPERTY}.
+     * has type {@link ConstraintType#UNIQUENESS} or {@link ConstraintType#NODE_PROPERTY_EXISTENCE}.
      * Type of the constraint can be examined by calling {@link #getConstraintType()} or
      * {@link #isConstraintType(ConstraintType)} methods.
      *

--- a/community/kernel/src/main/java/org/neo4j/graphdb/schema/ConstraintType.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/schema/ConstraintType.java
@@ -26,7 +26,7 @@ package org.neo4j.graphdb.schema;
 public enum ConstraintType
 {
     UNIQUENESS,
-    MANDATORY_NODE_PROPERTY,
-    MANDATORY_RELATIONSHIP_PROPERTY,
+    NODE_PROPERTY_EXISTENCE,
+    RELATIONSHIP_PROPERTY_EXISTENCE,
     ;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWrite.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWrite.java
@@ -19,8 +19,8 @@
  */
 package org.neo4j.kernel.api;
 
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
@@ -46,10 +46,10 @@ interface SchemaWrite
     UniquenessConstraint uniquePropertyConstraintCreate( int labelId, int propertyKeyId )
             throws CreateConstraintFailureException, AlreadyConstrainedException, AlreadyIndexedException;
 
-    MandatoryNodePropertyConstraint mandatoryNodePropertyConstraintCreate( int labelId, int propertyKeyId )
+    NodePropertyExistenceConstraint nodePropertyExistenceConstraintCreate( int labelId, int propertyKeyId )
             throws CreateConstraintFailureException, AlreadyConstrainedException;
 
-    MandatoryRelationshipPropertyConstraint mandatoryRelationshipPropertyConstraintCreate( int relationshipTypeId,
+    RelationshipPropertyExistenceConstraint relationshipPropertyExistenceConstraintCreate( int relationshipTypeId,
             int propertyKeyId ) throws CreateConstraintFailureException, AlreadyConstrainedException;
 
     void constraintDrop( NodePropertyConstraint constraint ) throws DropConstraintFailureException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/MandatoryNodePropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/MandatoryNodePropertyConstraint.java
@@ -20,9 +20,12 @@
 
 package org.neo4j.kernel.api.constraints;
 
+import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.StatementTokenNameLookup;
+import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.impl.coreapi.schema.InternalSchemaActions;
 import org.neo4j.kernel.impl.coreapi.schema.MandatoryNodePropertyConstraintDefinition;
 
@@ -46,21 +49,33 @@ public class MandatoryNodePropertyConstraint extends NodePropertyConstraint
     }
 
     @Override
-    String constraintString()
-    {
-        return "NOT NULL";
-    }
-
-    @Override
     public ConstraintDefinition asConstraintDefinition( InternalSchemaActions schemaActions, ReadOperations readOps )
     {
-        return new MandatoryNodePropertyConstraintDefinition( schemaActions, labelById( label(), readOps ),
-                propertyKeyById( propertyKeyId, readOps ) );
+        StatementTokenNameLookup lookup = new StatementTokenNameLookup( readOps );
+        return new MandatoryNodePropertyConstraintDefinition( schemaActions,
+                DynamicLabel.label( lookup.labelGetName( labelId ) ),
+                lookup.propertyKeyGetName( propertyKeyId ) );
     }
 
     @Override
     public ConstraintType type()
     {
         return ConstraintType.MANDATORY_NODE_PROPERTY;
+    }
+
+    @Override
+    public String userDescription( TokenNameLookup tokenNameLookup )
+    {
+        String labelName = tokenNameLookup.labelGetName( labelId );
+        String boundIdentifier = labelName.toLowerCase();
+        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT exists(%s.%s)",
+                boundIdentifier, labelName, boundIdentifier, tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "CONSTRAINT ON ( n:label[%s] ) ASSERT exists(n.property[%s])",
+                labelId, propertyKeyId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyConstraint.java
@@ -19,11 +19,9 @@
  */
 package org.neo4j.kernel.api.constraints;
 
-import org.neo4j.kernel.api.TokenNameLookup;
-
 public abstract class NodePropertyConstraint extends PropertyConstraint
 {
-    private final int labelId;
+    protected final int labelId;
 
     public NodePropertyConstraint( int labelId, int propertyKeyId )
     {
@@ -31,18 +29,9 @@ public abstract class NodePropertyConstraint extends PropertyConstraint
         this.labelId = labelId;
     }
 
-    public int label()
+    public final int label()
     {
         return labelId;
-    }
-
-    @Override
-    public String userDescription( TokenNameLookup tokenNameLookup )
-    {
-        String labelName = tokenNameLookup.labelGetName( labelId );
-        String boundIdentifier = labelName.toLowerCase();
-        return String.format( "CONSTRAINT ON ( %s:%s ) ASSERT %s.%s IS %s", boundIdentifier, labelName,
-                boundIdentifier, tokenNameLookup.propertyKeyGetName( propertyKeyId ), constraintString() );
     }
 
     @Override
@@ -65,12 +54,5 @@ public abstract class NodePropertyConstraint extends PropertyConstraint
     public int hashCode()
     {
         return 31 * propertyKeyId + labelId;
-    }
-
-    @Override
-    public String toString()
-    {
-        return String.format( "CONSTRAINT ON ( n:label[%s] ) ASSERT n.property[%s] IS %s",
-                labelId, propertyKeyId, constraintString() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyExistenceConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/NodePropertyExistenceConstraint.java
@@ -27,11 +27,11 @@ import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.impl.coreapi.schema.InternalSchemaActions;
-import org.neo4j.kernel.impl.coreapi.schema.MandatoryNodePropertyConstraintDefinition;
+import org.neo4j.kernel.impl.coreapi.schema.NodePropertyExistenceConstraintDefinition;
 
-public class MandatoryNodePropertyConstraint extends NodePropertyConstraint
+public class NodePropertyExistenceConstraint extends NodePropertyConstraint
 {
-    public MandatoryNodePropertyConstraint( int labelId, int propertyKeyId )
+    public NodePropertyExistenceConstraint( int labelId, int propertyKeyId )
     {
         super( labelId, propertyKeyId );
     }
@@ -39,20 +39,20 @@ public class MandatoryNodePropertyConstraint extends NodePropertyConstraint
     @Override
     public void added( ChangeVisitor visitor )
     {
-        visitor.visitAddedNodeMandatoryPropertyConstraint( this );
+        visitor.visitAddedNodePropertyExistenceConstraint( this );
     }
 
     @Override
     public void removed( ChangeVisitor visitor )
     {
-        visitor.visitRemovedNodeMandatoryPropertyConstraint( this );
+        visitor.visitRemovedNodePropertyExistenceConstraint( this );
     }
 
     @Override
     public ConstraintDefinition asConstraintDefinition( InternalSchemaActions schemaActions, ReadOperations readOps )
     {
         StatementTokenNameLookup lookup = new StatementTokenNameLookup( readOps );
-        return new MandatoryNodePropertyConstraintDefinition( schemaActions,
+        return new NodePropertyExistenceConstraintDefinition( schemaActions,
                 DynamicLabel.label( lookup.labelGetName( labelId ) ),
                 lookup.propertyKeyGetName( propertyKeyId ) );
     }
@@ -60,7 +60,7 @@ public class MandatoryNodePropertyConstraint extends NodePropertyConstraint
     @Override
     public ConstraintType type()
     {
-        return ConstraintType.MANDATORY_NODE_PROPERTY;
+        return ConstraintType.NODE_PROPERTY_EXISTENCE;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
@@ -19,17 +19,10 @@
  */
 package org.neo4j.kernel.api.constraints;
 
-import org.neo4j.graphdb.DynamicLabel;
-import org.neo4j.graphdb.DynamicRelationshipType;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.TokenNameLookup;
-import org.neo4j.kernel.api.exceptions.LabelNotFoundKernelException;
-import org.neo4j.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
-import org.neo4j.kernel.api.exceptions.RelationshipTypeIdNotFoundKernelException;
 import org.neo4j.kernel.impl.coreapi.schema.InternalSchemaActions;
 
 public abstract class PropertyConstraint
@@ -67,8 +60,6 @@ public abstract class PropertyConstraint
 
     public abstract ConstraintType type();
 
-    abstract String constraintString();
-
     public abstract String userDescription( TokenNameLookup tokenNameLookup );
 
     public abstract ConstraintDefinition asConstraintDefinition( InternalSchemaActions schemaActions,
@@ -82,40 +73,4 @@ public abstract class PropertyConstraint
 
     @Override
     public abstract String toString();
-
-    protected static Label labelById( int id, ReadOperations readOps )
-    {
-        try
-        {
-            return DynamicLabel.label( readOps.labelGetName( id ) );
-        }
-        catch ( LabelNotFoundKernelException e )
-        {
-            throw new IllegalStateException( "Couldn't find label name for id: " + id );
-        }
-    }
-
-    protected static String propertyKeyById( int id, ReadOperations readOps )
-    {
-        try
-        {
-            return readOps.propertyKeyGetName( id );
-        }
-        catch ( PropertyKeyIdNotFoundKernelException e )
-        {
-            throw new IllegalStateException( "Couldn't find property for id: " + id );
-        }
-    }
-
-    protected static RelationshipType relTypeById( int id, ReadOperations readOps )
-    {
-        try
-        {
-            return DynamicRelationshipType.withName( readOps.relationshipTypeGetName( id ) );
-        }
-        catch ( RelationshipTypeIdNotFoundKernelException e )
-        {
-            throw new IllegalStateException( "Couldn't find relationship type name for id: " + id );
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/PropertyConstraint.java
@@ -33,13 +33,13 @@ public abstract class PropertyConstraint
 
         void visitRemovedUniquePropertyConstraint( UniquenessConstraint constraint );
 
-        void visitAddedNodeMandatoryPropertyConstraint( MandatoryNodePropertyConstraint constraint );
+        void visitAddedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint );
 
-        void visitRemovedNodeMandatoryPropertyConstraint( MandatoryNodePropertyConstraint constraint );
+        void visitRemovedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint );
 
-        void visitAddedRelationshipMandatoryPropertyConstraint( MandatoryRelationshipPropertyConstraint constraint );
+        void visitAddedRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint constraint );
 
-        void visitRemovedRelationshipMandatoryPropertyConstraint( MandatoryRelationshipPropertyConstraint constraint );
+        void visitRemovedRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint constraint );
     }
 
     protected final int propertyKeyId;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/RelationshipPropertyConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/RelationshipPropertyConstraint.java
@@ -19,11 +19,9 @@
  */
 package org.neo4j.kernel.api.constraints;
 
-import org.neo4j.kernel.api.TokenNameLookup;
-
 public abstract class RelationshipPropertyConstraint extends PropertyConstraint
 {
-    private final int relationshipTypeId;
+    protected final int relationshipTypeId;
 
     public RelationshipPropertyConstraint( int relationshipTypeId, int propertyKeyId )
     {
@@ -31,18 +29,9 @@ public abstract class RelationshipPropertyConstraint extends PropertyConstraint
         this.relationshipTypeId = relationshipTypeId;
     }
 
-    public int relationshipType()
+    public final int relationshipType()
     {
         return relationshipTypeId;
-    }
-
-    @Override
-    public String userDescription( TokenNameLookup tokenNameLookup )
-    {
-        String typeName = tokenNameLookup.relationshipTypeGetName( relationshipTypeId );
-        String boundIdentifier = typeName.toLowerCase();
-        return String.format( "CONSTRAINT ON ()-[ %s:%s ]-() ASSERT %s.%s IS %s", boundIdentifier, typeName,
-                boundIdentifier, tokenNameLookup.propertyKeyGetName( propertyKeyId ), constraintString() );
     }
 
     @Override
@@ -65,12 +54,5 @@ public abstract class RelationshipPropertyConstraint extends PropertyConstraint
     public int hashCode()
     {
         return 31 * propertyKeyId + relationshipTypeId;
-    }
-
-    @Override
-    public String toString()
-    {
-        return String.format( "CONSTRAINT ON ()-[ n:relationshipType[%s] ]-() ASSERT n.property[%s] IS %s",
-                relationshipTypeId, propertyKeyId, constraintString() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/RelationshipPropertyExistenceConstraint.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/constraints/RelationshipPropertyExistenceConstraint.java
@@ -26,11 +26,11 @@ import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.impl.coreapi.schema.InternalSchemaActions;
-import org.neo4j.kernel.impl.coreapi.schema.MandatoryRelationshipPropertyConstraintDefinition;
+import org.neo4j.kernel.impl.coreapi.schema.RelationshipPropertyExistenceConstraintDefinition;
 
-public class MandatoryRelationshipPropertyConstraint extends RelationshipPropertyConstraint
+public class RelationshipPropertyExistenceConstraint extends RelationshipPropertyConstraint
 {
-    public MandatoryRelationshipPropertyConstraint( int relTypeId, int propertyKeyId )
+    public RelationshipPropertyExistenceConstraint( int relTypeId, int propertyKeyId )
     {
         super( relTypeId, propertyKeyId );
     }
@@ -38,26 +38,26 @@ public class MandatoryRelationshipPropertyConstraint extends RelationshipPropert
     @Override
     public void added( ChangeVisitor visitor )
     {
-        visitor.visitAddedRelationshipMandatoryPropertyConstraint( this );
+        visitor.visitAddedRelationshipPropertyExistenceConstraint( this );
     }
 
     @Override
     public void removed( ChangeVisitor visitor )
     {
-        visitor.visitRemovedRelationshipMandatoryPropertyConstraint( this );
+        visitor.visitRemovedRelationshipPropertyExistenceConstraint( this );
     }
 
     @Override
     public ConstraintType type()
     {
-        return ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY;
+        return ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE;
     }
 
     @Override
     public ConstraintDefinition asConstraintDefinition( InternalSchemaActions schemaActions, ReadOperations readOps )
     {
         StatementTokenNameLookup lookup = new StatementTokenNameLookup( readOps );
-        return new MandatoryRelationshipPropertyConstraintDefinition( schemaActions,
+        return new RelationshipPropertyExistenceConstraintDefinition( schemaActions,
                 DynamicRelationshipType.withName( lookup.relationshipTypeGetName( relationshipTypeId ) ),
                 lookup.propertyKeyGetName( propertyKeyId ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceConstraintVerificationFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceConstraintVerificationFailedKernelException.java
@@ -20,28 +20,28 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.TokenNameLookup;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 
-public class MandatoryRelationshipPropertyConstraintVerificationFailedKernelException
+public class NodePropertyExistenceConstraintVerificationFailedKernelException
         extends ConstraintVerificationFailedKernelException
 {
-    private final MandatoryRelationshipPropertyConstraint constraint;
-    private final long relationshipId;
+    private final NodePropertyExistenceConstraint constraint;
+    private final long nodeId;
 
-    public MandatoryRelationshipPropertyConstraintVerificationFailedKernelException(
-            MandatoryRelationshipPropertyConstraint constraint, long relationshipId )
+    public NodePropertyExistenceConstraintVerificationFailedKernelException( NodePropertyExistenceConstraint constraint,
+            long nodeId )
     {
         super( constraint );
         this.constraint = constraint;
-        this.relationshipId = relationshipId;
+        this.nodeId = nodeId;
     }
 
     @Override
     public String getUserMessage( TokenNameLookup tokenNameLookup )
     {
-        return String.format( "Relationship(%s) with type `%s` has no value for property `%s`",
-                relationshipId,
-                tokenNameLookup.relationshipTypeGetName( constraint.relationshipType() ),
+        return String.format( "Node(%s) with label `%s` has no value for property `%s`",
+                nodeId,
+                tokenNameLookup.labelGetName( constraint.label() ),
                 tokenNameLookup.propertyKeyGetName( constraint.propertyKey() ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceConstraintViolationKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/NodePropertyExistenceConstraintViolationKernelException.java
@@ -20,28 +20,38 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.TokenNameLookup;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
 
-public class MandatoryNodePropertyConstraintVerificationFailedKernelException
-        extends ConstraintVerificationFailedKernelException
+import static java.lang.String.format;
+
+public class NodePropertyExistenceConstraintViolationKernelException extends ConstraintViolationKernelException
 {
-    private final MandatoryNodePropertyConstraint constraint;
+    private final int labelId;
+    private final int propertyKeyId;
     private final long nodeId;
 
-    public MandatoryNodePropertyConstraintVerificationFailedKernelException( MandatoryNodePropertyConstraint constraint,
-            long nodeId )
+    public NodePropertyExistenceConstraintViolationKernelException( int labelId, int propertyKeyId, long nodeId )
     {
-        super( constraint );
-        this.constraint = constraint;
+        super( "Node %d with label %d does not have the property %d", nodeId, labelId, propertyKeyId);
+        this.labelId = labelId;
+        this.propertyKeyId = propertyKeyId;
         this.nodeId = nodeId;
     }
 
     @Override
     public String getUserMessage( TokenNameLookup tokenNameLookup )
     {
-        return String.format( "Node(%s) with label `%s` has no value for property `%s`",
-                nodeId,
-                tokenNameLookup.labelGetName( constraint.label() ),
-                tokenNameLookup.propertyKeyGetName( constraint.propertyKey() ) );
+        return format( "Node %d with label \"%s\" does not have a \"%s\" property", nodeId,
+                tokenNameLookup.labelGetName( labelId ),
+                tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
+    }
+
+    public int labelId()
+    {
+        return labelId;
+    }
+
+    public int propertyKeyId()
+    {
+        return propertyKeyId;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RelationshipPropertyExistenceConstraintVerificationFailedKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RelationshipPropertyExistenceConstraintVerificationFailedKernelException.java
@@ -20,38 +20,28 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 
-import static java.lang.String.format;
-
-public class MandatoryNodePropertyConstraintViolationKernelException extends ConstraintViolationKernelException
+public class RelationshipPropertyExistenceConstraintVerificationFailedKernelException
+        extends ConstraintVerificationFailedKernelException
 {
-    private final int labelId;
-    private final int propertyKeyId;
-    private final long nodeId;
+    private final RelationshipPropertyExistenceConstraint constraint;
+    private final long relationshipId;
 
-    public MandatoryNodePropertyConstraintViolationKernelException( int labelId, int propertyKeyId, long nodeId )
+    public RelationshipPropertyExistenceConstraintVerificationFailedKernelException(
+            RelationshipPropertyExistenceConstraint constraint, long relationshipId )
     {
-        super( "Node %d with label %d does not have the property %d", nodeId, labelId, propertyKeyId);
-        this.labelId = labelId;
-        this.propertyKeyId = propertyKeyId;
-        this.nodeId = nodeId;
+        super( constraint );
+        this.constraint = constraint;
+        this.relationshipId = relationshipId;
     }
 
     @Override
     public String getUserMessage( TokenNameLookup tokenNameLookup )
     {
-        return format( "Node %d with label \"%s\" does not have a \"%s\" property", nodeId,
-                tokenNameLookup.labelGetName( labelId ),
-                tokenNameLookup.propertyKeyGetName( propertyKeyId ) );
-    }
-
-    public int labelId()
-    {
-        return labelId;
-    }
-
-    public int propertyKeyId()
-    {
-        return propertyKeyId;
+        return String.format( "Relationship(%s) with type `%s` has no value for property `%s`",
+                relationshipId,
+                tokenNameLookup.relationshipTypeGetName( constraint.relationshipType() ),
+                tokenNameLookup.propertyKeyGetName( constraint.propertyKey() ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RelationshipPropertyExistenceConstraintViolationKernelException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/RelationshipPropertyExistenceConstraintViolationKernelException.java
@@ -23,13 +23,13 @@ import org.neo4j.kernel.api.TokenNameLookup;
 
 import static java.lang.String.format;
 
-public class MandatoryRelationshipPropertyConstraintViolationKernelException extends ConstraintViolationKernelException
+public class RelationshipPropertyExistenceConstraintViolationKernelException extends ConstraintViolationKernelException
 {
     private final int relationshipTypeId;
     private final int propertyKeyId;
     private final long relationshipId;
 
-    public MandatoryRelationshipPropertyConstraintViolationKernelException( int relationshipTypeId, int propertyKeyId,
+    public RelationshipPropertyExistenceConstraintViolationKernelException( int relationshipTypeId, int propertyKeyId,
             long relationshipId )
     {
         super( "Relationship %d with type %d does not have the property %d", relationshipId, relationshipTypeId,

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
@@ -21,8 +21,8 @@ package org.neo4j.kernel.api.txstate;
 
 import java.util.Map;
 
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
@@ -89,9 +89,9 @@ public interface TransactionState extends ReadableTxState
 
     void constraintDoAdd( UniquenessConstraint constraint, long indexId );
 
-    void constraintDoAdd( MandatoryNodePropertyConstraint constraint );
+    void constraintDoAdd( NodePropertyExistenceConstraint constraint );
 
-    void constraintDoAdd( MandatoryRelationshipPropertyConstraint constraint );
+    void constraintDoAdd( RelationshipPropertyExistenceConstraint constraint );
 
     void constraintDoDrop( NodePropertyConstraint constraint );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TxStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TxStateVisitor.java
@@ -23,8 +23,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -68,13 +68,13 @@ public interface TxStateVisitor
 
     void visitRemovedUniquePropertyConstraint( UniquenessConstraint element );
 
-    void visitAddedNodeMandatoryPropertyConstraint( MandatoryNodePropertyConstraint element );
+    void visitAddedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint element );
 
-    void visitRemovedNodeMandatoryPropertyConstraint( MandatoryNodePropertyConstraint element );
+    void visitRemovedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint element );
 
-    void visitAddedRelationshipMandatoryPropertyConstraint( MandatoryRelationshipPropertyConstraint element );
+    void visitAddedRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint element );
 
-    void visitRemovedRelationshipMandatoryPropertyConstraint( MandatoryRelationshipPropertyConstraint element );
+    void visitRemovedRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint element );
 
     void visitCreatedLabelToken( String name, int id );
 
@@ -226,38 +226,39 @@ public interface TxStateVisitor
         }
 
         @Override
-        public void visitAddedNodeMandatoryPropertyConstraint( MandatoryNodePropertyConstraint element )
+        public void visitAddedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint element )
         {
             if ( next != null )
             {
-                next.visitAddedNodeMandatoryPropertyConstraint( element );
+                next.visitAddedNodePropertyExistenceConstraint( element );
             }
         }
 
         @Override
-        public void visitRemovedNodeMandatoryPropertyConstraint( MandatoryNodePropertyConstraint element )
+        public void visitRemovedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint element )
         {
             if ( next != null )
             {
-                next.visitRemovedNodeMandatoryPropertyConstraint( element );
+                next.visitRemovedNodePropertyExistenceConstraint( element );
             }
         }
 
         @Override
-        public void visitAddedRelationshipMandatoryPropertyConstraint( MandatoryRelationshipPropertyConstraint element )
+        public void visitAddedRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint element )
         {
             if ( next != null )
             {
-                next.visitAddedRelationshipMandatoryPropertyConstraint( element );
+                next.visitAddedRelationshipPropertyExistenceConstraint( element );
             }
         }
 
         @Override
-        public void visitRemovedRelationshipMandatoryPropertyConstraint( MandatoryRelationshipPropertyConstraint element )
+        public void visitRemovedRelationshipPropertyExistenceConstraint(
+                RelationshipPropertyExistenceConstraint element )
         {
             if ( next != null )
             {
-                next.visitRemovedRelationshipMandatoryPropertyConstraint( element );
+                next.visitRemovedRelationshipPropertyExistenceConstraint( element );
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -28,8 +28,8 @@ import org.neo4j.function.Predicate;
 import org.neo4j.function.Predicates;
 import org.neo4j.helpers.ObjectUtil;
 import org.neo4j.helpers.collection.FilteringIterator;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -46,8 +46,8 @@ import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
-import org.neo4j.kernel.api.exceptions.schema.MandatoryNodePropertyConstraintVerificationFailedKernelException;
-import org.neo4j.kernel.api.exceptions.schema.MandatoryRelationshipPropertyConstraintVerificationFailedKernelException;
+import org.neo4j.kernel.api.exceptions.schema.NodePropertyExistenceConstraintVerificationFailedKernelException;
+import org.neo4j.kernel.api.exceptions.schema.RelationshipPropertyExistenceConstraintVerificationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.schema.UnableToValidateConstraintKernelException;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyConstraintViolationKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -529,7 +529,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public MandatoryNodePropertyConstraint mandatoryNodePropertyConstraintCreate( KernelStatement state, int labelId,
+    public NodePropertyExistenceConstraint nodePropertyExistenceConstraintCreate( KernelStatement state, int labelId,
             int propertyKeyId ) throws AlreadyConstrainedException, CreateConstraintFailureException
     {
         PrimitiveLongIterator nodes = nodesGetForLabel( state, labelId );
@@ -542,21 +542,21 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
                 {
                     if ( !node.get().hasProperty( propertyKeyId ) )
                     {
-                        MandatoryNodePropertyConstraint constraint = new MandatoryNodePropertyConstraint( labelId,
+                        NodePropertyExistenceConstraint constraint = new NodePropertyExistenceConstraint( labelId,
                                 propertyKeyId );
                         throw new CreateConstraintFailureException( constraint,
-                                new MandatoryNodePropertyConstraintVerificationFailedKernelException( constraint,
+                                new NodePropertyExistenceConstraintVerificationFailedKernelException( constraint,
                                         nodeId ) );
                     }
                 }
             }
         }
 
-        return schemaWriteOperations.mandatoryNodePropertyConstraintCreate( state, labelId, propertyKeyId );
+        return schemaWriteOperations.nodePropertyExistenceConstraintCreate( state, labelId, propertyKeyId );
     }
 
     @Override
-    public MandatoryRelationshipPropertyConstraint mandatoryRelationshipPropertyConstraintCreate( KernelStatement state,
+    public RelationshipPropertyExistenceConstraint relationshipPropertyExistenceConstraintCreate( KernelStatement state,
             int relTypeId, int propertyKeyId ) throws AlreadyConstrainedException, CreateConstraintFailureException
     {
         PrimitiveLongIterator relationships = relationshipsGetAll( state );
@@ -569,13 +569,13 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
                 {
                     if ( relationship.get().type() == relTypeId && !relationship.get().hasProperty( propertyKeyId ) )
                     {
-                        MandatoryRelationshipPropertyConstraint constraint = new
-                                MandatoryRelationshipPropertyConstraint(
+                        RelationshipPropertyExistenceConstraint constraint = new
+                                RelationshipPropertyExistenceConstraint(
 
                                 relTypeId,
                                 propertyKeyId );
                         throw new CreateConstraintFailureException( constraint,
-                                new MandatoryRelationshipPropertyConstraintVerificationFailedKernelException(
+                                new RelationshipPropertyExistenceConstraintVerificationFailedKernelException(
                                         constraint,
                                         relationshipId ) );
                     }
@@ -583,7 +583,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
             }
         }
 
-        return schemaWriteOperations.mandatoryRelationshipPropertyConstraintCreate( state, relTypeId, propertyKeyId );
+        return schemaWriteOperations.relationshipPropertyExistenceConstraintCreate( state, relTypeId, propertyKeyId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/DataIntegrityValidatingStatementOperations.java
@@ -23,8 +23,8 @@ import java.util.Iterator;
 
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -159,7 +159,7 @@ public class DataIntegrityValidatingStatementOperations implements
     }
 
     @Override
-    public MandatoryNodePropertyConstraint mandatoryNodePropertyConstraintCreate( KernelStatement state, int labelId,
+    public NodePropertyExistenceConstraint nodePropertyExistenceConstraintCreate( KernelStatement state, int labelId,
             int propertyKey ) throws AlreadyConstrainedException, CreateConstraintFailureException
     {
         Iterator<NodePropertyConstraint> constraints = schemaReadDelegate.constraintsGetForLabelAndPropertyKey(
@@ -167,18 +167,18 @@ public class DataIntegrityValidatingStatementOperations implements
         while ( constraints.hasNext() )
         {
             NodePropertyConstraint constraint = constraints.next();
-            if ( constraint instanceof MandatoryNodePropertyConstraint )
+            if ( constraint instanceof NodePropertyExistenceConstraint )
             {
                 throw new AlreadyConstrainedException( constraint, OperationContext.CONSTRAINT_CREATION,
                         new StatementTokenNameLookup( state.readOperations() ) );
             }
         }
 
-        return schemaWriteDelegate.mandatoryNodePropertyConstraintCreate( state, labelId, propertyKey );
+        return schemaWriteDelegate.nodePropertyExistenceConstraintCreate( state, labelId, propertyKey );
     }
 
     @Override
-    public MandatoryRelationshipPropertyConstraint mandatoryRelationshipPropertyConstraintCreate( KernelStatement state,
+    public RelationshipPropertyExistenceConstraint relationshipPropertyExistenceConstraintCreate( KernelStatement state,
             int relTypeId, int propertyKeyId ) throws AlreadyConstrainedException, CreateConstraintFailureException
     {
         Iterator<RelationshipPropertyConstraint> constraints = schemaReadDelegate.constraintsGetForRelationshipTypeAndPropertyKey(
@@ -186,14 +186,14 @@ public class DataIntegrityValidatingStatementOperations implements
         while ( constraints.hasNext() )
         {
             RelationshipPropertyConstraint constraint = constraints.next();
-            if ( constraint instanceof MandatoryRelationshipPropertyConstraint )
+            if ( constraint instanceof RelationshipPropertyExistenceConstraint )
             {
                 throw new AlreadyConstrainedException( constraint, OperationContext.CONSTRAINT_CREATION,
                         new StatementTokenNameLookup( state.readOperations() ) );
             }
         }
 
-        return schemaWriteDelegate.mandatoryRelationshipPropertyConstraintCreate( state, relTypeId, propertyKeyId );
+        return schemaWriteDelegate.relationshipPropertyExistenceConstraintCreate( state, relTypeId, propertyKeyId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -23,8 +23,8 @@ import java.util.Iterator;
 
 import org.neo4j.function.Function;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -311,21 +311,21 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public MandatoryNodePropertyConstraint mandatoryNodePropertyConstraintCreate( KernelStatement state, int labelId,
+    public NodePropertyExistenceConstraint nodePropertyExistenceConstraintCreate( KernelStatement state, int labelId,
             int propertyKeyId ) throws AlreadyConstrainedException, CreateConstraintFailureException
     {
         state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
         state.assertOpen();
-        return schemaWriteDelegate.mandatoryNodePropertyConstraintCreate( state, labelId, propertyKeyId );
+        return schemaWriteDelegate.nodePropertyExistenceConstraintCreate( state, labelId, propertyKeyId );
     }
 
     @Override
-    public MandatoryRelationshipPropertyConstraint mandatoryRelationshipPropertyConstraintCreate( KernelStatement state,
+    public RelationshipPropertyExistenceConstraint relationshipPropertyExistenceConstraintCreate( KernelStatement state,
             int relTypeId, int propertyKeyId ) throws AlreadyConstrainedException, CreateConstraintFailureException
     {
         state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
         state.assertOpen();
-        return schemaWriteDelegate.mandatoryRelationshipPropertyConstraintCreate( state, relTypeId, propertyKeyId );
+        return schemaWriteDelegate.relationshipPropertyExistenceConstraintCreate( state, relTypeId, propertyKeyId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -33,8 +33,8 @@ import org.neo4j.kernel.api.LegacyIndexHits;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.StatementConstants;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -918,20 +918,20 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
-    public MandatoryNodePropertyConstraint mandatoryNodePropertyConstraintCreate( int labelId, int propertyKeyId )
+    public NodePropertyExistenceConstraint nodePropertyExistenceConstraintCreate( int labelId, int propertyKeyId )
             throws CreateConstraintFailureException, AlreadyConstrainedException
     {
         statement.assertOpen();
-        return schemaWrite().mandatoryNodePropertyConstraintCreate( statement, labelId, propertyKeyId );
+        return schemaWrite().nodePropertyExistenceConstraintCreate( statement, labelId, propertyKeyId );
     }
 
     @Override
-    public MandatoryRelationshipPropertyConstraint mandatoryRelationshipPropertyConstraintCreate(
+    public RelationshipPropertyExistenceConstraint relationshipPropertyExistenceConstraintCreate(
             int relTypeId, int propertyKeyId )
             throws CreateConstraintFailureException, AlreadyConstrainedException
     {
         statement.assertOpen();
-        return schemaWrite().mandatoryRelationshipPropertyConstraintCreate( statement, relTypeId, propertyKeyId );
+        return schemaWrite().relationshipPropertyExistenceConstraintCreate( statement, relTypeId, propertyKeyId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -33,8 +33,8 @@ import org.neo4j.kernel.api.EntityType;
 import org.neo4j.kernel.api.LegacyIndex;
 import org.neo4j.kernel.api.LegacyIndexHits;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -525,20 +525,20 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
-    public MandatoryNodePropertyConstraint mandatoryNodePropertyConstraintCreate( KernelStatement state, int labelId,
+    public NodePropertyExistenceConstraint nodePropertyExistenceConstraintCreate( KernelStatement state, int labelId,
             int propertyKeyId ) throws CreateConstraintFailureException
     {
-        MandatoryNodePropertyConstraint constraint = new MandatoryNodePropertyConstraint( labelId, propertyKeyId );
+        NodePropertyExistenceConstraint constraint = new NodePropertyExistenceConstraint( labelId, propertyKeyId );
         state.txState().constraintDoAdd( constraint );
         return constraint;
     }
 
     @Override
-    public MandatoryRelationshipPropertyConstraint mandatoryRelationshipPropertyConstraintCreate( KernelStatement state,
+    public RelationshipPropertyExistenceConstraint relationshipPropertyExistenceConstraintCreate( KernelStatement state,
             int relTypeId, int propertyKeyId ) throws AlreadyConstrainedException, CreateConstraintFailureException
     {
-        MandatoryRelationshipPropertyConstraint constraint =
-                new MandatoryRelationshipPropertyConstraint( relTypeId, propertyKeyId );
+        RelationshipPropertyExistenceConstraint constraint =
+                new RelationshipPropertyExistenceConstraint( relTypeId, propertyKeyId );
         state.txState().constraintDoAdd( constraint );
         return constraint;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
@@ -19,8 +19,8 @@
  */
 package org.neo4j.kernel.impl.api.operations;
 
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
@@ -53,10 +53,11 @@ public interface SchemaWriteOperations
     UniquenessConstraint uniquePropertyConstraintCreate( KernelStatement state, int labelId, int propertyKeyId )
             throws AlreadyConstrainedException, CreateConstraintFailureException, AlreadyIndexedException;
 
-    MandatoryNodePropertyConstraint mandatoryNodePropertyConstraintCreate( KernelStatement state, int labelId, int propertyKeyId )
+    NodePropertyExistenceConstraint nodePropertyExistenceConstraintCreate( KernelStatement state, int labelId,
+            int propertyKeyId )
             throws AlreadyConstrainedException, CreateConstraintFailureException;
 
-    MandatoryRelationshipPropertyConstraint mandatoryRelationshipPropertyConstraintCreate( KernelStatement state,
+    RelationshipPropertyExistenceConstraint relationshipPropertyExistenceConstraintCreate( KernelStatement state,
             int relTypeId, int propertyKeyId ) throws AlreadyConstrainedException, CreateConstraintFailureException;
 
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -36,8 +36,8 @@ import org.neo4j.function.Function;
 import org.neo4j.function.Predicate;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -431,27 +431,29 @@ public final class TxState implements TransactionState, RelationshipVisitor.Home
         }
 
         @Override
-        public void visitAddedNodeMandatoryPropertyConstraint( MandatoryNodePropertyConstraint constraint )
+        public void visitAddedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint )
         {
-            visitor.visitAddedNodeMandatoryPropertyConstraint( constraint );
+            visitor.visitAddedNodePropertyExistenceConstraint( constraint );
         }
 
         @Override
-        public void visitRemovedNodeMandatoryPropertyConstraint( MandatoryNodePropertyConstraint constraint )
+        public void visitRemovedNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint )
         {
-            visitor.visitRemovedNodeMandatoryPropertyConstraint( constraint );
+            visitor.visitRemovedNodePropertyExistenceConstraint( constraint );
         }
 
         @Override
-        public void visitAddedRelationshipMandatoryPropertyConstraint( MandatoryRelationshipPropertyConstraint constraint )
+        public void visitAddedRelationshipPropertyExistenceConstraint(
+                RelationshipPropertyExistenceConstraint constraint )
         {
-            visitor.visitAddedRelationshipMandatoryPropertyConstraint( constraint );
+            visitor.visitAddedRelationshipPropertyExistenceConstraint( constraint );
         }
 
         @Override
-        public void visitRemovedRelationshipMandatoryPropertyConstraint( MandatoryRelationshipPropertyConstraint constraint )
+        public void visitRemovedRelationshipPropertyExistenceConstraint(
+                RelationshipPropertyExistenceConstraint constraint )
         {
-            visitor.visitRemovedRelationshipMandatoryPropertyConstraint( constraint );
+            visitor.visitRemovedRelationshipPropertyExistenceConstraint( constraint );
         }
     }
 
@@ -1096,7 +1098,7 @@ public final class TxState implements TransactionState, RelationshipVisitor.Home
     }
 
     @Override
-    public void constraintDoAdd( MandatoryNodePropertyConstraint constraint )
+    public void constraintDoAdd( NodePropertyExistenceConstraint constraint )
     {
         constraintsChangesDiffSets().add( constraint );
         getOrCreateLabelState( constraint.label() ).getOrCreateConstraintsChanges().add( constraint );
@@ -1104,7 +1106,7 @@ public final class TxState implements TransactionState, RelationshipVisitor.Home
     }
 
     @Override
-    public void constraintDoAdd( MandatoryRelationshipPropertyConstraint constraint )
+    public void constraintDoAdd( RelationshipPropertyExistenceConstraint constraint )
     {
         constraintsChangesDiffSets().add( constraint );
         relationshipConstraintChangesByType( constraint.relationshipType() ).add( constraint );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/SchemaCache.java
@@ -80,7 +80,7 @@ public class SchemaCache
             @Override
             public boolean test( SchemaRule schemaRule )
             {
-                return schemaRule.getKind() != SchemaRule.Kind.MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT &&
+                return schemaRule.getKind() != SchemaRule.Kind.RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT &&
                        schemaRule.getLabel() == label;
             }
         }, schemaRules() );
@@ -93,7 +93,7 @@ public class SchemaCache
             @Override
             public boolean test( SchemaRule schemaRule )
             {
-                return schemaRule.getKind() == SchemaRule.Kind.MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT &&
+                return schemaRule.getKind() == SchemaRule.Kind.RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT &&
                        schemaRule.getRelationshipType() == typeId;
             }
         }, schemaRules() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/BaseRelationshipConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/BaseRelationshipConstraintCreator.java
@@ -37,6 +37,6 @@ public class BaseRelationshipConstraintCreator extends AbstractConstraintCreator
     @Override
     public RelationshipConstraintCreator assertPropertyExists( String propertyKey )
     {
-        return new RelationshipPropertyExistsConstraintCreator( actions, type, propertyKey );
+        return new RelationshipPropertyExistenceConstraintCreator( actions, type, propertyKey );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MandatoryNodePropertyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MandatoryNodePropertyConstraintDefinition.java
@@ -48,7 +48,7 @@ public class MandatoryNodePropertyConstraintDefinition extends NodeConstraintDef
     @Override
     public String toString()
     {
-        return format( "ON (%1$s:%2$s) ASSERT %1$s.%3$s IS NOT NULL",
+        return format( "ON (%1$s:%2$s) ASSERT exists(%1$s.%3$s)",
                 label.name().toLowerCase(), label.name(), propertyKey );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MandatoryRelationshipPropertyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/MandatoryRelationshipPropertyConstraintDefinition.java
@@ -48,7 +48,7 @@ public class MandatoryRelationshipPropertyConstraintDefinition extends Relations
     @Override
     public String toString()
     {
-        return format( "ON ()-[%1$s:%2$s]-() ASSERT %1$s.%3$s IS NOT NULL",
+        return format( "ON ()-[%1$s:%2$s]-() ASSERT exists(%1$s.%3$s)",
                 relationshipType.name().toLowerCase(), relationshipType.name(), propertyKey );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodePropertyExistenceConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodePropertyExistenceConstraintDefinition.java
@@ -19,36 +19,36 @@
  */
 package org.neo4j.kernel.impl.coreapi.schema;
 
-import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.schema.ConstraintType;
 
 import static java.lang.String.format;
 
-public class MandatoryRelationshipPropertyConstraintDefinition extends RelationshipConstraintDefinition
+public class NodePropertyExistenceConstraintDefinition extends NodeConstraintDefinition
 {
-    public MandatoryRelationshipPropertyConstraintDefinition( InternalSchemaActions actions,
-            RelationshipType relationshipType, String propertyKey )
+    public NodePropertyExistenceConstraintDefinition( InternalSchemaActions actions, Label label, String propertyKey )
     {
-        super( actions, relationshipType, propertyKey );
+        super( actions, label, propertyKey );
     }
 
     @Override
     public void drop()
     {
         assertInUnterminatedTransaction();
-        actions.dropRelationshipPropertyExistenceConstraint( relationshipType, propertyKey );
+        actions.dropNodePropertyExistenceConstraint( label, propertyKey );
     }
 
     @Override
     public ConstraintType getConstraintType()
     {
-        return ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY;
+        assertInUnterminatedTransaction();
+        return ConstraintType.NODE_PROPERTY_EXISTENCE;
     }
 
     @Override
     public String toString()
     {
-        return format( "ON ()-[%1$s:%2$s]-() ASSERT exists(%1$s.%3$s)",
-                relationshipType.name().toLowerCase(), relationshipType.name(), propertyKey );
+        return format( "ON (%1$s:%2$s) ASSERT exists(%1$s.%3$s)",
+                label.name().toLowerCase(), label.name(), propertyKey );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodePropertyExistsConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/NodePropertyExistsConstraintCreator.java
@@ -38,14 +38,14 @@ public class NodePropertyExistsConstraintCreator extends BaseNodeConstraintCreat
     @Override
     public final ConstraintCreator assertPropertyIsUnique( String propertyKey )
     {
-        throw new UnsupportedOperationException( "You are already creating a mandatory node property constraint." );
+        throw new UnsupportedOperationException( "You are already creating a node property existence constraint." );
     }
 
     @Override
     public final ConstraintCreator assertPropertyExists( String propertyKey )
     {
         throw new UnsupportedOperationException(
-                "You can only create one mandatory node property constraint at a time." );
+                "You can only create one node property existence constraint at a time." );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/RelationshipPropertyExistenceConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/RelationshipPropertyExistenceConstraintCreator.java
@@ -25,11 +25,11 @@ import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.RelationshipConstraintCreator;
 import org.neo4j.kernel.api.exceptions.KernelException;
 
-public class RelationshipPropertyExistsConstraintCreator extends BaseRelationshipConstraintCreator
+public class RelationshipPropertyExistenceConstraintCreator extends BaseRelationshipConstraintCreator
 {
     protected final String propertyKey;
 
-    RelationshipPropertyExistsConstraintCreator( InternalSchemaActions internalCreator, RelationshipType type,
+    RelationshipPropertyExistenceConstraintCreator( InternalSchemaActions internalCreator, RelationshipType type,
             String propertyKey )
     {
         super( internalCreator, type );
@@ -40,7 +40,7 @@ public class RelationshipPropertyExistsConstraintCreator extends BaseRelationshi
     public final RelationshipConstraintCreator assertPropertyExists( String propertyKey )
     {
         throw new UnsupportedOperationException(
-                "You can only create one mandatory relationship property constraint at a time." );
+                "You can only create one relationship property existence constraint at a time." );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/RelationshipPropertyExistenceConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/RelationshipPropertyExistenceConstraintDefinition.java
@@ -19,36 +19,36 @@
  */
 package org.neo4j.kernel.impl.coreapi.schema;
 
-import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.schema.ConstraintType;
 
 import static java.lang.String.format;
 
-public class MandatoryNodePropertyConstraintDefinition extends NodeConstraintDefinition
+public class RelationshipPropertyExistenceConstraintDefinition extends RelationshipConstraintDefinition
 {
-    public MandatoryNodePropertyConstraintDefinition( InternalSchemaActions actions, Label label, String propertyKey )
+    public RelationshipPropertyExistenceConstraintDefinition( InternalSchemaActions actions,
+            RelationshipType relationshipType, String propertyKey )
     {
-        super( actions, label, propertyKey );
+        super( actions, relationshipType, propertyKey );
     }
 
     @Override
     public void drop()
     {
         assertInUnterminatedTransaction();
-        actions.dropNodePropertyExistenceConstraint( label, propertyKey );
+        actions.dropRelationshipPropertyExistenceConstraint( relationshipType, propertyKey );
     }
 
     @Override
     public ConstraintType getConstraintType()
     {
-        assertInUnterminatedTransaction();
-        return ConstraintType.MANDATORY_NODE_PROPERTY;
+        return ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE;
     }
 
     @Override
     public String toString()
     {
-        return format( "ON (%1$s:%2$s) ASSERT exists(%1$s.%3$s)",
-                label.name().toLowerCase(), label.name(), propertyKey );
+        return format( "ON ()-[%1$s:%2$s]-() ASSERT exists(%1$s.%3$s)",
+                relationshipType.name().toLowerCase(), relationshipType.name(), propertyKey );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -40,8 +40,8 @@ import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -466,8 +466,8 @@ public class SchemaImpl implements Schema
                 {
                     int labelId = statement.schemaWriteOperations().labelGetOrCreateForName( label.name() );
                     int propertyKeyId = statement.schemaWriteOperations().propertyKeyGetOrCreateForName( propertyKey );
-                    statement.schemaWriteOperations().mandatoryNodePropertyConstraintCreate( labelId, propertyKeyId );
-                    return new MandatoryNodePropertyConstraintDefinition( this, label, propertyKey );
+                    statement.schemaWriteOperations().nodePropertyExistenceConstraintCreate( labelId, propertyKeyId );
+                    return new NodePropertyExistenceConstraintDefinition( this, label, propertyKey );
                 }
                 catch ( AlreadyConstrainedException | CreateConstraintFailureException e )
                 {
@@ -499,9 +499,9 @@ public class SchemaImpl implements Schema
                 {
                     int typeId = statement.schemaWriteOperations().relationshipTypeGetOrCreateForName( type.name() );
                     int propertyKeyId = statement.schemaWriteOperations().propertyKeyGetOrCreateForName( propertyKey );
-                    statement.schemaWriteOperations().mandatoryRelationshipPropertyConstraintCreate( typeId,
+                    statement.schemaWriteOperations().relationshipPropertyExistenceConstraintCreate( typeId,
                             propertyKeyId );
-                    return new MandatoryRelationshipPropertyConstraintDefinition( this, type, propertyKey );
+                    return new RelationshipPropertyExistenceConstraintDefinition( this, type, propertyKey );
                 }
                 catch ( AlreadyConstrainedException | CreateConstraintFailureException e )
                 {
@@ -552,7 +552,7 @@ public class SchemaImpl implements Schema
                 {
                     int labelId = statement.schemaWriteOperations().labelGetForName( label.name() );
                     int propertyKeyId = statement.schemaWriteOperations().propertyKeyGetForName( propertyKey );
-                    NodePropertyConstraint constraint = new MandatoryNodePropertyConstraint( labelId, propertyKeyId );
+                    NodePropertyConstraint constraint = new NodePropertyExistenceConstraint( labelId, propertyKeyId );
                     statement.schemaWriteOperations().constraintDrop( constraint );
                 }
                 catch ( DropConstraintFailureException e )
@@ -576,7 +576,7 @@ public class SchemaImpl implements Schema
                 {
                     int typeId = statement.schemaWriteOperations().relationshipTypeGetForName( type.name() );
                     int propertyKeyId = statement.schemaWriteOperations().propertyKeyGetForName( propertyKey );
-                    RelationshipPropertyConstraint constraint = new MandatoryRelationshipPropertyConstraint( typeId,
+                    RelationshipPropertyConstraint constraint = new RelationshipPropertyExistenceConstraint( typeId,
                             propertyKeyId );
                     statement.schemaWriteOperations().constraintDrop( constraint );
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStorage.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/SchemaStorage.java
@@ -35,8 +35,8 @@ import org.neo4j.kernel.api.exceptions.schema.MalformedSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.IndexRule;
-import org.neo4j.kernel.impl.store.record.MandatoryNodePropertyConstraintRule;
-import org.neo4j.kernel.impl.store.record.MandatoryRelationshipPropertyConstraintRule;
+import org.neo4j.kernel.impl.store.record.NodePropertyExistenceConstraintRule;
+import org.neo4j.kernel.impl.store.record.RelationshipPropertyExistenceConstraintRule;
 import org.neo4j.kernel.impl.store.record.NodePropertyConstraintRule;
 import org.neo4j.kernel.impl.store.record.RelationshipPropertyConstraintRule;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
@@ -270,16 +270,16 @@ public class SchemaStorage implements SchemaRuleAccess
         return schemaStore.nextId();
     }
 
-    public MandatoryNodePropertyConstraintRule mandatoryNodePropertyConstraint( int labelId, int propertyKeyId )
+    public NodePropertyExistenceConstraintRule nodePropertyExistenceConstraint( int labelId, int propertyKeyId )
             throws SchemaRuleNotFoundException, DuplicateSchemaRuleException
     {
-        return nodeConstraintRule( MandatoryNodePropertyConstraintRule.class, labelId, propertyKeyId );
+        return nodeConstraintRule( NodePropertyExistenceConstraintRule.class, labelId, propertyKeyId );
     }
 
-    public MandatoryRelationshipPropertyConstraintRule mandatoryRelationshipPropertyConstraint( int typeId,
+    public RelationshipPropertyExistenceConstraintRule relationshipPropertyExistenceConstraint( int typeId,
             int propertyKeyId ) throws SchemaRuleNotFoundException, DuplicateSchemaRuleException
     {
-        return relationshipConstraintRule( MandatoryRelationshipPropertyConstraintRule.class, typeId, propertyKeyId );
+        return relationshipConstraintRule( RelationshipPropertyExistenceConstraintRule.class, typeId, propertyKeyId );
     }
 
     public UniquePropertyConstraintRule uniquenessConstraint( int labelId, final int propertyKeyId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/NodePropertyExistenceConstraintRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/NodePropertyExistenceConstraintRule.java
@@ -22,35 +22,35 @@ package org.neo4j.kernel.impl.store.record;
 
 import java.nio.ByteBuffer;
 
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 
-public class MandatoryNodePropertyConstraintRule extends NodePropertyConstraintRule
+public class NodePropertyExistenceConstraintRule extends NodePropertyConstraintRule
 {
     private final int propertyKeyId;
 
-    public static MandatoryNodePropertyConstraintRule mandatoryNodePropertyConstraintRule( long id, int labelId,
+    public static NodePropertyExistenceConstraintRule nodePropertyExistenceConstraintRule( long id, int labelId,
             int propertyKeyId )
     {
-        return new MandatoryNodePropertyConstraintRule( id, labelId, propertyKeyId );
+        return new NodePropertyExistenceConstraintRule( id, labelId, propertyKeyId );
     }
 
-    public static MandatoryNodePropertyConstraintRule readMandatoryNodePropertyConstraintRule( long id, int labelId,
+    public static NodePropertyExistenceConstraintRule readNodePropertyExistenceConstraintRule( long id, int labelId,
             ByteBuffer buffer )
     {
-        return new MandatoryNodePropertyConstraintRule( id, labelId, readPropertyKey( buffer ) );
+        return new NodePropertyExistenceConstraintRule( id, labelId, readPropertyKey( buffer ) );
     }
 
-    private MandatoryNodePropertyConstraintRule( long id, int labelId, int propertyKeyId )
+    private NodePropertyExistenceConstraintRule( long id, int labelId, int propertyKeyId )
     {
-        super( id, labelId, Kind.MANDATORY_NODE_PROPERTY_CONSTRAINT );
+        super( id, labelId, Kind.NODE_PROPERTY_EXISTENCE_CONSTRAINT );
         this.propertyKeyId = propertyKeyId;
     }
 
     @Override
     public String toString()
     {
-        return "MandatoryNodePropertyConstraintRule[id=" + id + ", label=" + label + ", kind=" + kind +
+        return "NodePropertyExistenceConstraintRule[id=" + id + ", label=" + label + ", kind=" + kind +
                ", propertyKeyId=" + propertyKeyId + "]";
     }
 
@@ -83,7 +83,7 @@ public class MandatoryNodePropertyConstraintRule extends NodePropertyConstraintR
     @Override
     public NodePropertyConstraint toConstraint()
     {
-        return new MandatoryNodePropertyConstraint( getLabel(), getPropertyKey() );
+        return new NodePropertyExistenceConstraint( getLabel(), getPropertyKey() );
     }
 
     @Override
@@ -107,7 +107,7 @@ public class MandatoryNodePropertyConstraintRule extends NodePropertyConstraintR
         {
             return false;
         }
-        return propertyKeyId == ((MandatoryNodePropertyConstraintRule) o).propertyKeyId;
+        return propertyKeyId == ((NodePropertyExistenceConstraintRule) o).propertyKeyId;
 
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipPropertyExistenceConstraintRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/RelationshipPropertyExistenceConstraintRule.java
@@ -21,35 +21,35 @@ package org.neo4j.kernel.impl.store.record;
 
 import java.nio.ByteBuffer;
 
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 
-public class MandatoryRelationshipPropertyConstraintRule extends RelationshipPropertyConstraintRule
+public class RelationshipPropertyExistenceConstraintRule extends RelationshipPropertyConstraintRule
 {
     private final int propertyKeyId;
 
-    public static MandatoryRelationshipPropertyConstraintRule mandatoryRelPropertyConstraintRule( long id,
+    public static RelationshipPropertyExistenceConstraintRule relPropertyExistenceConstraintRule( long id,
             int relTypeId, int propertyKeyId )
     {
-        return new MandatoryRelationshipPropertyConstraintRule( id, relTypeId, propertyKeyId );
+        return new RelationshipPropertyExistenceConstraintRule( id, relTypeId, propertyKeyId );
     }
 
-    public static MandatoryRelationshipPropertyConstraintRule readMandatoryRelPropertyConstraintRule( long id,
+    public static RelationshipPropertyExistenceConstraintRule readRelPropertyExistenceConstraintRule( long id,
             int relTypeId, ByteBuffer buffer )
     {
-        return new MandatoryRelationshipPropertyConstraintRule( id, relTypeId, readPropertyKey( buffer ) );
+        return new RelationshipPropertyExistenceConstraintRule( id, relTypeId, readPropertyKey( buffer ) );
     }
 
-    private MandatoryRelationshipPropertyConstraintRule( long id, int relTypeId, int propertyKeyId )
+    private RelationshipPropertyExistenceConstraintRule( long id, int relTypeId, int propertyKeyId )
     {
-        super( id, relTypeId, Kind.MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT );
+        super( id, relTypeId, Kind.RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT );
         this.propertyKeyId = propertyKeyId;
     }
 
     @Override
     public String toString()
     {
-        return "MandatoryRelationshipPropertyConstraint" + id + ", relationshipType=" + relationshipType +
+        return "RelationshipPropertyExistenceConstraint" + id + ", relationshipType=" + relationshipType +
                ", kind=" + kind + ", propertyKeyId=" + propertyKeyId + "]";
     }
 
@@ -82,7 +82,7 @@ public class MandatoryRelationshipPropertyConstraintRule extends RelationshipPro
     @Override
     public RelationshipPropertyConstraint toConstraint()
     {
-        return new MandatoryRelationshipPropertyConstraint( getRelationshipType(), getPropertyKey() );
+        return new RelationshipPropertyExistenceConstraint( getRelationshipType(), getPropertyKey() );
     }
 
     @Override
@@ -106,7 +106,7 @@ public class MandatoryRelationshipPropertyConstraintRule extends RelationshipPro
         {
             return false;
         }
-        return propertyKeyId == ((MandatoryRelationshipPropertyConstraintRule) o).propertyKeyId;
+        return propertyKeyId == ((RelationshipPropertyExistenceConstraintRule) o).propertyKeyId;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRule.java
@@ -32,14 +32,14 @@ public interface SchemaRule extends RecordSerializable
 
     /**
      * @return id of label to which this schema rule has been attached
-     * @throws IllegalStateException when this rule has kind {@link Kind#MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT}
+     * @throws IllegalStateException when this rule has kind {@link Kind#RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT}
      */
     int getLabel();
 
     /**
      * @return id of relationship type to which this schema rule has been attached
      * @throws IllegalStateException when this rule has kind different from
-     * {@link Kind#MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT}
+     * {@link Kind#RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT}
      */
     int getRelationshipType();
 
@@ -74,20 +74,22 @@ public interface SchemaRule extends RecordSerializable
                 return UniquePropertyConstraintRule.readUniquenessConstraintRule( id, labelId, buffer );
             }
         },
-        MANDATORY_NODE_PROPERTY_CONSTRAINT( 4, MandatoryNodePropertyConstraintRule.class )
+        NODE_PROPERTY_EXISTENCE_CONSTRAINT( 4, NodePropertyExistenceConstraintRule.class )
         {
             @Override
             protected SchemaRule newRule( long id, int labelId, ByteBuffer buffer )
             {
-                return MandatoryNodePropertyConstraintRule.readMandatoryNodePropertyConstraintRule( id, labelId, buffer );
+                return NodePropertyExistenceConstraintRule
+                        .readNodePropertyExistenceConstraintRule( id, labelId, buffer );
             }
         },
-        MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT( 5, MandatoryRelationshipPropertyConstraintRule.class )
+        RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT( 5, RelationshipPropertyExistenceConstraintRule.class )
         {
             @Override
             protected SchemaRule newRule( long id, int labelId, ByteBuffer buffer )
             {
-                return MandatoryRelationshipPropertyConstraintRule.readMandatoryRelPropertyConstraintRule( id, labelId, buffer );
+                return RelationshipPropertyExistenceConstraintRule
+                        .readRelPropertyExistenceConstraintRule( id, labelId, buffer );
             }
         };
 
@@ -141,8 +143,8 @@ public interface SchemaRule extends RecordSerializable
             case 1: return INDEX_RULE;
             case 2: return CONSTRAINT_INDEX_RULE;
             case 3: return UNIQUENESS_CONSTRAINT;
-            case 4: return MANDATORY_NODE_PROPERTY_CONSTRAINT;
-            case 5: return MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT;
+            case 4: return NODE_PROPERTY_EXISTENCE_CONSTRAINT;
+            case 5: return RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT;
             default:
                 throw new MalformedSchemaRuleException( null, "Unknown kind id %d", id );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureArgumentFormatter.java
@@ -25,8 +25,8 @@ import java.util.Collection;
 import java.util.List;
 
 import org.neo4j.helpers.Strings;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
@@ -94,19 +94,19 @@ public enum DbStructureArgumentFormatter implements ArgumentFormatter
             int propertyKeyId = constraint.propertyKey();
             builder.append( format( "new UniquenessConstraint( %s, %s )", labelId, propertyKeyId ) );
         }
-        else if ( arg instanceof MandatoryNodePropertyConstraint )
+        else if ( arg instanceof NodePropertyExistenceConstraint )
         {
-            MandatoryNodePropertyConstraint constraint = (MandatoryNodePropertyConstraint) arg;
+            NodePropertyExistenceConstraint constraint = (NodePropertyExistenceConstraint) arg;
             int labelId = constraint.label();
             int propertyKeyId = constraint.propertyKey();
-            builder.append( format( "new MandatoryNodePropertyConstraint( %s, %s )", labelId, propertyKeyId ) );
+            builder.append( format( "new NodePropertyExistenceConstraint( %s, %s )", labelId, propertyKeyId ) );
         }
-        else if ( arg instanceof MandatoryRelationshipPropertyConstraint )
+        else if ( arg instanceof RelationshipPropertyExistenceConstraint )
         {
-            MandatoryRelationshipPropertyConstraint constraint = (MandatoryRelationshipPropertyConstraint) arg;
+            RelationshipPropertyExistenceConstraint constraint = (RelationshipPropertyExistenceConstraint) arg;
             int relTypeId = constraint.relationshipType();
             int propertyKeyId = constraint.propertyKey();
-            builder.append( format( "new MandatoryRelationshipPropertyConstraint( %s, %s )", relTypeId, propertyKeyId ) );
+            builder.append( format( "new RelationshipPropertyExistenceConstraint( %s, %s )", relTypeId, propertyKeyId ) );
         }
         else
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollector.java
@@ -28,8 +28,9 @@ import java.util.Set;
 import org.neo4j.function.Function;
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
@@ -43,8 +44,8 @@ public class DbStructureCollector implements DbStructureVisitor
     private final IndexDescriptorMap regularIndices = new IndexDescriptorMap( "regular" );
     private final IndexDescriptorMap uniqueIndices = new IndexDescriptorMap( "unique" );
     private final Set<UniquenessConstraint> uniquenessConstraints = new HashSet<>();
-    private final Set<MandatoryNodePropertyConstraint> mandatoryNodePropertyConstraints = new HashSet<>();
-    private final Set<MandatoryRelationshipPropertyConstraint> mandatoryRelPropertyConstraints = new HashSet<>();
+    private final Set<NodePropertyExistenceConstraint> nodePropertyExistenceConstraints = new HashSet<>();
+    private final Set<RelationshipPropertyExistenceConstraint> relPropertyExistenceConstraints = new HashSet<>();
     private final Map<Integer, Long> nodeCounts = new HashMap<>();
     private final Map<RelSpecifier, Long> relCounts = new HashMap<>();
     private long allNodesCount = -1l;
@@ -100,25 +101,25 @@ public class DbStructureCollector implements DbStructureVisitor
             }
 
             @Override
-            public Iterator<Pair<String,String>> knownMandatoryNodePropertyConstraints()
+            public Iterator<Pair<String,String>> knownNodePropertyExistenceConstraints()
             {
-                return Iterables.map( new Function<MandatoryNodePropertyConstraint,Pair<String,String>>()
+                return Iterables.map( new Function<NodePropertyExistenceConstraint,Pair<String,String>>()
                 {
                     @Override
-                    public Pair<String,String> apply( MandatoryNodePropertyConstraint uniquenessConstraint )
+                    public Pair<String,String> apply( NodePropertyExistenceConstraint uniquenessConstraint )
                             throws RuntimeException
                     {
                         String label = labels.byIdOrFail( uniquenessConstraint.label() );
                         String propertyKey = propertyKeys.byIdOrFail( uniquenessConstraint.propertyKey() );
                         return Pair.of( label, propertyKey );
                     }
-                }, mandatoryNodePropertyConstraints.iterator() );
+                }, nodePropertyExistenceConstraints.iterator() );
             }
 
             @Override
-            public Iterator<Pair<String,String>> knownMandatoryRelationshipPropertyConstraints()
+            public Iterator<Pair<String,String>> knownRelationshipPropertyExistenceConstraints()
             {
-                return null;
+                return IteratorUtil.emptyIterator();
             }
 
             @Override
@@ -196,23 +197,23 @@ public class DbStructureCollector implements DbStructureVisitor
     }
 
     @Override
-    public void visitMandatoryNodePropertyConstraint( MandatoryNodePropertyConstraint constraint, String userDescription )
+    public void visitNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint, String userDescription )
     {
-        if ( !mandatoryNodePropertyConstraints.add( constraint ) )
+        if ( !nodePropertyExistenceConstraints.add( constraint ) )
         {
             throw new IllegalArgumentException(
-                    format( "Duplicated mandatory node property constraint %s for %s", constraint, userDescription )
+                    format( "Duplicated node property existence constraint %s for %s", constraint, userDescription )
             );
         }
     }
 
     @Override
-    public void visitMandatoryRelationshipPropertyConstraint( MandatoryRelationshipPropertyConstraint constraint, String userDescription )
+    public void visitRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint constraint, String userDescription )
     {
-        if ( !mandatoryRelPropertyConstraints.add( constraint ) )
+        if ( !relPropertyExistenceConstraints.add( constraint ) )
         {
             throw new IllegalArgumentException(
-                    format( "Duplicated mandatory relationship property constraint %s for %s",
+                    format( "Duplicated relationship property existence constraint %s for %s",
                             constraint, userDescription )
             );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLookup.java
@@ -32,8 +32,8 @@ public interface DbStructureLookup
     Iterator<Pair<String, String>> knownIndices();
     Iterator<Pair<String, String>> knownUniqueIndices();
     Iterator<Pair<String, String>> knownUniqueConstraints();
-    Iterator<Pair<String, String>> knownMandatoryNodePropertyConstraints();
-    Iterator<Pair<String, String>> knownMandatoryRelationshipPropertyConstraints();
+    Iterator<Pair<String, String>> knownNodePropertyExistenceConstraints();
+    Iterator<Pair<String, String>> knownRelationshipPropertyExistenceConstraints();
 
     long nodesWithLabelCardinality( int labelId );
     long cardinalityByLabelsAndRelationshipType( int fromLabelId, int relTypeId, int toLabelId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureVisitor.java
@@ -19,8 +19,8 @@
  */
 package org.neo4j.kernel.impl.util.dbstructure;
 
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 
@@ -33,8 +33,9 @@ public interface DbStructureVisitor
     void visitIndex( IndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long size );
     void visitUniqueIndex( IndexDescriptor descriptor, String userDescription, double uniqueValuesPercentage, long size );
     void visitUniqueConstraint( UniquenessConstraint constraint, String userDescription );
-    void visitMandatoryNodePropertyConstraint( MandatoryNodePropertyConstraint constraint, String userDescription );
-    void visitMandatoryRelationshipPropertyConstraint( MandatoryRelationshipPropertyConstraint constraint, String userDescription );
+    void visitNodePropertyExistenceConstraint( NodePropertyExistenceConstraint constraint, String userDescription );
+    void visitRelationshipPropertyExistenceConstraint( RelationshipPropertyExistenceConstraint constraint,
+            String userDescription );
 
     void visitAllNodesCount( long nodeCount );
     void visitNodeCount( int labelId, String labelName, long nodeCount );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
@@ -32,8 +32,8 @@ import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.TokenNameLookup;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
@@ -179,15 +179,15 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
             {
                 visitor.visitUniqueConstraint( (UniquenessConstraint) constraint, userDescription );
             }
-            else if ( constraint instanceof MandatoryNodePropertyConstraint )
+            else if ( constraint instanceof NodePropertyExistenceConstraint )
             {
-                MandatoryNodePropertyConstraint mandatoryConstraint = (MandatoryNodePropertyConstraint) constraint;
-                visitor.visitMandatoryNodePropertyConstraint( mandatoryConstraint, userDescription );
+                NodePropertyExistenceConstraint existenceConstraint = (NodePropertyExistenceConstraint) constraint;
+                visitor.visitNodePropertyExistenceConstraint( existenceConstraint, userDescription );
             }
-            else if ( constraint instanceof MandatoryRelationshipPropertyConstraint )
+            else if ( constraint instanceof RelationshipPropertyExistenceConstraint )
             {
-                MandatoryRelationshipPropertyConstraint mandatoryConstraint = (MandatoryRelationshipPropertyConstraint) constraint;
-                visitor.visitMandatoryRelationshipPropertyConstraint( mandatoryConstraint, userDescription );
+                RelationshipPropertyExistenceConstraint existenceConstraint = (RelationshipPropertyExistenceConstraint) constraint;
+                visitor.visitRelationshipPropertyExistenceConstraint( existenceConstraint, userDescription );
             }
             else
             {

--- a/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/SchemaAcceptanceTest.java
@@ -333,20 +333,20 @@ public class SchemaAcceptanceTest
     }
 
     @Test
-    public void shouldCreateMandatoryNodePropertyConstraint()
+    public void shouldCreateNodePropertyExistenceConstraint()
     {
         // When
-        ConstraintDefinition constraint = createMandatoryNodePropertyConstraint( label, propertyKey );
+        ConstraintDefinition constraint = createNodePropertyExistenceConstraint( label, propertyKey );
 
         // Then
         assertThat( getConstraints( db ), containsOnly( constraint ) );
     }
 
     @Test
-    public void shouldCreateMandatoryRelationshipPropertyConstraint()
+    public void shouldCreateRelationshipPropertyExistenceConstraint()
     {
         // When
-        ConstraintDefinition constraint = createMandatoryRelationshipPropertyConstraint( Types.MY_TYPE , propertyKey );
+        ConstraintDefinition constraint = createRelationshipPropertyExistenceConstraint( Types.MY_TYPE, propertyKey );
 
         // Then
         assertThat( getConstraints( db ), containsOnly( constraint ) );
@@ -357,8 +357,8 @@ public class SchemaAcceptanceTest
     {
         // GIVEN
         ConstraintDefinition constraint1 = createUniquenessConstraint( label, propertyKey );
-        ConstraintDefinition constraint2 = createMandatoryNodePropertyConstraint( label, propertyKey );
-        createMandatoryNodePropertyConstraint( Labels.MY_OTHER_LABEL, propertyKey );
+        ConstraintDefinition constraint2 = createNodePropertyExistenceConstraint( label, propertyKey );
+        createNodePropertyExistenceConstraint( Labels.MY_OTHER_LABEL, propertyKey );
 
         // WHEN THEN
         assertThat( getConstraints( db, label ), containsOnly( constraint1, constraint2 ) );
@@ -368,8 +368,8 @@ public class SchemaAcceptanceTest
     public void shouldListAddedConstraintsByRelationshipType() throws Exception
     {
         // GIVEN
-        ConstraintDefinition constraint1 = createMandatoryRelationshipPropertyConstraint( Types.MY_TYPE, propertyKey );
-        createMandatoryRelationshipPropertyConstraint( Types.MY_OTHER_TYPE, propertyKey );
+        ConstraintDefinition constraint1 = createRelationshipPropertyExistenceConstraint( Types.MY_TYPE, propertyKey );
+        createRelationshipPropertyExistenceConstraint( Types.MY_OTHER_TYPE, propertyKey );
 
         // WHEN THEN
         assertThat( getConstraints( db, Types.MY_TYPE ), containsOnly( constraint1 ) );
@@ -380,8 +380,8 @@ public class SchemaAcceptanceTest
     {
         // GIVEN
         ConstraintDefinition constraint1 = createUniquenessConstraint( label, propertyKey );
-        ConstraintDefinition constraint2 = createMandatoryNodePropertyConstraint( label, propertyKey );
-        ConstraintDefinition constraint3 = createMandatoryRelationshipPropertyConstraint( Types.MY_TYPE, propertyKey );
+        ConstraintDefinition constraint2 = createNodePropertyExistenceConstraint( label, propertyKey );
+        ConstraintDefinition constraint3 = createRelationshipPropertyExistenceConstraint( Types.MY_TYPE, propertyKey );
 
         // WHEN THEN
         assertThat( getConstraints( db ), containsOnly( constraint1, constraint2, constraint3 ) );
@@ -550,7 +550,7 @@ public class SchemaAcceptanceTest
         }
     }
 
-    private ConstraintDefinition createMandatoryNodePropertyConstraint( Label label, String prop )
+    private ConstraintDefinition createNodePropertyExistenceConstraint( Label label, String prop )
     {
         try ( Transaction tx = db.beginTx() )
         {
@@ -560,7 +560,7 @@ public class SchemaAcceptanceTest
         }
     }
 
-    private ConstraintDefinition createMandatoryRelationshipPropertyConstraint( RelationshipType type, String prop )
+    private ConstraintDefinition createRelationshipPropertyExistenceConstraint( RelationshipType type, String prop )
     {
         try ( Transaction tx = db.beginTx() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ConstraintCreationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ConstraintCreationIT.java
@@ -44,8 +44,8 @@ import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
@@ -85,14 +85,14 @@ import static org.neo4j.kernel.impl.api.integrationtest.ConstraintCreationIT.*;
 
 @RunWith( Suite.class )
 @SuiteClasses( {
-        MandatoryNodePropertyConstraintCreationIT.class,
-        MandatoryRelationshipPropertyConstraintCreationIT.class,
+        NodePropertyExistenceConstraintCreationIT.class,
+        RelationshipPropertyExistenceConstraintCreationIT.class,
         UniquenessConstraintCreationIT.class
 } )
 public class ConstraintCreationIT
 {
-    public static class MandatoryNodePropertyConstraintCreationIT
-            extends AbstractConstraintCreationIT<MandatoryNodePropertyConstraint>
+    public static class NodePropertyExistenceConstraintCreationIT
+            extends AbstractConstraintCreationIT<NodePropertyExistenceConstraint>
     {
         @Override
         int initializeLabelOrRelType( SchemaWriteOperations writeOps, String name ) throws KernelException
@@ -101,10 +101,10 @@ public class ConstraintCreationIT
         }
 
         @Override
-        MandatoryNodePropertyConstraint createConstraint( SchemaWriteOperations writeOps, int type, int property )
+        NodePropertyExistenceConstraint createConstraint( SchemaWriteOperations writeOps, int type, int property )
                 throws Exception
         {
-            return writeOps.mandatoryNodePropertyConstraintCreate( type, property );
+            return writeOps.nodePropertyExistenceConstraintCreate( type, property );
         }
 
         @Override
@@ -114,13 +114,13 @@ public class ConstraintCreationIT
         }
 
         @Override
-        MandatoryNodePropertyConstraint newConstraintObject( int type, int property )
+        NodePropertyExistenceConstraint newConstraintObject( int type, int property )
         {
-            return new MandatoryNodePropertyConstraint( type, property );
+            return new NodePropertyExistenceConstraint( type, property );
         }
 
         @Override
-        void dropConstraint( SchemaWriteOperations writeOps, MandatoryNodePropertyConstraint constraint )
+        void dropConstraint( SchemaWriteOperations writeOps, NodePropertyExistenceConstraint constraint )
                 throws Exception
         {
             writeOps.constraintDrop( constraint );
@@ -145,7 +145,7 @@ public class ConstraintCreationIT
         }
 
         @Test
-        public void shouldNotDropMandatoryPropertyConstraintThatDoesNotExistWhenThereIsAUniquePropertyConstraint()
+        public void shouldNotDropPropertyExistenceConstraintThatDoesNotExistWhenThereIsAUniquePropertyConstraint()
                 throws Exception
         {
             // given
@@ -161,7 +161,7 @@ public class ConstraintCreationIT
             {
                 SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
                 statement.constraintDrop(
-                        new MandatoryNodePropertyConstraint( constraint.label(), constraint.propertyKey() ) );
+                        new NodePropertyExistenceConstraint( constraint.label(), constraint.propertyKey() ) );
 
                 fail( "expected exception" );
             }
@@ -187,8 +187,8 @@ public class ConstraintCreationIT
         }
     }
 
-    public static class MandatoryRelationshipPropertyConstraintCreationIT
-            extends AbstractConstraintCreationIT<MandatoryRelationshipPropertyConstraint>
+    public static class RelationshipPropertyExistenceConstraintCreationIT
+            extends AbstractConstraintCreationIT<RelationshipPropertyExistenceConstraint>
     {
         @Override
         int initializeLabelOrRelType( SchemaWriteOperations writeOps, String name ) throws KernelException
@@ -197,10 +197,10 @@ public class ConstraintCreationIT
         }
 
         @Override
-        MandatoryRelationshipPropertyConstraint createConstraint( SchemaWriteOperations writeOps, int type,
+        RelationshipPropertyExistenceConstraint createConstraint( SchemaWriteOperations writeOps, int type,
                 int property ) throws Exception
         {
-            return writeOps.mandatoryRelationshipPropertyConstraintCreate( type, property );
+            return writeOps.relationshipPropertyExistenceConstraintCreate( type, property );
         }
 
         @Override
@@ -210,13 +210,13 @@ public class ConstraintCreationIT
         }
 
         @Override
-        MandatoryRelationshipPropertyConstraint newConstraintObject( int type, int property )
+        RelationshipPropertyExistenceConstraint newConstraintObject( int type, int property )
         {
-            return new MandatoryRelationshipPropertyConstraint( type, property );
+            return new RelationshipPropertyExistenceConstraint( type, property );
         }
 
         @Override
-        void dropConstraint( SchemaWriteOperations writeOps, MandatoryRelationshipPropertyConstraint constraint )
+        void dropConstraint( SchemaWriteOperations writeOps, RelationshipPropertyExistenceConstraint constraint )
                 throws Exception
         {
             writeOps.constraintDrop( constraint );
@@ -389,14 +389,14 @@ public class ConstraintCreationIT
         }
 
         @Test
-        public void shouldNotDropUniquePropertyConstraintThatDoesNotExistWhenThereIsAMandatoryPropertyConstraint()
+        public void shouldNotDropUniquePropertyConstraintThatDoesNotExistWhenThereIsAPropertyExistenceConstraint()
                 throws Exception
         {
             // given
-            MandatoryNodePropertyConstraint constraint;
+            NodePropertyExistenceConstraint constraint;
             {
                 SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
-                constraint = statement.mandatoryNodePropertyConstraintCreate( typeId, propertyKeyId );
+                constraint = statement.nodePropertyExistenceConstraintCreate( typeId, propertyKeyId );
                 commit();
             }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintValidationIT.java
@@ -41,17 +41,17 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.neo4j.kernel.impl.api.integrationtest.MandatoryPropertyConstraintValidationIT.*;
+import static org.neo4j.kernel.impl.api.integrationtest.PropertyExistenceConstraintValidationIT.*;
 
 @RunWith( Suite.class )
 @SuiteClasses( {
-        MandatoryNodePropertyConstraintValidationIT.class,
-        MandatoryRelationshipPropertyConstraintValidationIT.class
+        NodePropertyExistenceExistenceConstraintValidationIT.class,
+        RelationshipPropertyExistenceExistenceConstraintValidationIT.class
 } )
-public class MandatoryPropertyConstraintValidationIT
+public class PropertyExistenceConstraintValidationIT
 {
-    public static class MandatoryNodePropertyConstraintValidationIT
-            extends AbstractMandatoryPropertyConstraintValidationIT
+    public static class NodePropertyExistenceExistenceConstraintValidationIT
+            extends AbstractPropertyExistenceConstraintValidationIT
     {
         @Test
         public void shouldAllowNoopLabelUpdate() throws Exception
@@ -76,7 +76,7 @@ public class MandatoryPropertyConstraintValidationIT
             commit();
 
             SchemaWriteOperations schemaWrite = schemaWriteOperationsInNewTransaction();
-            schemaWrite.mandatoryNodePropertyConstraintCreate( label, propertyKey );
+            schemaWrite.nodePropertyExistenceConstraintCreate( label, propertyKey );
             commit();
         }
 
@@ -144,8 +144,8 @@ public class MandatoryPropertyConstraintValidationIT
         }
     }
 
-    public static class MandatoryRelationshipPropertyConstraintValidationIT
-            extends AbstractMandatoryPropertyConstraintValidationIT
+    public static class RelationshipPropertyExistenceExistenceConstraintValidationIT
+            extends AbstractPropertyExistenceConstraintValidationIT
     {
         @Override
         void createConstraint( String key, String property ) throws KernelException
@@ -156,7 +156,7 @@ public class MandatoryPropertyConstraintValidationIT
             commit();
 
             SchemaWriteOperations schemaWrite = schemaWriteOperationsInNewTransaction();
-            schemaWrite.mandatoryRelationshipPropertyConstraintCreate( relTypeId, propertyKeyId );
+            schemaWrite.relationshipPropertyExistenceConstraintCreate( relTypeId, propertyKeyId );
             commit();
         }
 
@@ -230,7 +230,7 @@ public class MandatoryPropertyConstraintValidationIT
         }
     }
 
-    public abstract static class AbstractMandatoryPropertyConstraintValidationIT extends KernelIntegrationTest
+    public abstract static class AbstractPropertyExistenceConstraintValidationIT extends KernelIntegrationTest
     {
         abstract void createConstraint( String key, String property ) throws KernelException;
 
@@ -251,7 +251,7 @@ public class MandatoryPropertyConstraintValidationIT
         abstract int entityCount() throws TransactionFailureException;
 
         @Test
-        public void shouldEnforceMandatoryConstraintWhenCreatingEntityWithoutProperty() throws Exception
+        public void shouldEnforcePropertyExistenceConstraintWhenCreatingEntityWithoutProperty() throws Exception
         {
             // given
             createConstraint( "Type1", "key1" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintVerificationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintVerificationIT.java
@@ -55,18 +55,18 @@ import static org.junit.Assert.fail;
 import static org.junit.runners.Suite.SuiteClasses;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
-import static org.neo4j.kernel.impl.api.integrationtest.MandatoryPropertyConstraintVerificationIT.*;
+import static org.neo4j.kernel.impl.api.integrationtest.PropertyExistenceConstraintVerificationIT.*;
 import static org.neo4j.test.ThreadingRule.waitingWhileIn;
 
 @RunWith( Suite.class )
 @SuiteClasses( {
-        MandatoryNodePropertyConstrainVerificationIT.class,
-        MandatoryRelationshipPropertyConstrainVerificationIT.class
+        NodePropertyExistenceExistenceConstrainVerificationIT.class,
+        RelationshipPropertyExistenceExistenceConstrainVerificationIT.class
 } )
-public class MandatoryPropertyConstraintVerificationIT
+public class PropertyExistenceConstraintVerificationIT
 {
-    public static class MandatoryNodePropertyConstrainVerificationIT
-            extends AbstractMandatoryPropertyConstraintVerificationIT
+    public static class NodePropertyExistenceExistenceConstrainVerificationIT
+            extends AbstractPropertyExistenceConstraintVerificationIT
     {
         @Override
         void createConstraint( DatabaseRule db, String label, String property )
@@ -77,7 +77,7 @@ public class MandatoryPropertyConstraintVerificationIT
         @Override
         String constraintCreationMethodName()
         {
-            return "mandatoryNodePropertyConstraintCreate";
+            return "nodePropertyExistenceConstraintCreate";
         }
 
         @Override
@@ -101,8 +101,8 @@ public class MandatoryPropertyConstraintVerificationIT
         }
     }
 
-    public static class MandatoryRelationshipPropertyConstrainVerificationIT
-            extends AbstractMandatoryPropertyConstraintVerificationIT
+    public static class RelationshipPropertyExistenceExistenceConstrainVerificationIT
+            extends AbstractPropertyExistenceConstraintVerificationIT
     {
         @Override
         public void createConstraint( DatabaseRule db, String relType, String property )
@@ -113,7 +113,7 @@ public class MandatoryPropertyConstraintVerificationIT
         @Override
         public String constraintCreationMethodName()
         {
-            return "mandatoryRelationshipPropertyConstraintCreate";
+            return "relationshipPropertyExistenceConstraintCreate";
         }
 
         @Override
@@ -138,7 +138,7 @@ public class MandatoryPropertyConstraintVerificationIT
         }
     }
 
-    public abstract static class AbstractMandatoryPropertyConstraintVerificationIT
+    public abstract static class AbstractPropertyExistenceConstraintVerificationIT
     {
         private static final String KEY = "Foo";
         private static final String PROPERTY = "bar";

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
@@ -35,7 +35,7 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -1028,10 +1028,10 @@ public class TxStateTest
     }
 
     @Test
-    public void shouldAddMandatoryRelationshipPropertyConstraint()
+    public void shouldAddRelationshipPropertyExistenceConstraint()
     {
         // Given
-        MandatoryRelationshipPropertyConstraint constraint = new MandatoryRelationshipPropertyConstraint( 1, 42 );
+        RelationshipPropertyExistenceConstraint constraint = new RelationshipPropertyExistenceConstraint( 1, 42 );
 
         // When
         state.constraintDoAdd( constraint );
@@ -1041,11 +1041,11 @@ public class TxStateTest
     }
 
     @Test
-    public void addingMandatoryRelPropertyConstraintConstraintShouldBeIdempotent()
+    public void addingRelationshipPropertyExistenceConstraintConstraintShouldBeIdempotent()
     {
         // Given
-        MandatoryRelationshipPropertyConstraint constraint1 = new MandatoryRelationshipPropertyConstraint( 1, 42 );
-        MandatoryRelationshipPropertyConstraint constraint2 = new MandatoryRelationshipPropertyConstraint( 1, 42 );
+        RelationshipPropertyExistenceConstraint constraint1 = new RelationshipPropertyExistenceConstraint( 1, 42 );
+        RelationshipPropertyExistenceConstraint constraint2 = new RelationshipPropertyExistenceConstraint( 1, 42 );
 
         // When
         state.constraintDoAdd( constraint1 );
@@ -1057,10 +1057,10 @@ public class TxStateTest
     }
 
     @Test
-    public void shouldDropMandatoryRelationshipPropertyConstraint()
+    public void shouldDropRelationshipPropertyExistenceConstraint()
     {
         // Given
-        MandatoryRelationshipPropertyConstraint constraint = new MandatoryRelationshipPropertyConstraint( 1, 42 );
+        RelationshipPropertyExistenceConstraint constraint = new RelationshipPropertyExistenceConstraint( 1, 42 );
         state.constraintDoAdd( constraint );
 
         // When
@@ -1071,12 +1071,12 @@ public class TxStateTest
     }
 
     @Test
-    public void shouldDifferentiateMandatoryRelationshipPropertyConstraints() throws Exception
+    public void shouldDifferentiateRelationshipPropertyExistenceConstraints() throws Exception
     {
         // Given
-        MandatoryRelationshipPropertyConstraint constraint1 = new MandatoryRelationshipPropertyConstraint( 1, 11 );
-        MandatoryRelationshipPropertyConstraint constraint2 = new MandatoryRelationshipPropertyConstraint( 1, 22 );
-        MandatoryRelationshipPropertyConstraint constraint3 = new MandatoryRelationshipPropertyConstraint( 3, 33 );
+        RelationshipPropertyExistenceConstraint constraint1 = new RelationshipPropertyExistenceConstraint( 1, 11 );
+        RelationshipPropertyExistenceConstraint constraint2 = new RelationshipPropertyExistenceConstraint( 1, 22 );
+        RelationshipPropertyExistenceConstraint constraint3 = new RelationshipPropertyExistenceConstraint( 3, 33 );
 
         // When
         state.constraintDoAdd( constraint1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerSchemaTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerSchemaTest.java
@@ -30,8 +30,8 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -50,8 +50,8 @@ public class DiskLayerSchemaTest extends DiskLayerTest
         createUniquenessConstraint( label1, propertyKey );
         createUniquenessConstraint( label2, propertyKey );
 
-        createMandatoryNodePropertyConstraint( label2, propertyKey );
-        createMandatoryRelationshipPropertyConstraint( relType1, propertyKey );
+        createNodePropertyExistenceConstraint( label2, propertyKey );
+        createRelationshipPropertyExistenceConstraint( relType1, propertyKey );
 
         // When
         Set<PropertyConstraint> constraints = asSet( disk.constraintsGetAll() );
@@ -62,8 +62,8 @@ public class DiskLayerSchemaTest extends DiskLayerTest
         Set<PropertyConstraint> expectedConstraints = asSet(
                 new UniquenessConstraint( labelId( label1 ), propKeyId ),
                 new UniquenessConstraint( labelId( label2 ), propKeyId ),
-                new MandatoryNodePropertyConstraint( labelId( label2 ), propKeyId ),
-                new MandatoryRelationshipPropertyConstraint( relationshipTypeId( relType1 ), propKeyId ) );
+                new NodePropertyExistenceConstraint( labelId( label2 ), propKeyId ),
+                new RelationshipPropertyExistenceConstraint( relationshipTypeId( relType1 ), propKeyId ) );
 
         assertEquals( expectedConstraints, constraints );
     }
@@ -72,8 +72,8 @@ public class DiskLayerSchemaTest extends DiskLayerTest
     public void shouldListAllConstraintsForLabel()
     {
         // Given
-        createMandatoryNodePropertyConstraint( label1, propertyKey );
-        createMandatoryNodePropertyConstraint( label2, propertyKey );
+        createNodePropertyExistenceConstraint( label1, propertyKey );
+        createNodePropertyExistenceConstraint( label2, propertyKey );
 
         createUniquenessConstraint( label1, propertyKey );
 
@@ -83,7 +83,7 @@ public class DiskLayerSchemaTest extends DiskLayerTest
         // Then
         Set<NodePropertyConstraint> expectedConstraints = asSet(
                 new UniquenessConstraint( labelId( label1 ), propertyKeyId( propertyKey ) ),
-                new MandatoryNodePropertyConstraint( labelId( label1 ), propertyKeyId( propertyKey ) ) );
+                new NodePropertyExistenceConstraint( labelId( label1 ), propertyKeyId( propertyKey ) ) );
 
         assertEquals( expectedConstraints, constraints );
     }
@@ -95,8 +95,8 @@ public class DiskLayerSchemaTest extends DiskLayerTest
         createUniquenessConstraint( label1, propertyKey );
         createUniquenessConstraint( label1, otherPropertyKey );
 
-        createMandatoryNodePropertyConstraint( label1, propertyKey );
-        createMandatoryNodePropertyConstraint( label2, propertyKey );
+        createNodePropertyExistenceConstraint( label1, propertyKey );
+        createNodePropertyExistenceConstraint( label2, propertyKey );
 
         // When
         Set<NodePropertyConstraint> constraints = asSet(
@@ -105,7 +105,7 @@ public class DiskLayerSchemaTest extends DiskLayerTest
         // Then
         Set<NodePropertyConstraint> expectedConstraints = asSet(
                 new UniquenessConstraint( labelId( label1 ), propertyKeyId( propertyKey ) ),
-                new MandatoryNodePropertyConstraint( labelId( label1 ), propertyKeyId( propertyKey ) ) );
+                new NodePropertyExistenceConstraint( labelId( label1 ), propertyKeyId( propertyKey ) ) );
 
         assertEquals( expectedConstraints, constraints );
     }
@@ -114,9 +114,9 @@ public class DiskLayerSchemaTest extends DiskLayerTest
     public void shouldListAllConstraintsForRelationshipType()
     {
         // Given
-        createMandatoryRelationshipPropertyConstraint( relType1, propertyKey );
-        createMandatoryRelationshipPropertyConstraint( relType2, propertyKey );
-        createMandatoryRelationshipPropertyConstraint( relType2, otherPropertyKey );
+        createRelationshipPropertyExistenceConstraint( relType1, propertyKey );
+        createRelationshipPropertyExistenceConstraint( relType2, propertyKey );
+        createRelationshipPropertyExistenceConstraint( relType2, otherPropertyKey );
 
         // When
         int relTypeId = relationshipTypeId( relType2 );
@@ -124,8 +124,8 @@ public class DiskLayerSchemaTest extends DiskLayerTest
 
         // Then
         Set<RelationshipPropertyConstraint> expectedConstraints = IteratorUtil.<RelationshipPropertyConstraint>asSet(
-                new MandatoryRelationshipPropertyConstraint( relTypeId, propertyKeyId( propertyKey ) ),
-                new MandatoryRelationshipPropertyConstraint( relTypeId, propertyKeyId( otherPropertyKey ) ) );
+                new RelationshipPropertyExistenceConstraint( relTypeId, propertyKeyId( propertyKey ) ),
+                new RelationshipPropertyExistenceConstraint( relTypeId, propertyKeyId( otherPropertyKey ) ) );
 
         assertEquals( expectedConstraints, constraints );
     }
@@ -134,11 +134,11 @@ public class DiskLayerSchemaTest extends DiskLayerTest
     public void shouldListAllConstraintsForRelationshipTypeAndProperty()
     {
         // Given
-        createMandatoryRelationshipPropertyConstraint( relType1, propertyKey );
-        createMandatoryRelationshipPropertyConstraint( relType1, otherPropertyKey );
+        createRelationshipPropertyExistenceConstraint( relType1, propertyKey );
+        createRelationshipPropertyExistenceConstraint( relType1, otherPropertyKey );
 
-        createMandatoryRelationshipPropertyConstraint( relType2, propertyKey );
-        createMandatoryRelationshipPropertyConstraint( relType2, otherPropertyKey );
+        createRelationshipPropertyExistenceConstraint( relType2, propertyKey );
+        createRelationshipPropertyExistenceConstraint( relType2, otherPropertyKey );
 
         // When
         int relTypeId = relationshipTypeId( relType1 );
@@ -148,7 +148,7 @@ public class DiskLayerSchemaTest extends DiskLayerTest
 
         // Then
         Set<RelationshipPropertyConstraint> expectedConstraints = IteratorUtil.<RelationshipPropertyConstraint>asSet(
-                new MandatoryRelationshipPropertyConstraint( relTypeId, propKeyId ) );
+                new RelationshipPropertyExistenceConstraint( relTypeId, propKeyId ) );
 
         assertEquals( expectedConstraints, constraints );
     }
@@ -162,7 +162,7 @@ public class DiskLayerSchemaTest extends DiskLayerTest
         }
     }
 
-    private void createMandatoryNodePropertyConstraint( Label label, String propertyKey )
+    private void createNodePropertyExistenceConstraint( Label label, String propertyKey )
     {
         try ( Transaction tx = db.beginTx() )
         {
@@ -171,7 +171,7 @@ public class DiskLayerSchemaTest extends DiskLayerTest
         }
     }
 
-    private void createMandatoryRelationshipPropertyConstraint( RelationshipType type, String propertyKey )
+    private void createRelationshipPropertyExistenceConstraint( RelationshipType type, String propertyKey )
     {
         try ( Transaction tx = db.beginTx() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/SchemaCacheTest.java
@@ -27,14 +27,14 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.kernel.api.constraints.MandatoryNodePropertyConstraint;
-import org.neo4j.kernel.api.constraints.MandatoryRelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
-import org.neo4j.kernel.impl.store.record.MandatoryNodePropertyConstraintRule;
-import org.neo4j.kernel.impl.store.record.MandatoryRelationshipPropertyConstraintRule;
+import org.neo4j.kernel.impl.store.record.NodePropertyExistenceConstraintRule;
+import org.neo4j.kernel.impl.store.record.RelationshipPropertyExistenceConstraintRule;
 import org.neo4j.kernel.impl.store.record.UniquePropertyConstraintRule;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
@@ -45,8 +45,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
-import static org.neo4j.kernel.impl.store.record.MandatoryNodePropertyConstraintRule.mandatoryNodePropertyConstraintRule;
-import static org.neo4j.kernel.impl.store.record.MandatoryRelationshipPropertyConstraintRule.mandatoryRelPropertyConstraintRule;
+import static org.neo4j.kernel.impl.store.record.NodePropertyExistenceConstraintRule.nodePropertyExistenceConstraintRule;
+import static org.neo4j.kernel.impl.store.record.RelationshipPropertyExistenceConstraintRule.relPropertyExistenceConstraintRule;
 import static org.neo4j.kernel.impl.store.record.UniquePropertyConstraintRule.uniquenessConstraintRule;
 
 public class SchemaCacheTest
@@ -106,14 +106,14 @@ public class SchemaCacheTest
         // WHEN
         cache.addSchemaRule( uniquenessConstraintRule( 0l, 1, 2, 133l ) );
         cache.addSchemaRule( uniquenessConstraintRule( 1l, 3, 4, 133l ) );
-        cache.addSchemaRule( mandatoryRelPropertyConstraintRule( 2l, 5, 6 ) );
-        cache.addSchemaRule( mandatoryNodePropertyConstraintRule( 3l, 7, 8 ) );
+        cache.addSchemaRule( relPropertyExistenceConstraintRule( 2l, 5, 6 ) );
+        cache.addSchemaRule( nodePropertyExistenceConstraintRule( 3l, 7, 8 ) );
 
         // THEN
         assertEquals(
                 asSet( new UniquenessConstraint( 1, 2 ), new UniquenessConstraint( 3, 4 ),
-                        new MandatoryRelationshipPropertyConstraint( 5, 6 ),
-                        new MandatoryNodePropertyConstraint( 7, 8 ) ),
+                        new RelationshipPropertyExistenceConstraint( 5, 6 ),
+                        new NodePropertyExistenceConstraint( 7, 8 ) ),
                 asSet( cache.constraints() ) );
 
         assertEquals(
@@ -129,11 +129,11 @@ public class SchemaCacheTest
                 asSet( cache.constraintsForLabelAndProperty( 1, 3 ) ) );
 
         assertEquals(
-                asSet( new MandatoryRelationshipPropertyConstraint( 5, 6 ) ),
+                asSet( new RelationshipPropertyExistenceConstraint( 5, 6 ) ),
                 asSet( cache.constraintsForRelationshipType( 5 ) ) );
 
         assertEquals(
-                asSet( new MandatoryRelationshipPropertyConstraint( 5, 6 ) ),
+                asSet( new RelationshipPropertyExistenceConstraint( 5, 6 ) ),
                 asSet( cache.constraintsForRelationshipTypeAndProperty( 5, 6 ) ) );
     }
 
@@ -217,7 +217,7 @@ public class SchemaCacheTest
         // Given
         UniquePropertyConstraintRule rule1 = uniquenessConstraintRule( 0, 1, 1, 0 );
         UniquePropertyConstraintRule rule2 = uniquenessConstraintRule( 1, 2, 1, 0 );
-        MandatoryNodePropertyConstraintRule rule3 = mandatoryNodePropertyConstraintRule( 2, 1, 2 );
+        NodePropertyExistenceConstraintRule rule3 = nodePropertyExistenceConstraintRule( 2, 1, 2 );
 
         SchemaCache cache = newSchemaCache( rule1, rule2, rule3 );
 
@@ -235,7 +235,7 @@ public class SchemaCacheTest
         // Given
         UniquePropertyConstraintRule rule1 = uniquenessConstraintRule( 0, 1, 1, 0 );
         UniquePropertyConstraintRule rule2 = uniquenessConstraintRule( 1, 2, 1, 0 );
-        MandatoryNodePropertyConstraintRule rule3 = mandatoryNodePropertyConstraintRule( 2, 1, 2 );
+        NodePropertyExistenceConstraintRule rule3 = nodePropertyExistenceConstraintRule( 2, 1, 2 );
 
         SchemaCache cache = newSchemaCache( rule1, rule2, rule3 );
 
@@ -250,9 +250,9 @@ public class SchemaCacheTest
     public void shouldListConstraintsForRelationshipType()
     {
         // Given
-        MandatoryRelationshipPropertyConstraintRule rule1 = mandatoryRelPropertyConstraintRule( 0, 1, 1 );
-        MandatoryRelationshipPropertyConstraintRule rule2 = mandatoryRelPropertyConstraintRule( 0, 2, 1 );
-        MandatoryRelationshipPropertyConstraintRule rule3 = mandatoryRelPropertyConstraintRule( 0, 1, 2 );
+        RelationshipPropertyExistenceConstraintRule rule1 = relPropertyExistenceConstraintRule( 0, 1, 1 );
+        RelationshipPropertyExistenceConstraintRule rule2 = relPropertyExistenceConstraintRule( 0, 2, 1 );
+        RelationshipPropertyExistenceConstraintRule rule3 = relPropertyExistenceConstraintRule( 0, 1, 2 );
 
         SchemaCache cache = newSchemaCache( rule1, rule2, rule3 );
 
@@ -268,9 +268,9 @@ public class SchemaCacheTest
     public void shouldListConstraintsForRelationshipTypeAndProperty()
     {
         // Given
-        MandatoryRelationshipPropertyConstraintRule rule1 = mandatoryRelPropertyConstraintRule( 0, 1, 1 );
-        MandatoryRelationshipPropertyConstraintRule rule2 = mandatoryRelPropertyConstraintRule( 0, 2, 1 );
-        MandatoryRelationshipPropertyConstraintRule rule3 = mandatoryRelPropertyConstraintRule( 0, 1, 2 );
+        RelationshipPropertyExistenceConstraintRule rule1 = relPropertyExistenceConstraintRule( 0, 1, 1 );
+        RelationshipPropertyExistenceConstraintRule rule2 = relPropertyExistenceConstraintRule( 0, 2, 1 );
+        RelationshipPropertyExistenceConstraintRule rule3 = relPropertyExistenceConstraintRule( 0, 1, 2 );
 
         SchemaCache cache = newSchemaCache( rule1, rule2, rule3 );
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertTest.java
@@ -1460,7 +1460,7 @@ public class BatchInsertTest
     }
 
     @Test
-    public void shouldCreateMandatoryNodePropertyConstraint() throws Exception
+    public void shouldCreateNodePropertyExistenceConstraint() throws Exception
     {
         // Given
         Label label = label( "Person" );
@@ -1490,7 +1490,7 @@ public class BatchInsertTest
                 db.createNode( label );
                 tx.success();
             }
-            fail( "Mandatory node property constraint was violated, exception expected" );
+            fail( "Node property existence constraint was violated, exception expected" );
         }
         catch ( ConstraintViolationException e )
         {
@@ -1506,7 +1506,7 @@ public class BatchInsertTest
     }
 
     @Test
-    public void shouldCreateMandatoryRelationshipPropertyConstraint() throws Exception
+    public void shouldCreateRelationshipPropertyExistenceConstraint() throws Exception
     {
         // Given
         RelationshipType type = DynamicRelationshipType.withName( "KNOWS" );
@@ -1536,7 +1536,7 @@ public class BatchInsertTest
                 db.createNode().createRelationshipTo( db.createNode(), type );
                 tx.success();
             }
-            fail( "Mandatory relationship property constraint was violated, exception expected" );
+            fail( "Relationship property existence constraint was violated, exception expected" );
         }
         catch ( ConstraintViolationException e )
         {
@@ -1552,7 +1552,7 @@ public class BatchInsertTest
     }
 
     @Test
-    public void shouldAllowCreationOfIndexAndMandatoryPropertyConstraintOnSameLabelAndProperty() throws Exception
+    public void shouldAllowCreationOfIndexAndExistenceConstraintOnSameLabelAndProperty() throws Exception
     {
         // Given
         Label label = label( "Person" );
@@ -1590,7 +1590,7 @@ public class BatchInsertTest
     }
 
     @Test
-    public void shouldAllowCreationOfUniquenessAndMandatoryPropertyConstraintOnSameLabelAndProperty() throws Exception
+    public void shouldAllowCreationOfUniquenessAndExistenceConstraintOnSameLabelAndProperty() throws Exception
     {
         // Given
         Label label = label( "Person" );
@@ -1613,7 +1613,7 @@ public class BatchInsertTest
                 for ( ConstraintDefinition constraint : constraints )
                 {
                     if ( constraint.getConstraintType() == ConstraintType.UNIQUENESS ||
-                         constraint.getConstraintType() == ConstraintType.MANDATORY_NODE_PROPERTY )
+                         constraint.getConstraintType() == ConstraintType.NODE_PROPERTY_EXISTENCE )
                     {
                         assertEquals( label.name(), constraint.getLabel().name() );
                         assertEquals( property, single( constraint.getPropertyKeys() ) );
@@ -1704,7 +1704,7 @@ public class BatchInsertTest
     }
 
     @Test
-    public void shouldNotAllowDuplicatedMandatoryNodePropertyConstraints() throws Exception
+    public void shouldNotAllowDuplicatedNodePropertyExistenceConstraints() throws Exception
     {
         // Given
         Label label = label( "Person" );
@@ -1723,13 +1723,13 @@ public class BatchInsertTest
         {
             // Then
             assertEquals(
-                    "Mandatory node property constraint for given {label;property} already exists",
+                    "Node property existence constraint for given {label;property} already exists",
                     e.getMessage() );
         }
     }
 
     @Test
-    public void shouldNotAllowDuplicatedMandatoryRelationshipPropertyConstraints() throws Exception
+    public void shouldNotAllowDuplicatedRelationshipPropertyExistenceConstraints() throws Exception
     {
         // Given
         RelationshipType type = DynamicRelationshipType.withName( "KNOWS" );
@@ -1748,7 +1748,7 @@ public class BatchInsertTest
         {
             // Then
             assertEquals(
-                    "Mandatory relationship property constraint for given {type;property} already exists",
+                    "Relationship property existence constraint for given {type;property} already exists",
                     e.getMessage() );
         }
     }

--- a/community/server/src/docs/dev/rest-api/constraints.asciidoc
+++ b/community/server/src/docs/dev/rest-api/constraints.asciidoc
@@ -9,23 +9,23 @@ include::get-all-uniqueness-constraints-for-a-label.asciidoc[]
 
 include::drop-uniqueness-constraint.asciidoc[]
 
-include::create-mandatory-node-property-constraint.asciidoc[]
+include::create-node-property-existence-constraint.asciidoc[]
 
-include::get-a-specific-mandatory-node-property-constraint.asciidoc[]
+include::get-a-specific-node-property-existence-constraint.asciidoc[]
 
-include::get-all-mandatory-node-property-constraints-for-a-label.asciidoc[]
+include::get-all-node-property-existence-constraints-for-a-label.asciidoc[]
 
-include::drop-mandatory-node-property-constraint.asciidoc[]
+include::drop-node-property-existence-constraint.asciidoc[]
 
 include::get-all-constraints-for-a-label.asciidoc[]
 
-include::create-mandatory-relationship-property-constraint.asciidoc[]
+include::create-relationship-property-existence-constraint.asciidoc[]
 
-include::get-a-specific-mandatory-relationship-property-constraint.asciidoc[]
+include::get-a-specific-relationship-property-existence-constraint.asciidoc[]
 
-include::get-all-mandatory-relationship-property-constraints-for-a-type.asciidoc[]
+include::get-all-relationship-property-existence-constraints-for-a-type.asciidoc[]
 
-include::drop-mandatory-relationship-property-constraint.asciidoc[]
+include::drop-relationship-property-existence-constraint.asciidoc[]
 
 include::get-all-constraints.asciidoc[]
 

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/ConstraintDefinitionRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/ConstraintDefinitionRepresentation.java
@@ -42,10 +42,10 @@ public class ConstraintDefinitionRepresentation extends MappingRepresentation
         switch ( constraintDefinition.getConstraintType() )
         {
         case UNIQUENESS:
-        case MANDATORY_NODE_PROPERTY:
+        case NODE_PROPERTY_EXISTENCE:
             serializer.putString( "label", constraintDefinition.getLabel().name() );
             break;
-        case MANDATORY_RELATIONSHIP_PROPERTY:
+        case RELATIONSHIP_PROPERTY_EXISTENCE:
             serializer.putString( "relationshipType", constraintDefinition.getRelationshipType().name() );
             break;
         default:

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
@@ -1714,7 +1714,7 @@ public class DatabaseActions
             @Override
             public boolean test( ConstraintDefinition item )
             {
-                return item.isConstraintType( ConstraintType.MANDATORY_NODE_PROPERTY ) &&
+                return item.isConstraintType( ConstraintType.NODE_PROPERTY_EXISTENCE ) &&
                        propertyKeysSet.equals( asSet( item.getPropertyKeys() ) );
             }
         };
@@ -1727,7 +1727,7 @@ public class DatabaseActions
             @Override
             public boolean test( ConstraintDefinition item )
             {
-                return item.isConstraintType( ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY ) &&
+                return item.isConstraintType( ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE ) &&
                        propertyKeysSet.equals( asSet( item.getPropertyKeys() ) );
             }
         };
@@ -1754,12 +1754,12 @@ public class DatabaseActions
     public Representation getLabelExistenceConstraints( String labelName )
     {
         return new ListRepresentation( CONSTRAINT_DEFINITION, map( CONSTRAINT_DEF_TO_REPRESENTATION,
-                filteredNodeConstraints( labelName, ConstraintType.MANDATORY_NODE_PROPERTY ) ) );
+                filteredNodeConstraints( labelName, ConstraintType.NODE_PROPERTY_EXISTENCE ) ) );
     }
 
     public Representation getRelationshipTypeExistenceConstraints( String typeName )
     {
         return new ListRepresentation( CONSTRAINT_DEFINITION, map( CONSTRAINT_DEF_TO_REPRESENTATION,
-                filteredRelationshipConstraints( typeName, ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY ) ) );
+                filteredRelationshipConstraints( typeName, ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE ) ) );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/SchemaConstraintsDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/SchemaConstraintsDocIT.java
@@ -79,13 +79,13 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     }
 
     /**
-     * Create mandatory node property constraint.
-     * Create a mandatory node property constraint for a label and a property.
+     * Create node property existence constraint.
+     * Create a node property existence constraint for a label and a property.
      */
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void createNodeMandatoryPropertyConstraint() throws JsonParseException
+    public void createNodePropertyExistenceConstraint() throws JsonParseException
     {
         data.get();
 
@@ -98,7 +98,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         Map<String, Object> serialized = jsonToMap( result );
 
         Map<String, Object> constraint = new HashMap<>(  );
-        constraint.put( "type", ConstraintType.MANDATORY_NODE_PROPERTY.name() );
+        constraint.put( "type", ConstraintType.NODE_PROPERTY_EXISTENCE.name() );
         constraint.put( "label", labelName );
         constraint.put( "property_keys", singletonList( propertyKey ) );
 
@@ -106,13 +106,13 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     }
 
     /**
-     * Create mandatory relationship property constraint.
-     * Create a mandatory relationship property constraint for a relationship type and a property.
+     * Create relationship property existence constraint.
+     * Create a relationship property existence constraint for a relationship type and a property.
      */
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void createRelationshipMandatoryPropertyConstraint() throws JsonParseException
+    public void createRelationshipPropertyExistenceConstraint() throws JsonParseException
     {
         data.get();
 
@@ -125,7 +125,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         Map<String, Object> serialized = jsonToMap( result );
 
         Map<String, Object> constraint = new HashMap<>(  );
-        constraint.put( "type", ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY.name() );
+        constraint.put( "type", ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE.name() );
         constraint.put( "relationshipType", relationshipTypeName );
         constraint.put( "property_keys", singletonList( propertyKey ) );
 
@@ -160,18 +160,18 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     }
 
     /**
-     * Get a specific mandatory node property constraint.
-     * Get a specific mandatory node property constraint for a label and a property.
+     * Get a specific node property existence constraint.
+     * Get a specific node property existence constraint for a label and a property.
      */
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void getLabelMandatoryPropertyConstraint() throws JsonParseException
+    public void getLabelPropertyExistenceConstraint() throws JsonParseException
     {
         data.get();
 
         String labelName = labels.newInstance(), propertyKey = properties.newInstance();
-        createLabelMandatoryPropertyConstraint( labelName, propertyKey );
+        createLabelPropertyExistenceConstraint( labelName, propertyKey );
 
         String result = gen.get().noGraph().expectedStatus( 200 ).get(
                 getSchemaConstraintLabelExistencePropertyUri( labelName, propertyKey ) ).entity();
@@ -179,7 +179,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         List<Map<String, Object>> serializedList = jsonToList( result );
 
         Map<String, Object> constraint = new HashMap<>(  );
-        constraint.put( "type", ConstraintType.MANDATORY_NODE_PROPERTY.name() );
+        constraint.put( "type", ConstraintType.NODE_PROPERTY_EXISTENCE.name() );
         constraint.put( "label", labelName );
         constraint.put( "property_keys", singletonList( propertyKey ) );
 
@@ -187,18 +187,18 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     }
 
     /**
-     * Get a specific mandatory relationship property constraint.
-     * Get a specific mandatory relationship property constraint for a label and a property.
+     * Get a specific relationship property existence constraint.
+     * Get a specific relationship property existence constraint for a label and a property.
      */
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void getRelationshipTypeMandatoryPropertyConstraint() throws JsonParseException
+    public void getRelationshipTypePropertyExistenceConstraint() throws JsonParseException
     {
         data.get();
 
         String typeName = relationshipTypes.newInstance(), propertyKey = properties.newInstance();
-        createRelationshipTypeMandatoryPropertyConstraint( typeName, propertyKey );
+        createRelationshipTypePropertyExistenceConstraint( typeName, propertyKey );
 
         String result = gen.get().noGraph().expectedStatus( 200 ).get(
                 getSchemaRelationshipConstraintTypeExistencePropertyUri( typeName, propertyKey ) ).entity();
@@ -206,7 +206,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         List<Map<String, Object>> serializedList = jsonToList( result );
 
         Map<String, Object> constraint = new HashMap<>(  );
-        constraint.put( "type", ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY.name() );
+        constraint.put( "type", ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE.name() );
         constraint.put( "relationshipType", typeName );
         constraint.put( "property_keys", singletonList( propertyKey ) );
 
@@ -246,31 +246,31 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     }
 
     /**
-     * Get all mandatory node property constraints for a label.
+     * Get all node property existence constraints for a label.
      */
     @SuppressWarnings( "unchecked" )
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void getLabelMandatoryPropertyConstraints() throws JsonParseException
+    public void getLabelPropertyExistenceConstraints() throws JsonParseException
     {
         data.get();
 
         String labelName = labels.newInstance(), propertyKey1 = properties.newInstance(), propertyKey2 = properties.newInstance();
-        createLabelMandatoryPropertyConstraint( labelName, propertyKey1 );
-        createLabelMandatoryPropertyConstraint( labelName, propertyKey2 );
+        createLabelPropertyExistenceConstraint( labelName, propertyKey1 );
+        createLabelPropertyExistenceConstraint( labelName, propertyKey2 );
 
         String result = gen.get().noGraph().expectedStatus( 200 ).get( getSchemaConstraintLabelExistenceUri( labelName ) ).entity();
 
         List<Map<String, Object>> serializedList = jsonToList( result );
 
         Map<String, Object> constraint1 = new HashMap<>(  );
-        constraint1.put( "type", ConstraintType.MANDATORY_NODE_PROPERTY.name() );
+        constraint1.put( "type", ConstraintType.NODE_PROPERTY_EXISTENCE.name() );
         constraint1.put( "label", labelName );
         constraint1.put( "property_keys", singletonList( propertyKey1 ) );
 
         Map<String, Object> constraint2 = new HashMap<>(  );
-        constraint2.put( "type", ConstraintType.MANDATORY_NODE_PROPERTY.name() );
+        constraint2.put( "type", ConstraintType.NODE_PROPERTY_EXISTENCE.name() );
         constraint2.put( "label", labelName );
         constraint2.put( "property_keys", singletonList( propertyKey2 ) );
 
@@ -278,20 +278,20 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     }
 
     /**
-     * Get all mandatory relationship property constraints for a type.
+     * Get all relationship property existence constraints for a type.
      */
     @SuppressWarnings( "unchecked" )
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void getRelationshipTypeMandatoryPropertyConstraints() throws JsonParseException
+    public void getRelationshipTypePropertyExistenceConstraints() throws JsonParseException
     {
         data.get();
 
         String typeName = relationshipTypes.newInstance(), propertyKey1 = properties.newInstance(),
                 propertyKey2 = properties.newInstance();
-        createRelationshipTypeMandatoryPropertyConstraint( typeName, propertyKey1 );
-        createRelationshipTypeMandatoryPropertyConstraint( typeName, propertyKey2 );
+        createRelationshipTypePropertyExistenceConstraint( typeName, propertyKey1 );
+        createRelationshipTypePropertyExistenceConstraint( typeName, propertyKey2 );
 
         String result = gen.get().noGraph().expectedStatus( 200 )
                 .get( getSchemaRelationshipConstraintTypeExistenceUri( typeName ) ).entity();
@@ -299,12 +299,12 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         List<Map<String, Object>> serializedList = jsonToList( result );
 
         Map<String, Object> constraint1 = new HashMap<>(  );
-        constraint1.put( "type", ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY.name() );
+        constraint1.put( "type", ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE.name() );
         constraint1.put( "relationshipType", typeName );
         constraint1.put( "property_keys", singletonList( propertyKey1 ) );
 
         Map<String, Object> constraint2 = new HashMap<>(  );
-        constraint2.put( "type", ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY.name() );
+        constraint2.put( "type", ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE.name() );
         constraint2.put( "relationshipType", typeName );
         constraint2.put( "property_keys", singletonList( propertyKey2 ) );
 
@@ -324,7 +324,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
 
         String labelName = labels.newInstance(), propertyKey1 = properties.newInstance(), propertyKey2 = properties.newInstance();
         createLabelUniquenessPropertyConstraint( labelName, propertyKey1 );
-        createLabelMandatoryPropertyConstraint( labelName, propertyKey2 );
+        createLabelPropertyExistenceConstraint( labelName, propertyKey2 );
 
         String result = gen.get().noGraph().expectedStatus( 200 ).get( getSchemaConstraintLabelUri( labelName ) ).entity();
 
@@ -336,7 +336,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         constraint1.put( "property_keys", singletonList( propertyKey1 ) );
 
         Map<String, Object> constraint2 = new HashMap<>(  );
-        constraint2.put( "type", ConstraintType.MANDATORY_NODE_PROPERTY.name() );
+        constraint2.put( "type", ConstraintType.NODE_PROPERTY_EXISTENCE.name() );
         constraint2.put( "label", labelName );
         constraint2.put( "property_keys", singletonList( propertyKey2 ) );
 
@@ -357,7 +357,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         String labelName1 = labels.newInstance(), propertyKey1 = properties.newInstance();
         String labelName2 = labels.newInstance(), propertyKey2 = properties.newInstance();
         createLabelUniquenessPropertyConstraint( labelName1, propertyKey1 );
-        createLabelMandatoryPropertyConstraint( labelName2, propertyKey2 );
+        createLabelPropertyExistenceConstraint( labelName2, propertyKey2 );
 
         String result = gen.get().noGraph().expectedStatus( 200 ).get( getSchemaConstraintUri() ).entity();
 
@@ -369,7 +369,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         constraint1.put( "property_keys", singletonList( propertyKey1 ) );
 
         Map<String, Object> constraint2 = new HashMap<>(  );
-        constraint2.put( "type", ConstraintType.MANDATORY_NODE_PROPERTY.name() );
+        constraint2.put( "type", ConstraintType.NODE_PROPERTY_EXISTENCE.name() );
         constraint2.put( "label", labelName2 );
         constraint2.put( "property_keys", singletonList( propertyKey2 ) );
 
@@ -397,18 +397,18 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     }
 
     /**
-     * Drop mandatory node property constraint.
-     * Drop mandatory node property constraint for a label and a property.
+     * Drop node property existence constraint.
+     * Drop node property existence constraint for a label and a property.
      */
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void drop_mandatory_node_property_constraint() throws Exception
+    public void drop_node_property_existence_constraint() throws Exception
     {
         data.get();
 
         String labelName = labels.newInstance(), propertyKey = properties.newInstance();
-        ConstraintDefinition constraintDefinition = createLabelMandatoryPropertyConstraint( labelName, propertyKey );
+        ConstraintDefinition constraintDefinition = createLabelPropertyExistenceConstraint( labelName, propertyKey );
         assertThat( getConstraints( graphdb(), label( labelName ) ), containsOnly( constraintDefinition ) );
 
         gen.get().noGraph().expectedStatus( 204 ).delete( getSchemaConstraintLabelExistencePropertyUri( labelName, propertyKey ) ).entity();
@@ -417,19 +417,19 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
     }
 
     /**
-     * Drop mandatory relationship property constraint.
-     * Drop mandatory relationship property constraint for a relationship type and a property.
+     * Drop relationship property existence constraint.
+     * Drop relationship property existence constraint for a relationship type and a property.
      */
     @Documented
     @Test
     @GraphDescription.Graph( nodes = {} )
-    public void drop_mandatory_relationship_property_constraint() throws Exception
+    public void drop_relationship_property_existence_constraint() throws Exception
     {
         data.get();
 
         String typeName = relationshipTypes.newInstance(), propertyKey = properties.newInstance();
         DynamicRelationshipType type = DynamicRelationshipType.withName( typeName );
-        ConstraintDefinition constraintDefinition = createRelationshipTypeMandatoryPropertyConstraint( typeName,
+        ConstraintDefinition constraintDefinition = createRelationshipTypePropertyExistenceConstraint( typeName,
                 propertyKey );
         assertThat( getConstraints( graphdb(), type ), containsOnly( constraintDefinition ) );
 
@@ -486,7 +486,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         }
     }
 
-    private ConstraintDefinition createLabelMandatoryPropertyConstraint( String labelName, String propertyKey )
+    private ConstraintDefinition createLabelPropertyExistenceConstraint( String labelName, String propertyKey )
     {
         try ( Transaction tx = graphdb().beginTx() )
         {
@@ -497,7 +497,7 @@ public class SchemaConstraintsDocIT extends AbstractRestFunctionalTestBase
         }
     }
 
-    private ConstraintDefinition createRelationshipTypeMandatoryPropertyConstraint( String typeName,
+    private ConstraintDefinition createRelationshipTypePropertyExistenceConstraint( String typeName,
             String propertyKey )
     {
         try ( Transaction tx = graphdb().beginTx() )

--- a/community/server/src/test/java/org/neo4j/server/rest/domain/GraphDbHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/domain/GraphDbHelper.java
@@ -400,7 +400,7 @@ public class GraphDbHelper
         {
             Iterable<ConstraintDefinition> definitions = filterByConstraintTypeAndPropertyKey(
                     database.getGraph().schema().getConstraints( label( labelName ) ),
-                    ConstraintType.MANDATORY_NODE_PROPERTY, propertyKey );
+                    ConstraintType.NODE_PROPERTY_EXISTENCE, propertyKey );
             tx.success();
             return definitions;
         }
@@ -414,7 +414,7 @@ public class GraphDbHelper
             DynamicRelationshipType type = DynamicRelationshipType.withName( typeName );
             Iterable<ConstraintDefinition> definitions = filterByConstraintTypeAndPropertyKey(
                     database.getGraph().schema().getConstraints( type ),
-                    ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY, propertyKey );
+                    ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE, propertyKey );
             tx.success();
             return definitions;
         }

--- a/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseActionsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/DatabaseActionsTest.java
@@ -1450,7 +1450,7 @@ public class DatabaseActionsTest
         Map<?, ?> definition = (Map<?, ?>) serialized.get( 0 );
         assertEquals( labelName, definition.get( "label" ) );
         assertEquals( Collections.singletonList( propertyKey ), definition.get( "property_keys" ) );
-        assertEquals( ConstraintType.MANDATORY_NODE_PROPERTY.name(), definition.get( "type" ) );
+        assertEquals( ConstraintType.NODE_PROPERTY_EXISTENCE.name(), definition.get( "type" ) );
     }
 
     @Test
@@ -1473,7 +1473,7 @@ public class DatabaseActionsTest
         Map<?, ?> definition = (Map<?, ?>) serialized.get( 0 );
         assertEquals( typeName, definition.get( "relationshipType" ) );
         assertEquals( Collections.singletonList( propertyKey ), definition.get( "property_keys" ) );
-        assertEquals( ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY.name(), definition.get( "type" ) );
+        assertEquals( ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE.name(), definition.get( "type" ) );
     }
 
     @Test

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
@@ -450,12 +450,12 @@ public class Schema extends TransactionProvidingApp
     private static boolean isNodeConstraint( ConstraintDefinition constraint )
     {
         return constraint.isConstraintType( ConstraintType.UNIQUENESS ) ||
-               constraint.isConstraintType( ConstraintType.MANDATORY_NODE_PROPERTY );
+               constraint.isConstraintType( ConstraintType.NODE_PROPERTY_EXISTENCE );
     }
 
     private static boolean isRelationshipConstraint( ConstraintDefinition constraint )
     {
-        return constraint.isConstraintType( ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY );
+        return constraint.isConstraintType( ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE );
     }
 
     private boolean isMatchingConstraint( ConstraintDefinition constraint, final String property )

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -870,7 +870,7 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
-    public void canListMandatoryNodePropertyConstraints() throws Exception
+    public void canListNodePropertyExistenceConstraints() throws Exception
     {
         // GIVEN
         Label label = label( "Person" );
@@ -883,7 +883,7 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
-    public void canListMandatoryRelationshipPropertyConstraints() throws Exception
+    public void canListRelationshipPropertyExistenceConstraints() throws Exception
     {
         // GIVEN
         RelationshipType relType = DynamicRelationshipType.withName( "KNOWS" );
@@ -909,7 +909,7 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
-    public void canListMandatoryNodePropertyConstraintsByLabel() throws Exception
+    public void canListNodePropertyExistenceConstraintsByLabel() throws Exception
     {
         // GIVEN
         Label label1 = label( "Person" );
@@ -922,7 +922,7 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
-    public void canListMandatoryRelationshipPropertyConstraintsByType() throws Exception
+    public void canListRelationshipPropertyExistenceConstraintsByType() throws Exception
     {
         // GIVEN
         RelationshipType relType = DynamicRelationshipType.withName( "KNOWS" );
@@ -935,7 +935,7 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
-    public void canListMandatoryRelationshipPropertyConstraintsByTypeAndProperty() throws Exception
+    public void canListRelationshipPropertyExistenceConstraintsByTypeAndProperty() throws Exception
     {
         // GIVEN
         RelationshipType relType = DynamicRelationshipType.withName( "KNOWS" );
@@ -949,7 +949,7 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
-    public void canListBothNodeAndRelationshipMandatoryPropertyConstraints() throws Exception
+    public void canListBothNodeAndRelationshipPropertyExistenceConstraints() throws Exception
     {
         // GIVEN
         Label label = DynamicLabel.label( "Person" );
@@ -971,7 +971,7 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
-    public void canListBothNodeAndRelationshipMandatoryPropertyConstraintsByLabelAndType() throws Exception
+    public void canListBothNodeAndRelationshipPropertyExistenceConstraintsByLabelAndType() throws Exception
     {
         // GIVEN
         Label label = DynamicLabel.label( "Person" );
@@ -1036,7 +1036,7 @@ public class TestApps extends AbstractShellTest
     }
 
     @Test
-    public void canListMandatoryNodePropertyConstraintsByLabelAndProperty() throws Exception
+    public void canListNodePropertyExistenceConstraintsByLabelAndProperty() throws Exception
     {
         // GIVEN
         Label label1 = label( "Person" );

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -879,7 +879,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls", "ON \\(person:Person\\) ASSERT person.name IS NOT NULL" );
+        executeCommand( "schema ls", "ON \\(person:Person\\) ASSERT exists\\(person.name\\)" );
     }
 
     @Test
@@ -892,7 +892,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+        executeCommand( "schema ls", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT exists\\(knows.since\\)" );
     }
 
     @Test
@@ -918,7 +918,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls -l :Person", "ON \\(person:Person\\) ASSERT person.name IS NOT NULL" );
+        executeCommand( "schema ls -l :Person", "ON \\(person:Person\\) ASSERT exists\\(person.name\\)" );
     }
 
     @Test
@@ -931,7 +931,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls -r :KNOWS", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+        executeCommand( "schema ls -r :KNOWS", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT exists\\(knows.since\\)" );
     }
 
     @Test
@@ -944,7 +944,8 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls -r :KNOWS -p since", "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+        executeCommand( "schema ls -r :KNOWS -p since",
+                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT exists\\(knows.since\\)" );
     }
 
     @Test
@@ -965,8 +966,8 @@ public class TestApps extends AbstractShellTest
 
         // THEN
         executeCommand( "schema ls",
-                "ON \\(person:Person\\) ASSERT person.name IS NOT NULL",
-                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+                "ON \\(person:Person\\) ASSERT exists\\(person.name\\)",
+                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT exists\\(knows.since\\)" );
     }
 
     @Test
@@ -987,8 +988,8 @@ public class TestApps extends AbstractShellTest
 
         // THEN
         executeCommand( "schema ls -l :Person -r :KNOWS",
-                "ON \\(person:Person\\) ASSERT person.name IS NOT NULL",
-                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+                "ON \\(person:Person\\) ASSERT exists\\(person.name\\)",
+                "ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT exists\\(knows.since\\)" );
     }
 
     @Test
@@ -1017,8 +1018,8 @@ public class TestApps extends AbstractShellTest
                 "  ON :Person\\(name\\) ONLINE \\(for uniqueness constraint\\)",
                 "Constraints",
                 "  ON \\(person:Person\\) ASSERT person.name IS UNIQUE",
-                "  ON \\(person:Person\\) ASSERT person.name IS NOT NULL",
-                "  ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT knows.since IS NOT NULL" );
+                "  ON \\(person:Person\\) ASSERT exists\\(person.name\\)",
+                "  ON \\(\\)-\\[knows:KNOWS\\]-\\(\\) ASSERT exists\\(knows.since\\)" );
     }
 
     @Test
@@ -1044,7 +1045,7 @@ public class TestApps extends AbstractShellTest
         finishTx();
 
         // WHEN / THEN
-        executeCommand( "schema ls -l :Person -p name", "ON \\(person:Person\\) ASSERT person.name IS NOT NULL" );
+        executeCommand( "schema ls -l :Person -p name", "ON \\(person:Person\\) ASSERT exists\\(person.name\\)" );
     }
 
     @Test

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
@@ -39,8 +39,8 @@ import org.neo4j.kernel.TopLevelTransaction;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.kernel.impl.coreapi.schema.MandatoryNodePropertyConstraintDefinition;
-import org.neo4j.kernel.impl.coreapi.schema.MandatoryRelationshipPropertyConstraintDefinition;
+import org.neo4j.kernel.impl.coreapi.schema.NodePropertyExistenceConstraintDefinition;
+import org.neo4j.kernel.impl.coreapi.schema.RelationshipPropertyExistenceConstraintDefinition;
 import org.neo4j.kernel.impl.coreapi.schema.UniquenessConstraintDefinition;
 import org.neo4j.test.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterRule;
@@ -63,13 +63,13 @@ import static org.neo4j.kernel.api.ConstraintHaIT.*;
 
 @RunWith( Suite.class )
 @SuiteClasses( {
-        MandatoryNodePropertyConstraintHaIT.class,
-        MandatoryRelationshipPropertyConstraintHaIT.class,
+        NodePropertyExistenceConstraintHaIT.class,
+        RelationshipPropertyExistenceConstraintHaIT.class,
         UniquenessConstraintHaIT.class
 } )
 public class ConstraintHaIT
 {
-    public static class MandatoryNodePropertyConstraintHaIT extends AbstractConstraintHaIT
+    public static class NodePropertyExistenceConstraintHaIT extends AbstractConstraintHaIT
     {
         @Override
         protected void createConstraint( GraphDatabaseService db, String type, String value )
@@ -113,11 +113,11 @@ public class ConstraintHaIT
         @Override
         protected Class<? extends ConstraintDefinition> constraintDefinitionClass()
         {
-            return MandatoryNodePropertyConstraintDefinition.class;
+            return NodePropertyExistenceConstraintDefinition.class;
         }
     }
 
-    public static class MandatoryRelationshipPropertyConstraintHaIT extends AbstractConstraintHaIT
+    public static class RelationshipPropertyExistenceConstraintHaIT extends AbstractConstraintHaIT
     {
         @Override
         protected void createConstraint( GraphDatabaseService db, String type, String value )
@@ -166,7 +166,7 @@ public class ConstraintHaIT
         @Override
         protected Class<? extends ConstraintDefinition> constraintDefinitionClass()
         {
-            return MandatoryRelationshipPropertyConstraintDefinition.class;
+            return RelationshipPropertyExistenceConstraintDefinition.class;
         }
     }
 
@@ -415,7 +415,7 @@ public class ConstraintHaIT
 
         private static void validateLabelOrRelationshipType( ConstraintDefinition constraint )
         {
-            if ( constraint.isConstraintType( ConstraintType.MANDATORY_RELATIONSHIP_PROPERTY ) )
+            if ( constraint.isConstraintType( ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE ) )
             {
                 assertEquals( TYPE, constraint.getRelationshipType().name() );
             }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
@@ -96,8 +96,8 @@ public class PropertyConstraintsStressIT
     {
         return Arrays.asList( new Object[][]{
                 {UNIQUE_PROPERTY_CONSTRAINT_OPS},
-                {MANDATORY_NODE_PROPERTY_CONSTRAINT_OPS},
-                {MANDATORY_REL_PROPERTY_CONSTRAINT_OPS},
+                {NODE_PROPERTY_EXISTENCE_CONSTRAINT_OPS},
+                {REL_PROPERTY_EXISTENCE_CONSTRAINT_OPS},
         } );
     }
 
@@ -450,7 +450,7 @@ public class PropertyConstraintsStressIT
         }
     };
 
-    private static final ConstraintOperations MANDATORY_NODE_PROPERTY_CONSTRAINT_OPS = new ConstraintOperations()
+    private static final ConstraintOperations NODE_PROPERTY_EXISTENCE_CONSTRAINT_OPS = new ConstraintOperations()
     {
         @Override
         public void createEntity( HighlyAvailableGraphDatabase db, String type, String propertyKey, Object value )
@@ -511,11 +511,11 @@ public class PropertyConstraintsStressIT
         @Override
         public String toString()
         {
-            return "MANDATORY_NODE_PROPERTY_CONSTRAINT";
+            return "NODE_PROPERTY_EXISTENCE_CONSTRAINT";
         }
     };
 
-    private static final ConstraintOperations MANDATORY_REL_PROPERTY_CONSTRAINT_OPS = new ConstraintOperations()
+    private static final ConstraintOperations REL_PROPERTY_EXISTENCE_CONSTRAINT_OPS = new ConstraintOperations()
     {
         @Override
         public void createEntity( HighlyAvailableGraphDatabase db, String type, String propertyKey, Object value )
@@ -581,7 +581,7 @@ public class PropertyConstraintsStressIT
         @Override
         public String toString()
         {
-            return "MANDATORY_RELATIONSHIP_PROPERTY_CONSTRAINT";
+            return "RELATIONSHIP_PROPERTY_EXISTENCE_CONSTRAINT";
         }
     };
 }


### PR DESCRIPTION
PR fixes all code and documentation occurrences and changes Cypher syntax:
- `CREATE CONSTRAINT ON (node:Label1) ASSERT node.key1 IS NOT NULL`
        to
        `CREATE CONSTRAINT ON (node:Label1) ASSERT exists(node.key1)`
- `DROP CONSTRAINT ON (node:Label1) ASSERT node.key1 IS NOT NULL`
       to
      `DROP CONSTRAINT ON (node:Label1) ASSERT exists(node.key1)`
- `CREATE CONSTRAINT ON ()-[rel:KNOWS]-() ASSERT rel.since IS NOT NULL`
       to
       `CREATE CONSTRAINT ON ()-[rel:KNOWS]-() ASSERT exists(rel.since)`
- `DROP CONSTRAINT ON ()-[rel:KNOWS]-() ASSERT rel.since IS NOT NULL`
       to
       `DROP CONSTRAINT ON ()-[rel:KNOWS]-() ASSERT exists(rel.since)`
