### PR TITLE
performance fix to for creating unique constraints

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/DeferredConstraintVerificationUniqueLuceneIndexPopulator.java
@@ -34,6 +34,7 @@ import org.apache.lucene.search.TermQuery;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.neo4j.collection.primitive.PrimitiveLongSet;
@@ -268,7 +269,7 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
         private final PropertyAccessor accessor;
         private final LuceneDocumentStructure documentStructure;
         private final int propertyKeyId;
-        private final EntrySet actualValues;
+        private EntrySet actualValues;
         private IndexReader reader;
         private int docBase;
 
@@ -355,7 +356,7 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
 
         public void reset()
         {
-            actualValues.reset(); // TODO benchmark this vs. not clearing and instead creating a new object, perhaps
+            actualValues = new EntrySet();
         }
     }
 
@@ -367,23 +368,15 @@ class DeferredConstraintVerificationUniqueLuceneIndexPopulator extends LuceneInd
      */
     private static class EntrySet
     {
-        static final int INCREMENT = 100;
+        static final int INCREMENT = 10000;
 
         Object[] value = new Object[INCREMENT];
         long[] nodeId = new long[INCREMENT];
         EntrySet next;
 
-        public void reset()
+        EntrySet()
         {
-            EntrySet current = this;
-            do {
-                for (int i = 0; i < INCREMENT; i++)
-                {
-                    current.value[i] = null;
-                    current.nodeId[i] = StatementConstants.NO_SUCH_NODE;
-                }
-                current = next;
-            } while ( current != null );
+	       Arrays.fill( nodeId, StatementConstants.NO_SUCH_NODE );
         }
     }
 }


### PR DESCRIPTION
renew EntrySet instead of clearing it for massive performance difference on creating unique constraints on larger node-sets - 500k
