### PR TITLE
Add setting to disable auth on HA status endpoint

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -28,6 +28,7 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
 import javax.servlet.Filter;
 
 import org.neo4j.function.Function;
@@ -110,6 +111,12 @@ public abstract class AbstractNeoServer implements NeoServer
      * This ensures the expiry time displayed to the user is always at least 1 second, even after it is rounded down.
      */
     private static final long ROUNDING_SECOND = 1000L;
+
+    private static final Pattern[] DEFAULT_URI_WHITELIST = new Pattern[]{
+            Pattern.compile( "/browser.*" ),
+            Pattern.compile( "/webadmin.*" ),
+            Pattern.compile( "/" )
+    };
 
     private final Database.Factory dbFactory;
     private final GraphDatabaseFacadeFactory.Dependencies dependencies;
@@ -441,6 +448,11 @@ public abstract class AbstractNeoServer implements NeoServer
     protected String getWebServerAddress()
     {
         return config.get( ServerSettings.webserver_address );
+    }
+
+    protected Pattern[] getUriWhitelist()
+    {
+        return DEFAULT_URI_WHITELIST;
     }
 
     protected KeyStoreInformation createKeyStore()

--- a/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
@@ -91,7 +91,7 @@ public class CommunityNeoServer extends AbstractNeoServer
                 new ThirdPartyJAXRSModule( webServer, getConfig(), logProvider, this ),
                 new WebAdminModule( webServer, getConfig() ),
                 new Neo4jBrowserModule( webServer ),
-                new AuthorizationModule( webServer, authManager, getConfig(), logProvider ),
+                new AuthorizationModule( webServer, authManager, logProvider, getConfig(), getUriWhitelist() ),
                 new SecurityRulesModule( webServer, getConfig(), logProvider ) );
     }
 

--- a/community/server/src/main/java/org/neo4j/server/WrappingNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/WrappingNeoServer.java
@@ -72,7 +72,6 @@ public class WrappingNeoServer extends CommunityNeoServer
                 GraphDatabaseDependencies.newDependencies().userLogProvider(
                         logProvider
                 ).monitors( db.getDependencyResolver().resolveDependency( Monitors.class ) ), logProvider );
-        init();
     }
 
     static Config toConfig( ConfigurationBuilder configurator )

--- a/community/server/src/main/java/org/neo4j/server/modules/AuthorizationModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/AuthorizationModule.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.modules;
 
+import java.util.regex.Pattern;
+
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.configuration.ServerSettings;
@@ -32,13 +34,15 @@ public class AuthorizationModule implements ServerModule
     private final Config config;
     private final AuthManager authManager;
     private final LogProvider logProvider;
+    private final Pattern[] uriWhitelist;
 
-    public AuthorizationModule( WebServer webServer, AuthManager authManager, Config config, LogProvider logProvider )
+    public AuthorizationModule( WebServer webServer, AuthManager authManager, LogProvider logProvider, Config config, Pattern[] uriWhitelist )
     {
         this.webServer = webServer;
         this.config = config;
         this.authManager = authManager;
         this.logProvider = logProvider;
+        this.uriWhitelist = uriWhitelist;
     }
 
     @Override
