### PR TITLE
new ForbiddenSecurityRule to deny authenticated but forbidden access

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/security/ForbiddingSecurityRule.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/security/ForbiddingSecurityRule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.security;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * A variant of SecurityRule which adds the ability to forbid access, even if the request is authenticated,
+ * which results in an HTTP 403.
+ */
+public interface ForbiddingSecurityRule extends SecurityRule {
+
+    /**
+     * @param request The HTTP request currently under consideration.
+     * @return <code>true</code> if the rule is triggered and the request is to be rejected with a "403 Forbidden",
+     *  and <code>false</code> otherwise.
+     */
+    boolean isForbidden(HttpServletRequest request);
+
+}

--- a/community/server/src/main/java/org/neo4j/server/rest/security/SecurityRule.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/security/SecurityRule.java
@@ -30,7 +30,7 @@ public interface SecurityRule
     /**
      * @param request The HTTP request currently under consideration.
      * @return <code>true</code> if the rule passes, <code>false</code> if the
-     *         rule fails and the request is to be rejected.
+     *         rule fails and the request is to be rejected with a "401 Unauthorized".
      */
     boolean isAuthorized(HttpServletRequest request);
 

--- a/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyForbiddenSecurityRule.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/PermanentlyForbiddenSecurityRule.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.security;
+
+import javax.servlet.http.HttpServletRequest;
+
+//START SNIPPET: forbiddenRule
+public class PermanentlyForbiddenSecurityRule implements ForbiddingSecurityRule
+{
+
+    public static final String REALM = "WallyWorld"; // as per RFC2617 :-)
+
+    @Override
+    public boolean isAuthorized( HttpServletRequest request )
+    {
+        return true; // always authenticated
+    }
+
+    @Override
+    public boolean isForbidden(HttpServletRequest request)
+    {
+        return true;
+    }
+
+    @Override
+    public String forUriPath()
+    {
+        return "/*";
+    }
+
+    @Override
+    public String wwwAuthenticateHeader()
+    {
+        return SecurityFilter.basicAuthenticationResponse(REALM);
+    }
+}
+// END SNIPPET: forbiddenRule

--- a/community/server/src/test/java/org/neo4j/server/rest/security/SecurityRulesDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/SecurityRulesDocIT.java
@@ -38,9 +38,7 @@ import org.neo4j.test.TestData.Title;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class SecurityRulesDocIT extends ExclusiveServerTestBase
 {
@@ -144,7 +142,7 @@ public class SecurityRulesDocIT extends ExclusiveServerTestBase
 
         // then
         assertTrue( NoAccessToDatabaseSecurityRule.wasInvoked() );
-        assertTrue( NoAccessToWebAdminSecurityRule.wasInvoked() );
+        assertTrue(NoAccessToWebAdminSecurityRule.wasInvoked());
     }
 
     @Test
@@ -209,7 +207,7 @@ public class SecurityRulesDocIT extends ExclusiveServerTestBase
         gen.get().addTestSourceSnippets( PermanentlyFailingSecurityRuleWithWildcardPath.class,
                 "failingRuleWithWildcardPath" );
 
-        gen.get().setSection( "ops" );
+        gen.get().setSection("ops");
 
         functionalTestHelper = new FunctionalTestHelper( server );
 
@@ -221,7 +219,7 @@ public class SecurityRulesDocIT extends ExclusiveServerTestBase
                         + mountPoint + "/more/stuff" )
                 .response();
 
-        assertEquals( 401, clientResponse.getStatus() );
+        assertEquals(401, clientResponse.getStatus());
     }
 
     /**
@@ -254,7 +252,7 @@ public class SecurityRulesDocIT extends ExclusiveServerTestBase
         gen.get().addSnippet(
                 "config",
                 "\n[source,properties]\n----\norg.neo4j.server.rest.security_rules=my.rules" +
-                        ".PermanentlyFailingSecurityRuleWithComplexWildcardPath\n----\n" );
+                        ".PermanentlyFailingSecurityRuleWithComplexWildcardPath\n----\n");
         gen.get().addTestSourceSnippets( PermanentlyFailingSecurityRuleWithComplexWildcardPath.class,
                 "failingRuleWithComplexWildcardPath" );
         gen.get().setSection( "ops" );
@@ -270,6 +268,28 @@ public class SecurityRulesDocIT extends ExclusiveServerTestBase
                 .response();
 
         assertEquals( 401, clientResponse.getStatus() );
+    }
+
+
+    @Test
+    public void should403WhenAuthenticatedButForbidden()
+            throws Exception
+    {
+        server = CommunityServerBuilder.server().withDefaultDatabaseTuning().withSecurityRules(
+                PermanentlyForbiddenSecurityRule.class.getCanonicalName(),
+                PermanentlyPassingSecurityRule.class.getCanonicalName() )
+                .usingDatabaseDir( folder.directory( name.getMethodName() ).getAbsolutePath() )
+                .build();
+        server.start();
+        functionalTestHelper = new FunctionalTestHelper( server );
+
+        JaxRsResponse clientResponse = gen.get()
+                .expectedStatus(403)
+                .expectedType(MediaType.APPLICATION_JSON_TYPE)
+                .get(trimTrailingSlash(functionalTestHelper.baseUri()))
+                .response();
+
+        assertEquals(403, clientResponse.getStatus());
     }
 
     private String trimTrailingSlash( URI uri )


### PR DESCRIPTION
- after authentication SecurityFilter now checks isForbidden() to possibly return 403 
- uses SecurityEnforcer as a facade for all SecurityRule variants
