### PR TITLE
Tidy up leftovers for 2.3

### DIFF
--- a/community/browser/Gruntfile.coffee
+++ b/community/browser/Gruntfile.coffee
@@ -277,7 +277,7 @@ module.exports = (grunt) ->
             dot: true
             cwd: "<%= yeoman.app %>"
             dest: "<%= yeoman.dist %>/fonts"
-            src: ["components/**/*.{otf,woff,ttf,svg}"]
+            src: ["components/**/*.{otf,woff,woff2,ttf,svg}"]
         }]
     shell:
       dirListing:

--- a/community/browser/app/content/guides/start.jade
+++ b/community/browser/app/content/guides/start.jade
@@ -4,7 +4,7 @@ article.guide
       .col-sm-3
         .box-max
           img.img-responsive(src='images/neo4j-world.png')
-          p.lead.text-center {{ neo4j.version }}
+          p.lead.text-center {{ neo4j.version }} - {{ neo4j.edition | uppercase }}
       .col-sm-9
         .teaser.teaser-3
           h3 Learn about Neo4j

--- a/community/browser/app/content/help/help.jade
+++ b/community/browser/app/content/help/help.jade
@@ -44,5 +44,9 @@ article.help
             th Reference:
             td
               a(href="http://neo4j.com/docs/{{neo4j.version}}/") Neo4j Manual
+              br
+              a(href="http://neo4j.com/developer") Neo4j Developer Pages
+              br
+              a(href="http://neo4j.com/docs/{{neo4j.version}}/cypher-refcard") Cypher Refcard
 
 

--- a/community/browser/app/views/partials/drawer-database.jade
+++ b/community/browser/app/views/partials/drawer-database.jade
@@ -2,7 +2,7 @@
   h4 Neo4j {{ neo4j.version }}
   h5 Node labels
 
-  a.token.token-label(ng-show="labels.length", ng-click="editor.execScript('MATCH n RETURN n LIMIT 25')") *
+  a.token.token-label(ng-show="labels.length", ng-click="editor.execScript('MATCH (n) RETURN n LIMIT 25')") *
   span(ng-repeat='label in labels | orderBy: identity')
     a.token.token-label(ng-click="editor.execScript(substituteToken('MATCH (n:<token>) RETURN n LIMIT 25', label))") {{label}}
 


### PR DESCRIPTION
- Show edition on `:play start` frame.
- Add links to :help.
- Update built in Cypher queries to not generate Cypher warnings.
- Copy .woff2 font files to build.
