### PR TITLE
Reusable Ids clash in db that based on incremental backup result

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/IdType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/IdType.java
@@ -44,12 +44,12 @@ public enum IdType
     private final long max;
     private final boolean allowAggressiveReuse;
 
-    private IdType( boolean allowAggressiveReuse )
+    IdType( boolean allowAggressiveReuse )
     {
         this( 32, allowAggressiveReuse );
     }
 
-    private IdType( int bits, boolean allowAggressiveReuse )
+    IdType( int bits, boolean allowAggressiveReuse )
     {
         this.allowAggressiveReuse = allowAggressiveReuse;
         this.max = (long)Math.pow( 2, bits )-1;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
@@ -221,7 +221,7 @@ public class HighIdTransactionApplier implements NeoCommandHandler
         HighId highId = highIds.get( store );
         if ( highId == null )
         {
-            highIds.put( store, highId = new HighId( id ) );
+            highIds.put( store, new HighId( id ) );
         }
         else
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.kernel.impl.store.id;
 
-import java.io.File;
-
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.test.EphemeralFileSystemRule;
@@ -56,6 +56,21 @@ public class IdGeneratorImplTest
         catch ( UnderlyingStorageException e )
         {   // OK
         }
+    }
+
+    @Test
+    public void correctDefragCountWhenHaveIdsInFile()
+    {
+        IdGeneratorImpl.createGenerator( fsr.get(), file );
+        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, true, 100 );
+
+        idGenerator.freeId( 5 );
+        idGenerator.close();
+
+        IdGenerator reloadedIdGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, true, 100 );
+        assertEquals( 1, reloadedIdGenerator.getDefragCount() );
+        assertEquals( 5, reloadedIdGenerator.nextId() );
+        assertEquals( 0, reloadedIdGenerator.getDefragCount() );
     }
 
     @Test

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -180,6 +180,7 @@ class BackupService
                     logger.flush();
                 }
             }
+            removeIdFiles( targetDirectory );
             return new BackupOutcome( lastCommittedTx, consistent );
         }
         catch ( IOException e )
@@ -219,6 +220,7 @@ class BackupService
                 targetDb.shutdown();
             }
             bumpMessagesDotLogFile( targetDirectory, backupStartTime );
+            removeIdFiles( targetDirectory );
             return outcome;
         }
         catch ( IOException e )
@@ -402,6 +404,18 @@ class BackupService
             kernelExtensions.add( factory );
         }
         return kernelExtensions;
