### PR TITLE
Fixes a legacy index lifecycle issue around store copy

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/index/IndexImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/index/IndexImplementation.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
+import org.neo4j.kernel.lifecycle.Lifecycle;
 
 /**
  * An index provider which can create and give access to index transaction state and means of applying
@@ -32,7 +33,7 @@ import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
  * An {@link IndexImplementation} is typically tied to one implementation, f.ex.
  * lucene, http://lucene.apache.org/java.
  */
-public interface IndexImplementation
+public interface IndexImplementation extends Lifecycle
 {
     /**
      * Returns a {@link LegacyIndexProviderTransaction} that keeps transaction state for all
@@ -71,4 +72,28 @@ public interface IndexImplementation
      * @throws IOException
      */
     ResourceIterator<File> listStoreFiles() throws IOException;
+
+    /**
+     * Makes available index resource for recovery.
+     */
+    @Override
+    void init() throws Throwable;
+
+    /**
+     * Makes available index resource for online transaction processing.
+     */
+    @Override
+    void start() throws Throwable;
+
+    /**
+     * Makes unavailable index resource from online transaction processing.
+     */
+    @Override
+    void stop() throws Throwable;
+
+    /**
+     * Makes unavailable the index resource as a whole.
+     */
+    @Override
+    void shutdown() throws Throwable;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -150,6 +150,7 @@ import org.neo4j.kernel.info.DiagnosticsPhase;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.kernel.lifecycle.Lifecycles;
 import org.neo4j.kernel.logging.Logging;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
@@ -455,6 +456,8 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
                 recoveredCount.incrementAndGet();
             }
         } );
+
+        life.add( new Lifecycle.Delegate( Lifecycles.multiple( indexProviders.values() ) ) );
 
         // Upgrade the store before we begin
         upgradeStore( store, storeMigrationProcess, indexProvider );

--- a/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/Lifecycle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/Lifecycle.java
@@ -20,11 +20,11 @@
 package org.neo4j.kernel.lifecycle;
 
 /**
- * Lifecycle interface for kernel components. Init is called first, 
- * followed by start, 
+ * Lifecycle interface for kernel components. Init is called first,
+ * followed by start,
  * and then any number of stop-start sequences,
  * and finally stop and shutdown.
- * 
+ *
  * As a stop-start cycle could be due to change of configuration, please perform anything that depends on config
  * in start().
  *
@@ -38,13 +38,47 @@ public interface Lifecycle
 {
     void init()
         throws Throwable;
-    
+
     void start()
         throws Throwable;
-    
+
     void stop()
         throws Throwable;
-    
+
     void shutdown()
         throws Throwable;
+
+    class Delegate implements Lifecycle
+    {
+        private final Lifecycle delegate;
+
+        public Delegate( Lifecycle delegate )
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void init() throws Throwable
+        {
+            delegate.init();
+        }
+
+        @Override
+        public void start() throws Throwable
+        {
+            delegate.start();
+        }
+
+        @Override
+        public void stop() throws Throwable
+        {
+            delegate.stop();
+        }
+
+        @Override
+        public void shutdown() throws Throwable
+        {
+            delegate.shutdown();
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/Lifecycles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/Lifecycles.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.lifecycle;
+
+public class Lifecycles
+{
+    private Lifecycles()
+    {   // No instances allowed or even necessary
+    }
+
+    public static Lifecycle multiple( final Iterable<? extends Lifecycle> lifecycles )
+    {
+        return new Lifecycle()
+        {
+            @Override
+            public void init() throws Throwable
+            {
+                for ( Lifecycle lifecycle : lifecycles )
+                {
+                    lifecycle.init();
+                }
+            }
+
+            @Override
+            public void start() throws Throwable
+            {
+                for ( Lifecycle lifecycle : lifecycles )
+                {
+                    lifecycle.start();
+                }
+            }
+
+            @Override
+            public void stop() throws Throwable
+            {
+                for ( Lifecycle lifecycle : lifecycles )
+                {
+                    lifecycle.stop();
+                }
+            }
+
+            @Override
+            public void shutdown() throws Throwable
+            {
+                for ( Lifecycle lifecycle : lifecycles )
+                {
+                    lifecycle.shutdown();
+                }
+            }
+        };
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexExtensionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexExtensionFactory.java
@@ -68,16 +68,6 @@ public class DummyIndexExtensionFactory extends
         }
 
         @Override
-        public void start() throws Throwable
-        {
-        }
-
-        @Override
-        public void stop() throws Throwable
-        {
-        }
-
-        @Override
         public void shutdown() throws Throwable
         {
             indexProviders.unregisterIndexProvider( IDENTIFIER );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexImplementation.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/DummyIndexImplementation.java
@@ -31,8 +31,9 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.LegacyIndex;
 import org.neo4j.kernel.api.LegacyIndexHits;
 import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
-public class DummyIndexImplementation implements IndexImplementation
+public class DummyIndexImplementation extends LifecycleAdapter implements IndexImplementation
 {
     @Override
     public Map<String, String> fillInDefaults( Map<String, String> config )

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneDataSource.java
@@ -66,14 +66,14 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.cache.LruCache;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.index.IndexEntityType;
-import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 import static org.neo4j.index.impl.lucene.MultipleBackupDeletionPolicy.SNAPSHOT_ID;
 
 /**
  * An DataSource optimized for the {@link LuceneIndexImplementation}.
  */
