### PR TITLE
Fixed handling of large numbers in index range seeks

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NodeCorrectlyIndexedCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NodeCorrectlyIndexedCheckTest.java
@@ -221,8 +221,7 @@ public class NodeCorrectlyIndexedCheckTest
                 }
 
                 @Override
-                public PrimitiveLongIterator rangeSeekByNumber( Number lower, boolean includeLower,
-                                                                Number upper, boolean includeUpper )
+                public PrimitiveLongIterator rangeSeekByNumberInclusive( Number lower, Number upper )
                 {
                     throw new UnsupportedOperationException();
                 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -197,18 +197,17 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
 
   private def indexSeekByNumericalRange(index: IndexDescriptor, range: InequalitySeekRange[Number]): scala.Iterator[Node] = {
     val readOps = statement.readOperations()
-    val propertyKeyId = index.getPropertyKeyId
-    val matchingNodes: PrimitiveLongIterator = range match {
+    val matchingNodes: PrimitiveLongIterator = (range match {
 
       case rangeLessThan: RangeLessThan[Number] =>
         rangeLessThan.limit(BY_NUMBER).map { limit =>
           readOps.nodesGetFromIndexRangeSeekByNumber( index, null, false, limit.endPoint, limit.isInclusive )
-        }.getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
+        }
 
       case rangeGreaterThan: RangeGreaterThan[Number] =>
         rangeGreaterThan.limit(BY_NUMBER).map { limit =>
           readOps.nodesGetFromIndexRangeSeekByNumber( index, limit.endPoint, limit.isInclusive, null, false )
-        }.getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
+        }
 
       case RangeBetween(rangeGreaterThan, rangeLessThan) =>
         rangeGreaterThan.limit(BY_NUMBER).flatMap { greaterThanLimit =>
@@ -218,9 +217,8 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
               greaterThanLimit.endPoint, greaterThanLimit.isInclusive,
               lessThanLimit.endPoint, lessThanLimit.isInclusive )
           }
-        }.getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
-    }
-
+        }
+    }).getOrElse(EMPTY_PRIMITIVE_LONG_COLLECTION.iterator)
     JavaConversionSupport.mapToScalaENFXSafe(matchingNodes)(nodeOps.getById)
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexUsageAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexUsageAcceptanceTest.scala
@@ -121,6 +121,38 @@ class IndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTe
     result.toList should equal(List(Map("p" -> null, "placeName" -> null)))
   }
 
