### PR TITLE
Fix a rule planner bug related to unique indexes

### DIFF
--- a/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/builders/NodeFetchStrategy.scala
+++ b/community/cypher/cypher-compiler-2.1/src/main/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/builders/NodeFetchStrategy.scala
@@ -128,9 +128,10 @@ object IndexSeekStrategy extends NodeStrategy {
       labelPredicate <- labelPredicates;
       propertyPredicate <- propertyPredicates if ctx.getIndexRule(labelPredicate.solution, propertyPredicate.solution).nonEmpty
     ) yield {
-      val schemaIndex = SchemaIndex(node, labelPredicate.solution, propertyPredicate.solution, AnyIndex, None)
       val optConstraint = ctx.getUniquenessConstraint(labelPredicate.solution, propertyPredicate.solution)
       val rating = if (optConstraint.isDefined) Single else IndexEquality
+      val indexType = if (optConstraint.isDefined) UniqueIndex else AnyIndex
+      val schemaIndex = SchemaIndex(node, labelPredicate.solution, propertyPredicate.solution, indexType, None)
       val predicates = Seq.empty // These are still not solved.
       RatedStartItem(schemaIndex, rating, predicates)
     }

--- a/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/builders/StartPointChoosingBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.1/src/test/scala/org/neo4j/cypher/internal/compiler/v2_1/executionplan/builders/StartPointChoosingBuilderTest.scala
@@ -143,7 +143,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
     val plan = assertAccepts(query)
 
     // Then
-    plan.query.start.toList should equal(Seq(Unsolved(SchemaIndex(identifier, label, property, AnyIndex, None))))
+    plan.query.start.toList should equal(Seq(Unsolved(SchemaIndex(identifier, label, property, UniqueIndex, None))))
   }
 
 
@@ -182,7 +182,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
     val plan = assertAccepts(query)
 
     // Then
-    plan.query.start.toList should equal(Seq(Unsolved(SchemaIndex(identifier, label, property, AnyIndex, None))))
+    plan.query.start.toList should equal(Seq(Unsolved(SchemaIndex(identifier, label, property, UniqueIndex, None))))
   }
 
   test("should_pick_an_index_if_only_one_possible_nullable_property_exists") {
@@ -239,7 +239,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
     val plan = assertAccepts(query)
 
     // Then
-    plan.query.start.toList should equal(Seq(Unsolved(SchemaIndex(identifier, label, property, AnyIndex, None))))
+    plan.query.start.toList should equal(Seq(Unsolved(SchemaIndex(identifier, label, property, UniqueIndex, None))))
   }
 
   test("should_pick_any_index_available") {
@@ -282,7 +282,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
     val result = assertAccepts(query).query
 
     // Then
-    result.start.find(_.token.isInstanceOf[SchemaIndex]) should equal(Some(Unsolved(SchemaIndex(identifier, label, otherProperty, AnyIndex, None))))
+    result.start.find(_.token.isInstanceOf[SchemaIndex]) should equal(Some(Unsolved(SchemaIndex(identifier, label, otherProperty, UniqueIndex, None))))
   }
 
   test("should_prefer_uniqueness_constraint_indexes_over_other_indexes_other_side") {
@@ -304,7 +304,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
     val result = assertAccepts(query).query
 
     // Then
-    result.start.find(_.token.isInstanceOf[SchemaIndex]) should equal(Some(Unsolved(SchemaIndex(identifier, label, property, AnyIndex, None))))
+    result.start.find(_.token.isInstanceOf[SchemaIndex]) should equal(Some(Unsolved(SchemaIndex(identifier, label, property, UniqueIndex, None))))
   }
 
   test("should_produce_label_start_points_when_no_property_predicate_is_used") {
@@ -415,7 +415,7 @@ class StartPointChoosingBuilderTest extends BuilderTest {
         Equals(Property(Identifier(otherIdentifier), propertyKey), expression2)),
 
       patterns = Seq(
-        ShortestPath("p", SingleNode(identifier), SingleNode(otherIdentifier), Nil, Direction.OUTGOING, false, None, single = true, None))
+        ShortestPath("p", SingleNode(identifier), SingleNode(otherIdentifier), Nil, Direction.OUTGOING, allowZeroLength = false, None, single = true, None))
     )
 
     when(context.getIndexRule(label, property)).thenReturn(None)


### PR DESCRIPTION
Previously, the rule planner planned a normal index seek, regardless of whether
there existed a uniqueness constraint for the label/property pair. This caused
the index reader to not be refreshed at every read, leading to concurrency
issues in some circumstances.

Tests were in place, but they asserted the SchemaIndex would plan AnyIndex and
not UniqueIndex.
