### PR TITLE
Removed tracking of deleted node/rel ids from tx state

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
@@ -1173,6 +1173,23 @@ public class TxStateTest
     }
 
     @Test
+    public void shouldVisitDeletedNode() throws Exception
+    {
+        // GIVEN
+        state.nodeDoDelete( 42 );
+
+        // WHEN
+        state.accept( new TxStateVisitor.Adapter()
+        {
+            @Override
+            public void visitDeletedNode( long id )
+            {
+                assertEquals( "Wrong deleted node id", 42, id );
+            }
+        } );
+    }
+
+    @Test
     public void shouldNotChangeRecordForCreatedAndDeletedRelationship() throws Exception
     {
         // GIVEN

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
@@ -19,22 +19,38 @@
  */
 package org.neo4j.kernel.impl.core;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.core.RelationshipProxy.RelationshipActions;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.Iterables.single;
 
 public class RelationshipProxyTest
 {
+    private static final RelationshipType TYPE = DynamicRelationshipType.withName( "TYPE" );
+    private static final String PROPERTY_KEY = "PROPERTY_KEY";
+
+    @Rule
+    public final DatabaseRule db = new ImpermanentDatabaseRule();
+
     @Test
     public void shouldBeAbleToReferToIdsBeyondMaxInt() throws Exception
     {
@@ -45,7 +61,7 @@ public class RelationshipProxyTest
             @Override
             public Node answer( InvocationOnMock invocation ) throws Throwable
             {
-                return nodeWithId( (Long)invocation.getArguments()[0] );
+                return nodeWithId( (Long) invocation.getArguments()[0] );
             }
         } );
         when( actions.getRelationshipTypeById( anyInt() ) ).then( new Answer<RelationshipType>()
@@ -53,11 +69,11 @@ public class RelationshipProxyTest
             @Override
             public RelationshipType answer( InvocationOnMock invocation ) throws Throwable
             {
-                return new RelationshipTypeToken( "whatever", (Integer)invocation.getArguments()[0] );
+                return new RelationshipTypeToken( "whatever", (Integer) invocation.getArguments()[0] );
             }
         } );
 
-        long[] ids = new long[] {
+        long[] ids = new long[]{
                 1437589437,
                 2047587483,
                 2147496246L,
@@ -67,7 +83,7 @@ public class RelationshipProxyTest
                 57587348738L,
                 59892898932L
         };
-        int[] types = new int[] {
+        int[] types = new int[]{
                 0,
                 10,
                 101,
@@ -77,14 +93,64 @@ public class RelationshipProxyTest
         };
 
         // WHEN/THEN
-        for ( int i = 0; i < ids.length-2; i++ )
+        for ( int i = 0; i < ids.length - 2; i++ )
         {
             long id = ids[i];
-            long nodeId1 = ids[i+1];
-            long nodeId2 = ids[i+2];
+            long nodeId1 = ids[i + 1];
+            long nodeId2 = ids[i + 2];
             int type = types[i];
             verifyIds( actions, id, nodeId1, type, nodeId2 );
             verifyIds( actions, id, nodeId2, type, nodeId1 );
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenSettingPropertyOnADeletedRelationship()
+    {
+        // Given
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode().createRelationshipTo( db.createNode(), TYPE ).setProperty( PROPERTY_KEY, "foo" );
+            tx.success();
+        }
+
+        long relationshipId = -1;
+        try ( Transaction ignored = db.beginTx() )
+        {
+            // When
+            Relationship relationship = single( GlobalGraphOperations.at( db ).getAllRelationships() );
+            relationshipId = relationship.getId();
+            relationship.delete();
+            relationship.setProperty( PROPERTY_KEY, "bar" );
+            fail( "Setting property on a deleted relationship should not work" );
+        }
+        catch ( NotFoundException e )
+        {
+            // Then
+            // exception is thrown - expected
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenSettingPropertyOnARelationshipDeletedInSameTx()
+    {
+        long relationshipId = -1;
+        try ( Transaction ignored = db.beginTx() )
+        {
+            // Given
+            db.createNode().createRelationshipTo( db.createNode(), TYPE ).setProperty( PROPERTY_KEY, "foo" );
+
+            // When
+            Relationship relationship = single( GlobalGraphOperations.at( db ).getAllRelationships() );
+            relationshipId = relationship.getId();
+            relationship.delete();
+            relationship.setProperty( PROPERTY_KEY, "bar" );
+            fail( "Setting property on a deleted relationship should not work" );
+        }
+        catch ( NotFoundException e )
+        {
+            // Then
+            // exception is thrown - expected
         }
     }
 
@@ -93,7 +159,7 @@ public class RelationshipProxyTest
         RelationshipProxy proxy = new RelationshipProxy( actions, relationshipId, nodeId1, typeId, nodeId2 );
         assertEquals( relationshipId, proxy.getId() );
         // our mock above is known to return RelationshipTypeToken
-        assertEquals( typeId, ((RelationshipTypeToken)proxy.getType()).id() );
+        assertEquals( typeId, ((RelationshipTypeToken) proxy.getType()).id() );
         assertEquals( nodeId1, proxy.getStartNode().getId() );
         assertEquals( nodeId2, proxy.getEndNode().getId() );
         assertEquals( nodeId2, proxy.getOtherNode( nodeWithId( nodeId1 ) ).getId() );


### PR DESCRIPTION
Ids of nodes and relationships deleted in particular transaction were explicitly tracked by tx state in separate sets. This was done to remove placeholders from object cache when node/rel was added and deleted in same transaction. Diff sets treat such addition-removal as no-op and were not helpful.

Such tracking of ids is no longer needed because object cache was removed.
