### PR TITLE
Reenable vectored IO in the page cache

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
@@ -81,7 +81,7 @@ public class SingleFilePageSwapper implements PageSwapper
             UnsafeUtil.getFieldOffset( SingleFilePageSwapper.class, "fileSize" );
 
     private static final ThreadLocal<ByteBuffer> proxyCache = new ThreadLocal<>();
-    private static final MethodHandle positionLockGetter = null;//getPositionLockGetter();
+    private static final MethodHandle positionLockGetter = getPositionLockGetter();
 
     private static MethodHandle getPositionLockGetter()
     {


### PR DESCRIPTION
It was disabled because we found bugs in it.
These bugs were fixed in #5170 so now let's try reenabling this feature.