-public class LuceneDataSource implements Lifecycle
+public class LuceneDataSource extends LifecycleAdapter
 {
     private final Config config;
     private final FileSystemAbstraction fileSystemAbstraction;
@@ -143,11 +143,6 @@ public class LuceneDataSource implements Lifecycle
     @Override
     public void init()
     {
-    }
-
-    @Override
-    public void start()
-    {
         this.filesystemFacade = config.get( Configuration.ephemeral ) ? LuceneFilesystemFacade.MEMORY
                 : LuceneFilesystemFacade.FS;
         indexSearchers = new IndexClockCache( config.get( Configuration.lucene_searcher_cache_size ) );
@@ -171,7 +166,7 @@ public class LuceneDataSource implements Lifecycle
     }
 
     @Override
-    public void stop() throws IOException
+    public void shutdown() throws IOException
     {
         synchronized ( this )
         {
@@ -186,11 +181,6 @@ public class LuceneDataSource implements Lifecycle
             }
             indexSearchers.clear();
         }
-    }
-
-    @Override
-    public void shutdown()
-    {
     }
 
     private synchronized IndexReference[] getAllIndexes()
@@ -209,7 +199,8 @@ public class LuceneDataSource implements Lifecycle
             }
             catch ( IOException e )
             {
-                throw new RuntimeException( "unable to commit changes to " + index.getIdentifier(), e );
+                throw new RuntimeException( "Unable to commit changes to " + index.getIdentifier() + " in " +
+                        config.get( GraphDatabaseSettings.store_dir ).getAbsolutePath(), e );
             }
         }
     }
@@ -544,25 +535,30 @@ public class LuceneDataSource implements Lifecycle
             SnapshotDeletionPolicy deletionPolicy = (SnapshotDeletionPolicy) writer.getWriter().getConfig()
                     .getIndexDeletionPolicy();
             File indexDirectory = getFileDirectory( baseStorePath, writer.getIdentifier() );
+            IndexCommit commit;
             try
             {
                 // Throws IllegalStateException if no commits yet
-                IndexCommit commit = deletionPolicy.snapshot( SNAPSHOT_ID );
-                for ( String fileName : commit.getFileNames() )
-                {
-                    files.add( new File( indexDirectory, fileName ) );
-                }
-                snapshots.add( deletionPolicy );
+                commit = deletionPolicy.snapshot( SNAPSHOT_ID );
             }
             catch ( IllegalStateException e )
             {
-                // TODO Review this
                 /*
                  * This is insane but happens if we try to snapshot an existing index
                  * that has no commits. This is a bad API design - it should return null
                  * or something. This is not exceptional.
+                 *
+                 * For the time being we just do a commit and try again.
                  */
+                writer.getWriter().commit();
+                commit = deletionPolicy.snapshot( SNAPSHOT_ID );
             }
