### PR TITLE
Removed extra projection needed for compiled runtime

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGenContext.scala
@@ -27,8 +27,6 @@ import org.neo4j.cypher.internal.compiler.v2_3.symbols.CypherType
 
 import scala.collection.mutable
 
-// STATEFUL!
-
 case class Variable(name: String, cypherType: CypherType, nullable: Boolean = false)
 
 class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, Id], val namer: Namer = Namer()) {
@@ -38,13 +36,13 @@ class CodeGenContext(val semanticTable: SemanticTable, idMap: Map[LogicalPlan, I
   private val parents: mutable.Stack[CodeGenPlan] = mutable.Stack()
   val operatorIds: mutable.Map[Id, String] = mutable.Map()
 
-  def addVariable(name: String, variable: Variable) {
-    variables.put(name, variable)
+  def addVariable(queryIdentifier: String, variable: Variable) {
+    variables.put(queryIdentifier, variable)
   }
 
-  def getVariable(name: String): Variable = variables(name)
+  def getVariable(queryIdentifier: String): Variable = variables(queryIdentifier)
 
-  def variableNames(): Set[String] = variables.keySet.toSet
+  def variableQueryIdentifiers(): Set[String] = variables.keySet.toSet
 
   def addProbeTable(plan: CodeGenPlan, codeThunk: JoinData) {
     probeTables.put(plan, codeThunk)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeStructure.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeStructure.scala
@@ -45,6 +45,7 @@ case class LongsToListTable(structure: Map[String, CypherType], localMap: Map[St
 trait MethodStructure[E] {
 
   // misc
+  def projectVariable(variableName: String, value: E)
   def declareFlag(name: String, initialValue: Boolean)
   def updateFlag(name: String, newValue: Boolean)
   def declarePredicate(name: String): Unit
@@ -136,6 +137,7 @@ trait MethodStructure[E] {
   def node(nodeIdVar: String): E
   def materializeRelationship(relIdVar: String): E
   def relationship(relIdVar: String): E
-  def visitRow(): Unit
+  /** Feed single row to the given visitor */
+  def visitorAccept(): Unit
   def setInRow(column: String, value: E): Unit
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/expressions/ExpressionConverter.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/expressions/ExpressionConverter.scala
@@ -19,8 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.codegen.ir.expressions
 
-import org.neo4j.cypher.internal.compiler.v2_3.{symbols, ast}
-import org.neo4j.cypher.internal.compiler.v2_3.codegen.{MethodStructure, CodeGenContext}
+import org.neo4j.cypher.internal.compiler.v2_3.symbols.{CTRelationship, CTNode}
+import org.neo4j.cypher.internal.compiler.v2_3.{InternalException, symbols, ast}
+import org.neo4j.cypher.internal.compiler.v2_3.codegen.{Variable, MethodStructure, CodeGenContext}
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.ir.expressions
 import org.neo4j.cypher.internal.compiler.v2_3.planner.CantCompileQueryException
 
@@ -81,6 +82,18 @@ object ExpressionConverter {
         RelationshipProjection(context.getVariable(name))
 
       case e => expressionConverter(e, createProjection)
+    }
+  }
+
+  def createExpressionForVariable(variableQueryIdentifier: String)
+                                 (implicit context: CodeGenContext): CodeGenExpression = {
+
+    val variable = context.getVariable(variableQueryIdentifier)
+
+    variable.cypherType match {
+      case CTNode => NodeProjection(variable)
+      case CTRelationship => RelationshipProjection(variable)
+      case _ => throw new InternalException("The compiled runtime only handles identifiers pointing to rels and nodes at this time")
     }
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/LogicalPlanProducer.scala
@@ -322,6 +322,10 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends Colle
   def planSingleRow()(implicit context: LogicalPlanningContext) =
     SingleRow()(PlannerQuery.empty)
 
+  def planStarProjection(inner: LogicalPlan, expressions: Map[String, Expression])
+                        (implicit context: LogicalPlanningContext) =
+    inner.updateSolved(_.updateTailOrSelf(_.updateQueryProjection(_.withProjections(expressions))))
+
   def planRegularProjection(inner: LogicalPlan, expressions: Map[String, Expression])
                            (implicit context: LogicalPlanningContext) = {
     val solved = inner.solved.updateTailOrSelf(_.updateQueryProjection(_.withProjections(expressions)))

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
@@ -221,10 +221,4 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
   implicit def propertyKeyId(label: String)(implicit plan: SemanticPlan): PropertyKeyId =
     plan.semanticTable.resolvedPropertyKeyNames(label)
-
-  implicit class RichPlan(plan: SemanticPlan) {
-    def innerPlan = plan.plan match {
-      case Projection(inner, _) => inner
-    }
-  }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/CartesianProductPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/CartesianProductPlanningIntegrationTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.test_helpers.CypherFunSuite
 class CartesianProductPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
   test("should build plans for simple cartesian product") {
-    planFor("MATCH n, m RETURN n, m").innerPlan should equal(
+    planFor("MATCH n, m RETURN n, m").plan should equal(
       CartesianProduct(
         AllNodesScan(IdName("n"), Set.empty)(solved),
         AllNodesScan(IdName("m"), Set.empty)(solved)
@@ -45,7 +45,7 @@ class CartesianProductPlanningIntegrationTest extends CypherFunSuite with Logica
       cardinality = mapCardinality {
         case PlannerQuery(queryGraph, _, _) if queryGraph.selections.predicates.size == 1 => 10
       }
-    } planFor "MATCH n, m WHERE n.prop = 12 AND m:Label RETURN n, m").innerPlan should beLike {
+    } planFor "MATCH n, m WHERE n.prop = 12 AND m:Label RETURN n, m").plan should beLike {
       case CartesianProduct(_: Selection, _: NodeByLabelScan) => ()
     }
   }
@@ -59,7 +59,7 @@ class CartesianProductPlanningIntegrationTest extends CypherFunSuite with Logica
       )
     } planFor "MATCH a, b, c WHERE a:A AND b:B AND c:C RETURN a, b, c"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       CartesianProduct(
         NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solved),
         CartesianProduct(
@@ -81,7 +81,7 @@ class CartesianProductPlanningIntegrationTest extends CypherFunSuite with Logica
     // A x B = 30 * 2 + 30 * (20 * 2) => 1260
     // B x A = 20 * 2 + 20 * (30 * 2) => 1240
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       CartesianProduct(
         NodeByLabelScan("b", LazyLabel("B"), Set.empty)(solved),
         NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solved)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/DefaultQueryPlannerTest.scala
@@ -97,7 +97,7 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     })
     when(context.withStrictness(any())).thenReturn(context)
     val producer = mock[LogicalPlanProducer]
-    when(producer.planRegularProjection(any(), any())(any())).thenReturn(lp)
+    when(producer.planStarProjection(any(), any())(any())).thenReturn(lp)
     when(context.logicalPlanProducer).thenReturn(producer)
     val queryPlanner = new DefaultQueryPlanner(planRewriter = Rewriter.noop,
       planSingleQuery = PlanSingleQuery(expressionRewriterFactory = (lpc) => Rewriter.noop ))

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/ExpandPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/ExpandPlanningIntegrationTest.scala
@@ -31,7 +31,7 @@ import org.neo4j.graphdb.Direction
 class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
   test("Should build plans containing expand for single relationship pattern") {
-    planFor("MATCH (a)-[r]->(b) RETURN r").innerPlan should equal(
+    planFor("MATCH (a)-[r]->(b) RETURN r").plan should equal(
         Expand(
           AllNodesScan("b", Set.empty)(solved),
           "b", Direction.INCOMING, Seq.empty, "a", "r"
@@ -49,7 +49,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
         case PlannerQuery(queryGraph, _, _) if queryGraph.patternNodes == Set(IdName("d")) => 4000.0
         case _ => 100.0
       }
-    } planFor "MATCH (a)-[r1]->(b), (c)-[r2]->(d) RETURN r1, r2").innerPlan should beLike {
+    } planFor "MATCH (a)-[r1]->(b), (c)-[r2]->(d) RETURN r1, r2").plan should beLike {
       case
         Selection(_,
           CartesianProduct(
@@ -63,7 +63,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
   }
 
   test("Should build plans containing expand for self-referencing relationship patterns") {
-    val result = planFor("MATCH (a)-[r]->(a) RETURN r").innerPlan
+    val result = planFor("MATCH (a)-[r]->(a) RETURN r").plan
 
     result should equal(
       Expand(
@@ -80,7 +80,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
         case _                                                                   => 1.0
       }
 
-    } planFor "MATCH (a)-[r1]->(b)<-[r2]-(a) RETURN r1, r2").innerPlan should equal(
+    } planFor "MATCH (a)-[r1]->(b)<-[r2]-(a) RETURN r1, r2").plan should equal(
       Selection(Seq(Not(Equals(Identifier("r1")_,Identifier("r2")_)_)_),
         Expand(
           Expand(
@@ -100,7 +100,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
 
     (new given {
       cardinality = PartialFunction(myCardinality)
-    } planFor "MATCH (start)-[rel:x]-(a) WHERE a.name = 'Andres' return a").innerPlan should equal(
+    } planFor "MATCH (start)-[rel:x]-(a) WHERE a.name = 'Andres' return a").plan should equal(
         Expand(
           Selection(
             Seq(In(Property(Identifier("a")_, PropertyKeyName("name")_)_, Collection(Seq(StringLiteral("Andres")_))_)_),
@@ -119,7 +119,7 @@ class ExpandPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningT
       }
 
       indexOn("Person", "name")
-    } planFor "MATCH (a)-[r]->(b) USING INDEX b:Person(name) WHERE b:Person AND b.name = 'Andres' return r").innerPlan should equal(
+    } planFor "MATCH (a)-[r]->(b) USING INDEX b:Person(name) WHERE b:Person AND b.name = 'Andres' return r").plan should equal(
         Expand(
           NodeIndexSeek("b", LabelToken("Person", LabelId(0)), PropertyKeyToken("name", PropertyKeyId(0)), SingleQueryExpression(StringLiteral("Andres")_), Set.empty)(solved),
           "b", Direction.INCOMING, Seq.empty, "a", "r"

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
@@ -29,7 +29,7 @@ import org.neo4j.graphdb.Direction
 class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
   test("finds shortest paths") {
-    planFor("MATCH a, b, shortestPath(a-[r]->b) RETURN b").innerPlan should equal(
+    planFor("MATCH a, b, shortestPath(a-[r]->b) RETURN b").plan should equal(
       FindShortestPaths(
         CartesianProduct(
           AllNodesScan("b", Set.empty)(solved),
@@ -45,7 +45,7 @@ class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with Logic
   }
 
   test("finds all shortest paths") {
-    planFor("MATCH a, b, allShortestPaths(a-[r]->b) RETURN b").innerPlan should equal(
+    planFor("MATCH a, b, allShortestPaths(a-[r]->b) RETURN b").plan should equal(
       FindShortestPaths(
         CartesianProduct(
           AllNodesScan("b", Set.empty)(solved),
@@ -71,7 +71,7 @@ class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with Logic
         case PlannerQuery(queryGraph, _, _) if queryGraph.patternRelationships.size == 1 => 100.0
         case _                             => Double.MaxValue
       }
-    } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X), p = shortestPath((a)-[r]->(c)) RETURN p").innerPlan
+    } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X), p = shortestPath((a)-[r]->(c)) RETURN p").plan
 
     val expected =
       FindShortestPaths(

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/LeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/LeafPlanningIntegrationTest.scala
@@ -35,7 +35,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     (new given {
       indexOn("Person", "name")
       cost = nodeIndexScanCost
-    } planFor "MATCH (a:Person) WHERE a.name LIKE 'prefix%' RETURN a").innerPlan should equal(
+    } planFor "MATCH (a:Person) WHERE a.name LIKE 'prefix%' RETURN a").plan should equal(
       NodeIndexSeek(
         "a",
         LabelToken("Person", LabelId(0)),
@@ -49,7 +49,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     val result = (new given {
       indexOn("Person", "name")
       cost = nodeIndexScanCost
-    } planFor "MATCH (a:Person) WHERE a.name LIKE '%' RETURN a").innerPlan
+    } planFor "MATCH (a:Person) WHERE a.name LIKE '%' RETURN a").plan
 
     result should equal(
       Selection(Seq(Like(Property(Identifier("a") _, PropertyKeyName("name") _) _,
@@ -68,7 +68,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Person", "lastname")
       cost = nodeIndexScanCost
     } planFor "MATCH (a:Person) WHERE a.name LIKE 'short%' AND a.lastname LIKE 'longer%' RETURN a")
-      .innerPlan should equal(
+      .plan should equal(
       Selection(Seq(Like(Property(Identifier("a") _, PropertyKeyName("name") _) _,
                          LikePattern(StringLiteral("short%") _)) _),
                 NodeIndexSeek(
@@ -86,7 +86,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Person", "lastname")
       cost = nodeIndexScanCost
     } planFor "MATCH (a:Person) WHERE a.name LIKE 'longer%' AND NOT a.lastname LIKE 'short%' RETURN a")
-      .innerPlan should equal(
+      .plan should equal(
       Selection(Seq(Not(Like(Property(Identifier("a") _, PropertyKeyName("lastname") _) _,
                              LikePattern(StringLiteral("short%") _)) _) _),
                 NodeIndexSeek(
@@ -102,7 +102,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     (new given {
       indexOn("Person", "name")
       cost = nodeIndexScanCost
-    } planFor "MATCH (a:Person) WHERE a.name LIKE 'prefix%suffix' RETURN a").innerPlan should equal(
+    } planFor "MATCH (a:Person) WHERE a.name LIKE 'prefix%suffix' RETURN a").plan should equal(
       Selection(
         Seq(Like(Property(ident("a"), PropertyKeyName("name")_)_, LikePattern(StringLiteral("prefix%suffix")_))_),
         NodeIndexSeek(
@@ -121,7 +121,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     (new given {
       indexOn("Person", "name")
       cost = nodeIndexScanCost
-    } planFor "MATCH (a:Person) WHERE a.name LIKE 'prefix%' AND a.name = 'prefix1' RETURN a").innerPlan should equal(
+    } planFor "MATCH (a:Person) WHERE a.name LIKE 'prefix%' AND a.name = 'prefix1' RETURN a").plan should equal(
       Selection(Seq(like),
                 NodeIndexSeek(
                   "a",
@@ -138,7 +138,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     (new given {
       indexOn("Person", "name")
       cost = nodeIndexScanCost
-    } planFor "MATCH (a:Person) WHERE a.name LIKE 'prefix%' AND a.name in ['prefix1', 'prefix2'] RETURN a").innerPlan should equal(
+    } planFor "MATCH (a:Person) WHERE a.name LIKE 'prefix%' AND a.name in ['prefix1', 'prefix2'] RETURN a").plan should equal(
       Selection(Seq(like),
                 NodeIndexSeek(
                   "a",
@@ -151,7 +151,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
 
   test("should build plans for all nodes scans") {
     (new given {
-    } planFor "MATCH (n) RETURN n").innerPlan should equal(
+    } planFor "MATCH (n) RETURN n").plan should equal(
       AllNodesScan("n", Set.empty)(solved)
     )
   }
@@ -164,7 +164,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         case (_: NodeByLabelScan, _) => 1.0
         case _ => Double.MaxValue
       }
-    } planFor "MATCH (n:Awesome) RETURN n").innerPlan should equal(
+    } planFor "MATCH (n:Awesome) RETURN n").plan should equal(
       NodeByLabelScan("n", LazyLabel("Awesome"), Set.empty)(solved)
     )
   }
@@ -180,7 +180,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       knownLabels = Set("Awesome")
     } planFor "MATCH (n:Awesome) RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeByLabelScan("n", lazyLabel("Awesome"), Set.empty)(solved)
     )
   }
@@ -200,7 +200,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       cost = nodeIndexScanCost
     } planFor "MATCH (n:Awesome) WHERE has(n.prop) RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeIndexScan(
         "n",
         LabelToken("Awesome", LabelId(0)),
@@ -215,7 +215,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       cost = nodeIndexScanCost
     } planFor "MATCH (n:Awesome) WHERE has(n.prop) RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeIndexScan(
         "n",
         LabelToken("Awesome", LabelId(0)),
@@ -231,7 +231,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       cost = nodeIndexScanCost
     } planFor "MATCH (n:Awesome) WHERE has(n.prop) RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeIndexScan(
         "n",
         LabelToken("Awesome", LabelId(0)),
@@ -246,7 +246,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       cost = nodeIndexScanCost
     } planFor "MATCH (n:Awesome) WHERE has(n.prop) AND n.prop = 42 RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       Selection(Seq(FunctionInvocation(FunctionName("has") _, Property(ident("n"), PropertyKeyName("prop") _) _) _),
         NodeIndexSeek(
           "n",
@@ -262,7 +262,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop")
     } planFor "MATCH (n:Awesome) WHERE n.prop = 42 RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeIndexSeek(
         "n",
         LabelToken("Awesome", LabelId(0)),
@@ -277,7 +277,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop")
     } planFor "MATCH (n:Awesome) WHERE n.prop = 42 RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeUniqueIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)), SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
   }
@@ -288,7 +288,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop")
     } planFor "MATCH (n:Awesome) WHERE n.prop = 42 RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeUniqueIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)),
         SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
@@ -297,7 +297,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for node by ID mixed with label scan when node by ID is cheaper") {
     (new given {
       knownLabels = Set("Awesome")
-    } planFor "MATCH (n:Awesome) WHERE id(n) = 42 RETURN n").innerPlan should equal (
+    } planFor "MATCH (n:Awesome) WHERE id(n) = 42 RETURN n").plan should equal (
       Selection(
         List(HasLabels(Identifier("n")_, Seq(LabelName("Awesome")_))_),
         NodeByIdSeek("n", ManySeekableArgs(Collection(Seq(SignedDecimalIntegerLiteral("42")_))_), Set.empty)(solved)
@@ -308,7 +308,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for node by ID when the predicate is IN and rhs is a param") {
     (new given {
       knownLabels = Set("Awesome")
-    } planFor "MATCH (n:Awesome) WHERE id(n) IN {param} RETURN n").innerPlan should equal (
+    } planFor "MATCH (n:Awesome) WHERE id(n) IN {param} RETURN n").plan should equal (
       Selection(
         List(HasLabels(Identifier("n")_, Seq(LabelName("Awesome")_))_),
         NodeByIdSeek("n", ManySeekableArgs(Parameter("param")_), Set.empty)(solved)
@@ -318,14 +318,14 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
 
   test("should build plans for directed rel by ID when the predicate is IN and rhs is a param") {
     (new given {
-    } planFor "MATCH (a)-[r]->(b) WHERE id(r) IN {param} RETURN a, r, b").innerPlan should equal (
+    } planFor "MATCH (a)-[r]->(b) WHERE id(r) IN {param} RETURN a, r, b").plan should equal (
       DirectedRelationshipByIdSeek("r", ManySeekableArgs(Parameter("param")_), "a", "b", Set.empty)(solved)
     )
   }
 
   test("should build plans for undirected rel by ID when the predicate is IN and rhs is a param") {
     (new given {
-    } planFor "MATCH (a)-[r]-(b) WHERE id(r) IN {param} RETURN a, r, b").innerPlan should equal (
+    } planFor "MATCH (a)-[r]-(b) WHERE id(r) IN {param} RETURN a, r, b").plan should equal (
       UndirectedRelationshipByIdSeek("r", ManySeekableArgs(Parameter("param")_), "a", "b", Set.empty)(solved)
     )
   }
@@ -333,7 +333,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for node by ID when the predicate is IN") {
     (new given {
       knownLabels = Set("Awesome")
-    } planFor "MATCH (n:Awesome) WHERE id(n) IN [42, 64] RETURN n").innerPlan should equal (
+    } planFor "MATCH (n:Awesome) WHERE id(n) IN [42, 64] RETURN n").plan should equal (
       Selection(
         List(HasLabels(Identifier("n")_, Seq(LabelName("Awesome")_))_),
         NodeByIdSeek("n", ManySeekableArgs(Collection(Seq(SignedDecimalIntegerLiteral("42")_, SignedDecimalIntegerLiteral("64")_))_), Set.empty)(solved)
@@ -344,7 +344,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for index seek when there is an index on the property and an IN predicate") {
     (new given {
       indexOn("Awesome", "prop")
-    } planFor "MATCH (n:Awesome) WHERE n.prop IN [42] RETURN n").innerPlan should beLike {
+    } planFor "MATCH (n:Awesome) WHERE n.prop IN [42] RETURN n").plan should beLike {
       case NodeIndexSeek(
               IdName("n"),
               LabelToken("Awesome", _),
@@ -361,7 +361,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     // should not win
     (new given {
       indexOn("Awesome", "prop")
-    } planFor "MATCH (n:Awesome) WHERE n.prop IN [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] RETURN n").innerPlan should beLike {
+    } planFor "MATCH (n:Awesome) WHERE n.prop IN [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] RETURN n").plan should beLike {
       case _: Selection => ()
     }
   }
@@ -377,7 +377,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop")
     } planFor "MATCH (n:Awesome) WHERE n.prop IN [1,2,3,4,5] RETURN n"
 
-    result.innerPlan should beLike {
+    result.plan should beLike {
       case _: NodeUniqueIndexSeek => ()
     }
   }
@@ -392,7 +392,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       }
     } planFor "MATCH (n:Foo:Bar:Baz) USING SCAN n:Bar RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       Selection(
         Seq(HasLabels(ident("n"), Seq(LabelName("Foo")_))_, HasLabels(ident("n"), Seq(LabelName("Baz")_))_),
         NodeByLabelScan("n", LazyLabel("Bar"), Set.empty)(solved)
@@ -405,7 +405,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop) WHERE n:Awesome AND n.prop = 42 RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)), SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
   }
@@ -415,7 +415,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop) WHERE n:Awesome AND n.prop = 42 RETURN *"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)), SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
   }
@@ -426,7 +426,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       indexOn("Awesome", "prop2")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop2) WHERE n:Awesome AND n.prop1 = 42 and n.prop2 = 3 RETURN n "
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       Selection(
         List(In(Property(ident("n"), PropertyKeyName("prop1")_)_, Collection(Seq(SignedDecimalIntegerLiteral("42")_))_)_),
         NodeIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop2", PropertyKeyId(1)), SingleQueryExpression(SignedDecimalIntegerLiteral("3")_), Set.empty)(solved)
@@ -439,7 +439,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop) WHERE n:Awesome AND n.prop = 42 RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       NodeUniqueIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop", PropertyKeyId(0)), SingleQueryExpression(SignedDecimalIntegerLiteral("42")_), Set.empty)(solved)
     )
   }
@@ -450,7 +450,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop2")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop2) WHERE n:Awesome AND n.prop1 = 42 and n.prop2 = 3 RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       Selection(
         List(In(Property(ident("n"), PropertyKeyName("prop1")_)_, Collection(Seq(SignedDecimalIntegerLiteral("42")_))_)_),
         NodeUniqueIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop2", PropertyKeyId(1)), SingleQueryExpression(SignedDecimalIntegerLiteral("3")_), Set.empty)(solved)
@@ -464,7 +464,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       uniqueIndexOn("Awesome", "prop2")
     } planFor "MATCH (n) USING INDEX n:Awesome(prop2) WHERE n:Awesome AND n.prop1 = 42 and n.prop2 IN [3] RETURN n"
 
-    plan.innerPlan should equal(
+    plan.plan should equal(
       Selection(
         List(In(Property(ident("n"), PropertyKeyName("prop1")_)_, Collection(Seq(SignedDecimalIntegerLiteral("42")_))_)_),
         NodeUniqueIndexSeek("n", LabelToken("Awesome", LabelId(0)), PropertyKeyToken("prop2", PropertyKeyId(1)), SingleQueryExpression(SignedDecimalIntegerLiteral("3")_), Set.empty)(solved)
@@ -484,12 +484,11 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
 
     plan.plan should equal(
       Aggregation(
-      Projection(
         Apply(
           Projection(SingleRow()(solved),Map("arr" -> Collection(List(SignedDecimalIntegerLiteral("0")_, SignedDecimalIntegerLiteral("1")_, SignedDecimalIntegerLiteral("3")_))_))(solved),
           NodeByIdSeek(IdName("n"), ManySeekableArgs(Identifier("arr")_),Set(IdName("arr")))(solved)
         )(solved),
-        Map())(solved), Map(), Map("count(*)" -> CountStar()_)
+        Map(), Map("count(*)" -> CountStar()_)
       )(solved)
     )
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
@@ -45,17 +45,14 @@ class NamedPathProjectionPlanningIntegrationTest extends CypherFunSuite with Log
     val result = planFor("MATCH p = (a:X)-[r]->(b) WHERE head(nodes(p)) = a RETURN b").plan
 
     result should equal(
-      Projection(
-        Selection(
-          Seq(Equals(
-            FunctionInvocation(FunctionName("head")_, FunctionInvocation(FunctionName("nodes")_, ident("p"))_)_,
-            ident("a")
-          )_),
-          Projection(
-            Expand( NodeByLabelScan("a",  LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING,  Seq.empty, "b", "r")(solved),
-            expressions = Map("a" -> ident("a"), "b" -> ident("b"), "p" -> pathExpr, "r" -> ident("r")))(solved)
-        )(solved),
-        expressions = Map("b" -> ident("b"))
+      Selection(
+        Seq(Equals(
+          FunctionInvocation(FunctionName("head") _, FunctionInvocation(FunctionName("nodes") _, ident("p")) _) _,
+          ident("a")
+        ) _),
+        Projection(
+          Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING, Seq.empty, "b", "r")(solved),
+          expressions = Map("a" -> ident("a"), "b" -> ident("b"), "p" -> pathExpr, "r" -> ident("r")))(solved)
       )(solved)
     )
   }
@@ -66,24 +63,21 @@ class NamedPathProjectionPlanningIntegrationTest extends CypherFunSuite with Log
     val result = planFor("MATCH p = (a:X)-[r]->(b) WHERE head(nodes(p)) = a AND length(p) > 10 RETURN b").plan
 
     result should equal(
-      Projection(
-        Selection(
-          Seq(
-            Equals(
-              FunctionInvocation(FunctionName("head")_, FunctionInvocation(FunctionName("nodes")_, ident("p"))_)_,
-              Identifier("a")_
-            )_,
-            GreaterThan(
-              FunctionInvocation(FunctionName("length")_, ident("p"))_,
-              SignedDecimalIntegerLiteral("10")_
-            )_
-          ),
-          Projection(
-            Expand( NodeByLabelScan("a",  LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING,  Seq.empty, "b", "r")(solved),
-            expressions = Map("a" -> ident("a"), "b" -> ident("b"), "p" -> pathExpr, "r" -> ident("r"))
-          )(solved)
-        )(solved),
-        expressions = Map("b" -> Identifier("b") _)
+      Selection(
+        Seq(
+          Equals(
+            FunctionInvocation(FunctionName("head") _, FunctionInvocation(FunctionName("nodes") _, ident("p")) _) _,
+            Identifier("a") _
+          ) _,
+          GreaterThan(
+            FunctionInvocation(FunctionName("length") _, ident("p")) _,
+            SignedDecimalIntegerLiteral("10") _
+          ) _
+        ),
+        Projection(
+          Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING, Seq.empty, "b", "r")(solved),
+          expressions = Map("a" -> ident("a"), "b" -> ident("b"), "p" -> pathExpr, "r" -> ident("r"))
+        )(solved)
       )(solved)
     )
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
@@ -42,7 +42,7 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
         case _                             => Double.MaxValue
       }
 
-    } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X) RETURN b").innerPlan
+    } planFor "MATCH (a:X)<-[r1]-(b)-[r2]->(c:X) RETURN b").plan
 
     val expected =
       Selection(
@@ -74,7 +74,7 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
       }
 
       indexOn("Person", "name")
