### PR TITLE
Return null when property does not exist

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/EntityItem.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/cursor/EntityItem.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.api.cursor;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveIntStack;
 import org.neo4j.cursor.Cursor;
+import org.neo4j.graphdb.NotFoundException;
 
 /**
  * Represents a single node or relationship cursor item.
@@ -49,6 +50,10 @@ public interface EntityItem
                 {
                     return cursor.get().value();
                 }
+            }
+            catch ( NotFoundException e )
+            {
+                return null;
             }
 
             return null;


### PR DESCRIPTION
Under concurrent modification we could run across property records that are not in use. Instead of throwing an exception in this case, return `null` to note that the property was not found.

This was an issue found by the cypher concurrency robustness suite.
