### PR TITLE
PackStream map streams

### DIFF
--- a/community/bolt/messaging-v1/src/main/java/org/neo4j/bolt/messaging/v1/PackStreamMessageFormatV1.java
+++ b/community/bolt/messaging-v1/src/main/java/org/neo4j/bolt/messaging/v1/PackStreamMessageFormatV1.java
@@ -282,14 +282,14 @@ public class PackStreamMessageFormatV1 implements MessageFormat
         private <E extends Exception> void unpackSuccessMessage( MessageHandler<E> output )
                 throws E, IOException
         {
-            Map<String,Object> map = unpacker.unpackRawMap();
+            Map<String,Object> map = unpacker.unpackMap();
             output.handleSuccessMessage( map );
         }
 
         private <E extends Exception> void unpackFailureMessage( MessageHandler<E> output )
                 throws E, IOException
         {
-            Map<String,Object> map = unpacker.unpackRawMap();
+            Map<String,Object> map = unpacker.unpackMap();
 
             String codeStr = map.containsKey( "code" ) ?
                     (String) map.get( "code" ) :
@@ -324,7 +324,7 @@ public class PackStreamMessageFormatV1 implements MessageFormat
                 throws E, IOException
         {
             String statement = unpacker.unpackText();
-            Map<String,Object> params = unpacker.unpackRawMap();
+            Map<String,Object> params = unpacker.unpackMap();
             output.handleRunMessage( statement, params );
         }
 

--- a/community/bolt/messaging-v1/src/main/java/org/neo4j/bolt/messaging/v1/infrastructure/ValueNode.java
+++ b/community/bolt/messaging-v1/src/main/java/org/neo4j/bolt/messaging/v1/infrastructure/ValueNode.java
@@ -87,7 +87,7 @@ public class ValueNode
             labels = Collections.emptyList();
         }
 
-        Map<String, Object> props = unpacker.unpackProperties();
+        Map<String, Object> props = unpacker.unpackMap();
 
         return new ValueNode( id, labels, props );
     }

--- a/community/bolt/messaging-v1/src/main/java/org/neo4j/bolt/messaging/v1/infrastructure/ValueRelationship.java
+++ b/community/bolt/messaging-v1/src/main/java/org/neo4j/bolt/messaging/v1/infrastructure/ValueRelationship.java
@@ -60,7 +60,7 @@ public class ValueRelationship extends ValuePropertyContainer implements Relatio
         long endNodeId = unpacker.unpackNodeIdentity();
         String relTypeName = unpacker.unpackText();
 
-        Map<String, Object> props = unpacker.unpackProperties();
+        Map<String, Object> props = unpacker.unpackMap();
 
         RelationshipType relType = DynamicRelationshipType.withName( relTypeName );
 

--- a/community/bolt/messaging-v1/src/main/java/org/neo4j/bolt/messaging/v1/infrastructure/ValueUnboundRelationship.java
+++ b/community/bolt/messaging-v1/src/main/java/org/neo4j/bolt/messaging/v1/infrastructure/ValueUnboundRelationship.java
@@ -58,7 +58,7 @@ public class ValueUnboundRelationship
         long relId = unpacker.unpackRelationshipIdentity();
         String relTypeName = unpacker.unpackText();
 
-        Map<String, Object> props = unpacker.unpackProperties();
+        Map<String, Object> props = unpacker.unpackMap();
 
         RelationshipType relType = DynamicRelationshipType.withName( relTypeName );
 

--- a/community/bolt/messaging-v1/src/test/java/org/neo4j/bolt/messaging/v1/Neo4jPackTest.java
+++ b/community/bolt/messaging-v1/src/test/java/org/neo4j/bolt/messaging/v1/Neo4jPackTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.bolt.messaging.v1;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -56,6 +57,27 @@ public class Neo4jPackTest
         PackedInputArray input = new PackedInputArray( bytes );
         Neo4jPack.Unpacker unpacker = new Neo4jPack.Unpacker( input );
         return unpacker.unpack();
+    }
+
+    @Test
+    public void shouldBeAbleToPackAndUnpackMapStream() throws IOException
+    {
+        // Given
+        PackedOutputArray output = new PackedOutputArray();
+        Neo4jPack.Packer packer = new Neo4jPack.Packer( output );
+        packer.packMapStreamHeader();
+        for ( Map.Entry<String, Object> entry : ALICE.getAllProperties().entrySet() )
+        {
+            packer.pack( entry.getKey() );
+            packer.pack( entry.getValue() );
+        }
+        packer.packMapStreamFooter();
+        Object unpacked = unpacked( output.bytes() );
+
+        // Then
+        assertThat( unpacked, instanceOf( Map.class ) );
+        Map<String, Object> unpackedMap = (Map<String, Object>) unpacked;
+        assertThat( unpackedMap, equalTo( ALICE.getAllProperties() ) );
     }
 
     @Test

--- a/community/bolt/packstream-v1/src/main/java/org/neo4j/packstream/PackStream.java
+++ b/community/bolt/packstream-v1/src/main/java/org/neo4j/packstream/PackStream.java
@@ -123,7 +123,7 @@ public class PackStream
     public static final byte MAP_8 = (byte) 0xD8;
     public static final byte MAP_16 = (byte) 0xD9;
     public static final byte MAP_32 = (byte) 0xDA;
-    public static final byte RESERVED_DB = (byte) 0xDB;
+    public static final byte MAP_STREAM = (byte) 0xDB;
     public static final byte STRUCT_8 = (byte) 0xDC;
     public static final byte STRUCT_16 = (byte) 0xDD;
     public static final byte RESERVED_DE = (byte) 0xDE;
