### PR TITLE
Triadic selection labels and finder

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/TriadicSelectionAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/TriadicSelectionAcceptanceTest.scala
@@ -24,10 +24,24 @@ import org.neo4j.graphdb.Node
 
 import scala.collection.mutable
 
-class TriadicSelectionAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
+/*
+The tests here are all designed to resemble permutations of the triadic case,
+whether or not the current version of Cypher is able to actually use the
+TriadicSelection to solve them. The idea being that we should have a relatively
+exhaustive test suite that verifies that Cypher always returns the correct
+results with or without TriadicSelection, and with both RULE and COST planners,
+and this behaviour should not change as we expand support for TriadicSelection
+to a wider set of queries. For this reason we do not test for the
+TriadicSelection here. For that take a look at TriadicIntegrationTest and
+TriadicSelectionFinderTest.
+ */
+class TriadicSelectionAcceptanceTest extends ExecutionEngineFunSuite
+                                     with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
-  private def makeTriadicModel(relTypeAB1: String = "KNOWS", relTypeAB2: String = "FOLLOWS", relTypeBC: String = "FRIEND",
-                               aLabel: String = "A", bLabel: String = "B", cLabel: String = "C"): Map[String, Node] = {
+  private def makeTriadicModel(relTypeAB1: String = "KNOWS",
+                               relTypeAB2: String = "FOLLOWS", relTypeBC: String = "FRIEND",
+                               aLabel: String = "A", bLabel: String = "X",
+                               cLabel1: String = "X", cLabel2: String = "X"): Map[String, Node] = {
     val nodes = mutable.Map[String, Node]()
     def addNamedNode(name: String, label: String) {
       nodes(name) = createLabeledNode(Map("name" -> name), label)
@@ -37,14 +51,14 @@ class TriadicSelectionAcceptanceTest extends ExecutionEngineFunSuite with QueryS
     addNamedNode("b2", bLabel)
     addNamedNode("b3", bLabel)
     addNamedNode("b4", bLabel)
-    addNamedNode("c11", cLabel)
-    addNamedNode("c12", cLabel)
-    addNamedNode("c21", cLabel)
-    addNamedNode("c22", cLabel)
-    addNamedNode("c31", cLabel)
-    addNamedNode("c32", cLabel)
-    addNamedNode("c41", cLabel)
-    addNamedNode("c42", cLabel)
+    addNamedNode("c11", cLabel1)
+    addNamedNode("c12", cLabel2)
+    addNamedNode("c21", cLabel1)
+    addNamedNode("c22", cLabel2)
+    addNamedNode("c31", cLabel1)
+    addNamedNode("c32", cLabel2)
+    addNamedNode("c41", cLabel1)
+    addNamedNode("c42", cLabel2)
 
     // create relationships to match (a)-->(b)
     relate(nodes("a"), nodes("b1"), relTypeAB1)
@@ -124,7 +138,7 @@ class TriadicSelectionAcceptanceTest extends ExecutionEngineFunSuite with QueryS
     // Given
     val nodes = makeTriadicModel()
     // When
-    val result = executeWithCostPlannerOnly("PROFILE MATCH (a:A)-->(b)-->(c) WHERE NOT (a)-[:KNOWS]->(c) RETURN c.name")
+    val result = executeWithCostPlannerOnly("MATCH (a:A)-->(b)-->(c) WHERE NOT (a)-[:KNOWS]->(c) RETURN c.name")
     // Then
     result.columnAs("c.name").toSet[Node] should equal(Set("c11", "c12", "c21", "c22", "c31", "c32", "c41", "c42", "b3", "b4"))
   }
@@ -133,9 +147,45 @@ class TriadicSelectionAcceptanceTest extends ExecutionEngineFunSuite with QueryS
     // Given
     val nodes = makeTriadicModel()
     // When
-    val result = executeWithAllPlanners("PROFILE MATCH (a:A)-[:KNOWS|FOLLOWS]->(b)-->(c) WHERE NOT (a)-[:KNOWS]->(c) RETURN c.name")
+    val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS|FOLLOWS]->(b)-->(c) WHERE NOT (a)-[:KNOWS]->(c) RETURN c.name")
     // Then
     result.columnAs("c.name").toSet[Node] should equal(Set("c11", "c12", "c21", "c22", "c31", "c32", "c41", "c42", "b3", "b4"))
+  }
+
+  test("should handle triadic friend of a friend that is not a friend with same labels") {
+    // Given
+    val nodes = makeTriadicModel(bLabel = "X", cLabel1 = "X", cLabel2 = "Y")
+    // When
+    val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS]->(b:X)-->(c:X) WHERE NOT (a)-[:KNOWS]->(c) RETURN c.name")
+    // Then
+    result.columnAs("c.name").toSet[Node] should equal(Set("c11", "c21", "b3"))
+  }
+
+  test("should handle triadic friend of a friend that is not a friend with different labels") {
+    // Given
+    val nodes = makeTriadicModel(bLabel = "X", cLabel1 = "X", cLabel2 = "Y")
+    // When
+    val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS]->(b:X)-->(c:Y) WHERE NOT (a)-[:KNOWS]->(c) RETURN c.name")
+    // Then
+    result.columnAs("c.name").toSet[Node] should equal(Set("c12", "c22"))
+  }
+
+  test("should handle triadic friend of a friend that is not a friend with implicit subset of labels") {
+    // Given
+    val nodes = makeTriadicModel(bLabel = "X", cLabel1 = "X", cLabel2 = "Y")
+    // When
+    val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS]->(b)-->(c:X) WHERE NOT (a)-[:KNOWS]->(c) RETURN c.name")
+    // Then
+    result.columnAs("c.name").toSet[Node] should equal(Set("c11", "c21", "b3"))
+  }
+
+  test("should handle triadic friend of a friend that is not a friend with implicit superset of labels") {
+    // Given
+    val nodes = makeTriadicModel(bLabel = "X", cLabel1 = "X", cLabel2 = "Y")
+    // When
+    val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS]->(b:X)-->(c) WHERE NOT (a)-[:KNOWS]->(c) RETURN c.name")
+    // Then
+    result.columnAs("c.name").toSet[Node] should equal(Set("c11", "c12", "c21", "c22", "b3"))
   }
 
   // Positive predicate
