### PR TITLE
Cypher support for operator chaining

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ComparisonOperatorAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ComparisonOperatorAcceptanceTest.scala
@@ -19,8 +19,7 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, SyntaxException}
-import org.neo4j.graphdb.Node
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
 
 class ComparisonOperatorAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
@@ -76,6 +75,4 @@ class ComparisonOperatorAcceptanceTest extends ExecutionEngineFunSuite with NewP
 
     executeWithAllPlanners("MATCH (n)-->(m) WHERE n.prop1 < m.prop1 = n.prop2 <> m.prop2 RETURN m").toSet should equal(Set(Map("m" -> node2)))
   }
-
-
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ComparisonOperatorAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ComparisonOperatorAcceptanceTest.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, SyntaxException}
+import org.neo4j.graphdb.Node
+
+class ComparisonOperatorAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  test("should handle numeric ranges") {
+    val one = createNode(Map("value" -> 1))
+    val two = createNode(Map("value" -> 2))
+    val three = createNode(Map("value" -> 3))
+
+    executeWithAllPlanners("MATCH n WHERE 1 < n.value < 3 RETURN n").toSet should equal(
+      Set(Map("n" -> two)))
+
+    executeWithAllPlanners("MATCH n WHERE 1 < n.value <= 3 RETURN n").toSet should equal(
+      Set(Map("n" -> two), Map("n" -> three)))
+
+    executeWithAllPlanners("MATCH n WHERE 1 <= n.value < 3 RETURN n").toSet should equal(
+      Set(Map("n" -> one), Map("n" -> two)))
+
+    executeWithAllPlanners("MATCH n WHERE 1 <= n.value <= 3 RETURN n").toSet should equal(
+      Set(Map("n" -> one), Map("n" -> two), Map("n" -> three)))
+  }
+
+  test("should handle string ranges") {
+    val a = createNode(Map("value" -> "a"))
+    val b = createNode(Map("value" -> "b"))
+    val c = createNode(Map("value" -> "c"))
+
+    executeWithAllPlanners("MATCH n WHERE 'a' < n.value < 'c' RETURN n").toSet should equal(
+      Set(Map("n" -> b)))
+
+    executeWithAllPlanners("MATCH n WHERE 'a' < n.value <= 'c' RETURN n").toSet should equal(
+      Set(Map("n" -> b), Map("n" -> c)))
+
+    executeWithAllPlanners("MATCH n WHERE 'a' <= n.value < 'c' RETURN n").toSet should equal(
+      Set(Map("n" -> a), Map("n" -> b)))
+
+    executeWithAllPlanners("MATCH n WHERE 'a' <= n.value <= 'c' RETURN n").toSet should equal(
+      Set(Map("n" -> a), Map("n" -> b), Map("n" -> c)))
+  }
+
+  test("should handle empty ranges") {
+    createNode(Map("value" -> 3))
+
+    executeWithAllPlanners("MATCH n WHERE 10 < n.value < 3 RETURN n").toSet shouldBe empty
+  }
+
+  test("should handle long chains of operators") {
+    val node1 = createNode(Map("prop1" -> 3, "prop2" -> 4))
+    val node2 = createNode(Map("prop1" -> 4, "prop2" -> 5))
+    val node3 = createNode(Map("prop1" -> 4, "prop2" -> 4))
+    relate(node1, node2)
+    relate(node2, node3)
+    relate(node3, node1)
+
+    executeWithAllPlanners("MATCH (n)-->(m) WHERE n.prop1 < m.prop1 = n.prop2 <> m.prop2 RETURN m").toSet should equal(Set(Map("m" -> node2)))
+  }
+
+
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ASTRewriter.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ASTRewriter.scala
@@ -36,6 +36,7 @@ class ASTRewriter(rewriterSequencer: (String) => RewriterStepSequencer, shouldEx
       (Rewriter.lift(PartialFunction.empty), Map.empty[String, Any])
 
     val contract = rewriterSequencer("ASTRewriter")(
+      normalizeComparisons,
       enableCondition(noReferenceEqualityAmongIdentifiers),
       enableCondition(containsNoNodesOfType[UnaliasedReturnItem]),
       enableCondition(orderByOnlyOnIdentifiers),

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ASTRewriter.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ASTRewriter.scala
@@ -64,5 +64,3 @@ class ASTRewriter(rewriterSequencer: (String) => RewriterStepSequencer, shouldEx
     (rewrittenStatement, extractedParameters, contract.postConditions)
   }
 }
-
-

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/normalizeComparisons.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/normalizeComparisons.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{Equals, NotEquals, LessThan, _}
+import org.neo4j.cypher.internal.frontend.v2_3.{Rewriter, topDown}
+
+case object normalizeComparisons extends Rewriter {
+
+  override def apply(that: AnyRef): AnyRef = topDown(instance)(that)
+
+  private val instance: Rewriter = Rewriter.lift {
+    case c@NotEquals(lhs, rhs) =>
+      NotEquals(lhs.endoRewrite(copyIdentifiers), rhs.endoRewrite(copyIdentifiers))(c.position)
+    case c@Equals(lhs, rhs) =>
+      Equals(lhs.endoRewrite(copyIdentifiers), rhs.endoRewrite(copyIdentifiers))(c.position)
+    case c@LessThan(lhs, rhs) =>
+      LessThan(lhs.endoRewrite(copyIdentifiers), rhs.endoRewrite(copyIdentifiers))(c.position)
+    case c@LessThanOrEqual(lhs, rhs) =>
+      LessThanOrEqual(lhs.endoRewrite(copyIdentifiers), rhs.endoRewrite(copyIdentifiers))(c.position)
+    case c@GreaterThan(lhs, rhs) =>
+      GreaterThan(lhs.endoRewrite(copyIdentifiers), rhs.endoRewrite(copyIdentifiers))(c.position)
+    case c@GreaterThanOrEqual(lhs, rhs) =>
+      GreaterThanOrEqual(lhs.endoRewrite(copyIdentifiers), rhs.endoRewrite(copyIdentifiers))(c.position)
+    case c@InvalidNotEquals(lhs, rhs) =>
+      InvalidNotEquals(lhs.endoRewrite(copyIdentifiers), rhs.endoRewrite(copyIdentifiers))(c.position)
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/NormalizeComparisonsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/NormalizeComparisonsTest.scala
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters
 
 import org.neo4j.cypher.internal.frontend.v2_3.DummyPosition

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/NormalizeComparisonsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/NormalizeComparisonsTest.scala
@@ -1,0 +1,27 @@
+package org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v2_3.DummyPosition
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{Equals, Expression, Identifier, InvalidNotEquals, NotEquals, _}
+import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
+
+class NormalizeComparisonsTest extends CypherFunSuite {
+  val pos = DummyPosition(0)
+  val expression: Expression = Identifier("foo")(pos)
+  val comparisons = List(
+    Equals(expression, expression)(pos),
+    NotEquals(expression, expression)(pos),
+    LessThan(expression, expression)(pos),
+    LessThanOrEqual(expression, expression)(pos),
+    GreaterThan(expression, expression)(pos),
+    GreaterThanOrEqual(expression, expression)(pos),
+    InvalidNotEquals(expression, expression)(pos)
+  )
+
+  comparisons.foreach { operator =>
+    test(operator.toString) {
+      val rewritten = operator.endoRewrite(normalizeComparisons)
+
+      rewritten.lhs shouldNot be theSameInstanceAs rewritten.rhs
+    }
+  }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -459,7 +459,7 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   test("should reject unicode versions of hyphens") {
     executeAndEnsureError(
       "RETURN 42 — 41",
-      "Invalid input '—': expected whitespace, comment, '.', node labels, '[', \"=~\", IN, LIKE, NOT, ILIKE, IS, '^', '*', '/', '%', '+', '-', '<', '>', \"<=\", \">=\", '=', \"<>\", \"!=\", AND, XOR, OR, AS, ',', ORDER, SKIP, LIMIT, LOAD CSV, START, MATCH, UNWIND, MERGE, CREATE, SET, DELETE, REMOVE, FOREACH, WITH, RETURN, UNION, ';' or end of input (line 1, column 11 (offset: 10))")
+      "Invalid input '—': expected whitespace, comment, '.', node labels, '[', \"=~\", IN, LIKE, NOT, ILIKE, IS, '^', '*', '/', '%', '+', '-', '=', \"<>\", \"!=\", '<', '>', \"<=\", \">=\", AND, XOR, OR, AS, ',', ORDER, SKIP, LIMIT, LOAD CSV, START, MATCH, UNWIND, MERGE, CREATE, SET, DELETE, REMOVE, FOREACH, WITH, RETURN, UNION, ';' or end of input (line 1, column 11 (offset: 10))")
   }
 
   test("fail when parsing larger than 64 bit integers") {

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/Expressions.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/Expressions.scala
@@ -57,13 +57,13 @@ trait Expressions extends Parser
   )
 
   private def Expression8: Rule1[ast.Expression] = rule("comparison expression") {
-    val produceComparisons: (ast.Expression, List[PartialComparison]) => (InputPosition)=>ast.Expression = comparisons
+    val produceComparisons: (ast.Expression, List[PartialComparison]) => InputPosition => ast.Expression = comparisons
     Expression7 ~ zeroOrMore(WS ~ PartialComparisonExpression) ~~>> produceComparisons
   }
 
-  private case class PartialComparison(op:(ast.Expression,ast.Expression)=>(InputPosition)=>ast.Expression,
-                                          expr:ast.Expression, pos:InputPosition) {
-    def apply(lhs:ast.Expression)= op(lhs,expr)(pos)
+  private case class PartialComparison(op: (ast.Expression, ast.Expression) => (InputPosition) => ast.Expression,
+                                       expr: ast.Expression, pos: InputPosition) {
+    def apply(lhs: ast.Expression) = op(lhs, expr)(pos)
   }
 
   private def PartialComparisonExpression: Rule1[PartialComparison] = (
@@ -75,15 +75,15 @@ trait Expressions extends Parser
     | group(operator("<=") ~~ Expression7) ~~>> { expr: ast.Expression => pos: InputPosition => PartialComparison(lte, expr, pos) }
     | group(operator(">=") ~~ Expression7) ~~>> { expr: ast.Expression => pos: InputPosition => PartialComparison(gte, expr, pos) } )
 
-  private def eq(lhs:ast.Expression, rhs:ast.Expression): (InputPosition) => ast.Expression = ast.Equals(lhs, rhs)
-  private def ne(lhs:ast.Expression, rhs:ast.Expression): (InputPosition) => ast.Expression = ast.NotEquals(lhs, rhs)
-  private def bne(lhs:ast.Expression, rhs:ast.Expression): (InputPosition) => ast.Expression = ast.InvalidNotEquals(lhs, rhs)
-  private def lt(lhs:ast.Expression, rhs:ast.Expression): (InputPosition) => ast.Expression = ast.LessThan(lhs, rhs)
-  private def gt(lhs:ast.Expression, rhs:ast.Expression): (InputPosition) => ast.Expression = ast.GreaterThan(lhs, rhs)
-  private def lte(lhs:ast.Expression, rhs:ast.Expression): (InputPosition) => ast.Expression = ast.LessThanOrEqual(lhs, rhs)
-  private def gte(lhs:ast.Expression, rhs:ast.Expression): (InputPosition) => ast.Expression = ast.GreaterThanOrEqual(lhs, rhs)
+  private def eq(lhs:ast.Expression, rhs:ast.Expression): InputPosition => ast.Expression = ast.Equals(lhs, rhs)
+  private def ne(lhs:ast.Expression, rhs:ast.Expression): InputPosition => ast.Expression = ast.NotEquals(lhs, rhs)
+  private def bne(lhs:ast.Expression, rhs:ast.Expression): InputPosition => ast.Expression = ast.InvalidNotEquals(lhs, rhs)
+  private def lt(lhs:ast.Expression, rhs:ast.Expression): InputPosition => ast.Expression = ast.LessThan(lhs, rhs)
+  private def gt(lhs:ast.Expression, rhs:ast.Expression): InputPosition => ast.Expression = ast.GreaterThan(lhs, rhs)
+  private def lte(lhs:ast.Expression, rhs:ast.Expression): InputPosition => ast.Expression = ast.LessThanOrEqual(lhs, rhs)
+  private def gte(lhs:ast.Expression, rhs:ast.Expression): InputPosition => ast.Expression = ast.GreaterThanOrEqual(lhs, rhs)
 
-  private def comparisons(first: ast.Expression, rest: List[PartialComparison]): (InputPosition)=>ast.Expression = {
+  private def comparisons(first: ast.Expression, rest: List[PartialComparison]): InputPosition => ast.Expression = {
     rest match {
       case Nil => _ => first
       case second :: Nil => _ => second(first)
@@ -94,7 +94,7 @@ trait Expressions extends Parser
           result.append(rhs(lhs))
           lhs = rhs.expr
         }
-        ast.Ands(Set(result:_*))
+        ast.Ands(Set(result: _*))
     }
   }
 

--- a/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/ComparisonTest.scala
+++ b/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/ComparisonTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.frontend.v2_3.parser
+
+import org.neo4j.cypher.internal.frontend.v2_3.ast
+
+class ComparisonTest extends ParserAstTest[ast.Expression] with Expressions {
+  implicit val parser = Expression
+
+  test("a < b") {
+    yields(lt(id("a"), id("b")))
+  }
+
+  test("a > b") {
+    yields(gt(id("a"), id("b")))
+  }
+
+  test("a > b AND b > c") {
+    yields(and(gt(id("a"), id("b")), gt(id("b"), id("c"))))
+  }
+
+  test("a > b > c") {
+    yields(ands(gt(id("a"), id("b")), gt(id("b"), id("c"))))
+  }
+}

--- a/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/ParserAstTest.scala
+++ b/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/ParserAstTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.frontend.v2_3.parser
+
+import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.TestName
+import org.neo4j.cypher.internal.frontend.v2_3.{InputPosition, ast}
+import org.parboiled.scala._
+
+trait ParserAstTest[AST] extends ParserTest[AST, AST] with TestName {
+  final override def convert(ast: AST): AST = ast
+
+  final def yields(expr: (InputPosition) => AST)(implicit parser: Rule1[AST]) = parsing(testName) shouldGive expr
+
+  private type Expression = (InputPosition) => ast.Expression
+
+  final def id(id: String) = ast.Identifier(id)(_)
+
+  final def lt(lhs: Expression, rhs: Expression): Expression = { pos => ast.LessThan(lhs(pos), rhs(pos))(pos) }
+
+  final def lte(lhs: Expression, rhs: Expression): Expression = { pos => ast.LessThanOrEqual(lhs(pos), rhs(pos))(pos) }
+
+  final def gt(lhs: Expression, rhs: Expression): Expression = { pos => ast.GreaterThan(lhs(pos), rhs(pos))(pos) }
+
+  final def gte(lhs: Expression, rhs: Expression): Expression = { pos => ast.GreaterThanOrEqual(lhs(pos), rhs(pos))(pos) }
+
+  final def eq(lhs: Expression, rhs: Expression): Expression = { pos => ast.Equals(lhs(pos), rhs(pos))(pos) }
+
+  final def ne(lhs: Expression, rhs: Expression): Expression = { pos => ast.NotEquals(lhs(pos), rhs(pos))(pos) }
+
+  final def and(lhs: Expression, rhs: Expression): Expression = { pos => ast.And(lhs(pos), rhs(pos))(pos) }
+
+  final def ands(parts: Expression*): Expression = { pos => ast.Ands(parts.map(_(pos)).toSet)(pos) }
+}

--- a/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/ParserTest.scala
+++ b/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/ParserTest.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.frontend.v2_3.parser
 
+import org.neo4j.cypher.internal.frontend.v2_3.InputPosition
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
 import org.parboiled.errors.InvalidInputError
 import org.parboiled.scala._
@@ -38,11 +39,17 @@ trait ParserTest[T, J] extends CypherFunSuite {
       }
     }
 
+    def shouldGive(expected: ((InputPosition) => J)) {
+      shouldGive(expected(InputPosition(0,0,0)))
+    }
+
     def shouldMatch(expected: PartialFunction[J, Unit]) {
       actuals foreach {
         actual => expected.isDefinedAt(actual) should equal(true)
       }
     }
+
+    override def toString: String = s"ResultCheck( $text -> $actuals )"
   }
 
   def parsing(s: String)(implicit p: Rule1[T]): ResultCheck = convertResult(parseRule(p ~ EOI, s), s)

--- a/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/test_helpers/CypherFunSuite.scala
+++ b/community/cypher/frontend-2.3/src/test/scala/org/neo4j/cypher/internal/frontend/v2_3/test_helpers/CypherFunSuite.scala
@@ -49,3 +49,18 @@ abstract class CypherFunSuite
     ArgumentCaptor.forClass(manifest.runtimeClass.asInstanceOf[Class[T]])
   }
 }
