### PR TITLE
Provide a setting for enabling debug entries in the internal log

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
+import java.util.List;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.kernel.configuration.ConfigurationMigrator;
@@ -50,6 +51,7 @@ import static org.neo4j.helpers.Settings.STRING;
 import static org.neo4j.helpers.Settings.TRUE;
 import static org.neo4j.helpers.Settings.basePath;
 import static org.neo4j.helpers.Settings.illegalValueMessage;
+import static org.neo4j.helpers.Settings.list;
 import static org.neo4j.helpers.Settings.matches;
 import static org.neo4j.helpers.Settings.max;
 import static org.neo4j.helpers.Settings.min;
@@ -146,6 +148,11 @@ public abstract class GraphDatabaseSettings
 
     @Description( "Threshold for rotation of the internal log." )
     public static final Setting<Long> store_internal_log_rotation_threshold = setting("store.internal_log.rotation_threshold", BYTES, "20m", min(0L), max( Long.MAX_VALUE ) );
+
+    @Description( "Internal log contexts that should output debug level logging" )
+    @Internal
+    public static final Setting<List<String>> store_internal_debug_contexts = setting( "store.internal_log.debug_contexts",
+            list( ",", STRING ), "" );
 
     @Description("Log level threshold.")
     public static final Setting<Level> store_internal_log_level = setting( "store.internal_log.level",

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -227,7 +227,7 @@ public class PlatformModule
             }
         } );
 
-        builder.withLevel( config.get( GraphDatabaseSettings.store_internal_log_level ) );
+        builder.withDefaultLevel( config.get( GraphDatabaseSettings.store_internal_log_level ) );
 
         File internalLog = config.get( GraphDatabaseSettings.store_internal_log_location );
         LogService logService;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -56,6 +56,7 @@ import org.neo4j.kernel.info.JvmMetadataRepository;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
+import org.neo4j.logging.Level;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.udc.UsageData;
@@ -227,6 +228,10 @@ public class PlatformModule
             }
         } );
 
+        for ( String debugContext : config.get( GraphDatabaseSettings.store_internal_debug_contexts ) )
+        {
+            builder.withLevel( debugContext, Level.DEBUG );
+        }
         builder.withDefaultLevel( config.get( GraphDatabaseSettings.store_internal_log_level ) );
 
         File internalLog = config.get( GraphDatabaseSettings.store_internal_log_location );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseInternalLogIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseInternalLogIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.StringWriter;
+
+import org.neo4j.function.Predicate;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.logging.StoreLogService;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.core.Is.is;
+import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
+
+public class GraphDatabaseInternalLogIT
+{
+    @Rule
+    public TargetDirectory.TestDirectory testDir = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void shouldWriteToInternalDiagnosticsLog() throws Exception
+    {
+        // Given
+        new TestGraphDatabaseFactory().newEmbeddedDatabase( testDir.graphDbDir() ).shutdown();
+        final File internalLog = new File( testDir.graphDbDir(), StoreLogService.INTERNAL_LOG_NAME );
+
+        // Then
+        assertThat( internalLog.isFile(), is( true ) );
+        assertThat( internalLog.length(), greaterThan( 0L ) );
+
+        assertThat( IteratorUtil.count( asIterable( internalLog, "UTF-8" ), new Predicate<String>()
+        {
+            @Override
+            public boolean test( String line )
+            {
+                return line.contains( "Database is now ready" );
+            }
+        } ), is( 1 ) );
+
+        assertThat( IteratorUtil.count( asIterable( internalLog, "UTF-8" ), new Predicate<String>()
+        {
+            @Override
+            public boolean test( String line )
+            {
+                return line.contains( "Database is now unavailable" );
+            }
+        } ), is( 1 ) );
+    }
+
+    @Test
+    public void shouldNotWriteDebugToInternalDiagnosticsLogByDefault() throws Exception
+    {
+        // Given
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( testDir.graphDbDir() );
+
+        // When
+        LogService logService = ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency( LogService.class );
+        logService.getInternalLog( getClass() ).debug( "A debug entry" );
+
+        db.shutdown();
+        final File internalLog = new File( testDir.graphDbDir(), StoreLogService.INTERNAL_LOG_NAME );
+
+        // Then
+        assertThat( internalLog.isFile(), is( true ) );
+        assertThat( internalLog.length(), greaterThan( 0L ) );
+
+        assertThat( IteratorUtil.count( asIterable( internalLog, "UTF-8" ), new Predicate<String>()
+        {
+            @Override
+            public boolean test( String line )
+            {
+                return line.contains( "A debug entry" );
+            }
+        } ), is( 0 ) );
+    }
+
+    @Test
+    public void shouldWriteDebugToInternalDiagnosticsLogForEnabledContexts() throws Exception
+    {
+        // Given
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDir.graphDbDir() )
+                .setConfig( GraphDatabaseSettings.store_internal_debug_contexts, getClass().getName() + ",java.io" )
+                .newGraphDatabase();
+
+        // When
+        LogService logService = ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency( LogService.class );
+        logService.getInternalLog( getClass() ).debug( "A debug entry" );
+        logService.getInternalLog( GraphDatabaseService.class ).debug( "A GDS debug entry" );
+        logService.getInternalLog( StringWriter.class ).debug( "A SW debug entry" );
+
+        db.shutdown();
+        final File internalLog = new File( testDir.graphDbDir(), StoreLogService.INTERNAL_LOG_NAME );
+
+        // Then
+        assertThat( internalLog.isFile(), is( true ) );
+        assertThat( internalLog.length(), greaterThan( 0L ) );
+
+        assertThat( IteratorUtil.count( asIterable( internalLog, "UTF-8" ), new Predicate<String>()
+        {
+            @Override
+            public boolean test( String line )
+            {
+                return line.contains( "A debug entry" );
+            }
+        } ), is( 1 ) );
+
+        assertThat( IteratorUtil.count( asIterable( internalLog, "UTF-8" ), new Predicate<String>()
+        {
+            @Override
+            public boolean test( String line )
+            {
+                return line.contains( "A GDS debug entry" );
+            }
+        } ), is( 0 ) );
+
+        assertThat( IteratorUtil.count( asIterable( internalLog, "UTF-8" ), new Predicate<String>()
+        {
+            @Override
+            public boolean test( String line )
+            {
+                return line.contains( "A SW debug entry" );
+            }
+        } ), is( 1 ) );
+    }
+}