+
+            for ( String fileName : commit.getFileNames() )
+            {
+                files.add( new File( indexDirectory, fileName ) );
+            }
+            snapshots.add( deletionPolicy );
         }
         return new PrefetchingResourceIterator<File>()
         {

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
@@ -20,12 +20,10 @@
 package org.neo4j.index.lucene;
 
 import org.neo4j.graphdb.index.IndexProviders;
-import org.neo4j.index.impl.lucene.LuceneDataSource;
 import org.neo4j.index.impl.lucene.LuceneIndexImplementation;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
-import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 public class LuceneKernelExtension extends LifecycleAdapter
@@ -34,8 +32,6 @@ public class LuceneKernelExtension extends LifecycleAdapter
     private final IndexConfigStore indexStore;
     private final FileSystemAbstraction fileSystemAbstraction;
     private final IndexProviders indexProviders;
-    private LuceneDataSource luceneDataSource;
-    private final LifeSupport life = new LifeSupport();
 
     public LuceneKernelExtension( Config config, IndexConfigStore indexStore,
             FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders )
@@ -49,10 +45,8 @@ public class LuceneKernelExtension extends LifecycleAdapter
     @Override
     public void init()
     {
-        luceneDataSource = life.add( new LuceneDataSource( config, indexStore, fileSystemAbstraction ) );
-        // TODO Don't do this here, do proper life cycle management
-        life.start();
-        LuceneIndexImplementation indexImplementation = new LuceneIndexImplementation( luceneDataSource );
+        LuceneIndexImplementation indexImplementation =
+                new LuceneIndexImplementation( config, indexStore, fileSystemAbstraction );
         indexProviders.registerIndexProvider( LuceneIndexImplementation.SERVICE_NAME, indexImplementation );
     }
 
@@ -60,7 +54,5 @@ public class LuceneKernelExtension extends LifecycleAdapter
     public void shutdown()
     {
         indexProviders.unregisterIndexProvider( LuceneIndexImplementation.SERVICE_NAME );
-        // TODO Don't do this here, do proper life cycle management
-        life.shutdown();
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/RecoveryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/RecoveryTest.java
@@ -132,7 +132,7 @@ public class RecoveryTest
     }
 
     @Test
-    public void recoveryForRelationshipCommandsOnly() throws Exception
+    public void recoveryForRelationshipCommandsOnly() throws Throwable
     {
         // shutdown db here
         String storeDir = db.getStoreDir();

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
@@ -19,37 +19,53 @@
  */
 package org.neo4j.ha;
 
-import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
+import org.neo4j.graphdb.index.Index;
 import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.ha.BranchedDataPolicy;
+import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
+import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.impl.util.StringLogger;
-import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.LifeRule;
 import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterManager.ManagedCluster;
 import org.neo4j.test.ha.ClusterManager.RepairKit;
+import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import static java.lang.String.format;
+
 import static org.neo4j.helpers.SillyUtils.nonNull;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.test.ha.ClusterManager.clusterOfSize;
 
 public class TestBranchedData
 {
-    private final File dir = TargetDirectory.forTest( getClass() ).makeGraphDbDir();
+    public final @Rule LifeRule life = new LifeRule( true );
+    public final @Rule TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
 
     @Test
     public void migrationOfBranchedDataDirectories() throws Exception
@@ -62,6 +78,7 @@ public class TestBranchedData
             Thread.sleep( 1 ); // To make sure we get different timestamps
         }
 
+        File dir = directory.directory();
         new TestHighlyAvailableGraphDatabaseFactory().
                 newHighlyAvailableDatabaseBuilder( dir.getAbsolutePath() )
                 .setConfig( ClusterSettings.server_id, "1" )
@@ -76,18 +93,18 @@ public class TestBranchedData
                     BranchedDataPolicy.getBranchedDataDirectory( dir, timestamp ).exists() );
         }
     }
