### PR TITLE
Deadlock on db shutdown caused by NeoStoreDataSource and CheckPointScheduler waiting for each other.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -257,7 +257,7 @@ public class NeoStoreDataSource implements NeoStoreSupplier, Lifecycle, IndexPro
 
         private final String message;
 
-        private Diagnostics( String message )
+        Diagnostics( String message )
         {
             this.message = message;
         }
@@ -1085,6 +1085,10 @@ public class NeoStoreDataSource implements NeoStoreSupplier, Lifecycle, IndexPro
         // Here we're zooming in and focusing on getting committed transactions to close.
         awaitAllTransactionsClosed();
         LogFile logFile = transactionLogModule.logFile();
+        // In order to prevent various issues with life components that can perform operations with logFile on their
+        // stop phase before performing further shutdown/cleanup work and taking a lock on a logfile
+        // we stop all other life components to make sure that we are the last and only one (from current life)
+        life.stop();
         synchronized ( logFile )
         {
             // Under the guard of the logFile monitor do a second pass of waiting committing transactions

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
@@ -109,8 +109,11 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
         writer = new PhysicalWritableLogChannel( channel );
     }
 
+    // In order to be able to write into a logfile after life.stop during shutdown sequence
+    // we will close channel and writer only during shutdown phase when all pending changes (like last
+    // checkpoint) are already in
     @Override
-    public void stop() throws Throwable
+    public void shutdown() throws Throwable
     {
         writer.close();
         channel.close();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
@@ -40,15 +40,13 @@ public class CheckPointScheduler extends LifecycleAdapter
         @Override
         public void run()
         {
-            checkPointing = true;
-
-            if ( stopped )
-            {
-                return;
-            }
-
             try
             {
+                checkPointing = true;
+                if ( stopped )
+                {
+                    return;
+                }
                 checkPointer.checkPointIfNeeded();
             }
             catch ( IOException e )
@@ -56,7 +54,10 @@ public class CheckPointScheduler extends LifecycleAdapter
                 // no need to reschedule since the check pointer has raised a kernel panic and a shutdown is expected
                 throw new UnderlyingStorageException( e );
             }
-            checkPointing = false;
+            finally
+            {
+                checkPointing = false;
+            }
 
             // reschedule only if it is not stopped
             if ( !stopped )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
@@ -73,6 +73,24 @@ public class CheckPointerIntegrationTest
     }
 
     @Test
+    public void databaseShutdownDuringConstantCheckPointing() throws
+            InterruptedException, IOException
+    {
+        GraphDatabaseService db = builder
+                .setConfig( GraphDatabaseSettings.check_point_interval_time, 0 + "ms" )
+                .setConfig( GraphDatabaseSettings.check_point_interval_tx, "1" )
+                .setConfig( GraphDatabaseSettings.logical_log_rotation_threshold, "1g" )
+                .newGraphDatabase();
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+        Thread.sleep( 10 );
+        db.shutdown();
+    }
+
+    @Test
     public void shouldCheckPointBasedOnTime() throws Throwable
     {
         // given

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -64,15 +64,15 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class NeoStoreDataSourceRule extends ExternalResource
 {
-    private NeoStoreDataSource theDs;
+    private NeoStoreDataSource dataSource;
 
     public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
                                              PageCache pageCache, Map<String, String> additionalConfig, KernelHealth kernelHealth )
     {
-        if ( theDs != null )
+        if ( dataSource != null )
         {
-            theDs.stop();
-            theDs.shutdown();
+            dataSource.stop();
+            dataSource.shutdown();
         }
         final Config config = new Config( stringMap( additionalConfig ),
                 GraphDatabaseSettings.class );
@@ -83,7 +83,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
         Locks locks = mock( Locks.class );
         when( locks.newClient() ).thenReturn( mock( Locks.Client.class ) );
 
-        theDs = new NeoStoreDataSource( storeDir, config, sf, NullLogProvider.getInstance(),
+        dataSource = new NeoStoreDataSource( storeDir, config, sf, NullLogProvider.getInstance(),
                 mock( JobScheduler.class, RETURNS_MOCKS ), mock( TokenNameLookup.class ),
                 dependencyResolverForNoIndexProvider(), mock( PropertyKeyTokenHolder.class ),
                 mock( LabelTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ), locks,
@@ -94,7 +94,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 CommunityEditionModule.createCommitProcessFactory(), mock( PageCache.class ),
                 new Monitors(), new Tracers( "null", NullLog.getInstance() ) );
 
-        return theDs;
+        return dataSource;
     }
 
     public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,


### PR DESCRIPTION
Before db shutdown we will try to shutdown all the life components first.
Life.shutdown was invoked while holding logFile lock. That causing deadlock between NeoStoreDataSource
that holding it and life component - CheckPointScheduler that on stop will wait for currently running checkpoint to finish
if any. In that case checkpointer will be blocked forever because it needs to lock logFile to operate.
Also fix incorrect handling of stop flag in checkpointer job.