+  test("should handle comparing large integers") {
+    // Given
+    val person = createLabeledNode(Map("age" -> 5987523281782486379L), "Person")
+
+
+    graph.createIndex("Person", "age")
+
+    // When
+    val result = executeWithCostPlannerOnly(
+      "MATCH (p:Person) USING INDEX p:Person(age) WHERE p.age > 5987523281782486378 RETURN p")
+
+    // Then
+    result.toList should equal(List(Map("p" -> person)))
+    result.executionPlanDescription().toString should include("NodeIndexSeek")
+  }
+
+  test("should handle comparing large integers 2") {
+    // Given
+    val person = createLabeledNode(Map("age" -> 5987523281782486379L), "Person")
+
+
+    graph.createIndex("Person", "age")
+
+    // When
+    val result = executeWithCostPlannerOnly(
+      "MATCH (p:Person) USING INDEX p:Person(age) WHERE p.age > 5987523281782486379 RETURN p")
+
+    // Then
+    result.toList shouldBe empty
+    result.executionPlanDescription().toString should include("NodeIndexSeek")
+  }
+
   private def setUpDatabaseForTests() {
     executeWithRulePlanner(
       """CREATE (architect:Matrix { name:'The Architect' }),

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticIndexAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticIndexAcceptanceTest.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3
+
+import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+
+class SemanticIndexAcceptanceTest extends ExecutionEngineFunSuite with PropertyChecks {
+
+  //the actual test
+  List("<", "<=", "=", ">", ">=").foreach(testOperator)
+
+  override protected def initTest(): Unit = {
+    super.initTest()
+    for(i <- 1 to 1000) createLabeledNode("Label")
+  }
+
+  def changeLastChar(f: Char => Char)(in: String) =
+    if (in.isEmpty) ""
+    else
+      in.substring(0, in.length - 1) + (in.last - 1).toChar
+
+  def testOperator(operator: String) = {
+
+    val queryNotUsingIndex = s"match (n:Label) where n.nonIndexed $operator {prop} return n order by id(n)"
+    val queryUsingIndex = s"match (n:Label) where n.indexed $operator {prop} return n order by id(n)"
+
+    def testValue(queryNotUsingIndex: String, queryUsingIndex: String, value: Any): Unit = {
+      val indexedResult = execute(queryUsingIndex, "prop" -> value)
+      execute(queryNotUsingIndex, "prop" -> value).toList should equal(indexedResult.toList)
+      indexedResult.executionPlanDescription().toString should include("NodeIndexSeek")
+    }
+
+    def tester[T](propertyValue: T, prev: T => T, next: T => T) = {
+      graph.inTx {
+        createLabeledNode(Map("nonIndexed" -> propertyValue, "indexed" -> propertyValue), "Label")
+
+        withClue("with TxState") {
+          testValue(queryNotUsingIndex, queryUsingIndex, propertyValue)
+          testValue(queryNotUsingIndex, queryUsingIndex, prev(propertyValue))
+          testValue(queryNotUsingIndex, queryUsingIndex, next(propertyValue))
+        }
+      }
+      withClue("without TxState") {
+        testValue(queryNotUsingIndex, queryUsingIndex, propertyValue)
+        testValue(queryNotUsingIndex, queryUsingIndex, prev(propertyValue))
+        testValue(queryNotUsingIndex, queryUsingIndex, next(propertyValue))
+      }
+    }
+
+    test(s"testing long with $operator") {
+      graph.createIndex("Label", "indexed")
+      forAll { propertyValue: Long =>
+        tester(propertyValue, (l: Long) => l - 1L, (l: Long) => l + 1)
+      }
+    }
+
+    test(s"testing double with $operator") {
+      graph.createIndex("Label", "indexed")
+      forAll { propertyValue: Double =>
+        tester(propertyValue, (d: Double) => d - 0.5, (d: Double) => d + 0.5)
+      }
+    }
+
+    test(s"testing string with $operator") {
+      graph.createIndex("Label", "indexed")
+      forAll (Gen.alphaStr){ propertyValue: String =>
+        tester(propertyValue, changeLastChar(c => (c - 1).toChar), changeLastChar(c => (c + 1).toChar))
+      }
+    }
+
+  }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexReader.java
@@ -42,9 +42,9 @@ public interface IndexReader extends Resource
     PrimitiveLongIterator seek( Object value );
 
     /**
-     * Numerical range query by index seek
+     * Inclusive numerical range query by index seek
      */
-    PrimitiveLongIterator rangeSeekByNumber( Number lower, boolean includeLower, Number upper, boolean includeUpper );
+    PrimitiveLongIterator rangeSeekByNumberInclusive( Number lower, Number upper );
 
     /**
      * String range query by index seek
@@ -96,10 +96,9 @@ public interface IndexReader extends Resource
         }
 
         @Override
-        public PrimitiveLongIterator rangeSeekByNumber( Number lower, boolean includeLower,
-                                                        Number upper, boolean includeUpper )
+        public PrimitiveLongIterator rangeSeekByNumberInclusive( Number lower, Number upper )
         {
-            return delegate.rangeSeekByNumber( lower, includeLower, upper, includeUpper );
+            return delegate.rangeSeekByNumberInclusive( lower, upper );
         }
 
         @Override
@@ -161,8 +160,7 @@ public interface IndexReader extends Resource
         }
 
         @Override
-        public PrimitiveLongIterator rangeSeekByNumber( Number lower, boolean includeLower,
-                                                        Number upper, boolean includeUpper )
+        public PrimitiveLongIterator rangeSeekByNumberInclusive( Number lower, Number upper )
         {
             return PrimitiveLongCollections.emptyIterator();
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -69,7 +69,6 @@ import org.neo4j.kernel.impl.util.PrimitiveLongResourceIterator;
 
 import static org.neo4j.helpers.collection.Iterables.filter;
 import static org.neo4j.helpers.collection.Iterables.map;
-import static org.neo4j.kernel.impl.api.PropertyValueComparison.COMPARE_NUMBERS;
 import static org.neo4j.kernel.impl.api.PropertyValueComparison.COMPARE_STRINGS;
 
 /**
@@ -263,16 +262,14 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( KernelStatement state,
-                                                                     IndexDescriptor index,
-                                                                     Number lower, boolean includeLower,
-                                                                     Number upper, boolean includeUpper )
+    public PrimitiveLongIterator nodesGetFromInclusiveNumericIndexRangeSeek( KernelStatement state,
+            IndexDescriptor index,
+            Number lower,
+            Number upper )
             throws IndexNotFoundKernelException
 
     {
-        return COMPARE_NUMBERS.isEmptyRange( lower, includeLower, upper, includeUpper )
-            ? PrimitiveLongCollections.emptyIterator()
-            : diskLayer.nodesGetFromIndexRangeSeekByNumber( state, index, lower, includeLower, upper, includeUpper );
+        return diskLayer.nodesGetFromInclusiveNumericIndexRangeSeek( state, index, lower, upper );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
@@ -212,15 +212,15 @@ public class DiskLayer implements StoreReadLayer
     }
 
     @Override
-    public PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( KernelStatement statement,
-                                                                     IndexDescriptor index,
-                                                                     Number lower, boolean includeLower,
-                                                                     Number upper, boolean includeUpper )
+    public PrimitiveLongIterator nodesGetFromInclusiveNumericIndexRangeSeek( KernelStatement statement,
+            IndexDescriptor index,
+            Number lower,
+            Number upper )
             throws IndexNotFoundKernelException
 
     {
         IndexReader reader = statement.getIndexReader( index );
-        return reader.rangeSeekByNumber( lower, includeLower, upper, includeUpper );
+        return reader.rangeSeekByNumberInclusive( lower, upper );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -94,7 +94,7 @@ public interface StoreReadLayer
     PrimitiveLongIterator nodesGetFromIndexSeek( KernelStatement state, IndexDescriptor index, Object value )
             throws IndexNotFoundKernelException;
 
-    PrimitiveLongIterator nodesGetFromIndexRangeSeekByNumber( KernelStatement statement, IndexDescriptor index, Number lower, boolean includeLower, Number upper, boolean includeUpper )
+    PrimitiveLongIterator nodesGetFromInclusiveNumericIndexRangeSeek( KernelStatement statement, IndexDescriptor index, Number lower, Number upper )
             throws IndexNotFoundKernelException;
 
     PrimitiveLongIterator nodesGetFromIndexRangeSeekByString( KernelStatement statement, IndexDescriptor index, String lower, boolean includeLower, String upper, boolean includeUpper )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexAccessorCompatibility.java
@@ -82,15 +82,15 @@ public abstract class IndexAccessorCompatibility extends IndexProviderCompatibil
                 NodePropertyUpdate.add( 4L, PROPERTY_KEY_ID, 10.0, new long[]{1000} ),
                 NodePropertyUpdate.add( 5L, PROPERTY_KEY_ID, 100.0, new long[]{1000} ) ) );
 
-        assertThat( getAllNodesFromIndexSeekByNumber( 0, true, 10, false ), equalTo( asList( 2L, 3L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( 10, true, null, false ), equalTo( asList( 4L, 5L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( 10, false, null, true ), equalTo( singletonList( 5L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( 100, false, 0, true ), equalTo( EMPTY_LIST ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( null, false, 5.5, false ), equalTo( asList( 1L, 2L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( null, true, 5.5, true ), equalTo( asList( 1L, 2L, 3L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( null, true, null, true ), equalTo( asList( 1L, 2L, 3L, 4L, 5L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( -5, false, 0, true ), equalTo( singletonList( 2L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( -5, false, 5.5, false ), equalTo( singletonList( 2L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( 0, 10 ), equalTo( asList( 2L, 3L, 4L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( 10, null ), equalTo( asList( 4L, 5L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( 10, null ), equalTo( asList( 4L, 5L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( 100, 0 ), equalTo( EMPTY_LIST ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( null, 5.5 ), equalTo( asList( 1L, 2L, 3L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( null, 5.5 ), equalTo( asList( 1L, 2L, 3L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( null, null ), equalTo( asList( 1L, 2L, 3L, 4L, 5L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( -5, 0 ), equalTo( asList( 1L, 2L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( -5, 5.5 ), equalTo( asList( 1L, 2L, 3L ) ) );
     }
 
     @Test
@@ -153,12 +153,12 @@ public abstract class IndexAccessorCompatibility extends IndexProviderCompatibil
         }
     }
 
-    protected List<Long> getAllNodesFromIndexSeekByNumber( Number lower, boolean includeLower, Number upper, boolean includeUpper ) throws IOException
+    protected List<Long> getAllNodesFromInclusiveIndexSeekByNumber( Number lower, Number upper ) throws IOException
     {
         try ( IndexReader reader = accessor.newReader() )
         {
             List<Long> list = new LinkedList<>();
-            for ( PrimitiveLongIterator iterator = reader.rangeSeekByNumber( lower, includeLower, upper, includeUpper ); iterator.hasNext(); )
+            for ( PrimitiveLongIterator iterator = reader.rangeSeekByNumberInclusive( lower, upper ); iterator.hasNext(); )
             {
                 list.add( iterator.next() );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/NonUniqueIndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/NonUniqueIndexAccessorCompatibility.java
@@ -83,11 +83,11 @@ public class NonUniqueIndexAccessorCompatibility extends IndexAccessorCompatibil
                 NodePropertyUpdate.add( 4L, PROPERTY_KEY_ID, 5, new long[]{1000} ),
                 NodePropertyUpdate.add( 5L, PROPERTY_KEY_ID, 5, new long[]{1000} ) ) );
 
-        assertThat( getAllNodesFromIndexSeekByNumber( -5, false, 5, false ), equalTo( singletonList( 3L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( -3, false, 0, false ), equalTo( EMPTY_LIST ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( -5, true, 5, false ), equalTo( asList( 1L, 2L, 3L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( -5, false, 5, true ), equalTo( asList( 3L, 4L, 5L ) ) );
-        assertThat( getAllNodesFromIndexSeekByNumber( -5, true, 5, true ), equalTo( asList( 1L, 2L, 3L, 4L, 5L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( -5, 5 ), equalTo( asList( 1L, 2L, 3L, 4L, 5L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( -3, -1 ), equalTo( EMPTY_LIST ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( -5, 4 ), equalTo( asList( 1L, 2L, 3L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( -4, 5 ), equalTo( asList( 3L, 4L, 5L ) ) );
+        assertThat( getAllNodesFromInclusiveIndexSeekByNumber( -5, 5 ), equalTo( asList( 1L, 2L, 3L, 4L, 5L ) ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SchemaIndexProviderApprovalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SchemaIndexProviderApprovalTest.java
@@ -100,7 +100,7 @@ public abstract class SchemaIndexProviderApprovalTest
 
         private final Object value;
 
-        private TestValue( Object value )
+        TestValue( Object value )
         {
             this.value = value;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/NumericRangeMatchPredicateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/NumericRangeMatchPredicateTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.api.LookupFilter.NumericRangeMatchPredicate;
+import org.neo4j.kernel.impl.api.operations.EntityOperations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class NumericRangeMatchPredicateTest
+{
+
+    @Test
+    public void testInclusiveLowerInclusiveUpper()
+    {
+        NumericRangeMatchPredicate range = createRange( 11, true, 13, true );
+
+        assertFalse( range.inRange( 10 ) );
+        assertTrue( range.inRange( 11 ) );
+        assertTrue( range.inRange( 12 ) );
+        assertTrue( range.inRange( 13 ) );
+        assertFalse( range.inRange( 14 ) );
+    }
+
+    @Test
+    public void testExclusiveLowerExclusiveLower()
+    {
+        NumericRangeMatchPredicate range = createRange( 11, false, 13, false );
+
+        assertFalse( range.inRange( 11 ) );
+        assertTrue( range.inRange( 12 ) );
+        assertFalse( range.inRange( 13 ) );
+    }
+
+    @Test
+    public void testInclusiveLowerExclusiveUpper()
+    {
+        NumericRangeMatchPredicate range = createRange( 11, true, 13, false );
+
+        assertFalse( range.inRange( 10 ) );
+        assertTrue( range.inRange( 11 ) );
+        assertTrue( range.inRange( 12 ) );
+        assertFalse( range.inRange( 13 ) );
+    }
+
+    @Test
+    public void testExclusiveLowerInclusiveUpper()
+    {
+        NumericRangeMatchPredicate range = createRange( 11, false, 13, true );
+
+        assertFalse( range.inRange( 11 ) );
+        assertTrue( range.inRange( 12 ) );
+        assertTrue( range.inRange( 13 ) );
+        assertFalse( range.inRange( 14 ) );
+    }
+
+    @Test
+    public void testLowerNullValue()
+    {
+        NumericRangeMatchPredicate range = createRange( null, true, 13, true );
+
+        assertTrue( range.inRange( 10 ) );
+        assertTrue( range.inRange( 11 ) );
+        assertTrue( range.inRange( 12 ) );
+        assertTrue( range.inRange( 13 ) );
+        assertFalse( range.inRange( 14 ) );
+    }
+
+    @Test
+    public void testUpperNullValue()
+    {
+        NumericRangeMatchPredicate range = createRange( 11, true, null, true );
+
+        assertFalse( range.inRange( 10 ) );
+        assertTrue( range.inRange( 11 ) );
+        assertTrue( range.inRange( 12 ) );
+        assertTrue( range.inRange( 13 ) );
+        assertTrue( range.inRange( 14 ) );
+    }
+
+
+    @Test
+    public void testComparingBigDoublesAndLongs()
+    {
+        NumericRangeMatchPredicate range = createRange( 9007199254740993L, true, null, true );
+
+        assertFalse( range.inRange( 9007199254740992D ) );
+    }
+
+    @Test
+    public void testNullValue()
+    {
+        NumericRangeMatchPredicate range = createRange( 11, true, 13, true );
+
+        assertFalse( range.inRange( null ) );
+    }
+
+
+
+
+
+    private NumericRangeMatchPredicate createRange( Number lower, boolean includeLower, Number upper, boolean includeUpper )
+    {
+        return new NumericRangeMatchPredicate( mock( EntityOperations.class ), mock( KernelStatement.class ), 11, lower,
+                includeLower, upper, includeUpper );
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
@@ -78,8 +78,7 @@ class HashBasedIndex extends InMemoryIndexImplementation
     }
 
     @Override
-    public PrimitiveLongIterator rangeSeekByNumber( Number lower, boolean includeLower,
-                                                    Number upper, boolean includeUpper )
+    public PrimitiveLongIterator rangeSeekByNumberInclusive( Number lower, Number upper )
     {
         Set<Long> nodeIds = new HashSet<>();
         for ( Map.Entry<Object,Set<Long>> entry : data.entrySet() )
@@ -87,28 +86,8 @@ class HashBasedIndex extends InMemoryIndexImplementation
             Object key = entry.getKey();
             if ( NUMBER.isSuperTypeOf( key ) )
             {
-                boolean lowerFilter = false;
-                boolean upperFilter = false;
-
-                if ( lower == null )
-                {
-                    lowerFilter = true;
-                }
-                else
-                {
-                    int cmp = COMPARE_VALUES.compare( key, lower );
-                    lowerFilter = (includeLower && cmp >= 0) || (cmp > 0);
-                }
-
-                if ( upper == null )
-                {
-                    upperFilter = true;
-                }
-                else
-                {
-                    int cmp = COMPARE_VALUES.compare( key, upper );
-                    upperFilter = (includeUpper && cmp <= 0) || (cmp < 0);
-                }
+                boolean lowerFilter = lower == null || COMPARE_VALUES.compare( key, lower ) >= 0;
+                boolean upperFilter = upper == null || COMPARE_VALUES.compare( key, upper ) <= 0;
 
                 if ( lowerFilter && upperFilter )
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StubCursors.java
@@ -27,6 +27,7 @@ import org.neo4j.cursor.Cursor;
 import org.neo4j.function.Function;
 import org.neo4j.function.IntSupplier;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.helpers.ArrayUtil;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.cursor.DegreeItem;
 import org.neo4j.kernel.api.cursor.LabelItem;
@@ -44,6 +45,16 @@ public class StubCursors
     public static Cursor<NodeItem> asNodeCursor( final long nodeId )
     {
         return asNodeCursor( nodeId, Cursors.<PropertyItem>empty(), Cursors.<LabelItem>empty() );
+    }
+
+    public static Cursor<NodeItem> asNodeCursor( final long... nodeIds)
+    {
+        NodeItem[] nodeItems = new NodeItem[nodeIds.length];
+        for (int i = 0; i < nodeIds.length; i++)
+        {
+            nodeItems[i] = asNode( nodeIds[i] );
+        }
+        return Cursors.cursor( nodeItems);
     }
 
     public static Cursor<NodeItem> asNodeCursor( final long nodeId,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CacheLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CacheLayerTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.api.store;
 
 import org.junit.Test;
+
 import java.util.Set;
 
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
@@ -75,26 +76,6 @@ public class CacheLayerTest
 
         // When & Then
         assertThat( asSet( context.constraintsGetForLabelAndPropertyKey( labelId, propertyId ) ), equalTo( constraints ) );
-    }
-
-
-    @Test
-    public void shouldNotCallToDiskLayerOnEmptyRangeSeekByNumber() throws Exception
-    {
-        // Given
-        int labelId = 0, propertyId = 1;
-        IndexDescriptor index = new IndexDescriptor( labelId, propertyId );
-        KernelStatement statement = mock( KernelStatement.class );
-
-        // When
-        assertFalse(
-            context.nodesGetFromIndexRangeSeekByNumber( statement, index, 20, true, 10, false ).hasNext()
-        );
-
-        // Then
-        verifyZeroInteractions( schemaCache );
-        verifyZeroInteractions( statement );
-        verifyZeroInteractions( diskLayer );
     }
 
     @Test

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneDocumentStructure.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneDocumentStructure.java
@@ -231,38 +231,19 @@ public class LuceneDocumentStructure
         throw new IllegalArgumentException( format( "Unable to create query for %s", value ) );
     }
 
-    public TermRangeQuery newRangeSeekByNumberQuery( Number lower, boolean includeLower,
-                                                     Number upper, boolean upperInclusive )
+    /**
+     * Range queries are always inclusive, in order to do exclusive range queries the result must be filtered after the
+     * fact. The reason we can't do inclusive range queries is that longs are coerced to doubles in the index.
+     */
+    public TermRangeQuery newInclusiveNumericRangeSeekQuery( Number lower, Number upper )
     {
-        String chosenLower, chosenUpper;
-        boolean includeChosenLower, includeChosenUpper;
-
-        if ( lower == null )
-        {
-            chosenLower = null;
-            includeChosenLower = true;
-        }
-        else
-        {
-            chosenLower = NumericUtils.doubleToPrefixCoded( lower.doubleValue() );
-            includeChosenLower = includeLower;
-        }
-
-        if ( upper == null )
-        {
-            chosenUpper = null;
-            includeChosenUpper = true;
-        }
-        else
-        {
-            chosenUpper = NumericUtils.doubleToPrefixCoded( upper.doubleValue() );
-            includeChosenUpper = upperInclusive;
-        }
+        String chosenLower = (lower == null) ? null : NumericUtils.doubleToPrefixCoded( lower.doubleValue() );
+        String chosenUpper = (upper == null) ? null : NumericUtils.doubleToPrefixCoded( upper.doubleValue() );
 
         return new TermRangeQuery(
-            ValueEncoding.Number.key(),
-            chosenLower, chosenUpper,
-            includeChosenLower, includeChosenUpper
+                ValueEncoding.Number.key(),
+                chosenLower, chosenUpper,
+                true, true
         );
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReader.java
@@ -94,10 +94,9 @@ class LuceneIndexAccessorReader implements IndexReader
     }
 
     @Override
-    public PrimitiveLongIterator rangeSeekByNumber( Number lower, boolean includeLower,
-                                                    Number upper, boolean includeUpper )
+    public PrimitiveLongIterator rangeSeekByNumberInclusive( Number lower, Number upper )
     {
-        return query( documentLogic.newRangeSeekByNumberQuery( lower, includeLower, upper, includeUpper ) );
+        return query( documentLogic.newInclusiveNumericRangeSeekQuery( lower, upper ) );
     }
 
     @Override

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AbstractLuceneIndexAccessorReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AbstractLuceneIndexAccessorReaderTest.java
@@ -65,13 +65,13 @@ public abstract class AbstractLuceneIndexAccessorReaderTest<R extends LuceneInde
     public void shouldUseCorrectLuceneQueryForRangeSeekByNumberQuery() throws Exception
     {
         // Given
-        when( documentLogic.newRangeSeekByNumberQuery( 12, true, null, false ) ).thenReturn( mock( TermRangeQuery.class) );
+        when( documentLogic.newInclusiveNumericRangeSeekQuery( 12, null ) ).thenReturn( mock( TermRangeQuery.class ) );
 
         // When
-        accessor.rangeSeekByNumber( 12, true, null, false );
+        accessor.rangeSeekByNumberInclusive( 12, null );
 
         // Then
-        verify( documentLogic ).newRangeSeekByNumberQuery( 12, true, null, false );
+        verify( documentLogic ).newInclusiveNumericRangeSeekQuery( 12, null );
         verifyNoMoreInteractions( documentLogic );
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneDocumentStructureTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneDocumentStructureTest.java
@@ -133,12 +133,12 @@ public class LuceneDocumentStructureTest
     public void shouldBuildRangeSeekByNumberQueryForStrings() throws Exception
     {
         // given
-        TermRangeQuery query = documentStructure.newRangeSeekByNumberQuery( 12.0d, false, null, true );
+        TermRangeQuery query = documentStructure.newInclusiveNumericRangeSeekQuery( 12.0d, null );
 
         // then
         assertEquals( "number", query.getField() );
         assertEquals( NumericUtils.doubleToPrefixCoded( 12.0d ) , query.getLowerTerm() );
-        assertEquals( false, query.includesLower() );
+        assertEquals( true, query.includesLower() );
         assertEquals( null, query.getUpperTerm() );
         assertEquals( true, query.includesUpper() );
     }


### PR DESCRIPTION
Since all numbers are converted to double before adding to index we cannot
trust lucene to properly handle exlusive ranges. Lucene is now only doing
inclusive seeks, and then the result is post processed to get the correct behaviour.
