### PR TITLE
Support evaluation of predicates within shortestPath

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ShortestPathExpression.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ShortestPathExpression.scala
@@ -21,21 +21,25 @@ package org.neo4j.cypher.internal.compiler.v2_3.commands.expressions
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.DirectionConverter.toGraphDb
-import org.neo4j.cypher.internal.compiler.v2_3.commands.{PathExtractor, Pattern, ShortestPath, SingleNode}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates._
+import org.neo4j.cypher.internal.compiler.v2_3.commands._
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.SyntaxException
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{Property, FunctionName, FunctionInvocation}
+import org.neo4j.cypher.internal.frontend.v2_3.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
 import org.neo4j.graphalgo.GraphAlgoFactory
-import org.neo4j.graphdb.{DynamicRelationshipType, Expander, Node, Path}
+import org.neo4j.graphalgo.impl.path.ShortestPath.ShortestPathPredicate
+import org.neo4j.graphdb._
 import org.neo4j.kernel.Traversal
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
 
-case class ShortestPathExpression(ast: ShortestPath) extends Expression with PathExtractor {
-  val pathPattern:Seq[Pattern] = Seq(ast)
+case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates: Seq[Predicate] = Seq.empty) extends Expression with PathExtractor {
+  val pathPattern:Seq[Pattern] = Seq(shortestPathPattern)
 
   def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = {
     if (anyStartpointsContainNull(ctx)) {
@@ -45,51 +49,109 @@ case class ShortestPathExpression(ast: ShortestPath) extends Expression with Pat
     }
   }
 
-  private def getMatches(m: Map[String, Any]): Any = {
-    val start = getEndPoint(m, ast.left)
-    val end = getEndPoint(m, ast.right)
+  private def getMatches(ctx: ExecutionContext)(implicit state: QueryState): Any = {
+    val start = getEndPoint(ctx, shortestPathPattern.left)
+    val end = getEndPoint(ctx, shortestPathPattern.right)
+    val expander: Expander = addPredicates(ctx, makeRelationshipTypeExpander())
+    val shortestPathPredicate = createShortestPathPredicate(ctx, predicates)
+    val shortestPathStrategy = if (shortestPathPattern.single)
+      new SingleShortestPathStrategy(expander, shortestPathPattern.allowZeroLength, shortestPathPattern.maxDepth.getOrElse(15), shortestPathPredicate)
+    else
+      new AllShortestPathsStrategy(expander, shortestPathPattern.allowZeroLength, shortestPathPattern.maxDepth.getOrElse(15), shortestPathPredicate)
+
     shortestPathStrategy.findResult(start, end)
   }
 
-  def getEndPoint(m: Map[String, Any], start: SingleNode): Node = m.getOrElse(start.name,
-    throw new SyntaxException(s"To find a shortest path, both ends of the path need to be provided. Couldn't find `${start}`")).asInstanceOf[Node]
-
-  private def anyStartpointsContainNull(m: Map[String, Any]): Boolean =
-    m(ast.left.name) == null || m(ast.right.name) == null
-
-  override def children = Seq(ast)
-
-  def arguments = Seq.empty
-
-  def rewrite(f: (Expression) => Expression): Expression = f(ShortestPathExpression(ast.rewrite(f)))
-
-  private lazy val expander: Expander = if (ast.relTypes.isEmpty) {
-    Traversal.expanderForAllTypes(toGraphDb(ast.dir))
-  } else {
-    ast.relTypes.foldLeft(Traversal.emptyExpander()) {
-      case (e, t) => e.add(DynamicRelationshipType.withName(t), toGraphDb(ast.dir))
+  private def createShortestPathPredicate(incomingCtx: ExecutionContext, predicates: Seq[Predicate])(implicit state: QueryState): ShortestPathPredicate = new ShortestPathPredicate {
+    override def test(path: Path): Boolean = if (predicates.isEmpty) true else {
+      val ctx = incomingCtx.newWith(Map(
+        shortestPathPattern.pathName -> path,
+        shortestPathPattern.relIterator.get -> path.relationships()
+      ))
+      val ands = Ands(NonEmptyList.from(predicates))
+      ands.isTrue(ctx)
     }
   }
 
-  val shortestPathStrategy = if (ast.single)
-    new SingleShortestPathStrategy(expander, ast.allowZeroLength, ast.maxDepth.getOrElse(15))
-  else
-    new AllShortestPathsStrategy(expander, ast.allowZeroLength, ast.maxDepth.getOrElse(15))
+  private def getEndPoint(m: Map[String, Any], start: SingleNode): Node = m.getOrElse(start.name,
+    throw new SyntaxException(s"To find a shortest path, both ends of the path need to be provided. Couldn't find `${start}`")).asInstanceOf[Node]
 
-  def calculateType(symbols: SymbolTable) =  shortestPathStrategy.typ
+  private def anyStartpointsContainNull(m: Map[String, Any]): Boolean =
+    m(shortestPathPattern.left.name) == null || m(shortestPathPattern.right.name) == null
 
-  def symbolTableDependencies = ast.symbolTableDependencies + ast.left.name + ast.right.name
+  override def children = Seq(shortestPathPattern)
+
+  def arguments = Seq.empty
+
+  def rewrite(f: (Expression) => Expression): Expression = f(ShortestPathExpression(shortestPathPattern.rewrite(f)))
+
+  def calculateType(symbols: SymbolTable) =  if (shortestPathPattern.single) CTPath else CTCollection(CTPath)
+
+  def symbolTableDependencies = shortestPathPattern.symbolTableDependencies + shortestPathPattern.left.name + shortestPathPattern.right.name
 
   override def localEffects(symbols: SymbolTable) = Effects(ReadsNodes, ReadsRelationships)
+
+  private def propertyExistsExpander(name: String) = new org.neo4j.function.Predicate[Relationship] {
+    override def test(t: Relationship): Boolean = {
+      t.hasProperty(name)
+    }
+  }
+
+  private def propertyNotExistsExpander(name: String) = new org.neo4j.function.Predicate[Relationship] {
+    override def test(t: Relationship): Boolean = {
+      !t.hasProperty(name)
+    }
+  }
+
+  private def cypherPredicatesAsExpander(incomingCtx: ExecutionContext, relName: String, predicate: Predicate)(implicit state: QueryState) = new org.neo4j.function.Predicate[Relationship] {
+    override def test(t: Relationship): Boolean = {
+      predicate.isTrue(incomingCtx.newWith(relName -> t))
+    }
+  }
+
+  private def addAllOrNoneRelationshipExpander(ctx: ExecutionContext, currentExpander: Expander, all: Boolean, predicate: Predicate, relName: String)(implicit state: QueryState) = {
+    predicate match {
+      case PropertyExists(_, propertyKey) =>
+        currentExpander.addRelationshipFilter(
+          if(all) propertyExistsExpander(propertyKey.name)
+          else propertyNotExistsExpander(propertyKey.name))
+      case Not(PropertyExists(_, propertyKey)) =>
+        currentExpander.addRelationshipFilter(
+          if(all) propertyNotExistsExpander(propertyKey.name)
+          else propertyExistsExpander(propertyKey.name))
+      case _ => currentExpander.addRelationshipFilter(
+        cypherPredicatesAsExpander(ctx, relName, predicate))
+    }
+  }
+
+  private def makeRelationshipTypeExpander() = if (shortestPathPattern.relTypes.isEmpty) {
+    Traversal.expanderForAllTypes(toGraphDb(shortestPathPattern.dir))
+  } else {
+    shortestPathPattern.relTypes.foldLeft(Traversal.emptyExpander()) {
+      case (e, t) => e.add(DynamicRelationshipType.withName(t), toGraphDb(shortestPathPattern.dir))
+    }
+  }
+
+  private def addPredicates(ctx: ExecutionContext, relTypeAndDirExpander: Expander)(implicit state: QueryState): Expander = if (predicates.isEmpty) relTypeAndDirExpander
+  else
+    predicates.foldLeft(relTypeAndDirExpander) {
+      case (currentExpander, predicate) =>
+        predicate match {
+          case NoneInCollection(RelationshipFunction(_), symbolName, innerPredicate) => addAllOrNoneRelationshipExpander(ctx, currentExpander, false, innerPredicate, symbolName)
+          case AllInCollection(RelationshipFunction(_), symbolName, innerPredicate) => addAllOrNoneRelationshipExpander(ctx, currentExpander, true, innerPredicate, symbolName)
+          case _ => currentExpander
+        }
+    }
+
+
 }
 
 trait ShortestPathStrategy {
   def findResult(start: Node, end: Node): Any
-  def typ: CypherType
 }
 
-class SingleShortestPathStrategy(expander: Expander, allowZeroLength: Boolean, depth: Int) extends ShortestPathStrategy {
-  private val finder = GraphAlgoFactory.shortestPath(expander, depth)
+class SingleShortestPathStrategy(expander: Expander, allowZeroLength: Boolean, depth: Int, predicate: ShortestPathPredicate) extends ShortestPathStrategy {
+  private val finder = GraphAlgoFactory.shortestPath(expander, depth, predicate)
 
   def findResult(start: Node, end: Node): Path = {
     val result = finder.findSinglePath(start, end)
@@ -98,16 +160,12 @@ class SingleShortestPathStrategy(expander: Expander, allowZeroLength: Boolean, d
     else
       result
   }
-
-  def typ = CTPath
 }
 
-class AllShortestPathsStrategy(expander: Expander, allowZeroLength: Boolean, depth: Int) extends ShortestPathStrategy {
-  private val finder = GraphAlgoFactory.shortestPath(expander, depth)
+class AllShortestPathsStrategy(expander: Expander, allowZeroLength: Boolean, depth: Int, predicate: ShortestPathPredicate) extends ShortestPathStrategy {
+  private val finder = GraphAlgoFactory.shortestPath(expander, depth, predicate)
 
   def findResult(start: Node, end: Node): Stream[Path] = {
     finder.findAllPaths(start, end).asScala.toStream
   }.filter { p => allowZeroLength || p.length() > 0 }
-
-  def typ = CTCollection(CTPath)
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ShortestPathPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ShortestPathPipe.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.ShortestPathExpression
+import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CastSupport, CollectionSupport}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -31,20 +32,20 @@ import scala.collection.JavaConverters._
 /**
  * Shortest pipe inserts a single shortest path between two already found nodes
  */
-case class ShortestPathPipe(source: Pipe, ast: ShortestPath)
+case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, predicates: Seq[Predicate] = Seq.empty)
                            (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with CollectionSupport with RonjaPipe {
-  private def pathName = ast.pathName
-  private val expression = ShortestPathExpression(ast)
+  private def pathName = shortestPathCommand.pathName
+  private val shortestPathExpression = ShortestPathExpression(shortestPathCommand, predicates)
 
   protected def internalCreateResults(input:Iterator[ExecutionContext], state: QueryState) = input.flatMap(ctx => {
-    val result: Stream[Path] = expression(ctx)(state) match {
+    val result: Stream[Path] = shortestPathExpression(ctx)(state) match {
       case in: Stream[_] => CastSupport.castOrFail[Stream[Path]](in)
       case null          => Stream()
       case path: Path    => Stream(path)
     }
 
-    ast.relIterator match {
+    shortestPathCommand.relIterator match {
       case Some(relName) =>
         result.map { (path: Path) => ctx.newWith2(pathName, path, relName, path.relationships().asScala.toSeq) }
       case None =>
@@ -54,7 +55,7 @@ case class ShortestPathPipe(source: Pipe, ast: ShortestPath)
 
   val symbols = {
     val withPath = source.symbols.add(pathName, CTPath)
-    ast.relIterator match {
+    shortestPathCommand.relIterator match {
       case None    => withPath
       case Some(x) => withPath.add(x, CTCollection(CTRelationship))
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ShortestPathPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ShortestPathPipe.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.ShortestPath
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CastSupport, CollectionSupport}
+import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.LegacyExpression
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
 import org.neo4j.graphdb.Path
 
@@ -61,8 +62,12 @@ case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, pre
     }
   }
 
-  override def planDescriptionWithoutCardinality =
-    source.planDescription.andThen(this.id, "ShortestPath", identifiers)
+  override def planDescriptionWithoutCardinality = {
+    val args = predicates.map { p =>
+      LegacyExpression(p)
+    }
+    source.planDescription.andThen(this.id, "ShortestPath", identifiers, args:_*)
+  }
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
@@ -199,10 +199,9 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
             Eagerly.immutableMapValues[String, ast.Expression, AggregationExpression](aggregatingExpressions, buildExpression(_).asInstanceOf[AggregationExpression])
           )()
 
-        case FindShortestPaths(source, shortestPath) =>
-          val legacyShortestPaths = shortestPath.expr.asLegacyPatterns(shortestPath.name.map(_.name))
-          val legacyShortestPath = legacyShortestPaths.head
-          new ShortestPathPipe(buildPipe(source), legacyShortestPath)()
+        case FindShortestPaths(source, shortestPathPattern, predicates) =>
+          val legacyShortestPath = shortestPathPattern.expr.asLegacyPatterns(shortestPathPattern.name.map(_.name)).head
+          new ShortestPathPipe(buildPipe(source), legacyShortestPath, predicates.map(toCommandPredicate))()
 
         case Union(lhs, rhs) =>
           NewUnionPipe(buildPipe(lhs), buildPipe(rhs))()

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/findShortestPaths.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/findShortestPaths.scala
@@ -29,9 +29,9 @@ object findShortestPaths extends CandidateGenerator[GreedyPlanTable] {
     qg.shortestPathPatterns.flatMap { (shortestPath: ShortestPathPattern) =>
       input.plans.collect {
         case plan if shortestPath.isFindableFrom(plan.availableSymbols) =>
-          val pathDependencies = Set(shortestPath.name, Some(shortestPath.rel.name)).flatten
+          val pathIdentifiers = Set(shortestPath.name, Some(shortestPath.rel.name)).flatten
           val pathPredicates = qg.selections.predicates.collect {
-            case Predicate(dependencies, expr: Expression) if (dependencies intersect pathDependencies).nonEmpty => expr
+            case Predicate(dependencies, expr: Expression) if (dependencies intersect pathIdentifiers).nonEmpty => expr
           }.toSeq
           context.logicalPlanProducer.planShortestPaths(plan, shortestPath, pathPredicates)
       }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/findShortestPaths.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/greedy/findShortestPaths.scala
@@ -19,16 +19,21 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.greedy
 
-import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_3.planner.{Predicate, QueryGraph}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{LogicalPlan, ShortestPathPattern}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{CandidateGenerator, LogicalPlanningContext}
+import org.neo4j.cypher.internal.frontend.v2_3.ast.Expression
 
 object findShortestPaths extends CandidateGenerator[GreedyPlanTable] {
   def apply(input: GreedyPlanTable, qg: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] =
     qg.shortestPathPatterns.flatMap { (shortestPath: ShortestPathPattern) =>
       input.plans.collect {
         case plan if shortestPath.isFindableFrom(plan.availableSymbols) =>
-          context.logicalPlanProducer.planShortestPaths(plan, shortestPath)
+          val pathDependencies = Set(shortestPath.name, Some(shortestPath.rel.name)).flatten
+          val pathPredicates = qg.selections.predicates.collect {
+            case Predicate(dependencies, expr: Expression) if (dependencies intersect pathDependencies).nonEmpty => expr
+          }.toSeq
+          context.logicalPlanProducer.planShortestPaths(plan, shortestPath, pathPredicates)
       }
     }.toSeq
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
@@ -20,13 +20,16 @@
 package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.idp
 
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.IteratorSupport._
-import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
+import org.neo4j.cypher.internal.compiler.v2_3.planner.{Predicate, QueryGraph}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.idp.expandSolverStep.{planSinglePatternSide, planSingleProjectEndpoints}
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.solveOptionalMatches.OptionalSolver
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.steps.{applyOptional, outerHashJoin}
 import org.neo4j.cypher.internal.frontend.v2_3.InternalException
+import org.neo4j.cypher.internal.frontend.v2_3.ast._
+import org.neo4j.function
+import org.neo4j.graphdb.Relationship
 
 import scala.annotation.tailrec
 
@@ -73,7 +76,11 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
                                 (implicit context: LogicalPlanningContext): LogicalPlan =
     qg.shortestPathPatterns.foldLeft(kit.select(initialPlan, qg)) {
       case (plan, sp) if sp.isFindableFrom(plan.availableSymbols) =>
-        val shortestPath = context.logicalPlanProducer.planShortestPaths(plan, sp)
+        val pathDependencies = Set(sp.name, Some(sp.rel.name)).flatten
+        val pathPredicates = qg.selections.predicates.collect {
+          case Predicate(dependencies, expr: Expression) if (dependencies intersect pathDependencies).nonEmpty => expr
+        }.toSeq
+        val shortestPath = context.logicalPlanProducer.planShortestPaths(plan, sp, pathPredicates)
         kit.select(shortestPath, qg)
       case (plan, _) => plan
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/idp/IDPQueryGraphSolver.scala
@@ -76,9 +76,9 @@ case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
                                 (implicit context: LogicalPlanningContext): LogicalPlan =
     qg.shortestPathPatterns.foldLeft(kit.select(initialPlan, qg)) {
       case (plan, sp) if sp.isFindableFrom(plan.availableSymbols) =>
-        val pathDependencies = Set(sp.name, Some(sp.rel.name)).flatten
+        val pathIdentifiers = Set(sp.name, Some(sp.rel.name)).flatten
         val pathPredicates = qg.selections.predicates.collect {
-          case Predicate(dependencies, expr: Expression) if (dependencies intersect pathDependencies).nonEmpty => expr
+          case Predicate(dependencies, expr: Expression) if (dependencies intersect pathIdentifiers).nonEmpty => expr
         }.toSeq
         val shortestPath = context.logicalPlanProducer.planShortestPaths(plan, sp, pathPredicates)
         kit.select(shortestPath, qg)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/FindShortestPaths.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/FindShortestPaths.scala
@@ -20,8 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans
 
 import org.neo4j.cypher.internal.compiler.v2_3.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.frontend.v2_3.ast.Expression
 
-case class FindShortestPaths(left: LogicalPlan, shortestPath: ShortestPathPattern)
+case class FindShortestPaths(left: LogicalPlan, shortestPath: ShortestPathPattern, predicates: Seq[Expression] = Seq.empty)
                             (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalPlan with LogicalPlanWithoutExpressions with LazyLogicalPlan {
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/LogicalPlanProducer.scala
@@ -29,6 +29,8 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.{Limit => L
 import org.neo4j.cypher.internal.frontend.v2_3.ast._
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
 import org.neo4j.cypher.internal.frontend.v2_3.{InternalException, SemanticDirection, ast, symbols}
+import org.neo4j.function
+import org.neo4j.graphdb.Relationship
 
 case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends CollectionSupport {
   def solvePredicate(plan: LogicalPlan, solved: Expression)(implicit context: LogicalPlanningContext) =
@@ -381,10 +383,11 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends Colle
     planSkip(sortedLimit, skip)
   }
 
-  def planShortestPaths(inner: LogicalPlan, shortestPaths: ShortestPathPattern)
+  def planShortestPaths(inner: LogicalPlan, shortestPaths: ShortestPathPattern, predicates: Seq[Expression])
                        (implicit context: LogicalPlanningContext) = {
+    // TODO: Tell the planner that the shortestPath predicates are solved in shortestPath
     val solved = inner.solved.updateGraph(_.addShortestPath(shortestPaths))
-    FindShortestPaths(inner, shortestPaths)(solved)
+    FindShortestPaths(inner, shortestPaths, predicates)(solved)
   }
 
   def planEndpointProjection(inner: LogicalPlan, start: IdName, startInScope: Boolean, end: IdName, endInScope: Boolean, patternRel: PatternRelationship)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
@@ -1251,24 +1251,24 @@ class CypherParserTest extends CypherFunSuite {
     )
   }
 
-//  test("testShortestPathExpression") {
-//    expectQuery(
-//      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*0..3]->b) AS path""",
-//      Query.
-//        start(NodeById("a", 0), NodeById("b", 1)).
-//        returns(ReturnItem(ShortestPathExpression(
-//        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), SemanticDirection.OUTGOING, true, Some(3), single = true, relIterator = None)), "path")))
-//  }
-//
-//  test("shortest path with 0 as min length and no max length") {
-//    expectQuery(
-//      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*0..]->b) AS path""",
-//      Query.
-//        start(NodeById("a", 0), NodeById("b", 1)).
-//        returns(ReturnItem(ShortestPathExpression(
-//        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), SemanticDirection.OUTGOING, true, None, single = true, relIterator = None)),
-//        "path")))
-//  }
+  test("testShortestPathExpression") {
+    expectQuery(
+      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*0..3]->b) AS path""",
+      Query.
+        start(NodeById("a", 0), NodeById("b", 1)).
+        returns(ReturnItem(ShortestPathExpression(
+        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), SemanticDirection.OUTGOING, true, Some(3), single = true, relIterator = None)), "path")))
+  }
+
+  test("shortest path with 0 as min length and no max length") {
+    expectQuery(
+      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*0..]->b) AS path""",
+      Query.
+        start(NodeById("a", 0), NodeById("b", 1)).
+        returns(ReturnItem(ShortestPathExpression(
+        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), SemanticDirection.OUTGOING, true, None, single = true, relIterator = None)),
+        "path")))
+  }
 
   test("testForNull") {
     expectQuery(

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/parser/CypherParserTest.scala
@@ -1251,24 +1251,24 @@ class CypherParserTest extends CypherFunSuite {
     )
   }
 
-  test("testShortestPathExpression") {
-    expectQuery(
-      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*0..3]->b) AS path""",
-      Query.
-        start(NodeById("a", 0), NodeById("b", 1)).
-        returns(ReturnItem(ShortestPathExpression(
-        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), SemanticDirection.OUTGOING, true, Some(3), single = true, relIterator = None)), "path")))
-  }
-
-  test("shortest path with 0 as min length and no max length") {
-    expectQuery(
-      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*0..]->b) AS path""",
-      Query.
-        start(NodeById("a", 0), NodeById("b", 1)).
-        returns(ReturnItem(ShortestPathExpression(
-        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), SemanticDirection.OUTGOING, true, None, single = true, relIterator = None)),
-        "path")))
-  }
+//  test("testShortestPathExpression") {
+//    expectQuery(
+//      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*0..3]->b) AS path""",
+//      Query.
+//        start(NodeById("a", 0), NodeById("b", 1)).
+//        returns(ReturnItem(ShortestPathExpression(
+//        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), SemanticDirection.OUTGOING, true, Some(3), single = true, relIterator = None)), "path")))
+//  }
+//
+//  test("shortest path with 0 as min length and no max length") {
+//    expectQuery(
+//      """start a=node(0), b=node(1) return shortestPath(a-[:KNOWS*0..]->b) AS path""",
+//      Query.
+//        start(NodeById("a", 0), NodeById("b", 1)).
+//        returns(ReturnItem(ShortestPathExpression(
+//        ShortestPath("  UNNAMED34", SingleNode("a"), SingleNode("b"), Seq("KNOWS"), SemanticDirection.OUTGOING, true, None, single = true, relIterator = None)),
+//        "path")))
+//  }
 
   test("testForNull") {
     expectQuery(

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/GraphAlgoFactory.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/GraphAlgoFactory.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.graphalgo;
 
+import java.util.List;
+
 import org.neo4j.graphalgo.impl.path.AStar;
 import org.neo4j.graphalgo.impl.path.AllPaths;
 import org.neo4j.graphalgo.impl.path.AllSimplePaths;
@@ -129,6 +131,11 @@ public abstract class GraphAlgoFactory
     public static PathFinder<Path> shortestPath( RelationshipExpander expander, int maxDepth )
     {
         return new ShortestPath( maxDepth, expander );
+    }
+
+    public static PathFinder<Path> shortestPath( RelationshipExpander expander, int maxDepth, ShortestPath.ShortestPathPredicate predicate )
+    {
+        return new ShortestPath( maxDepth, expander, predicate );
     }
 
     /**

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import org.neo4j.graphalgo.PathFinder;
@@ -68,6 +69,11 @@ public class ShortestPath implements PathFinder<Path>
     private final int maxResultCount;
     private final PathExpander expander;
     private Metadata lastMetadata;
+    private ShortestPathPredicate predicate;
+
+    public interface ShortestPathPredicate {
+        boolean test(Path path);
+    }
 
     /**
      * Constructs a new shortest path algorithm.
@@ -86,6 +92,12 @@ public class ShortestPath implements PathFinder<Path>
         this( maxDepth, toPathExpander( expander ), Integer.MAX_VALUE );
     }
 
+    public ShortestPath( int maxDepth, RelationshipExpander expander, ShortestPathPredicate predicate )
+    {
+        this(maxDepth, toPathExpander( expander ));
+        this.predicate = predicate;
+    }
+
     public ShortestPath( int maxDepth, RelationshipExpander expander, int maxResultCount )
     {
         this( maxDepth, toPathExpander( expander ), maxResultCount );
@@ -95,7 +107,7 @@ public class ShortestPath implements PathFinder<Path>
      * Constructs a new shortest path algorithm.
      * @param maxDepth the maximum depth for the traversal. Returned paths
      * will never have a greater {@link Path#length()} than {@code maxDepth}.
-     * @param expander the {@link RelationshipExpander} to use for deciding
+     * @param expander the {@link PathExpander} to use for deciding
      * which relationships to expand for each {@link Node}.
      * @param maxResultCount the maximum number of hits to return. If this number
      * of hits are encountered the traversal will stop.
@@ -144,7 +156,7 @@ public class ShortestPath implements PathFinder<Path>
             goOneStep( endData, startData, hits, startData, stopAsap );
         }
         Collection<Hit> least = hits.least();
-        return least != null ? hitsToPaths( least, start, end, stopAsap ) : Collections.<Path> emptyList();
+        return least != null ? filterPaths(hitsToPaths( least, start, end, stopAsap )) : Collections.<Path> emptyList();
     }
 
     @Override
@@ -215,21 +227,51 @@ public class ShortestPath implements PathFinder<Path>
                 // Add it to the list of hits
                 DirectionData startSideData = directionData == startSide ? directionData : otherSide;
                 DirectionData endSideData = directionData == startSide ? otherSide : directionData;
-                if ( hits.add( new Hit( startSideData, endSideData, nextNode ), depth ) >= maxResultCount )
+                Hit hit = new Hit( startSideData, endSideData, nextNode );
+                Node start = startSide.startNode;
+                Node end = (startSide == directionData) ? otherSide.startNode : directionData.startNode;
+                if ( filterPaths( hitToPaths( hit, start, end, stopAsap ) ).size() > 0 )
                 {
-                    directionData.stop = true;
-                    otherSide.stop = true;
-                    lastMetadata.paths++;
-                }
-                else if ( stopAsap )
-                {   // This side found a hit, but wait for the other side to complete its current depth
-                    // to see if it finds a shorter path. (i.e. stop this side and freeze the depth).
-                    // but only if the other side has not stopped, otherwise we might miss shorter paths
-                    if ( otherSide.stop == true )
-                        return;
-                    directionData.stop = true;
+                    if ( hits.add( hit, depth ) >= maxResultCount )
+                    {
+                        directionData.stop = true;
+                        otherSide.stop = true;
+                        lastMetadata.paths++;
+                    }
+                    else if ( stopAsap )
+                    {   // This side found a hit, but wait for the other side to complete its current depth
+                        // to see if it finds a shorter path. (i.e. stop this side and freeze the depth).
+                        // but only if the other side has not stopped, otherwise we might miss shorter paths
+                        if ( otherSide.stop )
+                        { return; }
+                        directionData.stop = true;
+                    }
+                } else {
+                    directionData.haveFoundSomething = false;
+                    directionData.sharedFrozenDepth.value = NULL;
+                    otherSide.stop = false;
                 }
             }
+        }
+    }
+
+    private Collection<Path> filterPaths( Collection<Path> paths )
+    {
+        if ( predicate == null )
+        {
+            return paths;
+        }
+        else
+        {
+            Collection<Path> filteredPaths = new ArrayList<>();
+            for ( Path path : paths )
+            {
+                if ( predicate.test( path ) )
+                {
+                    filteredPaths.add( path );
+                }
+            }
+            return filteredPaths;
         }
     }
 
@@ -518,22 +560,29 @@ public class ShortestPath implements PathFinder<Path>
         }
     }
 
-    private static Iterable<Path> hitsToPaths( Collection<Hit> depthHits, Node start, Node end, boolean stopAsap )
+    private static Collection<Path> hitsToPaths( Collection<Hit> depthHits, Node start, Node end, boolean stopAsap )
     {
         Collection<Path> paths = new ArrayList<Path>();
         for ( Hit hit : depthHits )
         {
-            Iterable<LinkedList<Relationship>> startPaths = getPaths( hit.connectingNode, hit.start, stopAsap );
-            Iterable<LinkedList<Relationship>> endPaths = getPaths( hit.connectingNode, hit.end, stopAsap );
-            for ( LinkedList<Relationship> startPath : startPaths )
+            paths.addAll( hitToPaths( hit, start, end, stopAsap ) );
+        }
+        return paths;
+    }
+
+    private static Collection<Path> hitToPaths( Hit hit, Node start, Node end, boolean stopAsap )
+    {
+        Collection<Path> paths = new ArrayList<Path>();
+        Iterable<LinkedList<Relationship>> startPaths = getPaths( hit.connectingNode, hit.start, stopAsap );
+        Iterable<LinkedList<Relationship>> endPaths = getPaths( hit.connectingNode, hit.end, stopAsap );
+        for ( LinkedList<Relationship> startPath : startPaths )
+        {
+            PathImpl.Builder startBuilder = toBuilder( start, startPath );
+            for ( LinkedList<Relationship> endPath : endPaths )
             {
-                PathImpl.Builder startBuilder = toBuilder( start, startPath );
-                for ( LinkedList<Relationship> endPath : endPaths )
-                {
-                    PathImpl.Builder endBuilder = toBuilder( end, endPath );
-                    Path path = startBuilder.build( endBuilder );
-                    paths.add( path );
-                }
+                PathImpl.Builder endBuilder = toBuilder( end, endPath );
+                Path path = startBuilder.build( endBuilder );
+                paths.add( path );
             }
         }
         return paths;

--- a/community/kernel/src/main/java/org/neo4j/kernel/StandardExpander.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/StandardExpander.java
@@ -311,8 +311,7 @@ public abstract class StandardExpander implements Expander, PathExpander
         {
             Map<String, Exclusion> exclude = new HashMap<String, Exclusion>();
             exclude.put( type.name(), Exclusion.ALL );
-            return new ExcludingExpander( Exclusion.include( direction ),
-                    exclude );
+            return new ExcludingExpander( Exclusion.include( direction ), exclude );
         }
 
         @Override


### PR DESCRIPTION
- All predicates evaluated on each path found before shortest filtering
- ALL(...) and NONE(...) predicates evaluated within Expander for early branch pruning performance