@@ -46,7 +50,8 @@ public class AuthorizationModule implements ServerModule
     {
         if ( config.get( ServerSettings.auth_enabled ) )
         {
-            webServer.addFilter( new AuthorizationFilter( authManager, logProvider ), "/*" );
+            final AuthorizationFilter authorizationFilter = new AuthorizationFilter( authManager, logProvider, uriWhitelist );
+            webServer.addFilter( authorizationFilter, "/*" );
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationWhitelistIT.java
+++ b/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationWhitelistIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.auth;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.neo4j.server.CommunityNeoServer;
+import org.neo4j.server.configuration.ServerSettings;
+import org.neo4j.server.helpers.CommunityServerBuilder;
+import org.neo4j.test.server.ExclusiveServerTestBase;
+import org.neo4j.test.server.HTTP;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class AuthorizationWhitelistIT extends ExclusiveServerTestBase
+{
+    private CommunityNeoServer server;
+
+    @Test
+    public void shouldWhitelistBrowser() throws Exception
+    {
+        // Given
+        server = CommunityServerBuilder.server().withProperty( ServerSettings.auth_enabled.name(), "true" ).build();
+
+        // When
+        server.start();
+
+        // Then I should be able to access the browser
+        HTTP.Response response = HTTP.GET( server.baseUri().resolve( "browser/index.html" ).toString() );
+        assertThat( response.status(), equalTo( 200 ) );
+    }
+
+    @Test
+    public void shouldWhitelistWebadmin() throws Exception
+    {
+        // Given
+        server = CommunityServerBuilder.server().withProperty( ServerSettings.auth_enabled.name(), "true" ).build();
+
+        // When
+        server.start();
+
+        // Then I should be able to access the webadmin
+        HTTP.Response response = HTTP.GET( server.baseUri().resolve( "webadmin/index.html" ).toString() );
+        assertThat( response.status(), equalTo( 200 ) );
+    }
+
+    @Test
+    public void shouldNotWhitelistDB() throws Exception
+    {
+        // Given
+        server = CommunityServerBuilder.server().withProperty( ServerSettings.auth_enabled.name(), "true" ).build();
+
+        // When
+        server.start();
+
+        // Then I should get a unauthorized response for access to the DB
+        HTTP.Response response = HTTP.GET( server.baseUri().resolve( "db/data" ).toString() );
+        assertThat( response.status(), equalTo( 401 ) );
+    }
+
+    @After
+    public void cleanup()
+    {
+        if ( server != null ) { server.stop(); }
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
@@ -68,6 +68,9 @@ public class HaSettings
     public static final Setting<BranchedDataPolicy> branched_data_policy = setting( "ha.branched_data_policy",
             options( BranchedDataPolicy.class ), "keep_all" );
 
+    @Description( "Enable public access to the HA status endpoints." )
+    public static final Setting<Boolean> ha_status_auth_enabled = setting( "dbms.security.ha_status_auth_enabled", BOOLEAN, Settings.TRUE );
+
     @Description( "Max size of the data chunks that flows between master and slaves in HA. Bigger size may increase " +
             "throughput, but may also be more sensitive to variations in bandwidth, whereas lower size increases tolerance" +
             " for bandwidth variations." )

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseNeoServer.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseNeoServer.java
@@ -20,10 +20,15 @@
 package org.neo4j.server.enterprise;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
 
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Dependencies;
 import org.neo4j.logging.LogProvider;
@@ -85,5 +90,16 @@ public class EnterpriseNeoServer extends AdvancedNeoServer
         {
             return super.getServices();
         }
+    }
+
+    @Override
+    protected Pattern[] getUriWhitelist()
+    {
+        final List<Pattern> uriWhitelist = new ArrayList<>( Arrays.asList( super.getUriWhitelist() ) );
+        if ( !getConfig().get( HaSettings.ha_status_auth_enabled ) )
+        {
+            uriWhitelist.add( Pattern.compile( "/db/manage/server/ha.*" ) );
+        }
+        return uriWhitelist.toArray( new Pattern[uriWhitelist.size()] );
     }
 }

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/EnterpriseServerIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/EnterpriseServerIT.java
@@ -32,9 +32,11 @@ import java.io.IOException;
 import java.util.Properties;
 
 import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.configuration.Configurator;
+import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.enterprise.helpers.EnterpriseServerBuilder;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -76,6 +78,72 @@ public class EnterpriseServerIT
             Client client = Client.create();
             ClientResponse r = client.resource( "http://localhost:" + DEFAULT_WEBSERVER_PORT +
                     "/db/manage/server/ha" ).accept( APPLICATION_JSON ).get( ClientResponse.class );
+            assertEquals( 200, r.getStatus() );
+            assertThat( r.getEntity( String.class ), containsString( "master" ) );
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void shouldRequireAuthorizationForHAStatusEndpoints() throws Exception
+    {
+        // Given
+        File tuningFile = createNeo4jProperties();
+
+        NeoServer server = EnterpriseServerBuilder.server()
+                .withProperty( ServerSettings.auth_enabled.name(), "true" )
+                .usingDatabaseDir( folder.getRoot().getAbsolutePath() )
+                .withProperty( mode.name(), "HA" )
+                .withProperty( Configurator.DB_TUNING_PROPERTY_FILE_KEY, tuningFile.getAbsolutePath() )
+                .persistent()
+                .build();
+
+        try
+        {
+            server.start();
+            server.getDatabase();
+
+            assertThat( server.getDatabase().getGraph(), is( instanceOf(HighlyAvailableGraphDatabase.class) ) );
+
+            Client client = Client.create();
+            ClientResponse r = client.resource( "http://localhost:" + DEFAULT_WEBSERVER_PORT +
+                                                "/db/manage/server/ha" ).accept( APPLICATION_JSON ).get( ClientResponse.class );
+            assertEquals( 401, r.getStatus() );
+        }
+        finally
+        {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void shouldAllowDisablingAuthorizationOnHAStatusEndpoints() throws Exception
+    {
+        // Given
+        File tuningFile = createNeo4jProperties();
+
+        NeoServer server = EnterpriseServerBuilder.server()
+                .withProperty( ServerSettings.auth_enabled.name(), "true" )
+                .withProperty( HaSettings.ha_status_auth_enabled.name(), "false" )
+                .usingDatabaseDir( folder.getRoot().getAbsolutePath() )
+                .withProperty( mode.name(), "HA" )
+                .withProperty( Configurator.DB_TUNING_PROPERTY_FILE_KEY, tuningFile.getAbsolutePath() )
+                .persistent()
+                .build();
+
+        try
+        {
+            server.start();
+            server.getDatabase();
+
+            assertThat( server.getDatabase().getGraph(), is( instanceOf(HighlyAvailableGraphDatabase.class) ) );
+
+            Client client = Client.create();
+            ClientResponse r = client.resource( "http://localhost:" + DEFAULT_WEBSERVER_PORT +
+                                                "/db/manage/server/ha" ).accept( APPLICATION_JSON ).get( ClientResponse.class );
             assertEquals( 200, r.getStatus() );
             assertThat( r.getEntity( String.class ), containsString( "master" ) );
         }


### PR DESCRIPTION
Adds `dbms.security.ha_status_auth_enabled=false` (Enterprise only), which disables auth for ha status endpoints (`db/manage/server/ha.*`).
