### PR TITLE
Rewriter should take the scope of ORDER BY into account

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NormalizeWithClausesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NormalizeWithClausesTest.scala
@@ -569,6 +569,22 @@ class NormalizeWithClausesTest extends CypherFunSuite with RewriteTest with AstC
     )
   }
 
+  test("match (n) with n, 0 as foo with n as n order by foo, n.bar return n") {
+    assertRewrite(
+      """MATCH (n)
+        |WITH n, 0 AS foo
+        |WITH n AS n ORDER BY foo, n.bar
+        |RETURN n
+      """.stripMargin,
+    """MATCH (n)
+      |WITH n AS n, 0 AS foo
+      |WITH foo AS foo, n AS n
+      |WITH n AS n, foo AS foo, n.bar AS `  FRESHID55` ORDER BY foo, `  FRESHID55`
+      |_PRAGMA WITHOUT `  FRESHID55`
+      |RETURN n
+    """.stripMargin)
+  }
+
   test("match n with n as n order by max(n) return n") {
     evaluating { rewriting("match n with n as n order by max(n) return n") } should produce[SyntaxException]
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/OrderByAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/OrderByAcceptanceTest.scala
@@ -64,4 +64,24 @@ class OrderByAcceptanceTest extends ExecutionEngineFunSuite with CustomMatchers 
         Map("n" -> 3)
       ))
   }
+
+  test("Properly handle projections and ORDER BY (GH#4937)") {
+    val crew1 = createLabeledNode(Map("name" -> "Neo", "rank" -> 1), "Crew")
+    val crew2 = createLabeledNode(Map("name" -> "Neo", "rank" -> 2), "Crew")
+    val crew3 = createLabeledNode(Map("name" -> "Neo", "rank" -> 3), "Crew")
+    val crew4 = createLabeledNode(Map("name" -> "Neo", "rank" -> 4), "Crew")
+    val crew5 = createLabeledNode(Map("name" -> "Neo", "rank" -> 5), "Crew")
+
+    val query = """MATCH (crew:Crew {name: 'Neo'})
+                  |WITH crew, 0 AS relevance RETURN crew
+                  |ORDER BY relevance, crew.rank""".stripMargin
+
+    executeWithAllPlanners(query).toList should equal(List(
+      Map("crew" -> crew1),
+      Map("crew"-> crew2),
+      Map("crew" -> crew3),
+      Map("crew" -> crew4),
+      Map("crew" -> crew5)
+    ))
+  }
 }


### PR DESCRIPTION
Rewriter `normalizedWithClauses` was not considering identifiers needed in the inner scope of
`ORDER BY` when doing rewriting.

Fixes #4937
