### PR TITLE
[Test Failure] ResourcePoolTest is flaky in 2.3 on Java 8.

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/ResourcePool.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ResourcePool.java
@@ -32,17 +32,17 @@ public abstract class ResourcePool<R>
 {
     public interface Monitor<R>
     {
-        public void updatedCurrentPeakSize( int currentPeakSize );
+        void updatedCurrentPeakSize( int currentPeakSize );
 
-        public void updatedTargetSize( int targetSize );
+        void updatedTargetSize( int targetSize );
 
-        public void created( R resource );
+        void created( R resource );
 
-        public void acquired( R resource );
+        void acquired( R resource );
 
-        public void disposed( R resource );
+        void disposed( R resource );
 
-        public class Adapter<R> implements Monitor<R>
+        class Adapter<R> implements Monitor<R>
         {
             @Override
             public void updatedCurrentPeakSize( int currentPeakSize )
@@ -73,12 +73,12 @@ public abstract class ResourcePool<R>
 
     public interface CheckStrategy
     {
-        public boolean shouldCheck();
+        boolean shouldCheck();
 
-        public class TimeoutCheckStrategy implements CheckStrategy
+        class TimeoutCheckStrategy implements CheckStrategy
         {
             private final long interval;
-            private long lastCheckTime;
+            private volatile long lastCheckTime;
             private final Clock clock;
 
             public TimeoutCheckStrategy( long interval, Clock clock )


### PR DESCRIPTION
Update handling of lastCheckTime ResourcePool.TimeoutCheckStrategy
Cleanup of ResourcePoolTest.
