### PR TITLE
Count store hanging and inconsistent state after rotation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/EntryUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/EntryUpdater.java
@@ -68,4 +68,23 @@ public abstract class EntryUpdater<Key> implements AutoCloseable
             throw new IllegalStateException( "The updater is not available." );
         }
     }
+
+    @SuppressWarnings( "unchecked" )
+    static <Key> EntryUpdater<Key> noUpdates()
+    {
+        return NO_UPDATES;
+    }
+
+    private static final EntryUpdater NO_UPDATES = new EntryUpdater( null )
+    {
+        @Override
+        public void apply( Object o, ValueUpdate update )
+        {
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    };
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IdOrderingQueue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IdOrderingQueue.java
@@ -56,7 +56,7 @@ public interface IdOrderingQueue
 
     boolean isEmpty();
 
-    public static final IdOrderingQueue BYPASS = new IdOrderingQueue()
+    IdOrderingQueue BYPASS = new IdOrderingQueue()
     {
         @Override
         public void offer( long value )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LegacyIndexApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LegacyIndexApplierTest.java
@@ -53,15 +53,17 @@ import static org.neo4j.kernel.impl.util.IdOrderingQueue.BYPASS;
 
 public class LegacyIndexApplierTest
 {
-    public final @Rule LifeRule life = new LifeRule( true );
-    public final @Rule EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+    @Rule
+    public final LifeRule life = new LifeRule( true );
+    @Rule
+    public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
 
     @Test
     public void shouldOnlyCreateOneApplierPerProvider() throws Exception
     {
         // GIVEN
-        Map<String,Integer> names = MapUtil.<String,Integer> genericMap( "first", 0, "second", 1 );
-        Map<String,Integer> keys = MapUtil.<String,Integer> genericMap( "key", 0 );
+        Map<String,Integer> names = MapUtil.genericMap( "first", 0, "second", 1 );
+        Map<String,Integer> keys = MapUtil.genericMap( "key", 0 );
         String applierName = "test-applier";
         IndexConfigStore config = newIndexConfigStore( names, applierName );
         LegacyIndexApplierLookup applierLookup = mock( LegacyIndexApplierLookup.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
@@ -23,7 +23,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,11 +33,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.function.Functions;
@@ -149,7 +148,6 @@ public class TransactionRepresentationCommitProcessIT
     @After
     public void tearDown()
     {
-        lifeRule.shutdown();
         neoStore.close();
     }
 
@@ -357,7 +355,7 @@ public class TransactionRepresentationCommitProcessIT
 
         private void randomSleep() throws InterruptedException
         {
-            Thread.sleep( new Random( System.currentTimeMillis() ).nextInt( 50 ) );
+            Thread.sleep( ThreadLocalRandom.current().nextInt( 50 ) );
         }
 
         private PhysicalTransactionRepresentation createPhysicalTransactionRepresentation()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.function.Functions;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.index.IndexImplementation;
+import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.helpers.Provider;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.KernelHealth;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
+import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
+import org.neo4j.kernel.impl.index.DummyIndexImplementation;
+import org.neo4j.kernel.impl.index.IndexCommand;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.index.IndexDefineCommand;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.locking.LockService;
+import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.BatchingTransactionAppender;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
+import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointerImpl;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CountCommittedTransactionThreshold;
+import org.neo4j.kernel.impl.transaction.log.pruning.LogPruning;
+import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
+import org.neo4j.kernel.impl.transaction.log.rotation.StoreFlusher;
+import org.neo4j.kernel.impl.transaction.tracing.CheckPointTracer;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+import org.neo4j.kernel.impl.util.IdOrderingQueue;
+import org.neo4j.kernel.impl.util.SynchronizedArrayIdOrderingQueue;
+import org.neo4j.kernel.lifecycle.LifeRule;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.DefaultFileSystemRule;
+import org.neo4j.test.PageCacheRule;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class TransactionRepresentationCommitProcessIT
+{
+
+    private static final String INDEX_NAME = "index";
+    private static final int TOTAL_ACTIVE_THREADS = 6;
+    private static final String TEST_PROVIDER_NAME = "testProvider";
+
+    private static ExecutorService executorService;
+
+    @Rule
+    public TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+    @Rule
+    public DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+    @Rule
+    public PageCacheRule pageCacheRule = new PageCacheRule();
+    @Rule
+    public LifeRule lifeRule = new LifeRule();
+
+    private PageCache pageCache;
+    private NeoStore neoStore;
+    private DefaultFileSystemAbstraction fileSystem;
+    private File storeDir;
+
+    @BeforeClass
+    public static void startExecutor()
+    {
+        executorService = Executors.newCachedThreadPool();
+    }
+
+    @AfterClass
+    public static void stopExecutor()
+    {
+        executorService.shutdownNow();
+    }
+
+    @Before
+    public void setUp()
+    {
+        fileSystem = fileSystemRule.get();
+        pageCache = pageCacheRule.getPageCache( fileSystem );
+        storeDir = testDirectory.graphDbDir();
+        StoreFactory storeFactory = new StoreFactory( fileSystem, storeDir, pageCache,
+                NullLogProvider.getInstance(), new Monitors() );
+        neoStore = storeFactory.createNeoStore();
+
+    }
+
+    @After
+    public void tearDown()
+    {
+        lifeRule.shutdown();
+        neoStore.close();
+    }
+
+    @Test(timeout = 5000)
+    public void commitDuringContinuousCheckpointing() throws Exception
+    {
+        // prepare
+        IndexConfigStore indexStore = new IndexConfigStore( storeDir, fileSystem );
+        indexStore.set( Node.class, INDEX_NAME, stringMap( IndexManager.PROVIDER, TEST_PROVIDER_NAME ) );
+        LegacyIndexApplierLookup legacyIndexApplierLookup = new LegacyIndexApplierLookup.Direct( Functions.map(
+                MapUtil.<String,IndexImplementation>genericMap( TEST_PROVIDER_NAME, new DummyIndexImplementation() )
+        ) );
+
+
+        TransactionMetadataCache transactionMetadataCache = new TransactionMetadataCache( 1000, 100_000 );
+        IdOrderingQueue legacyIndexTransactionOrdering = new SynchronizedArrayIdOrderingQueue( 20 );
+
+        final PhysicalLogFiles logFiles = new PhysicalLogFiles( storeDir, PhysicalLogFile.DEFAULT_NAME,
+                fileSystem );
+        final PhysicalLogFile logFile = new PhysicalLogFile( fileSystem, logFiles,
+                10000, neoStore, neoStore, new Monitors().newMonitor( PhysicalLogFile.Monitor.class ),
+                transactionMetadataCache );
+
+        KernelHealth kernelHealth = mock( KernelHealth.class );
+
+        final TransactionRepresentationStoreApplier storeApplier = createStoreApplier( neoStore, indexStore,
+                legacyIndexApplierLookup, legacyIndexTransactionOrdering, kernelHealth );
+
+        final TransactionAppender appender = createTransactionAppender( neoStore, transactionMetadataCache,
+                legacyIndexTransactionOrdering, logFile, kernelHealth );
+
+        final CheckPointerImpl checkPointer = createCheckPointer( neoStore, kernelHealth, appender );
+
+        lifeRule.add( logFile );
+        lifeRule.add( indexStore );
+        lifeRule.add( appender );
+        lifeRule.start();
+
+        neoStore.rebuildCountStoreIfNeeded();
+
+        // when
+        CountDownLatch completionLatch = new CountDownLatch( TOTAL_ACTIVE_THREADS );
+
+        InsaneCheckPointer insaneCheckPointer = new InsaneCheckPointer( checkPointer, completionLatch );
+        executorService.submit( insaneCheckPointer );
+
+        List<TransactionalWorker> workers = createTransactionWorkers( 5, neoStore, appender, storeApplier, completionLatch );
+        for ( TransactionalWorker worker : workers )
+        {
+            executorService.submit( worker );
+        }
+
+        executorService.invokeAll( workers, 0, TimeUnit.MILLISECONDS );
+
+        // sleep for some time
+        Thread.sleep( TimeUnit.SECONDS.toMillis( 2 ) );
+
+        insaneCheckPointer.complete();
+        for ( TransactionalWorker worker : workers )
+        {
+            worker.complete();
+        }
+
+        // wait all threads to finish
+        completionLatch.await();
+
+        // do checkpoint to catch up latest updates
+        checkPointer.forceCheckPoint();
+
+        // verify
+        assertTrue( "All legacy index commands should be applied", legacyIndexTransactionOrdering.isEmpty() );
+        assertEquals( "NeoStore last closed transaction id should be equal to count store transaction id.",
+                neoStore.getLastClosedTransactionId(), neoStore.getCounts().txId());
+    }
+
+    private List<TransactionalWorker> createTransactionWorkers( int numberOfWorkers, NeoStore neoStore,
+            TransactionAppender appender,
+            TransactionRepresentationStoreApplier storeApplier, CountDownLatch completedLatch )
+    {
+        List<TransactionalWorker> workers = new ArrayList<>( numberOfWorkers );
+        for ( int i = 0; i < numberOfWorkers; i++ )
+        {
+            workers.add( new TransactionalWorker( neoStore, appender, storeApplier, completedLatch ) );
+        }
+        return workers;
+    }
+
+    private BatchingTransactionAppender createTransactionAppender( NeoStore neoStore,
+            TransactionMetadataCache transactionMetadataCache, IdOrderingQueue legacyIndexTransactionOrdering,
+            PhysicalLogFile logFile, KernelHealth kernelHealth )
+    {
+        return new BatchingTransactionAppender( logFile, mock( LogRotation.class ),
+                transactionMetadataCache, neoStore, legacyIndexTransactionOrdering, kernelHealth );
+    }
+
+    private TransactionRepresentationStoreApplier createStoreApplier( NeoStore neoStore, IndexConfigStore indexStore,
+            LegacyIndexApplierLookup legacyIndexApplierLookup, IdOrderingQueue legacyIndexTransactionOrdering,
+            KernelHealth kernelHealth )
+    {
+        return new TransactionRepresentationStoreApplier( mock( IndexingService.class ),
+                mock( Provider.class ), neoStore, mock( CacheAccessBackDoor.class ), mock( LockService.class ),
+                legacyIndexApplierLookup, indexStore, kernelHealth, legacyIndexTransactionOrdering );
+    }
+
+    private CheckPointerImpl createCheckPointer( NeoStore neoStore, KernelHealth kernelHealth,
+            TransactionAppender appender )
+    {
+        CountCommittedTransactionThreshold committedTransactionThreshold =
+                new CountCommittedTransactionThreshold( 1 );
+        final StoreFlusher storeFlusher = new StoreFlusher( neoStore, mock( IndexingService.class ),
+                mock( LabelScanStore.class ), Iterables.<IndexImplementation>empty() );
+        LogProvider logProvider = mock( LogProvider.class );
+        when( logProvider.getLog( any( Class.class ) ) ).thenReturn( mock( Log.class ) );
+        return new CheckPointerImpl( neoStore, committedTransactionThreshold, storeFlusher,
+                mock( LogPruning.class ),
+                appender, kernelHealth, logProvider, mock( CheckPointTracer.class ) );
+    }
+
+    private static class InsaneCheckPointer implements Callable<Void>
+    {
+
+        private volatile boolean completed = false;
+        private final CheckPointer checkPointer;
+        private CountDownLatch completedLatch;
+
+        public InsaneCheckPointer( CheckPointer checkPointer, CountDownLatch completedLatch )
+        {
+            this.checkPointer = checkPointer;
+            this.completedLatch = completedLatch;
+        }
+
+        @Override
+        public Void call()
+        {
+            while ( !isCompleted() )
+            {
+                try
+                {
+                    checkPointer.forceCheckPoint();
+                    Thread.sleep( 10 );
+                }
+                catch ( Exception e )
+                {
+                    throw new RuntimeException( e );
+                }
+            }
+            completedLatch.countDown();
+            return null;
+        }
+
+        public boolean isCompleted()
+        {
+            return completed;
+        }
+
+        public void complete()
+        {
+            this.completed = true;
+        }
+    }
+
+    private static class TransactionalWorker implements Callable<Long>
+    {
+
+        private NeoStore neoStore;
+        private final TransactionAppender appender;
+        private final TransactionRepresentationStoreApplier storeApplier;
+        private CountDownLatch completedLatch;
+        private volatile boolean completed = false;
+
+        public TransactionalWorker( NeoStore neoStore, TransactionAppender appender,
+                TransactionRepresentationStoreApplier storeApplier, CountDownLatch completedLatch )
+        {
+            this.neoStore = neoStore;
+            this.appender = appender;
+            this.storeApplier = storeApplier;
+            this.completedLatch = completedLatch;
+        }
+
+        @Override
+        public Long call()
+        {
+            long lastCommittedTransaction = 0;
+            while ( !isCompleted() )
+            {
+                try
+                {
+                    TransactionRepresentationCommitProcess transactionCommit = createTransactionCommitProcess();
+                    PhysicalTransactionRepresentation transactionRepresentation =
+                            createPhysicalTransactionRepresentation();
+
+                    randomSleep();
+
+                    lastCommittedTransaction = transactionCommit.commit( transactionRepresentation, new LockGroup(),
+                        CommitEvent.NULL, TransactionApplicationMode.INTERNAL );
+                }
+                catch ( Exception e )
+                {
+                    throw new RuntimeException( e );
+                }
+            }
+            completedLatch.countDown();
+            return lastCommittedTransaction;
+        }
+
+        private void randomSleep() throws InterruptedException
+        {
+            Thread.sleep( new Random( System.currentTimeMillis() ).nextInt( 50 ) );
+        }
+
+        private PhysicalTransactionRepresentation createPhysicalTransactionRepresentation()
+        {
+
+            long nextId = neoStore.getNodeStore().nextId();
+            PhysicalTransactionRepresentation transactionRepresentation =
+                    new PhysicalTransactionRepresentation( CommandHelper.createListOfCommands( nextId ) );
+            transactionRepresentation.setHeader( new byte[0], 0, 0, System.currentTimeMillis(),
+                    neoStore.getLastCommittedTransactionId(), 0, 0 );
+            return transactionRepresentation;
+        }
+
+        private TransactionRepresentationCommitProcess createTransactionCommitProcess() throws IOException
+        {
+            IndexUpdatesValidator updatesValidator = mock( IndexUpdatesValidator.class );
+            when( updatesValidator.validate( any( TransactionRepresentation.class ), any
+                    ( TransactionApplicationMode.class ) ) ).thenReturn( mock( ValidatedIndexUpdates.class ) );
+
+            return new TransactionRepresentationCommitProcess( appender, storeApplier, updatesValidator );
+        }
+
+        public boolean isCompleted()
+        {
+            return completed;
+        }
+
+        public void complete()
+        {
+            this.completed = true;
+        }
+
+    }
+
+    private static final class CommandHelper {
+
+        static List<Command> createListOfCommands(long highId) {
+            IndexDefineCommand indexDefineCommand = createIndexDefinedCommand();
+            return Arrays.asList( indexDefineCommand, createAddNodeCommand( indexDefineCommand ),
+                    createNodeCommand( highId ));
+        }
+
+        private static IndexDefineCommand createIndexDefinedCommand()
+        {
+            Map<String,Integer> indexNames = MapUtil.genericMap( INDEX_NAME, 0 );
+            IndexDefineCommand indexDefineCommand = new IndexDefineCommand();
+            indexDefineCommand.init( indexNames, Collections.<String,Integer>emptyMap() );
+            return indexDefineCommand;
+        }
+
+        private static Command createAddNodeCommand( IndexDefineCommand indexDefineCommand )
+        {
+            IndexCommand.AddNodeCommand addNodeCommand = new IndexCommand.AddNodeCommand();
+            addNodeCommand.init( indexDefineCommand.getOrAssignIndexNameId( INDEX_NAME ), 0, 0, "test" );
+            return addNodeCommand;
+        }
+
+        private static Command createNodeCommand(long currentHighId)
+        {
+            Command.NodeCommand nodeCommand = new Command.NodeCommand();
+            NodeRecord beforeRecord = new NodeRecord( currentHighId - 1);
+            NodeRecord afterRecord = new NodeRecord( currentHighId );
+            nodeCommand.init( beforeRecord, afterRecord );
+            return nodeCommand;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
@@ -55,18 +55,20 @@ import static org.neo4j.kernel.impl.store.kvstore.Resources.TestPath.FILE_IN_EXI
 
 public class CountsTrackerTest
 {
-    public final @Rule Resources the = new Resources( FILE_IN_EXISTING_DIRECTORY );
-    public final @Rule ThreadingRule threading = new ThreadingRule();
+    @Rule
+    public final Resources resourceManager = new Resources( FILE_IN_EXISTING_DIRECTORY );
+    @Rule
+    public final ThreadingRule threading = new ThreadingRule();
 
     @Test
     public void shouldBeAbleToStartAndStopTheStore() throws Exception
     {
         // given
-        the.managed( newTracker() );
+        resourceManager.managed( newTracker() );
 
         // when
-        the.lifeStarts();
-        the.lifeShutsDown();
+        resourceManager.lifeStarts();
+        resourceManager.lifeShutsDown();
     }
 
     @Test
@@ -74,7 +76,7 @@ public class CountsTrackerTest
     public void shouldBeAbleToWriteDataToCountsTracker() throws Exception
     {
         // given
-        CountsTracker tracker = the.managed( newTracker() );
+        CountsTracker tracker = resourceManager.managed( newTracker() );
         CountsOracle oracle = new CountsOracle();
         {
             CountsOracle.Node a = oracle.node( 1 );
@@ -200,7 +202,8 @@ public class CountsTrackerTest
         {
             final Barrier.Control barrier = new Barrier.Control();
             CountsTracker tracker = life.add( new CountsTracker(
-                    the.logProvider(), the.fileSystem(), the.pageCache(), new Config(), the.testPath() )
+                    resourceManager.logProvider(), resourceManager.fileSystem(), resourceManager.pageCache(),
+                    new Config(), resourceManager.testPath() )
             {
                 @Override
                 protected boolean include( CountsKey countsKey, ReadableBuffer value )
@@ -255,7 +258,7 @@ public class CountsTrackerTest
     public void shouldNotRotateIfNoDataChanges() throws Exception
     {
         // given
-        CountsTracker tracker = the.managed( newTracker() );
+        CountsTracker tracker = resourceManager.managed( newTracker() );
         File before = tracker.currentFile();
 
         // when
@@ -270,7 +273,7 @@ public class CountsTrackerTest
     public void shouldRotateOnDataChangesEvenIfTransactionIsUnchanged() throws Exception
     {
         // given
-        CountsTracker tracker = the.managed( newTracker() );
+        CountsTracker tracker = resourceManager.managed( newTracker() );
         File before = tracker.currentFile();
         try ( CountsAccessor.IndexStatsUpdater updater = tracker.updateIndexCounts() )
         {
@@ -289,7 +292,7 @@ public class CountsTrackerTest
     public void shouldSupportTransactionsAppliedOutOfOrderOnRotation() throws Exception
     {
         // given
-        final CountsTracker tracker = the.managed( newTracker() );
+        final CountsTracker tracker = resourceManager.managed( newTracker() );
         try ( CountsAccessor.Updater tx = tracker.apply( 2 ).get() )
         {
             tx.incrementNodeCount( 1, 1 );
@@ -344,7 +347,8 @@ public class CountsTrackerTest
 
     private CountsTracker newTracker()
     {
-        return new CountsTracker( the.logProvider(), the.fileSystem(), the.pageCache(), new Config(), the.testPath() )
+        return new CountsTracker( resourceManager.logProvider(), resourceManager.fileSystem(),
+                resourceManager.pageCache(), new Config(), resourceManager.testPath() )
                 .setInitializer( new DataInitializer<CountsAccessor.Updater>()
                 {
                     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/AbstractKeyValueStoreTest.java
@@ -26,8 +26,10 @@ import org.junit.rules.ExpectedException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.neo4j.function.IOFunction;
 import org.neo4j.function.Predicate;
@@ -35,6 +37,7 @@ import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.helpers.Clock;
 import org.neo4j.helpers.Pair;
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.lifecycle.Lifespan;
 import org.neo4j.test.ThreadingRule;
 
@@ -48,7 +51,7 @@ import static org.neo4j.kernel.impl.store.kvstore.Resources.TestPath.FILE_IN_EXI
 public class AbstractKeyValueStoreTest
 {
     @Rule
-    public final Resources the = new Resources( FILE_IN_EXISTING_DIRECTORY );
+    public final Resources resourceManager = new Resources( FILE_IN_EXISTING_DIRECTORY );
     @Rule
     public final ThreadingRule threading = new ThreadingRule();
     @Rule
@@ -79,30 +82,30 @@ public class AbstractKeyValueStoreTest
     public void shouldStartAndStopStore() throws Exception
     {
         // given
-        the.managed( new Store() );
+        resourceManager.managed( new Store() );
 
         // when
-        the.lifeStarts();
-        the.lifeShutsDown();
+        resourceManager.lifeStarts();
+        resourceManager.lifeShutsDown();
     }
 
     @Test
-    @Resources.Life(STARTED)
+    @Resources.Life( STARTED )
     public void shouldRotateStore() throws Exception
     {
         // given
-        Store store = the.managed( new Store() );
+        Store store = resourceManager.managed( new Store() );
 
         // when
         store.prepareRotation( 0 ).rotate();
     }
 
     @Test
-    @Resources.Life(STARTED)
+    @Resources.Life( STARTED )
     public void shouldStoreEntries() throws Exception
     {
         // given
-        Store store = the.managed( new Store() );
+        Store store = resourceManager.managed( new Store() );
 
         // when
         store.put( "message", "hello world" );
@@ -123,49 +126,9 @@ public class AbstractKeyValueStoreTest
     @Test
     public void shouldPickFileWithGreatestTransactionId() throws Exception
     {
-        // given
-        class Impl extends Store
-        {
-            Impl()
-            {
-                super( TX_ID );
-            }
-
-            @SuppressWarnings("unchecked")
-            @Override
-            <Value> Value initialHeader( HeaderField<Value> field )
-            {
-                if ( field == TX_ID )
-                {
-                    return (Value) (Object) 1l;
-                }
-                else
-                {
-                    return super.initialHeader( field );
-                }
-            }
-
-            @Override
-            protected int compareHeaders( Headers lhs, Headers rhs )
-            {
-                return Long.compare( lhs.get( TX_ID ), rhs.get( TX_ID ) );
-            }
-
-            @Override
-            protected long version( Headers headers )
-            {
-                return headers.get( TX_ID );
-            }
-
-            @Override
-            protected void updateHeaders( Headers.Builder headers, long version )
-            {
-                headers.put( TX_ID, version );
-            }
-        }
         try ( Lifespan life = new Lifespan() )
         {
-            Store store = life.add( new Impl() );
+            Store store = life.add( createTestStore() );
 
             // when
             for ( long txId = 2; txId <= 10; txId++ )
@@ -178,7 +141,7 @@ public class AbstractKeyValueStoreTest
         // then
         try ( Lifespan life = new Lifespan() )
         {
-            Store store = life.add( new Impl() );
+            Store store = life.add( createTestStore() );
             assertEquals( 10l, store.headers().get( TX_ID ).longValue() );
         }
     }
@@ -187,34 +150,13 @@ public class AbstractKeyValueStoreTest
     public void shouldNotPickCorruptStoreFile() throws Exception
     {
         // given
-        Store store = new Store( TX_ID )
-        {
-            @SuppressWarnings("unchecked")
-            @Override
-            <Value> Value initialHeader( HeaderField<Value> field )
-            {
-                if ( field == TX_ID )
-                {
-                    return (Value) (Object) 1l;
-                }
-                else
-                {
-                    return super.initialHeader( field );
-                }
-            }
-
-            @Override
-            protected int compareHeaders( Headers lhs, Headers rhs )
-            {
-                return Long.compare( lhs.get( TX_ID ), rhs.get( TX_ID ) );
-            }
-        };
+        Store store = createTestStore();
         RotationStrategy rotation = store.rotationStrategy;
 
         // when
         File[] files = new File[10];
         {
-            Pair<File, KeyValueStoreFile> file = rotation.create( EMPTY_DATA_PROVIDER, 1 );
+            Pair<File,KeyValueStoreFile> file = rotation.create( EMPTY_DATA_PROVIDER, 1 );
             files[0] = file.first();
             for ( int txId = 2, i = 1; i < files.length; txId <<= 1, i++ )
             {
@@ -239,7 +181,7 @@ public class AbstractKeyValueStoreTest
             file.other().close();
         }
         // Corrupt the last files
-        try ( StoreChannel channel = the.fileSystem().open( files[9], "rw" ) )
+        try ( StoreChannel channel = resourceManager.fileSystem().open( files[9], "rw" ) )
         {   // ruin the header
             channel.position( 16 );
             ByteBuffer value = ByteBuffer.allocate( 16 );
@@ -247,7 +189,7 @@ public class AbstractKeyValueStoreTest
             value.flip();
             channel.writeAll( value );
         }
-        try ( StoreChannel channel = the.fileSystem().open( files[8], "rw" ) )
+        try ( StoreChannel channel = resourceManager.fileSystem().open( files[8], "rw" ) )
         {   // ruin the header
             channel.position( 32 );
             ByteBuffer value = ByteBuffer.allocate( 16 );
@@ -255,7 +197,7 @@ public class AbstractKeyValueStoreTest
             value.flip();
             channel.writeAll( value );
         }
-        try ( StoreChannel channel = the.fileSystem().open( files[7], "rw" ) )
+        try ( StoreChannel channel = resourceManager.fileSystem().open( files[7], "rw" ) )
         {   // ruin the header
             channel.position( 32 + 32 + 32 + 16 );
             ByteBuffer value = ByteBuffer.allocate( 16 );
@@ -275,54 +217,15 @@ public class AbstractKeyValueStoreTest
     }
 
     @Test
-    @Resources.Life(STARTED)
+    @Resources.Life( STARTED )
     public void shouldRotateWithCorrectVersion() throws Exception
     {
         // given
-        final Store store = the.managed( new Store( TX_ID )
-        {
-            @SuppressWarnings("unchecked")
-            @Override
-            <Value> Value initialHeader( HeaderField<Value> field )
-            {
-                if ( field == TX_ID )
-                {
-                    return (Value) (Object) 1l;
-                }
-                else
-                {
-                    return super.initialHeader( field );
-                }
-            }
+        final Store store = resourceManager.managed( createTestStore() );
+        updateStore( store, 1 );
 
-            @Override
-            protected void updateHeaders( Headers.Builder headers, long version )
-            {
-                headers.put( TX_ID, version );
-            }
-
-            @Override
-            protected int compareHeaders( Headers lhs, Headers rhs )
-            {
-                return Long.compare( lhs.get( TX_ID ), rhs.get( TX_ID ) );
-            }
-        } );
-        ThrowingConsumer<Long, IOException> update = new ThrowingConsumer<Long, IOException>()
-        {
-            @Override
-            public void accept( Long update ) throws IOException
-            {
-                try ( EntryUpdater<String> updater = store.updater( update ).get() )
-                {
-                    updater.apply( "key " + update, store.value( "value " + update ) );
-                }
-            }
-        };
-
-        // when
-        update.accept( 1l );
         PreparedRotation rotation = store.prepareRotation( 2 );
-        update.accept( 2l );
+        updateStore( store, 2 );
         rotation.rotate();
 
         // then
@@ -331,52 +234,46 @@ public class AbstractKeyValueStoreTest
     }
 
     @Test
-    @Resources.Life(STARTED)
+    @Resources.Life( STARTED )
+    public void postStateUpdatesCountedOnlyForTransactionsGreaterThanRotationVersion()
+            throws IOException, TimeoutException, InterruptedException, ExecutionException
+    {
+        final Store store = resourceManager.managed( createTestStore() );
+
+        PreparedRotation rotation = store.prepareRotation( 2 );
+        updateStore( store, 4 );
+        updateStore( store, 3 );
+        updateStore( store, 1 );
+        updateStore( store, 2 );
+
+        assertEquals( 2, rotation.rotate() );
+
+        Future<Long> rotationFuture = threading.executeAndAwait( store.rotation, 5l, new Predicate<Thread>()
+        {
+            @Override
+            public boolean test( Thread thread )
+            {
+                return Thread.State.TIMED_WAITING == thread.getState();
+            }
+        }, 100, SECONDS );
+
+        Thread.sleep( TimeUnit.SECONDS.toMillis( 1 ) );
+
+        assertFalse( rotationFuture.isDone() );
+        updateStore( store, 5 );
+
+        assertEquals( 5, rotationFuture.get().longValue() );
+    }
+
+    @Test
+    @Resources.Life( STARTED )
     public void shouldBlockRotationUntilRequestedTransactionsAreApplied() throws Exception
     {
         // given
-        final Store store = the.managed( new Store( TX_ID )
-        {
-            @SuppressWarnings("unchecked")
-            @Override
-            <Value> Value initialHeader( HeaderField<Value> field )
-            {
-                if ( field == TX_ID )
-                {
-                    return (Value) (Object) 1l;
-                }
-                else
-                {
-                    return super.initialHeader( field );
-                }
-            }
-
-            @Override
-            protected void updateHeaders( Headers.Builder headers, long version )
-            {
-                headers.put( TX_ID, version );
-            }
-
-            @Override
-            protected int compareHeaders( Headers lhs, Headers rhs )
-            {
-                return Long.compare( lhs.get( TX_ID ), rhs.get( TX_ID ) );
-            }
-        } );
-        ThrowingConsumer<Long, IOException> update = new ThrowingConsumer<Long, IOException>()
-        {
-            @Override
-            public void accept( Long update ) throws IOException
-            {
-                try ( EntryUpdater<String> updater = store.updater( update ).get() )
-                {
-                    updater.apply( "key " + update, store.value( "value " + update ) );
-                }
-            }
-        };
+        final Store store = resourceManager.managed( createTestStore() );
 
         // when
-        update.accept( 1l );
+        updateStore( store, 1 );
         Future<Long> rotation = threading.executeAndAwait( store.rotation, 3l, new Predicate<Thread>()
         {
             @Override
@@ -399,19 +296,19 @@ public class AbstractKeyValueStoreTest
         SECONDS.sleep( 1 );
         assertFalse( rotation.isDone() );
         // apply update
-        update.accept( 3l );
+        updateStore( store, 3 );
         // rotation should still wait...
         assertFalse( rotation.isDone() );
         SECONDS.sleep( 1 );
         assertFalse( rotation.isDone() );
         // apply update
-        update.accept( 4l );
+        updateStore( store, 4 );
         // rotation should still wait...
         assertFalse( rotation.isDone() );
         SECONDS.sleep( 1 );
         assertFalse( rotation.isDone() );
         // apply update
-        update.accept( 2l );
+        updateStore( store, 2 );
 
         // then
         assertEquals( 3, rotation.get().longValue() );
@@ -425,7 +322,23 @@ public class AbstractKeyValueStoreTest
     {
 
         // GIVEN
-        final Store store = the.managed( new Store( 0, TX_ID )
+        final Store store = resourceManager.managed( createTestStore( 0 ) );
+
+        // THEN
+        expectedException.expect( RotationTimeoutException.class );
+
+        // WHEN
+        store.prepareRotation( 10l ).rotate();
+    }
+
+    private Store createTestStore()
+    {
+        return createTestStore( TimeUnit.SECONDS.toMillis( 100 ) );
+    }
+
+    private Store createTestStore( long rotationTimeout )
+    {
+        return new Store( rotationTimeout, TX_ID )
         {
             @SuppressWarnings( "unchecked" )
             @Override
@@ -452,14 +365,25 @@ public class AbstractKeyValueStoreTest
             {
                 return Long.compare( lhs.get( TX_ID ), rhs.get( TX_ID ) );
             }
-        } );
-
-        // THEN
-        expectedException.expect( RotationTimeoutException.class );
-
-        // WHEN
-        store.prepareRotation( 10l ).rotate();
+        };
     }
+
+    private void updateStore( final Store store, long transaction ) throws IOException
+    {
+        ThrowingConsumer<Long,IOException> update = new ThrowingConsumer<Long,IOException>()
+        {
+            @Override
+            public void accept( Long update ) throws IOException
+            {
+                try ( EntryUpdater<String> updater = store.updater( update ).get() )
+                {
+                    updater.apply( "key " + update, store.value( "value " + update ) );
+                }
+            }
+        };
+        update.accept( transaction );
+    }
+
 
     static DataProvider data( final Entry... data )
     {
@@ -490,11 +414,11 @@ public class AbstractKeyValueStoreTest
         void write( WritableBuffer key, WritableBuffer value );
     }
 
-    @Rotation(Rotation.Strategy.INCREMENTING)
+    @Rotation( Rotation.Strategy.INCREMENTING )
     class Store extends AbstractKeyValueStore<String>
     {
         private final HeaderField<?>[] headerFields;
-        final IOFunction<Long, Long> rotation = new IOFunction<Long, Long>()
+        final IOFunction<Long,Long> rotation = new IOFunction<Long,Long>()
         {
             @Override
             public Long apply( Long version ) throws IOException
@@ -510,8 +434,9 @@ public class AbstractKeyValueStoreTest
 
         private Store( long rotationTimeout, HeaderField<?>... headerFields )
         {
-            super( the.fileSystem(), the.pageCache(), the.testPath(), null, new RotationTimerFactory( Clock.SYSTEM_CLOCK,
-                    rotationTimeout ), 16, 16, headerFields );
+            super( resourceManager.fileSystem(), resourceManager.pageCache(), resourceManager.testPath(), null,
+                    new RotationTimerFactory( Clock.SYSTEM_CLOCK,
+                            rotationTimeout ), 16, 16, headerFields );
             this.headerFields = headerFields;
             setEntryUpdaterInitializer( new DataInitializer<EntryUpdater<String>>()
             {
@@ -555,7 +480,7 @@ public class AbstractKeyValueStoreTest
             return 0;
         }
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings( "unchecked" )
         private <Value> void putField( Headers.Builder builder, HeaderField<Value> field, Object change )
         {
             builder.put( field, (Value) change );
@@ -600,20 +525,15 @@ public class AbstractKeyValueStoreTest
         @Override
         protected void updateHeaders( Headers.Builder headers, long version )
         {
+            headers.put( TX_ID, version );
         }
 
         @Override
         protected long version( Headers headers )
         {
-            try
-            {
-                String filename = this.currentFile().getName();
-                return Integer.parseInt( filename.substring( filename.lastIndexOf( '.' ) + 1 ) );
-            }
-            catch ( IllegalStateException e )
-            {
-                return 0;
-            }
+            Long transactionId = headers.get( TX_ID );
+            return Math.max( TransactionIdStore.BASE_TX_ID,
+                    transactionId != null ? transactionId.longValue() : TransactionIdStore.BASE_TX_ID );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/ConcurrentMapStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/ConcurrentMapStateTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.locks.Lock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -133,52 +132,18 @@ public class ConcurrentMapStateTest
     }
 
     @Test
-    public void shouldFailIfApplyingAVersionUpdateWithAVersionLowerOrEqualToTheInitialVersion() throws Exception
+    public void shouldUseEmptyUpdaterOnVersionLowerOrEqualToTheInitialVersion() throws Exception
     {
         // given
         long initialVersion = 42;
         when( store.version() ).thenReturn( initialVersion );
         ConcurrentMapState<?> state = new ConcurrentMapState<>( store, file );
 
-        try
-        {
-            // when
-            state.updater( initialVersion, lock );
-            fail( "should have thrown" );
-        }
-        catch ( IllegalStateException ex )
-        {
-            // then
-            assertEquals( "Cannot apply update with given version " + initialVersion +
-                          " when base version is " + initialVersion, ex.getMessage() );
-        }
-    }
+        // when
+        EntryUpdater<?> updater = state.updater( initialVersion, lock );
 
-    @Test
-    public void shouldFailIfApplyingAVersionUpdateTwiceWithSameVersion() throws Exception
-    {
-        // given
-        long initialVersion = 42;
-        when( store.version() ).thenReturn( initialVersion );
-        ConcurrentMapState<?> state = new ConcurrentMapState<>( store, file );
-
-        EntryUpdater<?> updater;
-
-        long updateVersion = 45;
-        updater = state.updater( updateVersion, lock );
-        updater.close();
-
-        try
-        {
-            // when
-            state.updater( updateVersion, lock );
-            fail( "should have thrown" );
-        }
-        catch ( IllegalStateException ex )
-        {
-            // then
-            assertEquals( "Cannot apply update with given version " + updateVersion +
-                          " when base version is " + initialVersion, ex.getMessage() );
-        }
+        // expected
+        assertEquals( "Empty updater should be used for version less or equal to initial",
+                EntryUpdater.noUpdates(), updater );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
+++ b/community/kernel/src/test/java/org/neo4j/test/OtherThreadExecutor.java
@@ -107,7 +107,7 @@ public class OtherThreadExecutor<T> implements ThreadFactory, Closeable
         };
     }
 
-    private static enum ExecutionState
+    private enum ExecutionState
     {
         REQUESTED_EXECUTION,
         EXECUTING,


### PR DESCRIPTION
Revert changes introduced to ConcurrentMapState that cause exception
on updates with old versions.
Prevent cases when count store rotation causing TransactionRepresentationCommitProcess to hang.
Hang scenario:

```
+------------------------+---------------------------------+
| T1:Checkpointer        |       T2:CommitProcess          |
+----------------------------------------------------------+
|                        |publish transaction as commited  |
|                        |                                 |
|   rotation             |                                 |
|                        |                                 |
|                        |apply transaction to the store   |
|                        |                                 |
+------------------------+---------------------------------+
```

On the last step of T2 exception will be raised. And in case if transaction contains legacy indexes
that will prevent closing LegacyIndexApplier and removing current transactionId from
transactionOrdering queue. As result all new transaction will not be able to appendToLog
since their will wait forever on orderLegacyIndexChanges.
