### PR TITLE
Triadic probe for cost planner

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherException.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherException.scala
@@ -44,7 +44,7 @@ class EntityNotFoundException(message: String, cause: Throwable = null) extends 
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.entityNotFoundException(message, this)
 }
 
-class CypherTypeException(message: String, cause: Throwable = null) extends CypherException(cause) {
+class CypherTypeException(message: String, cause: Throwable = null) extends CypherException(message, cause) {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.cypherTypeException(message, this)
 }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/NestedPipeExpression.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/NestedPipeExpression.scala
@@ -25,8 +25,8 @@ import org.neo4j.cypher.internal.compiler.v2_3.symbols._
 
 case class NestedPipeExpression(pipe: Pipe, path: ProjectedPath) extends Expression {
   def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = {
-    val innerState = state.copy(initialContext = Some(ctx))
-    pipe.createResults(innerState.withDecorator(innerState.decorator.innerDecorator )).map(ctx => path(ctx)).toSeq
+    val innerState = state.withInitialContext(ctx).withDecorator(state.decorator.innerDecorator )
+    pipe.createResults(innerState).map(ctx => path(ctx)).toSeq
   }
 
   def rewrite(f: (Expression) => Expression) = f(this)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/CreateUniqueAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/CreateUniqueAction.scala
@@ -49,7 +49,7 @@ case class CreateUniqueAction(incomingLinks: UniqueLink*) extends UpdateAction {
         val lockingContext = state.query.upgradeToLockingQueryContext
 
         try {
-          executionContext = tryAgain(linksToDo, executionContext, state.copy(query = lockingContext))
+          executionContext = tryAgain(linksToDo, executionContext, state.withQueryContext(lockingContext))
         } finally {
           lockingContext.releaseLocks()
         }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ApplyPipe.scala
@@ -31,7 +31,7 @@ case class ApplyPipe(source: Pipe, inner: Pipe)(val estimatedCardinality: Option
     input.flatMap {
       (outerContext) =>
         val original = outerContext.clone()
-        val innerState = state.copy(initialContext = Some(outerContext))
+        val innerState = state.withInitialContext(outerContext)
         val innerResults = inner.createResults(innerState)
         innerResults.map { context => context ++ original }
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LetSelectOrSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LetSelectOrSemiApplyPipe.scala
@@ -36,7 +36,7 @@ case class LetSelectOrSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: Strin
     input.map {
       (outerContext) =>
         val holds = predicate.isTrue(outerContext)(state) || {
-          val innerState = state.copy(initialContext = Some(outerContext))
+          val innerState = state.withInitialContext(outerContext)
           val innerResults = inner.createResults(innerState)
           if (negated) innerResults.isEmpty else innerResults.nonEmpty
         }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LetSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LetSemiApplyPipe.scala
@@ -30,7 +30,7 @@ case class LetSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: String, negat
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.map {
       (outerContext) =>
-        val innerState = state.copy(initialContext = Some(outerContext))
+        val innerState = state.withInitialContext(outerContext)
         val innerResults = inner.createResults(innerState)
         val holds = if (negated) innerResults.isEmpty else innerResults.nonEmpty
         outerContext += (letVarName -> holds)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/QueryState.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/QueryState.scala
@@ -19,11 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
-import java.util.UUID
+import java.util.{Set, UUID}
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.PathValueBuilder
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
+
+import scala.collection.mutable
 
 case class QueryState(query: QueryContext,
                       resources: ExternalResource,
@@ -31,13 +33,12 @@ case class QueryState(query: QueryContext,
                       decorator: PipeDecorator,
                       timeReader: TimeReader = new TimeReader,
                       var initialContext: Option[ExecutionContext] = None,
-                      queryId: AnyRef = UUID.randomUUID().toString) {
-
+                      queryId: AnyRef = UUID.randomUUID().toString,
+                      triadicSets: mutable.Map[String, Set[Long]] = new mutable.HashMap[String, Set[Long]]()) {
   private var _pathValueBuilder: PathValueBuilder = null
 
   def clearPathValueBuilder = {
-    if (_pathValueBuilder == null )
-    {
+    if (_pathValueBuilder == null) {
       _pathValueBuilder = new PathValueBuilder()
     }
     _pathValueBuilder.clear()
@@ -60,4 +61,3 @@ object QueryState {
 class TimeReader {
   lazy val getTime = System.currentTimeMillis()
 }
-

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/QueryState.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/QueryState.scala
@@ -19,22 +19,23 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
-import java.util.{Set, UUID}
+import java.util.UUID
 
+import org.neo4j.collection.primitive.PrimitiveLongSet
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.PathValueBuilder
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
 
 import scala.collection.mutable
 
-case class QueryState(query: QueryContext,
-                      resources: ExternalResource,
-                      params: Map[String, Any],
-                      decorator: PipeDecorator,
-                      timeReader: TimeReader = new TimeReader,
-                      var initialContext: Option[ExecutionContext] = None,
-                      queryId: AnyRef = UUID.randomUUID().toString,
-                      triadicSets: mutable.Map[String, Set[Long]] = new mutable.HashMap[String, Set[Long]]()) {
+class QueryState(val query: QueryContext,
+                 val resources: ExternalResource,
+                 val params: Map[String, Any],
+                 val decorator: PipeDecorator,
+                 val timeReader: TimeReader = new TimeReader,
+                 var initialContext: Option[ExecutionContext] = None,
+                 val queryId: AnyRef = UUID.randomUUID().toString,
+                 val triadicSets: mutable.Map[String, PrimitiveLongSet] = new mutable.HashMap[String, PrimitiveLongSet]()) {
   private var _pathValueBuilder: PathValueBuilder = null
 
   def clearPathValueBuilder = {
@@ -51,7 +52,15 @@ case class QueryState(query: QueryContext,
 
   def getStatistics = query.getOptStatistics.getOrElse(QueryState.defaultStatistics)
 
-  def withDecorator(decorator: PipeDecorator) = copy(decorator = decorator)
+  def withDecorator(decorator: PipeDecorator) =
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicSets)
+
+  def withInitialContext(initialContext: ExecutionContext) =
+    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), queryId, triadicSets)
+
+  def withQueryContext(query: QueryContext) =
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicSets)
+
 }
 
 object QueryState {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/SelectOrSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/SelectOrSemiApplyPipe.scala
@@ -36,7 +36,7 @@ case class SelectOrSemiApplyPipe(source: Pipe, inner: Pipe, predicate: Predicate
     input.filter {
       (outerContext) =>
         predicate.isTrue(outerContext)(state) || {
-          val innerState = state.copy(initialContext = Some(outerContext))
+          val innerState = state.withInitialContext(outerContext)
           val innerResults = inner.createResults(innerState)
           if (negated) innerResults.isEmpty else innerResults.nonEmpty
         }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/SemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/SemiApplyPipe.scala
@@ -30,7 +30,7 @@ case class SemiApplyPipe(source: Pipe, inner: Pipe, negated: Boolean)
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.filter {
       (outerContext) =>
-        val innerState = state.copy(initialContext = Some(outerContext))
+        val innerState = state.withInitialContext(outerContext)
         val innerResults = inner.createResults(innerState)
         if (negated) innerResults.isEmpty else innerResults.nonEmpty
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipe.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import java.util
 
+import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.KeyNames
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{InternalPlanDescription, PlanDescriptionImpl, SingleChild}
 import org.neo4j.cypher.internal.compiler.v2_3.{CypherTypeException, ExecutionContext}
 import org.neo4j.graphdb.Node
@@ -43,7 +44,8 @@ case class TriadicBuildPipe(source: Pipe, identifier: String)
   }
 
   override def planDescriptionWithoutCardinality: InternalPlanDescription =
-    PlanDescriptionImpl(this.id, "TriadicBuild", SingleChild(source.planDescription), Seq(), identifiers)
+    PlanDescriptionImpl(this.id, "TriadicBuild", SingleChild(source.planDescription),
+      Seq(KeyNames(Seq(identifier))), identifiers)
 
   override def withEstimatedCardinality(estimated: Double) =
     copy()(Some(estimated))
@@ -73,7 +75,8 @@ case class TriadicProbePipe(source: Pipe, triadicSet: String, identifier: String
   }
 
   override def planDescriptionWithoutCardinality: InternalPlanDescription =
-    PlanDescriptionImpl(this.id, "TriadicProbe", SingleChild(source.planDescription), Seq(), identifiers)
+    PlanDescriptionImpl(this.id, "TriadicProbe", SingleChild(source.planDescription),
+      Seq(KeyNames(Seq(triadicSet, identifier))), identifiers)
 
   override def withEstimatedCardinality(estimated: Double) =
     copy()(Some(estimated))

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipe.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.pipes
+
+import java.util
+
+import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{InternalPlanDescription, PlanDescriptionImpl, SingleChild}
+import org.neo4j.cypher.internal.compiler.v2_3.{CypherTypeException, ExecutionContext}
+import org.neo4j.graphdb.Node
+
+case class TriadicBuildPipe(source: Pipe, identifier: String)
+                           (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+  extends PipeWithSource(source, pipeMonitor) with RonjaPipe with NoEffectsPipe {
+  override def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
+    val triadicSeen = new util.HashSet[Long]
+    state.triadicSets.put(identifier, triadicSeen)
+    input.map { ctx =>
+      ctx(identifier) match {
+        case null =>
+        case n: Node =>
+          triadicSeen.add(n.getId)
+        case x => throw new CypherTypeException(s"Expected a node at `$identifier` but got $x")
+      }
+      ctx
+    }.toList.toIterator
+  }
+
+  override def planDescriptionWithoutCardinality: InternalPlanDescription =
+    PlanDescriptionImpl(this.id, "TriadicBuild", SingleChild(source.planDescription), Seq(), identifiers)
+
+  override def withEstimatedCardinality(estimated: Double) =
+    copy()(Some(estimated))
+
+  override def symbols =
+    source.symbols
+
+  override def dup(sources: List[Pipe]) = {
+    val (head :: Nil) = sources
+    copy(source = head)(estimatedCardinality)
+  }
+}
+
+case class TriadicProbePipe(source: Pipe, triadicSet: String, identifier: String)
+                           (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+  extends PipeWithSource(source, pipeMonitor) with RonjaPipe with NoEffectsPipe {
+
+  override def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
+    val set = state.triadicSets(triadicSet)
+    input.filter {
+      ctx =>
+        ctx(identifier) match {
+          case n: Node => !set.contains(n.getId)
+          case _ => false
+        }
+    }
+  }
+
+  override def planDescriptionWithoutCardinality: InternalPlanDescription =
+    PlanDescriptionImpl(this.id, "TriadicProbe", SingleChild(source.planDescription), Seq(), identifiers)
+
+  override def withEstimatedCardinality(estimated: Double) =
+    copy()(Some(estimated))
+
+  override def symbols =
+    source.symbols
+
+  override def dup(sources: List[Pipe]) = {
+    val (head :: Nil) = sources
+    copy(source = head)(estimatedCardinality)
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipe.scala
@@ -19,8 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
-import java.util
-
+import org.neo4j.collection.primitive.Primitive
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.KeyNames
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{InternalPlanDescription, PlanDescriptionImpl, SingleChild}
 import org.neo4j.cypher.internal.compiler.v2_3.{CypherTypeException, ExecutionContext}
@@ -30,7 +29,7 @@ case class TriadicBuildPipe(source: Pipe, identifier: String)
                            (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with RonjaPipe with NoEffectsPipe {
   override def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
-    val triadicSeen = new util.HashSet[Long]
+    val triadicSeen = Primitive.longSet()
     state.triadicSets.put(identifier, triadicSeen)
     input.map { ctx =>
       ctx(identifier) match {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/Selections.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/Selections.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.planner
 import org.neo4j.cypher.internal.compiler.v2_3.ast._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.plannerQuery.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v2_3.perty.PageDocFormatting
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.IdName
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{LogicalPlan, IdName}
 import org.neo4j.helpers.ThisShouldNotHappenError
 
 case class Predicate(dependencies: Set[IdName], expr: Expression) extends PageDocFormatting { // with ToPrettyString[Predicate] {
@@ -60,6 +60,10 @@ case class Selections(predicates: Set[Predicate] = Set.empty) extends PageDocFor
   def predicatesGivenForRequiredSymbol(allowed: Set[IdName], required: IdName): Seq[Expression] = predicates.collect {
     case p@Predicate(_, predicate) if p.hasDependenciesMetForRequiredSymbol(allowed, required) => predicate
   }.toSeq
+
+  def unsolvedPredicates(plan: LogicalPlan): Seq[Expression] =
+    scalarPredicatesGiven(plan.availableSymbols)
+      .filterNot(predicate => plan.solved.exists(_.graph.selections.contains(predicate)))
 
   def scalarPredicatesGiven(ids: Set[IdName]): Seq[Expression] = predicatesGiven(ids).filterNot(containsPatternPredicates)
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
@@ -217,6 +217,14 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
           val source = buildPipe(lhs)
           ProduceResultsPipe(source, columns)()
 
+        case TriadicBuild(lhs, id) =>
+          val source = buildPipe(lhs)
+          TriadicBuildPipe(source, id.name)()
+
+        case TriadicProbe(lhs, triadicSet, id) =>
+          val source = buildPipe(lhs)
+          TriadicProbePipe(source, triadicSet.name, id.name)()
+
         case x =>
           throw new CantHandleQueryException(x.toString)
       }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
@@ -28,11 +28,11 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.solveOption
 object QueryPlannerConfiguration {
   val default = QueryPlannerConfiguration(
     pickBestCandidate = pickBestPlanUsingHintsAndCost,
-    applySelections = Selector(
-      pickBestPlanUsingHintsAndCost,
-      selectPatternPredicates(pickBestPlanUsingHintsAndCost),
+    applySelections = Selector(pickBestPlanUsingHintsAndCost,
+      selectPatternPredicates,
       triadicSelection,
-      selectCovered
+      selectCovered,
+      selectHasLabelWithJoin
     ),
     projectAllEndpoints = projectEndpoints.all,
     optionalSolvers = Seq(

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
@@ -28,7 +28,12 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.solveOption
 object QueryPlannerConfiguration {
   val default = QueryPlannerConfiguration(
     pickBestCandidate = pickBestPlanUsingHintsAndCost,
-    applySelections = Selector(Seq(selectPatternPredicates(pickBestPlanUsingHintsAndCost), selectCovered(pickBestPlanUsingHintsAndCost)), pickBestPlanUsingHintsAndCost),
+    applySelections = Selector(
+      Seq(
+        selectPatternPredicates(pickBestPlanUsingHintsAndCost),
+        triadicSelection,
+        selectCovered(pickBestPlanUsingHintsAndCost)),
+      pickBestPlanUsingHintsAndCost),
     projectAllEndpoints = projectEndpoints.all,
     optionalSolvers = Seq(
       applyOptional,

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.solveOption
 object QueryPlannerConfiguration {
   val default = QueryPlannerConfiguration(
     pickBestCandidate = pickBestPlanUsingHintsAndCost,
-    applySelections = selectPatternPredicates(selectCovered(pickBestPlanUsingHintsAndCost), pickBestPlanUsingHintsAndCost),
+    applySelections = Selector(Seq(selectPatternPredicates(pickBestPlanUsingHintsAndCost), selectCovered(pickBestPlanUsingHintsAndCost)), pickBestPlanUsingHintsAndCost),
     projectAllEndpoints = projectEndpoints.all,
     optionalSolvers = Seq(
       applyOptional,

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryPlannerConfiguration.scala
@@ -29,11 +29,11 @@ object QueryPlannerConfiguration {
   val default = QueryPlannerConfiguration(
     pickBestCandidate = pickBestPlanUsingHintsAndCost,
     applySelections = Selector(
-      Seq(
-        selectPatternPredicates(pickBestPlanUsingHintsAndCost),
-        triadicSelection,
-        selectCovered(pickBestPlanUsingHintsAndCost)),
-      pickBestPlanUsingHintsAndCost),
+      pickBestPlanUsingHintsAndCost,
+      selectPatternPredicates(pickBestPlanUsingHintsAndCost),
+      triadicSelection,
+      selectCovered
+    ),
     projectAllEndpoints = projectEndpoints.all,
     optionalSolvers = Seq(
       applyOptional,

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/TriadicBuild.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/TriadicBuild.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans
+
+import org.neo4j.cypher.internal.compiler.v2_3.planner.{CardinalityEstimation, PlannerQuery}
+
+
+/*
+Triadic build and probe is used to solve a common query pattern:
+MATCH (a)-->(b)-->(c) WHERE NOT (a)-->(c)
+
+If this query was solved by starting from (a) and expanding out, after expanding
+to (b), a TriadicBuild would be done, which eagerly puts all seen (b) nodes in a Set
+while expanding. After expanding to (c), we can check in the triadic set if the (c) is already seen.
+ */
+case class TriadicBuild(left: LogicalPlan, identifier: IdName)(val solved: PlannerQuery with CardinalityEstimation)
+  extends LogicalPlan with EagerLogicalPlan with LogicalPlanWithoutExpressions {
+  override val lhs = Some(left)
+
+  override def availableSymbols = left.availableSymbols
+
+  override def rhs = None
+}
+
+case class TriadicProbe(left: LogicalPlan, triadicSet:IdName, identifier: IdName)
+                       (val solved: PlannerQuery with CardinalityEstimation)
+  extends LogicalPlan with LazyLogicalPlan with LogicalPlanWithoutExpressions {
+  override val lhs = Some(left)
+
+  override def availableSymbols = left.availableSymbols
+
+  override def rhs = None
+}
+

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/LogicalPlanProducer.scala
@@ -402,6 +402,15 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends Colle
     Aggregation(left, returnAll.toMap, Map.empty)(left.solved)
   }
 
+  def planTriadicBuild(left: LogicalPlan, id: IdName)(implicit context: LogicalPlanningContext): LogicalPlan =
+    TriadicBuild(left, id)(left.solved)
+
+  def planTriadicProbe(left: LogicalPlan, triadicSet: IdName, id: IdName, predicate: Expression)
+                      (implicit context: LogicalPlanningContext): LogicalPlan = {
+    val solved = left.solved.updateTailOrSelf(_.updateGraph(_.addPredicates(predicate)))
+    TriadicProbe(left, triadicSet, id)(solved)
+  }
+
   private implicit def estimatePlannerQuery(plannerQuery: PlannerQuery)(implicit context: LogicalPlanningContext): PlannerQuery with CardinalityEstimation = {
     val cardinality = cardinalityModel(plannerQuery, context.input, context.semanticTable)
     CardinalityEstimation.lift(plannerQuery, cardinality)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/Selector.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/Selector.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps
+
+import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{LogicalPlanningContext, CandidateSelector, LogicalPlanningFunction0, PlanTransformer}
+
+import scala.annotation.tailrec
+
+case class Selector(selectionSteps: Seq[PlanTransformer[QueryGraph]],
+                    pickBestFactory: LogicalPlanningFunction0[CandidateSelector]) extends PlanTransformer[QueryGraph] {
+  def apply(input: LogicalPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan = {
+    val pickBest = pickBestFactory(context)
+
+    @tailrec
+    def selectIt(plan: LogicalPlan): LogicalPlan = {
+      val plans = selectionSteps.
+        map(step => step(plan, queryGraph)).
+        filterNot(p => p.solved == plan.solved)
+
+      pickBest(plans) match {
+        case Some(p) => selectIt(p)
+        case None => plan
+      }
+    }
+
+    selectIt(input)
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/selectPatternPredicates.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/selectPatternPredicates.scala
@@ -23,114 +23,103 @@ import org.neo4j.cypher.internal.compiler.v2_3.ast._
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.FreshIdNameGenerator
 import org.neo4j.cypher.internal.compiler.v2_3.planner._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical._
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.greedy.GreedyPlanTable
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
 import org.neo4j.helpers.ThisShouldNotHappenError
 
-case class selectPatternPredicates(pickBestFactory: LogicalPlanningFunction0[CandidateSelector]) extends CandidateGenerator[LogicalPlan] {
+case object selectPatternPredicates extends CandidateGenerator[LogicalPlan] {
 
-  private object candidatesProducer extends CandidateGenerator[GreedyPlanTable] {
-    def apply(planTable: GreedyPlanTable, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] = {
-      for (
-        lhs <- planTable.plans;
-        pattern <- queryGraph.selections.patternPredicatesGiven(lhs.availableSymbols)
-        if applicable(lhs, queryGraph, pattern))
-        yield {
-          pattern match {
-            case patternExpression: PatternExpression =>
-              val rhs = rhsPlan(lhs, patternExpression)
-              context.logicalPlanProducer.planSemiApply(lhs, rhs, patternExpression)
-            case p@Not(patternExpression: PatternExpression) =>
-              val rhs = rhsPlan(lhs, patternExpression)
-              context.logicalPlanProducer.planAntiSemiApply(lhs, rhs, patternExpression, p)
-            case p@Ors(exprs) =>
-              val (patternExpressions, expressions) = exprs.partition {
-                case _: PatternExpression => true
-                case Not(_: PatternExpression) => true
-                case _ => false
-              }
-              val (plan, solvedPredicates) = planPredicates(lhs, patternExpressions, expressions, None)
-              context.logicalPlanProducer.solvePredicate(plan, onePredicate(solvedPredicates))
-          }
+  def apply(lhs: LogicalPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] = {
+    for (
+      pattern <- queryGraph.selections.patternPredicatesGiven(lhs.availableSymbols)
+      if applicable(lhs, queryGraph, pattern))
+      yield {
+        pattern match {
+          case patternExpression: PatternExpression =>
+            val rhs = rhsPlan(lhs, patternExpression)
+            context.logicalPlanProducer.planSemiApply(lhs, rhs, patternExpression)
+          case p@Not(patternExpression: PatternExpression) =>
+            val rhs = rhsPlan(lhs, patternExpression)
+            context.logicalPlanProducer.planAntiSemiApply(lhs, rhs, patternExpression, p)
+          case p@Ors(exprs) =>
+            val (patternExpressions, expressions) = exprs.partition {
+              case _: PatternExpression => true
+              case Not(_: PatternExpression) => true
+              case _ => false
+            }
+            val (plan, solvedPredicates) = planPredicates(lhs, patternExpressions, expressions, None)
+            context.logicalPlanProducer.solvePredicate(plan, onePredicate(solvedPredicates))
         }
-    }
-
-    private def planPredicates(lhs: LogicalPlan, patternExpressions: Set[Expression], expressions: Set[Expression], letExpression: Option[Expression])
-                              (implicit context: LogicalPlanningContext): (LogicalPlan, Set[Expression]) = {
-      patternExpressions.toList match {
-        case (patternExpression: PatternExpression) :: Nil =>
-          val rhs = rhsPlan(lhs, patternExpression)
-          val plan = context.logicalPlanProducer.planSelectOrSemiApply(lhs, rhs, onePredicate(expressions ++ letExpression.toSet))
-          (plan, expressions + patternExpression)
-
-        case (p@Not(patternExpression: PatternExpression)) :: Nil =>
-          val rhs = rhsPlan(lhs, patternExpression)
-          val plan = context.logicalPlanProducer.planSelectOrAntiSemiApply(lhs, rhs, onePredicate(expressions ++ letExpression.toSet))
-          (plan, expressions + p)
-
-        case (patternExpression: PatternExpression) :: tail =>
-          val rhs = rhsPlan(lhs, patternExpression)
-          val (newLhs, newLetExpr) = createLetSemiApply(lhs, rhs, patternExpression, expressions, letExpression)
-          val (plan, solvedPredicates) = planPredicates(newLhs, tail.toSet, Set.empty, Some(newLetExpr))
-          (plan, solvedPredicates ++ Set(patternExpression) ++ expressions)
-
-        case (p@Not(patternExpression: PatternExpression)) :: tail =>
-          val rhs = rhsPlan(lhs, patternExpression)
-          val (newLhs, newLetExpr) = createLetAntiSemiApply(lhs, rhs, patternExpression, p, expressions, letExpression)
-          val (plan, solvedPredicates) = planPredicates(newLhs, tail.toSet, Set.empty, Some(newLetExpr))
-          (plan, solvedPredicates ++ Set(p) ++ expressions)
-
-        case _ =>
-          throw new ThisShouldNotHappenError("Davide", "There should be at least one pattern expression")
       }
-    }
+  }
 
-    private def createLetSemiApply(lhs: LogicalPlan, rhs: LogicalPlan, patternExpression: PatternExpression, expressions: Set[Expression], letExpression: Option[Expression])
-                                  (implicit context: LogicalPlanningContext) = {
-      val (idName, ident) = freshId(patternExpression)
-      if (expressions.isEmpty && letExpression.isEmpty)
-        (context.logicalPlanProducer.planLetSemiApply(lhs, rhs, idName), ident)
-      else
-        (context.logicalPlanProducer.planLetSelectOrSemiApply(lhs, rhs, idName, onePredicate(expressions ++ letExpression.toSet)), ident)
-    }
+  private def planPredicates(lhs: LogicalPlan, patternExpressions: Set[Expression], expressions: Set[Expression], letExpression: Option[Expression])
+                            (implicit context: LogicalPlanningContext): (LogicalPlan, Set[Expression]) = {
+    patternExpressions.toList match {
+      case (patternExpression: PatternExpression) :: Nil =>
+        val rhs = rhsPlan(lhs, patternExpression)
+        val plan = context.logicalPlanProducer.planSelectOrSemiApply(lhs, rhs, onePredicate(expressions ++ letExpression.toSet))
+        (plan, expressions + patternExpression)
 
-    private def createLetAntiSemiApply(lhs: LogicalPlan, rhs: LogicalPlan, patternExpression: PatternExpression, predicate: Expression, expressions: Set[Expression], letExpression: Option[Expression])
-                                      (implicit context: LogicalPlanningContext) = {
-      val (idName, ident) = freshId(patternExpression)
-      if (expressions.isEmpty && letExpression.isEmpty)
-        (context.logicalPlanProducer.planLetAntiSemiApply(lhs, rhs, idName), ident)
-      else
-        (context.logicalPlanProducer.planLetSelectOrAntiSemiApply(lhs, rhs, idName, onePredicate(expressions ++ letExpression.toSet)), ident)
-    }
+      case (p@Not(patternExpression: PatternExpression)) :: Nil =>
+        val rhs = rhsPlan(lhs, patternExpression)
+        val plan = context.logicalPlanProducer.planSelectOrAntiSemiApply(lhs, rhs, onePredicate(expressions ++ letExpression.toSet))
+        (plan, expressions + p)
 
-    private def rhsPlan(lhs: LogicalPlan, pattern: PatternExpression)(implicit ctx: LogicalPlanningContext) = {
-      val context = ctx.recurse(lhs)
-      val (plan, _) = context.strategy.planPatternExpression(lhs.availableSymbols, pattern)(context)
-      plan
-    }
+      case (patternExpression: PatternExpression) :: tail =>
+        val rhs = rhsPlan(lhs, patternExpression)
+        val (newLhs, newLetExpr) = createLetSemiApply(lhs, rhs, patternExpression, expressions, letExpression)
+        val (plan, solvedPredicates) = planPredicates(newLhs, tail.toSet, Set.empty, Some(newLetExpr))
+        (plan, solvedPredicates ++ Set(patternExpression) ++ expressions)
 
-    private def onePredicate(expressions: Set[Expression]): Expression = if (expressions.size == 1)
-      expressions.head
-    else
-      Ors(expressions)(expressions.head.position)
+      case (p@Not(patternExpression: PatternExpression)) :: tail =>
+        val rhs = rhsPlan(lhs, patternExpression)
+        val (newLhs, newLetExpr) = createLetAntiSemiApply(lhs, rhs, patternExpression, p, expressions, letExpression)
+        val (plan, solvedPredicates) = planPredicates(newLhs, tail.toSet, Set.empty, Some(newLetExpr))
+        (plan, solvedPredicates ++ Set(p) ++ expressions)
 
-    private def applicable(outerPlan: LogicalPlan, qg: QueryGraph, expression: Expression) = {
-      val symbolsAvailable = qg.argumentIds.subsetOf(outerPlan.availableSymbols)
-      val isSolved = outerPlan.solved.exists(_.graph.selections.contains(expression))
-      symbolsAvailable && !isSolved
+      case _ =>
+        throw new ThisShouldNotHappenError("Davide", "There should be at least one pattern expression")
     }
   }
+
+  private def createLetSemiApply(lhs: LogicalPlan, rhs: LogicalPlan, patternExpression: PatternExpression, expressions: Set[Expression], letExpression: Option[Expression])
+                                (implicit context: LogicalPlanningContext) = {
+    val (idName, ident) = freshId(patternExpression)
+    if (expressions.isEmpty && letExpression.isEmpty)
+      (context.logicalPlanProducer.planLetSemiApply(lhs, rhs, idName), ident)
+    else
+      (context.logicalPlanProducer.planLetSelectOrSemiApply(lhs, rhs, idName, onePredicate(expressions ++ letExpression.toSet)), ident)
+  }
+
+  private def createLetAntiSemiApply(lhs: LogicalPlan, rhs: LogicalPlan, patternExpression: PatternExpression, predicate: Expression, expressions: Set[Expression], letExpression: Option[Expression])
+                                    (implicit context: LogicalPlanningContext) = {
+    val (idName, ident) = freshId(patternExpression)
+    if (expressions.isEmpty && letExpression.isEmpty)
+      (context.logicalPlanProducer.planLetAntiSemiApply(lhs, rhs, idName), ident)
+    else
+      (context.logicalPlanProducer.planLetSelectOrAntiSemiApply(lhs, rhs, idName, onePredicate(expressions ++ letExpression.toSet)), ident)
+  }
+
+  private def rhsPlan(lhs: LogicalPlan, pattern: PatternExpression)(implicit ctx: LogicalPlanningContext) = {
+    val context = ctx.recurse(lhs)
+    val (plan, _) = context.strategy.planPatternExpression(lhs.availableSymbols, pattern)(context)
+    plan
+  }
+
+  private def onePredicate(expressions: Set[Expression]): Expression = if (expressions.size == 1)
+    expressions.head
+  else
+    Ors(expressions)(expressions.head.position)
+
+  private def applicable(outerPlan: LogicalPlan, qg: QueryGraph, expression: Expression) = {
+    val symbolsAvailable = qg.argumentIds.subsetOf(outerPlan.availableSymbols)
+    val isSolved = outerPlan.solved.exists(_.graph.selections.contains(expression))
+    symbolsAvailable && !isSolved
+  }
+
 
   private def freshId(patternExpression: PatternExpression) = {
     val name = FreshIdNameGenerator.name(patternExpression.position)
     (IdName(name), Identifier(name)(patternExpression.position))
-  }
-
-  def apply(input: LogicalPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] = {
-    val pickBest = pickBestFactory(context)
-
-    val secretPlanTable = GreedyPlanTable.empty + input
-    val result = candidatesProducer(secretPlanTable, queryGraph)
-    pickBest(result).toSeq
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/selectPatternPredicates.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/selectPatternPredicates.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.greedy.GreedyPlan
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
 import org.neo4j.helpers.ThisShouldNotHappenError
 
-case class selectPatternPredicates(pickBestFactory: LogicalPlanningFunction0[CandidateSelector]) extends PlanTransformer[QueryGraph] {
+case class selectPatternPredicates(pickBestFactory: LogicalPlanningFunction0[CandidateSelector]) extends CandidateGenerator[LogicalPlan] {
 
   private object candidatesProducer extends CandidateGenerator[GreedyPlanTable] {
     def apply(planTable: GreedyPlanTable, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] = {
@@ -126,11 +126,11 @@ case class selectPatternPredicates(pickBestFactory: LogicalPlanningFunction0[Can
     (IdName(name), Identifier(name)(patternExpression.position))
   }
 
-  def apply(input: LogicalPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan = {
+  def apply(input: LogicalPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] = {
     val pickBest = pickBestFactory(context)
 
     val secretPlanTable = GreedyPlanTable.empty + input
     val result = candidatesProducer(secretPlanTable, queryGraph)
-    pickBest(result).getOrElse(input)
+    pickBest(result).toSeq
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/triadicSelection.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/triadicSelection.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps
+
+import org.neo4j.cypher.internal.compiler.v2_3.ast._
+import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{LogicalPlanningContext, PlanTransformer}
+import org.neo4j.graphdb.Direction
+
+object triadicSelection extends PlanTransformer[QueryGraph] {
+  override def apply(in: LogicalPlan, qg: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan = in match {
+    case sel@Selection(predicates,
+           exp2@Expand(
+             exp1@Expand(lhs, from1, dir1, types1, to1, _, ExpandAll),
+                              from2, dir2, types2, to2, rel2, ExpandAll))
+      if to1 == from2 && types1 == types2 && dir1 == dir2 =>
+
+      val newPlan = matchingPredicateExists(qg, in.availableSymbols, from1.name, to2.name, types1, dir1) map {
+        predicate =>
+          val triadicBuild = context.logicalPlanProducer.planTriadicBuild(exp1, to1)
+          val newExpand2 = Expand(triadicBuild, from2, dir2, types2, to2, rel2, ExpandAll)(exp2.solved)
+          val newSelection = context.logicalPlanProducer.planSelection(sel.predicates, newExpand2)
+          context.logicalPlanProducer.planTriadicProbe(newSelection, to1, to2, predicate)
+      }
+
+      newPlan.getOrElse(in)
+
+    case _ => in
+  }
+
+  private def matchingPredicateExists(qg: QueryGraph, availableSymbols: Set[IdName], from: String, to: String, types: Seq[RelTypeName], dir: Direction): Option[Expression] =
+    qg.selections.patternPredicatesGiven(availableSymbols).collectFirst {
+      case p@Not(PatternExpression(
+                  RelationshipsPattern(
+                  RelationshipChain(
+                  NodePattern(Some(Identifier(pfrom)), List(), None, false),
+                  RelationshipPattern(None, false, ptypes, None, None, pdir),
+                  NodePattern(Some(Identifier(pto)), List(), None, false)))))
+        if pfrom == from && pto == to && ptypes == ptypes && pdir == dir => p
+    }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/triadicSelection.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/triadicSelection.scala
@@ -22,11 +22,11 @@ package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps
 import org.neo4j.cypher.internal.compiler.v2_3.ast._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{LogicalPlanningContext, PlanTransformer}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{CandidateGenerator, LogicalPlanningContext, PlanTransformer}
 import org.neo4j.graphdb.Direction
 
-object triadicSelection extends PlanTransformer[QueryGraph] {
-  override def apply(in: LogicalPlan, qg: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan = in match {
+object triadicSelection extends CandidateGenerator[LogicalPlan] {
+  override def apply(in: LogicalPlan, qg: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] = in match {
     case sel@Selection(predicates,
            exp2@Expand(
              exp1@Expand(lhs, from1, dir1, types1, to1, _, ExpandAll),
@@ -41,9 +41,9 @@ object triadicSelection extends PlanTransformer[QueryGraph] {
           context.logicalPlanProducer.planTriadicProbe(newSelection, to1, to2, predicate)
       }
 
-      newPlan.getOrElse(in)
+      newPlan.toSeq
 
-    case _ => in
+    case _ => Seq.empty
   }
 
   private def matchingPredicateExists(qg: QueryGraph, availableSymbols: Set[IdName], from: String, to: String, types: Seq[RelTypeName], dir: Direction): Option[Expression] =

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/Profiler.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/Profiler.scala
@@ -51,7 +51,7 @@ class Profiler extends PipeDecorator {
       case _ => new ProfilingQueryContext(state.query, pipe)
     })
 
-    state.copy(query = decoratedContext)
+    state.withQueryContext(decoratedContext)
   }
 
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndexTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndexTest.scala
@@ -34,7 +34,7 @@ import scala.collection.JavaConverters._
 class ContainerIndexTest extends CypherFunSuite {
 
   val qtx = mock[QueryContext]
-  implicit val state = QueryStateHelper.empty.copy(query = qtx)
+  implicit val state = QueryStateHelper.empty.withQueryContext(qtx)
   val ctx = ExecutionContext.empty
   val expectedNull: Any = null
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ArgumentPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ArgumentPipeTest.scala
@@ -59,5 +59,5 @@ class ArgumentPipeTest extends CypherFunSuite {
   }
 
   def newQueryState(entries: (String, Any)*): QueryState =
-    QueryStateHelper.empty.copy(initialContext = Some(ExecutionContext.from(entries: _*)))
+    QueryStateHelper.empty.withInitialContext(ExecutionContext.from(entries: _*))
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/QueryStateHelper.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/QueryStateHelper.scala
@@ -28,6 +28,6 @@ object QueryStateHelper {
   def emptyWith(query: QueryContext = null, resources: ExternalResource = null,
                 params: Map[String, Any] = Map.empty, decorator: PipeDecorator = NullPipeDecorator,
                 initialContext: Option[ExecutionContext] = None) =
-    QueryState(query = query, resources = resources, params = params, decorator = decorator,
+    new QueryState(query = query, resources = resources, params = params, decorator = decorator,
       initialContext = initialContext)
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/QueryStateTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/QueryStateTest.scala
@@ -35,30 +35,4 @@ class QueryStateTest extends CypherFunSuite {
     //THEN
     ts1 should equal(ts2)
   }
-
-  test("case_class_copying_should_still_see_same_time") {
-    //GIVEN
-    val state = QueryStateHelper.empty
-
-    //WHEN
-    val ts1 = state.readTimeStamp()
-    Thread.sleep(10)
-    val stateCopy = state.copy(params = Map.empty)
-
-    //THEN
-    ts1 should equal(stateCopy.readTimeStamp())
-  }
-
-  test("if_state_is_copied_and_time_seen_in_one_querystate_it_should_be_reflected_in_copies") {
-    //GIVEN
-    val state = QueryStateHelper.empty
-
-    //WHEN
-    val stateCopy = state.copy(params = Map.empty)
-    val ts1 = state.readTimeStamp()
-    Thread.sleep(10)
-
-    //THEN
-    ts1 should equal(stateCopy.readTimeStamp())
-  }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipeTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.pipes
+
+import org.neo4j.cypher.internal.compiler.v2_3.symbols._
+import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.Node
+
+import scala.collection.JavaConverters._
+
+class TriadicBuildPipeTest extends CypherFunSuite {
+  private implicit val monitor = mock[PipeMonitor]
+
+  test("build from input") {
+    val input = createFakePipeWith(0, 1, 2, 3, 4, 5)
+    val pipe = TriadicBuildPipe(input, "a")()
+    val queryState = QueryStateHelper.empty
+    pipe.createResults(queryState).map(ctx => ctx("a"))
+
+    queryState.triadicSets("a").asScala should equal(Set(0, 1, 2, 3, 4, 5))
+  }
+
+  test("build from input with doubles") {
+    val input = createFakePipeWith(0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5)
+    val pipe = TriadicBuildPipe(input, "a")()
+    val queryState = QueryStateHelper.empty
+    pipe.createResults(queryState).map(ctx => ctx("a"))
+
+    queryState.triadicSets("a").asScala should equal(Set(0, 1, 2, 3, 4, 5))
+  }
+
+  test("build ignores nulls") {
+    val input = createFakePipeWith(0, 2, 3, null)
+    val pipe = TriadicBuildPipe(input, "a")()
+    val queryState = QueryStateHelper.empty
+    pipe.createResults(queryState).map(ctx => ctx("a"))
+
+    queryState.triadicSets("a").asScala should equal(Set(0, 2, 3))
+  }
+
+  private def createFakePipeWith(count: Any*): FakePipe = {
+    import org.mockito.Mockito.when
+
+    def nodeWithId(id: Long) = {
+      val n = mock[Node]
+      when(n.getId).thenReturn(id)
+      n
+    }
+
+    val in = count.map {
+      case i: Int => Map("a" -> nodeWithId(i))
+      case null => Map("a" -> null)
+    }
+
+    new FakePipe(in, "x" -> CTNode)
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicBuildPipeTest.scala
@@ -19,11 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
+import org.neo4j.collection.primitive.PrimitiveLongIterable
 import org.neo4j.cypher.internal.compiler.v2_3.symbols._
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.Node
-
-import scala.collection.JavaConverters._
 
 class TriadicBuildPipeTest extends CypherFunSuite {
   private implicit val monitor = mock[PipeMonitor]
@@ -34,7 +33,7 @@ class TriadicBuildPipeTest extends CypherFunSuite {
     val queryState = QueryStateHelper.empty
     pipe.createResults(queryState).map(ctx => ctx("a"))
 
-    queryState.triadicSets("a").asScala should equal(Set(0, 1, 2, 3, 4, 5))
+    asScalaSet(queryState.triadicSets("a")) should equal(Set(0, 1, 2, 3, 4, 5))
   }
 
   test("build from input with doubles") {
@@ -43,7 +42,7 @@ class TriadicBuildPipeTest extends CypherFunSuite {
     val queryState = QueryStateHelper.empty
     pipe.createResults(queryState).map(ctx => ctx("a"))
 
-    queryState.triadicSets("a").asScala should equal(Set(0, 1, 2, 3, 4, 5))
+    asScalaSet(queryState.triadicSets("a")) should equal(Set(0, 1, 2, 3, 4, 5))
   }
 
   test("build ignores nulls") {
@@ -52,7 +51,16 @@ class TriadicBuildPipeTest extends CypherFunSuite {
     val queryState = QueryStateHelper.empty
     pipe.createResults(queryState).map(ctx => ctx("a"))
 
-    queryState.triadicSets("a").asScala should equal(Set(0, 2, 3))
+    asScalaSet(queryState.triadicSets("a")) should equal(Set(0, 2, 3))
+  }
+
+  private def asScalaSet(in: PrimitiveLongIterable):Set[Long] = {
+    val builder = Set.newBuilder[Long]
+    val iter = in.iterator()
+    while (iter.hasNext) {
+      builder += iter.next()
+    }
+    builder.result()
   }
 
   private def createFakePipeWith(count: Any*): FakePipe = {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicProbePipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicProbePipeTest.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
+import org.neo4j.collection.primitive.Primitive
 import org.neo4j.cypher.internal.compiler.v2_3.symbols._
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.Node
@@ -29,12 +30,20 @@ class TriadicProbePipeTest extends CypherFunSuite {
   private implicit val monitor = mock[PipeMonitor]
 
   test("build from input") {
+    // given
     val input = createFakePipeWith(0, 1, 2, 3, 4, 5)
     val pipe = TriadicProbePipe(input, "x", "a")()
     val queryState = QueryStateHelper.empty
-    queryState.triadicSets("x") = Set[Long](2, 3, 4).asJava
+    val set = Primitive.longSet()
+    set.add(2)
+    set.add(3)
+    set.add(4)
+    queryState.triadicSets.update("x", set)
 
+    // when
     val result = pipe.createResults(queryState).map(m => m("a").asInstanceOf[Node].getId).toList
+
+    // then we don't see nodes in the TriadicSet
     result should equal(List(0, 1, 5))
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicProbePipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TriadicProbePipeTest.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.pipes
+
+import org.neo4j.cypher.internal.compiler.v2_3.symbols._
+import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.Node
+
+import scala.collection.JavaConverters._
+
+class TriadicProbePipeTest extends CypherFunSuite {
+  private implicit val monitor = mock[PipeMonitor]
+
+  test("build from input") {
+    val input = createFakePipeWith(0, 1, 2, 3, 4, 5)
+    val pipe = TriadicProbePipe(input, "x", "a")()
+    val queryState = QueryStateHelper.empty
+    queryState.triadicSets("x") = Set[Long](2, 3, 4).asJava
+
+    val result = pipe.createResults(queryState).map(m => m("a").asInstanceOf[Node].getId).toList
+    result should equal(List(0, 1, 5))
+  }
+
+
+  private def createFakePipeWith(count: Any*): FakePipe = {
+    import org.mockito.Mockito.when
+
+    def nodeWithId(id: Long) = {
+      val n = mock[Node]
+      when(n.getId).thenReturn(id)
+      n
+    }
+
+    val in = count.map {
+      case i: Int => Map("a" -> nodeWithId(i))
+      case null => Map("a" -> null)
+    }
+
+    new FakePipe(in, "x" -> CTNode)
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectCoveredTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectCoveredTest.scala
@@ -19,15 +19,15 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps
 
+import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compiler.v2_3.ast._
 import org.neo4j.cypher.internal.compiler.v2_3.planner._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{ProjectingSelector, CandidateSelector, LogicalPlanningFunction0}
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{CandidateSelector, LogicalPlanningFunction0}
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
-import org.mockito.Matchers._
 
 class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
   private implicit val planContext = newMockedPlanContext
@@ -56,10 +56,10 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val qg = QueryGraph(selections = selections)
 
     // When
-    val result = selectCovered(pickBestFactory)(LogicalPlan, qg)
+    val result = selectCovered(LogicalPlan, qg)
 
     // Then
-    result should equal(Selection(Seq(predicate), LogicalPlan)(solved))
+    result should equal(Seq(Selection(Seq(predicate), LogicalPlan)(solved)))
   }
 
   test("should not try to solve predicates with unmet dependencies") {
@@ -73,10 +73,10 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val qg = QueryGraph(selections = selections)
 
     // When
-    val result = selectCovered(pickBestFactory)(LogicalPlan, qg)
+    val result = selectCovered(LogicalPlan, qg)
 
     // Then
-    result should equal(Selection(Seq(predicate), LogicalPlan)(solved))
+    result should equal(Seq(Selection(Seq(predicate), LogicalPlan)(solved)))
   }
 
   test("when two predicates not already solved are solvable, they should be applied") {
@@ -95,10 +95,10 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val qg = QueryGraph(selections = selections)
 
     // When
-    val result = selectCovered(pickBestFactory)(LogicalPlan, qg)
+    val result = selectCovered(LogicalPlan, qg)
 
     // Then
-    result should equal(Selection(Seq(predicate1, predicate2), LogicalPlan)(solved))
+    result should equal(Seq(Selection(Seq(predicate1, predicate2), LogicalPlan)(solved)))
   }
 
   test("when a predicate is already solved, it should not be applied again") {
@@ -109,10 +109,10 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val LogicalPlan = newMockedLogicalPlanWithProjections("x").updateSolved(solved)
 
     // When
-    val result = selectCovered(pickBestFactory)(LogicalPlan, qg)
+    val result = selectCovered(LogicalPlan, qg)
 
     // Then
-    result should equal(LogicalPlan)
+    result should equal(Seq())
   }
 
   test("a predicate without all dependencies covered should not be applied ") {
@@ -123,10 +123,10 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val qg = QueryGraph(selections = selections)
 
     // When
-    val result = selectCovered(pickBestFactory)(LogicalPlan, qg)
+    val result = selectCovered(LogicalPlan, qg)
 
     // Then
-    result should equal(LogicalPlan)
+    result should equal(Seq())
   }
 
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectCoveredTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectCoveredTest.scala
@@ -19,33 +19,17 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps
 
-import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compiler.v2_3.ast._
 import org.neo4j.cypher.internal.compiler.v2_3.planner._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
-import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{CandidateSelector, LogicalPlanningFunction0}
 import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
 
 class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
   private implicit val planContext = newMockedPlanContext
   private implicit val subQueryLookupTable = Map.empty[PatternExpression, QueryGraph]
   private implicit val context = newMockedLogicalPlanningContext(planContext)
-  val pickBestFactory = mock[LogicalPlanningFunction0[CandidateSelector]]
 
-  val selector = mock[CandidateSelector]
-  when(selector.apply(any())).thenAnswer(new Answer[Option[LogicalPlan]] {
-    override def answer(invocationOnMock: InvocationOnMock): Option[LogicalPlan] = {
-      val arguments = invocationOnMock.getArguments
-      val apply = arguments.apply(0)
-      val plans = apply.asInstanceOf[Iterable[LogicalPlan]]
-      plans.headOption
-    }
-  })
-
-  when(pickBestFactory.apply(any())).thenReturn(selector)
   test("when a predicate that isn't already solved is solvable it should be applied") {
     // Given
     val predicate = mock[Expression]
@@ -127,28 +111,5 @@ class SelectCoveredTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
     // Then
     result should equal(Seq())
-  }
-
-}
-
-class SelectCoveredTest2 extends CypherFunSuite with LogicalPlanningTestSupport2 {
-  test("should solve labels with joins") {
-
-    implicit val plan = new given {
-      cost = {
-        case (_: Selection, _) => 1000.0
-        case (_: NodeHashJoin, _) => 20.0
-        case (_: NodeByLabelScan, _) => 20.0
-      }
-    } planFor "MATCH (n:Foo:Bar:Baz) RETURN n"
-
-    plan.innerPlan match {
-      case NodeHashJoin(_,
-      NodeHashJoin(_,
-      NodeByLabelScan(_, _, _),
-      NodeByLabelScan(_, _, _)),
-      NodeByLabelScan(_, _, _)) => ()
-      case _ => fail("Not what we expected!")
-    }
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectPatternPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectPatternPredicatesTest.scala
@@ -31,8 +31,6 @@ import org.neo4j.graphdb.Direction
 
 class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
-  private val pickBest = QueryPlannerConfiguration.default.pickBestCandidate
-
   val dir = Direction.OUTGOING
   val types = Seq.empty[RelTypeName]
   val relName = "  UNNAMED1"
@@ -69,15 +67,14 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val aPlan = newMockedLogicalPlan("a")
     val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(aPlan, qg)
 
     // Then
     result should equal(Seq(SemiApply(aPlan, inner)(solved)))
@@ -102,15 +99,14 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val aPlan = newMockedLogicalPlan("a")
     val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(aPlan, qg)
 
     // Then
     result should equal(Seq(AntiSemiApply(aPlan, inner)(solved)))
@@ -135,13 +131,12 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val bPlan = newMockedLogicalPlan("b")
     // When
-    val result = selectPatternPredicates(pickBest)(bPlan, qg)
+    val result = selectPatternPredicates(bPlan, qg)
 
     // Then
     result should equal(Seq.empty)
@@ -170,8 +165,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -179,7 +173,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner = Expand(singleRow, IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(aPlan, qg)
 
     // Then
     result should equal(Seq(SelectOrSemiApply(aPlan, inner, equals)(solved)))
@@ -208,15 +202,14 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val aPlan = newMockedLogicalPlan("a")
     val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(aPlan, qg)
 
     // Then
     result should equal(Seq(SelectOrAntiSemiApply(aPlan, inner, equals)(solved)))
@@ -255,8 +248,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -264,7 +256,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(aPlan, qg)
 
     // Then
     result should equal(Seq(SelectOrSemiApply(LetSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved)))
@@ -302,8 +294,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -311,7 +302,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(aPlan, qg)
 
     // Then
     result should equal(Seq(SelectOrAntiSemiApply(LetSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved)))
@@ -349,8 +340,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -358,7 +348,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(aPlan, qg)
 
     // Then
     result should equal(Seq(SelectOrSemiApply(LetAntiSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved)))
@@ -401,8 +391,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -410,7 +399,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(aPlan, qg)
 
     // Then
     result should equal(Seq(SelectOrAntiSemiApply(LetSelectOrSemiApply(aPlan, inner, IdName("  FRESHID0"), equals)(solved), inner2, ident("  FRESHID0"))(solved)))
@@ -453,8 +442,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     implicit val subQueryLookupTable = Map(patternExp -> patternQG, patternExp2 -> patternQG2)
 
     implicit val context = newMockedLogicalPlanningContext(
-      planContext = newMockedPlanContext,
-      metrics = factory.newMetrics(hardcodedStatistics)
+      planContext = newMockedPlanContext
     )
 
     val aPlan = newMockedLogicalPlan("a")
@@ -462,7 +450,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(aPlan, qg)
 
     // Then
     result should equal(Seq(SelectOrSemiApply(LetSelectOrAntiSemiApply(aPlan, inner, IdName("  FRESHID0"), equals)(solved), inner2, ident("  FRESHID0"))(solved)))

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectPatternPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectPatternPredicatesTest.scala
@@ -51,10 +51,6 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     case _ => Cardinality(1000)
   })
 
-  val passThrough = new PlanTransformer[QueryGraph] {
-    def apply(input: LogicalPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): LogicalPlan = input
-  }
-
   test("should introduce semi apply for unsolved exclusive pattern predicate") {
     // Given
     val predicate = Predicate(Set(IdName("a")), patternExp)
@@ -81,7 +77,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
     result should equal(SemiApply(aPlan, inner)(solved))
@@ -114,7 +110,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
     result should equal(AntiSemiApply(aPlan, inner)(solved))
@@ -145,7 +141,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
 
     val bPlan = newMockedLogicalPlan("b")
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(bPlan, qg)
+    val result = selectPatternPredicates(pickBest)(bPlan, qg)
 
     // Then
     result should equal(bPlan)
@@ -183,7 +179,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner = Expand(singleRow, IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
     result should equal(SelectOrSemiApply(aPlan, inner, equals)(solved))
@@ -220,7 +216,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
     result should equal(SelectOrAntiSemiApply(aPlan, inner, equals)(solved))
@@ -268,7 +264,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
     result should equal(SelectOrSemiApply(LetSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved))
@@ -315,7 +311,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
     result should equal(SelectOrAntiSemiApply(LetSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved))
@@ -362,7 +358,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
     result should equal(SelectOrSemiApply(LetAntiSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved))
@@ -414,7 +410,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
     result should equal(SelectOrAntiSemiApply(LetSelectOrSemiApply(aPlan, inner, IdName("  FRESHID0"), equals)(solved), inner2, ident("  FRESHID0"))(solved))
@@ -466,7 +462,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
-    val result = selectPatternPredicates(passThrough, pickBest)(aPlan, qg)
+    val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
     result should equal(SelectOrSemiApply(LetSelectOrAntiSemiApply(aPlan, inner, IdName("  FRESHID0"), equals)(solved), inner2, ident("  FRESHID0"))(solved))

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectPatternPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectPatternPredicatesTest.scala
@@ -80,7 +80,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
-    result should equal(SemiApply(aPlan, inner)(solved))
+    result should equal(Seq(SemiApply(aPlan, inner)(solved)))
   }
 
   test("should introduce anti semi apply for unsolved exclusive negated pattern predicate") {
@@ -113,7 +113,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
-    result should equal(AntiSemiApply(aPlan, inner)(solved))
+    result should equal(Seq(AntiSemiApply(aPlan, inner)(solved)))
   }
 
   test("should not introduce semi apply for unsolved exclusive pattern predicate when nodes not applicable") {
@@ -144,7 +144,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(bPlan, qg)
 
     // Then
-    result should equal(bPlan)
+    result should equal(Seq.empty)
   }
 
   test("should introduce select or semi apply for unsolved pattern predicates in disjunction with expressions") {
@@ -182,7 +182,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
-    result should equal(SelectOrSemiApply(aPlan, inner, equals)(solved))
+    result should equal(Seq(SelectOrSemiApply(aPlan, inner, equals)(solved)))
   }
 
   test("should introduce select or anti semi apply for unsolved negated pattern predicates in disjunction with an expression") {
@@ -219,7 +219,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
-    result should equal(SelectOrAntiSemiApply(aPlan, inner, equals)(solved))
+    result should equal(Seq(SelectOrAntiSemiApply(aPlan, inner, equals)(solved)))
   }
 
   test("should introduce let semi apply and select or semi apply for multiple pattern predicates in or") {
@@ -267,7 +267,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
-    result should equal(SelectOrSemiApply(LetSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved))
+    result should equal(Seq(SelectOrSemiApply(LetSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved)))
   }
 
   test("should introduce let semi apply and select or anti semi apply for multiple pattern predicates in or") {
@@ -314,7 +314,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
-    result should equal(SelectOrAntiSemiApply(LetSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved))
+    result should equal(Seq(SelectOrAntiSemiApply(LetSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved)))
   }
 
   test("should introduce let anti semi apply and select or semi apply for multiple pattern predicates in or") {
@@ -361,7 +361,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
-    result should equal(SelectOrSemiApply(LetAntiSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved))
+    result should equal(Seq(SelectOrSemiApply(LetAntiSemiApply(aPlan, inner, IdName("  FRESHID0"))(solved), inner2, ident("  FRESHID0"))(solved)))
   }
 
   test("should introduce let select or semi apply and select or anti semi apply for multiple pattern predicates in or") {
@@ -413,7 +413,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
-    result should equal(SelectOrAntiSemiApply(LetSelectOrSemiApply(aPlan, inner, IdName("  FRESHID0"), equals)(solved), inner2, ident("  FRESHID0"))(solved))
+    result should equal(Seq(SelectOrAntiSemiApply(LetSelectOrSemiApply(aPlan, inner, IdName("  FRESHID0"), equals)(solved), inner2, ident("  FRESHID0"))(solved)))
   }
 
   test("should introduce let anti select or semi apply and select or semi apply for multiple pattern predicates in or") {
@@ -465,6 +465,6 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     val result = selectPatternPredicates(pickBest)(aPlan, qg)
 
     // Then
-    result should equal(SelectOrSemiApply(LetSelectOrAntiSemiApply(aPlan, inner, IdName("  FRESHID0"), equals)(solved), inner2, ident("  FRESHID0"))(solved))
+    result should equal(Seq(SelectOrSemiApply(LetSelectOrAntiSemiApply(aPlan, inner, IdName("  FRESHID0"), equals)(solved), inner2, ident("  FRESHID0"))(solved)))
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/TriadicSelectionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/TriadicSelectionTest.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps
+
+import org.neo4j.cypher.internal.compiler.v2_3.ast.{RelTypeName, Equals, Identifier, Not}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.LazyLabel
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.QueryGraphProducer
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v2_3.planner.{LogicalPlanningTestSupport, QueryGraph}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.Direction
+
+class TriadicSelectionTest extends CypherFunSuite with LogicalPlanningTestSupport with QueryGraphProducer {
+
+  implicit val ctx = newMockedLogicalPlanningContext(mock[PlanContext])
+
+  test("plan passes through") {
+    val plan = newMockedLogicalPlan()
+
+    triadicSelection(plan, QueryGraph.empty) should equal(plan)
+  }
+
+  test("MATCH (a:X)-->(b)-->(c) WHERE NOT (a)-->(c)") {
+    implicit val (plannerQuery, semanticTable) = producePlannerQueryForPattern("MATCH (a:X)-[r1]->(b)-[r2]->(c) WHERE NOT (a)-->(c)")
+
+    val lblScan = NodeByLabelScan(IdName("a"), LazyLabel("X"), Set.empty)(solved)
+    val expand1 = Expand(lblScan, IdName("a"), Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
+    val expand2 = Expand(expand1, IdName("b"), Direction.OUTGOING, Seq.empty, IdName("c"), IdName("r2"), ExpandAll)(solved)
+    val selection = Selection(Seq(Not(Equals(Identifier("r1")(pos), Identifier("r2")(pos))(pos))(pos)), expand2)(solved)
+
+    val triadicBuild = TriadicBuild(expand1, IdName("b"))(solved)
+    val expand2B = Expand(triadicBuild, IdName("b"), Direction.OUTGOING, Seq.empty, IdName("c"), IdName("r2"), ExpandAll)(solved)
+    val selectionB = Selection(Seq(Not(Equals(Identifier("r1")(pos), Identifier("r2")(pos))(pos))(pos)), expand2B)(solved)
+    val triadicProbe = TriadicProbe(selectionB, IdName("b"), IdName("c"))(solved)
+
+    triadicSelection(selection, plannerQuery.lastQueryGraph) should equal(triadicProbe)
+  }
+
+  test("MATCH (a:X)-[:A]->(b)-[:B]->(c) WHERE NOT (a)-->(c) passes through") {
+    implicit val (plannerQuery, semanticTable) = producePlannerQueryForPattern("MATCH (a:X)-[:A]->(b)-[:B]->(c) WHERE NOT (a)-->(c)")
+
+    val lblScan = NodeByLabelScan(IdName("a"), LazyLabel("X"), Set.empty)(solved)
+    val expand1 = Expand(lblScan, IdName("a"), Direction.OUTGOING, Seq(RelTypeName("A")(pos)), IdName("b"), IdName("r1"), ExpandAll)(solved)
+    val expand2 = Expand(expand1, IdName("b"), Direction.OUTGOING, Seq(RelTypeName("B")(pos)), IdName("c"), IdName("r2"), ExpandAll)(solved)
+    val selection = Selection(Seq(Not(Equals(Identifier("r1")(pos), Identifier("r2")(pos))(pos))(pos)), expand2)(solved)
+
+    triadicSelection(selection, plannerQuery.lastQueryGraph) should equal(selection)
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/TriadicSelectionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/TriadicSelectionTest.scala
@@ -35,7 +35,7 @@ class TriadicSelectionTest extends CypherFunSuite with LogicalPlanningTestSuppor
   test("plan passes through") {
     val plan = newMockedLogicalPlan()
 
-    triadicSelection(plan, QueryGraph.empty) should equal(plan)
+    triadicSelection(plan, QueryGraph.empty) should equal(Seq.empty)
   }
 
   test("MATCH (a:X)-->(b)-->(c) WHERE NOT (a)-->(c)") {
@@ -51,7 +51,7 @@ class TriadicSelectionTest extends CypherFunSuite with LogicalPlanningTestSuppor
     val selectionB = Selection(Seq(Not(Equals(Identifier("r1")(pos), Identifier("r2")(pos))(pos))(pos)), expand2B)(solved)
     val triadicProbe = TriadicProbe(selectionB, IdName("b"), IdName("c"))(solved)
 
-    triadicSelection(selection, plannerQuery.lastQueryGraph) should equal(triadicProbe)
+    triadicSelection(selection, plannerQuery.lastQueryGraph) should equal(Seq(triadicProbe))
   }
 
   test("MATCH (a:X)-[:A]->(b)-[:B]->(c) WHERE NOT (a)-->(c) passes through") {
@@ -62,6 +62,6 @@ class TriadicSelectionTest extends CypherFunSuite with LogicalPlanningTestSuppor
     val expand2 = Expand(expand1, IdName("b"), Direction.OUTGOING, Seq(RelTypeName("B")(pos)), IdName("c"), IdName("r2"), ExpandAll)(solved)
     val selection = Selection(Seq(Not(Equals(Identifier("r1")(pos), Identifier("r2")(pos))(pos))(pos)), expand2)(solved)
 
-    triadicSelection(selection, plannerQuery.lastQueryGraph) should equal(selection)
+    triadicSelection(selection, plannerQuery.lastQueryGraph) should equal(Seq.empty)
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/ProfilerTest.scala
@@ -165,7 +165,7 @@ class ProfilerTest extends CypherFunSuite {
 
     val pipe1 = SingleRowPipe()
     val ctx1 = mock[QueryContext]
-    val state1 = QueryState(ctx1, mock[ExternalResource], Map.empty, mock[PipeDecorator])
+    val state1 = new QueryState(ctx1, mock[ExternalResource], Map.empty, mock[PipeDecorator])
 
     val profiled1 = profiler.decorate(pipe1, state1)
     profiled1.query.createNode()
@@ -173,7 +173,7 @@ class ProfilerTest extends CypherFunSuite {
 
     val pipe2 = SingleRowPipe()
     val ctx2 = mock[QueryContext]
-    val state2 = QueryState(ctx2, mock[ExternalResource], Map.empty, mock[PipeDecorator])
+    val state2 = new QueryState(ctx2, mock[ExternalResource], Map.empty, mock[PipeDecorator])
 
     val profiled2 = profiler.decorate(pipe2, state2)
     profiled2.query.createNode()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/CreateRelationshipTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/CreateRelationshipTest.scala
@@ -40,7 +40,7 @@ class CreateRelationshipTest extends GraphDatabaseFunSuite {
 
     val tx = graph.beginTx()
     try {
-      val state = QueryStateHelper.queryStateFrom(graph, tx).copy(params = props)
+      val state = QueryStateHelper.queryStateFrom(graph, tx, props)
       val ctx = ExecutionContext.from("a" -> a, "b" -> b)
 
       //when

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/QueryStateHelper.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/QueryStateHelper.scala
@@ -32,7 +32,7 @@ object QueryStateHelper {
 
   def emptyWith(db: GraphDatabaseService = null, query: QueryContext = null, resources: ExternalResource = null,
                 params: Map[String, Any] = Map.empty, decorator: PipeDecorator = NullPipeDecorator) =
-    QueryState(query = query, resources = resources, params = params, decorator = decorator)
+    new QueryState(query = query, resources = resources, params = params, decorator = decorator)
 
   def queryStateFrom(db: GraphDatabaseAPI, tx: Transaction, params: Map[String, Any] = Map.empty): QueryState = {
     val statement: Statement = db.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge]).get()
@@ -40,5 +40,5 @@ object QueryStateHelper {
     emptyWith(db = db, query = context, params = params)
   }
 
-  def countStats(q: QueryState) = q.copy(query = new UpdateCountingQueryContext(q.query))
+  def countStats(q: QueryState) = q.withQueryContext(query = new UpdateCountingQueryContext(q.query))
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/QueryStateHelper.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/QueryStateHelper.scala
@@ -34,10 +34,10 @@ object QueryStateHelper {
                 params: Map[String, Any] = Map.empty, decorator: PipeDecorator = NullPipeDecorator) =
     QueryState(query = query, resources = resources, params = params, decorator = decorator)
 
-  def queryStateFrom(db: GraphDatabaseAPI, tx: Transaction): QueryState = {
+  def queryStateFrom(db: GraphDatabaseAPI, tx: Transaction, params: Map[String, Any] = Map.empty): QueryState = {
     val statement: Statement = db.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge]).get()
     val context = new TransactionBoundQueryContext(db, tx, isTopLevelTx = true, statement)
-    emptyWith(db = db, query = context)
+    emptyWith(db = db, query = context, params = params)
   }
 
   def countStats(q: QueryState) = q.copy(query = new UpdateCountingQueryContext(q.query))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ActualCostCalculationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ActualCostCalculationTest.scala
@@ -60,7 +60,7 @@ class ActualCostCalculationTest extends CypherFunSuite {
     graph.withTx { tx =>
       val resources: ExternalResource = mock[ExternalResource]
       val queryContext = new TransactionBoundQueryContext(graph.asInstanceOf[GraphDatabaseAPI], tx, true, graph.statement)
-      val state = QueryState(queryContext, resources, params = Map.empty, decorator = NullPipeDecorator)
+      val state = new QueryState(queryContext, resources, params = Map.empty, decorator = NullPipeDecorator)
 
       for (x <- 0 to 30) {
         for ((name, pipe) <- pipes) {


### PR DESCRIPTION
Triadic checking is a new operator for Cypher in Neo4j, which makes a very common pattern, friend of a friend that is not already a friend, much faster.

An example is the best way I know of explaining. The query that is optimised: 

```
MATCH (a:X {id: 0})--(b)--(c) WHERE NOT (a)--(c) RETURN *
```

This query is solved with a logical plan that looks like this:

```
+-----------------+----------------+------+---------+-----------------------------+---------------------------+
| Operator        | Estimated Rows | Rows | DB Hits | Identifiers                 | Other                     |
+-----------------+----------------+------+---------+-----------------------------+---------------------------+
| +ProduceResults |            100 |  574 |       0 | a, b, c                     | a, b, c                   |
| |               +----------------+------+---------+-----------------------------+---------------------------+
| +Projection     |            100 |  574 |       0 | anon[20], anon[25], a, b, c | a; b; c                   |
| |               +----------------+------+---------+-----------------------------+---------------------------+
| +TriadicProbe   |            100 |  574 |       0 | anon[20], anon[25], a, b, c |                           |
| |               +----------------+------+---------+-----------------------------+---------------------------+
| +Filter         |            400 |  576 |       0 | anon[20], anon[25], a, b, c | NOT(anon[20] == anon[25]) |
| |               +----------------+------+---------+-----------------------------+---------------------------+
| +Expand(All)    |            400 |  604 |     632 | anon[20], anon[25], a, b, c | (b)--(c)                  |
| |               +----------------+------+---------+-----------------------------+---------------------------+
| +TriadicBuild   |             20 |   28 |       0 | anon[20], a, b              |                           |
| |               +----------------+------+---------+-----------------------------+---------------------------+
| +Expand(All)    |             20 |   28 |      29 | anon[20], a, b              | (a)--(b)                  |
| |               +----------------+------+---------+-----------------------------+---------------------------+
| +NodeIndexSeek  |              1 |    1 |       2 | a                           | :X(id)                    |
+-----------------+----------------+------+---------+-----------------------------+---------------------------+
```

This is done by starting from `a` and then expanding into `b`. Here `TriadicBuild` eagerly builds up a set of all `b` nodes seen. The plan continues expanding into `c`, and then filtering out relationships to maintain relationship uniqueness. Finally, we filter out any `c` nodes with `TriadicProbe`, which uses the set built by the `TriadicBuild` to filter out nodes already seen having a relationship to `a`.

This commit only takes on a few scenarios, and should be extended into handling more types of plans.