--- a/community/logging/src/main/java/org/neo4j/logging/AbstractLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/AbstractLogProvider.java
@@ -45,25 +45,25 @@ public abstract class AbstractLogProvider<T extends Log> implements LogProvider
     }
 
     @Override
-    public T getLog( final String context )
+    public T getLog( final String name )
     {
-        return getLog( context, new Supplier<T>()
+        return getLog( name, new Supplier<T>()
         {
             @Override
             public T get()
             {
-                return buildLog( context );
+                return buildLog( name );
             }
         } );
     }
 
-    private T getLog( String context, Supplier<T> logSupplier )
+    private T getLog( String name, Supplier<T> logSupplier )
     {
-        T log = logCache.get( context );
+        T log = logCache.get( name );
         if ( log == null )
         {
             T newLog = logSupplier.get();
-            log = logCache.putIfAbsent( context, newLog );
+            log = logCache.putIfAbsent( name, newLog );
             if ( log == null )
             {
                 log = newLog;
@@ -82,13 +82,13 @@ public abstract class AbstractLogProvider<T extends Log> implements LogProvider
 
     /**
      * @param loggingClass the context for the returned {@link Log}
-     * @return a {@link Log} that logs messages with the {@code loggingClass} as context
+     * @return a {@link Log} that logs messages with the {@code loggingClass} as the context
      */
     protected abstract T buildLog( Class loggingClass );
 
     /**
-     * @param context the named context for the returned {@link Log}
-     * @return a {@link Log} that logs messages with the given context
+     * @param name the context for the returned {@link Log}
+     * @return a {@link Log} that logs messages with the specified name as the context
      */
-    protected abstract T buildLog( String context );
+    protected abstract T buildLog( String name );
 }

--- a/community/logging/src/main/java/org/neo4j/logging/DuplicatingLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/DuplicatingLogProvider.java
@@ -79,14 +79,14 @@ public class DuplicatingLogProvider extends AbstractLogProvider<DuplicatingLog>
     }
 
     @Override
-    protected DuplicatingLog buildLog( final String context )
+    protected DuplicatingLog buildLog( final String name )
     {
         return buildLog( new Function<LogProvider, Log>()
         {
             @Override
             public Log apply( LogProvider logProvider )
             {
-                return logProvider.getLog( context );
+                return logProvider.getLog( name );
             }
         } );
     }

--- a/community/logging/src/main/java/org/neo4j/logging/FormattedLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/FormattedLogProvider.java
@@ -54,7 +54,7 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
         }
 
         /**
-         * Disable rendering of the context (or class name) in each output line.
+         * Disable rendering of the context (the class name or log name) in each output line.
          *
          * @return this builder
          */
@@ -175,7 +175,7 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
     private final boolean autoFlush;
 
     /**
-     * Start creating a {@link FormattedLogProvider} which will not render the context (or class name) in each output line.
+     * Start creating a {@link FormattedLogProvider} which will not render the context (the class name or log name) in each output line.
      * Use {@link Builder#toOutputStream} to complete.
      *
      * @return a builder for a {@link FormattedLogProvider}
@@ -304,8 +304,8 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
     }
 
     @Override
-    protected FormattedLog buildLog( String context )
+    protected FormattedLog buildLog( String name )
     {
-        return new FormattedLog( currentDateSupplier, writerSupplier, timezone, this, renderContext ? context : null, defaultLevel, autoFlush );
+        return new FormattedLog( currentDateSupplier, writerSupplier, timezone, this, renderContext ? name : null, defaultLevel, autoFlush );
     }
 }

--- a/community/logging/src/main/java/org/neo4j/logging/FormattedLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/FormattedLogProvider.java
@@ -46,7 +46,7 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
     {
         private boolean renderContext = true;
         private TimeZone timezone = TimeZone.getDefault();
-        private Level level = Level.INFO;
+        private Level defaultLevel = Level.INFO;
         private boolean autoFlush = true;
 
         private Builder()
@@ -92,9 +92,9 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
          * @param level the log level to use as a default
          * @return this builder
          */
-        public Builder withLogLevel( Level level )
+        public Builder withDefaultLogLevel( Level level )
         {
-            this.level = level;
+            this.defaultLevel = level;
             return this;
         }
 
@@ -163,7 +163,7 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
          */
         public FormattedLogProvider toPrintWriter( Supplier<PrintWriter> writerSupplier )
         {
-            return new FormattedLogProvider( DEFAULT_CURRENT_DATE_SUPPLIER, writerSupplier, timezone, renderContext, level, autoFlush );
+            return new FormattedLogProvider( DEFAULT_CURRENT_DATE_SUPPLIER, writerSupplier, timezone, renderContext, defaultLevel, autoFlush );
         }
     }
 
