### PR TITLE
[Test Failure] ImportToolTest.shouldIncludeSourceInformationInNodeIdCollisionError is flaky

### DIFF
--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -82,6 +82,18 @@ import static org.neo4j.tooling.ImportTool.MULTI_FILE_DELIMITER;
 
 public class ImportToolTest
 {
+
+    private static final int RELATIONSHIP_COUNT = 10_000;
+    private static final int NODE_COUNT = 100;
+
+    @Rule
+    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
+    @Rule
+    public final RandomRule random = new RandomRule();
+    @Rule
+    public final Mute mute = Mute.mute( Mute.System.values() );
+    private int dataIndex;
+
     @Test
     public void shouldImportWithAsManyDefaultsAsAvailable() throws Exception
     {
@@ -1062,13 +1074,4 @@ public class ImportToolTest
     {
         ImportTool.main( arguments, true );
     }
-
-    private static final int RELATIONSHIP_COUNT = 10_000;
-    private static final int NODE_COUNT = 100;
-
-    @Rule
-    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
-    public final @Rule RandomRule random = new RandomRule();
-    public final @Rule Mute mute = Mute.mute( Mute.System.values() );
-    private int dataIndex;
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/Resource.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/Resource.java
@@ -26,12 +26,12 @@ package org.neo4j.graphdb;
 public interface Resource extends AutoCloseable
 {
     @Override
-    public void close();
+    void close();
 
     /**
      * Empty resource that doesn't {@link #close() close} anything.
      */
-    public static final Resource EMPTY = new Resource()
+    Resource EMPTY = new Resource()
     {
         @Override
         public void close()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityStoreUpdaterStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EntityStoreUpdaterStep.java
@@ -42,8 +42,8 @@ import org.neo4j.unsafe.impl.batchimport.store.io.IoMonitor;
 import static java.lang.Math.max;
 
 /**
- * Writes {@link RecordBatch entity batches} to the underlying stores. Also makes final composition of the
- * {@link BatchEntity entities} before writing, such as clumping up {@link PropertyBlock properties} into
+ * Writes {@link RECORD entity batches} to the underlying stores. Also makes final composition of the
+ * {@link Batch entities} before writing, such as clumping up {@link PropertyBlock properties} into
  * {@link PropertyRecord property records}.
  *
  * @param <RECORD> type of entities.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
+import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.InputCache;
@@ -29,7 +30,7 @@ import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
 import static org.neo4j.unsafe.impl.batchimport.Utils.idsOf;
 
 /**
- * Performs {@link IdMapper#prepare(InputIterable, org.neo4j.helpers.progress.ProgressListener)}
+ * Performs {@link IdMapper#prepare(InputIterable, Collector, ProgressListener)}
  * embedded in a {@link Stage} as to take advantage of statistics and monitoring provided by that framework.
  */
 public class IdMapperPreparationStage extends Stage

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStep.java
@@ -28,7 +28,7 @@ import org.neo4j.unsafe.impl.batchimport.staging.Step;
 import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
 
 /**
- * Preparation of an {@link IdMapper}, {@link IdMapper#prepare(InputIterable, ProgressListener)}
+ * Preparation of an {@link IdMapper}, {@link IdMapper#prepare(InputIterable, Collector, ProgressListener)}
  * under running as a normal {@link Step} so that normal execution monitoring can be applied.
  * Useful since preparing an {@link IdMapper} can take a significant amount of time.
  */

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/PropertyEncoderStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/PropertyEncoderStep.java
@@ -36,7 +36,7 @@ import static java.util.Arrays.copyOf;
 
 /**
  * Encodes property data into {@link PropertyBlock property blocks}, attaching them to each
- * {@link BatchEntity}. This step is designed to handle multiple threads doing the property encoding,
+ * {@link Batch}. This step is designed to handle multiple threads doing the property encoding,
  * since property encoding is potentially the most costly step in this {@link Stage}.
  */
 public class PropertyEncoderStep<RECORD extends PrimitiveRecord,INPUT extends InputEntity>

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
@@ -40,24 +40,24 @@ public interface IdMapper extends MemoryStatsVisitor.Home
      * @param actualId the actual node id that the inputId will represent.
      * @param group {@link Group} this input id will be added to. Used for handling input ids collisions
      * where multiple equal input ids might be added, as long as all input ids within a single group is unique.
-     * Group ids are also passed into {@link #get(Object, PrimitiveIntPredicate)}.
+     * Group ids are also passed into {@link #get(Object, Group)}.
      * It is required that all input ids belonging to a specific group are put in sequence before putting any
      * input ids for another group.
      */
     void put( Object inputId, long actualId, Group group );
 
     /**
-     * @return whether or not a call to {@link #prepare()} needs to commence after all calls to
-     * {@link #put(Object, long)} and before any call to {@link #get(Object)}. I.e. whether or not all ids
-     * needs to be put before making any call to {@link #get(Object)}.
+     * @return whether or not a call to {@link #prepare(InputIterable, Collector, ProgressListener)} needs to commence after all calls to
+     * {@link #put(Object, long, Group)} and before any call to {@link #get(Object, Group)}. I.e. whether or not all ids
+     * needs to be put before making any call to {@link #get(Object, Group)}.
      */
     boolean needsPreparation();
 
     /**
-     * After all mappings have been {@link #put(Object, long)} call this method to prepare for
-     * {@link #get(Object) querying}.
+     * After all mappings have been {@link #put(Object, long, Group)} call this method to prepare for
+     * {@link #get(Object, Group)}.
      *
-     * @param all ids put earlier, in the event of difficult collisions so that more information have to be read
+     * @param allIds put earlier, in the event of difficult collisions so that more information have to be read
      * from the input data again, data that normally isn't necessary and hence discarded.
      * @param collector {@link Collector} for bad entries, such as duplicate node ids.
      * @param progress reports preparation progress.
@@ -65,14 +65,14 @@ public interface IdMapper extends MemoryStatsVisitor.Home
     void prepare( InputIterable<Object> allIds, Collector collector, ProgressListener progress );
 
     /**
-     * Returns an actual node id representing {@code inputId}. For this call to work {@link #prepare()} must have
-     * been called after all calls to {@link #put(Object, long)} have been made,
+     * Returns an actual node id representing {@code inputId}. For this call to work {@link #prepare(InputIterable, Collector, ProgressListener)} must have
+     * been called after all calls to {@link #put(Object, long, Group)} have been made,
      * iff {@link #needsPreparation()} returns {@code true}. Otherwise ids can be retrieved right after
      * @link #put(Object, long) being put}
      *
      * @param inputId the input id to get the actual node id for.
      * @param group {@link Group} the given {@code inputId} must exist in, i.e. have been put with.
-     * @return the actual node id previously specified by {@link #put(Object, long)}, or {@code -1} if not found.
+     * @return the actual node id previously specified by {@link #put(Object, long, Group)}, or {@code -1} if not found.
      */
     long get( Object inputId, Group group );
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/TaskExecutor.java
@@ -48,7 +48,7 @@ public interface TaskExecutor<LOCAL> extends Parallelizable
     void submit( Task<LOCAL> task );
 
     /**
-     * Shuts down this {@link TaskExecutor}, disallowing new tasks to be {@link #submit(Runnable) submitted}.
+     * Shuts down this {@link TaskExecutor}, disallowing new tasks to be {@link #submit(Task) submitted}.
      *
      * @param awaitAllCompleted if {@code true} will wait for all queued or already executing tasks to be
      * executed and completed, before returning from this method.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -130,7 +130,7 @@ public abstract class AbstractStep<T> implements Step<T>
 
     protected boolean stillWorking()
     {
-        if ( panic != null )
+        if ( isPanic() )
         {   // There has been a panic, so we'll just stop working
             return false;
         }
@@ -142,6 +142,11 @@ public abstract class AbstractStep<T> implements Step<T>
 
         // We're still working
         return true;
+    }
+
+    protected boolean isPanic()
+    {
+        return panic != null;
     }
 
     @Override
@@ -195,7 +200,7 @@ public abstract class AbstractStep<T> implements Step<T>
 
     protected void assertHealthy()
     {
-        if ( panic != null )
+        if ( isPanic() )
         {
             throw new RuntimeException( "Panic called, so exiting", panic );
         }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/LonelyProcessingStepTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.test.Mute;
+
+public class LonelyProcessingStepTest
+{
+    @Rule
+    public Mute mute = Mute.muteAll();
+
+    @Test( timeout = 1000 )
+    public void issuePanicBeforeCompletionOnError() throws Exception
+    {
+        List<Step<?>> stepsPipeline = new ArrayList<>();
+        FaultyLonelyProcessingStepTest faultyStep = new FaultyLonelyProcessingStepTest( stepsPipeline );
+        stepsPipeline.add( faultyStep );
+
+        faultyStep.receive( 1, null );
+
+        while ( !faultyStep.isCompleted() )
+        {
+            Thread.sleep( 10 );
+        }
+
+        Assert.assertTrue( "On upstream end step should be already on panic in case of exception",
+                faultyStep.isPanicOnEndUpstream() );
+        Assert.assertTrue( faultyStep.isPanic() );
+        Assert.assertFalse( faultyStep.stillWorking() );
+    }
+
+    private class FaultyLonelyProcessingStepTest extends LonelyProcessingStep
+    {
+
+        private volatile boolean panicOnEndUpstream = false;
+
+        public FaultyLonelyProcessingStepTest( List<Step<?>> pipeLine )
+        {
+            super( new StageExecution( "Faulty", Configuration.DEFAULT, pipeLine, 0 ),
+                    "Faulty", Configuration.DEFAULT );
+        }
+
+        @Override
+        protected void process()
+        {
+            throw new RuntimeException( "Process exception" );
+        }
+
+        @Override
+        public void endOfUpstream()
+        {
+            panicOnEndUpstream = isPanic();
+            super.endOfUpstream();
+        }
+
+        public boolean isPanicOnEndUpstream()
+        {
+            return panicOnEndUpstream;
+        }
+    }
+
+}


### PR DESCRIPTION
Update LonelyProcessingStep to issuePanic before endOfUpstream in case of exception.
Fixing race when next import stage is scheduled and started before panic exception was updated on endOfUpstream.
