### PR TITLE
Remove legacy auto indexing settings from default config

### DIFF
--- a/community/embedded-examples/src/test/resources/neo4j.properties
+++ b/community/embedded-examples/src/test/resources/neo4j.properties
@@ -20,20 +20,6 @@
 # as: "7 days" or "100M size" instead of "true".
 keep_logical_logs=true
 
-# Autoindexing
-
-# Enable auto-indexing for nodes, default is false.
-#node_auto_indexing=true
-
-# The node property keys to be auto-indexed, if enabled.
-#node_keys_indexable=name,age
-
-# Enable auto-indexing for relationships, default is false.
-#relationship_auto_indexing=true
-
-# The relationship property keys to be auto-indexed, if enabled.
-#relationship_keys_indexable=name,age
-
 # Enable shell server so that remote clients can connect via Neo4j shell.
 #remote_shell_enabled=true
 # The network interface IP the shell will listen on (use 0.0.0 for all interfaces).

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.properties
@@ -20,20 +20,6 @@
 # as: "7 days" or "100M size" instead of "true".
 #keep_logical_logs=7 days
 
-# Autoindexing
-
-# Enable auto-indexing for nodes, default is false.
-#node_auto_indexing=true
-
-# The node property keys to be auto-indexed, if enabled.
-#node_keys_indexable=name,age
-
-# Enable auto-indexing for relationships, default is false.
-#relationship_auto_indexing=true
-
-# The relationship property keys to be auto-indexed, if enabled.
-#relationship_keys_indexable=name,age
-
 # Enable shell server so that remote clients can connect via Neo4j shell.
 #remote_shell_enabled=true
 # The network interface IP the shell will listen on (use 0.0.0 for all interfaces).

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -26,20 +26,6 @@
 # as: "7 days" or "100M size" instead of "true".
 #keep_logical_logs=7 days
 
-# Autoindexing
-
-# Enable auto-indexing for nodes, default is false.
-#node_auto_indexing=true
-
-# The node property keys to be auto-indexed, if enabled.
-#node_keys_indexable=name,age
-
-# Enable auto-indexing for relationships, default is false.
-#relationship_auto_indexing=true
-
-# The relationship property keys to be auto-indexed, if enabled.
-#relationship_keys_indexable=name,age
-
 # Enable shell server so that remote clients can connect via Neo4j shell.
 #remote_shell_enabled=true
 # The network interface IP the shell will listen on (use 0.0.0 for all interfaces).

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -26,20 +26,6 @@
 # as: "7 days" or "100M size" instead of "true".
 #keep_logical_logs=7 days
 
-# Autoindexing
-
-# Enable auto-indexing for nodes, default is false.
-#node_auto_indexing=true
-
-# The node property keys to be auto-indexed, if enabled.
-#node_keys_indexable=name,age
-
-# Enable auto-indexing for relationships, default is false.
-#relationship_auto_indexing=true
-
-# The relationship property keys to be auto-indexed, if enabled.
-#relationship_keys_indexable=name,age
-
 # Enable shell server so that remote clients can connect via Neo4j shell.
 #remote_shell_enabled=true
 # The network interface IP the shell will listen on (use 0.0.0 for all interfaces).

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -26,20 +26,6 @@
 # as: "7 days" or "100M size" instead of "true".
 #keep_logical_logs=7 days
 
-# Autoindexing
-
-# Enable auto-indexing for nodes, default is false.
-#node_auto_indexing=true
-
-# The node property keys to be auto-indexed, if enabled.
-#node_keys_indexable=name,age
-
-# Enable auto-indexing for relationships, default is false.
-#relationship_auto_indexing=true
-
-# The relationship property keys to be auto-indexed, if enabled.
-#relationship_keys_indexable=name,age
-
 # Enable shell server so that remote clients can connect via Neo4j shell.
 #remote_shell_enabled=true
 # The network interface IP the shell will listen on (use 0.0.0 for all interfaces).


### PR DESCRIPTION
As the legacy auto indexes are no longer recommended, and we instead recommend using schema indexes, this PR removes the related settings from the default configuration files.