@@ -144,6 +144,8 @@ public class PackStream
     public static final byte RESERVED_ED = (byte) 0xED;
     public static final byte RESERVED_EE = (byte) 0xEE;
     public static final byte RESERVED_EF = (byte) 0xEF;
+
+    public static final long UNKNOWN_SIZE = -1;
 
     private static final long PLUS_2_TO_THE_31 = 2147483648L;
     private static final long PLUS_2_TO_THE_15 = 32768L;
@@ -443,6 +445,16 @@ public class PackStream
             }
         }
 
+        public void packMapStreamHeader() throws IOException
+        {
+            out.writeByte( MAP_STREAM );
+        }
+
+        public void packMapStreamFooter() throws IOException
+        {
+            out.writeByte( NULL );
+        }
+
         public void packStructHeader( int size, byte signature ) throws IOException
         {
             if ( size < 0x10 )
@@ -542,6 +554,8 @@ public class PackStream
                 return unpackUINT16();
             case MAP_32:
                 return unpackUINT32();
+            case MAP_STREAM:
+                return UNKNOWN_SIZE;
             default:
                 throw new Unexpected( PackType.MAP, markerByte);
             }
@@ -855,6 +869,7 @@ public class PackStream
         case MAP_8:
         case MAP_16:
         case MAP_32:
+        case MAP_STREAM:
             return PackType.MAP;
         case STRUCT_8:
         case STRUCT_16:

--- a/community/bolt/packstream-v1/src/main/java/org/neo4j/packstream/PackType.java
+++ b/community/bolt/packstream-v1/src/main/java/org/neo4j/packstream/PackType.java
@@ -43,6 +43,8 @@ public enum PackType
     MAP,
     /** A composite data structure, made up of zero or more packstream values and a type signature. */
     STRUCT,
+    /** A marker that denotes the end of a streamed value */
+    END_OF_STREAM,
     /** Undefined type, reserved for future use */
     RESERVED
 }

--- a/community/bolt/packstream-v1/src/test/java/org/neo4j/packstream/PackStreamTest.java
+++ b/community/bolt/packstream-v1/src/test/java/org/neo4j/packstream/PackStreamTest.java
@@ -470,6 +470,33 @@ public class PackStreamTest
     }
 
     @Test
+    public void testCanPackAndUnpackListStream() throws Throwable
+    {
+        // Given
+        Machine machine = new Machine();
+
+        // When
+        PackStream.Packer packer = machine.packer();
+        packer.packListStreamHeader();
+        packer.pack( "eins" );
+        packer.pack( "zwei" );
+        packer.pack( "drei" );
+        packer.packEndOfStream();
+        packer.flush();
+        PackStream.Unpacker unpacker = newUnpacker( machine.output() );
+
+        // Then
+
+        assertThat( unpacker.unpackListHeader(), equalTo( PackStream.UNKNOWN_SIZE ) );
+
+        assertThat( unpacker.unpackText(), equalTo( "eins" ) );
+        assertThat( unpacker.unpackText(), equalTo( "zwei" ) );
+        assertThat( unpacker.unpackText(), equalTo( "drei" ) );
+
+        unpacker.unpackEndOfStream();
+    }
+
+    @Test
     public void testCanPackAndUnpackMap() throws Throwable
     {
         // Given
@@ -508,7 +535,7 @@ public class PackStreamTest
         packer.pack( 1 );
         packer.pack( "two" );
         packer.pack( 2 );
-        packer.packMapStreamFooter();
+        packer.packEndOfStream();
         packer.flush();
         PackStream.Unpacker unpacker = newUnpacker( machine.output() );
 
@@ -521,7 +548,7 @@ public class PackStreamTest
         assertThat( unpacker.unpackText(), equalTo( "two" ) );
         assertThat( unpacker.unpackLong(), equalTo( 2L ) );
 
-        unpacker.unpackNull();
+        unpacker.unpackEndOfStream();
     }
 
     @Test

--- a/community/bolt/packstream-v1/src/test/java/org/neo4j/packstream/PackStreamTest.java
+++ b/community/bolt/packstream-v1/src/test/java/org/neo4j/packstream/PackStreamTest.java
@@ -496,6 +496,35 @@ public class PackStreamTest
     }
 
     @Test
+    public void testCanPackAndUnpackMapStream() throws Throwable
+    {
+        // Given
+        Machine machine = new Machine();
+
+        // When
+        PackStream.Packer packer = machine.packer();
+        packer.packMapStreamHeader();
+        packer.pack( "one" );
+        packer.pack( 1 );
+        packer.pack( "two" );
+        packer.pack( 2 );
+        packer.packMapStreamFooter();
+        packer.flush();
+        PackStream.Unpacker unpacker = newUnpacker( machine.output() );
+
+        // Then
+
+        assertThat( unpacker.unpackMapHeader(), equalTo( PackStream.UNKNOWN_SIZE ) );
+
+        assertThat( unpacker.unpackText(), equalTo( "one" ) );
+        assertThat( unpacker.unpackLong(), equalTo( 1L ) );
+        assertThat( unpacker.unpackText(), equalTo( "two" ) );
+        assertThat( unpacker.unpackLong(), equalTo( 2L ) );
+
+        unpacker.unpackNull();
+    }
+
+    @Test
     public void testCanPackAndUnpackStruct() throws Throwable
     {
         // Given


### PR DESCRIPTION
Adds "continuous" list and map types to PackStream where the size does not need to be known up front. List items and map entries can be continually written/read and are terminated with an END_OF_STREAM marker.
