### PR TITLE
Always record notifications

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticChecker.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/SemanticChecker.scala
@@ -23,13 +23,10 @@ import org.neo4j.cypher.internal.frontend.v2_3._
 import org.neo4j.cypher.internal.frontend.v2_3.ast.Statement
 
 class SemanticChecker {
-  def check(queryText: String, statement: Statement, notificationLogger: InternalNotificationLogger = devNullLogger,
+  def check(queryText: String, statement: Statement,
             mkException: (String, InputPosition) => CypherException): SemanticState = {
 
     val SemanticCheckResult(semanticState, semanticErrors) = statement.semanticCheck(SemanticState.clean)
-
-    // TODO: Actually replace this mutable-state logger with an immutable structure
-    semanticState.notifications.foreach(notificationLogger += _)
 
     val scopeTreeIssues = ScopeTreeVerifier.verify(semanticState.scopeTree)
     if (scopeTreeIssues.nonEmpty)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -53,7 +53,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
         ast
 
     val semanticChecker = new SemanticChecker
-    val semanticState = semanticChecker.check(query, cleanedStatement, devNullLogger, mkException)
+    val semanticState = semanticChecker.check(query, cleanedStatement, mkException)
     val statement = astRewriter.rewrite(query, cleanedStatement, semanticState)._1
     val semanticTable: SemanticTable = SemanticTable(types = semanticState.typeTable)
     val (rewrittenAst: Statement, _) = CostBasedExecutablePlanBuilder.rewriteStatement(statement, semanticState.scopeTree, semanticTable, RewriterStepSequencer.newValidating, semanticChecker, Set.empty, mock[AstRewritingMonitor])

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/RewriteTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/RewriteTest.scala
@@ -36,7 +36,7 @@ trait RewriteTest {
     val original = parseForRewriting(originalQuery)
     val expected = parseForRewriting(expectedQuery)
     val mkException = new SyntaxExceptionCreator(originalQuery, Some(DummyPosition(0)))
-    semanticChecker.check(originalQuery, original, devNullLogger, mkException)
+    semanticChecker.check(originalQuery, original, mkException)
 
     val result = rewrite(original)
     assert(result === expected, "\n" + originalQuery)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport.scala
@@ -174,11 +174,11 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
   def produceLogicalPlan(queryText: String)(implicit planner: CostBasedExecutablePlanBuilder, planContext: PlanContext): LogicalPlan = {
     val parsedStatement = parser.parse(queryText)
     val mkException = new SyntaxExceptionCreator(queryText, Some(pos))
-    val semanticState = semanticChecker.check(queryText, parsedStatement, devNullLogger, mkException)
+    val semanticState = semanticChecker.check(queryText, parsedStatement, mkException)
     val (rewrittenStatement, _, postConditions) = astRewriter.rewrite(queryText, parsedStatement, semanticState)
     CostBasedExecutablePlanBuilder.rewriteStatement(rewrittenStatement, semanticState.scopeTree, SemanticTable(types = semanticState.typeTable), rewriterSequencer, semanticChecker, postConditions, monitors.newMonitor[AstRewritingMonitor]()) match {
       case (ast: Query, newTable) =>
-        val semanticState = semanticChecker.check(queryText, ast, devNullLogger, mkException)
+        val semanticState = semanticChecker.check(queryText, ast, mkException)
         tokenResolver.resolve(ast)(newTable, planContext)
         val (logicalPlan, _) = planner.produceLogicalPlan(ast, newTable)(planContext, devNullLogger)
         logicalPlan

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
@@ -149,9 +149,9 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
       val parsedStatement = parser.parse(queryString)
       val mkException = new SyntaxExceptionCreator(queryString, Some(pos))
       val cleanedStatement: Statement = parsedStatement.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
-      val semanticState = semanticChecker.check(queryString, cleanedStatement, devNullLogger, mkException)
+      val semanticState = semanticChecker.check(queryString, cleanedStatement, mkException)
       val (rewrittenStatement, _, postConditions) = astRewriter.rewrite(queryString, cleanedStatement, semanticState)
-      val postRewriteSemanticState = semanticChecker.check(queryString, rewrittenStatement, devNullLogger, mkException)
+      val postRewriteSemanticState = semanticChecker.check(queryString, rewrittenStatement, mkException)
       val semanticTable = SemanticTable(types = postRewriteSemanticState.typeTable)
       CostBasedExecutablePlanBuilder.rewriteStatement(rewrittenStatement, postRewriteSemanticState.scopeTree, semanticTable, rewriterSequencer, semanticChecker, postConditions, mock[AstRewritingMonitor]) match {
         case (ast: Query, newTable) =>
@@ -169,7 +169,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
     def getLogicalPlanFor(queryString: String): (LogicalPlan, SemanticTable) = {
       val parsedStatement = parser.parse(queryString)
       val mkException = new SyntaxExceptionCreator(queryString, Some(pos))
-      val semanticState = semanticChecker.check(queryString, parsedStatement, devNullLogger, mkException)
+      val semanticState = semanticChecker.check(queryString, parsedStatement, mkException)
       val (rewrittenStatement, _, postConditions) = astRewriter.rewrite(queryString, parsedStatement, semanticState)
 
       val table = SemanticTable(types = semanticState.typeTable, recordedScopes = semanticState.recordedScopes)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryGraphProducer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryGraphProducer.scala
@@ -38,7 +38,7 @@ trait QueryGraphProducer extends MockitoSugar {
     val mkException = new SyntaxExceptionCreator(query, Some(pos))
     val semanticChecker = new SemanticChecker
     val cleanedStatement: Statement = ast.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
-    val semanticState = semanticChecker.check(query, cleanedStatement, devNullLogger, mkException)
+    val semanticState = semanticChecker.check(query, cleanedStatement, mkException)
 
     val (firstRewriteStep, _, postConditions) = astRewriter.rewrite(query, cleanedStatement, semanticState)
     val semanticTable = SemanticTable(types = semanticState.typeTable, recordedScopes = semanticState.recordedScopes)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -138,4 +138,12 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     result.notifications shouldBe empty
   }
+
+  test("Warnings should work on potentially cached queries") {
+    val resultWithoutExplain = executeWithAllPlannersAndRuntimes("match (a)-->(b), (c)-->(d) return *")
+    val resultWithExplain = executeWithAllPlannersAndRuntimes("explain match (a)-->(b), (c)-->(d) return *")
+
+    resultWithoutExplain shouldBe empty
+    resultWithExplain.notifications.toList should equal(List(CartesianProductNotification(InputPosition(0, 1, 1), Set("c", "d"))))
+  }
 }


### PR DESCRIPTION
Notifications were only recorded when using `EXPLAIN`, this caused issues with cached plans and this PR
changes so that notifications are always recorded. Note, however we still only return the notifications for
queries starting with `EXPLAIN`.
