### PR TITLE
LOAD CSV also detects and uses BOM in file header (backport of #5220 to 2.2)

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/Magic.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Magic.java
@@ -121,6 +121,11 @@ public class Magic
         return NONE;
     }
 
+    public static int longest()
+    {
+        return LONGEST;
+    }
+
     private final String description;
     private final Charset encoding;
     private final byte[] bytes;

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Readables.java
@@ -24,9 +24,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PushbackInputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
@@ -75,6 +77,36 @@ public class Readables
             return "EMPTY";
         }
     };
+
+    public static CharReadable wrap( final InputStream stream, final String sourceName, Charset charset )
+            throws IOException
+    {
+        byte[] bytes = new byte[Magic.longest()];
+        PushbackInputStream pushbackStream = new PushbackInputStream( stream, bytes.length );
+        Charset usedCharset = charset;
+        int read = stream.read( bytes );
+        if ( read >= 0 )
+        {
+            bytes = read < bytes.length ? Arrays.copyOf( bytes, read ) : bytes;
+            Magic magic = Magic.of( bytes );
+            int excessiveBytes = read;
+            if ( magic.impliesEncoding() )
+            {
+                // Unread the diff between the BOM and the longest magic we gathered bytes for
+                excessiveBytes -= magic.length();
+                usedCharset = magic.encoding();
+            }
+            pushbackStream.unread( bytes, read - excessiveBytes, excessiveBytes );
+        }
+        return wrap( new InputStreamReader( pushbackStream, usedCharset )
+        {
+            @Override
+            public String toString()
+            {
+                return sourceName;
+            }
+        } );
+    }
 
     /**
      * Remember that the {@link Reader#toString()} must provide a description of the data source.

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResources.scala
@@ -21,10 +21,11 @@ package org.neo4j.cypher.internal.compiler.v2_2.spi
 
 import java.io._
 import java.net.{CookieHandler, CookieManager, CookiePolicy, URL}
+import java.nio.charset.Charset
 
 import org.neo4j.csv.reader._
-import org.neo4j.cypher.internal.compiler.v2_2.{LoadExternalResourceException, TaskCloser}
 import org.neo4j.cypher.internal.compiler.v2_2.pipes.ExternalResource
+import org.neo4j.cypher.internal.compiler.v2_2.{LoadExternalResourceException, TaskCloser}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.Breaks._
@@ -47,9 +48,7 @@ class CSVResources(cleaner: TaskCloser) extends ExternalResource {
 
   def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]] = {
     val inputStream = openStream(url)
-    val reader = Readables.wrap(new InputStreamReader(inputStream, "UTF-8") {
-      override def toString = url.toString
-    })
+    val reader = Readables.wrap( inputStream, url.toString(), Charset.forName( "UTF-8" ) )
     val delimiter: Char = fieldTerminator.map(_.charAt(0)).getOrElse(CSVResources.DEFAULT_FIELD_TERMINATOR)
     val seeker = CharSeekers.charSeeker(reader, CSVResources.defaultConfig, true)
     val extractor = new Extractors(delimiter).string()


### PR DESCRIPTION
Previously only Readables.files(File...) did this. Now introducing
Readables.wrap(InputStream) w/ possibility to also specify default charset
if there's no BOM, otherwise the BOM controls the charset.
