### PR TITLE
Create a single working directory for the BackupService stress test

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -695,7 +695,7 @@ public class BackupServiceIT
         Callable<Integer> callable = new BackupServiceStressTestingBuilder()
                 .until( untilTimeExpired( 10, SECONDS ) )
                 .withStore( storeDir )
-                .withWorkingDirectory( backupDir )
+                .withBackupDirectory( backupDir )
                 .withBackupAddress( BACKUP_HOST, backupPort )
                 .build();
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
@@ -55,8 +55,8 @@ import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 public class BackupServiceStressTestingBuilder
 {
     private Condition untilCondition;
-    private File storeDir;
-    private File workingDirectory;
+    private File storeDirectory;
+    private File backupDirectory;
     private String backupHostname = "localhost";
     private int backupPort = 8200;
 
@@ -80,19 +80,19 @@ public class BackupServiceStressTestingBuilder
         return this;
     }
 
-    public BackupServiceStressTestingBuilder withStore( File storeDir )
+    public BackupServiceStressTestingBuilder withStore( File storeDirectory )
     {
-        Objects.requireNonNull( storeDir );
-        assert storeDir.exists() && storeDir.isDirectory();
-        this.storeDir = storeDir;
+        Objects.requireNonNull( storeDirectory );
+        assert storeDirectory.exists() && storeDirectory.isDirectory();
+        this.storeDirectory = storeDirectory;
         return this;
     }
 
-    public BackupServiceStressTestingBuilder withWorkingDirectory( File workingDirectory )
+    public BackupServiceStressTestingBuilder withBackupDirectory( File backupDirectory )
     {
-        Objects.requireNonNull( workingDirectory );
-        assert workingDirectory.exists() && workingDirectory.isDirectory();
-        this.workingDirectory = workingDirectory;
+        Objects.requireNonNull( backupDirectory );
+        assert backupDirectory.exists() && backupDirectory.isDirectory();
+        this.backupDirectory = backupDirectory;
         return this;
     }
 
@@ -107,9 +107,9 @@ public class BackupServiceStressTestingBuilder
     public Callable<Integer> build()
     {
         Objects.requireNonNull( untilCondition, "must specify a condition" );
-        Objects.requireNonNull( storeDir, "must specify a directory containing the db to backup from" );
-        Objects.requireNonNull( workingDirectory, "must specify a directory where to save backups/broken stores" );
-        return new RunTest( untilCondition, storeDir, workingDirectory, backupHostname, backupPort );
+        Objects.requireNonNull( storeDirectory, "must specify a directory containing the db to backup from" );
+        Objects.requireNonNull( backupDirectory, "must specify a directory where to save backups/broken stores" );
+        return new RunTest( untilCondition, storeDirectory, backupDirectory, backupHostname, backupPort );
     }
 
     private static class RunTest implements Callable<Integer>
@@ -123,15 +123,15 @@ public class BackupServiceStressTestingBuilder
         private final File backupDir;
         private final File brokenDir;
 
-        private RunTest( Condition until, File storeDir, File workingDir, String backupHostname, int backupPort )
+        private RunTest( Condition until, File storeDir, File backupDir, String backupHostname, int backupPort )
         {
             this.until = until;
             this.storeDir = storeDir;
             this.backupHostname = backupHostname;
             this.backupPort = backupPort;
-            this.backupDir = new File( workingDir, "backup" );
-            fileSystem.mkdir( backupDir );
-            this.brokenDir = new File( workingDir, "broken_stores" );
+            this.backupDir = new File( backupDir, "backup" );
+            fileSystem.mkdir( this.backupDir );
+            this.brokenDir = new File( backupDir, "broken_stores" );
             fileSystem.mkdir( brokenDir );
         }
 

--- a/stresstests/src/test/java/org/neo4j/backup/BackupServiceStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/backup/BackupServiceStressTesting.java
@@ -37,9 +37,8 @@ import static org.neo4j.backup.BackupServiceStressTestingBuilder.untilTimeExpire
  */
 public class BackupServiceStressTesting
 {
-    private static final String DEFAULT_DURATION_IN_MINUTES = "10";
-    private static final String DEFAULT_STORE_DIR = new File( getProperty( "java.io.tmpdir" ), "store" ).getPath();
-    private static final String DEFAULT_WORKING_DIR = new File( getProperty( "java.io.tmpdir" ), "work" ).getPath();
+    private static final String DEFAULT_DURATION_IN_MINUTES = "1";
+    private static final String DEFAULT_WORKING_DIR = new File( getProperty( "java.io.tmpdir" ) ).getPath();
     private static final String DEFAULT_HOSTNAME = "localhost";
     private static final String DEFAULT_PORT = "8200";
 
@@ -47,15 +46,14 @@ public class BackupServiceStressTesting
     public void shouldBehaveCorrectlyUnderStress() throws Exception
     {
         long durationInMinutes = parseLong( fromEnv( "BACKUP_SERVICE_STRESS_DURATION", DEFAULT_DURATION_IN_MINUTES ) );
-        String storeDirectory = fromEnv( "BACKUP_SERVICE_STRESS_STORE_DIRECTORY", DEFAULT_STORE_DIR );
-        String workingDirectory = fromEnv( "BACKUP_SERVICE_STRESS_WORKING_DIRECTORY", DEFAULT_WORKING_DIR );
+        String directory = fromEnv( "BACKUP_SERVICE_STRESS_WORKING_DIRECTORY", DEFAULT_WORKING_DIR );
         String backupHostname = fromEnv( "BACKUP_SERVICE_STRESS_BACKUP_HOSTNAME", DEFAULT_HOSTNAME );
         int backupPort = parseInt( fromEnv( "BACKUP_SERVICE_STRESS_BACKUP_PORT", DEFAULT_PORT ) );
 
         Callable<Integer> callable = new BackupServiceStressTestingBuilder()
                 .until( untilTimeExpired( durationInMinutes, MINUTES ) )
-                .withStore( ensureExists( storeDirectory ) )
-                .withWorkingDirectory( ensureExists( workingDirectory ) )
+                .withStore( ensureExists( new File( directory, "store" ) ) )
+                .withBackupDirectory( ensureExists( new File( directory, "work" ) ) )
                 .withBackupAddress( backupHostname, backupPort )
                 .build();
 
@@ -64,11 +62,10 @@ public class BackupServiceStressTesting
         assertEquals( 0, brokenStores );
     }
 
-    private File ensureExists( String directory )
+    private File ensureExists( File directory )
     {
-        File dir = new File( directory );
-        dir.mkdirs();
-        return dir;
+        directory.mkdirs();
+        return directory;
     }
 
     private static String fromEnv( String environmentVariableName, String defaultValue )


### PR DESCRIPTION
This should simplify the configuration needed to run the stress test in CI and also simplify collecting stores in case of failure.
