### PR TITLE
Update IdleChannelReaper to respect possibly active conversation on idle client close.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -102,6 +102,12 @@ public interface Locks extends Lifecycle
         /** Release all locks. */
         void releaseAll();
 
+        /**
+         * Stop all active lock waiters and release them. All already held locks remains.
+         * All new attempts to acquire any locks will cause exceptions.
+         */
+        void stop();
+
         /** Releases all locks, using the client after calling this is undefined. */
         @Override
         void close();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -63,6 +63,11 @@ public class NoOpClient implements Locks.Client
     }
 
     @Override
+    public void stop()
+    {
+    }
+
+    @Override
     public void close()
     {
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockClient.java
@@ -270,10 +270,10 @@ public class CommunityLockClient implements Locks.Client
     }
 
     @Override
-    public void close()
+    public void stop()
     {
         // closing client to prevent any new client to come
-        stateHolder.closeClient();
+        stateHolder.stopClient();
         // wake up and terminate waiters
         terminateAllWaiters();
         // wait for all active clients to go and terminate latecomers
@@ -282,6 +282,12 @@ public class CommunityLockClient implements Locks.Client
             terminateAllWaiters();
             LockSupport.parkNanos( TimeUnit.MILLISECONDS.toNanos( 20 ) );
         }
+    }
+
+    @Override
+    public void close()
+    {
+        stop();
         // now we are only one who operate on this client
         // safe to release all the locks
         releaseLocks();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/TimedRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/TimedRepository.java
@@ -117,28 +117,18 @@ public class TimedRepository<KEY, VALUE> implements Runnable
         }
     }
 
-    public void remove( KEY key )
-    {
-        Entry entry = repo.get( key );
-        if (entry == null)
-        {
-            return;
-        }
-        end0(key, entry.value);
-    }
-
     /**
      * End the life of a stored entry. If the entry is currently in use, it will be thrown out as soon as the other client
      * is done with it.
      */
-    public void end( KEY key )
+    public VALUE end( KEY key )
     {
         while(true)
         {
             Entry entry = repo.get( key );
             if ( entry == null )
             {
-                return;
+                return null;
             }
 
             // Ending the life of an entry is somewhat complicated, because we promise the callee here that if someone
@@ -150,7 +140,7 @@ public class TimedRepository<KEY, VALUE> implements Runnable
             {
                 // The entry was indeed in use, and we successfully marked it to be ended. That's all we need to do here,
                 // the other user will see the ending flag when releasing the entry.
-                return;
+                return entry.value;
             }
 
             // Marking it for ending failed, likely because the entry is currently idle - lets try and just acquire it
@@ -159,7 +149,7 @@ public class TimedRepository<KEY, VALUE> implements Runnable
             {
                 // Got it, just throw it away
                 end0( key, entry.value );
-                return;
+                return entry.value;
             }
 
             // We didn't manage to mark this for ending, and we didn't manage to acquire it to end it ourselves, which
@@ -168,7 +158,7 @@ public class TimedRepository<KEY, VALUE> implements Runnable
             if ( entry.isMarkedForEnding() )
             {
                 // Someone did indeed manage to mark it for ending, which means it will be thrown out (or has already).
-                return;
+                return entry.value;
             }
         }
     }