@@ -171,7 +171,7 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
     private final Supplier<PrintWriter> writerSupplier;
     private final TimeZone timezone;
     private final boolean renderContext;
-    private final Level level;
+    private final Level defaultLevel;
     private final boolean autoFlush;
 
     /**
@@ -213,9 +213,9 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
      * @param level the log level to use as a default
      * @return a builder for a {@link FormattedLogProvider}
      */
-    public static Builder withLogLevel( Level level )
+    public static Builder withDefaultLogLevel( Level level )
     {
-        return new Builder().withLogLevel( level );
+        return new Builder().withDefaultLogLevel( level );
     }
 
     /**
@@ -286,13 +286,13 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
         return new Builder().toPrintWriter( writerSupplier );
     }
 
-    FormattedLogProvider( Supplier<Date> currentDateSupplier, Supplier<PrintWriter> writerSupplier, TimeZone timezone, boolean renderContext, Level level, boolean autoFlush )
+    FormattedLogProvider( Supplier<Date> currentDateSupplier, Supplier<PrintWriter> writerSupplier, TimeZone timezone, boolean renderContext, Level defaultLevel, boolean autoFlush )
     {
         this.currentDateSupplier = currentDateSupplier;
         this.writerSupplier = writerSupplier;
         this.timezone = timezone;
         this.renderContext = renderContext;
-        this.level = level;
+        this.defaultLevel = defaultLevel;
         this.autoFlush = autoFlush;
     }
 
@@ -306,6 +306,6 @@ public class FormattedLogProvider extends AbstractLogProvider<FormattedLog>
     @Override
     protected FormattedLog buildLog( String context )
     {
-        return new FormattedLog( currentDateSupplier, writerSupplier, timezone, this, renderContext ? context : null, level, autoFlush );
+        return new FormattedLog( currentDateSupplier, writerSupplier, timezone, this, renderContext ? context : null, defaultLevel, autoFlush );
     }
 }

--- a/community/logging/src/main/java/org/neo4j/logging/LogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/LogProvider.java
@@ -26,13 +26,13 @@ public interface LogProvider
 {
     /**
      * @param loggingClass the context for the returned {@link Log}
-     * @return a {@link Log} that logs messages with the {@code loggingClass} as context
+     * @return a {@link Log} that logs messages with the {@code loggingClass} as the context
      */
     Log getLog( Class loggingClass );
 
     /**
-     * @param context the named context for the returned {@link Log}
-     * @return a {@link Log} that logs messages with the given context
+     * @param name the context for the returned {@link Log}
+     * @return a {@link Log} that logs messages with the specified name as the context
      */
-    Log getLog( String context );
+    Log getLog( String name );
 }

--- a/community/logging/src/main/java/org/neo4j/logging/NullLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/NullLogProvider.java
@@ -45,7 +45,7 @@ public class NullLogProvider implements LogProvider
     }
 
     @Override
-    public Log getLog( String context )
+    public Log getLog( String name )
     {
         return NullLog.getInstance();
     }


### PR DESCRIPTION
Configuration setting is `store.internal_log.debug_contexts`, and accepts a comma-separated list of contexts, e.g. `store.internal_log.debug_contexts=org.neo4j.kernel.NeoStoreDataSource,org.neo4j.cypher`

Setting is currently marked with `@Internal`, to avoid public documentation.
