### PR TITLE
Fixes #5195 - USING INDEX hints breaks some queries

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/Namespacer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/Namespacer.scala
@@ -58,7 +58,8 @@ object Namespacer {
         (acc, children) => children(acc ++ Seq(Ref(index)))
       case RelationshipByIndexQuery(_, index, _) =>
         (acc, children) => children(acc ++ Seq(Ref(index)))
-
+      case UsingIndexHint(_, _, prop) =>
+        (acc, children) => children(acc ++ Seq(Ref(prop)))
       case Return(_, ReturnItems(_, items), _, _, _) =>
         val identifiers = items.map(_.alias.map(Ref[Identifier]).get)
         (acc, children) => children(acc ++ identifiers)

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -1,3 +1,7 @@
+2.2.6
+-----
+o Fixes #5195 - USING INDEX hints breaks some queries
+
 2.2.5
 -----
 o Fixes #4907 - Result.columnAs should throw exception on invalid column name

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UsingAcceptanceTest.scala
@@ -208,4 +208,17 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     e.getMessage should startWith("Multiple hints for same identifier are not supported")
   }
+
+  test("USING INDEX hint should not clash with used identifiers") {
+    graph.createIndex("PERSON", "id")
+
+    val result = executeWithAllPlanners(
+      """MATCH (actor:PERSON {id: 1})
+        |USING INDEX actor:PERSON(id)
+        |WITH 14 as id
+        |RETURN 13 as id""".stripMargin)
+
+    result.toList should be(empty)
+  }
+
 }


### PR DESCRIPTION
Hints using already existing identifiers could break semantic checking.