+
+trait TestName extends Suite {
+  final def testName = __testName.get
+
+  private var __testName: Option[String] = None
+
+  override protected def runTest(testName: String, args: Args): Status = {
+    __testName = Some(testName)
+    try {
+      super.runTest(testName, args)
+    } finally {
+      __testName = None
+    }
+  }
+}

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/comparison.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/comparison.asciidoc
@@ -34,5 +34,43 @@ The following points give some details on how the comparison is performed.
 * Comparing for ordering when one argument is +NULL+ is +NULL+ (e.g. `NULL < 3` is +NULL+).
 * It is an error to compare other types of values with each other for ordering.
 
-For other comparison operators, see <<query-operators-comparison>>.
+== Chaining Comparison Operations ==
+Comparisons can be chained arbitrarily, e.g., `x < y <= z` is equivalent to `x < y AND y <= z`.
 
+Formally, if `a, b, c, ..., y, z` are expressions and `op1, op2, ..., opN` are comparison operators, then `a op1 b op2 c ... y opN z` is equivalent to a `op1 b and b op2 c and ... y opN z`.
+
+Note that `a op1 b op2 c` does not imply any kind of comparison between a and c, so that, e.g., `x < y > z` is perfectly legal (though perhaps not pretty).
+
+The example:
+
+[source,cypher]
+----
+MATCH (n) WHERE 21 < n.age <= 30 RETURN n
+----
+
+is equivalent to
+
+[source,cypher]
+----
+MATCH (n) WHERE 21 < n.age AND n.age <= 30 RETURN n
+----
+
+Thus it will match all nodes where the age is between 21 and 30.
+
+This syntax extends to all equality and inequality comparisons, as well as extending to chains longer than three.
+
+For example:
+
+[source,cypher]
+----
+a < b = c <= d <> e
+----
+
+Is equivalent to:
+
+[source,cypher]
+----
+a < b AND b = c AND c <= d AND d <> e
+----
+
+For other comparison operators, see <<query-operators-comparison>>.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
@@ -101,6 +101,16 @@ RETURN n,m###
 Use boolean operators to combine predicates.
 
 ###assertion=returns-one
+MATCH (n)-->(m)
+WHERE id(n) = %A% AND id(m) = %B% AND
+
+1 <= n.number <= 10
+
+RETURN n,m###
+
+Use chained operators to combine predicates.
+
+###assertion=returns-one
 MATCH (n:Person)
 WHERE
 


### PR DESCRIPTION
Support for operator chaining in Cypher. We have extended the syntax for comparisons with

```
a < b <=c
```

as a shorthand for

```
a < b AND b <= c
```

This works for chains of indefinite length using all the normal comparison operators, `=`, `<`, `>`, `<=`, `>=`, and `<>`. 
