### PR TITLE
In-memory storage for procedures.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/Neo4jTypes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/Neo4jTypes.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+/**
+ * See also type_system.txt in the cypher code base, this is a mapping of that type system definition
+ * down to this level. Ideally this becomes canonical.
+ *
+ * This should also move to replace the specialized type handling in packstream, or be tied to it in some
+ * way to ensure a strict mapping.
+ */
+public class Neo4jTypes
+{
+    public static final AnyType NTAny = new AnyType();
+    public static final TextType NTText = new TextType();
+    public static final NumberType NTNumber = new NumberType();
+    public static final IntegerType NTInteger = new IntegerType();
+    public static final FloatType NTFloat = new FloatType();
+    public static final BooleanType NTBoolean = new BooleanType();
+    public static final MapType NTMap = new MapType();
+    public static final NodeType NTNode = new NodeType();
+    public static final RelationshipType NTRelationship = new RelationshipType();
+    public static final PathType NTPath = new PathType();
+    public static ListType NTList( AnyType innerType ) { return new ListType( innerType ); }
+
+    public static final int ORD_ANY = 0;
+    public static final int ORD_TEXT = 1;
+    public static final int ORD_NUMBER = 2;
+    public static final int ORD_INTEGER = 3;
+    public static final int ORD_FLOAT = 4;
+    public static final int ORD_BOOLEAN = 5;
+    public static final int ORD_LIST = 6;
+    public static final int ORD_MAP = 7;
+    public static final int ORD_NODE = 8;
+    public static final int ORD_RELATIONSHIP = 9;
+    public static final int ORD_PATH = 10;
+
+    public static class AnyType
+    {
+        /**
+         * A unique simple number assigned to each type, used when representing types in
+         * various forms. This is expected to be durably stored and potentially public,
+         * don't change ordinals.
+         */
+        private final int ordinal;
+
+        private final String name;
+
+        public int ordinal()
+        {
+            return ordinal;
+        }
+
+        public AnyType()
+        {
+            this( ORD_ANY, "Any" );
+        }
+
+        protected AnyType( int ordinal, String name )
+        {
+            this.ordinal = ordinal;
+            this.name = name;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name;
+        }
+    }
+
+    public static class TextType extends AnyType
+    {
+        public TextType()
+        {
+            super( ORD_TEXT, "Text" );
+        }
+    }
+
+    public static class NumberType extends AnyType
+    {
+        public NumberType()
+        {
+            super( ORD_NUMBER, "Number" );
+        }
+
+        protected NumberType( int ordinal, String name )
+        {
+            super( ordinal, name );
+        }
+    }
+
+    public static class IntegerType extends NumberType
+    {
+        public IntegerType()
+        {
+            super( ORD_INTEGER, "Integer" );
+        }
+    }
+
+    public static class FloatType extends NumberType
+    {
+        public FloatType()
+        {
+            super( ORD_FLOAT, "Float");
+        }
+    }
+
+    public static class BooleanType extends AnyType
+    {
+        public BooleanType()
+        {
+            super( ORD_BOOLEAN, "Boolean" );
+        }
+    }
+
+    public static class ListType extends AnyType
+    {
+        /** The type of values in this collection */
+        private final AnyType innerType;
+
+        public ListType( AnyType innerType )
+        {
+            super( ORD_LIST, "Collection[" + innerType.toString() + "]" );
+            this.innerType = innerType;
+        }
+
+        public AnyType innerType()
+        {
+            return innerType;
+        }
+    }
+
+    public static class MapType extends AnyType
+    {
+        public MapType()
+        {
+            super( ORD_MAP, "Map" );
+        }
+
+        protected MapType(int ordinal, String name)
+        {
+            super( ordinal, name );
+        }
+    }
+
+    public static class NodeType extends MapType
+    {
+        public NodeType()
+        {
+            super( ORD_NODE, "Node" );
+        }
+    }
+
+    public static class RelationshipType extends MapType
+    {
+        public RelationshipType()
+        {
+            super( ORD_RELATIONSHIP, "Relationship" );
+        }
+    }
+
+    public static class PathType extends AnyType
+    {
+        public PathType()
+        {
+            super( ORD_PATH, "Path" );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaRead.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaRead.java
@@ -24,11 +24,15 @@ import java.util.Iterator;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.DuplicateIndexSchemaRuleException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
+import org.neo4j.kernel.api.procedures.ProcedureSignature.ProcedureName;
 
 interface SchemaRead
 {
@@ -98,4 +102,10 @@ interface SchemaRead
      * Get the owning constraint for a constraint index. Returns null if the index does not have an owning constraint.
      */
     Long indexGetOwningUniquenessConstraintId( IndexDescriptor index ) throws SchemaRuleNotFoundException;
+
+    /** Get all procedures defined in the system */
+    Iterator<ProcedureSignature> proceduresGetAll();
+
+    /** Fetch a procedure given its signature. */
+    ProcedureDescriptor procedureGet( ProcedureName name ) throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWrite.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/SchemaWrite.java
@@ -19,17 +19,21 @@
  */
 package org.neo4j.kernel.api;
 
-import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
-import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
+import org.neo4j.kernel.api.exceptions.schema.ProcedureConstraintViolation;
 import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
+import org.neo4j.kernel.api.procedures.ProcedureSignature.ProcedureName;
 
 interface SchemaWrite
 {
@@ -61,4 +65,17 @@ interface SchemaWrite
      * That external job should become an internal job, at which point this operation should go away.
      */
     void uniqueIndexDrop( IndexDescriptor descriptor ) throws DropIndexFailureException;
+
+    /**
+     * @param signature the namespace, name, typed inputs and typed outputs
+     * @param language named procedure language, eg "js"
+     * @param body the procedure code, format is language-handler specific
+     */
+    void procedureCreate( ProcedureSignature signature, String language, String body ) throws ProcedureException, ProcedureConstraintViolation;
+
+    /**
+     * Drop a procedure from the database.
+     * @param name
+     */
+    void procedureDrop( ProcedureName name ) throws ProcedureConstraintViolation, ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ProcedureException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/ProcedureException.java
@@ -17,18 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.api.exceptions.schema;
+package org.neo4j.kernel.api.exceptions;
 
-/**
- * Constraint violation happens when a user attempts to perform an action that violates
- * an existing constraint.
- *
- * @see ConstraintVerificationFailedKernelException
- */
-public abstract class ConstraintViolationKernelException extends ConstraintValidationKernelException
+public class ProcedureException extends KernelException
 {
-    public ConstraintViolationKernelException( String message, Object... parameters )
+    public ProcedureException( Status statusCode, Throwable cause,
+                               String message, Object... parameters )
     {
-        super( message, parameters );
+        super( statusCode, cause, message, parameters );
+    }
+
+    public ProcedureException( Status statusCode, String message,
+                               Object... parameters )
+    {
+        super( statusCode, message, parameters );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/ProcedureConstraintViolation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/schema/ProcedureConstraintViolation.java
@@ -20,14 +20,11 @@
 package org.neo4j.kernel.api.exceptions.schema;
 
 /**
- * Constraint violation happens when a user attempts to perform an action that violates
- * an existing constraint.
- *
- * @see ConstraintVerificationFailedKernelException
+ * Caused by creating a procedure that would not be distinguishable from an already existing procedure.
  */
-public abstract class ConstraintViolationKernelException extends ConstraintValidationKernelException
+public class ProcedureConstraintViolation extends ConstraintViolationKernelException
 {
-    public ConstraintViolationKernelException( String message, Object... parameters )
+    public ProcedureConstraintViolation( String message, Object... parameters )
     {
         super( message, parameters );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/procedures/ProcedureDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/procedures/ProcedureDescriptor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.procedures;
+
+/** Describes a procedure stored in the database */
+public class ProcedureDescriptor
+{
+    private final ProcedureSignature signature;
+    private final String language;
+    private final String procedureBody;
+
+    public ProcedureDescriptor( ProcedureSignature signature, String language, String procedureBody )
+    {
+        this.signature = signature;
+        this.language = language;
+        this.procedureBody = procedureBody;
+    }
+
+    public ProcedureSignature signature()
+    {
+        return signature;
+    }
+
+    public String language()
+    {
+        return language;
+    }
+
+    public String procedureBody()
+    {
+        return procedureBody;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        // Note that equality is *only* checked on signature, this is probably wrong, but is depended on in
+        // TxState. Please don't change this without modifying how txstate tracks changes to procedures.
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        ProcedureDescriptor that = (ProcedureDescriptor) o;
+
+        return signature.equals( that.signature );
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return signature.hashCode();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/procedures/ProcedureSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/procedures/ProcedureSignature.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.procedures;
+
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.api.Neo4jTypes.AnyType;
+
+import static java.util.Arrays.asList;
+
+/**
+ * This describes the signature of a procedure, made up of its namespace, name, and input/output description.
+ * Procedure uniqueness is currently *only* on the namespace/name level - no procedure overloading allowed (yet).
+ */
+public class ProcedureSignature
+{
+    public static class ProcedureName
+    {
+        private final String[] namespace;
+        private final String name;
+
+        public ProcedureName( List<String> namespace, String name )
+        {
+            this(namespace.toArray( new String[namespace.size()] ), name);
+        }
+
+        public ProcedureName( String[] namespace, String name )
+        {
+            this.namespace = namespace;
+            this.name = name;
+        }
+
+        public String[] namespace()
+        {
+            return namespace;
+        }
+
+        public String name()
+        {
+            return name;
+        }
+
+        @Override
+        public String toString()
+        {
+            String strNamespace = namespace.length > 0 ? Iterables.toString( asList( namespace ), "." ) + "." : "";
+            return String.format("%s%s", strNamespace, name);
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o ) { return true; }
+            if ( o == null || getClass() != o.getClass() ) { return false; }
+
+            ProcedureName that = (ProcedureName) o;
+
+            // Probably incorrect - comparing Object[] arrays with Arrays.equals
+            if ( !Arrays.equals( namespace, that.namespace ) ) { return false; }
+            return name.equals( that.name );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = Arrays.hashCode( namespace );
+            result = 31 * result + name.hashCode();
+            return result;
+        }
+    }
+
+    /** Represents a type and a name for an input or output argument in a procedure. */
+    public static class ArgumentSignature
+    {
+        private final String name;
+        private final AnyType type;
+
+        public ArgumentSignature( String name, AnyType type )
+        {
+            this.name = name;
+            this.type = type;
+        }
+
+        public String name()
+        {
+            return name;
+        }
+
+        public AnyType neo4jType()
+        {
+            return type;
+        }
+    }
+
+    private final ProcedureName name;
+    private final List<ArgumentSignature> inputSignature;
+    private final List<ArgumentSignature> outputSignature;
+
+    public ProcedureSignature( ProcedureName name, List<ArgumentSignature> inputSignature, List<ArgumentSignature> outputSignature )
+    {
+        this.name = name;
+        this.inputSignature = inputSignature;
+        this.outputSignature = outputSignature;
+    }
+
+    public ProcedureSignature( ProcedureName name )
+    {
+        this( name, null, null );
+    }
+
+    public ProcedureName name()
+    {
+        return name;
+    }
+
+    public List<ArgumentSignature> inputSignature()
+    {
+        return inputSignature;
+    }
+
+    public List<ArgumentSignature> outputSignature()
+    {
+        return outputSignature;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o ) { return true; }
+        if ( o == null || getClass() != o.getClass() ) { return false; }
+
+        ProcedureSignature that = (ProcedureSignature) o;
+
+        if ( !name.equals( that.name ) ) { return false; }
+        if ( inputSignature != null ? !inputSignature.equals( that.inputSignature ) : that.inputSignature != null ) { return false; }
+        return !(outputSignature != null ? !outputSignature.equals( that.outputSignature ) : that.outputSignature != null);
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return name.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        String strInSig = inputSignature == null ? "..." : Iterables.toString( typesOf( inputSignature ), ", " );
+        String strOutSig = outputSignature == null ? "..." : Iterables.toString( typesOf( outputSignature ), ", " );
+        return String.format( "%s(%s) : (%s)", name, strInSig, strOutSig );
+    }
+
+    public static class Builder
+    {
+        private final ProcedureName name;
+        private final List<ArgumentSignature> inputSignature = new LinkedList<>();
+        private final List<ArgumentSignature> outputSignature = new LinkedList<>();
+
+        public Builder( String[] namespace, String name )
+        {
+            this.name = new ProcedureName( namespace, name );
+        }
+
+        /** Define an input field */
+        public Builder in( String name, AnyType type )
+        {
+            inputSignature.add( new ArgumentSignature( name, type ) );
+            return this;
+        }
+
+        /** Define an output field */
+        public Builder out( String name, AnyType type )
+        {
+            outputSignature.add( new ArgumentSignature( name, type ) );
+            return this;
+        }
+
+        public ProcedureSignature build()
+        {
+            return new ProcedureSignature(name, inputSignature, outputSignature );
+        }
+    }
+
+    public static Builder procedureSignature(String ... namespaceAndName)
+    {
+        String[] namespace = namespaceAndName.length > 1 ? Arrays.copyOf( namespaceAndName, namespaceAndName.length - 1 ) : new String[0];
+        String name = namespaceAndName[namespaceAndName.length - 1];
+        return procedureSignature( namespace, name );
+    }
+
+    public static Builder procedureSignature(String[] namespace, String name)
+    {
+        return new Builder(namespace, name);
+    }
+
+    private static List<AnyType> typesOf( List<ArgumentSignature> namedSig )
+    {
+        List<AnyType> out = new LinkedList<>();
+        for ( int i = 0; i < namedSig.size(); i++ )
+        {
+            out.add( namedSig.get( i ).neo4jType() );
+        }
+        return out;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/ReadableTxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/ReadableTxState.java
@@ -36,6 +36,8 @@ import org.neo4j.kernel.api.cursor.RelationshipItem;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature.ProcedureName;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.state.NodeState;
@@ -183,6 +185,10 @@ public interface ReadableTxState
     Cursor<NodeItem> augmentNodesGetAllCursor( Cursor<NodeItem> cursor );
 
     Cursor<RelationshipItem> augmentRelationshipsGetAllCursor( Cursor<RelationshipItem> cursor );
+
+    Iterator<ProcedureDescriptor> augmentProcedures( Iterator<ProcedureDescriptor> procs );
+
+    ProcedureDescriptor getProcedure( ProcedureName name );
 
     /**
      * The way tokens are created is that the first time a token is needed it gets created in its own little

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
@@ -21,12 +21,14 @@ package org.neo4j.kernel.api.txstate;
 
 import java.util.Map;
 
-import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
-import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 
@@ -108,4 +110,8 @@ public interface TransactionState extends ReadableTxState
     // </Legacy index>
 
     void indexDoUpdateProperty( IndexDescriptor descriptor, long nodeId, DefinedProperty before, DefinedProperty after );
+
+    void procedureDoCreate( ProcedureSignature signature, String language, String code );
+
+    void procedureDoDrop( ProcedureDescriptor name );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TxStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TxStateVisitor.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.api.state.RelationshipChangesForNode;
 
@@ -88,6 +89,10 @@ public interface TxStateVisitor
     void visitCreatedNodeLegacyIndex( String name, Map<String,String> config );
 
     void visitCreatedRelationshipLegacyIndex( String name, Map<String,String> config );
+
+    void visitCreatedProcedure( ProcedureDescriptor procedureDescriptor );
+
+    void visitDroppedProcedure( ProcedureDescriptor procedureDescriptor );
 
     class Adapter implements TxStateVisitor
     {
@@ -309,6 +314,24 @@ public interface TxStateVisitor
             if ( next != null )
             {
                 next.visitCreatedRelationshipLegacyIndex( name, config );
+            }
+        }
+
+        @Override
+        public void visitCreatedProcedure( ProcedureDescriptor procedureDescriptor )
+        {
+            if( next != null )
+            {
+                next.visitCreatedProcedure( procedureDescriptor );
+            }
+        }
+
+        @Override
+        public void visitDroppedProcedure( ProcedureDescriptor procedureDescriptor )
+        {
+            if( next != null )
+            {
+                next.visitDroppedProcedure( procedureDescriptor );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.api.cursor.LabelItem;
 import org.neo4j.kernel.api.cursor.NodeItem;
 import org.neo4j.kernel.api.cursor.RelationshipItem;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
@@ -47,8 +48,10 @@ import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
 import org.neo4j.kernel.api.exceptions.schema.UnableToValidateConstraintKernelException;
+import org.neo4j.kernel.api.exceptions.schema.ProcedureConstraintViolation;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyConstraintViolationKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
@@ -563,5 +566,18 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
             throws DropConstraintFailureException
     {
         schemaWriteOperations.constraintDrop( state, constraint );
+    }
+
+    @Override
+    public void procedureCreate( KernelStatement state, ProcedureSignature signature, String language, String code )
+            throws ProcedureException, ProcedureConstraintViolation
+    {
+        schemaWriteOperations.procedureCreate( state, signature, language, code );
+    }
+
+    @Override
+    public void procedureDrop( KernelStatement statement, ProcedureSignature.ProcedureName name ) throws ProcedureConstraintViolation, ProcedureException
+    {
+        schemaWriteOperations.procedureDrop( statement, name );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -29,7 +29,6 @@ import org.neo4j.collection.pool.MarshlandPool;
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.helpers.Clock;
-import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
@@ -37,7 +36,9 @@ import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.LegacyIndexTransactionStateImpl;
+import org.neo4j.kernel.impl.api.store.ProcedureCache;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
+import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.store.NeoStore;
@@ -85,6 +86,7 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
     private final ConstraintSemantics constraintSemantics;
     private final TransactionMonitor transactionMonitor;
     private final LifeSupport dataSourceLife;
+    private final ProcedureCache procedureCache;
     private final Tracers tracers;
 
     // End Tx Dependencies
@@ -117,7 +119,7 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
                                TransactionHooks hooks,
                                ConstraintSemantics constraintSemantics,
                                TransactionMonitor transactionMonitor,
-                               LifeSupport dataSourceLife,
+                               LifeSupport dataSourceLife, ProcedureCache procedureCache,
                                Tracers tracers )
     {
         this.neoStoreTransactionContextFactory = neoStoreTransactionContextFactory;
@@ -140,6 +142,7 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
         this.constraintSemantics = constraintSemantics;
         this.transactionMonitor = transactionMonitor;
         this.dataSourceLife = dataSourceLife;
+        this.procedureCache = procedureCache;
         this.tracers = tracers;
     }
 
@@ -162,7 +165,7 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
                     labelScanStore, indexingService, updateableSchemaState, recordState, providerMap,
                     neoStore, locksClient, hooks, constraintIndexCreator, transactionHeaderInformationFactory,
                     transactionCommitProcess, transactionMonitor, storeLayer, legacyIndexTransactionState,
-                    localTxPool, constraintSemantics, Clock.SYSTEM_CLOCK, tracers.transactionTracer );
+                    localTxPool, constraintSemantics, Clock.SYSTEM_CLOCK, tracers.transactionTracer, procedureCache );
 
             allTransactions.add( tx );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -23,13 +23,14 @@ import java.util.Iterator;
 
 import org.neo4j.function.Function;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
-import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
@@ -38,8 +39,12 @@ import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
+import org.neo4j.kernel.api.exceptions.schema.ProcedureConstraintViolation;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
+import org.neo4j.kernel.api.procedures.ProcedureSignature.ProcedureName;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
@@ -52,6 +57,9 @@ import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.store.SchemaStorage;
 
+import static org.neo4j.kernel.impl.locking.ResourceTypes.PROCEDURE;
+import static org.neo4j.kernel.impl.locking.ResourceTypes.SCHEMA;
+import static org.neo4j.kernel.impl.locking.ResourceTypes.procedureResourceId;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.schemaResource;
 
 public class LockingStatementOperations implements
@@ -389,6 +397,38 @@ public class LockingStatementOperations implements
         state.locks().acquireExclusive( ResourceTypes.SCHEMA, schemaResource() );
         state.assertOpen();
         schemaWriteDelegate.constraintDrop( state, constraint );
+    }
+
+    @Override
+    public void procedureCreate( KernelStatement state, ProcedureSignature signature, String language, String code )
+            throws ProcedureException, ProcedureConstraintViolation
+    {
+        // TODO: Document locking logic
+        // In order to keep other processes from creating procedures with conflicting names, we lock the procedure
+        // name. We don't exclusively lock the schema, since creating a new procedure will not influence any running
+        // operation.
+        state.locks().acquireExclusive( PROCEDURE, procedureResourceId( signature.name() ) );
+        schemaWriteDelegate.procedureCreate( state, signature, language, code );
+    }
+
+    @Override
+    public void procedureDrop( KernelStatement state, ProcedureName name ) throws ProcedureConstraintViolation, ProcedureException
+    {
+        state.locks().acquireExclusive( SCHEMA, schemaResource() );
+        state.locks().acquireExclusive( PROCEDURE, procedureResourceId( name ) );
+        schemaWriteDelegate.procedureDrop( state, name );
+    }
+
+    @Override
+    public Iterator<ProcedureDescriptor> proceduresGetAll( KernelStatement statement )
+    {
+        return schemaReadDelegate.proceduresGetAll( statement );
+    }
+
+    @Override
+    public ProcedureDescriptor procedureGet( KernelStatement statement, ProcedureName signature ) throws ProcedureException
+    {
+        return schemaReadDelegate.procedureGet( statement, signature );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaReadOperations.java
@@ -25,10 +25,13 @@ import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature.ProcedureName;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.store.SchemaStorage;
 
@@ -120,4 +123,13 @@ public interface SchemaReadOperations
      * - throws exception for indexes that aren't committed.
      */
     long indexGetCommittedId( KernelStatement state, IndexDescriptor index, SchemaStorage.IndexRuleKind constraint ) throws SchemaRuleNotFoundException;
+
+    /** List all defined procedures, given the current transactional context
+     * @param kernelStatement*/
+    Iterator<ProcedureDescriptor> proceduresGetAll( KernelStatement kernelStatement );
+
+    /**
+     * Load a procedure description given a signature, or return null if the procedure does not exist.
+     */
+    ProcedureDescriptor procedureGet( KernelStatement statement, ProcedureName signature ) throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/SchemaWriteOperations.java
@@ -24,12 +24,16 @@ import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyIndexedException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.DropIndexFailureException;
+import org.neo4j.kernel.api.exceptions.schema.ProcedureConstraintViolation;
 import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
+import org.neo4j.kernel.api.procedures.ProcedureSignature.ProcedureName;
 import org.neo4j.kernel.impl.api.KernelStatement;
 
 public interface SchemaWriteOperations
@@ -64,4 +68,9 @@ public interface SchemaWriteOperations
     void constraintDrop( KernelStatement state, NodePropertyConstraint constraint ) throws DropConstraintFailureException;
 
     void constraintDrop( KernelStatement state, RelationshipPropertyConstraint constraint ) throws DropConstraintFailureException;
+
+    void procedureCreate( KernelStatement state, ProcedureSignature signature, String language, String code )
+            throws ProcedureException, ProcedureConstraintViolation;
+
+    void procedureDrop( KernelStatement statement, ProcedureName name ) throws ProcedureException, ProcedureConstraintViolation;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -58,6 +58,8 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
@@ -92,13 +94,15 @@ public class CacheLayer implements StoreReadLayer
                 }
             };
 
+    private final ProcedureCache procedureCache;
     private final SchemaCache schemaCache;
     private final DiskLayer diskLayer;
 
-    public CacheLayer( DiskLayer diskLayer, SchemaCache schemaCache )
+    public CacheLayer( DiskLayer diskLayer, SchemaCache schemaCache, ProcedureCache procedureCache )
     {
         this.diskLayer = diskLayer;
         this.schemaCache = schemaCache;
+        this.procedureCache = procedureCache;
     }
 
     @Override
@@ -324,6 +328,18 @@ public class CacheLayer implements StoreReadLayer
     public double indexUniqueValuesPercentage( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         return diskLayer.indexUniqueValuesPercentage( descriptor );
+    }
+
+    @Override
+    public Iterator<ProcedureDescriptor> proceduresGetAll()
+    {
+        return procedureCache.getAll();
+    }
+
+    @Override
+    public ProcedureDescriptor procedureGet( ProcedureSignature.ProcedureName name )
+    {
+        return procedureCache.get( name );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
@@ -44,6 +44,8 @@ import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexReader;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.PropertyKeyIdIterator;
 import org.neo4j.kernel.impl.api.CountsAccessor;
@@ -385,6 +387,18 @@ public class DiskLayer implements StoreReadLayer
     public double indexUniqueValuesPercentage( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
     {
         return indexService.indexUniqueValuesPercentage( descriptor );
+    }
+
+    @Override
+    public Iterator<ProcedureDescriptor> proceduresGetAll()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ProcedureDescriptor procedureGet( ProcedureSignature.ProcedureName name )
+    {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/ProcedureCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/ProcedureCache.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
+import org.neo4j.kernel.impl.util.CopyOnWriteHashMap;
+
+/**
+ * A temporary in-memory storage for procedures, until we build "real" storage for them in 3.0.
+ * TODO!
+ */
+public class ProcedureCache
+{
+    private final Map<ProcedureSignature.ProcedureName, ProcedureDescriptor> procedures = new CopyOnWriteHashMap<>();
+
+    public Iterator<ProcedureDescriptor> getAll()
+    {
+        return procedures.values().iterator();
+    }
+
+    public ProcedureDescriptor get( ProcedureSignature.ProcedureName name )
+    {
+        return procedures.get( name );
+    }
+
+    // TODO: This is temporary, to be replaced by the regular tx log/store layer stuff
+    public synchronized void createProcedure( ProcedureDescriptor descriptor )
+    {
+        assert !procedures.containsKey( descriptor.signature().name() );
+        procedures.put( descriptor.signature().name(), descriptor );
+    }
+
+    public synchronized void dropProcedure( ProcedureDescriptor procedureDescriptor )
+    {
+        assert procedures.containsKey( procedureDescriptor.signature().name() );
+        procedures.remove( procedureDescriptor.signature().name() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -36,6 +36,8 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature.ProcedureName;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
@@ -164,4 +166,10 @@ public interface StoreReadLayer
     long indexSize( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
 
     double indexUniqueValuesPercentage( IndexDescriptor descriptor ) throws IndexNotFoundKernelException;
+
+    /** Return descriptors for all committed stored procedures */
+    Iterator<ProcedureDescriptor> proceduresGetAll();
+
+    /** Return the description of the specified procedure */
+    ProcedureDescriptor procedureGet( ProcedureName name );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ResourceTypes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ResourceTypes.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.locking;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.kernel.api.procedures.ProcedureSignature.ProcedureName;
 import org.neo4j.kernel.impl.util.concurrent.LockWaitStrategies;
 import org.neo4j.kernel.impl.util.concurrent.WaitStrategy;
 
@@ -37,7 +38,14 @@ public enum ResourceTypes implements Locks.ResourceType
     SCHEMA      (3, LockWaitStrategies.INCREMENTAL_BACKOFF),
     INDEX_ENTRY (4, LockWaitStrategies.INCREMENTAL_BACKOFF),
 
-    LEGACY_INDEX(5, LockWaitStrategies.INCREMENTAL_BACKOFF)
+    LEGACY_INDEX(5, LockWaitStrategies.INCREMENTAL_BACKOFF),
+
+    /**
+     * Procedure lock is used to keep multiple actors from creating procedures with conflicting names.
+     * Dropping procedures is done with the protection of an exclusive schema lock, meaning procedure creation
+     * is expected to be done holding both this lock and a shared schema lock.
+     */
+    PROCEDURE   (6, LockWaitStrategies.INCREMENTAL_BACKOFF)
     ;
 
     private final static Map<Integer, Locks.ResourceType> idToType = new HashMap<>();
@@ -97,6 +105,11 @@ public enum ResourceTypes implements Locks.ResourceType
         // this comment in case we need it for supporting rolling upgrades.
         // This comment can be deleted once RU from 2.1 to 2.2 is no longer a
         // concern.
+    }
+
+    public static long procedureResourceId( ProcedureName procedureName )
+    {
+        return procedureName.name().hashCode();
     }
 
     private static int hash( long value )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api;
 
 import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.Clock;
+import org.neo4j.kernel.impl.api.store.ProcedureCache;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
@@ -60,6 +61,6 @@ public class KernelTransactionFactory
                 mock(Pool.class),
                 mock( ConstraintSemantics.class ),
                 Clock.SYSTEM_CLOCK,
-                TransactionTracer.NULL );
+                TransactionTracer.NULL, new ProcedureCache() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
@@ -19,16 +19,15 @@
  */
 package org.neo4j.kernel.api;
 
-import java.util.Collection;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.Collection;
+
 import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.FakeClock;
-import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
@@ -36,8 +35,10 @@ import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionHooks;
+import org.neo4j.kernel.impl.api.store.ProcedureCache;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
+import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.store.NeoStore;
@@ -51,7 +52,6 @@ import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.test.DoubleLatch;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyListOf;
@@ -382,7 +382,7 @@ public class KernelTransactionImplementationTest
         KernelTransactionImplementation transaction = new KernelTransactionImplementation(
                 null, null, null, null, null, recordState, null, neoStore, new NoOpClient(),
                 hooks, null, headerInformationFactory, commitProcess, transactionMonitor, readLayer, legacyIndexState,
-                mock( Pool.class ), mock(ConstraintSemantics.class), clock, TransactionTracer.NULL );
+                mock( Pool.class ), mock(ConstraintSemantics.class), clock, TransactionTracer.NULL, new ProcedureCache() );
         transaction.initialize( 0 );
         return transaction;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -24,6 +24,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.impl.api.store.ProcedureCache;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -142,8 +143,8 @@ public class KernelTransactionsTest
         return new KernelTransactions( contextSupplier, mock( NeoStore.class ), locks,
                 mock( IntegrityValidator.class ), null, null, null, null, null, null, null,
                 TransactionHeaderInformationFactory.DEFAULT, readLayer, commitProcess, null,
-                null, new TransactionHooks(), mock( ConstraintSemantics.class ), mock( TransactionMonitor.class ), life,
-                new Tracers( "null", NullLog.getInstance() ) );
+                null, new TransactionHooks(), mock( ConstraintSemantics.class ), mock( TransactionMonitor.class ), life, new ProcedureCache(),
+                new Tracers( "null", NullLog.getInstance() ));
     }
 
     private static TransactionCommitProcess newRememberingCommitProcess( final TransactionRepresentation[] slot )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.integrationtest;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.neo4j.kernel.api.SchemaWriteOperations;
+import org.neo4j.kernel.api.exceptions.schema.ProcedureConstraintViolation;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
+
+import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertNull;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
+import static org.neo4j.kernel.api.Neo4jTypes.NTText;
+import static org.neo4j.kernel.api.procedures.ProcedureSignature.procedureSignature;
+
+public class ProceduresKernelIT extends KernelIntegrationTest
+{
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private final ProcedureSignature signature = procedureSignature( "example", "exampleProc" )
+            .in( "name", NTText )
+            .out( "name", NTText ).build();
+
+    @Test
+    public void shouldCreateProcedure() throws Throwable
+    {
+        // Given
+        SchemaWriteOperations ops = schemaWriteOperationsInNewTransaction();
+
+        // When
+        ops.procedureCreate( signature, "javascript", "emit(1);" );
+
+        // Then
+        Iterator<ProcedureSignature> all = ops.proceduresGetAll();
+        assertThat( asCollection( all ),
+                Matchers.<Collection<ProcedureSignature>>equalTo( asList( signature ) ) );
+
+        // And when
+        commit();
+
+        // Then
+        assertThat( asCollection( readOperationsInNewTransaction().proceduresGetAll() ),
+                Matchers.<Collection<ProcedureSignature>>equalTo( asList( signature ) ) );
+    }
+
+    @Test
+    public void shouldDropProcedure() throws Throwable
+    {
+        // Given
+        SchemaWriteOperations ops = schemaWriteOperationsInNewTransaction();
+        ops.procedureCreate( signature, "javascript", "emit(1);" );
+        commit();
+
+        // When
+        ops = schemaWriteOperationsInNewTransaction();
+        ops.procedureDrop( signature.name() );
+
+        // Then
+        Iterator<ProcedureSignature> all = ops.proceduresGetAll();
+        assertThat( asCollection( all ),
+                Matchers.<Collection<ProcedureSignature>>equalTo( Collections.<ProcedureSignature>emptyList() ) );
+
+        // And when
+        commit();
+
+        // Then
+        assertThat( asCollection( readOperationsInNewTransaction().proceduresGetAll() ),
+                Matchers.<Collection<ProcedureSignature>>equalTo( Collections.<ProcedureSignature>emptyList() ) );
+    }
+
+    @Test
+    public void shouldDropProcedureInSameTransaction() throws Throwable
+    {
+        // Given
+        SchemaWriteOperations ops = schemaWriteOperationsInNewTransaction();
+        ops.procedureCreate( signature, "javascript", "emit(1);" );
+
+        // When
+        ops.procedureDrop( signature.name() );
+
+        // Then
+        Iterator<ProcedureSignature> all = ops.proceduresGetAll();
+        assertThat( asCollection( all ),
+                Matchers.<Collection<ProcedureSignature>>equalTo( Collections.<ProcedureSignature>emptyList() ) );
+
+        // And when
+        commit();
+
+        // Then
+        assertThat( asCollection( readOperationsInNewTransaction().proceduresGetAll() ),
+                Matchers.<Collection<ProcedureSignature>>equalTo( Collections.<ProcedureSignature>emptyList() ) );
+    }
+
+    @Test
+    public void shouldGetProcedureByName() throws Throwable
+    {
+        // Given
+        shouldCreateProcedure();
+
+        // When
+        ProcedureSignature found = readOperationsInNewTransaction()
+                .procedureGet( new ProcedureSignature.ProcedureName( new String[]{"example"}, "exampleProc" ) )
+                .signature();
+
+        // Then
+        assertThat( found, equalTo( found ) );
+    }
+
+    @Test
+    public void nonexistentProcedureShouldReturnNull() throws Throwable
+    {
+        // When & Then
+        assertNull( readOperationsInNewTransaction()
+                .procedureGet( new ProcedureSignature.ProcedureName( new String[]{"example"}, "exampleProc" ) ) );
+    }
+
+    @Test
+    public void droppingNonExistentProcedureShouldThrow() throws Throwable
+    {
+        // Expect
+        exception.expect( ProcedureConstraintViolation.class );
+
+        // When
+        schemaWriteOperationsInNewTransaction().procedureDrop( new ProcedureSignature.ProcedureName( new String[]{"example"}, "exampleProc" ) );
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/operations/ConstraintEnforcingEntityOperationsTest.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api.operations;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.impl.api.ConstraintEnforcingEntityOperations;
@@ -28,8 +29,12 @@ import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
 import org.neo4j.kernel.impl.locking.Locks;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_NODE;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.INDEX_ENTRY;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.indexEntryResourceId;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/SchemaTransactionStateTest.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.kernel.impl.api.state;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,15 +31,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.kernel.api.Neo4jTypes;
 import org.neo4j.kernel.api.cursor.PropertyItem;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.procedures.ProcedureDescriptor;
+import org.neo4j.kernel.api.procedures.ProcedureSignature;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.LegacyPropertyTrackers;
@@ -52,11 +55,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.Iterables.option;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
+import static org.neo4j.kernel.api.procedures.ProcedureSignature.procedureSignature;
 
 public class SchemaTransactionStateTest
 {
@@ -124,7 +127,7 @@ public class SchemaTransactionStateTest
         IndexDescriptor rule = txContext.indexCreate( state, labelId1, key1 );
 
         // THEN
-        assertEquals( InternalIndexState.POPULATING, txContext.indexGetState(state, rule) );
+        assertEquals( InternalIndexState.POPULATING, txContext.indexGetState( state, rule ) );
     }
 
     @Test
@@ -202,6 +205,21 @@ public class SchemaTransactionStateTest
 
         // THEN
         assertEquals( emptySetOf( IndexDescriptor.class ), asSet( rulesByLabel ) );
+    }
+
+    @Test
+    public void shouldGetProcedureInCurrentTx() throws Throwable
+    {
+        // Given
+        ProcedureSignature signature = procedureSignature( "myproc" ).out( "field1", Neo4jTypes.NTInteger ).build();
+        txContext.procedureCreate( state, signature, "javascript", "emit(1);" );
+
+        // When
+        ProcedureDescriptor desc = txContext.procedureGet( state, signature.name() );
+
+        // Then
+        assertEquals( desc.language(), "javascript" );
+        assertEquals( desc.procedureBody(), "emit(1);" );
     }
 
     private interface ExceptionExpectingFunction<E extends Exception>

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CacheLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/CacheLayerTest.java
@@ -41,7 +41,7 @@ public class CacheLayerTest
 {
     private final DiskLayer diskLayer = mock( DiskLayer.class );
     private final SchemaCache schemaCache = mock( SchemaCache.class );
-    private final CacheLayer context = new CacheLayer( diskLayer, schemaCache );
+    private final CacheLayer context = new CacheLayer( diskLayer, schemaCache, new ProcedureCache() );
 
     @Test
     public void shouldLoadAllConstraintsFromCache() throws Exception


### PR DESCRIPTION
- This introduces kernel primitives for creating, listing, getting-by-name and dropping
  stored procedure definitions.
- Also introduces a temporary in-memory storage class for them, so as to
  not require store format changes until 3.0 branch time.
