### PR TITLE
Tweak relative cost of label scans

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/CardinalityCostModel.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/CardinalityCostModel.scala
@@ -43,9 +43,10 @@ object CardinalityCostModel extends CostModel {
          _: AllNodesScan |
          _: DirectedRelationshipByIdSeek |
          _: UndirectedRelationshipByIdSeek |
-         _: ProjectEndpoints |
-         _: NodeByLabelScan
+         _: ProjectEndpoints
     => FAST_STORE
+
+    case _: NodeByLabelScan => FAST_STORE * 1.4
 
     // Filtering on labels and properties
     case Selection(predicates, _) if predicates.exists {


### PR DESCRIPTION
In measurements label scans cost roughly 40 percent more per row than all node scans.
This commit updates the cost model to reflect that which also fixes a regression in idp planner.