@@ -201,6 +191,12 @@ public class TimedRepository<KEY, VALUE> implements Runnable
     public Set<KEY> keys()
     {
         return repo.keySet();
+    }
+
+    protected VALUE getValue( KEY key )
+    {
+        Entry entry = repo.get( key );
+        return entry == null ? null : entry.value;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockClientStateHolderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockClientStateHolderTest.java
@@ -52,7 +52,7 @@ public class LockClientStateHolderTest
         LockClientStateHolder lockClientStateHolder = new LockClientStateHolder();
 
         // when
-        lockClientStateHolder.closeClient();
+        lockClientStateHolder.stopClient();
 
         // then
         assertFalse( lockClientStateHolder.hasActiveClients() );
@@ -75,7 +75,7 @@ public class LockClientStateHolderTest
         assertTrue( lockClientStateHolder.hasActiveClients() );
 
         // and when
-        lockClientStateHolder.closeClient();
+        lockClientStateHolder.stopClient();
 
         // expect
         assertTrue( lockClientStateHolder.hasActiveClients() );
@@ -100,23 +100,23 @@ public class LockClientStateHolderTest
         assertTrue(lockClientStateHolder.hasActiveClients());
 
         // and when
-        lockClientStateHolder.closeClient();
+        lockClientStateHolder.stopClient();
 
         // expect
         assertTrue( lockClientStateHolder.hasActiveClients() );
-        assertTrue( lockClientStateHolder.isClosed() );
+        assertTrue( lockClientStateHolder.isStopped() );
 
         // and when
         lockClientStateHolder.reset();
 
         // expect
         assertFalse( lockClientStateHolder.hasActiveClients() );
-        assertFalse( lockClientStateHolder.isClosed() );
+        assertFalse( lockClientStateHolder.isStopped() );
 
         // when
         assertTrue( lockClientStateHolder.incrementActiveClients() );
         assertTrue( lockClientStateHolder.hasActiveClients() );
-        assertFalse( lockClientStateHolder.isClosed() );
+        assertFalse( lockClientStateHolder.isStopped() );
     }
 
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
@@ -47,6 +47,7 @@ import static org.neo4j.test.OtherThreadRule.isWaiting;
         DeadlockCompatibility.class,
         LockReentrancyCompatibility.class,
         RWLockCompatibility.class,
