### PR TITLE
Fix NonUniqueIndexPopulatorCompatibility flaky test

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/NonUniqueIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/NonUniqueIndexPopulatorCompatibility.java
@@ -76,6 +76,7 @@ public class NonUniqueIndexPopulatorCompatibility extends IndexProviderCompatibi
         IndexSamplingConfig indexSamplingConfig = new IndexSamplingConfig( new Config() );
         IndexPopulator populator = indexProvider.getPopulator( 17, descriptor, config, indexSamplingConfig );
         String failure = "The contrived failure";
+        populator.create();
 
         // WHEN
         populator.markAsFailed( failure );
@@ -92,6 +93,7 @@ public class NonUniqueIndexPopulatorCompatibility extends IndexProviderCompatibi
         IndexSamplingConfig indexSamplingConfig = new IndexSamplingConfig( new Config() );
         IndexPopulator populator = indexProvider.getPopulator( 17, descriptor, config, indexSamplingConfig );
         String failure = "The contrived failure";
+        populator.create();
 
         // WHEN
         populator.markAsFailed( failure );


### PR DESCRIPTION
Make sure to call populator.create() before failing the populator in order to guarantee that the index folder is created.  Otherwise some tests might fail by being unable to create the error message file in
a non-existent folder.
