### PR TITLE
Treat threshold possible value as long during ThresholdBasedPruneStrategy construction.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/FileCountThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/FileCountThreshold.java
@@ -25,11 +25,11 @@ import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
 
 public final class FileCountThreshold implements Threshold
 {
-    private final int maxNonEmptyLogs;
+    private final long maxNonEmptyLogs;
 
-    private int nonEmptyLogCount;
+    private long nonEmptyLogCount;
 
-    FileCountThreshold( int maxNonEmptyLogs )
+    FileCountThreshold( long maxNonEmptyLogs )
     {
         this.maxNonEmptyLogs = maxNonEmptyLogs;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactory.java
@@ -104,32 +104,39 @@ public class LogPruneStrategyFactory
             }
         }
 
-        String type = tokens[1];
-        int number = (int) parseLongWithUnit( boolOrNumber );
+        Threshold thresholdToUse = getThresholdByType( fileSystem, tokens[1], boolOrNumber, configValue );
+        return new ThresholdBasedPruneStrategy( fileSystem, logFileInformation, files, versionRepo, thresholdToUse );
+    }
+
+    // visible for testing
+    static Threshold getThresholdByType( FileSystemAbstraction fileSystem, String type, String thresholdValueString,
+            String originalConfigValue )
+    {
+        long thresholdValue = parseLongWithUnit( thresholdValueString );
 
         Threshold thresholdToUse;
         switch ( type )
         {
             case "files":
-                thresholdToUse = new FileCountThreshold( number );
+                thresholdToUse = new FileCountThreshold( thresholdValue );
                 break;
             case "size":
-                thresholdToUse = new FileSizeThreshold( fileSystem, number );
+                thresholdToUse = new FileSizeThreshold( fileSystem, thresholdValue );
                 break;
             case "txs":
-                thresholdToUse = new TransactionCountThreshold( number );
+                thresholdToUse = new TransactionCountThreshold( thresholdValue );
                 break;
             case "hours":
-                thresholdToUse = new TransactionTimespanThreshold( Clock.SYSTEM_CLOCK, TimeUnit.HOURS, number );
+                thresholdToUse = new TransactionTimespanThreshold( Clock.SYSTEM_CLOCK, TimeUnit.HOURS, thresholdValue );
                 break;
             case "days":
-                thresholdToUse = new TransactionTimespanThreshold( Clock.SYSTEM_CLOCK, TimeUnit.DAYS, number );
+                thresholdToUse = new TransactionTimespanThreshold( Clock.SYSTEM_CLOCK, TimeUnit.DAYS, thresholdValue );
                 break;
             default:
-                throw new IllegalArgumentException( "Invalid log pruning configuration value '" + configValue +
+                throw new IllegalArgumentException( "Invalid log pruning configuration value '" + originalConfigValue +
                         "'. Invalid type '" + type + "', valid are files, size, txs, hours, days." );
         }
-        return new ThresholdBasedPruneStrategy( fileSystem, logFileInformation, files, versionRepo, thresholdToUse );
+        return thresholdToUse;
     }
 
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/FileSizeThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/FileSizeThresholdTest.java
@@ -19,13 +19,12 @@
  */
 package org.neo4j.kernel.impl.transaction.log.pruning;
 
-import java.io.File;
-
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
-import org.neo4j.kernel.impl.transaction.log.pruning.FileSizeThreshold;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -34,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 public class FileSizeThresholdTest
 {
+
     private FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
     private final LogFileInformation source = mock( LogFileInformation.class );
     private final File file = mock( File.class );
@@ -60,10 +60,11 @@ public class FileSizeThresholdTest
     public void shouldReturnTrueWhenASingleFileSizeIsGreaterOrEqualThanMaxSize()
     {
         // given
-        final long maxSize = 10;
-        final FileSizeThreshold threshold = new FileSizeThreshold( fs, maxSize );
+        long sixteenGigabytes = 16l * 1024 * 1024 * 1024;
 
-        when( fs.getFileSize( file ) ).thenReturn( 10l );
+        final FileSizeThreshold threshold = new FileSizeThreshold( fs, sixteenGigabytes );
+
+        when( fs.getFileSize( file ) ).thenReturn( sixteenGigabytes );
 
         // when
         threshold.init();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.pruning;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class LogPruneStrategyFactoryTest
+{
+
+    @Test
+    public void testLogPruneThresholdsByType() throws Exception
+    {
+        assertThat( getPruneStrategy( "files", "25", "25 files" ), instanceOf( FileCountThreshold.class ) );
+        assertThat( getPruneStrategy( "size", "16G", "16G size" ), instanceOf( FileSizeThreshold.class ) );
+        assertThat( getPruneStrategy( "txs", "4G", "4G txs" ), instanceOf( TransactionCountThreshold.class ) );
+        assertThat( getPruneStrategy( "hours", "100", "100 hours" ), instanceOf( TransactionTimespanThreshold.class ) );
+        assertThat( getPruneStrategy( "days", "100k", "100k days" ),
+                    instanceOf( TransactionTimespanThreshold.class) );
+    }
+
+    private Threshold getPruneStrategy(String type, String value, String configValue)
+    {
+        FileSystemAbstraction fileSystem = Mockito.mock( FileSystemAbstraction.class );
+        return LogPruneStrategyFactory.getThresholdByType( fileSystem, type, value, configValue );
+    }
+}


### PR DESCRIPTION
Update possible value type to long instead of int.
Update file size threshold test to use 16G as condition.
Add basic test for possible thresholds that can be created during LogPruneStrategy construction.
