### PR TITLE
Cleaned up tracking of deleted node/rel ids in tx state

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
@@ -478,4 +478,14 @@ return distinct center""")
 
     assertStats(result, nodesCreated = 1)
   }
+
+  test("should be possible to remove nodes created in the same query") {
+    val result = execute(
+      """CREATE (a)-[:FOO]->(b)
+         WITH *
+         MATCH (x)-[r]-(y)
+         DELETE x, r, y""".stripMargin)
+
+    assertStats(result, nodesCreated = 2, relationshipsCreated = 1, nodesDeleted = 2, relationshipsDeleted = 1)
+  }
 }


### PR DESCRIPTION
This is a minor clean up commit that:
- removes not relevant comments
- changes sets of ids to primitive sets
- adds couple tests
