### PR TITLE
Warnings for dynamic property index lookups

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/NonSargable.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/NonSargable.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans
+
+import org.neo4j.cypher.internal.frontend.v2_3.ast._
+import org.neo4j.cypher.internal.frontend.v2_3.parser.{LikePatternOp, LikePatternParser, MatchText, WildcardLikePatternOp}
+
+// This is when dynamic properties are used
+object AsDynamicPropertyNonSeekable {
+  def unapply(v: Any) = v match {
+    case WithSeekableArgs(prop@ContainerIndex(identifier: Identifier, _), _) =>
+      Some(identifier)
+    case _ =>
+      None
+  }
+}
+
+// This is when dynamic properties are used
+object AsDynamicPropertyNonScannable {
+  def unapply(v: Any) = v match {
+
+    case func@FunctionInvocation(_, _, IndexedSeq(ContainerIndex(identifier: Identifier, _)))
+      if func.function.contains(functions.Has) =>
+      Some(identifier)
+
+    case Equals(ContainerIndex(identifier: Identifier, _), _) =>
+      Some(identifier)
+
+    case expr: InequalityExpression =>
+      expr.lhs match {
+        case ContainerIndex(identifier: Identifier, _) => Some(identifier)
+        case _ => None
+      }
+
+    case Like(ContainerIndex(identifier: Identifier, _), _, _) =>
+      Some(identifier)
+
+    case RegexMatch(ContainerIndex(identifier: Identifier, _), _) =>
+      Some(identifier)
+
+    case NotEquals(ContainerIndex(identifier: Identifier, _), _) =>
+      Some(identifier)
+
+    case _ =>
+      None
+  }
+}
+
+// This is when dynamic properties are used
+object AsStringRangeNonSeekable {
+  def unapply(v: Any) = v match {
+    case like@Like(prop@ContainerIndex(identifier: Identifier, _), LikePattern(lit@StringLiteral(value)), _)
+      if !like.caseInsensitive && isPrefixPattern(value) =>
+      Some(identifier)
+    case _ =>
+      None
+  }
+
+  def isPrefixPattern(literal: String): Boolean = {
+    val ops: List[LikePatternOp] = LikePatternParser(literal).compact.ops
+    ops match {
+      case MatchText(prefix) :: (_: WildcardLikePatternOp) :: tl => true
+      case _ => false
+    }
+  }
+}
+
+// This is when dynamic properties are used
+object AsValueRangeNonSeekable {
+  def unapply(v: Any) = v match {
+    case GreaterThan(prop@ContainerIndex(identifier: Identifier, _), _) =>
+      Some(identifier)
+    case GreaterThan(_, prop@ContainerIndex(identifier: Identifier, _)) =>
+      Some(identifier)
+
+    case GreaterThanOrEqual(prop@ContainerIndex(identifier: Identifier, _), _) =>
+      Some(identifier)
+    case GreaterThanOrEqual(_, prop@ContainerIndex(identifier: Identifier, _)) =>
+      Some(identifier)
+
+    case LessThan(prop@ContainerIndex(identifier: Identifier, _), _) =>
+      Some(identifier)
+    case LessThan(_, prop@ContainerIndex(identifier: Identifier, _)) =>
+      Some(identifier)
+
+    case LessThanOrEqual(prop@ContainerIndex(identifier: Identifier, _), _) =>
+      Some(identifier)
+    case LessThanOrEqual(_, prop@ContainerIndex(identifier: Identifier, _)) =>
+      Some(identifier)
+
+    case _ =>
+      None
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/DynamicPropertyNotifier.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/DynamicPropertyNotifier.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps
+
+import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.LogicalPlanningContext
+import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.IdName
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{Identifier, LabelName}
+import org.neo4j.cypher.internal.frontend.v2_3.notification.InternalNotification
+
+object DynamicPropertyNotifier {
+
+  def process(identifiers: Set[Identifier], notification: Set[String] => InternalNotification, qg: QueryGraph)
+             (implicit context: LogicalPlanningContext) = {
+
+    val indexedLabels = identifiers.flatMap { identifier =>
+      val labels = qg.selections.labelsOnNode(IdName(identifier.name))
+      labels.filter(withIndex)
+    }
+
+    if (indexedLabels.nonEmpty) {
+      val indexedLabelNames = indexedLabels.map(_.name)
+      context.notificationLogger.log(notification(indexedLabelNames))
+    }
+  }
+
+  private def withIndex(labelName: LabelName)(implicit context: LogicalPlanningContext) =
+    context.planContext.hasIndexRule(labelName.name)
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/IndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/IndexSeekLeafPlanner.scala
@@ -19,11 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps
 
-import org.neo4j.cypher.internal.frontend.v2_3.ast._
-import org.neo4j.cypher.internal.compiler.v2_3.commands.{ManyQueryExpression, QueryExpression}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.QueryExpression
 import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
+import org.neo4j.cypher.internal.frontend.v2_3.ast._
+import org.neo4j.cypher.internal.frontend.v2_3.notification.IndexSeekUnfulfillableNotification
 import org.neo4j.kernel.api.index.IndexDescriptor
 
 
@@ -53,7 +54,7 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner {
 
     val arguments = qg.argumentIds.map(n => Identifier(n.name)(null))
 
-    predicates.collect {
+    val resultPlans = predicates.collect {
       // n.prop IN [ ... ]
       case predicate@AsPropertySeekable(seekable)
         if seekable.args.dependencies.forall(arguments) && !arguments(seekable.ident) =>
@@ -67,7 +68,30 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner {
       case predicate@AsValueRangeSeekable(seekable) =>
         producePlanFor(seekable.name, seekable.propertyKeyName, predicate, seekable.asQueryExpression)
     }.flatten
+
+    if (resultPlans.isEmpty) {
+      DynamicPropertyNotifier.process(findNonSeekableIdentifiers(predicates), IndexSeekUnfulfillableNotification, qg)
+    }
+
+    resultPlans
   }
+
+  private def findNonSeekableIdentifiers(predicates: Seq[Expression])(implicit context: LogicalPlanningContext) =
+    predicates.flatMap {
+      // n['some' + n.prop] IN [ ... ]
+      case predicate@AsDynamicPropertyNonSeekable(nonSeekableId)
+        if context.semanticTable.isNode(nonSeekableId) => Some(nonSeekableId)
+
+      // n['some' + n.prop] LIKE "prefix%..."
+      case predicate@AsStringRangeNonSeekable(nonSeekableId)
+        if context.semanticTable.isNode(nonSeekableId) => Some(nonSeekableId)
+
+      // n['some' + n.prop] <|<=|>|>= value
+      case predicate@AsValueRangeNonSeekable(nonSeekableId)
+        if context.semanticTable.isNode(nonSeekableId) => Some(nonSeekableId)
+
+      case _ => None
+    }.toSet
 
   protected def constructPlan(idName: IdName,
                               label: LabelToken,
@@ -76,8 +100,6 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner {
                               hint: Option[UsingIndexHint],
                               argumentIds: Set[IdName])
                              (implicit context: LogicalPlanningContext): (Seq[Expression]) => LogicalPlan
-
-
 
   protected def findIndexesFor(label: String, property: String)(implicit context: LogicalPlanningContext): Option[IndexDescriptor]
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/PlanContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/PlanContext.scala
@@ -33,6 +33,8 @@ trait PlanContext extends TokenContext {
 
   def getIndexRule(labelName: String, propertyKey: String): Option[IndexDescriptor]
 
+  def hasIndexRule(labelName: String): Boolean
+
   def getUniqueIndexRule(labelName: String, propertyKey: String): Option[IndexDescriptor]
 
   def getUniquenessConstraint(labelName: String, propertyKey: String): Option[UniquenessConstraint]

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
@@ -115,6 +115,9 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
         else
           None
 
+      def hasIndexRule(labelName: String): Boolean =
+        config.indexes.exists(_._1 == labelName) || config.uniqueIndexes.exists(_._1 == labelName)
+
       def getOptPropertyKeyId(propertyKeyName: String) =
         semanticTable.resolvedPropertyKeyNames.get(propertyKeyName).map(_.id)
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -302,6 +302,10 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
       NotificationCode.JOIN_HINT_UNFULFILLABLE.notification(InputPosition.empty, NotificationDetail.Factory.joinKey(identifiers.asJava))
     case JoinHintUnsupportedNotification(identifiers) =>
       NotificationCode.JOIN_HINT_UNSUPPORTED.notification(InputPosition.empty, NotificationDetail.Factory.joinKey(identifiers.asJava))
+    case IndexSeekUnfulfillableNotification(labels) =>
+      NotificationCode.INDEX_SEEK_FOR_DYNAMIC_PROPERTY.notification(InputPosition.empty, NotificationDetail.Factory.indexSeekOrScan(labels.asJava))
+    case IndexScanUnfulfillableNotification(labels) =>
+      NotificationCode.INDEX_SCAN_FOR_DYNAMIC_PROPERTY.notification(InputPosition.empty, NotificationDetail.Factory.indexSeekOrScan(labels.asJava))
     case BareNodeSyntaxDeprecatedNotification(pos) =>
       NotificationCode.BARE_NODE_SYNTAX_DEPRECATED.notification(pos.asInputPosition)
   }

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
@@ -42,4 +42,8 @@ case class JoinHintUnfulfillableNotification(identified: Seq[String]) extends In
 
 case class JoinHintUnsupportedNotification(identified: Seq[String]) extends InternalNotification
 
+case class IndexSeekUnfulfillableNotification(labels: Set[String]) extends InternalNotification
+
+case class IndexScanUnfulfillableNotification(labels: Set[String]) extends InternalNotification
+
 case class BareNodeSyntaxDeprecatedNotification(position: InputPosition) extends InternalNotification

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -74,6 +74,16 @@ public enum NotificationCode
         Status.Statement.DeprecationWarning,
         "Using 'length' on anything that is not a path is deprecated, please use 'size' instead"
     ),
+    INDEX_SEEK_FOR_DYNAMIC_PROPERTY(
+        SeverityLevel.WARNING,
+        Status.Statement.DynamicPropertyWarning,
+        "Using a dynamic property makes it impossible to use an index seek for this query"
+    ),
+    INDEX_SCAN_FOR_DYNAMIC_PROPERTY(
+        SeverityLevel.WARNING,
+        Status.Statement.DynamicPropertyWarning,
+        "Using a dynamic property makes it impossible to use an index scan for this query"
+    ),
     BARE_NODE_SYNTAX_DEPRECATED(
         SeverityLevel.WARNING,
         Status.Statement.DeprecationWarning,

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
@@ -62,18 +62,29 @@ public interface NotificationDetail
 
         public static NotificationDetail cartesianProduct( Set<String> identifiers )
         {
+            return createNotificationDetail( identifiers, "identifier", "identifiers" );
+        }
+
+        public static NotificationDetail indexSeekOrScan( Set<String> labels )
+        {
+            return createNotificationDetail( labels, "indexed label", "indexed labels" );
+        }
+
+        private static NotificationDetail createNotificationDetail( Set<String> elements, String singularTerm,
+                String pluralTerm )
+        {
             StringBuilder builder = new StringBuilder();
             builder.append( "(" );
             String separator = "";
-            for ( String identifier : identifiers )
+            for ( String element : elements )
             {
                 builder.append( separator );
-                builder.append( identifier );
+                builder.append( element );
                 separator = ", ";
             }
             builder.append( ")" );
-            boolean singular = identifiers.size() == 1;
-            return createNotificationDetail( singular ? "identifier" : "identifiers", builder.toString(), singular );
+            boolean singular = elements.size() == 1;
+            return createNotificationDetail( singular ? singularTerm : pluralTerm, builder.toString(), singular );
         }
 
         private static NotificationDetail createNotificationDetail( final String name, final String value,

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -164,6 +164,8 @@ public interface Status
         DeprecationWarning( ClientNotification, "This feature is deprecated and will be removed in future versions." ),
         JoinHintUnfulfillableWarning( ClientNotification, "The database was unable to plan a hinted join." ),
         JoinHintUnsupportedWarning( ClientNotification, "Queries with join hints are not supported by the RULE planner." ),
+        DynamicPropertyWarning( ClientNotification, "Queries using dynamic properties will use neither index seeks " +
+                                                    "nor index scans for those properties" ),
         ;
 
         private final Code code;


### PR DESCRIPTION
A warning will be issued to the effect that dynamic properties in a query
will use neither an index seek nor an index scan for those properties.

Signed-off-by: @petraselmer
