### PR TITLE
StorePropertyCursor made non-lazy

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
@@ -20,115 +20,88 @@
 package org.neo4j.kernel.impl.api.store;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 import org.neo4j.cursor.Cursor;
-import org.neo4j.cursor.GenericCursor;
 import org.neo4j.function.Consumer;
 import org.neo4j.graphdb.NotFoundException;
-import org.neo4j.helpers.UTF8;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.api.cursor.PropertyItem;
-import org.neo4j.kernel.impl.store.AbstractDynamicStore;
-import org.neo4j.kernel.impl.store.DynamicArrayStore;
-import org.neo4j.kernel.impl.store.DynamicStringStore;
-import org.neo4j.kernel.impl.store.LongerShortString;
 import org.neo4j.kernel.impl.store.PropertyStore;
-import org.neo4j.kernel.impl.store.PropertyType;
-import org.neo4j.kernel.impl.store.ShortArray;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
-import org.neo4j.kernel.impl.store.record.DynamicRecord;
-import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.Record;
-import org.neo4j.kernel.impl.util.Bits;
-
-import static org.neo4j.kernel.impl.store.PropertyStore.DEFAULT_PAYLOAD_SIZE;
-import static org.neo4j.kernel.impl.store.PropertyType.ARRAY;
-import static org.neo4j.kernel.impl.store.PropertyType.BOOL;
-import static org.neo4j.kernel.impl.store.PropertyType.BYTE;
-import static org.neo4j.kernel.impl.store.PropertyType.CHAR;
-import static org.neo4j.kernel.impl.store.PropertyType.DOUBLE;
-import static org.neo4j.kernel.impl.store.PropertyType.FLOAT;
-import static org.neo4j.kernel.impl.store.PropertyType.INT;
-import static org.neo4j.kernel.impl.store.PropertyType.LONG;
-import static org.neo4j.kernel.impl.store.PropertyType.SHORT;
-import static org.neo4j.kernel.impl.store.PropertyType.SHORT_ARRAY;
-import static org.neo4j.kernel.impl.store.PropertyType.SHORT_STRING;
-import static org.neo4j.kernel.impl.store.PropertyType.STRING;
 
 /**
  * Cursor for all properties on a node or relationship.
  */
 public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
 {
-    private static final long KEY_BITMASK = 0xFFFFFFL;
-    private static final int BITS_BYTE_SIZE = 32;
-    private static final int INTERNAL_BYTE_ARRAY_SIZE = 4096;
-
-    private final ByteBuffer cachedBuffer = ByteBuffer.allocate( INTERNAL_BYTE_ARRAY_SIZE );
-    private final Block block = new Block();
-
     private final PropertyStore propertyStore;
     private final Consumer<StorePropertyCursor> instanceCache;
-    private final DynamicStringStore stringStore;
-    private final DynamicArrayStore arrayStore;
+    private final StorePropertyPayloadCursor payload;
 
     private long nextPropertyRecordId;
-    private PageCursor cursor;
-
-    private int offsetAtBeginning;
-    private PropertyType type;
-    private int keyId;
-    private ByteBuffer buffer;
-
-    private AbstractDynamicStore.DynamicRecordCursor recordCursor;
-    private long currentRecordId;
-    private boolean seekingForFirstBlock;
 
     public StorePropertyCursor( PropertyStore propertyStore, Consumer<StorePropertyCursor> instanceCache )
     {
         this.propertyStore = propertyStore;
         this.instanceCache = instanceCache;
-        this.stringStore = propertyStore.getStringStore();
-        this.arrayStore = propertyStore.getArrayStore();
+        this.payload = new StorePropertyPayloadCursor( propertyStore.getStringStore(), propertyStore.getArrayStore() );
     }
 
     public StorePropertyCursor init( long firstPropertyId )
     {
-        assert cursor == null;
-        assert recordCursor == null;
-        assert buffer == null;
-        assert type == null;
-
-        buffer = cachedBuffer;
         nextPropertyRecordId = firstPropertyId;
-        seekingForFirstBlock = false;
-        block.init();
-
         return this;
     }
 
     @Override
     public boolean next()
     {
-        do
+        if ( payload.next() )
         {
-            if ( cursor == null )
-            {
-                if ( nextPropertyRecordId == Record.NO_NEXT_PROPERTY.intValue() )
-                {
-                    return false;
-                }
-
-                nextRecord();
-            }
-
+            return true;
         }
-        while ( !nextBlock() );
 
+        if ( nextPropertyRecordId == Record.NO_NEXT_PROPERTY.intValue() )
+        {
+            return false;
+        }
+
+        long currentPropertyRecordId = nextPropertyRecordId;
+        try ( PageCursor cursor = propertyStore.newReadCursor( currentPropertyRecordId ) )
+        {
+            do
+            {
+                nextPropertyRecordId = readNextPropertyRecordId( cursor );
+
+                payload.clear();
+                payload.init( cursor );
+            }
+            while ( cursor.shouldRetry() );
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
+
+        if ( !payload.next() )
+        {
+            throw new NotFoundException( "Property record with id " + currentPropertyRecordId + " not in use" );
+        }
         return true;
+    }
+
+    @Override
+    public int propertyKeyId()
+    {
+        return payload.propertyKeyId();
+    }
+
+    @Override
+    public Object value()
+    {
+        return payloadValueAsObject( payload );
     }
 
     @Override
@@ -137,477 +110,59 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
         return this;
     }
 
-    private void readPropertyData() throws IOException
-    {
-        switch ( type )
-        {
-        case STRING:
-            readFromStore( stringStore );
-            break;
-        case ARRAY:
-            readFromStore( arrayStore );
-            break;
-        case SHORT_STRING:
-        case SHORT_ARRAY:
-            block.ensureLoadedData( cursor );
-            break;
-
-        default:
-            throw new IllegalStateException();
-        }
-    }
-
-    private void readFromStore( AbstractDynamicStore store ) throws IOException
-    {
-        int storeOffset = cursor.getOffset();
-        cursor.close();
-        cursor = null;
-
-        if ( recordCursor == null )
-        {
-            recordCursor = store.newDynamicRecordCursor();
-        }
-
-        buffer.clear();
-        long startBlockId = PropertyBlock.fetchLong( block.header() );
-        try ( GenericCursor<DynamicRecord> records = store.getRecordsCursor( startBlockId, true, recordCursor ) )
-        {
-            while ( records.next() )
-            {
-                DynamicRecord dynamicRecord = records.get();
-                byte[] data = dynamicRecord.getData();
-                if ( buffer.remaining() < data.length )
-                {
-                    buffer.flip();
-                    ByteBuffer newBuffer =
-                            ByteBuffer.allocate( newCapacity( data.length ) ).order( ByteOrder.LITTLE_ENDIAN );
-                    newBuffer.put( buffer );
-                    buffer = newBuffer;
-                }
-                buffer.put( data, 0, data.length );
-            }
-        }
-
-        cursor = propertyStore.newReadCursor( currentRecordId );
-        cursor.setOffset( storeOffset );
-    }
-
-    private int newCapacity( int required )
-    {
-        int newCapacity;
-        do
-        {
-            newCapacity = buffer.capacity() * 2;
-        }
-        while ( newCapacity - buffer.limit() < required );
-        return newCapacity;
-    }
-
-
     @Override
     public void close()
     {
-        if ( cursor != null )
-        {
-            cursor.close();
-            cursor = null;
-        }
-
-        type = null;
-        recordCursor = null;
-        buffer = null;
-
+        payload.clear();
         instanceCache.accept( this );
     }
 
-    private void nextRecord()
+    static Object payloadValueAsObject( StorePropertyPayloadCursor payload )
     {
-        try
-        {
-            cursor = propertyStore.newReadCursor( nextPropertyRecordId );
-            currentRecordId = nextPropertyRecordId;
-
-            offsetAtBeginning = cursor.getOffset();
-            byte modifiers;
-            long nextProp;
-            do
-            {
-                cursor.setOffset( offsetAtBeginning );
-                modifiers = cursor.getByte();
-                // We don't care about previous pointer (prevProp)
-                cursor.getUnsignedInt();
-                nextProp = cursor.getUnsignedInt();
-
-            }
-            while ( cursor.shouldRetry() );
-
-            long nextMod = (modifiers & 0x0FL) << 32;
-            nextPropertyRecordId = longFromIntAndMod( nextProp, nextMod );
-            seekingForFirstBlock = true;
-        }
-        catch ( IOException e )
-        {
-            throw new UnderlyingStorageException( e );
-        }
-    }
-
-    private boolean nextBlock()
-    {
-        // Skip remaining data from previous property (if it was not read)
-        block.skipUnreadData( cursor );
-        block.init();
-
-        if ( cursor.getOffset() - offsetAtBeginning < PropertyStore.RECORD_SIZE )
-        {
-            block.fetchHeader( cursor );
-            type = PropertyType.getPropertyType( block.header(), true );
-            if ( type != null )
-            {
-                seekingForFirstBlock = false;
-                keyId = (int) (block.header() & KEY_BITMASK);
-                block.remaining( type.calculateNumberOfBlocksUsed( block.header() ) - 1 );
-                return true;
-            }
-        }
-
-        if ( seekingForFirstBlock )
-        {
-            throw new NotFoundException( "Property record with id " + currentRecordId + " not in use" );
-        }
-        else
-        {
-            cursor.close();
-            cursor = null;
-            return false;
-        }
-    }
-
-    private long longFromIntAndMod( long base, long modifier )
-    {
-        return modifier == 0 && base == IdGeneratorImpl.INTEGER_MINUS_ONE ? -1 : base | modifier;
-    }
-
-    private Object getRightArray()
-    {
-        buffer.flip();
-        assert buffer.limit() > 0 : "buffer is empty";
-        byte typeId = buffer.get();
-        buffer.order( ByteOrder.BIG_ENDIAN );
-        try
-        {
-            if ( typeId == PropertyType.STRING.intValue() )
-            {
-                int arrayLength = buffer.getInt();
-                String[] result = new String[arrayLength];
-
-                for ( int i = 0; i < arrayLength; i++ )
-                {
-                    int byteLength = buffer.getInt();
-                    result[i] = UTF8.decode( buffer.array(), buffer.position(), byteLength );
-                    buffer.position( buffer.position() + byteLength );
-                }
-                return result;
-            }
-            else
-            {
-                ShortArray type = ShortArray.typeOf( typeId );
-                int bitsUsedInLastByte = buffer.get();
-                int requiredBits = buffer.get();
-                if ( requiredBits == 0 )
-                {
-                    return type.createEmptyArray();
-                }
-                Object result;
-                if ( type == ShortArray.BYTE && requiredBits == Byte.SIZE )
-                {   // Optimization for byte arrays (probably large ones)
-                    byte[] byteArray = new byte[buffer.limit() - buffer.position()];
-                    buffer.get( byteArray );
-                    result = byteArray;
-                }
-                else
-                {   // Fallback to the generic approach, which is a slower
-                    Bits bits = Bits.bitsFromBytes( buffer.array(), buffer.position() );
-                    int length = ((buffer.limit() - buffer.position()) * 8 - (8 - bitsUsedInLastByte)) / requiredBits;
-                    result = type.createArray( length, bits, requiredBits );
-                }
-                return result;
-            }
-        }
-        finally
-        {
-            buffer.order( ByteOrder.LITTLE_ENDIAN );
-        }
-    }
-
-    @Override
-    public int propertyKeyId()
-    {
-        return keyId;
-    }
-
-    @Override
-    public Object value()
-    {
-        switch ( type )
+        switch ( payload.type() )
         {
         case BOOL:
-            return parseBooleanValue();
+            return payload.booleanValue();
         case BYTE:
-            return parseByteValue();
+            return payload.byteValue();
         case SHORT:
-            return parseShortValue();
+            return payload.shortValue();
         case CHAR:
-            return parseCharValue();
+            return payload.charValue();
         case INT:
-            return parseIntValue();
+            return payload.intValue();
         case LONG:
-            return parseLongValue();
+            return payload.longValue();
         case FLOAT:
-            return parseFloatValue();
+            return payload.floatValue();
         case DOUBLE:
-            return parseDoubleValue();
+            return payload.doubleValue();
         case SHORT_STRING:
+            return payload.shortStringValue();
         case STRING:
-            return parseStringValue();
+            return payload.stringValue();
         case SHORT_ARRAY:
+            return payload.shortArrayValue();
         case ARRAY:
-            return parseArrayValue();
+            return payload.arrayValue();
         default:
-            throw new IllegalStateException( "No such type:" + type );
+            throw new IllegalStateException( "No such type:" + payload.type() );
         }
     }
 
-    private boolean parseBooleanValue()
+    private static long readNextPropertyRecordId( PageCursor cursor )
     {
-        assertReadingStatus();
-        assertOfType( BOOL );
-        return PropertyBlock.fetchByte( block.header() ) == 1;
+        byte modifiers = cursor.getByte();
+        // We don't care about previous pointer (prevProp)
+        cursor.getUnsignedInt();
+        long nextProp = cursor.getUnsignedInt();
+
+        long nextMod = (modifiers & 0x0FL) << 32;
+        return longFromIntAndMod( nextProp, nextMod );
     }
 
-    private byte parseByteValue()
+    private static long longFromIntAndMod( long base, long modifier )
     {
-        assertReadingStatus();
-        assertOfType( BYTE );
-        return PropertyBlock.fetchByte( block.header() );
-    }
-
-    private short parseShortValue()
-    {
-        assertReadingStatus();
-        assertOfType( SHORT );
-        return PropertyBlock.fetchShort( block.header() );
-    }
-
-    private int parseIntValue()
-    {
-        assertReadingStatus();
-        assertOfType( INT );
-        return PropertyBlock.fetchInt( block.header() );
-    }
-
-    private long parseLongValue()
-    {
-        assertReadingStatus();
-        assertOfType( LONG );
-        if ( PropertyBlock.valueIsInlined( block.header() ) )
-        {
-            return PropertyBlock.fetchLong( block.header() ) >>> 1;
-        }
-        else
-        {
-            block.ensureLoadedData( cursor );
-            return block.peekSingleValue();
-        }
-    }
-
-    private float parseFloatValue()
-    {
-        assertReadingStatus();
-        assertOfType( FLOAT );
-        return Float.intBitsToFloat( PropertyBlock.fetchInt( block.header() ) );
-    }
-
-    private double parseDoubleValue()
-    {
-        assertReadingStatus();
-        assertOfType( DOUBLE );
-        block.ensureLoadedData( cursor );
-        return Double.longBitsToDouble( block.peekSingleValue() );
-    }
-
-    private char parseCharValue()
-    {
-        assertReadingStatus();
-        assertOfType( CHAR );
-        return (char) PropertyBlock.fetchShort( block.header() );
-    }
-
-    private String parseStringValue()
-    {
-        assertReadingStatus();
-        assertOfOneOfTypes( SHORT_STRING, STRING );
-        try
-        {
-            readPropertyData();
-        }
-        catch ( IOException e )
-        {
-            throw new UnderlyingStorageException( e );
-        }
-        if ( type == SHORT_STRING )
-        {
-            return LongerShortString.decode( block.toBits() );
-        }
-        else // STRING
-        {
-            buffer.flip();
-            return UTF8.decode( buffer.array(), 0, buffer.limit() );
-        }
-    }
-
-    private Object parseArrayValue()
-    {
-        assertReadingStatus();
-        assertOfOneOfTypes( SHORT_ARRAY, ARRAY );
-        try
-        {
-            readPropertyData();
-        }
-        catch ( IOException e )
-        {
-            throw new UnderlyingStorageException( e );
-        }
-        if ( type == SHORT_ARRAY )
-        {
-            return ShortArray.decode( block.toBits() );
-        }
-        else
-        {
-            return getRightArray();
-        }
-    }
-
-    private void assertReadingStatus()
-    {
-        if ( type == null )
-        {
-            throw new IllegalStateException();
-        }
-    }
-
-    private void assertOfType( PropertyType type )
-    {
-        if ( this.type != type )
-        {
-            throw new IllegalStateException( "Expected type " + type + " but was " + this.type );
-        }
-    }
-
-    private void assertOfOneOfTypes( PropertyType type1, PropertyType type2 )
-    {
-        if ( this.type != type1 && this.type != type2 )
-        {
-            throw new IllegalStateException( "Expected type " + type1 + " or " + type2 + " but was " + this.type );
-        }
-    }
-
-    private static class Block
-    {
-        public static final int VALUES_SIZE = DEFAULT_PAYLOAD_SIZE / 8;
-
-        private int writeIndex;
-        private long[] values = new long[VALUES_SIZE];
-        private int remaining;
-
-        public void init()
-        {
-            writeIndex = 0;
-            remaining = 0;
-            for ( int i = 0; i < VALUES_SIZE; i++ )
-            {
-                values[i] = -1;
-            }
-        }
-
-        public long header()
-        {
-            assert writeIndex > 0;
-            return values[0];
-        }
-
-        public long peekSingleValue()
-        {
-            assert writeIndex > 1;
-            return values[1];
-        }
-
-        public Bits toBits()
-        {
-            Bits bits = Bits.bits( BITS_BYTE_SIZE );
-            for ( int i = 0; i < writeIndex; i++ )
-            {
-                bits.put( values[i] );
-            }
-            return bits;
-        }
-
-        public void fetchHeader( PageCursor cursor )
-        {
-            try
-            {
-                fetchLongs( cursor, 1 );
-            }
-            catch ( IOException e )
-            {
-                throw new UnderlyingStorageException( e );
-            }
-        }
-
-        public void remaining( int remaining )
-        {
-            this.remaining = remaining;
-        }
-
-        public void ensureLoadedData( PageCursor cursor )
-        {
-            if ( remaining <= 0)
-            {
-                return;
-            }
-
-            try
-            {
-                fetchLongs( cursor, remaining );
-                remaining = 0;
-            }
-            catch ( IOException e )
-            {
-                throw new UnderlyingStorageException( e );
-            }
-        }
-
-        private void fetchLongs( PageCursor cursor, int num ) throws IOException
-        {
-            int offset = cursor.getOffset();
-            do
-            {
-                cursor.setOffset( offset );
-                for ( int i = 0; i < num; i++ )
-                {
-                    values[writeIndex+i] = cursor.getLong();
-                }
-            }
-            while ( cursor.shouldRetry() );
-            writeIndex += num;
-        }
-
-        public void skipUnreadData( PageCursor cursor )
-        {
-            if ( remaining > 0 )
-            {
-                cursor.setOffset( cursor.getOffset() + remaining * 8 );
-                remaining = 0;
-            }
-        }
+        return modifier == 0 && base == IdGeneratorImpl.INTEGER_MINUS_ONE ? -1 : base | modifier;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import org.neo4j.cursor.GenericCursor;
+import org.neo4j.helpers.UTF8;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.impl.store.AbstractDynamicStore;
+import org.neo4j.kernel.impl.store.DynamicArrayStore;
+import org.neo4j.kernel.impl.store.DynamicStringStore;
+import org.neo4j.kernel.impl.store.LongerShortString;
+import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.PropertyType;
+import org.neo4j.kernel.impl.store.ShortArray;
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.kernel.impl.util.Bits;
+
+import static org.neo4j.kernel.impl.store.PropertyType.ARRAY;
+import static org.neo4j.kernel.impl.store.PropertyType.BOOL;
+import static org.neo4j.kernel.impl.store.PropertyType.BYTE;
+import static org.neo4j.kernel.impl.store.PropertyType.CHAR;
+import static org.neo4j.kernel.impl.store.PropertyType.DOUBLE;
+import static org.neo4j.kernel.impl.store.PropertyType.FLOAT;
+import static org.neo4j.kernel.impl.store.PropertyType.INT;
+import static org.neo4j.kernel.impl.store.PropertyType.LONG;
+import static org.neo4j.kernel.impl.store.PropertyType.SHORT;
+import static org.neo4j.kernel.impl.store.PropertyType.SHORT_ARRAY;
+import static org.neo4j.kernel.impl.store.PropertyType.SHORT_STRING;
+import static org.neo4j.kernel.impl.store.PropertyType.STRING;
+
+/**
+ * Cursor that provides a view on property blocks of a particular property record.
+ * This cursor is reusable and can be re-initialized with
+ * {@link #init(PageCursor)} method and cleaned up using {@link #clear()} method.
+ * <p/>
+ * During initialization {@link #MAX_NUMBER_OF_PAYLOAD_LONG_ARRAY} number of longs is read from
+ * the given {@linkplain PageCursor}. This is done eagerly to avoid reading property blocks from different versions
+ * of the page.
+ * <p/>
+ * Internally, this cursor is mainly an array of {@link #MAX_NUMBER_OF_PAYLOAD_LONG_ARRAY} and a current-position
+ * pointer.
+ */
+class StorePropertyPayloadCursor
+{
+    static final int MAX_NUMBER_OF_PAYLOAD_LONG_ARRAY = PropertyStore.DEFAULT_PAYLOAD_SIZE / 8;
+
+    private static final long PROPERTY_KEY_ID_BITMASK = 0xFFFFFFL;
+    private static final int MAX_BYTES_IN_SHORT_STRING_OR_SHORT_ARRAY = 32;
+    private static final int INTERNAL_BYTE_ARRAY_SIZE = 4096;
+    private static final int INITIAL_POSITION = -1;
+
+    /**
+     * Reusable initial buffer for reading of dynamic records.
+     */
+    private final ByteBuffer cachedBuffer = ByteBuffer.allocate( INTERNAL_BYTE_ARRAY_SIZE );
+
+    private final DynamicStringStore stringStore;
+    private final DynamicArrayStore arrayStore;
+
+    private AbstractDynamicStore.DynamicRecordCursor recordCursor;
+    private ByteBuffer buffer = cachedBuffer;
+
+    private final long[] data = new long[MAX_NUMBER_OF_PAYLOAD_LONG_ARRAY];
+    private int position = INITIAL_POSITION;
+
+    StorePropertyPayloadCursor( DynamicStringStore stringStore, DynamicArrayStore arrayStore )
+    {
+        this.stringStore = stringStore;
+        this.arrayStore = arrayStore;
+    }
+
+    void init( PageCursor cursor )
+    {
+        for ( int i = 0; i < data.length; i++ )
+        {
+            data[i] = cursor.getLong();
+        }
+    }
+
+    void clear()
+    {
+        position = INITIAL_POSITION;
+        buffer = cachedBuffer;
+        // Array of data should be filled with '0' because it is possible to call next() without calling init().
+        // In such case 'false' should be returned, which might not be the case if there is stale data in the buffer.
+        Arrays.fill( data, 0 );
+    }
+
+    boolean next()
+    {
+        if ( position == INITIAL_POSITION )
+        {
+            position = 0;
+        }
+        else
+        {
+            position += currentBlocksUsed();
+        }
+        if ( position >= data.length )
+        {
+            return false;
+        }
+        return type() != null;
+    }
+
+    PropertyType type()
+    {
+        return PropertyType.getPropertyType( currentHeader(), true );
+    }
+
+    int propertyKeyId()
+    {
+        return (int) (currentHeader() & PROPERTY_KEY_ID_BITMASK);
+    }
+
+    boolean booleanValue()
+    {
+        assertOfType( BOOL );
+        return PropertyBlock.fetchByte( currentHeader() ) == 1;
+    }
+
+    byte byteValue()
+    {
+        assertOfType( BYTE );
+        return PropertyBlock.fetchByte( currentHeader() );
+    }
+
+    short shortValue()
+    {
+        assertOfType( SHORT );
+        return PropertyBlock.fetchShort( currentHeader() );
+    }
+
+    char charValue()
+    {
+        assertOfType( CHAR );
+        return (char) PropertyBlock.fetchShort( currentHeader() );
+    }
+
+    int intValue()
+    {
+        assertOfType( INT );
+        return PropertyBlock.fetchInt( currentHeader() );
+    }
+
+    float floatValue()
+    {
+        assertOfType( FLOAT );
+        return Float.intBitsToFloat( PropertyBlock.fetchInt( currentHeader() ) );
+    }
+
+    long longValue()
+    {
+        assertOfType( LONG );
+        if ( PropertyBlock.valueIsInlined( currentHeader() ) )
+        {
+            return PropertyBlock.fetchLong( currentHeader() ) >>> 1;
+        }
+
+        return data[position + 1];
+    }
+
+    double doubleValue()
+    {
+        assertOfType( DOUBLE );
+        return Double.longBitsToDouble( data[position + 1] );
+    }
+
+    String shortStringValue()
+    {
+        assertOfType( SHORT_STRING );
+        Bits bits = valueAsBits();
+        return LongerShortString.decode( bits );
+    }
+
+    String stringValue()
+    {
+        assertOfType( STRING );
+        try
+        {
+            readFromStore( stringStore );
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
+        buffer.flip();
+        return UTF8.decode( buffer.array(), 0, buffer.limit() );
+    }
+
+    Object shortArrayValue()
+    {
+        assertOfType( SHORT_ARRAY );
+        Bits bits = valueAsBits();
+        return ShortArray.decode( bits );
+    }
+
+    Object arrayValue()
+    {
+        assertOfType( ARRAY );
+        try
+        {
+            readFromStore( arrayStore );
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( e );
+        }
+        buffer.flip();
+        return readArrayFromBuffer( buffer );
+    }
+
+    private long currentHeader()
+    {
+        return data[position];
+    }
+
+    private int currentBlocksUsed()
+    {
+        return type().calculateNumberOfBlocksUsed( currentHeader() );
+    }
+
+    private Bits valueAsBits()
+    {
+        Bits bits = Bits.bits( MAX_BYTES_IN_SHORT_STRING_OR_SHORT_ARRAY );
+        for ( int i = 0; i < currentBlocksUsed(); i++ )
+        {
+            bits.put( data[position + i] );
+        }
+        return bits;
+    }
+
+    private void readFromStore( AbstractDynamicStore store ) throws IOException
+    {
+        if ( recordCursor == null )
+        {
+            recordCursor = store.newDynamicRecordCursor();
+        }
+
+        buffer.clear();
+        long startBlockId = PropertyBlock.fetchLong( currentHeader() );
+        try ( GenericCursor<DynamicRecord> records = store.getRecordsCursor( startBlockId, true, recordCursor ) )
+        {
+            while ( records.next() )
+            {
+                DynamicRecord dynamicRecord = records.get();
+                byte[] data = dynamicRecord.getData();
+                if ( buffer.remaining() < data.length )
+                {
+                    buffer.flip();
+                    ByteBuffer newBuffer = newBiggerBuffer( data.length );
+                    newBuffer.put( buffer );
+                    buffer = newBuffer;
+                }
+                buffer.put( data, 0, data.length );
+            }
+        }
+    }
+
+    private ByteBuffer newBiggerBuffer( int requiredCapacity )
+    {
+        int newCapacity;
+        do
+        {
+            newCapacity = buffer.capacity() * 2;
+        }
+        while ( newCapacity - buffer.limit() < requiredCapacity );
+
+        return ByteBuffer.allocate( newCapacity ).order( ByteOrder.LITTLE_ENDIAN );
+    }
+
+    private static Object readArrayFromBuffer( ByteBuffer buffer )
+    {
+        if ( buffer.limit() <= 0 )
+        {
+            throw new IllegalStateException( "Given buffer is empty" );
+        }
+
+        byte typeId = buffer.get();
+        buffer.order( ByteOrder.BIG_ENDIAN );
+        try
+        {
+            if ( typeId == PropertyType.STRING.intValue() )
+            {
+                int arrayLength = buffer.getInt();
+                String[] result = new String[arrayLength];
+
+                for ( int i = 0; i < arrayLength; i++ )
+                {
+                    int byteLength = buffer.getInt();
+                    result[i] = UTF8.decode( buffer.array(), buffer.position(), byteLength );
+                    buffer.position( buffer.position() + byteLength );
+                }
+                return result;
+            }
+            else
+            {
+                ShortArray type = ShortArray.typeOf( typeId );
+                int bitsUsedInLastByte = buffer.get();
+                int requiredBits = buffer.get();
+                if ( requiredBits == 0 )
+                {
+                    return type.createEmptyArray();
+                }
+                Object result;
+                if ( type == ShortArray.BYTE && requiredBits == Byte.SIZE )
+                {   // Optimization for byte arrays (probably large ones)
+                    byte[] byteArray = new byte[buffer.limit() - buffer.position()];
+                    buffer.get( byteArray );
+                    result = byteArray;
+                }
+                else
+                {   // Fallback to the generic approach, which is a slower
+                    Bits bits = Bits.bitsFromBytes( buffer.array(), buffer.position() );
+                    int length = ((buffer.limit() - buffer.position()) * 8 - (8 - bitsUsedInLastByte)) / requiredBits;
+                    result = type.createArray( length, bits, requiredBits );
+                }
+                return result;
+            }
+        }
+        finally
+        {
+            buffer.order( ByteOrder.LITTLE_ENDIAN );
+        }
+    }
+
+    private void assertOfType( PropertyType expected )
+    {
+        if ( type() != expected )
+        {
+            throw new IllegalStateException( "Expected type " + expected + " but was " + type() );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
@@ -629,7 +629,7 @@ public enum ShortArray
         return array.getClass().getComponentType().isPrimitive();
     }
 
-    private final static Map<Class, ShortArray> all = new IdentityHashMap<Class, ShortArray>( values().length * 2 );
+    private static final Map<Class<?>, ShortArray> all = new IdentityHashMap<>( values().length * 2 );
 
     static
     {
@@ -646,7 +646,7 @@ public enum ShortArray
     private final Class<?> primitiveClass;
     private final PropertyType type;
 
-    private ShortArray( PropertyType type, int maxBits, Class<?> boxedClass, Class<?> primitiveClass)
+    ShortArray( PropertyType type, int maxBits, Class<?> boxedClass, Class<?> primitiveClass )
     {
         this.type = type;
         this.maxBits = maxBits;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
@@ -1,0 +1,501 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.neo4j.helpers.Strings;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.StubPageCursor;
+import org.neo4j.kernel.impl.store.DynamicArrayStore;
+import org.neo4j.kernel.impl.store.DynamicRecordAllocator;
+import org.neo4j.kernel.impl.store.DynamicStringStore;
+import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.PropertyType;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.PropertyBlock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.kernel.impl.api.store.StorePropertyCursor.payloadValueAsObject;
+import static org.neo4j.kernel.impl.api.store.StorePropertyPayloadCursorTest.Param.param;
+import static org.neo4j.kernel.impl.api.store.StorePropertyPayloadCursorTest.Param.paramArg;
+import static org.neo4j.kernel.impl.api.store.StorePropertyPayloadCursorTest.Params.params;
+import static org.neo4j.test.Assert.assertObjectOrArrayEquals;
+
+@RunWith( Enclosed.class )
+public class StorePropertyPayloadCursorTest
+{
+    @Test
+    public void shouldBeOkToClearUnusedCursor()
+    {
+        // Given
+        StorePropertyPayloadCursor cursor = newCursor( "cat-dog" );
+
+        // When
+        cursor.clear();
+
+        // Then
+        // clear() on an unused cursor works just fine
+    }
+
+    @Test
+    public void shouldBeOkToClearPartiallyExhaustedCursor()
+    {
+        // Given
+        StorePropertyPayloadCursor cursor = newCursor( 1, 2, 3L );
+
+        cursor.next();
+        cursor.next();
+
+        // When
+        cursor.clear();
+
+        // Then
+        // clear() on an used cursor works just fine
+    }
+
+    @Test
+    public void shouldBeOkToClearExhaustedCursor()
+    {
+        // Given
+        StorePropertyPayloadCursor cursor = newCursor( 1, 2, 3 );
+
+        cursor.next();
+        cursor.next();
+        cursor.next();
+
+        // When
+        cursor.clear();
+
+        // Then
+        // clear() on an exhausted cursor works just fine
+    }
+
+    @Test
+    public void shouldBePossibleToCallClearOnEmptyCursor()
+    {
+        // Given
+        StorePropertyPayloadCursor cursor = newCursor();
+
+        // When
+        cursor.clear();
+
+        // Then
+        // clear() on an empty cursor works just fine
+    }
+
+    @Test
+    public void shouldBePossibleToCallNextOnEmptyCursor()
+    {
+        // Given
+        StorePropertyPayloadCursor cursor = newCursor();
+
+        // When
+        cursor.next();
+
+        // Then
+        // next() on an empty cursor works just fine
+    }
+
+    @RunWith( Parameterized.class )
+    public static class SingleValuePayload
+    {
+        @Parameter( 0 )
+        public Param param;
+
+        @Parameterized.Parameters( name = "{0}" )
+        public static List<Object[]> parameters()
+        {
+            return Arrays.asList(
+                    param( false, PropertyType.BOOL ),
+                    param( true, PropertyType.BOOL ),
+                    param( (byte) 24, PropertyType.BYTE ),
+                    param( Byte.MIN_VALUE, PropertyType.BYTE ),
+                    param( Byte.MAX_VALUE, PropertyType.BYTE ),
+                    param( (short) 99, PropertyType.SHORT ),
+                    param( Short.MIN_VALUE, PropertyType.SHORT ),
+                    param( Short.MAX_VALUE, PropertyType.SHORT ),
+                    param( 'c', PropertyType.CHAR ),
+                    param( Character.MIN_LOW_SURROGATE, PropertyType.CHAR ),
+                    param( Character.MAX_HIGH_SURROGATE, PropertyType.CHAR ),
+                    param( 10293, PropertyType.INT ),
+                    param( Integer.MIN_VALUE, PropertyType.INT ),
+                    param( Integer.MAX_VALUE, PropertyType.INT ),
+                    param( (float) 564.29393, PropertyType.FLOAT ),
+                    param( Float.MIN_VALUE, PropertyType.FLOAT ),
+                    param( Float.MAX_VALUE, PropertyType.FLOAT ),
+                    param( 93039173.12848, PropertyType.DOUBLE ),
+                    param( Double.MIN_VALUE, PropertyType.DOUBLE ),
+                    param( Double.MAX_VALUE, PropertyType.DOUBLE ),
+                    param( 484381293L, PropertyType.LONG ),
+                    param( Long.MIN_VALUE, PropertyType.LONG ),
+                    param( Long.MAX_VALUE, PropertyType.LONG ),
+                    param( "short", PropertyType.SHORT_STRING ),
+                    param( "alongershortstring", PropertyType.SHORT_STRING ),
+                    param( "areallylongshortstringbutstillnotsobig", PropertyType.SHORT_STRING ),
+                    param( new boolean[]{true}, PropertyType.SHORT_ARRAY ),
+                    param( new byte[]{(byte) 250}, PropertyType.SHORT_ARRAY ),
+                    param( new short[]{(short) 12000}, PropertyType.SHORT_ARRAY ),
+                    param( new char[]{'T'}, PropertyType.SHORT_ARRAY ),
+                    param( new int[]{314}, PropertyType.SHORT_ARRAY ),
+                    param( new float[]{(float) 3.14}, PropertyType.SHORT_ARRAY ),
+                    param( new double[]{314159.2653}, PropertyType.SHORT_ARRAY ),
+                    param( new long[]{1234567890123L}, PropertyType.SHORT_ARRAY )
+            );
+        }
+
+        @Test
+        public void shouldReturnCorrectSingleValue()
+        {
+            // Given
+            StorePropertyPayloadCursor cursor = newCursor( param );
+
+            // When
+            boolean next = cursor.next();
+
+            // Then
+            assertTrue( next );
+            assertEquals( param.type, cursor.type() );
+            assertObjectOrArrayEquals( param.value, payloadValueAsObject( cursor ) );
+        }
+    }
+
+    @RunWith( Parameterized.class )
+    public static class MultipleValuePayload
+    {
+        @Parameter( 0 )
+        public Params parameters;
+
+        @Parameterized.Parameters( name = "{0}" )
+        public static List<Object[]> parameters()
+        {
+            return Arrays.asList(
+                    params(
+                            paramArg( false, PropertyType.BOOL ),
+                            paramArg( true, PropertyType.BOOL )
+                    ),
+                    params(
+                            paramArg( (byte) 24, PropertyType.BYTE ),
+                            paramArg( Byte.MIN_VALUE, PropertyType.BYTE )
+                    ),
+                    params(
+                            paramArg( (short) 99, PropertyType.SHORT ),
+                            paramArg( Short.MAX_VALUE, PropertyType.SHORT )
+                    ),
+                    params(
+                            paramArg( 'c', PropertyType.CHAR ),
+                            paramArg( Character.MAX_HIGH_SURROGATE, PropertyType.CHAR )
+                    ),
+                    params(
+                            paramArg( 10293, PropertyType.INT ),
+                            paramArg( Integer.MIN_VALUE, PropertyType.INT )
+                    ),
+                    params(
+                            paramArg( (float) 564.29393, PropertyType.FLOAT ),
+                            paramArg( Float.MAX_VALUE, PropertyType.FLOAT )
+                    ),
+                    params(
+                            paramArg( Double.MAX_VALUE, PropertyType.DOUBLE ),
+                            paramArg( Double.MIN_VALUE, PropertyType.DOUBLE )
+                    ),
+                    params(
+                            paramArg( Long.MIN_VALUE, PropertyType.LONG ),
+                            paramArg( Long.MAX_VALUE, PropertyType.LONG )
+                    ),
+                    params(
+                            paramArg( new boolean[]{true}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new byte[]{(byte) 250}, PropertyType.SHORT_ARRAY )
+                    ),
+                    params(
+                            paramArg( new short[]{(short) 12000}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new short[]{Short.MIN_VALUE}, PropertyType.SHORT_ARRAY )
+                    ),
+                    params(
+                            paramArg( new char[]{'T'}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new int[]{314}, PropertyType.SHORT_ARRAY )
+                    ),
+                    params(
+                            paramArg( new float[]{(float) 3.14}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new long[]{1234567890123L}, PropertyType.SHORT_ARRAY )
+                    ),
+                    params(
+                            paramArg( new double[]{Double.MIN_VALUE}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new long[]{Long.MAX_VALUE}, PropertyType.SHORT_ARRAY )
+                    ),
+                    params(
+                            paramArg( new long[]{1234567890123L}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new long[]{Long.MIN_VALUE}, PropertyType.SHORT_ARRAY )
+                    ),
+                    params(
+                            paramArg( new long[]{1234567890123L}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new long[]{Long.MIN_VALUE}, PropertyType.SHORT_ARRAY )
+                    ),
+                    params(
+                            paramArg( false, PropertyType.BOOL ),
+                            paramArg( true, PropertyType.BOOL ),
+                            paramArg( false, PropertyType.BOOL ),
+                            paramArg( true, PropertyType.BOOL )
+                    ),
+                    params(
+                            paramArg( (byte) 24, PropertyType.BYTE ),
+                            paramArg( true, PropertyType.BOOL ),
+                            paramArg( (short) 99, PropertyType.SHORT )
+                    ),
+                    params(
+                            paramArg( Byte.MIN_VALUE, PropertyType.BYTE ),
+                            paramArg( Byte.MAX_VALUE, PropertyType.BYTE ),
+                            paramArg( (short) 99, PropertyType.SHORT ),
+                            paramArg( true, PropertyType.BOOL )
+                    ),
+                    params(
+                            paramArg( (short) 99, PropertyType.SHORT ),
+                            paramArg( (byte) 1, PropertyType.BYTE ),
+                            paramArg( Short.MIN_VALUE, PropertyType.SHORT ),
+                            paramArg( Short.MAX_VALUE, PropertyType.SHORT )
+                    ),
+                    params(
+                            paramArg( Short.MAX_VALUE, PropertyType.SHORT ),
+                            paramArg( 5L, PropertyType.LONG ),
+                            paramArg( 6L, PropertyType.LONG )
+                    ),
+                    params(
+                            paramArg( 'c', PropertyType.CHAR ),
+                            paramArg( 'h', PropertyType.CHAR ),
+                            paramArg( 'a', PropertyType.CHAR ),
+                            paramArg( 'r', PropertyType.CHAR )
+                    ),
+                    params(
+                            paramArg( 10293, PropertyType.INT ),
+                            paramArg( 'r', PropertyType.CHAR ),
+                            paramArg( 3.14, PropertyType.DOUBLE )
+                    ),
+                    params(
+                            paramArg( Integer.MIN_VALUE, PropertyType.INT ),
+                            paramArg( Integer.MAX_VALUE, PropertyType.INT ),
+                            paramArg( Integer.MAX_VALUE, PropertyType.INT ),
+                            paramArg( Integer.MAX_VALUE, PropertyType.INT )
+                    ),
+                    params(
+                            paramArg( Float.MIN_VALUE, PropertyType.FLOAT ),
+                            paramArg( (float) 256.256, PropertyType.FLOAT )
+                    ),
+                    params(
+                            paramArg( Double.MIN_VALUE + 1, PropertyType.DOUBLE ),
+                            paramArg( Double.MAX_VALUE - 1, PropertyType.DOUBLE )
+                    ),
+                    params(
+                            paramArg( Double.MIN_VALUE, PropertyType.DOUBLE ),
+                            paramArg( Short.MAX_VALUE, PropertyType.SHORT ),
+                            paramArg( Byte.MAX_VALUE, PropertyType.BYTE )
+                    ),
+                    params(
+                            paramArg( 484381293L, PropertyType.LONG ),
+                            paramArg( 'c', PropertyType.CHAR ),
+                            paramArg( 1, PropertyType.INT ),
+                            paramArg( true, PropertyType.BOOL )
+                    ),
+                    params(
+                            paramArg( 's', PropertyType.CHAR ),
+                            paramArg( 'o', PropertyType.CHAR ),
+                            paramArg( "rt", PropertyType.SHORT_STRING ),
+                            paramArg( true, PropertyType.BOOL )
+                    ),
+                    params(
+                            paramArg( "abc", PropertyType.SHORT_STRING ),
+                            paramArg( 11L, PropertyType.LONG )
+                    ),
+                    params(
+                            paramArg( new boolean[]{true}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new boolean[]{true, false, false}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new byte[]{(byte) 1024}, PropertyType.SHORT_ARRAY )
+                    ),
+
+                    params(
+                            paramArg( new byte[]{(byte) 250, (byte) 251, (byte) 252}, PropertyType.SHORT_ARRAY ),
+                            paramArg( new char[]{'C', 'T'}, PropertyType.SHORT_ARRAY ),
+                            paramArg( true, PropertyType.BOOL )
+                    ),
+                    params(
+                            paramArg( new long[]{1234567890123L, Long.MAX_VALUE}, PropertyType.SHORT_ARRAY ),
+                            paramArg( (byte) 42, PropertyType.BYTE )
+                    )
+            );
+        }
+
+        @Test
+        public void shouldReturnCorrectValues()
+        {
+            // Given
+            StorePropertyPayloadCursor cursor = newCursor( parameters );
+
+            for ( Param param : parameters )
+            {
+                // When
+                boolean next = cursor.next();
+
+                // Then
+                assertTrue( next );
+                assertEquals( param.type, cursor.type() );
+                assertObjectOrArrayEquals( param.value, payloadValueAsObject( cursor ) );
+            }
+        }
+    }
+
+    private static StorePropertyPayloadCursor newCursor( Params input )
+    {
+        return newCursor( input.params );
+    }
+
+    private static StorePropertyPayloadCursor newCursor( Param... params )
+    {
+        Object[] values = new Object[params.length];
+        for ( int i = 0; i < params.length; i++ )
+        {
+            values[i] = params[i].value;
+        }
+        return newCursor( values );
+    }
+
+    private static StorePropertyPayloadCursor newCursor( Object... values )
+    {
+        DynamicStringStore dynamicStringStore = mock( DynamicStringStore.class );
+        DynamicArrayStore dynamicArrayStore = mock( DynamicArrayStore.class );
+
+        StorePropertyPayloadCursor cursor = new StorePropertyPayloadCursor( dynamicStringStore, dynamicArrayStore );
+
+        PageCursor pageCursor = newPageCursor( values );
+        cursor.init( pageCursor );
+
+        return cursor;
+    }
+
+    private static PageCursor newPageCursor( Object... values )
+    {
+        RecordAllocator stringAllocator = new RecordAllocator();
+        RecordAllocator arrayAllocator = new RecordAllocator();
+
+        ByteBuffer page = ByteBuffer.allocateDirect( StorePropertyPayloadCursor.MAX_NUMBER_OF_PAYLOAD_LONG_ARRAY * 8 );
+        for ( int i = 0; i < values.length; i++ )
+        {
+            Object value = values[i];
+
+            PropertyBlock block = new PropertyBlock();
+            PropertyStore.encodeValue( block, i, value, stringAllocator, arrayAllocator );
+            long[] valueBlocks = block.getValueBlocks();
+            for ( long valueBlock : valueBlocks )
+            {
+                page.putLong( valueBlock );
+            }
+        }
+        while ( page.remaining() > 0 )
+        {
+            page.put( (byte) 0 );
+        }
+
+        return new StubPageCursor( 1, page );
+    }
+
+    static class Param
+    {
+        final Object value;
+        final PropertyType type;
+
+        Param( Object value, PropertyType type )
+        {
+            this.value = value;
+            this.type = type;
+        }
+
+        static Object[] param( Object value, PropertyType type )
+        {
+            return new Object[]{paramArg( value, type )};
+        }
+
+        static Param paramArg( Object value, PropertyType type )
+        {
+            return new Param( value, type );
+        }
+
+        @Override
+        public String toString()
+        {
+            return "{type=" + type + ", value=" + Strings.prettyPrint( value ) + "}";
+        }
+    }
+
+    static class Params implements Iterable<Param>
+    {
+        final Param[] params;
+
+        Params( Param[] params )
+        {
+            this.params = params;
+        }
+
+        static Object[] params( Param... input )
+        {
+            return new Object[]{new Params( input )};
+        }
+
+        @Override
+        public Iterator<Param> iterator()
+        {
+            return IteratorUtil.iterator( params );
+        }
+
+        @Override
+        public String toString()
+        {
+            return "{params=" + Arrays.toString( params ) + "}";
+        }
+    }
+
+    private static class RecordAllocator implements DynamicRecordAllocator
+    {
+        long id;
+
+        @Override
+        public int dataSize()
+        {
+            return 120;
+        }
+
+        @Override
+        public DynamicRecord nextUsedRecordOrNew( Iterator<DynamicRecord> recordsToUseFirst )
+        {
+            DynamicRecord record = new DynamicRecord( id++ );
+            record.setCreated();
+            record.setInUse( true );
+            return record;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/PropertyContainerProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/PropertyContainerProxyTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.CleanupRule;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.test.Assert.assertObjectOrArrayEquals;
+
+public abstract class PropertyContainerProxyTest
+{
+    @Rule
+    public final DatabaseRule db = new ImpermanentDatabaseRule();
+    @Rule
+    public final CleanupRule cleanup = new CleanupRule();
+
+    protected abstract long createPropertyContainer();
+
+    protected abstract PropertyContainer lookupPropertyContainer( long id );
+
+    @Test
+    public void shouldListAllProperties()
+    {
+        // Given
+        Map<String,Object> properties = new HashMap<>();
+        properties.put( "boolean", true );
+        properties.put( "short_string", "abc" );
+        properties.put( "string", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVW" +
+                                  "XYZabcdefghijklmnopqrstuvwxyz" );
+        properties.put( "long", Long.MAX_VALUE );
+        properties.put( "short_array", new long[]{1, 2, 3, 4} );
+        properties.put( "array", new long[]{Long.MAX_VALUE - 1, Long.MAX_VALUE - 2, Long.MAX_VALUE - 3,
+                Long.MAX_VALUE - 4, Long.MAX_VALUE - 5, Long.MAX_VALUE - 6, Long.MAX_VALUE - 7,
+                Long.MAX_VALUE - 8, Long.MAX_VALUE - 9, Long.MAX_VALUE - 10, Long.MAX_VALUE - 11} );
+
+        long containerId;
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            containerId = createPropertyContainer();
+            PropertyContainer container = lookupPropertyContainer( containerId );
+
+            for ( Map.Entry<String,Object> entry : properties.entrySet() )
+            {
+                container.setProperty( entry.getKey(), entry.getValue() );
+            }
+
+            tx.success();
+        }
+
+        // When
+        Map<String,Object> listedProperties;
+        try ( Transaction tx = db.beginTx() )
+        {
+            listedProperties = lookupPropertyContainer( containerId ).getAllProperties();
+            tx.success();
+        }
+
+        // Then
+        assertEquals( properties.size(), listedProperties.size() );
+        for ( String key : properties.keySet() )
+        {
+            assertObjectOrArrayEquals( properties.get( key ), listedProperties.get( key ) );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/Assert.java
+++ b/community/kernel/src/test/java/org/neo4j/test/Assert.java
@@ -23,13 +23,39 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.neo4j.function.ThrowingSupplier;
+import org.neo4j.helpers.ArrayUtil;
+import org.neo4j.helpers.Strings;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 public final class Assert
 {
     private Assert()
     {
+    }
+
+    public static void assertObjectOrArrayEquals( Object expected, Object actual )
+    {
+        assertObjectOrArrayEquals( "", expected, actual );
+    }
+
+    public static void assertObjectOrArrayEquals( String message, Object expected, Object actual )
+    {
+        if ( expected.getClass().isArray() )
+        {
+            if ( !ArrayUtil.equals( expected, actual ) )
+            {
+                throw newAssertionError( message, expected, actual );
+            }
+        }
+        else
+        {
+            if ( !Objects.equals( expected, actual ) )
+            {
+                throw newAssertionError( message, expected, actual );
+            }
+        }
     }
 
     public static <T, E extends Exception> void assertEventually(
@@ -61,5 +87,12 @@ public final class Assert
             throw new AssertionError( "Timeout hit (" + timeout + " " + timeUnit.toString().toLowerCase() +
                     ") while waiting for condition to match: " + description.toString() );
         }
+    }
+
+    private static AssertionError newAssertionError( String message, Object expected, Object actual )
+    {
+        return new AssertionError( ((message == null || message.isEmpty()) ? "" : message + "\n") +
+                                   "Expected: " + Strings.prettyPrint( expected ) +
+                                   ", actual: " + Strings.prettyPrint( actual ) );
     }
 }


### PR DESCRIPTION
This is done so to guarantee consistent view of a single property record while loading of a property chain. StorePropertyCursor is now only responsible for reading of property record header (previousPropertyId and nextPropertyId). Introduced new StorePropertyPayloadCursor that provides a view of the property blocks. Both property record header and blocks are initialized eagerly and using the same version of the page (guaranteed by reading inside single PageCursor should-retry loop).

Lazy loading of blocks was not correct because it did not ensure all blocks were read from the same version of the page. Under a heavy concurrent load this resulted in reading of stray propertyKeyId from property blocks.
