### PR TITLE
Moved traversal matchers out of cypher-compiler-2.3 

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/matching/PatternRelationship.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/matching/PatternRelationship.scala
@@ -20,16 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes.matching
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.DirectionConverter.toGraphDb
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.{LazyTypes, QueryState}
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection.{BOTH, INCOMING, OUTGOING}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
-import org.neo4j.graphdb.{DynamicRelationshipType, Node, Relationship}
-import org.neo4j.graphdb.traversal.{Evaluators, TraversalDescription}
-import org.neo4j.kernel.{Traversal, Uniqueness}
+import org.neo4j.graphdb.{Node, Path, Relationship}
 
 import scala.collection.JavaConverters._
 
@@ -141,30 +138,7 @@ class VariableLengthPatternRelationship(pathName: String,
       key -> CTCollection(CTRelationship)) ++ relIterable.map(_ -> CTCollection(CTRelationship)).toMap
 
   override def getGraphRelationships(node: PatternNode, realNode: Node, state: QueryState, f: => ExecutionContext): Seq[GraphRelationship] = {
-
-    val depthEval = (minHops, maxHops) match {
-      case (None, None)           => Evaluators.fromDepth(1)
-      case (Some(min), None)      => Evaluators.fromDepth(min)
-      case (None, Some(max))      => Evaluators.includingDepths(1, max)
-      case (Some(min), Some(max)) => Evaluators.includingDepths(min, max)
-    }
-
-    val baseTraversalDescription: TraversalDescription = Traversal.description()
-      .evaluator(depthEval)
-      .uniqueness(Uniqueness.RELATIONSHIP_PATH)
-
-    val traversalDescription = if (relType.isEmpty) {
-      baseTraversalDescription.expand(Traversal.expanderForAllTypes(toGraphDb(getDirection(node))))
-    } else {
-      val emptyExpander = Traversal.emptyExpander()
-      val dir = getDirection(node)
-      val expander = relType.foldLeft(emptyExpander) {
-        case (e, t) => e.add(DynamicRelationshipType.withName(t), toGraphDb(dir))
-      }
-      baseTraversalDescription.expand(expander)
-    }
-
-    val matchedPaths = traversalDescription.traverse(realNode).asScala
+    val matchedPaths: Iterator[Path] = state.query.variableLengthPathExpand(node, realNode, minHops, maxHops, getDirection(node), relType)
 
     val filteredPaths = if (properties.isEmpty) {
       matchedPaths

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
@@ -19,8 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.spi
 
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
-import org.neo4j.graphdb.{Relationship, PropertyContainer, Node}
+import org.neo4j.graphdb.{Path, Relationship, PropertyContainer, Node}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
 class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
@@ -129,6 +130,16 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
   def nodeGetDegree(node: Long, dir: SemanticDirection, relTypeId: Int): Int = singleDbHit(inner.nodeGetDegree(node, dir, relTypeId))
 
   def nodeIsDense(node: Long): Boolean = singleDbHit(inner.nodeIsDense(node))
+
+  // Legacy dependency between kernel and compiler
+  override def variableLengthPathExpand(node: PatternNode,
+                                        realNode: Node,
+                                        minHops: Option[Int],
+                                        maxHops: Option[Int],
+                                        direction: SemanticDirection,
+                                        relTypes: Seq[String]): Iterator[Path] =
+    manyDbHits(inner.variableLengthPathExpand(node, realNode, minHops, maxHops, direction, relTypes))
+
 }
 
 class DelegatingOperations[T <: PropertyContainer](protected val inner: Operations[T]) extends Operations[T] {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/PlanContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/PlanContext.scala
@@ -19,6 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.spi
 
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.EntityProducer
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.{TraversalMatcher, ExpanderStep}
+import org.neo4j.graphdb.Node
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.kernel.api.index.IndexDescriptor
 
@@ -48,4 +51,11 @@ trait PlanContext extends TokenContext {
   def txIdProvider: () => Long
 
   def statistics: GraphStatistics
+
+  // Legacy traversal matchers (pre-Ronja) (These were moved out to remove the dependency on the kernel)
+  def monoDirectionalTraversalMatcher(steps: ExpanderStep, start: EntityProducer[Node]): TraversalMatcher
+
+  def bidirectionalTraversalMatcher(steps: ExpanderStep,
+                                    start: EntityProducer[Node],
+                                    end: EntityProducer[Node]): TraversalMatcher
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
@@ -20,8 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v2_3.spi
 
 import org.neo4j.cypher.internal.compiler.v2_3.InternalQueryStatistics
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
-import org.neo4j.graphdb.{PropertyContainer, Relationship, Node}
+import org.neo4j.graphdb.{Path, PropertyContainer, Relationship, Node}
 import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
@@ -124,6 +125,14 @@ trait QueryContext extends TokenContext {
   def nodeGetDegree(node: Long, dir: SemanticDirection, relTypeId: Int): Int
 
   def nodeIsDense(node: Long): Boolean
+
+  // Legacy dependency between kernel and compiler
+  def variableLengthPathExpand(node: PatternNode,
+                               realNode: Node,
+                               minHops: Option[Int],
+                               maxHops: Option[Int],
+                               direction: SemanticDirection,
+                               relTypes: Seq[String]): Iterator[Path]
 }
 
 trait LockingQueryContext extends QueryContext {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/LogicalPlanningTestSupport2.scala
@@ -22,9 +22,8 @@ package org.neo4j.cypher.internal.compiler.v2_3.planner
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.plannerQuery.StatementConverters._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters.{normalizeReturnClauses, normalizeWithClauses}
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionResult
-import org.neo4j.cypher.internal.compiler.v2_3.pipes.LazyLabel
-import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.{ExpanderStep, TraversalMatcher}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.{EntityProducer, LazyLabel}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.cardinality.QueryGraphCardinalityModel
@@ -38,12 +37,12 @@ import org.neo4j.cypher.internal.frontend.v2_3.ast._
 import org.neo4j.cypher.internal.frontend.v2_3.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.frontend.v2_3.{Foldable, PropertyKeyId, SemanticTable, inSequence}
+import org.neo4j.graphdb.Node
 import org.neo4j.helpers.collection.Visitable
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.kernel.api.index.IndexDescriptor
 import org.neo4j.kernel.impl.util.dbstructure.DbStructureVisitor
-import org.scalatest.matchers.{BeMatcher, MatchResult, Matcher}
-import org.scalatest.verb.ShouldVerb
+import org.scalatest.matchers.{BeMatcher, MatchResult}
 
 import scala.language.reflectiveCalls
 import scala.reflect.ClassTag
@@ -151,6 +150,10 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
       def getLabelId(labelName: String): Int = ???
 
       def txIdProvider: () => Long = ???
+
+      override def monoDirectionalTraversalMatcher(steps: ExpanderStep, start: EntityProducer[Node]): TraversalMatcher = ???
+
+      override def bidirectionalTraversalMatcher(steps: ExpanderStep, start: EntityProducer[Node], end: EntityProducer[Node]): TraversalMatcher = ???
     }
 
     def planFor(queryString: String): SemanticPlan = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/BidirectionalTraversalMatcher.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/BidirectionalTraversalMatcher.scala
@@ -17,17 +17,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v2_3.pipes.matching
+package org.neo4j.cypher.internal.spi.v2_3
 
 import org.neo4j.cypher.internal.compiler.v2_3._
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.{TraversalMatcher, ExpanderStep, TraversalPathExpander}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.{EntityProducer, QueryState}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.Argument
 import org.neo4j.function.Predicate
-import pipes.{EntityProducer, QueryState}
+import org.neo4j.graphdb.traversal.{BranchCollisionPolicy, _}
 import org.neo4j.graphdb.{Node, Path}
-import org.neo4j.graphdb.traversal._
-import org.neo4j.kernel.{StandardBranchCollisionDetector, Uniqueness, Traversal}
-import org.neo4j.graphdb.traversal.BranchCollisionPolicy
-import collection.JavaConverters._
+import org.neo4j.kernel.{StandardBranchCollisionDetector, Traversal, Uniqueness}
+
+import scala.collection.JavaConverters._
 
 class BidirectionalTraversalMatcher(steps: ExpanderStep,
                                     start: EntityProducer[Node],

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/MonodirectionalTraversalMatcher.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/MonodirectionalTraversalMatcher.scala
@@ -17,16 +17,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v2_3.pipes.matching
+package org.neo4j.cypher.internal.spi.v2_3
 
 import org.neo4j.cypher.internal.compiler.v2_3._
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.{TraversalMatcher, ExpanderStep, TraversalPathExpander}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.{EntityProducer, QueryState}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.Argument
-import pipes.{EntityProducer, QueryState}
-import org.neo4j.kernel.{Uniqueness, Traversal}
-import org.neo4j.graphdb.{Path, Node}
 import org.neo4j.graphdb.traversal._
-import collection.JavaConverters._
+import org.neo4j.graphdb.{Node, Path}
 import org.neo4j.helpers.ThisShouldNotHappenError
+import org.neo4j.kernel.{Traversal, Uniqueness}
+
+import scala.collection.JavaConverters._
 
 class MonoDirectionalTraversalMatcher(steps: ExpanderStep, start: EntityProducer[Node])
   extends TraversalMatcher {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundPlanContext.scala
@@ -20,8 +20,10 @@
 package org.neo4j.cypher.internal.spi.v2_3
 
 import org.neo4j.cypher.MissingIndexException
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.EntityProducer
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.ExpanderStep
 import org.neo4j.cypher.internal.compiler.v2_3.spi._
-import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.graphdb.{Node, GraphDatabaseService}
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.Statement
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
@@ -101,6 +103,16 @@ class TransactionBoundPlanContext(initialStatement: Statement, val gdb: GraphDat
     }
     statement.readOperations().schemaStateGetOrCreate(key, javaCreator)
   }
+
+
+  // Legacy traversal matchers (pre-Ronja) (These were moved out to remove the dependency on the kernel)
+  override def monoDirectionalTraversalMatcher(steps: ExpanderStep, start: EntityProducer[Node]) =
+    new MonoDirectionalTraversalMatcher(steps, start)
+
+  override def bidirectionalTraversalMatcher(steps: ExpanderStep,
+                                             start: EntityProducer[Node],
+                                             end: EntityProducer[Node]) =
+    new BidirectionalTraversalMatcher(steps, start, end)
 
   val statistics: GraphStatistics =
     InstrumentedGraphStatistics(TransactionBoundGraphStatistics(statement), MutableGraphStatisticsSnapshot())

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -24,7 +24,6 @@ import org.neo4j.collection.primitive.base.Empty.EMPTY_PRIMITIVE_LONG_COLLECTION
 import org.neo4j.cypher.InternalException
 import org.neo4j.cypher.internal.compiler.v2_3.MinMaxOrdering.{BY_NUMBER, BY_STRING, BY_VALUE}
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.DirectionConverter
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.DirectionConverter.toGraphDb
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.JavaConversionSupport._
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{BeansAPIRelationshipIterator, JavaConversionSupport}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
@@ -23,9 +23,10 @@ import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Literal
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{KeyToken, TokenType}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.{LabelAction, LabelSetOp}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{IdempotentResult, LockingQueryContext, QueryContext}
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
-import org.neo4j.graphdb.{Node, Relationship}
+import org.neo4j.graphdb.{Path, Node, Relationship}
 import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
@@ -177,4 +178,7 @@ class SnitchingQueryContext extends QueryContext {
   def nodeGetDegree(node: Long, dir: SemanticDirection, relTypeId: Int): Int = ???
 
   def nodeIsDense(node: Long): Boolean = ???
+
+  // Legacy dependency between kernel and compiler
+  override def variableLengthPathExpand(node: PatternNode, realNode: Node, minHops: Option[Int], maxHops: Option[Int], direction: SemanticDirection, relTypes: Seq[String]): Iterator[Path] = ???
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LazyTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LazyTest.scala
@@ -37,6 +37,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching._
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.Argument
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v2_3.symbols.CTInteger
+import org.neo4j.cypher.internal.spi.v2_3.MonoDirectionalTraversalMatcher
 import org.neo4j.cypher.internal.{ExecutionPlan, CypherCompiler => Compiler}
 import org.neo4j.graphdb.Traverser.Order
 import org.neo4j.graphdb._

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/TraversalMatcherTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/TraversalMatcherTest.scala
@@ -22,9 +22,10 @@ package org.neo4j.cypher.internal.compiler.v2_3
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.True
 import org.neo4j.cypher.internal.compiler.v2_3.pipes._
-import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.{BidirectionalTraversalMatcher, MonoDirectionalTraversalMatcher, SingleStep}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.SingleStep
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.Argument
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection.{BOTH, OUTGOING}
+import org.neo4j.cypher.internal.spi.v2_3.{BidirectionalTraversalMatcher, MonoDirectionalTraversalMatcher}
 import org.neo4j.graphdb.{Node, Path}
 
 class TraversalMatcherTest extends GraphDatabaseFunSuite with QueryStateTestSupport {


### PR DESCRIPTION
This makes one less dependency between compiler and kernel
