### PR TITLE
Restructure token handling to allow for other implementations.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/NonTransactionalTokenNameLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/NonTransactionalTokenNameLookup.java
@@ -65,7 +65,7 @@ public class NonTransactionalTokenNameLookup implements TokenNameLookup
         return tokenById( propertyKeyTokenHolder, propertyKeyId, "property" );
     }
 
-    private static String tokenById( TokenHolder<?> tokenHolder, int tokenId, String tokenName )
+    private static String tokenById( TokenHolder tokenHolder, int tokenId, String tokenName )
     {
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
@@ -24,6 +24,7 @@ import org.neo4j.kernel.impl.api.store.SchemaCache;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
+import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.store.record.SchemaRule;
@@ -62,7 +63,7 @@ public class BridgingCacheAccess implements CacheAccessBackDoor
     }
 
     @Override
-    public void addRelationshipTypeToken( Token type )
+    public void addRelationshipTypeToken( RelationshipTypeToken type )
     {
         relationshipTypeTokenHolder.addToken( type );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/CacheAccessBackDoor.java
@@ -27,7 +27,7 @@ public interface CacheAccessBackDoor
 
     void removeSchemaRuleFromCache( long id );
 
-    void addRelationshipTypeToken( Token type );
+    void addRelationshipTypeToken( RelationshipTypeToken type );
 
     void addLabelToken( Token labelId );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingLabelTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingLabelTokenHolder.java
@@ -19,26 +19,10 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import org.neo4j.graphdb.RelationshipType;
-
-/**
- * Special sub-class of {@link Token} that implements the public-facing
- * interface {@link RelationshipType}, so that we can pass tokens directly to users
- * without first wrapping them in another object.
- */
-public class RelationshipTypeToken extends Token implements RelationshipType
+public class DelegatingLabelTokenHolder extends DelegatingTokenHolder<Token> implements LabelTokenHolder
 {
-    public RelationshipTypeToken( String name, int id )
+    public DelegatingLabelTokenHolder( TokenCreator tokenCreator )
     {
-        super( name, id );
-    }
-
-    public static class Factory implements TokenFactory<RelationshipTypeToken>
-    {
-        @Override
-        public RelationshipTypeToken newToken( String name, int id )
-        {
-            return new RelationshipTypeToken( name, id );
-        }
+        super( tokenCreator, new Token.Factory() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingPropertyKeyTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingPropertyKeyTokenHolder.java
@@ -19,26 +19,10 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import org.neo4j.graphdb.RelationshipType;
-
-/**
- * Special sub-class of {@link Token} that implements the public-facing
- * interface {@link RelationshipType}, so that we can pass tokens directly to users
- * without first wrapping them in another object.
- */
-public class RelationshipTypeToken extends Token implements RelationshipType
+public class DelegatingPropertyKeyTokenHolder extends DelegatingTokenHolder<Token> implements PropertyKeyTokenHolder
 {
-    public RelationshipTypeToken( String name, int id )
+    public DelegatingPropertyKeyTokenHolder( TokenCreator tokenCreator )
     {
-        super( name, id );
-    }
-
-    public static class Factory implements TokenFactory<RelationshipTypeToken>
-    {
-        @Override
-        public RelationshipTypeToken newToken( String name, int id )
-        {
-            return new RelationshipTypeToken( name, id );
-        }
+        super( tokenCreator, new Token.Factory() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingRelationshipTypeTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingRelationshipTypeTokenHolder.java
@@ -19,26 +19,10 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import org.neo4j.graphdb.RelationshipType;
-
-/**
- * Special sub-class of {@link Token} that implements the public-facing
- * interface {@link RelationshipType}, so that we can pass tokens directly to users
- * without first wrapping them in another object.
- */
-public class RelationshipTypeToken extends Token implements RelationshipType
+public class DelegatingRelationshipTypeTokenHolder extends DelegatingTokenHolder<RelationshipTypeToken> implements RelationshipTypeTokenHolder
 {
-    public RelationshipTypeToken( String name, int id )
+    public DelegatingRelationshipTypeTokenHolder( TokenCreator tokenCreator )
     {
-        super( name, id );
-    }
-
-    public static class Factory implements TokenFactory<RelationshipTypeToken>
-    {
-        @Override
-        public RelationshipTypeToken newToken( String name, int id )
-        {
-            return new RelationshipTypeToken( name, id );
-        }
+        super( tokenCreator, new RelationshipTypeToken.Factory() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingTokenHolder.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import java.util.List;
+
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+/**
+ * Keeps a cache of tokens using {@link InMemoryTokenCache}.
+ * When asked for a token that isn't in the cache, delegates to a TokenCreator to create the token,
+ * then stores it in the cache.
+ */
+public class DelegatingTokenHolder<TOKEN extends Token> extends LifecycleAdapter implements TokenHolder<TOKEN>
+{
+    protected InMemoryTokenCache<TOKEN> tokenCache = new InMemoryTokenCache<>(this.getClass());
+    private final TokenCreator tokenCreator;
+    private final TokenFactory<TOKEN> tokenFactory;
+
+    public DelegatingTokenHolder( TokenCreator tokenCreator, TokenFactory<TOKEN> tokenFactory )
+    {
+        this.tokenCreator = tokenCreator;
+        this.tokenFactory = tokenFactory;
+    }
+
+    @Override
+    public void setInitialTokens( List<TOKEN> tokens ) throws NonUniqueTokenException
+    {
+        tokenCache.clear();
+        tokenCache.putAll( tokens );
+    }
+
+    @Override
+    public void addToken( TOKEN token ) throws NonUniqueTokenException
+    {
+        tokenCache.put( token );
+    }
+
+    @Override
+    public int getOrCreateId( String name )
+    {
+        Integer id = tokenCache.getId( name );
+        if ( id != null )
+        {
+            return id;
+        }
+
+        // Let's create it
+        try
+        {
+            id = createToken( name );
+            return id;
+        }
+        catch ( Throwable e )
+        {
+            throw new TransactionFailureException( "Could not create token", e );
+        }
+    }
+
+    private synchronized int createToken( String name )
+            throws KernelException
+    {
+        Integer id = tokenCache.getId( name );
+        if ( id != null )
+        {
+            return id;
+        }
+
+        id = tokenCreator.getOrCreate( name );
+        try
+        {
+            tokenCache.put( tokenFactory.newToken( name, id ) );
+        }
+        catch ( NonUniqueTokenException e )
+        {
+            throw new IllegalStateException( "Newly created token should be unique.", e );
+        }
+        return id;
+    }
+
+    @Override
+    public TOKEN getTokenById( int id ) throws TokenNotFoundException
+    {
+        TOKEN result = getTokenByIdOrNull( id );
+        if ( result == null )
+        {
+            throw new TokenNotFoundException( "Token for id " + id );
+        }
+        return result;
+    }
+
+    @Override
+    public TOKEN getTokenByIdOrNull( int id )
+    {
+        return tokenCache.getToken( id );
+    }
+
+    @Override
+    public int getIdByName( String name )
+    {
+        Integer id = tokenCache.getId( name );
+        if ( id == null )
+        {
+            return NO_ID;
+        }
+        return id;
+    }
+
+    @Override
+    public Iterable<TOKEN> getAllTokens()
+    {
+        return tokenCache.allTokens();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/InMemoryTokenCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/InMemoryTokenCache.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.kernel.impl.util.CopyOnWriteHashMap;
+
+public class InMemoryTokenCache<TOKEN extends Token>
+{
+    private final Map<String, Integer> nameToId = new CopyOnWriteHashMap<>();
+    private final Map<Integer, TOKEN> idToToken = new CopyOnWriteHashMap<>();
+    private final Class<? extends TokenHolder> owningClass;
+
+    public InMemoryTokenCache( Class<? extends TokenHolder> owningClass )
+    {
+        this.owningClass = owningClass;
+    }
+
+    public void clear()
+    {
+        nameToId.clear();
+        idToToken.clear();
+    }
+
+    private static void putAndEnsureUnique( Map<String,Integer> nameToId, Token token, Class<? extends TokenHolder> owningClass )
+    {
+        Integer previous;
+        if ( (previous = nameToId.put( token.name(), token.id() )) != null && previous != token.id() )
+        {
+            throw new NonUniqueTokenException( owningClass, token.name(), token.id(), previous );
+        }
+    }
+
+    public void putAll( List<TOKEN> tokens ) throws NonUniqueTokenException
+    {
+        Map<String, Integer> newNameToId = new HashMap<>();
+        Map<Integer, TOKEN> newIdToToken = new HashMap<>();
+
+        for ( TOKEN token : tokens )
+        {
+            putAndEnsureUnique( newNameToId, token, owningClass );
+            newIdToToken.put( token.id(), token );
+        }
+
+        nameToId.putAll( newNameToId );
+        idToToken.putAll( newIdToToken );
+    }
+
+    public void put( TOKEN token ) throws NonUniqueTokenException
+    {
+        putAndEnsureUnique( nameToId, token, owningClass );
+        idToToken.put( token.id(), token );
+    }
+
+    public Integer getId( String name )
+    {
+        return nameToId.get( name );
+    }
+
+    public TOKEN getToken( int id )
+    {
+        return idToToken.get( id );
+    }
+
+    public Iterable<TOKEN> allTokens()
+    {
+        return idToToken.values();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/LabelTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/LabelTokenHolder.java
@@ -19,16 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-public class LabelTokenHolder extends TokenHolder<Token>
+public interface LabelTokenHolder extends TokenHolder<Token>
 {
-    public LabelTokenHolder( TokenCreator tokenCreator )
-    {
-        super( tokenCreator );
-    }
-
-    @Override
-    protected Token newToken( String name, int id )
-    {
-        return new Token( name, id );
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NonUniqueTokenException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NonUniqueTokenException.java
@@ -29,6 +29,6 @@ public class NonUniqueTokenException extends RuntimeException
     public NonUniqueTokenException( Class<? extends TokenHolder> holder, String tokenName, int tokenId, int existingId )
     {
         super( String.format( "The %s \"%s\" is not unique, it existed with id=%d before being added with id=%d.",
-                              holder.getSimpleName().replace( "TokenHolder", "" ), tokenName, existingId, tokenId ) );
+                              holder.getSimpleName().replace( "Delegating", "" ).replace( "TokenHolder", "" ), tokenName, existingId, tokenId ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PropertyKeyTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PropertyKeyTokenHolder.java
@@ -19,16 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-public class PropertyKeyTokenHolder extends TokenHolder<Token>
+public interface PropertyKeyTokenHolder extends TokenHolder<Token>
 {
-    public PropertyKeyTokenHolder( TokenCreator tokenCreator )
-    {
-        super( tokenCreator );
-    }
-
-    @Override
-    protected Token newToken( String name, int id )
-    {
-        return new Token( name, id );
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipTypeTokenHolder.java
@@ -19,16 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-public class RelationshipTypeTokenHolder extends TokenHolder<RelationshipTypeToken>
+public interface RelationshipTypeTokenHolder extends TokenHolder<RelationshipTypeToken>
 {
-    public RelationshipTypeTokenHolder( TokenCreator tokenCreator )
-    {
-        super( tokenCreator );
-    }
-
-    @Override
-    protected RelationshipTypeToken newToken( String name, int id )
-    {
-        return new RelationshipTypeToken( name, id );
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/Token.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/Token.java
@@ -61,4 +61,13 @@ public class Token
     {
         return getClass().getSimpleName() + "[name:" + name + ", id:" + id + "]";
     }
+
+    public static class Factory implements TokenFactory<Token>
+    {
+        @Override
+        public Token newToken( String name, int id )
+        {
+            return new Token( name, id );
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenCreator.java
@@ -23,6 +23,5 @@ import org.neo4j.kernel.api.exceptions.KernelException;
 
 public interface TokenCreator
 {
-    int getOrCreate( String name )
-            throws KernelException;
+    int getOrCreate( String name ) throws KernelException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/TokenFactory.java
@@ -19,26 +19,7 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import org.neo4j.graphdb.RelationshipType;
-
-/**
- * Special sub-class of {@link Token} that implements the public-facing
- * interface {@link RelationshipType}, so that we can pass tokens directly to users
- * without first wrapping them in another object.
- */
-public class RelationshipTypeToken extends Token implements RelationshipType
+public interface TokenFactory<TOKEN>
 {
-    public RelationshipTypeToken( String name, int id )
-    {
-        super( name, id );
-    }
-
-    public static class Factory implements TokenFactory<RelationshipTypeToken>
-    {
-        @Override
-        public RelationshipTypeToken newToken( String name, int id )
-        {
-            return new RelationshipTypeToken( name, id );
-        }
-    }
+    TOKEN newToken( String name, int id );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -387,7 +387,7 @@ public class DataSourceModule
     private static class StartupWaiter extends LifecycleAdapter
     {
         private final AvailabilityGuard availabilityGuard;
-        private long timeout;
+        private final long timeout;
 
         public StartupWaiter( AvailabilityGuard availabilityGuard, long timeout )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DumpStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DumpStore.java
@@ -29,6 +29,7 @@ import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -146,14 +147,14 @@ public class DumpStore<RECORD extends AbstractBaseRecord, STORE extends CommonAb
         dumpTokens( storeFactory.newRelationshipTypeTokenStore( file ), ids );
     }
 
-    private static <T extends TokenRecord> void dumpTokens( final TokenStore<T> store, long[] ids ) throws Exception
+    private static <R extends TokenRecord, T extends Token> void dumpTokens( final TokenStore<R, T> store, long[] ids ) throws Exception
     {
         try
         {
-            new DumpStore<T, TokenStore<T>>( System.out )
+            new DumpStore<R, TokenStore<R, T>>( System.out )
             {
                 @Override
-                protected Object transform( T record ) throws Exception
+                protected Object transform( R record ) throws Exception
                 {
                     if ( record.inUse() )
                     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelTokenStore.java
@@ -27,14 +27,15 @@ import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
 
 /**
- * Implementation of the property store.
+ * Implementation of the label store.
  */
-public class LabelTokenStore extends TokenStore<LabelTokenRecord>
+public class LabelTokenStore extends TokenStore<LabelTokenRecord, Token>
 {
     public static final String TYPE_DESCRIPTOR = "LabelTokenStore";
     public static final int RECORD_SIZE = 1/*inUse*/ + 4/*nameId*/;
@@ -50,8 +51,8 @@ public class LabelTokenStore extends TokenStore<LabelTokenRecord>
             StoreVersionMismatchHandler versionMismatchHandler,
             Monitors monitors )
     {
-        super(fileName, config, IdType.LABEL_TOKEN, idGeneratorFactory, pageCache,
-                fileSystemAbstraction, logProvider, nameStore, versionMismatchHandler, monitors );
+        super( fileName, config, IdType.LABEL_TOKEN, idGeneratorFactory, pageCache, fileSystemAbstraction,
+                logProvider, nameStore, versionMismatchHandler, monitors, new Token.Factory() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyKeyTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyKeyTokenStore.java
@@ -27,6 +27,7 @@ import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -34,7 +35,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 /**
  * Implementation of the property store.
  */
-public class PropertyKeyTokenStore extends TokenStore<PropertyKeyTokenRecord>
+public class PropertyKeyTokenStore extends TokenStore<PropertyKeyTokenRecord, Token>
 {
     // Historical type descriptor, should be called PropertyKeyTokenStore
     public static final String TYPE_DESCRIPTOR = "PropertyIndexStore";
@@ -52,8 +53,8 @@ public class PropertyKeyTokenStore extends TokenStore<PropertyKeyTokenRecord>
             StoreVersionMismatchHandler versionMismatchHandler,
             Monitors monitors )
     {
-        super(fileName, config, IdType.PROPERTY_KEY_TOKEN, idGeneratorFactory, pageCache,
-                fileSystemAbstraction, logProvider, nameStore, versionMismatchHandler, monitors );
+        super( fileName, config, IdType.PROPERTY_KEY_TOKEN, idGeneratorFactory, pageCache, fileSystemAbstraction,
+                logProvider, nameStore, versionMismatchHandler, monitors, new Token.Factory() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipTypeTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipTypeTokenStore.java
@@ -27,6 +27,7 @@ import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -36,7 +37,7 @@ import org.neo4j.logging.LogProvider;
  * Implementation of the relationship type store. Uses a dynamic store to store
  * relationship type names.
  */
-public class RelationshipTypeTokenStore extends TokenStore<RelationshipTypeTokenRecord>
+public class RelationshipTypeTokenStore extends TokenStore<RelationshipTypeTokenRecord, RelationshipTypeToken>
 {
     public static final String TYPE_DESCRIPTOR = "RelationshipTypeStore";
     public static final int RECORD_SIZE = 1/*inUse*/ + 4/*nameId*/;
@@ -52,8 +53,8 @@ public class RelationshipTypeTokenStore extends TokenStore<RelationshipTypeToken
             StoreVersionMismatchHandler versionMismatchHandler,
             Monitors monitors )
     {
-        super( fileName, config, IdType.RELATIONSHIP_TYPE_TOKEN, idGeneratorFactory, pageCache,
-                fileSystemAbstraction, logProvider, nameStore, versionMismatchHandler, monitors );
+        super( fileName, config, IdType.RELATIONSHIP_TYPE_TOKEN, idGeneratorFactory, pageCache, fileSystemAbstraction,
+                logProvider, nameStore, versionMismatchHandler, monitors, new RelationshipTypeToken.Factory() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -34,6 +35,7 @@ import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.Token;
+import org.neo4j.kernel.impl.core.TokenFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.TokenRecord;
@@ -44,7 +46,7 @@ import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
 import static org.neo4j.kernel.impl.store.PropertyStore.decodeString;
 
-public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordStore<T>
+public abstract class TokenStore<RECORD extends TokenRecord, TOKEN extends Token> extends AbstractRecordStore<RECORD>
 {
     public static abstract class Configuration
         extends AbstractStore.Configuration
@@ -55,6 +57,7 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
     public static final int NAME_STORE_BLOCK_SIZE = 30;
 
     private DynamicStringStore nameStore;
+    private final TokenFactory<TOKEN> tokenFactory;
 
     public TokenStore(
             File fileName,
@@ -66,11 +69,13 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
             LogProvider logProvider,
             DynamicStringStore nameStore,
             StoreVersionMismatchHandler versionMismatchHandler,
-            Monitors monitors )
+            Monitors monitors,
+            TokenFactory<TOKEN> tokenFactory )
     {
         super( fileName, configuration, idType, idGeneratorFactory, pageCache,
                 fileSystemAbstraction, logProvider, versionMismatchHandler, monitors );
         this.nameStore = nameStore;
+        this.tokenFactory = tokenFactory;
     }
 
     public DynamicStringStore getNameStore()
@@ -114,14 +119,14 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
         return false;
     }
 
-    public Token[] getTokens( int maxCount )
+    public List<TOKEN> getTokens( int maxCount )
     {
-        LinkedList<Token> recordList = new LinkedList<>();
+        LinkedList<TOKEN> records = new LinkedList<>();
         long maxIdInUse = getHighestPossibleIdInUse();
         int found = 0;
         for ( int i = 0; i <= maxIdInUse && found < maxCount; i++ )
         {
-            T record;
+            RECORD record;
             try
             {
                 record = getRecord( i );
@@ -133,22 +138,22 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
             found++;
             if ( record != null && record.inUse() && record.getNameId() != Record.RESERVED.intValue() )
             {
-                String name = getStringFor( record );
-                recordList.add( new Token( name, i ) );
+                records.add( tokenFactory.newToken( getStringFor( record ), i ) );
             }
         }
-        return recordList.toArray( new Token[recordList.size()] );
+
+        return records;
     }
 
-    public Token getToken( int id )
+    public TOKEN getToken( int id )
     {
-        T record = getRecord( id );
-        return new Token( getStringFor( record ), record.getId() );
+        RECORD record = getRecord( id );
+        return tokenFactory.newToken( getStringFor( record ), record.getId() );
     }
 
-    public T getRecord( int id )
+    public RECORD getRecord( int id )
     {
-        T record = newRecord( id );
+        RECORD record = newRecord( id );
         byte inUseByte = Record.NOT_IN_USE.byteValue();
 
         try ( PageCursor cursor = storeFile.io( pageIdForRecord( id ), PF_SHARED_LOCK ) )
@@ -179,19 +184,19 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
     }
 
     @Override
-    public T getRecord( long id )
+    public RECORD getRecord( long id )
     {
         return getRecord( (int) id );
     }
 
     @Override
-    public T forceGetRecord( long id )
+    public RECORD forceGetRecord( long id )
     {
         try ( PageCursor cursor = storeFile.io( pageIdForRecord( id ), PF_SHARED_LOCK ) )
         {
             if ( cursor.next() )
             {
-                T record = newRecord( (int) id );
+                RECORD record = newRecord( (int) id );
                 byte inUseByte;
                 do
                 {
@@ -230,7 +235,7 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
     }
 
     @Override
-    public void updateRecord( T record )
+    public void updateRecord( RECORD record )
     {
         forceUpdateRecord( record );
         if ( !record.isLight() )
@@ -243,7 +248,7 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
     }
 
     @Override
-    public void forceUpdateRecord( T record )
+    public void forceUpdateRecord( RECORD record )
     {
         try ( PageCursor cursor = storeFile.io( pageIdForRecord( record.getId() ), PF_EXCLUSIVE_LOCK ) )
         {
@@ -261,9 +266,9 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
         }
     }
 
-    protected abstract T newRecord( int id );
+    protected abstract RECORD newRecord( int id );
 
-    protected byte getRecord( int id, T record, PageCursor cursor )
+    protected byte getRecord( int id, RECORD record, PageCursor cursor )
     {
         cursor.setOffset( offsetForId( id ) );
         byte inUseByte = cursor.getByte();
@@ -277,12 +282,12 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
         return inUseByte;
     }
 
-    protected void readRecord( T record, PageCursor cursor )
+    protected void readRecord( RECORD record, PageCursor cursor )
     {
         record.setNameId( cursor.getInt() );
     }
 
-    protected void updateRecord( T record, PageCursor cursor )
+    protected void updateRecord( RECORD record, PageCursor cursor )
     {
         int id = record.getId();
         cursor.setOffset( offsetForId( id ) );
@@ -298,12 +303,12 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
         }
     }
 
-    protected void writeRecord( T record, PageCursor cursor )
+    protected void writeRecord( RECORD record, PageCursor cursor )
     {
         cursor.putInt( record.getNameId() );
     }
 
-    public void ensureHeavy( T record )
+    public void ensureHeavy( RECORD record )
     {
         if (!record.isLight())
         {
@@ -314,7 +319,7 @@ public abstract class TokenStore<T extends TokenRecord> extends AbstractRecordSt
         record.addNameRecords( nameStore.getRecords( record.getNameId() ) );
     }
 
-    public String getStringFor( T nameRecord )
+    public String getStringFor( RECORD nameRecord )
     {
         int recordToFind = nameRecord.getNameId();
         Iterator<DynamicRecord> records = nameRecord.getNameRecords().iterator();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/propertydeduplication/NonIndexedConflictResolver.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/propertydeduplication/NonIndexedConflictResolver.java
@@ -52,7 +52,7 @@ class NonIndexedConflictResolver implements PrimitiveLongObjectVisitor<List<Dupl
 
     private Map<String, Integer> buildPropertyKeyIndex( PropertyKeyTokenStore tokenStore ) throws IOException
     {
-        Token[] tokens = tokenStore.getTokens( (int) tokenStore.getHighestPossibleIdInUse() + 1 );
+        List<Token> tokens = tokenStore.getTokens( (int) tokenStore.getHighestPossibleIdInUse() + 1 );
         Map<String, Integer> map = new HashMap<>();
         for ( Token token : tokens )
         {
@@ -87,7 +87,7 @@ class NonIndexedConflictResolver implements PrimitiveLongObjectVisitor<List<Dupl
         {
             return token;
         }
-        TokenCreator<PropertyKeyTokenRecord> creator = new TokenCreator<>( keyTokenStore );
+        TokenCreator<PropertyKeyTokenRecord, Token> creator = new TokenCreator<>( keyTokenStore );
         DirectRecordAccess<Integer, PropertyKeyTokenRecord, Void> recordAccess = new DirectRecordAccess<>(
                 keyTokenStore, Loaders.propertyKeyTokenLoader( keyTokenStore )
         );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CacheInvalidationTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CacheInvalidationTransactionApplier.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.transaction.command;
 import java.io.IOException;
 
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
+import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.store.LabelTokenStore;
 import org.neo4j.kernel.impl.store.NeoStore;
@@ -53,7 +54,7 @@ public class CacheInvalidationTransactionApplier extends NeoCommandHandler.Deleg
     {
         super.visitRelationshipTypeTokenCommand( command );
 
-        Token type = relationshipTypeTokenStore.getToken( (int) command.getKey() );
+        RelationshipTypeToken type = relationshipTypeTokenStore.getToken( (int) command.getKey() );
         cacheAccess.addRelationshipTypeToken( type );
 
         return false;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.index.IndexCommand.AddNodeCommand;
 import org.neo4j.kernel.impl.index.IndexCommand.AddRelationshipCommand;
 import org.neo4j.kernel.impl.index.IndexCommand.CreateCommand;
@@ -242,8 +243,8 @@ public class HighIdTransactionApplier implements NeoCommandHandler
         }
     }
 
-    private <RECORD extends TokenRecord> void trackToken( TokenStore<RECORD> tokenStore,
-                                                          TokenCommand<RECORD> tokenCommand )
+    private <RECORD extends TokenRecord, TOKEN extends Token>
+    void trackToken( TokenStore<RECORD, TOKEN> tokenStore, TokenCommand<RECORD> tokenCommand )
     {
         track( tokenStore, tokenCommand );
         track( tokenStore.getNameStore(), tokenCommand.getRecord().getNameRecords() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/Loaders.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/Loaders.java
@@ -22,6 +22,8 @@ package org.neo4j.kernel.impl.transaction.state;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.neo4j.kernel.impl.core.RelationshipTypeToken;
+import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.RelationshipGroupStore;
@@ -220,7 +222,7 @@ public class Loaders
     }
 
     public static Loader<Integer,PropertyKeyTokenRecord,Void> propertyKeyTokenLoader(
-            final TokenStore<PropertyKeyTokenRecord> store )
+            final TokenStore<PropertyKeyTokenRecord, Token> store )
     {
         return new Loader<Integer, PropertyKeyTokenRecord, Void>()
         {
@@ -251,7 +253,7 @@ public class Loaders
     }
 
     public static Loader<Integer,LabelTokenRecord,Void> labelTokenLoader(
-            final TokenStore<LabelTokenRecord> store )
+            final TokenStore<LabelTokenRecord, Token> store )
     {
         return new Loader<Integer, LabelTokenRecord, Void>()
         {
@@ -282,7 +284,7 @@ public class Loaders
     }
 
     public static Loader<Integer,RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader(
-            final TokenStore<RelationshipTypeTokenRecord> store )
+            final TokenStore<RelationshipTypeTokenRecord, RelationshipTypeToken> store )
     {
         return new Loader<Integer, RelationshipTypeTokenRecord, Void>()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionContext.java
@@ -21,6 +21,8 @@ package org.neo4j.kernel.impl.transaction.state;
 
 import java.util.Collection;
 
+import org.neo4j.kernel.impl.core.RelationshipTypeToken;
+import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.locking.Locks.Client;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -93,21 +95,21 @@ public class NeoStoreTransactionContext
 
     public void createPropertyKeyToken( String name, int id )
     {
-        TokenCreator<PropertyKeyTokenRecord> creator =
+        TokenCreator<PropertyKeyTokenRecord, Token> creator =
                 new TokenCreator<>( neoStore.getPropertyKeyTokenStore() );
         creator.createToken( name, id, getPropertyKeyTokenRecords() );
     }
 
     public void createLabelToken( String name, int id )
     {
-        TokenCreator<LabelTokenRecord> creator =
+        TokenCreator<LabelTokenRecord, Token> creator =
                 new TokenCreator<>( neoStore.getLabelTokenStore() );
         creator.createToken( name, id, getLabelTokenRecords() );
     }
 
     public void createRelationshipTypeToken( String name, int id )
     {
-        TokenCreator<RelationshipTypeTokenRecord> creator =
+        TokenCreator<RelationshipTypeTokenRecord, RelationshipTypeToken> creator =
                 new TokenCreator<>( neoStore.getRelationshipTypeTokenStore() );
         creator.createToken( name, id, getRelationshipTypeTokenRecords() );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TokenCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TokenCreator.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.transaction.state;
 
 import java.util.Collection;
 
+import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.store.TokenStore;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.TokenRecord;
@@ -28,18 +29,18 @@ import org.neo4j.kernel.impl.store.record.TokenRecord;
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.kernel.impl.store.PropertyStore.encodeString;
 
-public class TokenCreator<T extends TokenRecord>
+public class TokenCreator<R extends TokenRecord, T extends Token>
 {
-    private final TokenStore<T> store;
+    private final TokenStore<R, T> store;
 
-    public TokenCreator( TokenStore<T> store )
+    public TokenCreator( TokenStore<R, T> store )
     {
         this.store = store;
     }
 
-    public void createToken( String name, int id, RecordAccess<Integer,T,Void> recordAccess )
+    public void createToken( String name, int id, RecordAccess<Integer, R,Void> recordAccess )
     {
-        T record = recordAccess.create( id, null ).forChangingData();
+        R record = recordAccess.create( id, null ).forChangingData();
         record.setInUse( true );
         record.setCreated();
         Collection<DynamicRecord> nameRecords = store.allocateNameRecords( encodeString( name ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -278,10 +278,10 @@ public class BatchInserterImpl implements BatchInserter
         neoStore = sf.newNeoStore( true );
         neoStore.verifyStoreOk();
         neoStore.makeStoreOk();
-        Token[] indexes = getPropertyKeyTokenStore().getTokens( 10000 );
+        List<Token> indexes = getPropertyKeyTokenStore().getTokens( 10000 );
         propertyKeyTokens = new BatchTokenHolder( indexes );
         labelTokens = new BatchTokenHolder( neoStore.getLabelTokenStore().getTokens( Integer.MAX_VALUE ) );
-        Token[] types = getRelationshipTypeStore().getTokens( Integer.MAX_VALUE );
+        List<RelationshipTypeToken> types = getRelationshipTypeStore().getTokens( Integer.MAX_VALUE );
         relationshipTypeTokens = new BatchTokenHolder( types );
         indexStore = life.add( new IndexConfigStore( this.storeDir, fileSystem ) );
         schemaCache = new SchemaCache( new StandardConstraintSemantics(), neoStore.getSchemaStore() );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchTokenHolder.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.batchinsert;
 
+import java.util.List;
+
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
 import org.neo4j.kernel.impl.core.Token;
@@ -29,7 +31,7 @@ class BatchTokenHolder
     private final ArrayMap<String,Token> nameToToken = new ArrayMap<>( (byte) 5, false, false );
     private final PrimitiveIntObjectMap<Token> idToToken = Primitive.intObjectMap( 20 );
 
-    BatchTokenHolder( Token[] tokens )
+    BatchTokenHolder( List<? extends Token> tokens )
     {
         for ( Token token : tokens )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipEncoderStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipEncoderStep.java
@@ -41,7 +41,7 @@ import static org.neo4j.graphdb.Direction.OUTGOING;
  */
 public class RelationshipEncoderStep extends ProcessorStep<Batch<InputRelationship,RelationshipRecord>>
 {
-    private final BatchingTokenRepository<?> relationshipTypeRepository;
+    private final BatchingTokenRepository<?, ?> relationshipTypeRepository;
     private final NodeRelationshipCache cache;
     private final ParallelizationCoordinator parallelization = new ParallelizationCoordinator();
 
@@ -54,7 +54,7 @@ public class RelationshipEncoderStep extends ProcessorStep<Batch<InputRelationsh
 
     public RelationshipEncoderStep( StageControl control,
             Configuration config,
-            BatchingTokenRepository<?> relationshipTypeRepository,
+            BatchingTokenRepository<?, ?> relationshipTypeRepository,
             NodeRelationshipCache cache,
             boolean specificIds )
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TokenHolderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TokenHolderTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Arrays.asList;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -34,26 +36,19 @@ public class TokenHolderTest
     {
         // GIVEN
         TokenCreator creator = mock( TokenCreator.class );
-        TokenHolder<Token> holder = new TokenHolder<Token>( creator )
-        {
-            @Override
-            protected Token newToken( String name, int id )
-            {
-                return new Token( name, id );
-            }
-        };
+        TokenHolder<Token> holder = new DelegatingTokenHolder<Token>( creator, new Token.Factory() ) {};
         holder.setInitialTokens(
-                token( "one", 1 ),
-                token( "two", 2 ) );
+                asList( token( "one", 1 ),
+                        token( "two", 2 ) ));
         assertTokens( holder.getAllTokens(),
                 token( "one", 1 ),
                 token( "two", 2 ) );
 
         // WHEN
-        holder.setInitialTokens(
+        holder.setInitialTokens(asList(
                 token( "two", 2 ),
                 token( "three", 3 ),
-                token( "four", 4 ) );
+                token( "four", 4 ) ));
 
         // THEN
         assertTokens( holder.getAllTokens(),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -61,6 +62,7 @@ import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
+import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.store.NeoStore.Position;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
@@ -667,19 +669,19 @@ public class TestNeoStore
         data = rtStore.getToken( relType2 );
         assertEquals( relType2, data.id() );
         assertEquals( "relationshiptype2", data.name() );
-        Token allData[] = rtStore.getTokens( Integer.MAX_VALUE );
-        assertEquals( 2, allData.length );
+        List<RelationshipTypeToken> allData = rtStore.getTokens( Integer.MAX_VALUE );
+        assertEquals( 2, allData.size() );
         for ( int i = 0; i < 2; i++ )
         {
-            if ( allData[i].id() == relType1 )
+            if ( allData.get(i).id() == relType1 )
             {
-                assertEquals( relType1, allData[i].id() );
-                assertEquals( "relationshiptype1", allData[i].name() );
+                assertEquals( relType1, allData.get(i).id() );
+                assertEquals( "relationshiptype1", allData.get(i).name() );
             }
-            else if ( allData[i].id() == relType2 )
+            else if ( allData.get(i).id() == relType2 )
             {
-                assertEquals( relType2, allData[i].id() );
-                assertEquals( "relationshiptype2", allData[i].name() );
+                assertEquals( relType2, allData.get(i).id() );
+                assertEquals( "relationshiptype2", allData.get(i).name() );
             }
             else
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionStoreApplierTest.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
+import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.core.Token;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.LockService;
@@ -443,7 +444,7 @@ public class NeoTransactionStoreApplierTest
         final RelationshipTypeTokenRecord record = new RelationshipTypeTokenRecord( 42 );
         final Command.RelationshipTypeTokenCommand command =
                 (RelationshipTypeTokenCommand) new Command.RelationshipTypeTokenCommand().init( record );
-        final Token token = new Token( "token", 21 );
+        final RelationshipTypeToken token = new RelationshipTypeToken( "token", 21 );
         when( relationshipTypeTokenStore.getToken( (int) command.getKey() ) ).thenReturn( token );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -382,7 +382,7 @@ public class CsvInputBatchImportIT
         return result;
     }
 
-    private Function<String, Integer> translationTable( TokenStore<?> tokenStore, final int anyValue )
+    private Function<String, Integer> translationTable( TokenStore<?, ?> tokenStore, final int anyValue )
     {
         final Map<String, Integer> translationTable = new HashMap<>();
         for ( Token token : tokenStore.getTokens( Integer.MAX_VALUE ) )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -125,6 +125,9 @@ import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
 import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.api.index.RemoveOrphanConstraintIndexesOnStartup;
+import org.neo4j.kernel.impl.core.DelegatingLabelTokenHolder;
+import org.neo4j.kernel.impl.core.DelegatingPropertyKeyTokenHolder;
+import org.neo4j.kernel.impl.core.DelegatingRelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.ReadOnlyTokenCreator;
@@ -515,12 +518,12 @@ public class HighlyAvailableEditionModule
                 createLockManager( highAvailabilityModeSwitcher, paxosLife, config, masterDelegateInvocationHandler,
                         requestContextFactory, platformModule.availabilityGuard, logging ) );
 
-        propertyKeyTokenHolder = dependencies.satisfyDependency( new PropertyKeyTokenHolder(
+        propertyKeyTokenHolder = dependencies.satisfyDependency( new DelegatingPropertyKeyTokenHolder(
                 createPropertyKeyCreator( config, paxosLife, highAvailabilityModeSwitcher, masterDelegateInvocationHandler,
                         requestContextFactory, kernelProvider ) ) );
-        labelTokenHolder = dependencies.satisfyDependency( new LabelTokenHolder( createLabelIdCreator( config,
+        labelTokenHolder = dependencies.satisfyDependency( new DelegatingLabelTokenHolder( createLabelIdCreator( config,
                 paxosLife, highAvailabilityModeSwitcher, masterDelegateInvocationHandler, requestContextFactory, kernelProvider ) ) );
-        relationshipTypeTokenHolder = dependencies.satisfyDependency( new RelationshipTypeTokenHolder(
+        relationshipTypeTokenHolder = dependencies.satisfyDependency( new DelegatingRelationshipTypeTokenHolder(
                 createRelationshipTypeCreator( config, paxosLife, highAvailabilityModeSwitcher, masterDelegateInvocationHandler,
                         requestContextFactory, kernelProvider ) ) );
 

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom19IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom19IT.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
@@ -168,7 +169,7 @@ public class StoreMigratorFrom19IT
         // verify that there are no duplicate keys in the store
         try ( PropertyKeyTokenStore tokenStore = storeFactory.newPropertyKeyTokenStore() )
         {
-            Token[] tokens = tokenStore.getTokens( MAX_VALUE );
+            List<Token> tokens = tokenStore.getTokens( MAX_VALUE );
             assertNoDuplicates( tokens );
         }
 
@@ -207,7 +208,7 @@ public class StoreMigratorFrom19IT
         assertEquals( 8L + 3, neoStore.getLastCommittedTransactionId() ); // prior verifications add 3 transactions
     }
 
-    private void assertNoDuplicates( Token[] tokens )
+    private void assertNoDuplicates( List<Token> tokens )
     {
         Set<String> visited = new HashSet<>();
         for ( Token token : tokens )


### PR DESCRIPTION
TokenHolder is now an interface. The previous implementation is renamed
to DelegatingToken holder, because it delegates its caching and creation
features to InMemoryTokenCache and TokenCreator respectively.

Handling of the RelationshipTypeToken special cases has been improved by
introducing TokenFactory, which encapsulates usage of the Token sub-type
constructors.

Usage of a TOKEN type parameter has been pushed right down to
TokenStore to avoid casting, and generally make the typing more solid.

Some Token arrays have been replaced with lists to make typing easier.
In all cases these were converted from lists anyway so there is
no additional allocation overhead.