@@ -183,6 +233,42 @@ class TriadicSelectionAcceptanceTest extends ExecutionEngineFunSuite with QueryS
     val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS|FOLLOWS]->(b)-->(c) WHERE (a)-[:KNOWS]->(c) RETURN c.name")
     // Then
     result.columnAs("c.name").toSet[Node] should equal(Set("b1", "b2"))
+  }
+
+  test("should handle triadic friend of a friend that is a friend with same labels") {
+    // Given
+    val nodes = makeTriadicModel(bLabel = "X", cLabel1 = "X", cLabel2 = "Y")
+    // When
+    val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS]->(b:X)-->(c:X) WHERE (a)-[:KNOWS]->(c) RETURN c.name")
+    // Then
+    result.columnAs("c.name").toSet[Node] should equal(Set("b2"))
+  }
+
+  test("should handle triadic friend of a friend that is a friend with different labels") {
+    // Given
+    val nodes = makeTriadicModel(bLabel = "X", cLabel1 = "X", cLabel2 = "Y")
+    // When
+    val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS]->(b:X)-->(c:Y) WHERE (a)-[:KNOWS]->(c) RETURN c.name")
+    // Then
+    result.columnAs("c.name").toSet[Node] should equal(Set.empty)
+  }
+
+  test("should handle triadic friend of a friend that is a friend with implicit subset of labels") {
+    // Given
+    val nodes = makeTriadicModel(bLabel = "X", cLabel1 = "X", cLabel2 = "Y")
+    // When
+    val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS]->(b)-->(c:X) WHERE (a)-[:KNOWS]->(c) RETURN c.name")
+    // Then
+    result.columnAs("c.name").toSet[Node] should equal(Set("b2"))
+  }
+
+  test("should handle triadic friend of a friend that is a friend with implicit superset of labels") {
+    // Given
+    val nodes = makeTriadicModel(bLabel = "X", cLabel1 = "X", cLabel2 = "Y")
+    // When
+    val result = executeWithAllPlanners("MATCH (a:A)-[:KNOWS]->(b:X)-->(c) WHERE (a)-[:KNOWS]->(c) RETURN c.name")
+    // Then
+    result.columnAs("c.name").toSet[Node] should equal(Set("b2"))
   }
 
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/DefaultQueryPlannerTest.scala
@@ -78,6 +78,7 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     val plannerQuery = mock[PlannerQuery with CardinalityEstimation]
     when(plannerQuery.preferredStrictness).thenReturn(Some(LazyMode))
     when(plannerQuery.graph).thenReturn(QueryGraph.empty)
