### PR TITLE
Track ids during recovery process

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplicationMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplicationMode.java
@@ -44,12 +44,13 @@ public enum TransactionApplicationMode
             ),
 
     /**
-     * Transaction that is recovered, where commands are read, much like {@link #external}, but should
+     * Transaction that is recovered, where commands are read, much like {@link #EXTERNAL}, but should
      * be applied differently where extra care should be taken to ensure idempotency. This is because
      * a recovered transaction may have already been applied previously to the store.
      */
     RECOVERY(
-            false, // id tracking not needed since recovery rebuilds id generators anyway
+            true,  // id tracking needed because of the cases when we will free ids of entities that was created as
+                   // part of recovery with ids that potentially higher then current highId
             false, // during recovery there's not really a cache to invalidate so don't bother
             true   // extra care needs to be taken to ensure idempotency since this transaction
                     // may have been applied previously
@@ -59,7 +60,7 @@ public enum TransactionApplicationMode
     private final boolean needsCacheInvalidation;
     private final boolean needsIdempotencyChecks;
 
-    private TransactionApplicationMode( boolean needsIdTracking, boolean needsCacheInvalidation,
+    TransactionApplicationMode( boolean needsIdTracking, boolean needsCacheInvalidation,
             boolean ensureIdempotency )
     {
         this.needsIdTracking = needsIdTracking;

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.helpers.Format;
+import org.neo4j.kernel.impl.storemigration.LogFiles;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class RecoveryIT
+{
+
+    @Rule
+    public final TargetDirectory.TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void deleteAndRemoveNodePropertyDuringOneRecoveryRun() throws IOException
+    {
+        GraphDatabaseService database = startDatabase( directory.graphDbDir() );
+        Label testLabel = DynamicLabel.label( "testLabel" );
+        final String propertyToDelete = "propertyToDelete";
+        final String validPropertyName = "validProperty";
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            Node node = database.createNode();
+            node.addLabel( testLabel );
+            transaction.success();
+        }
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            Node node = findNodeByLabel( database, testLabel );
+            node.setProperty( propertyToDelete, createLongString() );
+            node.setProperty( validPropertyName, createLongString() );
+            transaction.success();
+        }
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            Node node = findNodeByLabel( database, testLabel );
+            node.removeProperty( propertyToDelete );
+            transaction.success();
+        }
+
+        // copying only transaction log simulate non clean shutdown db that should be able to recover just from logs
+        File restoreDbStoreDir = copyTransactionLogs();
+
+        // database should be restored and node should have expected properties
+        GraphDatabaseService recoveredDatabase = startDatabase( restoreDbStoreDir );
+        try ( Transaction ignored = recoveredDatabase.beginTx() )
+        {
+            Node node = findNodeByLabel( recoveredDatabase, testLabel );
+            assertFalse( node.hasProperty( propertyToDelete ) );
+            assertTrue( node.hasProperty( validPropertyName ) );
+        }
+
+        database.shutdown();
+        recoveredDatabase.shutdown();
+    }
+
+    private String createLongString()
+    {
+        String[] strings = new String[Format.KB * 2];
+        Arrays.fill( strings, "a" );
+        return Arrays.toString( strings );
+    }
+
+    private GraphDatabaseService startDatabase( File storeDir )
+    {
+        return new GraphDatabaseFactory().newEmbeddedDatabase( storeDir.getAbsolutePath() );
+    }
+
+    private Node findNodeByLabel( GraphDatabaseService database, Label testLabel )
+    {
+        try ( ResourceIterator<Node> nodes = database.findNodes( testLabel ) )
+        {
+            return nodes.next();
+        }
+    }
+
+    private File copyTransactionLogs() throws IOException
+    {
+        File restoreDbStoreDir = this.directory.directory( "restore-db" );
+        LogFiles.move( new DefaultFileSystemAbstraction(), this.directory.graphDbDir(), restoreDbStoreDir );
+        return restoreDbStoreDir;
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
@@ -35,7 +35,7 @@ import org.neo4j.tooling.GlobalGraphOperations;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class RecoveryIT
+public class LuceneRecoveryIT
 {
     @Test
     public void testHardCoreRecovery() throws Exception


### PR DESCRIPTION
Track ids during recovery to be able to handle cases when recovery
will try to free ids that come with transaction logs that are higher
then current high id in current store
