### PR TITLE
Doesn't read properties when deleting the whole chain

### DIFF
--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityArnoldi.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityArnoldi.java
@@ -20,7 +20,6 @@
 package org.neo4j.graphalgo.impl.centrality;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityPower.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/centrality/EigenvectorCentralityPower.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.graphalgo.impl.centrality;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EigenvectorCentralityArnoldiTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/centrality/EigenvectorCentralityArnoldiTest.java
@@ -21,7 +21,6 @@ package org.neo4j.graphalgo.centrality;
 
 import java.util.Set;
 
-import org.junit.Test;
 import org.neo4j.graphalgo.CostEvaluator;
 import org.neo4j.graphalgo.impl.centrality.EigenvectorCentrality;
 import org.neo4j.graphalgo.impl.centrality.EigenvectorCentralityArnoldi;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionContext.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.core.RelationshipLoadingPosition;
 import org.neo4j.kernel.impl.locking.Locks.Client;
 import org.neo4j.kernel.impl.store.NeoStore;
@@ -39,7 +38,6 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess.RecordProxy;
-import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray.DirectionWrapper;
 
 public class NeoStoreTransactionContext
@@ -85,9 +83,9 @@ public class NeoStoreTransactionContext
         return recordChangeSet;
     }
 
-    public ArrayMap<Integer, DefinedProperty> relationshipDelete( long relId )
+    public void relationshipDelete( long relId )
     {
-        return relationshipDeleter.relDelete( relId, recordChangeSet );
+        relationshipDeleter.relDelete( relId, recordChangeSet );
     }
 
     public void relationshipCreate( long id, int typeId, long startNodeId, long endNodeId )
@@ -95,10 +93,9 @@ public class NeoStoreTransactionContext
         relationshipCreator.relationshipCreate( id, typeId, startNodeId, endNodeId, recordChangeSet );
     }
 
-    public ArrayMap<Integer, DefinedProperty> getAndDeletePropertyChain( NodeRecord nodeRecord )
+    public void getAndDeletePropertyChain( NodeRecord nodeRecord )
     {
-        return propertyDeleter.getAndDeletePropertyChain( nodeRecord,
-                recordChangeSet.getPropertyRecords() );
+        propertyDeleter.deletePropertyChain( nodeRecord, recordChangeSet.getPropertyRecords() );
     }
 
     public <T extends PrimitiveRecord> void removeProperty( RecordProxy<Long,T,Void> primitiveProxy, int propertyKey )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
@@ -19,14 +19,12 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
-import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess.RecordProxy;
-import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.RelIdArray;
 
 public class RelationshipDeleter
@@ -53,15 +51,13 @@ public class RelationshipDeleter
      * @return The properties of the relationship that were removed during the
      *         delete.
      */
-    public ArrayMap<Integer, DefinedProperty> relDelete( long id, RecordAccessSet recordChanges )
+    public void relDelete( long id, RecordAccessSet recordChanges )
     {
         RelationshipRecord record = recordChanges.getRelRecords().getOrLoad( id, null ).forChangingLinkage();
-        ArrayMap<Integer, DefinedProperty> propertyMap =
-                propertyChainDeleter.getAndDeletePropertyChain( record, recordChanges.getPropertyRecords() );
+        propertyChainDeleter.deletePropertyChain( record, recordChanges.getPropertyRecords() );
         disconnectRelationship( record, recordChanges );
         updateNodesForDeletedRelationship( record, recordChanges );
         record.setInUse( false );
-        return propertyMap;
     }
 
     private void disconnectRelationship( RelationshipRecord rel, RecordAccessSet recordChangeSet )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -48,7 +48,6 @@ import org.neo4j.kernel.impl.store.record.SchemaRule;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.command.Command.Mode;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess.RecordProxy;
-import org.neo4j.kernel.impl.util.ArrayMap;
 import org.neo4j.kernel.impl.util.statistics.IntCounter;
 
 import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
@@ -223,9 +222,9 @@ public class TransactionRecordState implements RecordState
         context.relationshipCreate( id, typeId, startNodeId, endNodeId );
     }
 
-    public ArrayMap<Integer, DefinedProperty> relDelete( long relId )
+    public void relDelete( long relId )
     {
-        return context.relationshipDelete( relId );
+        context.relationshipDelete( relId );
     }
 
     @SafeVarargs
@@ -260,7 +259,7 @@ public class TransactionRecordState implements RecordState
      * @param nodeId The id of the node to delete.
      * @return The properties of the node that were removed during the delete.
      */
-    public ArrayMap<Integer, DefinedProperty> nodeDelete( long nodeId )
+    public void nodeDelete( long nodeId )
     {
         NodeRecord nodeRecord = context.getNodeRecords().getOrLoad( nodeId, null ).forChangingData();
         if ( !nodeRecord.inUse() )
@@ -271,7 +270,7 @@ public class TransactionRecordState implements RecordState
         nodeRecord.setInUse( false );
         nodeRecord.setLabelField( Record.NO_LABELS_FIELD.intValue(),
                 markNotInUse( nodeRecord.getDynamicLabelRecords() ) );
-        return getAndDeletePropertyChain( nodeRecord );
+        getAndDeletePropertyChain( nodeRecord );
     }
 
     private Collection<DynamicRecord> markNotInUse( Collection<DynamicRecord> dynamicLabelRecords )
@@ -283,9 +282,9 @@ public class TransactionRecordState implements RecordState
         return dynamicLabelRecords;
     }
 
-    private ArrayMap<Integer, DefinedProperty> getAndDeletePropertyChain( NodeRecord nodeRecord )
+    private void getAndDeletePropertyChain( NodeRecord nodeRecord )
     {
-        return context.getAndDeletePropertyChain( nodeRecord );
+        context.getAndDeletePropertyChain( nodeRecord );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -816,7 +816,7 @@ public class BatchInserterImpl implements BatchInserter
         NodeRecord record = getNodeRecord( node ).forChangingData();
         if ( record.getNextProp() != Record.NO_NEXT_PROPERTY.intValue() )
         {
-            propertyDeletor.getAndDeletePropertyChain( record, recordAccess.getPropertyRecords() );
+            propertyDeletor.deletePropertyChain( record, recordAccess.getPropertyRecords() );
         }
         record.setNextProp( propertyCreator.createPropertyChain( record, propertiesIterator( properties ),
                 recordAccess.getPropertyRecords() ) );
@@ -829,7 +829,7 @@ public class BatchInserterImpl implements BatchInserter
         RelationshipRecord record = recordAccess.getRelRecords().getOrLoad( rel, null ).forChangingData();
         if ( record.getNextProp() != Record.NO_NEXT_PROPERTY.intValue() )
         {
-            propertyDeletor.getAndDeletePropertyChain( record, recordAccess.getPropertyRecords() );
+            propertyDeletor.deletePropertyChain( record, recordAccess.getPropertyRecords() );
         }
         record.setNextProp( propertyCreator.createPropertyChain( record, propertiesIterator( properties ),
                 recordAccess.getPropertyRecords() ) );


### PR DESCRIPTION
since no caller ever cared about those properties. Initially, reading
these properties would hit an issue during batch insert where a "before"
record were being accessed, assuming it would be read from the store, but
there was a chance that record wouldn't have made it to the store yet and
were just sitting in the current in-memory batch.
