### PR TITLE
Make recovery work when latest tx log file is empty

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
@@ -54,6 +54,7 @@ public class LatestCheckPointFinder
     public LatestCheckPoint find( long fromVersionBackwards ) throws IOException
     {
         long version = fromVersionBackwards;
+        long versionToSearchForCommits = fromVersionBackwards;
         LogEntryStart latestStartEntry = null;
         long oldestVersionFound = -1;
         while ( version >= INITIAL_LOG_VERSION )
@@ -80,7 +81,7 @@ public class LatestCheckPointFinder
                     {
                         latestCheckPoint = entry.as();
                     }
-                    if ( entry instanceof LogEntryStart && ( version == fromVersionBackwards ) )
+                    if ( entry instanceof LogEntryStart && ( version == versionToSearchForCommits ) )
                     {
                         latestStartEntry = entry.as();
                     }
@@ -95,6 +96,12 @@ public class LatestCheckPointFinder
             }
 
             version--;
+
+            // if we have found no commits in the latest log, keep searching in the next one
+            if ( latestStartEntry == null )
+            {
+                versionToSearchForCommits--;
+            }
         }
 
         return new LatestCheckPoint( null, latestStartEntry != null, oldestVersionFound );
@@ -139,6 +146,16 @@ public class LatestCheckPointFinder
             result = 31 * result + (commitsAfterCheckPoint ? 1 : 0);
             result = 31 * result + (int) (oldestLogVersionFound ^ (oldestLogVersionFound >>> 32));
             return result;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "LatestCheckPoint{" +
+                   "checkPoint=" + checkPoint +
+                   ", commitsAfterCheckPoint=" + commitsAfterCheckPoint +
+                   ", oldestLogVersionFound=" + oldestLogVersionFound +
+                   '}';
         }
     }
 }


### PR DESCRIPTION
The problem was that we were wrongly detecting no commits after a checkpointing if the latest tx log file was empty.  This is now fixed by making sure we keep searching for commits in older versions of the
tx log if we don't find any in the latest one.