+    }
+
+    private void removeIdFiles( String targetDirectory )
+    {
+        File dbDirectory = new File( targetDirectory );
+        for ( File file : fileSystem.listFiles( dbDirectory ) )
+        {
+            if ( !fileSystem.isDirectory( file ) && file.getName().endsWith( ".id" ) )
+            {
+                fileSystem.deleteFile( file );
+            }
+        }
     }
 
     private static class ProgressTxHandler implements TxHandler

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -34,11 +34,16 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.com.storecopy.StoreCopyServer;
+import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
@@ -77,6 +82,7 @@ import org.neo4j.test.EmbeddedDatabaseRule;
 import org.neo4j.test.Mute;
 import org.neo4j.test.TargetDirectory;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -87,13 +93,11 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.neo4j.backup.BackupServiceStressTestingBuilder.untilTimeExpired;
 
 public class BackupServiceIT
 {
+
     private static final class StoreSnoopingMonitor extends StoreCopyServer.Monitor.Adapter
     {
         private final Barrier barrier;
@@ -184,6 +188,102 @@ public class BackupServiceIT
         }
 
         assertEquals( DbRepresentation.of( storeDir ), DbRepresentation.of( backupDir ) );
+    }
+
+    /*
+     * During incremental backup destination db should not track free ids independently from source db
+     * for now we will always cleanup id files generated after incremental backup and will regenerate them afterwards
+     * This should prevent situation when destination db free id following master, but never allocates it from
+     * generator till some db will be started on top of it.
+     * That will cause all sorts of problems with several entities in a store with same id.
+     *
+     * As soon as backup will be able to align ids between participants please remove description and adapt test.
+     */
+    @Test
+    public void incrementallyBackupDatabaseShouldNotKeepGeneratedIdFiles()
+    {
+        defaultBackupPortHostParams();
+        GraphDatabaseAPI graphDatabase = dbRule.getGraphDatabaseAPI();
+        Label markerLabel = DynamicLabel.label( "marker" );
+
+        try ( Transaction transaction = graphDatabase.beginTx() )
+        {
+            Node node = graphDatabase.createNode();
+            node.addLabel( markerLabel );
+            transaction.success();
+        }
+
+        try ( Transaction transaction = graphDatabase.beginTx() )
+        {
+            Node node = findNodeByLabel( graphDatabase, markerLabel );
+            for ( int i = 0; i < 10; i++ )
+            {
+                node.setProperty( "property" + i, "testValue" + i );
+            }
+            transaction.success();
+        }
+        // propagate to backup node and properties
+        doIncrementalBackupOrFallbackToFull();
+
+        // removing properties will free couple of ids that will be reused during next properties creation
+        try ( Transaction transaction = graphDatabase.beginTx() )
+        {
+            Node node = findNodeByLabel( graphDatabase, markerLabel );
+            for ( int i = 0; i < 6; i++ )
+            {
+                node.removeProperty( "property" + i );
+            }
+
+            transaction.success();
+        }
+
+        // propagate removed properties
+        doIncrementalBackupOrFallbackToFull();
+
+        try ( Transaction transaction = graphDatabase.beginTx() )
+        {
+            Node node = findNodeByLabel( graphDatabase, markerLabel );
+            for ( int i = 10; i < 16; i++ )
+            {
+                node.setProperty( "property" + i, "updatedValue" + i );
+            }
+
+            transaction.success();
+        }
+
+        // propagate to backup new properties with reclaimed ids
+        doIncrementalBackupOrFallbackToFull();
+
+        // it should be possible to at this point to start db based on our backup and create couple of properties
+        // their ids should not clash with already existing
+        GraphDatabaseService backupBasedDatabase =
+                new GraphDatabaseFactory().newEmbeddedDatabase( backupDir.getAbsolutePath() );
+        try
+        {
+            try ( Transaction transaction = backupBasedDatabase.beginTx() )
+            {
+                Node node = findNodeByLabel( (GraphDatabaseAPI) backupBasedDatabase, markerLabel );
+                Iterable<String> propertyKeys = node.getPropertyKeys();
+                for ( String propertyKey : propertyKeys )
+                {
+                    node.setProperty( propertyKey, "updatedClientValue" + propertyKey );
+                }
+                node.setProperty( "newProperty", "updatedClientValue" );
+                transaction.success();
+            }
+
+            try ( Transaction transaction = backupBasedDatabase.beginTx() )
+            {
+                Node node = findNodeByLabel( (GraphDatabaseAPI) backupBasedDatabase, markerLabel );
+                // newProperty + 10 defined properties.
+                assertEquals( "We should be able to see all previously defined properties.",
+                        11, Iterables.toList( node.getPropertyKeys() ).size() );
+            }
+        }
+        finally
+        {
+            backupBasedDatabase.shutdown();
+        }
     }
 
     @Test
@@ -692,6 +792,21 @@ public class BackupServiceIT
         for ( File log : fileSystem.listFiles( backupDir, LogFiles.FILENAME_FILTER ) )
         {
             fileSystem.deleteFile( log );
+        }
+    }
+
+    private void doIncrementalBackupOrFallbackToFull()
+    {
+        BackupService backupService = backupService();
+        backupService.doIncrementalBackupOrFallbackToFull( BACKUP_HOST, backupPort,
+                backupDir.getAbsolutePath(), false, new Config(), BackupClient.BIG_READ_TIMEOUT, false );
+    }
+
+    private Node findNodeByLabel( GraphDatabaseAPI graphDatabase, Label label )
+    {
+        try ( ResourceIterator<Node> nodes = graphDatabase.findNodes( label ) )
+        {
+            return nodes.next();
         }
     }
 }


### PR DESCRIPTION
As part of incremental backup we will apply transaction from source db and will free up ids that become free on a source db.
In case if source will reuse those ids and will send them as part of next incremental backup batch
backup db will still assume those ids are free and will reuse them on some point.
That will eventually create duplicated entities in corresponding stores.
For now we will always remove id files that were generated during incremental backup to prevent that case.

Also introduce new parameter 'full-id-generator-rebuild' to backup tool that will allow
full id files rebuild as part of backup.
