### PR TITLE
Wait checkpointing to complete on stop

### DIFF
--- a/community/function/src/main/java/org/neo4j/function/Predicates.java
+++ b/community/function/src/main/java/org/neo4j/function/Predicates.java
@@ -199,17 +199,23 @@ public class Predicates
     public static <TYPE> void await( Supplier<TYPE> supplier, Predicate<TYPE> predicate, long timeout, TimeUnit unit )
             throws TimeoutException, InterruptedException
     {
+        await( Suppliers.compose( supplier, predicate ), timeout, unit );
+    }
+
+    public static void await( Supplier<Boolean> condition, long timeout, TimeUnit unit )
+            throws TimeoutException, InterruptedException
+    {
         long sleep = Math.max( unit.toMillis( timeout ) / 100, 1 );
         long deadline = System.currentTimeMillis() + unit.toMillis( timeout );
         do
         {
-            if ( predicate.test( supplier.get() ) )
+            if ( condition.get() )
             {
                 return;
             }
             Thread.sleep( sleep );
         }
         while ( System.currentTimeMillis() < deadline );
-        throw new TimeoutException( "Waited for " + timeout + " " + unit + ", but " + predicate + " was not accepted." );
+        throw new TimeoutException( "Waited for " + timeout + " " + unit + ", but " + condition + " was not accepted." );
     }
 }

--- a/community/function/src/main/java/org/neo4j/function/Suppliers.java
+++ b/community/function/src/main/java/org/neo4j/function/Suppliers.java
@@ -116,4 +116,16 @@ public final class Suppliers
             }
         };
     }
+
+    public static <T> Supplier<Boolean> compose( final Supplier<T> input, final Predicate<T> predicate )
+    {
+        return new Supplier<Boolean>()
+        {
+            @Override
+            public Boolean get()
+            {
+                return predicate.test( input.get() );
+            }
+        };
+    }
 }


### PR DESCRIPTION
This is necessary to avoid a race between the check pointing thread and the shutdown of the database.
