### PR TITLE
LOAD CSV also detects and uses BOM in file header

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/Magic.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Magic.java
@@ -121,6 +121,11 @@ public class Magic
         return NONE;
     }
 
+    public static int longest()
+    {
+        return LONGEST;
+    }
+
     private final String description;
     private final Charset encoding;
     private final byte[] bytes;

--- a/community/cypher/cypher-compiler-2.3/src/main/java/org/neo4j/cypher/internal/compiler/v2_3/executionplan/GeneratedQuery.java
+++ b/community/cypher/cypher-compiler-2.3/src/main/java/org/neo4j/cypher/internal/compiler/v2_3/executionplan/GeneratedQuery.java
@@ -26,7 +26,6 @@ import org.neo4j.cypher.internal.compiler.v2_3.TaskCloser;
 import org.neo4j.cypher.internal.compiler.v2_3.codegen.QueryExecutionTracer;
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription;
 import org.neo4j.function.Supplier;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.core.NodeManager;
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/CSVResources.scala
@@ -21,14 +21,13 @@ package org.neo4j.cypher.internal.compiler.v2_3.spi
 
 import java.io._
 import java.net.{CookieHandler, CookieManager, CookiePolicy, URL}
-
 import org.neo4j.csv.reader._
 import org.neo4j.cypher.internal.compiler.v2_3.TaskCloser
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.ExternalResource
 import org.neo4j.cypher.internal.frontend.v2_3.LoadExternalResourceException
-
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.Breaks._
+import java.nio.charset.Charset
 
 object CSVResources {
   val DEFAULT_FIELD_TERMINATOR: Char = ','
@@ -48,9 +47,7 @@ class CSVResources(cleaner: TaskCloser) extends ExternalResource {
 
   def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]] = {
     val inputStream = openStream(url)
-    val reader = Readables.wrap(new InputStreamReader(inputStream, "UTF-8") {
-      override def toString = url.toString
-    })
+    val reader = Readables.wrap( inputStream, url.toString(), Charset.forName( "UTF-8" ) )
     val delimiter: Char = fieldTerminator.map(_.charAt(0)).getOrElse(CSVResources.DEFAULT_FIELD_TERMINATOR)
     val seeker = CharSeekers.charSeeker(reader, CSVResources.defaultConfig, true)
     val extractor = new Extractors(delimiter).string()


### PR DESCRIPTION
Previously only Readables.files(File...) did this. Now introducing
Readables.wrap(InputStream) w/ possibility to also specify default charset
if there's no BOM, otherwise the BOM controls the charset.