-    } planFor "MATCH (a)-[r]->(b) USING INDEX a:Person(name) USING INDEX b:Person(name) WHERE a:Person AND b:Person AND a.name = 'Jakub' AND b.name = 'Andres' return r").innerPlan should equal(
+    } planFor "MATCH (a)-[r]->(b) USING INDEX a:Person(name) USING INDEX b:Person(name) WHERE a:Person AND b:Person AND a.name = 'Jakub' AND b.name = 'Andres' return r").plan should equal(
       NodeHashJoin(
         Set(IdName("b")),
         Selection(
@@ -104,7 +104,7 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
         case PlannerQuery(queryGraph, _, _) if queryGraph.patternNodes.size == 1 && queryGraph.selections.predicates.isEmpty => 10000.0
         case _ => Double.MaxValue
       }
-    } planFor cypherQuery).innerPlan
+    } planFor cypherQuery).plan
 
     val expected =
       Selection(

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -40,24 +40,21 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
         case _ => Double.MaxValue
       }
     } planFor "MATCH (a:X)-[r1]->(b) OPTIONAL MATCH (b)-[r2]->(c:Y) RETURN b").plan should equal(
-      Projection(
         OuterHashJoin(Set("b"),
           Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", Direction.OUTGOING, Seq(), "b", "r1")(solved),
           Expand(NodeByLabelScan("c", LazyLabel("Y"), Set.empty)(solved), "c", Direction.INCOMING, Seq(), "b", "r2")(solved)
-        )(solved),
-        Map("b" -> ident("b")))(solved)
+        )(solved)
     )
   }
 
   test("should build simple optional match plans") { // This should be built using plan rewriting
     planFor("OPTIONAL MATCH a RETURN a").plan should equal(
-      Projection(Optional(AllNodesScan("a", Set.empty)(solved))(solved), Map("a" -> ident("a")))(solved)
-    )
+      Optional(AllNodesScan("a", Set.empty)(solved))(solved))
   }
 
   test("should build simple optional expand") {
     planFor("MATCH n OPTIONAL MATCH n-[:NOT_EXIST]->x RETURN n").plan.endoRewrite(unnestOptional) match {
-      case Projection(OptionalExpand(
+      case OptionalExpand(
       AllNodesScan(IdName("n"), _),
       IdName("n"),
       Direction.OUTGOING,
@@ -66,33 +63,31 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       _,
       _,
       _
-      ), _) => ()
+      ) => ()
     }
   }
 
   test("should build optional ProjectEndpoints") {
     planFor("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a1)<-[r]-(b2) RETURN a1, r, b2").plan match {
       case
-      Projection(
-      Apply(
-      Projection(
-      Limit(
-      Expand(
-      AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _), _),
-      Optional(
-      ProjectEndpoints(
-      Argument(args), IdName("r"), IdName("b2"), false, IdName("a1"), true, None, true, SimplePatternLength
-      )
-      )
-      ), _) =>
+        Apply(
+        Limit(
+        Expand(
+        AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _),
+        Optional(
+        ProjectEndpoints(
+        Argument(args), IdName("r"), IdName("b2"), false, IdName("a1"), true, None, true, SimplePatternLength
+        )
+        )
+        ) =>
         args should equal(Set(IdName("r"), IdName("a1")))
     }
   }
 
   test("should build optional ProjectEndpoints with extra predicates") {
     planFor("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a2)<-[r]-(b2) WHERE a1 = a2 RETURN a1, r, b2").plan match {
-      case Projection(Apply(Projection(
-      Limit(Expand(AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _), _),
+      case Apply(
+      Limit(Expand(AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _),
       Optional(
       Selection(
       predicates,
@@ -102,7 +97,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       )
       )
       )
-      ), _) =>
+      ) =>
         args should equal(Set(IdName("r"), IdName("a1")))
         val predicate: Expression = Equals(Identifier("a1")_, Identifier("a2")_)_
         predicates should equal(Seq(predicate))
@@ -111,15 +106,15 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
 
   test("should build optional ProjectEndpoints with extra predicates 2") {
     planFor("MATCH (a1)-[r]->(b1) WITH r LIMIT 1 OPTIONAL MATCH (a2)-[r]->(b2) RETURN a2, r, b2").plan  match {
-      case Projection(Apply(Projection(
-      Limit(Expand(AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _), _),
+      case Apply(
+      Limit(Expand(AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _),
       Optional(
       ProjectEndpoints(
       Argument(args),
       IdName("r"), IdName("a2"), false, IdName("b2"), false, None, true, SimplePatternLength
       )
       )
-      ), _) =>
+      ) =>
         args should equal(Set(IdName("r")))
     }
   }
@@ -127,13 +122,11 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
   test("should solve multiple optional matches") {
     val plan = planFor("MATCH a OPTIONAL MATCH (a)-[:R1]->(x1) OPTIONAL MATCH (a)-[:R2]->(x2) RETURN a, x1, x2").plan.endoRewrite(unnestOptional)
     plan should equal(
-      Projection(
+      OptionalExpand(
         OptionalExpand(
-          OptionalExpand(
-            AllNodesScan(IdName("a"), Set.empty)(solved),
-            IdName("a"), Direction.OUTGOING, List(RelTypeName("R1") _), IdName("x1"), IdName("  UNNAMED27"), ExpandAll, Seq.empty)(solved),
-          IdName("a"), Direction.OUTGOING, List(RelTypeName("R2") _), IdName("x2"), IdName("  UNNAMED58"), ExpandAll, Seq.empty)(solved),
-        Map("a" -> ident("a"), "x1" -> ident("x1"), "x2" -> ident("x2")))(solved)
+          AllNodesScan(IdName("a"), Set.empty)(solved),
+          IdName("a"), Direction.OUTGOING, List(RelTypeName("R1") _), IdName("x1"), IdName("  UNNAMED27"), ExpandAll, Seq.empty)(solved),
+        IdName("a"), Direction.OUTGOING, List(RelTypeName("R2") _), IdName("x2"), IdName("  UNNAMED58"), ExpandAll, Seq.empty)(solved)
     )
   }
 
@@ -146,8 +139,8 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
     val allNodesN:LogicalPlan = AllNodesScan(IdName("n"),Set())(s)
     val predicate: Expression = In(Property(ident("m"), PropertyKeyName("prop") _) _, Collection(List(SignedDecimalIntegerLiteral("42") _)) _) _
     plan should equal(
-      Projection(OptionalExpand(allNodesN, IdName("n"), Direction.BOTH, Seq.empty, IdName("m"), IdName("r"), ExpandAll,
-        Vector(predicate))(s), Map("m" -> ident("m")))(s)
+      OptionalExpand(allNodesN, IdName("n"), Direction.BOTH, Seq.empty, IdName("m"), IdName("r"), ExpandAll,
+        Vector(predicate))(s)
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PatternPredicatePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/PatternPredicatePlanningIntegrationTest.scala
@@ -57,166 +57,145 @@ class PatternPredicatePlanningIntegrationTest extends CypherFunSuite with Logica
 
   test("should build plans containing semi apply for a single pattern predicate") {
     planFor("MATCH (a) WHERE (a)-[:X]->() RETURN a").plan should equal(
-      Projection(
-        SemiApply(
-          AllNodesScan("a", Set.empty)(solved),
-          Expand(
-            Argument(Set("a"))(solved)(),
-            "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED27", "  UNNAMED20"
-          )(solved)
-        )(solved),
-        Map("a" -> ident("a")))(solved)
+      SemiApply(
+        AllNodesScan("a", Set.empty)(solved),
+        Expand(
+          Argument(Set("a"))(solved)(),
+          "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED27", "  UNNAMED20"
+        )(solved)
+      )(solved)
     )
   }
 
   test("should build plans containing anti semi apply for a single negated pattern predicate") {
     planFor("MATCH (a) WHERE NOT (a)-[:X]->() RETURN a").plan should equal(
-      Projection(
       AntiSemiApply(
         AllNodesScan("a", Set.empty)(solved),
         Expand(
           Argument(Set("a"))(solved)(),
-          "a", Direction.OUTGOING, Seq(RelTypeName("X")_), "  UNNAMED31", "  UNNAMED24"
+          "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED31", "  UNNAMED24"
         )(solved)
-      )(solved),
-      Map("a" -> ident("a")))(solved)
+      )(solved)
     )
   }
 
   test("should build plans containing semi apply for two pattern predicates") {
     planFor("MATCH (a) WHERE (a)-[:X]->() AND (a)-[:Y]->() RETURN a").plan should equal(
-      Projection(
       SemiApply(
         SemiApply(
           AllNodesScan("a", Set.empty)(solved),
           Expand(
             Argument(Set("a"))(solved)(),
-            "a", Direction.OUTGOING, Seq(RelTypeName("Y")_), "  UNNAMED44", "  UNNAMED37"
+            "a", Direction.OUTGOING, Seq(RelTypeName("Y") _), "  UNNAMED44", "  UNNAMED37"
           )(solved)
         )(solved),
         Expand(
           Argument(Set("a"))(solved)(),
-          "a", Direction.OUTGOING, Seq(RelTypeName("X")_), "  UNNAMED27", "  UNNAMED20"
+          "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED27", "  UNNAMED20"
         )(solved)
-      )(solved),
-      Map("a" -> ident("a")))(solved)
+      )(solved)
     )
   }
 
   test("should build plans containing select or semi apply for a pattern predicate and an expression") {
     planFor("MATCH (a) WHERE (a)-[:X]->() OR a.prop > 4 RETURN a").plan should equal(
-      Projection(
-        SelectOrSemiApply(
-          AllNodesScan("a", Set.empty)(solved),
-          Expand(
-            Argument(Set("a"))(solved)(),
-            "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED27", "  UNNAMED20"
-          )(solved),
-          GreaterThan(Property(Identifier("a") _, PropertyKeyName("prop") _) _, SignedDecimalIntegerLiteral("4") _) _
+      SelectOrSemiApply(
+        AllNodesScan("a", Set.empty)(solved),
+        Expand(
+          Argument(Set("a"))(solved)(),
+          "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED27", "  UNNAMED20"
         )(solved),
-        Map("a" -> ident("a")))(solved)
+        GreaterThan(Property(Identifier("a") _, PropertyKeyName("prop") _) _, SignedDecimalIntegerLiteral("4") _) _
+      )(solved)
     )
   }
 
   test("should build plans containing select or semi apply for a pattern predicate and multiple expressions") {
     planFor("MATCH (a) WHERE a.prop2 = 9 OR (a)-[:X]->() OR a.prop > 4 RETURN a").plan should equal(
-      Projection(
-        SelectOrSemiApply(
-          AllNodesScan("a", Set.empty)(solved),
-          Expand(
-            Argument(Set("a"))(solved)(),
-            "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED42", "  UNNAMED35"
-          )(solved),
-          Ors(Set(
-            In(Property(Identifier("a") _, PropertyKeyName("prop2") _) _, Collection(Seq(SignedDecimalIntegerLiteral("9") _)) _) _,
-            GreaterThan(Property(Identifier("a") _, PropertyKeyName("prop") _) _, SignedDecimalIntegerLiteral("4") _) _
-          )) _
+      SelectOrSemiApply(
+        AllNodesScan("a", Set.empty)(solved),
+        Expand(
+          Argument(Set("a"))(solved)(),
+          "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED42", "  UNNAMED35"
         )(solved),
-        Map("a" -> ident("a")))(solved)
+        Ors(Set(
+          In(Property(Identifier("a") _, PropertyKeyName("prop2") _) _, Collection(Seq(SignedDecimalIntegerLiteral("9") _)) _) _,
+          GreaterThan(Property(Identifier("a") _, PropertyKeyName("prop") _) _, SignedDecimalIntegerLiteral("4") _) _
+        )) _
+      )(solved)
     )
   }
 
   test("should build plans containing select or anti semi apply for a single negated pattern predicate") {
     planFor("MATCH (a) WHERE a.prop = 9 OR NOT (a)-[:X]->() RETURN a").plan should equal(
-      Projection(
-        SelectOrAntiSemiApply(
-          AllNodesScan("a", Set.empty)(solved),
-          Expand(
-            Argument(Set("a"))(solved)(),
-            "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED45", "  UNNAMED38"
-          )(solved),
-          In(Property(Identifier("a") _, PropertyKeyName("prop") _) _, Collection(Seq(SignedDecimalIntegerLiteral("9") _)) _) _
+      SelectOrAntiSemiApply(
+        AllNodesScan("a", Set.empty)(solved),
+        Expand(
+          Argument(Set("a"))(solved)(),
+          "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED45", "  UNNAMED38"
         )(solved),
-        Map("a" -> ident("a")))(solved)
+        In(Property(Identifier("a") _, PropertyKeyName("prop") _) _, Collection(Seq(SignedDecimalIntegerLiteral("9") _)) _) _
+      )(solved)
     )
   }
 
   test("should build plans containing let select or semi apply and select or semi apply for two pattern predicates") {
     planFor("MATCH (a) WHERE a.prop = 9 OR (a)-[:Y]->() OR NOT (a)-[:X]->() RETURN a").plan should equal(
-      Projection(
-        SelectOrAntiSemiApply(
-          LetSelectOrSemiApply(
-            AllNodesScan("a", Set.empty)(solved),
-            Expand(
-              Argument(Set("a"))(solved)(),
-              "a", Direction.OUTGOING,  Seq(RelTypeName("Y") _), "  UNNAMED41", "  UNNAMED34"
-            )(solved),
-            "  FRESHID30",
-            In(Property(Identifier("a") _, PropertyKeyName("prop") _) _, Collection(Seq(SignedDecimalIntegerLiteral("9")_))_)_
-          )(solved),
+      SelectOrAntiSemiApply(
+        LetSelectOrSemiApply(
+          AllNodesScan("a", Set.empty)(solved),
           Expand(
             Argument(Set("a"))(solved)(),
-            "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED61", "  UNNAMED54"
+            "a", Direction.OUTGOING, Seq(RelTypeName("Y") _), "  UNNAMED41", "  UNNAMED34"
           )(solved),
-          ident("  FRESHID30")
+          "  FRESHID30",
+          In(Property(Identifier("a") _, PropertyKeyName("prop") _) _, Collection(Seq(SignedDecimalIntegerLiteral("9") _)) _) _
         )(solved),
-        Map("a" -> ident("a"))
+        Expand(
+          Argument(Set("a"))(solved)(),
+          "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED61", "  UNNAMED54"
+        )(solved),
+        ident("  FRESHID30")
       )(solved)
     )
   }
 
   test("should build plans containing let semi apply and select or semi apply for two pattern predicates") {
     planFor("MATCH (a) WHERE (a)-[:Y]->() OR NOT (a)-[:X]->() RETURN a").plan should equal(
-      Projection(
-        SelectOrAntiSemiApply(
-          LetSemiApply(
-            AllNodesScan("a", Set.empty)(solved),
-            Expand(
-              Argument(Set("a"))(solved)(),
-              "a", Direction.OUTGOING, Seq(RelTypeName("Y") _), "  UNNAMED27", "  UNNAMED20"
-            )(solved),
-            "  FRESHID16"
-          )(solved),
+      SelectOrAntiSemiApply(
+        LetSemiApply(
+          AllNodesScan("a", Set.empty)(solved),
           Expand(
             Argument(Set("a"))(solved)(),
-            "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED47", "  UNNAMED40"
+            "a", Direction.OUTGOING, Seq(RelTypeName("Y") _), "  UNNAMED27", "  UNNAMED20"
           )(solved),
-          ident("  FRESHID16")
+          "  FRESHID16"
         )(solved),
-        Map("a" -> ident("a"))
+        Expand(
+          Argument(Set("a"))(solved)(),
+          "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED47", "  UNNAMED40"
+        )(solved),
+        ident("  FRESHID16")
       )(solved)
     )
   }
 
   test("should build plans containing let anti semi apply and select or semi apply for two pattern predicates") {
     planFor("MATCH (a) WHERE NOT (a)-[:Y]->() OR NOT (a)-[:X]->() RETURN a").plan should equal(
-      Projection(
-        SelectOrAntiSemiApply(
-          LetAntiSemiApply(
-            AllNodesScan("a", Set.empty)(solved),
-            Expand(
-              Argument(Set("a"))(solved)(),
-              "a", Direction.OUTGOING, Seq(RelTypeName("Y") _), "  UNNAMED31", "  UNNAMED24"
-            )(solved),
-            "  FRESHID20"
-          )(solved),
+      SelectOrAntiSemiApply(
+        LetAntiSemiApply(
+          AllNodesScan("a", Set.empty)(solved),
           Expand(
             Argument(Set("a"))(solved)(),
-            "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED51", "  UNNAMED44"
+            "a", Direction.OUTGOING, Seq(RelTypeName("Y") _), "  UNNAMED31", "  UNNAMED24"
           )(solved),
-          ident("  FRESHID20")
+          "  FRESHID20"
         )(solved),
-        Map("a" -> ident("a"))
+        Expand(
+          Argument(Set("a"))(solved)(),
+          "a", Direction.OUTGOING, Seq(RelTypeName("X") _), "  UNNAMED51", "  UNNAMED44"
+        )(solved),
+        ident("  FRESHID20")
       )(solved)
     )
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/WithPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/WithPlanningIntegrationTest.scala
@@ -28,15 +28,13 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
   test("should build plans for simple WITH that adds a constant to the rows") {
     val result = planFor("MATCH (a) WITH a LIMIT 1 RETURN 1 as `b`").plan
     val expected =
-    Projection(
       Projection(
         Limit(
           AllNodesScan("a", Set.empty)(solved),
           UnsignedDecimalIntegerLiteral("1")(pos)
         )(solved),
-        Map[String, Expression]("a" -> ident("a"))
-      )(solved),
-      Map("b" -> SignedDecimalIntegerLiteral("1")_))(solved)
+        Map[String, Expression]("b" -> SignedDecimalIntegerLiteral("1") _)
+      )(solved)
 
     result should equal(expected)
   }
@@ -48,57 +46,62 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
 
     resultText should equal(
       // oh perty where art thou!?
-      "Projection(Projection(Limit(Expand(Apply(Projection(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Map(a -> Identifier(a))),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll),UnsignedDecimalIntegerLiteral(1)),Map(a -> Identifier(a), b -> Identifier(b), r1 -> Identifier(r1))),Map(b -> Identifier(b)))")
+      "Limit(Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll),UnsignedDecimalIntegerLiteral(1))")
   }
 
   test("should build plans with WITH and selections") {
     val result = planFor("MATCH (a) WITH a LIMIT 1 MATCH (a)-[r1]->(b) WHERE r1.prop = 42 RETURN r1").plan
 
     result.toString should equal(
-      "Projection(Selection(Vector(In(Property(Identifier(r1),PropertyKeyName(prop)),Collection(List(SignedDecimalIntegerLiteral(42))))),Apply(Projection(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Map(a -> Identifier(a))),Expand(Argument(Set(IdName(a))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll))),Map(r1 -> Identifier(r1)))")
+      "Selection(Vector(In(Property(Identifier(r1),PropertyKeyName(prop)),Collection(List(SignedDecimalIntegerLiteral(42))))),Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Expand(Argument(Set(IdName(a))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll)))")
   }
 
   test("should build plans for two matches separated by WITH") {
     val result = planFor("MATCH (a) WITH a LIMIT 1 MATCH (a)-[r]->(b) RETURN b").plan
+
     result.toString should equal(
-      "Projection(Expand(Apply(Projection(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Map(a -> Identifier(a))),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r),ExpandAll),Map(b -> Identifier(b)))")
+      "Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r),ExpandAll)")
   }
 
   test("should build plans that project endpoints of re-matched directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH r LIMIT 1 MATCH (u)-[r]->(v) RETURN r").plan
 
     plan.toString should equal(
-      "Projection(Apply(Projection(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),Map(r -> Identifier(r))),ProjectEndpoints(Argument(Set(IdName(r))),IdName(r),IdName(u),false,IdName(v),false,None,true,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(r))),IdName(r),IdName(u),false,IdName(v),false,None,true,SimplePatternLength))")
   }
 
   test("should build plans that project endpoints of re-matched reversed directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH r AS r, a AS a LIMIT 1 MATCH (b2)<-[r]-(a) RETURN r").plan
 
     plan.toString should equal(
-      "Projection(Apply(Projection(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),Map(r -> Identifier(r), a -> Identifier(a))),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength))")
   }
 
   test("should build plans that verify endpoints of re-matched directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH * LIMIT 1 MATCH (a)-[r]->(b) RETURN r").plan
+
     plan.toString should equal(
-      "Projection(Apply(Projection(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),Map(a -> Identifier(a), b -> Identifier(b), r -> Identifier(r))),ProjectEndpoints(Argument(Set(IdName(a), IdName(b), IdName(r))),IdName(r),IdName(a),true,IdName(b),true,None,true,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(b), IdName(r))),IdName(r),IdName(a),true,IdName(b),true,None,true,SimplePatternLength))")
   }
 
   test("should build plans that project and verify endpoints of re-matched directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH a AS a, r AS r LIMIT 1 MATCH (a)-[r]->(b2) RETURN r").plan
+
     plan.toString should equal(
-      "Projection(Apply(Projection(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),Map(a -> Identifier(a), r -> Identifier(r))),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength))")
   }
 
   test("should build plans that project and verify endpoints of re-matched undirected relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH a AS a, r AS r LIMIT 1 MATCH (a)-[r]-(b2) RETURN r").plan
+
     plan.toString should equal(
-      "Projection(Apply(Projection(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),Map(a -> Identifier(a), r -> Identifier(r))),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,false,SimplePatternLength)),Map(r -> Identifier(r)))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,false,SimplePatternLength))")
   }
 
   test("should build plans that project and verify endpoints of re-matched directed var length relationship arguments") {
     val plan = planFor("MATCH (a)-[r*]->(b) WITH a AS a, r AS r LIMIT 1 MATCH (a)-[r*]->(b2) RETURN r").plan
+
     plan.toString should equal(
-      "Projection(Apply(Projection(Limit(VarExpand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,OUTGOING,List(),IdName(a),IdName(r),VarPatternLength(1,None),ExpandAll,Vector()),UnsignedDecimalIntegerLiteral(1)),Map(a -> Identifier(a), r -> Identifier(r))),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,VarPatternLength(1,None))),Map(r -> Identifier(r)))")
+      "Apply(Limit(VarExpand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,OUTGOING,List(),IdName(a),IdName(r),VarPatternLength(1,None),ExpandAll,Vector()),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,VarPatternLength(1,None)))")
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/AggregationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/AggregationTest.scala
@@ -44,10 +44,10 @@ class AggregationTest extends CypherFunSuite with LogicalPlanningTestSupport {
       planContext = newMockedPlanContext
     )
 
-    val startPlan = Projection(newMockedLogicalPlan(), Map("count(*)" -> CountStar()_))(solved)
+    val startPlan = newMockedLogicalPlan()
 
     aggregation(startPlan, projection)(context) should equal(
-      Aggregation(Projection(startPlan, Map.empty)(solved), Map(), aggregatingMap)(solved)
+      Aggregation(startPlan, Map(), aggregatingMap)(solved)
     )
   }
 
@@ -92,7 +92,7 @@ class AggregationTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val result = aggregation(projectionPlan, projection)(context)
     // Then
     result should equal(
-      Aggregation(Projection(projectionPlan, groupingKeyMap)(solved), groupingKeyMap, aggregatingMap)(solved)
+      Aggregation(projectionPlan, groupingKeyMap, aggregatingMap)(solved)
     )
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/ProjectionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/ProjectionTest.scala
@@ -57,7 +57,7 @@ class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val result = projection(startPlan, projections)
 
     // then
-    result should equal(Projection(startPlan, projections)(solved))
+    result should equal(startPlan)
     result.solved.horizon should equal(RegularQueryProjection(projections))
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectHasLabelWithJoinTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/SelectHasLabelWithJoinTest.scala
@@ -35,7 +35,7 @@ class SelectHasLabelWithJoinTest extends CypherFunSuite with LogicalPlanningTest
       }
     } planFor "MATCH (n:Foo:Bar:Baz) RETURN n"
 
-    plan.innerPlan match {
+    plan.plan match {
       case NodeHashJoin(_,
       NodeHashJoin(_,
       NodeByLabelScan(_, _, _),

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -36,8 +36,8 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
 
     val result = profileWithAllPlannersAndRuntimes("MATCH (n) RETURN n")
 
-    assertRows(3)(result)("AllNodesScan", "ProduceResults", "Projection")
-    assertDbHits(0)(result)("ProduceResults", "Projection")
+    assertRows(3)(result)("AllNodesScan", "ProduceResults")
+    assertDbHits(0)(result)("ProduceResults")
     assertDbHits(4)(result)("AllNodesScan")
   }
 
@@ -48,7 +48,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
 
     val result = profileWithAllPlannersAndRuntimes("MATCH (n) RETURN (n:Foo)")
 
-    assertRows(3)(result)("AllNodesScan", "ProduceResults", "Projection")
+    assertRows(3)(result)("AllNodesScan", "ProduceResults")
     assertDbHits(0)(result)("ProduceResults")
     assertDbHits(3)(result)("Projection")
     assertDbHits(4)(result)("AllNodesScan")
@@ -80,8 +80,8 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     val result = profileWithAllPlannersAndRuntimes("match (n:A)-->(x:B) return *")
 
     //THEN
-    assertRows(1)(result)("ProduceResults", "Projection", "Filter", "Expand(All)", "NodeByLabelScan")
-    assertDbHits(0)(result)("ProduceResults", "Projection")
+    assertRows(1)(result)("ProduceResults", "Filter", "Expand(All)", "NodeByLabelScan")
+    assertDbHits(0)(result)("ProduceResults")
     assertDbHits(1)(result)("Filter")
     assertDbHits(2)(result)("NodeByLabelScan", "Expand(All)")
   }
@@ -203,8 +203,8 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     result.toList
 
     // THEN PASS
-    assertRows(1)(result)("AllNodesScan", "ProduceResults", "Projection")
-    assertDbHits(0)(result)("ProduceResults", "Projection")
+    assertRows(1)(result)("AllNodesScan", "ProduceResults")
+    assertDbHits(0)(result)("ProduceResults")
     assertDbHits(2)(result)("AllNodesScan")
 
     result.executionPlanDescription()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/RootPlanAcceptanceTest.scala
@@ -146,15 +146,14 @@ class RootPlanAcceptanceTest extends ExecutionEngineFunSuite {
     children.get(0).getName should be("AllNodesScan")
   }
 
-  test("DbHits should should contain proper values in compiled runtime") {
+  test("DbHits should contain proper values in compiled runtime") {
     val description = given("match n return n")
       .withRuntime(CompiledRuntimeName)
       .planDescription
     val children = description.getChildren
     children should have size 1
     description.getArguments.get("DbHits") should equal(0) // ProduceResults has no hits
-    children.get(0).getArguments.get("DbHits") should equal(0) // Projection has no hits
-    children.get(0).getChildren.get(0).getArguments.get("DbHits") should equal(1) // AllNodesScan has 1 hit
+    children.get(0).getArguments.get("DbHits") should equal(1) // AllNodesScan has 1 hit
   }
 
   test("Rows should be properly formatted in compiled runtime") {
@@ -163,15 +162,14 @@ class RootPlanAcceptanceTest extends ExecutionEngineFunSuite {
       .planDescription.getArguments.get("Rows") should equal(0)
   }
 
-  test("DbHits should should contain proper values in interpreted runtime") {
+  test("DbHits should contain proper values in interpreted runtime") {
     val description = given("match n return n")
       .withRuntime(InterpretedRuntimeName)
       .planDescription
     val children = description.getChildren
     children should have size 1
     description.getArguments.get("DbHits") should equal(0) // ProduceResults has no hits
-    children.get(0).getArguments.get("DbHits") should equal(0) // Projection has no hits
-    children.get(0).getChildren.get(0).getArguments.get("DbHits") should equal(1) // AllNodesScan has 1 hit
+    children.get(0).getArguments.get("DbHits") should equal(1) // AllNodesScan has 1 hit
   }
 
   test("Rows should be properly formatted in interpreted runtime") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/CodeGeneratorTest.scala
@@ -49,8 +49,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("all nodes scan") { // MATCH a RETURN a
     //given
-    val plan = ProduceResult(List("a"),
-      Projection(AllNodesScan(IdName("a"), Set.empty)(solved), Map("a" -> ident("a")))(solved))
+    val plan = ProduceResult(List("a"), AllNodesScan(IdName("a"), Set.empty)(solved))
 
     //when
     val compiled = compileAndExecute(plan)
@@ -71,8 +70,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("label scan") {// MATCH (a:T1) RETURN a
     //given
-    val plan = ProduceResult(List("a"),
-      Projection(NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), Map("a" -> ident("a")))(solved))
+    val plan = ProduceResult(List("a"), NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved))
 
     //when
     val compiled = compileAndExecute(plan)
@@ -91,8 +89,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val lhs = AllNodesScan(IdName("a"), Set.empty)(solved)
     val rhs = AllNodesScan(IdName("a"), Set.empty)(solved)
     val join = NodeHashJoin(Set(IdName("a")), lhs, rhs)(solved)
-    val plan = ProduceResult(List("a"),
-      Projection(join, Map("a" -> ident("a")))(solved))
+    val plan = ProduceResult(List("a"), join)
 
     //when
     val compiled = compileAndExecute(plan)
@@ -116,8 +113,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val lhs = Expand(AllNodesScan(IdName("a"), Set.empty)(solved), IdName("a"), Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
     val rhs = Expand(AllNodesScan(IdName("a"), Set.empty)(solved), IdName("a"), Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
     val join = NodeHashJoin(Set(IdName("a"), IdName("b")), lhs, rhs)(solved)
-    val plan = ProduceResult(List("a"),
-      Projection(join, Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+    val plan = ProduceResult(List("a"), join)
 
     //when
     val compiled = compileAndExecute(plan)
@@ -140,8 +136,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val lhs = NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved)
     val rhs = NodeByLabelScan(IdName("b"), LazyLabel("T2"), Set.empty)(solved)
     val join = CartesianProduct(lhs, rhs)(solved)
-    val plan = ProduceResult(List("a", "b"),
-                             Projection(join, Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+    val plan = ProduceResult(List("a", "b"), join)
 
     //when
     val compiled = compileAndExecute(plan)
@@ -160,10 +155,8 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   test("all nodes scan + expand") { // MATCH (a)-[r]->(b) RETURN a, b
     //given
     val plan = ProduceResult(List("a", "b"),
-      Projection(
         Expand(
-          AllNodesScan(IdName("a"), Set.empty)(solved), IdName("a"), Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved),
-        Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+          AllNodesScan(IdName("a"), Set.empty)(solved), IdName("a"), Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved))
 
     //when
     val compiled = compileAndExecute(plan)
@@ -184,11 +177,9 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   test("label scan + expand outgoing") { // MATCH (a:T1)-[r]->(b) RETURN a, b
     //given
     val plan = ProduceResult(List("a", "b"),
-      Projection(
         Expand(
           NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), IdName("a"),
-          Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved),
-        Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+          Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved))
 
     //when
     val compiled = compileAndExecute(plan)
@@ -206,10 +197,8 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   test("all node scan+ expand outgoing with one type") { // MATCH (a)-[r:R1]->(b) RETURN a, b
   //given
   val plan = ProduceResult(List("a", "b"),
-      Projection(
         Expand(
-          AllNodesScan(IdName("a"), Set.empty)(solved), IdName("a"), Direction.OUTGOING, Seq(RelTypeName("R1")(null)), IdName("b"), IdName("r"), ExpandAll)(solved),
-        Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+          AllNodesScan(IdName("a"), Set.empty)(solved), IdName("a"), Direction.OUTGOING, Seq(RelTypeName("R1")(null)), IdName("b"), IdName("r"), ExpandAll)(solved))
 
     //when
     val compiled = compileAndExecute(plan)
@@ -227,11 +216,9 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   test("all node scan+ expand outgoing with multiple types") { // MATCH (a)-[r:R1|R2]->(b) RETURN a, b
   //given
   val plan = ProduceResult(List("a", "b"),
-      Projection(
         Expand(
           AllNodesScan(IdName("a"), Set.empty)(solved), IdName("a"), Direction.OUTGOING,
-          Seq(RelTypeName("R1")(pos), RelTypeName("R2")(pos)), IdName("b"), IdName("r"), ExpandAll)(solved),
-          Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+          Seq(RelTypeName("R1")(pos), RelTypeName("R2")(pos)), IdName("b"), IdName("r"), ExpandAll)(solved))
 
     //when
     val compiled = compileAndExecute(plan)
@@ -250,11 +237,9 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   test("label scan + expand incoming") { // // MATCH (a:T1)<-[r]-(b) RETURN a, b
   //given
   val plan = ProduceResult(List("a", "b"),
-              Projection(
                 Expand(
                   NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), IdName("a"),
-                  Direction.INCOMING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved),
-                  Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+                  Direction.INCOMING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved))
 
     //when
     val compiled = compileAndExecute(plan)
@@ -268,12 +253,10 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   test("label scan + optional expand incoming") {
   //given
   val plan = ProduceResult(List("a", "b"),
-                           Projection(
                              OptionalExpand(
                                NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), IdName("a"),
                                Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll,
-                               Seq(HasLabels(ident("b"), Seq(LabelName("T1")(pos)))(pos)))(solved),
-                             Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+                               Seq(HasLabels(ident("b"), Seq(LabelName("T1")(pos)))(pos)))(solved))
 
     //when
     val compiled: InternalExecutionResult = compileAndExecute(plan)
@@ -290,11 +273,9 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   test("label scan + expand both directions") { // MATCH (a:T1)-[r]-(b) RETURN a, b
   //given
   val plan = ProduceResult(List("a", "b"),
-    Projection(
       Expand(
         NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), IdName("a"), Direction.BOTH,
-        Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved),
-      Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+        Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved))
 
     //when
     val compiled = compileAndExecute(plan)
@@ -320,10 +301,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
       Seq.empty, IdName("a"), IdName("r2"), ExpandInto)(solved)
 
 
-    val plan = ProduceResult(List("a", "b"),
-                             Projection(
-                               expandInto,
-                               Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+    val plan = ProduceResult(List("a", "b"), expandInto)
 
     //when
     val compiled = compileAndExecute(plan)
@@ -349,10 +327,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
       Seq.empty, IdName("b"), IdName("r2"), ExpandInto, Seq(HasLabels(ident("b"), Seq(LabelName("T2")(pos)))(pos)))(solved)
 
 
-    val plan = ProduceResult(List("a", "b", "r2"),
-      Projection(
-        optionalExpandInto,
-        Map("a" -> ident("a"), "b" -> ident("b"), "r2" -> ident("r2")))(solved))
+    val plan = ProduceResult(List("a", "b", "r2"), optionalExpandInto)
 
     //when
     val compiled = compileAndExecute(plan)
@@ -378,10 +353,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
       Seq(RelTypeName("R2")(pos)), IdName("a"), IdName("r2"), ExpandInto)(solved)
 
 
-    val plan = ProduceResult(List("a", "b"),
-                             Projection(
-                               expandInto,
-                               Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+    val plan = ProduceResult(List("a", "b"), expandInto)
 
     //when
     val compiled = compileAndExecute(plan)
@@ -406,10 +378,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
       Seq(RelTypeName("R2")(pos)), IdName("a"), IdName("r2"), ExpandInto)(solved)
 
 
-    val plan = ProduceResult(List("a", "b", "r2"),
-      Projection(
-        expandInto,
-        Map("a" -> ident("a"), "b" -> ident("b"), "r2" -> ident("r2")))(solved))
+    val plan = ProduceResult(List("a", "b", "r2"), expandInto)
 
     //when
     val compiled = compileAndExecute(plan)
@@ -435,10 +404,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
       Seq(RelTypeName("R3")(pos)), IdName("a"), IdName("r2"), ExpandInto)(solved)
 
 
-    val plan = ProduceResult(List("a", "b"),
-                             Projection(
-                               expandInto,
-                               Map("a" -> ident("a"), "b" -> ident("b")))(solved))
+    val plan = ProduceResult(List("a", "b"), expandInto)
 
     //when
     val compiled = compileAndExecute(plan)
@@ -464,10 +430,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
       Seq(HasLabels(ident("b"), Seq(LabelName("T2")(pos)))(pos)))(solved)
 
 
-    val plan = ProduceResult(List("a", "b", "r2"),
-      Projection(
-        expandInto,
-        Map("a" -> ident("a"), "b" -> ident("b"), "r2" -> ident("r2")))(solved))
+    val plan = ProduceResult(List("a", "b", "r2"), expandInto)
 
     //when
     val compiled = compileAndExecute(plan)
@@ -487,10 +450,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
     //given
     val lhs = Expand(AllNodesScan(IdName("a"), Set.empty)(solved), IdName("a"), Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
     val rhs = Expand(AllNodesScan(IdName("c"), Set.empty)(solved), IdName("c"), Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r2"), ExpandAll)(solved)
-    val plan = ProduceResult(List("a", "b", "c"),
-      Projection(
-        NodeHashJoin(Set(IdName("b")), lhs, rhs)(solved), Map("a" -> ident("a"), "b" -> ident("b"), "c" -> ident("c"))
-      )(solved))
+    val plan = ProduceResult(List("a", "b", "c"), NodeHashJoin(Set(IdName("b")), lhs, rhs)(solved))
 
     val compiled = compileAndExecute(plan)
 
@@ -524,8 +484,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
       Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
     val rhs = Expand(NodeByLabelScan(IdName("c"), LazyLabel("T2"), Set.empty)(solved), IdName("c"),
       Direction.OUTGOING, Seq.empty, IdName("b"), IdName("r2"), ExpandAll)(solved)
-    val join = Projection(NodeHashJoin(Set(IdName("b")), lhs, rhs)(solved),
-      Map("a" -> ident("a"), "b" -> ident("b"), "c" -> ident("c")))(solved)
+    val join = NodeHashJoin(Set(IdName("b")), lhs, rhs)(solved)
     val plan = ProduceResult(List("a", "b", "c"), join)
 
     val compiled = compileAndExecute(plan)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/BuildProbeTableInstructionsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/BuildProbeTableInstructionsTest.scala
@@ -182,8 +182,7 @@ class BuildProbeTableInstructionsTest extends CypherFunSuite with CodeGenSugar {
     //just put one node in the actual result
     val resultVar = probeVars.head
 
-    val acceptVisitor = AcceptVisitor("visitorOp", "projectionOp",
-                                      Map(resultRowKey -> expressions.NodeProjection(resultVar)))
+    val acceptVisitor = AcceptVisitor("visitorOp", Map(resultRowKey -> expressions.NodeProjection(resultVar)))
 
     val probeTheTable = GetMatchesFromProbeTable(keys = probeVars,
                                                  code = buildInstruction.joinData,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/CodeGenExpressionCompilationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/codegen/ir/CodeGenExpressionCompilationTest.scala
@@ -116,7 +116,7 @@ class CodeGenExpressionCompilationTest extends CypherFunSuite with Matchers with
     }
 
     def project(lhs: CodeGenExpression, rhs: CodeGenExpression) =
-      Seq(AcceptVisitor("id", "X", Map("result" -> apply(lhs, rhs))))
+      Seq(AcceptVisitor("id", Map("result" -> apply(lhs, rhs))))
     inputs.foreach {
       case (lhs, rhs, expected) =>
 


### PR DESCRIPTION
Compiled runtime needed additional projection before ProduceResults logical plan to be able to handle nested projections.
This commit removes the need for such projection to not penalize interpreted runtime which is default.
Projections are now generated by dedicated code gen plan.