-    
+
     @Test
     public void shouldCopyStoreFromMasterIfBranched() throws Throwable
     {
         // GIVEN
+        File dir = directory.directory();
         ClusterManager clusterManager = life.add( new ClusterManager( clusterOfSize( 2 ), dir, stringMap() ) );
-        life.start();
         ManagedCluster cluster = clusterManager.getDefaultCluster();
         cluster.await( allSeesAllAsAvailable() );
         createNode( cluster.getMaster(), "A" );
         cluster.sync();
-        
+
         // WHEN
         HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
         String storeDir = slave.getStoreDir();
@@ -95,23 +112,136 @@ public class TestBranchedData
         HighlyAvailableGraphDatabase master = cluster.getMaster();
         createNode( master, "B1" );
         createNode( master, "C" );
-        createTransaction( storeDir, "B2" );
+        createNodeOffline( storeDir, "B2" );
         slave = starter.repair();
 
         // THEN
         cluster.await( allSeesAllAsAvailable() );
         slave.beginTx().finish();
     }
-    
-    private final LifeSupport life = new LifeSupport();
 
-    @After
-    public void after()
+    /**
+     * Main difference to {@link #shouldCopyStoreFromMasterIfBranched()} is that no instances are shut down
+     * during the course of the test. This to test functionality of some internal components being restarted.
+     */
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldCopyStoreFromMasterIfBranchedInLiveScenario() throws Throwable
     {
-        life.shutdown();
+        // GIVEN a cluster of 3, all having the same data (node A)
+        // thor is whoever is the master to begin with
+        // odin is whoever is picked as _the_ slave given thor as initial master
+        File dir = directory.directory();
+        ClusterManager clusterManager = life.add( new ClusterManager( clusterOfSize( 3 ), dir, stringMap(
+                // Effectively disable automatic transaction propagation within the cluster
+                HaSettings.tx_push_factor.name(), "0",
+                HaSettings.pull_interval.name(), "0" ) ) );
+        ManagedCluster cluster = clusterManager.getDefaultCluster();
+        cluster.await( allSeesAllAsAvailable() );
+        HighlyAvailableGraphDatabase thor = cluster.getMaster();
+        String indexName = "valhalla";
+        createNode( thor, "A", andIndexInto( indexName ) );
+        cluster.sync();
+
+        // WHEN creating a node B1 on thor (note the disabled cluster transaction propagation)
+        createNode( thor, "B1", andIndexInto( indexName ) );
+        // and right after that failing the master so that it falls out of the cluster
+        HighlyAvailableGraphDatabase odin = cluster.getAnySlave();
+        cluster.info( format( "%n   ==== TAMPERING WITH " + thor + "'s CABLES ====%n" ) );
+        RepairKit thorRepairKit = cluster.fail( thor );
+        // try to create a transaction on odin until it succeeds
+        cluster.await( ClusterManager.masterAvailable( thor ) );
+        createNode( odin, "B2", andIndexInto( indexName ) );
+        assertTrue( odin.isMaster() );
+        // perform transactions so that index files changes under the hood
+        Set<File> odinLuceneFilesBefore = asSet( gatherLuceneFiles( odin, indexName ) );
+        for ( char prefix = 'C'; !changed( odinLuceneFilesBefore, asSet( gatherLuceneFiles( odin, indexName ) ) ); prefix++ )
+        {
+            createNodes( odin, String.valueOf( prefix ), 10_000, andIndexInto( indexName ) );
+            cluster.force(); // Force will most likely cause lucene legacy indexes to commit and change file structure
+        }
+        // so anyways, when thor comes back into the cluster
+        cluster.info( format( "%n   ==== REPAIRING CABLES ====%n" ) );
+        thorRepairKit.repair();
+        while ( thor.isMaster() )
+        {
+            Thread.sleep( 100 );
+        }
+        cluster.await( ClusterManager.masterSeesAllSlavesAsAvailable() );
+        assertFalse( thor.isMaster() );
+
+        // Now do some more transactions on current master (odin) and have thor pull those
+        for( int i = 0; i < 3; i++ )
+        {
+            createNodes( odin, String.valueOf( "" + i ), 100_000, andIndexInto( indexName ) );
+            cluster.sync();
+            cluster.force();
+        }
+
+        // THEN thor should be a slave, having copied a store from master and good to go
+        assertFalse( hasNode( thor, "B1" ) );
+        assertTrue( hasNode( thor, "B2" ) );
+        assertTrue( hasNode( thor, "C-0" ) );
+        assertTrue( hasNode( thor, "0-0" ) );
+        assertTrue( hasNode( odin, "0-0" ) );
     }
 
