### PR TITLE
support foreach in shell

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/ComparablePredicateTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/ComparablePredicateTest.scala
@@ -48,7 +48,7 @@ class ComparablePredicateTest extends CypherFunSuite {
     Double.NaN
 //    null TODO
   ).flatMap {
-    case v: Number => if (v == null) Seq(v) else Seq(v.doubleValue(), v.floatValue(), v.longValue(), v.intValue(), v.shortValue(), v.byteValue(), v)
+    case v: Number => if (v == null) Seq(v) else Seq[Number](v.doubleValue(), v.floatValue(), v.longValue(), v.intValue(), v.shortValue(), v.byteValue(), v)
   }
 
   val textualValues = Seq(

--- a/community/shell/src/main/java/org/neo4j/shell/AppCommandParser.java
+++ b/community/shell/src/main/java/org/neo4j/shell/AppCommandParser.java
@@ -107,13 +107,13 @@ public class AppCommandParser
      */
     public static String parseOutAppName( String line )
     {
-        int index = findNextWhiteSpace( line, 0 );
+        int index = findNextWhiteSpaceOrLeftParenthesis( line, 0 );
         return index == -1 ? line : line.substring( 0, index );
     }
 
     private void parseApp( String line ) throws Exception
     {
-        int index = findNextWhiteSpace( line, 0 );
+        int index = findNextWhiteSpaceOrLeftParenthesis( line, 0 );
         appName = index == -1 ? line : line.substring( 0, index );
         appName = appName.toLowerCase();
         app = server.findApp( appName );
@@ -227,10 +227,24 @@ public class AppCommandParser
         }
     }
 
-    private static int findNextWhiteSpace( String line, int fromIndex )
+    private static int findNextWhiteSpaceOrLeftParenthesis( String line, int fromIndex )
     {
-        int index = line.indexOf( ' ', fromIndex );
-        return index == -1 ? line.indexOf( '\t', fromIndex ) : index;
+        int indexOfWhiteSpace = line.indexOf( ' ', fromIndex );
+        if (indexOfWhiteSpace == - 1)
+        {
+            indexOfWhiteSpace = line.indexOf( '\t', fromIndex );
+        }
+        //allow using both create () and create()
+        int indexOfLeftParenthesis = line.indexOf( '(', fromIndex );
+
+        if (indexOfLeftParenthesis != -1)
+        {
+            return Math.min(indexOfWhiteSpace, indexOfLeftParenthesis);
+        }
+        else
+        {
+            return indexOfWhiteSpace;
+        }
     }
 
     /** @return the name of the app (from {@link #getLine()}). */

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Foreach.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Foreach.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.shell.kernel.apps.cypher;
+
+import org.neo4j.helpers.Service;
+import org.neo4j.shell.App;
+
+@Service.Implementation( App.class )
+public class Foreach extends Start
+{
+}

--- a/community/shell/src/main/resources/META-INF/services/org.neo4j.shell.App
+++ b/community/shell/src/main/resources/META-INF/services/org.neo4j.shell.App
@@ -22,6 +22,7 @@ org.neo4j.shell.kernel.apps.cypher.Start
 org.neo4j.shell.kernel.apps.cypher.Using
 org.neo4j.shell.kernel.apps.cypher.Unwind
 org.neo4j.shell.kernel.apps.cypher.With
+org.neo4j.shell.kernel.apps.cypher.Foreach
 org.neo4j.shell.kernel.apps.Ls
 org.neo4j.shell.kernel.apps.Mknode
 org.neo4j.shell.kernel.apps.Mkrel

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -1376,4 +1376,10 @@ public class TestApps extends AbstractShellTest
     {
         executeCommand( "FOREACH (x in range(0,10) | CREATE ()));" );
     }
+
+    @Test
+    public void canUseCommandsWithoutSpaceBeforeLeftParenthesis() throws Exception
+    {
+        executeCommand( "FOREACH(x in range(0,10) | CREATE ()));" );
+    }
 }

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -402,7 +402,7 @@ public class TestApps extends AbstractShellTest
     public void createNodeWithArrayProperty() throws Exception
     {
         executeCommand( "mknode --np \"{'values':[1,2,3,4]}\" --cd" );
-        assertThat( getCurrentNode(), inTx( db, hasProperty( "values" ).withValue( new int[] {1,2,3,4} ) ) );
+        assertThat( getCurrentNode(), inTx( db, hasProperty( "values" ).withValue( new int[]{1, 2, 3, 4} ) ) );
     }
 
     @Test
@@ -535,7 +535,7 @@ public class TestApps extends AbstractShellTest
     @Test
     public void startCypherQueryWithUnwind() throws Exception
     {
-        executeCommand( "unwind [1,2,3] as x return x;", "| x |", "| 1 |");
+        executeCommand( "unwind [1,2,3] as x return x;", "| x |", "| 1 |" );
     }
 
     @Test
@@ -575,7 +575,7 @@ public class TestApps extends AbstractShellTest
     public void canSetInitialSessionVariables() throws Exception
     {
         Map<String, Serializable> values = genericMap( "mykey", "myvalue",
-                                                       "my_other_key", "My other value" );
+                "my_other_key", "My other value" );
         ShellClient client = newShellClient( shellServer, values );
         String[] allStrings = new String[values.size()*2];
         int i = 0;
@@ -595,7 +595,8 @@ public class TestApps extends AbstractShellTest
         ShellClient client = new SameJvmClient( values, shellServer, out );
         client.shutdown();
         final String outString = out.asString();
-        assertEquals( "Shows welcome message: " + outString, false, outString.contains( "Welcome to the Neo4j Shell! Enter 'help' for a list of commands" ) );
+        assertEquals( "Shows welcome message: " + outString, false,
+                outString.contains( "Welcome to the Neo4j Shell! Enter 'help' for a list of commands" ) );
     }
 
     @Test
@@ -1366,6 +1367,13 @@ public class TestApps extends AbstractShellTest
         });
         thread.start();
 
-        executeCommandExpectingException("CYPHER 2.2 FOREACH(i IN range(0, 10000) | CREATE ());", "has been terminated" );
+        executeCommandExpectingException( "CYPHER 2.2 FOREACH(i IN range(0, 10000) | CREATE ());",
+                "has been terminated" );
+    }
+
+    @Test
+    public void canUseForeach() throws Exception
+    {
+        executeCommand( "FOREACH (x in range(0,10) | CREATE ()));" );
     }
 }


### PR DESCRIPTION
- support foreach in shell
- support in shell for parenthesis without preceding white space (e.g. supporting both `FOREACH(…)` and `FOREACH ()`)
- got rid of some compiler warnings  
