### PR TITLE
[GH#5086 - path.reverseNodes bug] Use correct relationship to find next node in a chain.

### DIFF
--- a/community/graph-algo/CHANGES.txt
+++ b/community/graph-algo/CHANGES.txt
@@ -1,3 +1,7 @@
+2.2.5
+-----
+o Fixes #5086 - path.reverseNodes bug
+
 2.2.3
 -----
 o ShortestPath no longer has the option to find only paths of the supplied exact depth,

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/PathImpl.java
@@ -168,16 +168,16 @@ public final class PathImpl implements Path
 
     public Iterable<Node> nodes()
     {
-        return nodeIterator( start );
+        return nodeIterator( start, relationships() );
     }
     
     @Override
     public Iterable<Node> reverseNodes()
     {
-        return nodeIterator( end );
+        return nodeIterator( end, reverseRelationships() );
     }
 
-    private Iterable<Node> nodeIterator( final Node start )
+    private Iterable<Node> nodeIterator( final Node start, final Iterable<Relationship> relationships )
     {
         return new Iterable<Node>()
         {
@@ -187,6 +187,7 @@ public final class PathImpl implements Path
                 {
                     Node current = start;
                     int index = 0;
+                    Iterator<Relationship> relationshipIterator = relationships.iterator();
 
                     public boolean hasNext()
                     {
@@ -202,7 +203,12 @@ public final class PathImpl implements Path
                         Node next = null;
                         if ( index < path.length )
                         {
-                            next = path[index].getOtherNode( current );
+                            if ( !relationshipIterator.hasNext() )
+                            {
+                                throw new IllegalStateException( String.format( "Number of relationships: %d does not" +
+                                                      " match with path length: %d.", index, path.length ) );
+                            }
+                            next = relationshipIterator.next().getOtherNode( current );
                         }
                         index += 1;
                         try
@@ -231,7 +237,7 @@ public final class PathImpl implements Path
             @Override
             public Iterator<Relationship> iterator()
             {
-                return new ArrayIterator<Relationship>( path );
+                return new ArrayIterator<>( path );
             }
         };
     }
@@ -244,7 +250,7 @@ public final class PathImpl implements Path
             @Override
             public Iterator<Relationship> iterator()
             {
-                return new ReverseArrayIterator<Relationship>( path );
+                return new ReverseArrayIterator<>( path );
             }
         };
     }

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/PathImplTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/PathImplTest.java
@@ -19,36 +19,44 @@
  */
 package org.neo4j.graphalgo.impl.util;
 
+import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
-import org.neo4j.graphdb.Direction;
-import org.neo4j.graphdb.DynamicRelationshipType;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Label;
+import java.util.List;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
-import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.graphdb.ResourceIterable;
-import org.neo4j.graphdb.ReturnableEvaluator;
-import org.neo4j.graphdb.StopEvaluator;
-import org.neo4j.graphdb.Traverser;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.impl.core.NodeProxy;
+import org.neo4j.kernel.impl.core.RelationshipProxy;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PathImplTest
 {
 
+    private NodeProxy.NodeActions nodeActions = mock( NodeProxy.NodeActions.class );
+    private RelationshipProxy.RelationshipActions relationshipActions = mock( RelationshipProxy.RelationshipActions.class );
+
     @Test
     public void pathsWithTheSameContentsShouldBeEqual() throws Exception
     {
+
+        Node node = createNode( 1337l );
+        Relationship relationship = createRelationship( 1337l, 7331l );
+
         // Given
-        Path firstPath = new PathImpl.Builder( node( 1337l ) ).push( rel( 1337l, 7331l ) ).build();
-        Path secondPath = new PathImpl.Builder( node( 1337l ) ).push( rel( 1337l, 7331l ) ).build();
+        Path firstPath = new PathImpl.Builder( node ).push( relationship ).build();
+        Path secondPath = new PathImpl.Builder( node ).push( relationship ).build();
 
         // When Then
         assertEquals( firstPath, secondPath );
@@ -58,308 +66,89 @@ public class PathImplTest
     @Test
     public void pathsWithDifferentLengthAreNotEqual() throws Exception
     {
+        Node node = createNode( 1337l );
+        Relationship relationship = createRelationship( 1337l, 7331l );
+
         // Given
-        Path firstPath = new PathImpl.Builder( node( 1337l ) ).push( rel( 1337l, 7331l ) ).build();
-        Path secondPath = new PathImpl.Builder( node( 1337l ) ).push( rel( 1337l, 7331l ) ).push( rel( 7331l, 13l ) ).build();
+        Path firstPath = new PathImpl.Builder( node ).push( relationship ).build();
+        Path secondPath = new PathImpl.Builder( node ).push( relationship ).push( createRelationship( 1337l, 7331l ) ).build();
 
         // When Then
         assertThat( firstPath, not( equalTo( secondPath ) ) );
         assertThat( secondPath, not( equalTo( firstPath ) ) );
     }
 
-    private Node node( final long id )
+    @Test
+    public void testPathReverseNodes()
     {
-        return new MockNode( id );
+        when( relationshipActions.newNodeProxy( Mockito.anyLong() ) ).thenAnswer( new NodeProxyAnswer() );
+
+        Path path = new PathImpl.Builder( createNodeProxy( 1 ) )
+                                .push( createRelationshipProxy( 1, 2 ) )
+                                .push( createRelationshipProxy( 2, 3 ) )
+                                .build( new PathImpl.Builder( createNodeProxy( 3 ) ) );
+
+        Iterable<Node> nodes = path.reverseNodes();
+        List<Node> nodeList = Iterables.toList( nodes );
+
+        Assert.assertEquals( 3, nodeList.size() );
+        Assert.assertEquals( 3, nodeList.get( 0 ).getId() );
+        Assert.assertEquals( 2, nodeList.get( 1 ).getId() );
+        Assert.assertEquals( 1, nodeList.get( 2 ).getId() );
     }
 
-    private Relationship rel( final long fromId, final long toId )
+    @Test
+    public void testPathNodes()
     {
-        return new MockRelationship( fromId, toId );
+        when( relationshipActions.newNodeProxy( Mockito.anyLong() ) ).thenAnswer( new NodeProxyAnswer() );
+
+        Path path = new PathImpl.Builder( createNodeProxy( 1 ) )
+                .push( createRelationshipProxy( 1, 2 ) )
+                .push( createRelationshipProxy( 2, 3 ) )
+                .build( new PathImpl.Builder( createNodeProxy( 3 ) ) );
+
+        Iterable<Node> nodes = path.nodes();
+        List<Node> nodeList = Iterables.toList( nodes );
+
+        Assert.assertEquals( 3, nodeList.size() );
+        Assert.assertEquals( 1, nodeList.get( 0 ).getId() );
+        Assert.assertEquals( 2, nodeList.get( 1 ).getId() );
+        Assert.assertEquals( 3, nodeList.get( 2 ).getId() );
     }
 
-    class MockPropertyContainer implements PropertyContainer
+    private RelationshipProxy createRelationshipProxy( int startNodeId, int endNodeId )
     {
-
-        @Override
-        public GraphDatabaseService getGraphDatabase()
-        {
-            return null;
-        }
-
-        @Override
-        public boolean hasProperty( String key )
-        {
-            return false;
-        }
-
-        @Override
-        public Object getProperty( String key )
-        {
-            return null;
-        }
-
-        @Override
-        public Object getProperty( String key, Object defaultValue )
-        {
-            return null;
-        }
-
-        @Override
-        public void setProperty( String key, Object value )
-        {
-        }
-
-        @Override
-        public Object removeProperty( String key )
-        {
-            return null;
-        }
-
-        @Override
-        public Iterable<String> getPropertyKeys()
-        {
-            return null;
-        }
-
+        return new RelationshipProxy( relationshipActions, 1l, startNodeId, 1, endNodeId );
     }
 
-    @SuppressWarnings("deprecation")
-    class MockNode extends MockPropertyContainer implements Node
+    private NodeProxy createNodeProxy( int nodeId )
     {
-
-        private final long id;
-
-        public MockNode( long id )
-        {
-            this.id = id;
-        }
-
-        @Override
-        public long getId()
-        {
-            return id;
-        }
-
-        @Override
-        public boolean equals( Object other )
-        {
-            return other instanceof Node && ((Node) other).getId() == id;
-        }
-
-        // Unimplemented
-
-        @Override
-        public void delete()
-        {
-        }
-
-        @Override
-        public Iterable<Relationship> getRelationships()
-        {
-            return null;
-        }
-
-        @Override
-        public boolean hasRelationship()
-        {
-            return false;
-        }
-
-        @Override
-        public Iterable<Relationship> getRelationships( RelationshipType... types )
-        {
-            return null;
-        }
-
-        @Override
-        public Iterable<Relationship> getRelationships( Direction direction, RelationshipType... types )
-        {
-            return null;
-        }
-
-        @Override
-        public boolean hasRelationship( RelationshipType... types )
-        {
-            return false;
-        }
-
-        @Override
-        public boolean hasRelationship( Direction direction, RelationshipType... types )
-        {
-            return false;
-        }
-
-        @Override
-        public Iterable<Relationship> getRelationships( Direction dir )
-        {
-            return null;
-        }
-
-        @Override
-        public boolean hasRelationship( Direction dir )
-        {
-            return false;
-        }
-
-        @Override
-        public Iterable<Relationship> getRelationships( RelationshipType type, Direction dir )
-        {
-            return null;
-        }
-
-        @Override
-        public boolean hasRelationship( RelationshipType type, Direction dir )
-        {
-            return false;
-        }
-
-        @Override
-        public Relationship getSingleRelationship( RelationshipType type, Direction dir )
-        {
-            return null;
-        }
-
-        @Override
-        public Relationship createRelationshipTo( Node otherNode, RelationshipType type )
-        {
-            return null;
-        }
-
-        @Override
-        public Traverser traverse( Traverser.Order traversalOrder, StopEvaluator stopEvaluator, ReturnableEvaluator returnableEvaluator, RelationshipType relationshipType, Direction direction )
-        {
-            return null;
-        }
-
-        @Override
-        public Traverser traverse( Traverser.Order traversalOrder, StopEvaluator stopEvaluator, ReturnableEvaluator returnableEvaluator, RelationshipType firstRelationshipType, Direction firstDirection, RelationshipType secondRelationshipType, Direction secondDirection )
-        {
-            return null;
-        }
-
-        @Override
-        public Traverser traverse( Traverser.Order traversalOrder, StopEvaluator stopEvaluator, ReturnableEvaluator returnableEvaluator, Object... relationshipTypesAndDirections )
-        {
-            return null;
-        }
-
-        @Override
-        public void addLabel( Label label )
-        {
-        }
-
-        @Override
-        public void removeLabel( Label label )
-        {
-        }
-
-        @Override
-        public boolean hasLabel( Label label )
-        {
-            return false;
-        }
-
-        @Override
-        public ResourceIterable<Label> getLabels()
-        {
-            return null;
-        }
-
-        @Override
-        public Iterable<RelationshipType> getRelationshipTypes()
-        {
-            return null;
-        }
-
-        @Override
-        public int getDegree()
-        {
-            return 0;
-        }
-
-        @Override
-        public int getDegree( RelationshipType type )
-        {
-            return 0;
-        }
-
-        @Override
-        public int getDegree( Direction direction )
-        {
-            return 0;
-        }
-
-        @Override
-        public int getDegree( RelationshipType type, Direction direction )
-        {
-            return 0;
-        }
+        return new NodeProxy( nodeActions, nodeId );
     }
 
-    class MockRelationship extends MockPropertyContainer implements Relationship
+    private Node createNode( long nodeId )
     {
+        Node node = mock( Node.class );
+        when( node.getId() ).thenReturn( nodeId );
+        return node;
+    }
 
-        private final long fromNode;
-        private final long toNode;
+    private Relationship createRelationship( long startNodeId, long endNodeId )
+    {
+        Relationship relationship = mock( Relationship.class );
+        Node startNode = createNode( startNodeId );
+        Node endNode = createNode( endNodeId );
+        when( relationship.getStartNode() ).thenReturn( startNode );
+        when( relationship.getEndNode() ).thenReturn( endNode );
+        return relationship;
+    }
 
-        public MockRelationship( long fromNode, long toNode )
-        {
-            this.fromNode = fromNode;
-
-            this.toNode = toNode;
-        }
-
+    private class NodeProxyAnswer implements Answer<NodeProxy>
+    {
         @Override
-        public long getId()
+        public NodeProxy answer( InvocationOnMock invocation ) throws Throwable
         {
-            return fromNode ^ toNode;
-        }
-
-        @Override
-        public boolean equals( Object other )
-        {
-            return other instanceof Relationship && ((Relationship) other).getId() == getId();
-        }
-
-        @Override
-        public Node getOtherNode( Node node )
-        {
-            return node.getId() == fromNode ? new MockNode( toNode ) : new MockNode( fromNode );
-        }
-
-        @Override
-        public Node getStartNode()
-        {
-            return new MockNode( fromNode );
-        }
-
-        @Override
-        public RelationshipType getType()
-        {
-            return DynamicRelationshipType.withName( "Banana" );
-        }
-
-        @Override
-        public void delete()
-        {
-        }
-
-        @Override
-        public Node getEndNode()
-        {
-            return null;
-        }
-
-        @Override
-        public Node[] getNodes()
-        {
-            return new Node[0];
-        }
-
-        @Override
-        public boolean isType( RelationshipType type )
-        {
-            return false;
+            return createNodeProxy( ((Number) invocation.getArguments()[0]).intValue() );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/traversal/Paths.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/traversal/Paths.java
@@ -122,7 +122,7 @@ public class Paths
      */
     public static String defaultPathToString( Path path )
     {
-        return pathToString( path, new DefaultPathDescriptor<Path>() );
+        return pathToString( path, new DefaultPathDescriptor<>() );
     }
 
     /**

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
@@ -7,6 +7,9 @@ o Fixes #4907 - Result.columnAs should throw exception on invalid column name
 o Fixes #4988 - predicate exceptions should be ignored for non-matching rows
 o Fixes #5114 - lower case exponent e unsupported
 
+Graph algo:
+o Fixes #5086 - path.reverseNodes bug
+
 2.2.4
 -----
 Cypher:

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
@@ -7,6 +7,9 @@ o Fixes #4907 - Result.columnAs should throw exception on invalid column name
 o Fixes #4988 - predicate exceptions should be ignored for non-matching rows
 o Fixes #5114 - lower case exponent e unsupported
 
+Graph algo:
+o Fixes #5086 - path.reverseNodes bug
+
 2.2.4
 -----
 Cypher:

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
@@ -7,6 +7,9 @@ o Fixes #4907 - Result.columnAs should throw exception on invalid column name
 o Fixes #4988 - predicate exceptions should be ignored for non-matching rows
 o Fixes #5114 - lower case exponent e unsupported
 
+Graph algo:
+o Fixes #5086 - path.reverseNodes bug
+
 2.2.4
 -----
 Cypher:


### PR DESCRIPTION
Restore possibility to get all nodes in the path in reversed order.
Use correct relationship to find next node in a chain.
Update test to be mock based.