-    private void createTransaction( String storeDir, String name )
+    private boolean changed( Set<File> before, Set<File> after )
+    {
+        return !before.containsAll( after ) && !after.containsAll( before );
+    }
+
+    private Collection<File> gatherLuceneFiles( HighlyAvailableGraphDatabase db, String indexName ) throws IOException
+    {
+        Collection<File> result = new ArrayList<>();
+        NeoStoreDataSource ds = db.getDependencyResolver().resolveDependency( NeoStoreDataSource.class );
+        try ( ResourceIterator<File> files = ds.listStoreFiles( false ) )
+        {
+            while ( files.hasNext() )
+            {
+                File file = files.next();
+                if ( file.getPath().contains( indexName ) )
+                {
+                    result.add( file );
+                }
+            }
+        }
+        return result;
+    }
+
+    private Listener<Node> andIndexInto( final String indexName )
+    {
+        return new Listener<Node>()
+        {
+            @Override
+            public void receive( Node node )
+            {
+                Index<Node> index = node.getGraphDatabase().index().forNodes( indexName );
+                for ( String key : node.getPropertyKeys() )
+                {
+                    index.add( node, key, node.getProperty( key ) );
+                }
+            }
+        };
+    }
+
+    private boolean hasNode( GraphDatabaseService db, String nodeName )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            {
+                if ( nodeName.equals( node.getProperty( "name", null ) ) )
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private void createNodeOffline( String storeDir, String name )
     {
         GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
         try
@@ -124,22 +254,47 @@ public class TestBranchedData
         }
     }
 
-    private void createNode( GraphDatabaseService db, String name )
+    @SuppressWarnings( "unchecked" )
+    private void createNode( GraphDatabaseService db, String name, Listener<Node>... additional )
     {
-        Transaction tx = db.beginTx();
-        try
+        try ( Transaction tx = db.beginTx() )
         {
-            db.createNode();//.setProperty( "name", name );
+            Node node = createNamedNode( db, name );
+            for ( Listener<Node> listener : additional )
+            {
+                listener.receive( node );
+            }
             tx.success();
         }
-        finally
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private void createNodes( GraphDatabaseService db, String namePrefix, int count, Listener<Node>... additional )
+    {
+        try ( Transaction tx = db.beginTx() )
         {
-            tx.finish();
+            for ( int i = 0; i < count; i++ )
+            {
+                Node node = createNamedNode( db, namePrefix + "-" + i );
+                for ( Listener<Node> listener : additional )
+                {
+                    listener.receive( node );
+                }
+            }
+            tx.success();
         }
+    }
+
+    private Node createNamedNode( GraphDatabaseService db, String name )
+    {
+        Node node = db.createNode();
+        node.setProperty( "name", name );
+        return node;
     }
 
     private long moveAwayToLookLikeOldBranchedDirectory() throws IOException
     {
+        File dir = directory.directory();
         long timestamp = System.currentTimeMillis();
         File branchDir = new File( dir, "branched-" + timestamp );
         assertTrue( "create directory: " + branchDir, branchDir.mkdirs() );
@@ -156,11 +311,15 @@ public class TestBranchedData
 
     private void startDbAndCreateNode()
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( dir.getAbsolutePath() );
-        Transaction tx = db.beginTx();
-        db.createNode();
-        tx.success();
-        tx.finish();
-        db.shutdown();
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( directory.absolutePath() );
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+        finally
+        {
+            db.shutdown();
+        }
     }
 }


### PR DESCRIPTION
where previously a LuceneIndexImplementation/LuceneDataSource would not be
restarted after a store copy, which means that indexes might refer to
stale files or files that doesn't exist after the store copy.

Now the licecycle management is better, although not perfect since
IndexImplementation can expect to see multiple calls to init()/shutdown().
Other than that the lifecycle of legacy indexes now work in and around
store copy. Further changing the legacy index lifecycle structure to
avoid this anomaly would require a bigger change and can be done later.
