### PR TITLE
Disables auto-parameterization of LIMIT

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/literalReplacement.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/literalReplacement.scala
@@ -37,7 +37,7 @@ object literalReplacement {
   private val literalMatcher: PartialFunction[Any, (LiteralReplacements, LiteralReplacements => LiteralReplacements) => LiteralReplacements] = {
     case _: ast.Match | _: ast.Create | _: ast.CreateUnique | _: ast.Merge | _: ast.SetClause | _: ast.Return | _: ast.With =>
       (acc, children) => children(acc)
-    case _: ast.Clause | _: ast.PeriodicCommitHint =>
+    case _: ast.Clause | _: ast.PeriodicCommitHint | _: ast.Limit =>
       (acc, _) => acc
     case n: ast.NodePattern =>
       (acc, _) => n.properties.treeFold(acc)(literalMatcher)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/LiteralReplacementTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/LiteralReplacementTest.scala
@@ -46,8 +46,8 @@ class LiteralReplacementTest extends CypherFunSuite  {
   test("should extract literals in skip limit clause") {
     assertRewrite(
       s"RETURN 0 as x SKIP 1 limit 2",
-      s"RETURN {`  AUTOINT0`} as x SKIP {`  AUTOINT1`} LIMIT {`  AUTOINT2`}",
-      Map("  AUTOINT0" -> 0, "  AUTOINT1" -> 1, "  AUTOINT2" -> 2)
+      s"RETURN {`  AUTOINT0`} as x SKIP {`  AUTOINT1`} LIMIT 2",
+      Map("  AUTOINT0" -> 0, "  AUTOINT1" -> 1)
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -171,13 +171,19 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     result.executionPlanDescription()
   }
 
-  test("LIMIT should influence cardinality estimation even when auto-parameterized") {
+  test("LIMIT should influence cardinality estimation even when parameterized") {
     (0 until 100).map(i => createLabeledNode("Person"))
-    val result = executeWithAllPlanners(s"PROFILE MATCH (p:Person) RETURN p LIMIT 10")
+    val result = executeWithAllPlanners(s"PROFILE MATCH (p:Person) RETURN p LIMIT {limit}", "limit" -> 10)
     assertEstimatedRows(GraphStatistics.DEFAULT_LIMIT_CARDINALITY.amount.toInt)(result)("Limit")
   }
 
   test("LIMIT should influence cardinality estimation with literal") {
+    (0 until 100).map(i => createLabeledNode("Person"))
+    val result = executeWithAllPlanners(s"PROFILE MATCH (p:Person) RETURN p LIMIT 10")
+    assertEstimatedRows(10)(result)("Limit")
+  }
+
+  test("LIMIT should influence cardinality estimation with literal and parameters") {
     (0 until 100).map(i => createLabeledNode("Person"))
     val result = executeWithAllPlanners(s"PROFILE MATCH (p:Person) WHERE 50 = {fifty} RETURN p LIMIT 10", "fifty" -> 50)
     assertEstimatedRows(10)(result)("Limit")


### PR DESCRIPTION
Since auto-parameterization of LIMIT can cause issues in ronja cost estimates, it is better to not do it. This makes sense primarily when considering that LIMIT literals are usually of a limited set of values, so we are likely to benefit from query cache even without auto-parameterization. The same is not true of SKIP, so that remains auto-parameterized.