+    when(plannerQuery.lastQueryGraph).thenReturn(QueryGraph.empty)
     when(plannerQuery.horizon).thenReturn(RegularQueryProjection())
     when(plannerQuery.lastQueryHorizon).thenReturn(RegularQueryProjection())
     when(plannerQuery.tail).thenReturn(None)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/TriadicIntegrationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/TriadicIntegrationTest.scala
@@ -79,6 +79,141 @@ class TriadicIntegrationTest extends ExecutionEngineFunSuite {
     result should (use("TriadicSelection") and be(empty))
   }
 
+  test("Triadic should support StackOverflow example") {
+    val create_contraints =
+      """
+        |CREATE CONSTRAINT ON (user:User) ASSERT user.neogen_id IS UNIQUE;
+        |CREATE CONSTRAINT ON (p1:Post) ASSERT p1.neogen_id IS UNIQUE;
+        |CREATE CONSTRAINT ON (p2:Post) ASSERT p2.neogen_id IS UNIQUE;
+      """.stripMargin
+
+    val create_model =
+      """
+        |MERGE (n1:User {neogen_id: '8aca6d28a0d2a9e1818bce6b69df6d3266a333bd' }) SET n1.firstname = 'You';
+        |MERGE (n2:User {neogen_id: 'bcd9b073e2d86d6ae2471695bb5980e552fb22bc' }) SET n2.firstname = 'Me';
+        |MERGE (n3:User {neogen_id: '7cc089d52179179c3f92c852b0f7ff60709edb57' }) SET n3.firstname = 'Someone';
+        |MERGE (n4:Post {neogen_id: 'ae47ef9c49274c3ed8de6a71c41936f6f290f947' });
+        |MERGE (n5:Post {neogen_id: '669a6c09b8b4846e48e2184a600d60030c0c43f0' });
+        |MERGE (n6:Post {neogen_id: 'd55657f432e06cfa81ff46044e7763bea0017168' });
+        |MERGE (n7:Post {neogen_id: 'a7e31ed01a6efa333885180c4ce09321ff36c9b3' });
+        |MERGE (n8:Post {neogen_id: '147aa22fa236c464bdc075d0dc00fd41d9f25112' });
+        |MERGE (n9:Post {neogen_id: '5e6479b37697a4bfc4a60b73c1f0c1cab2a90e55' });
+        |MERGE (n10:Post {neogen_id: '8f8cb41236fb3ecc7000e55be4fc571ecfec2462' });
+        |MERGE (n11:Post {neogen_id: '0cdd1458a98dd29912f52f73849ef6021a4a8e8b' });
+        |MERGE (n12:Post {neogen_id: 'be251e3d0f83ac550ed904c345e027504fbeb354' });
+        |MERGE (n13:Post {neogen_id: '65580e5c328d16c3248f77424135d2ec277a14e1' });
+        |MERGE (n14:Post {neogen_id: 'b72543b17d170b65b42359db60cc9df71155fd65' });
+        |MERGE (n15:Post {neogen_id: '5276d8ed757281704ec839089cdc62b508f76017' });
+        |MERGE (n16:Post {neogen_id: 'c7cff71b9c7d2f5d298593fe76281815f3238242' });
+        |MERGE (n17:Post {neogen_id: 'e1addbe6bd91eaaa7f8c6210786779eec9c12746' });
+        |MERGE (n18:Post {neogen_id: '3df095dc1a863d198994329d15a1bd0cdde1dfcd' });
+        |MATCH (s1:User {neogen_id: 'bcd9b073e2d86d6ae2471695bb5980e552fb22bc'}), (e1:Post { neogen_id: 'ae47ef9c49274c3ed8de6a71c41936f6f290f947'})
+        |MERGE (s1)-[edge1:POSTED]->(e1);
+        |MATCH (s2:User {neogen_id: 'bcd9b073e2d86d6ae2471695bb5980e552fb22bc'}), (e2:Post { neogen_id: '669a6c09b8b4846e48e2184a600d60030c0c43f0'})
+        |MERGE (s2)-[edge2:POSTED]->(e2);
+        |MATCH (s3:User {neogen_id: 'bcd9b073e2d86d6ae2471695bb5980e552fb22bc'}), (e3:Post { neogen_id: 'd55657f432e06cfa81ff46044e7763bea0017168'})
+        |MERGE (s3)-[edge3:POSTED]->(e3);
+        |MATCH (s4:User {neogen_id: '8aca6d28a0d2a9e1818bce6b69df6d3266a333bd'}), (e4:Post { neogen_id: 'a7e31ed01a6efa333885180c4ce09321ff36c9b3'})
+        |MERGE (s4)-[edge4:POSTED]->(e4);
+        |MATCH (s5:User {neogen_id: '7cc089d52179179c3f92c852b0f7ff60709edb57'}), (e5:Post { neogen_id: '147aa22fa236c464bdc075d0dc00fd41d9f25112'})
+        |MERGE (s5)-[edge5:POSTED]->(e5);
+        |MATCH (s6:User {neogen_id: '7cc089d52179179c3f92c852b0f7ff60709edb57'}), (e6:Post { neogen_id: '5e6479b37697a4bfc4a60b73c1f0c1cab2a90e55'})
+        |MERGE (s6)-[edge6:POSTED]->(e6);
+        |MATCH (s7:User {neogen_id: '7cc089d52179179c3f92c852b0f7ff60709edb57'}), (e7:Post { neogen_id: '8f8cb41236fb3ecc7000e55be4fc571ecfec2462'})
+        |MERGE (s7)-[edge7:POSTED]->(e7);
+        |MATCH (s8:User {neogen_id: '8aca6d28a0d2a9e1818bce6b69df6d3266a333bd'}), (e8:Post { neogen_id: '0cdd1458a98dd29912f52f73849ef6021a4a8e8b'})
+        |MERGE (s8)-[edge8:POSTED]->(e8);
+        |MATCH (s9:User {neogen_id: 'bcd9b073e2d86d6ae2471695bb5980e552fb22bc'}), (e9:Post { neogen_id: 'be251e3d0f83ac550ed904c345e027504fbeb354'})
+        |MERGE (s9)-[edge9:POSTED]->(e9);
+        |MATCH (s10:User {neogen_id: '8aca6d28a0d2a9e1818bce6b69df6d3266a333bd'}), (e10:Post { neogen_id: '65580e5c328d16c3248f77424135d2ec277a14e1'})
+        |MERGE (s10)-[edge10:POSTED]->(e10);
+        |MATCH (s11:User {neogen_id: '7cc089d52179179c3f92c852b0f7ff60709edb57'}), (e11:Post { neogen_id: 'b72543b17d170b65b42359db60cc9df71155fd65'})
+        |MERGE (s11)-[edge11:POSTED]->(e11);
+        |MATCH (s12:User {neogen_id: '7cc089d52179179c3f92c852b0f7ff60709edb57'}), (e12:Post { neogen_id: '5276d8ed757281704ec839089cdc62b508f76017'})
+        |MERGE (s12)-[edge12:POSTED]->(e12);
+        |MATCH (s13:User {neogen_id: 'bcd9b073e2d86d6ae2471695bb5980e552fb22bc'}), (e13:Post { neogen_id: 'c7cff71b9c7d2f5d298593fe76281815f3238242'})
+        |MERGE (s13)-[edge13:POSTED]->(e13);
+        |MATCH (s14:User {neogen_id: '8aca6d28a0d2a9e1818bce6b69df6d3266a333bd'}), (e14:Post { neogen_id: 'e1addbe6bd91eaaa7f8c6210786779eec9c12746'})
+        |MERGE (s14)-[edge14:POSTED]->(e14);
+        |MATCH (s15:User {neogen_id: '8aca6d28a0d2a9e1818bce6b69df6d3266a333bd'}), (e15:Post { neogen_id: '3df095dc1a863d198994329d15a1bd0cdde1dfcd'})
+        |MERGE (s15)-[edge15:POSTED]->(e15);
+        |MATCH (s16:Post {neogen_id: 'ae47ef9c49274c3ed8de6a71c41936f6f290f947'}), (e16:Post { neogen_id: '5e6479b37697a4bfc4a60b73c1f0c1cab2a90e55'})
+        |MERGE (s16)-[edge16:ANSWER]->(e16);
+        |MATCH (s17:Post {neogen_id: 'ae47ef9c49274c3ed8de6a71c41936f6f290f947'}), (e17:Post { neogen_id: '8f8cb41236fb3ecc7000e55be4fc571ecfec2462'})
+        |MERGE (s17)-[edge17:ANSWER]->(e17);
+        |MATCH (s18:Post {neogen_id: '669a6c09b8b4846e48e2184a600d60030c0c43f0'}), (e18:Post { neogen_id: '0cdd1458a98dd29912f52f73849ef6021a4a8e8b'})
+        |MERGE (s18)-[edge18:ANSWER]->(e18);
+        |MATCH (s19:Post {neogen_id: 'ae47ef9c49274c3ed8de6a71c41936f6f290f947'}), (e19:Post { neogen_id: 'be251e3d0f83ac550ed904c345e027504fbeb354'})
+        |MERGE (s19)-[edge19:ANSWER]->(e19);
+        |MATCH (s20:Post {neogen_id: '669a6c09b8b4846e48e2184a600d60030c0c43f0'}), (e20:Post { neogen_id: '65580e5c328d16c3248f77424135d2ec277a14e1'})
+        |MERGE (s20)-[edge20:ANSWER]->(e20);
+        |MATCH (s21:Post {neogen_id: 'a7e31ed01a6efa333885180c4ce09321ff36c9b3'}), (e21:Post { neogen_id: 'b72543b17d170b65b42359db60cc9df71155fd65'})
+        |MERGE (s21)-[edge21:ANSWER]->(e21);
+        |MATCH (s22:Post {neogen_id: 'a7e31ed01a6efa333885180c4ce09321ff36c9b3'}), (e22:Post { neogen_id: '5276d8ed757281704ec839089cdc62b508f76017'})
+        |MERGE (s22)-[edge22:ANSWER]->(e22);
+        |MATCH (s23:Post {neogen_id: 'ae47ef9c49274c3ed8de6a71c41936f6f290f947'}), (e23:Post { neogen_id: 'c7cff71b9c7d2f5d298593fe76281815f3238242'})
+        |MERGE (s23)-[edge23:ANSWER]->(e23);
+        |MATCH (s24:Post {neogen_id: 'a7e31ed01a6efa333885180c4ce09321ff36c9b3'}), (e24:Post { neogen_id: 'e1addbe6bd91eaaa7f8c6210786779eec9c12746'})
+        |MERGE (s24)-[edge24:ANSWER]->(e24);
+        |MATCH (s25:Post {neogen_id: 'd55657f432e06cfa81ff46044e7763bea0017168'}), (e25:Post { neogen_id: '3df095dc1a863d198994329d15a1bd0cdde1dfcd'})
+        |MERGE (s25)-[edge25:ANSWER]->(e25);
+        |MATCH (n1:User) REMOVE n1.neogen_id;
+        |MATCH (n2:Post) REMOVE n2.neogen_id;
+        |MATCH (n3:Post) REMOVE n3.neogen_id;
+      """.stripMargin
+
+    Seq(create_contraints, create_model) foreach { queries =>
+      queries.split(";").collect {
+        case q if (q.trim.length > 0) => q.trim
+      }.foreach { query =>
+        execute(query)
+      }
+    }
+
+    Map(
+      "non-triadic1" -> Map(
+        "query" -> "MATCH (u:User)-[:POSTED]->(q:Post)-[:ANSWER]->(a:Post)<-[:POSTED]-(u) RETURN u, a",
+        "command" -> "Expand(Into)",
+        "count" -> 3),
+      "non-triadic2" -> Map(
+        "query" -> "MATCH (u:User)-[:POSTED]->(q)-[:ANSWER]->(a)<-[:POSTED]-(u) RETURN u, a",
+        "command" -> "Expand(Into)",
+        "count" -> 3),
+      "triadic-neg1" -> Map(
+        "query" -> "MATCH (u:User)-[:POSTED]->(q:Post)-[:ANSWER]->(a:Post) WHERE NOT (u)-[:POSTED]->(a) RETURN u, a",
+        "command" -> "TriadicSelection",
+        "count" -> 7),
+      "triadic-neg2" -> Map(
+        "query" -> "MATCH (u:User)-[:POSTED]->(q)-[:ANSWER]->(a) WHERE NOT (u)-[:POSTED]->(a) RETURN u, a",
+        "command" -> "TriadicSelection",
+        "count" -> 7),
+      "triadic-neg3" -> Map(
+        "query" -> "MATCH (u:User)-[:POSTED]->(q)-[:ANSWER]->(a:Post) WHERE NOT (u)-[:POSTED]->(a) RETURN u, a",
+        "command" -> "TriadicSelection",
+        "count" -> 7),
+      "triadic-neg4" -> Map(
+        "query" -> "MATCH (u:User)-[:POSTED]->(q:Post)-[:ANSWER]->(a) WHERE NOT (u)-[:POSTED]->(a) RETURN u, a",
+        "command" -> "AntiSemiApply",
+        "count" -> 7),
+      "triadic-pos1" -> Map(
+        "query" -> "MATCH (u:User)-[:POSTED]->(q:Post)-[:ANSWER]->(a:Post) WHERE (u)-[:POSTED]->(a) RETURN u, a",
+        "command" -> "TriadicSelection",
+        "count" -> 3),
+      "triadic-pos2" -> Map(
+        "query" -> "MATCH (u:User)-[:POSTED]->(q)-[:ANSWER]->(a) WHERE (u)-[:POSTED]->(a) RETURN u, a",
+        "command" -> "TriadicSelection",
+        "count" -> 3)
+    ).collect {
+      case (name, config:Map[String,Any]) =>
+        val query = config("query").asInstanceOf[String]
+        val count = config("count").asInstanceOf[Int]
+        val command = config("command").asInstanceOf[String]
+        val result = execute(query)
+        result should haveCount(count)
+        result should use(command)
+    }
+  }
+
   def use(operator: String): Matcher[InternalExecutionResult] = new Matcher[InternalExecutionResult] {
     override def apply(result: InternalExecutionResult): MatchResult = {
       val plan: InternalPlanDescription = result.executionPlanDescription()
@@ -86,6 +221,15 @@ class TriadicIntegrationTest extends ExecutionEngineFunSuite {
         matches = plan.find(operator).nonEmpty,
         rawFailureMessage = s"Plan should use $operator:\n$plan",
         rawNegatedFailureMessage = s"Plan should not use $operator:\n$plan")
+    }
+  }
+
+  def haveCount(count: Int): Matcher[InternalExecutionResult] = new Matcher[InternalExecutionResult] {
+    override def apply(result: InternalExecutionResult): MatchResult = {
+      MatchResult(
+        matches = (count == result.toList.length),
+        rawFailureMessage = s"Result should have $count rows",
+        rawNegatedFailureMessage = s"Plan should not have $count rows")
     }
   }
 }


### PR DESCRIPTION
Triadic selection labels and finder
- Refactored finder to:
  - test predicate pattern first
  - handle labels and label subsets
  - support cases with and without Selection() on either Expand
- Assure mismatching labels are not solved as triadic selection
- Support label subsets to conform to integration test
- Fixed bugs found when testing on SO examples (optional Selection)