+        StopCompatibility.class,
         CloseCompatibility.class
 })
 public abstract class LockingCompatibilityTestSuite

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/StopCompatibility.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.neo4j.kernel.impl.locking.ResourceTypes.NODE;
+
+@Ignore( "Not a test. This is a compatibility suite, run from LockingCompatibilityTestSuite." )
+public class StopCompatibility extends LockingCompatibilityTestSuite.Compatibility
+{
+    public StopCompatibility( LockingCompatibilityTestSuite suite )
+    {
+        super( suite );
+    }
+
+    @Test
+    public void releaseWriteLockWaitersOnStop()
+    {
+        // given
+        clientA.acquireShared( NODE, 1L );
+        clientB.acquireShared( NODE, 2L );
+        clientC.acquireShared( NODE, 3L );
+        acquireExclusive( clientB, NODE, 1L ).callAndAssertWaiting();
+        acquireExclusive( clientC, NODE, 1L ).callAndAssertWaiting();
+
+        // when
+        clientC.stop();
+        clientB.stop();
+        clientA.stop();
+
+        // all locks clients should be stopped at this point and all clients should still hold their shared locks
+        LockCountVisitor lockCountVisitor = new LockCountVisitor();
+        locks.accept( lockCountVisitor );
+        Assert.assertEquals( 3, lockCountVisitor.getLockCount() );
+    }
+
+    @Test
+    public void releaseReadLockWaitersOnStop()
+    {  // given
+        clientA.acquireExclusive( NODE, 1L );
+        clientB.acquireExclusive( NODE, 2L );
+        acquireShared( clientB, NODE, 1L ).callAndAssertWaiting();
+
+        // when
+        clientB.stop();
+        clientA.stop();
+
+        // all locks clients should be stopped at this point and all clients should still hold their exclusive locks
+        LockCountVisitor lockCountVisitor = new LockCountVisitor();
+        locks.accept( lockCountVisitor );
+        Assert.assertEquals( 2, lockCountVisitor.getLockCount() );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/TimedRepositoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/TimedRepositoryTest.java
@@ -228,14 +228,15 @@ public class TimedRepositoryTest
     }
 
     @Test
-    public void shouldAllowBeginWithSameKeyAfterSessionRemoval() throws Exception
+    public void shouldAllowBeginWithSameKeyAfterSessionRelease() throws Exception
     {
         // Given
         repo.begin( 1l );
         repo.acquire( 1l );
 
         // when
-        repo.remove( 1l );
+        repo.release( 1l );
+        repo.end( 1l );
 
         //then
         repo.begin( 1l );

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupServer.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupServer.java
@@ -89,7 +89,7 @@ class BackupServer extends Server<TheBackupInterface, Object>
     }
 
     @Override
-    protected void cleanConversation( RequestContext context )
+    protected void stopConversation( RequestContext context )
     {
     }
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
 import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.helpers.Clock;
 import org.neo4j.helpers.Exceptions;
@@ -338,7 +339,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
     {
         try
         {
-            cleanConversation( slave );
+            stopConversation( slave );
             unmapSlave( channel );
         }
         catch ( Throwable failure ) // Unknown error trying to finish off the tx
@@ -373,7 +374,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
             {
                 try
                 {
-                    cleanConversation( slave );
+                    stopConversation( slave );
                 }
                 catch ( Throwable e )
                 {
@@ -540,7 +541,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
         return requestTarget;
     }
 
-    protected abstract void cleanConversation( RequestContext context );
+    protected abstract void stopConversation( RequestContext context );
 
     private ChunkingChannelBuffer newChunkingBuffer( Channel channel )
     {

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
@@ -103,7 +103,7 @@ public class MadeUpServer extends Server<MadeUpCommunicationInterface, Void>
     }
 
     @Override
-    protected void cleanConversation( RequestContext context )
+    protected void stopConversation( RequestContext context )
     {
     }
 

--- a/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/ServerTest.java
@@ -142,7 +142,7 @@ public class ServerTest
             }
 
             @Override
-            protected void cleanConversation( RequestContext context )
+            protected void stopConversation( RequestContext context )
             {
             }
         };

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Conversation.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/Conversation.java
@@ -20,6 +20,8 @@
 package org.neo4j.kernel.ha.com.master;
 
 
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.neo4j.kernel.impl.locking.Locks;
 
 /**
@@ -28,6 +30,10 @@ import org.neo4j.kernel.impl.locking.Locks;
 public class Conversation implements AutoCloseable
 {
     private Locks.Client locks;
+    private volatile boolean active = true;
+    // since some client locks use pooling we need to be sure that
+    // there is no race between client close and stop
+    private ReentrantLock lockClientCleanupLock = new ReentrantLock();
 
     public Conversation( Locks.Client locks )
     {
@@ -42,7 +48,40 @@ public class Conversation implements AutoCloseable
     @Override
     public void close()
     {
-        locks.close();
+        lockClientCleanupLock.lock();
+        try
+        {
+            if ( locks != null )
+            {
+                locks.close();
+                locks = null;
+                active = false;
+            }
+        }
+        finally
+        {
+            lockClientCleanupLock.unlock();
+        }
     }
 
+    public boolean isActive()
+    {
+        return active;
+    }
+
+    public void stop()
+    {
+        lockClientCleanupLock.lock();
+        try
+        {
+            if ( locks != null )
+            {
+                locks.stop();
+            }
+        }
+        finally
+        {
+            lockClientCleanupLock.unlock();
+        }
+    }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterServer.java
@@ -57,9 +57,9 @@ public class MasterServer extends Server<Master, Void>
     }
 
     @Override
-    protected void cleanConversation( RequestContext context )
+    protected void stopConversation( RequestContext context )
     {
-        conversationManager.remove( context );
+        conversationManager.stop( context );
     }
 
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveServer.java
@@ -51,7 +51,7 @@ public class SlaveServer extends Server<Slave, Void>
     }
 
     @Override
-    protected void cleanConversation( RequestContext context )
+    protected void stopConversation( RequestContext context )
     {
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -203,6 +203,12 @@ class SlaveLocksClient implements Locks.Client
     }
 
     @Override
+    public void stop()
+    {
+        throw new UnsupportedOperationException( "Lock client stop is unsupported on slave side." );
+    }
+
+    @Override
     public void close()
     {
         releaseAll();

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/forseti/ForsetiClient.java
@@ -160,7 +160,7 @@ public class ForsetiClient implements Locks.Client
             while(true)
             {
                 // client closed exiting
-                if ( stateHolder.isClosed() )
+                if ( stateHolder.isStopped() )
                 {
                     throw new LockClientAlreadyClosedException( String.format( "%s is already closed", this ) );
                 }
@@ -255,7 +255,7 @@ public class ForsetiClient implements Locks.Client
             while( (existingLock = lockMap.putIfAbsent( resourceId, myExclusiveLock )) != null)
             {
                 // client closed exiting
-                if ( stateHolder.isClosed() )
+                if ( stateHolder.isStopped() )
                 {
                     throw new LockClientAlreadyClosedException( String.format( "%s is already closed", this ) );
                 }
@@ -373,7 +373,7 @@ public class ForsetiClient implements Locks.Client
             while ( true )
             {
                 // client closed exiting
-                if ( stateHolder.isClosed() )
+                if ( stateHolder.isStopped() )
                 {
                     return false;
                 }
@@ -567,10 +567,10 @@ public class ForsetiClient implements Locks.Client
     }
 
     @Override
-    public void close()
+    public void stop()
     {
         // marking client as closed
-        stateHolder.closeClient();
+        stateHolder.stopClient();
         // waiting for all operations to be completed
         while ( stateHolder.hasActiveClients() )
         {
@@ -583,6 +583,12 @@ public class ForsetiClient implements Locks.Client
                 Thread.interrupted();
             }
         }
+    }
+
+    @Override
+    public void close()
+    {
+        stop();
         releaseAllClientLocks();
         clearWaitList();
         clientPool.release( this );
@@ -730,7 +736,7 @@ public class ForsetiClient implements Locks.Client
                 while(sharedLock.numberOfHolders() > 1)
                 {
                     // client closed exiting
-                    if ( stateHolder.isClosed() )
+                    if ( stateHolder.isStopped() )
                     {
                         sharedLock.releaseUpdateLock( this );
                         return false;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationManagerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationManagerTest.java
@@ -110,16 +110,22 @@ public class ConversationManagerTest
 
 
     @Test
-    public void testConversationClean()
+    public void testConversationStop()
     {
         RequestContext requestContext = getRequestContext();
         conversationManager = getConversationManager();
+
+        Conversation conversation = mock( Conversation.class );
+        when( conversation.isActive() ).thenReturn( true );
+
         TimedRepository conversationStorage = mock( TimedRepository.class );
+        when( conversationStorage.end( requestContext ) ).thenReturn( conversation );
         conversationManager.conversations = conversationStorage;
 
-        conversationManager.remove( requestContext );
+        conversationManager.stop( requestContext );
 
-        verify( conversationStorage ).remove( requestContext );
+        verify( conversationStorage ).end( requestContext );
+        verify( conversation ).stop();
     }
 
     private RequestContext getRequestContext()
@@ -129,7 +135,7 @@ public class ConversationManagerTest
 
     private ConversationManager getConversationManager()
     {
-        return new ConversationManager( conversationSPI, config, 1000 );
+        return new ConversationManager( conversationSPI, config, 1000, 5000 );
     }
 
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.com.master;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.function.Function;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.test.ThreadingRule;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@RunWith( MockitoJUnitRunner.class )
+public class ConversationTest
+{
+    @Mock
+    private Locks.Client client;
+    @InjectMocks
+    private Conversation conversation;
+    @Rule
+    public ThreadingRule threadingRule = new ThreadingRule();
+
+    @Test
+    public void stopAlreadyClosedConversationDoNotTouchLocks()
+    {
+        conversation.close();
+        conversation.stop();
+        conversation.stop();
+        conversation.stop();
+
+        verify( client ).close();
+        assertFalse( conversation.isActive() );
+        verifyNoMoreInteractions( client );
+    }
+
+    @Test
+    public void stopCloseConversation()
+    {
+        conversation.stop();
+        conversation.close();
+
+        verify( client ).stop();
+        verify( client ).close();
+        assertFalse( conversation.isActive() );
+    }
+
+    @Test(timeout = 3000)
+    public void conversationCanNotBeStoppedAndClosedConcurrently() throws InterruptedException
+    {
+        final CountDownLatch answerLatch = new CountDownLatch( 1 );
+        final CountDownLatch stopLatch = new CountDownLatch( 1 );
+        final CountDownLatch stopReadyLatch = new CountDownLatch( 1 );
+        final int sleepTime = 500;
+        doAnswer( new Answer<Void>()
+        {
+            @Override
+            public Void answer( InvocationOnMock invocation ) throws Throwable
+            {
+                stopReadyLatch.countDown();
+                stopLatch.await();
+                TimeUnit.MILLISECONDS.sleep( sleepTime );
+                return null;
+            }
+        } ).when( client ).stop();
+        doAnswer( new Answer<Void>()
+        {
+            @Override
+            public Void answer( InvocationOnMock invocation ) throws Throwable
+            {
+                answerLatch.countDown();
+                return null;
+            }
+        } ).when( client ).close();
+
+        threadingRule.execute( stopConversation(), conversation );
+
+        stopReadyLatch.await();
+        threadingRule.execute( closeConversation(), conversation );
+
+        long raceStartTime = System.currentTimeMillis();
+        stopLatch.countDown();
+        answerLatch.await();
+        // execution time should be at least 500 millis
+        long executionTime = System.currentTimeMillis() - raceStartTime;
+        assertTrue( executionTime  > sleepTime);
+    }
+
+    private Function<Conversation,Void> closeConversation()
+    {
+        return new Function<Conversation,Void>()
+        {
+            @Override
+            public Void apply( Conversation conversation )
+            {
+                conversation.close();
+                return null;
+            }
+        };
+    }
+
+    private Function<Conversation,Void> stopConversation()
+    {
+        return new Function<Conversation,Void>()
+        {
+            @Override
+            public Void apply( Conversation conversation )
+            {
+                conversation.stop();
+                return null;
+            }
+        };
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplConversationStopFuzzIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplConversationStopFuzzIT.java
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.com.master;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.com.RequestContext;
+import org.neo4j.com.ResourceReleaser;
+import org.neo4j.com.Response;
+import org.neo4j.com.TransactionNotPresentOnMasterException;
+import org.neo4j.com.TransactionObligationResponse;
+import org.neo4j.com.storecopy.StoreWriter;
+import org.neo4j.function.Consumer;
+import org.neo4j.function.Factory;
+import org.neo4j.helpers.Clock;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.cluster.ConversationSPI;
+import org.neo4j.kernel.ha.cluster.DefaultConversationSPI;
+import org.neo4j.kernel.ha.id.IdAllocation;
+import org.neo4j.kernel.ha.lock.forseti.ForsetiLockManager;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.ResourceTypes;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
+import org.neo4j.kernel.impl.util.collection.ConcurrentAccessException;
+import org.neo4j.kernel.impl.util.collection.TimedRepository;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.cluster.ClusterSettings.server_id;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.ha.HaSettings.lock_read_timeout;
+
+/**
+ *  Current test will try to emulate client master conversation lifecycle
+ *  starting from handshake till end of the session,
+ *  including simulation of idle conversations cleanup and inactive session removal.
+ *
+ *  Workers will try to follow common patterns of client-server communication using defined state machine.
+ *  Except common cases state machine will try to simulate abnormal behaviour and will
+ *  fall into sleep from time to time emulating inactivates.
+ *
+ */
+public class MasterImplConversationStopFuzzIT
+{
+    private static final int numberOfWorkers = 10;
+    private static final int numberOfOperations = 1_000;
+    private static final int numberOfResources = 100;
+
+    public static final StoreId StoreId = new StoreId();
+
+    private final LifeSupport life = new LifeSupport();
+    private final ExecutorService executor = Executors.newFixedThreadPool( numberOfWorkers + 1 );
+    private final JobScheduler scheduler = life.add( new Neo4jJobScheduler() );
+    private final Config config = new Config( stringMap( server_id.name(), "0", lock_read_timeout.name(), "1" ) );
+    private final Locks locks = new ForsetiLockManager( ResourceTypes.NODE, ResourceTypes.SCHEMA );
+
+    private static MasterExecutionStatistic executionStatistic = new MasterExecutionStatistic();
+
+    @Test( timeout = 50000 )
+    public void shouldHandleRandomizedLoad() throws Throwable
+    {
+        // Given
+        DefaultConversationSPI conversationSPI = new DefaultConversationSPI( locks, scheduler );
+        final ExposedConversationManager
+                conversationManager = new ExposedConversationManager( conversationSPI, config, 100, 0 );
+
+        ConversationTestMasterSPI conversationTestMasterSPI = new ConversationTestMasterSPI( conversationManager );
+        MasterImpl master = new MasterImpl( conversationTestMasterSPI, conversationManager,
+                new Monitors().newMonitor( MasterImpl.Monitor.class ), config );
+        life.add( conversationManager);
+        life.start();
+
+        ConversationKiller conversationKiller = new ConversationKiller( conversationManager );
+        executor.submit( conversationKiller );
+        List<Callable<Void>> slaveWorkers = workers( master, numberOfWorkers );
+        List<Future<Void>> workers = executor.invokeAll( slaveWorkers );
+
+        // Wait for all workers to complete
+        for ( Future<Void> future : workers )
+        {
+            future.get();
+        }
+        conversationKiller.stop();
+
+        assertTrue( executionStatistic.isSuccessfulExecution() );
+    }
+
+    @After
+    public void cleanup() throws InterruptedException
+    {
+        life.shutdown();
+        executor.shutdownNow();
+    }
+
+    private List<Callable<Void>> workers( MasterImpl master, int numWorkers )
+    {
+        LinkedList<Callable<Void>> workers = new LinkedList<>();
+        for ( int i = 0; i < numWorkers; i++ )
+        {
+            workers.add( new SlaveEmulatorWorker( master, i ) );
+        }
+        return workers;
+    }
+
+    static class SlaveEmulatorWorker implements Callable<Void>
+    {
+        private final Random random;
+        private final MasterImpl master;
+        private final int machineId;
+
+        private State state = State.UNINITIALIZED;
+        private long lastTx = 0;
+        private long epoch;
+        private RequestContext requestContext;
+
+        enum State
+        {
+            UNINITIALIZED
+                    {
+                        @Override
+                        State next( SlaveEmulatorWorker worker )
+                        {
+                            HandshakeResult handshake = worker.master.handshake( worker.lastTx, StoreId ).response();
+                            worker.epoch = handshake.epoch();
+                            return IDLE;
+                        }
+                    },
+            IDLE
+                    {
+                        @Override
+                        State next( SlaveEmulatorWorker worker ) throws Exception
+                        {
+                            if ( lowProbabilityEvent( worker ) )
+                            {
+                                return UNINITIALIZED;
+                            }
+                            else if ( lowProbabilityEvent( worker ) )
+                            {
+                                return commit( worker, new RequestContext( worker.epoch, worker.machineId, -1, worker.lastTx, 0 ) );
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    worker.master.newLockSession( worker.newRequestContext() );
+                                    return IN_SESSION;
+                                }
+                                catch ( TransactionFailureException e )
+                                {
+                                    if ( e.getCause() instanceof ConcurrentAccessException )
+                                    {
+                                        executionStatistic.reportAlreadyInUseError();
+                                        return IDLE;
+                                    }
+                                    else
+                                    {
+                                        throw e;
+                                    }
+                                }
+                            }
+                        }
+                    },
+            IN_SESSION
+                    {
+                        @Override
+                        State next( SlaveEmulatorWorker worker ) throws Exception
+                        {
+                            if ( lowProbabilityEvent( worker ) )
+                            {
+                                return UNINITIALIZED;
+                            }
+                            else
+                            {
+                                int i = worker.random.nextInt( 10 );
+                                if ( i >= 5 )
+                                {
+                                    return commit( worker, worker.requestContext );
+                                }
+                                else if ( i >= 4 )
+                                {
+                                    worker.master.acquireExclusiveLock( worker.requestContext, ResourceTypes.NODE,
+                                            randomResource( worker ) );
+                                    return IN_SESSION;
+                                }
+                                else if ( i >= 1 )
+                                {
+                                    worker.master.acquireSharedLock( worker.requestContext, ResourceTypes.NODE,
+                                            randomResource( worker ) );
+                                    return IN_SESSION;
+                                }
+                                else
+                                {
+                                    worker.master.endLockSession( worker.requestContext, true );
+                                    return IDLE;
+                                }
+                            }
+                        }
+                    },
+            CLOSING_SESSION
+                    {
+                        @Override
+                        State next( SlaveEmulatorWorker worker ) throws Exception
+                        {
+                            if ( lowProbabilityEvent( worker ) )
+                            {
+                                return UNINITIALIZED;
+                            }
+                            else
+                            {
+                                worker.master.endLockSession( worker.requestContext, true );
+                                return IDLE;
+                            }
+                        }
+                    };
+
+            abstract State next( SlaveEmulatorWorker worker ) throws Exception;
+
+            protected State commit( SlaveEmulatorWorker worker, RequestContext requestContext )
+                    throws IOException, TransactionFailureException
+            {
+                try
+                {
+                    worker.master.commit( requestContext, mock( TransactionRepresentation.class ) );
+                    executionStatistic.reportCommittedOperation();
+                    return CLOSING_SESSION;
+                }
+                catch ( TransactionNotPresentOnMasterException e )
+                {
+                    executionStatistic.reportTransactionNotPresentError();
+                    return IDLE;
+                }
+            }
+        }
+
+        private static boolean lowProbabilityEvent( SlaveEmulatorWorker worker )
+        {
+            return worker.random.nextInt( 100 ) <= 1;
+        }
+
+        private static long randomResource( SlaveEmulatorWorker worker )
+        {
+            return worker.random.nextInt( numberOfResources );
+        }
+
+        public SlaveEmulatorWorker( MasterImpl master, int clientNumber)
+        {
+            this.machineId = clientNumber;
+            this.random = new Random( machineId );
+            this.master = master;
+        }
+
+        @Override
+        public Void call() throws Exception
+        {
+            for ( int i = 0; i < numberOfOperations; i++ )
+            { 
+                state = state.next( this );
+            }
+            return null;
+        }
+
+        private RequestContext newRequestContext()
+        {
+            return requestContext = new RequestContext( epoch, machineId, newLockSessionId(), lastTx, random.nextInt() );
+        }
+
+        private int newLockSessionId()
+        {
+            return random.nextInt();
+        }
+    }
+
+    static class ConversationTestMasterSPI implements MasterImpl.SPI
+    {
+        private ExposedConversationManager conversationManager;
+
+        public ConversationTestMasterSPI( ExposedConversationManager conversationManager )
+        {
+            this.conversationManager = conversationManager;
+        }
+
+        @Override
+        public boolean isAccessible()
+        {
+            return true;
+        }
+
+        @Override
+        public StoreId storeId()
+        {
+            return StoreId;
+        }
+
+        @Override
+        public long applyPreparedTransaction( TransactionRepresentation preparedTransaction )
+                throws IOException, TransactionFailureException
+        {
+            // sleeping here and hope to be noticed by conversation killer.
+            sleep();
+            return 0;
+        }
+
+        private void sleep()
+        {
+            try
+            {
+                Thread.sleep( 20 );
+            }
+            catch ( InterruptedException e )
+            {
+                throw new RuntimeException( e );
+            }
+        }
+
+        @Override
+        public long getTransactionChecksum( long txId ) throws IOException
+        {
+            return 0;
+        }
+
+        @Override
+        public <T> Response<T> packEmptyResponse( T response )
+        {
+            return new TransactionObligationResponse<>( response, StoreId, TransactionIdStore.BASE_TX_ID,
+                    ResourceReleaser.NO_OP );
+        }
+
+        @Override
+        public <T> Response<T> packTransactionObligationResponse( RequestContext context, T response )
+        {
+            Conversation conversation = conversationManager.conversationStore.getValue( context );
+            if ( conversation != null )
+            {
+                assertTrue( conversation.isActive() );
+            }
+            return packEmptyResponse( response );
+        }
+
+        @Override
+        public IdAllocation allocateIds( IdType idType )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Integer createRelationshipType( String name )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RequestContext flushStoresAndStreamStoreFiles( StoreWriter writer )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> Response<T> packTransactionStreamResponse( RequestContext context, T response )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getOrCreateLabel( String name )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getOrCreateProperty( String name )
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * This emulates the MasterServer behavior of killing conversations after they have not had traffic sent on them for
+     * a certain time
+     */
+    private static class ConversationKiller implements Runnable
+    {
+        private volatile boolean running = true;
+        private final ConversationManager conversationManager;
+
+        public ConversationKiller( ConversationManager conversationManager )
+        {
+            this.conversationManager = conversationManager;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                while ( running )
+                {
+                    Iterator<RequestContext> conversationIterator = conversationManager.getActiveContexts().iterator();
+                    if ( conversationIterator.hasNext() )
+                    {
+                        RequestContext next = conversationIterator.next();
+                        conversationManager.end( next );
+                    }
+                    try
+                    {
+                        Thread.sleep( 10 );
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        throw new RuntimeException( e );
+                    }
+                }
+            }
+            catch ( Throwable e )
+            {
+                throw new RuntimeException( "Conversation killer failed.", e );
+            }
+        }
+
+        public void stop()
+        {
+            running = false;
+        }
+    }
+
+    private class ExposedConversationManager extends ConversationManager {
+
+        private ExposedTimedRepository<RequestContext,Conversation> conversationStore;
+
+        public ExposedConversationManager( ConversationSPI spi, Config config, int activityCheckInterval,
+                int lockTimeoutAddition )
+        {
+            super( spi, config, activityCheckInterval, lockTimeoutAddition );
+        }
+
+        @Override
+        protected TimedRepository<RequestContext,Conversation> createConversationStore()
+        {
+            conversationStore = new ExposedTimedRepository<>( getConversationFactory(), getConversationReaper(),
+                    1, Clock.SYSTEM_CLOCK );
+            return conversationStore;
+        }
+
+    }
+
+    private class ExposedTimedRepository<KEY, VALUE> extends TimedRepository<KEY, VALUE>
+    {
+
+        private ExposedTimedRepository(  Factory<VALUE> provider, Consumer<VALUE> reaper, long timeout,
+                Clock clock)
+        {
+            super(provider, reaper, timeout, clock);
+        }
+
+        @Override
+        public VALUE getValue( KEY key )
+        {
+            return super.getValue( key );
+        }
+    }
+
+    private static class MasterExecutionStatistic
+    {
+        private final AtomicLong alreadyInUseErrors = new AtomicLong();
+        private final AtomicLong transactionNotPresentErrors = new AtomicLong();
+        private final AtomicLong committedOperations = new AtomicLong();
+
+        public void reportAlreadyInUseError()
+        {
+            alreadyInUseErrors.incrementAndGet();
+        }
+
+        public void reportTransactionNotPresentError()
+        {
+            transactionNotPresentErrors.incrementAndGet();
+        }
+
+        public void reportCommittedOperation()
+        {
+            committedOperations.incrementAndGet();
+        }
+
+        public AtomicLong getAlreadyInUseErrors()
+        {
+            return alreadyInUseErrors;
+        }
+
+        public AtomicLong getTransactionNotPresentErrors()
+        {
+            return transactionNotPresentErrors;
+        }
+
+        public AtomicLong getCommittedOperations()
+        {
+            return committedOperations;
+        }
+
+        public boolean isSuccessfulExecution()
+        {
+            return committedOperations.get() > ((alreadyInUseErrors.get() + transactionNotPresentErrors.get()) * 10);
+        }
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
@@ -304,7 +304,7 @@ public class MasterImplTest
         // When
         master.newLockSession( requestContext );
         master.acquireSharedLock( requestContext, ResourceTypes.NODE, 1L );
-        conversationManager.remove( requestContext );
+        conversationManager.stop( requestContext );
         master.newLockSession( requestContext );
 
         //Then

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterServerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterServerTest.java
@@ -45,8 +45,8 @@ public class MasterServerTest
                 mock( ByteCounterMonitor.class ), mock( RequestMonitor.class ), conversationManager );
         RequestContext requestContext = new RequestContext( 1l, 1, 1, 0, 0l );
 
-        masterServer.cleanConversation( requestContext );
+        masterServer.stopConversation( requestContext );
 
-        Mockito.verify( conversationManager ).remove( requestContext );
+        Mockito.verify( conversationManager ).stop( requestContext );
     }
 }


### PR DESCRIPTION
Update conversation to support stop of all active locks acquisitions and termination of all new incoming requests
as part of IdleChannelReaper idle client closing.
Conversation will only be stopped by IdleChannelReaper, it will be completely closed by functionality already
defined in TimedRepository - by timeout or as soon as current active client will release conversation.

By this changes we will exclude possible of conversation being close by IdleChannelReaper during commit process.
