### PR TITLE
Send MemberIsUnavailable on executor thread

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServer.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServer.java
@@ -28,6 +28,7 @@ import org.neo4j.cluster.statemachine.StateMachineProxyFactory;
 import org.neo4j.cluster.statemachine.StateTransitionListener;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.Listeners;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
@@ -35,14 +36,16 @@ import org.neo4j.logging.LogProvider;
  * A ProtocolServer ties together the underlying StateMachines with an understanding of ones
  * own server address (me), and provides a proxy factory for creating clients to invoke the CSM.
  */
-public class ProtocolServer implements BindingNotifier
+public class ProtocolServer
+        extends LifecycleAdapter
+        implements BindingNotifier
 {
     private final InstanceId me;
     private URI boundAt;
     protected StateMachineProxyFactory proxyFactory;
     protected final StateMachines stateMachines;
     private Iterable<BindingListener> bindingListeners = Listeners.newListeners();
-    private final Log msgLog;
+    private Log msgLog;
 
     public ProtocolServer( InstanceId me, StateMachines stateMachines, LogProvider logProvider )
     {
@@ -53,6 +56,12 @@ public class ProtocolServer implements BindingNotifier
         StateMachineConversations conversations = new StateMachineConversations(me);
         proxyFactory = new StateMachineProxyFactory( stateMachines, conversations, me );
         stateMachines.addMessageProcessor( proxyFactory );
+    }
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+        msgLog = null;
     }
 
     @Override

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
@@ -199,6 +199,7 @@ public class ClusterClientModule
                 acceptorInstanceStore, electionCredentialsProvider, stateMachineExecutor, objectInputStreamFactory,
                 objectOutputStreamFactory );
 
+        this.life.add( server );
         this.life.add( sender );
         this.life.add( stateMachineExecutor );
         this.life.add( receiver );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
@@ -253,16 +253,8 @@ public class HighAvailabilityModeSwitcher
                 switchToSlave();
                 break;
             case PENDING:
-                if ( event.getOldState().equals( HighAvailabilityMemberState.SLAVE ) )
-                {
-                    clusterMemberAvailability.memberIsUnavailable( SLAVE );
-                }
-                else if ( event.getOldState().equals( HighAvailabilityMemberState.MASTER ) )
-                {
-                    clusterMemberAvailability.memberIsUnavailable( MASTER );
-                }
 
-                switchToPending();
+                switchToPending( event.getOldState() );
                 break;
             default:
                 // do nothing
@@ -436,7 +428,7 @@ public class HighAvailabilityModeSwitcher
         }, cancellationHandle );
     }
 
-    private void switchToPending()
+    private void switchToPending( final HighAvailabilityMemberState oldState )
     {
         msgLog.info( "I am %s, moving to pending", instanceId );
 
@@ -449,6 +441,15 @@ public class HighAvailabilityModeSwitcher
                 {
                     msgLog.info( "Switch to pending cancelled on start." );
                     return;
+                }
+
+                if ( oldState.equals( HighAvailabilityMemberState.SLAVE ) )
+                {
+                    clusterMemberAvailability.memberIsUnavailable( SLAVE );
+                }
+                else if ( oldState.equals( HighAvailabilityMemberState.MASTER ) )
+                {
+                    clusterMemberAvailability.memberIsUnavailable( MASTER );
                 }
 
                 Listeners.notifyListeners( modeSwitchListeners, new Listeners.Notification<ModeSwitcher>()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
@@ -65,6 +65,18 @@ public class ClusterMembers
         };
     }
 
+    public static Predicate<ClusterMember> hasInstanceId( final InstanceId instanceId )
+    {
+        return new Predicate<ClusterMember>()
+        {
+            @Override
+            public boolean test( ClusterMember item )
+            {
+                return item.getInstanceId().equals( instanceId );
+            }
+        };
+    }
+
     private final Map<InstanceId, ClusterMember> members = new CopyOnWriteHashMap<>();
 
     public ClusterMembers( Cluster cluster, Heartbeat heartbeat, ClusterMemberEvents events, InstanceId me )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.ha.cluster;
 
-import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -37,6 +32,11 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
@@ -97,6 +97,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import static org.neo4j.kernel.AvailabilityGuard.AvailabilityRequirement;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.MASTER;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.SLAVE;
@@ -771,7 +772,8 @@ public class HighAvailabilityMemberStateMachineTest
         public void switchToSlave( InstanceId me )
         {
             InstanceId someOneElseThanMyself = new InstanceId( me.toIntegerIndex() + 1 );
-            listener.memberIsAvailable( "master", someOneElseThanMyself, URI.create( "http://127.0.0.1:2390" ), null );
+            listener.memberIsAvailable( "master", someOneElseThanMyself,
+                    URI.create( "cluster://127.0.0.1:2390?serverId=2" ), null );
             listener.memberIsAvailable( "slave", me, null, null );
         }
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
@@ -19,12 +19,13 @@
  */
 package org.neo4j.kernel.ha.cluster;
 
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 
+import org.junit.Test;
+
+import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.com.Response;
 import org.neo4j.com.storecopy.StoreCopyClient;
@@ -65,6 +66,7 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.monitoring.Monitors;
 
 import static java.util.Arrays.asList;
+
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -101,7 +103,8 @@ public class SwitchToSlaveTest
         // When
         try
         {
-            switchToSlave.checkDataConsistency( masterClient, transactionIdStore, storeId, null, false );
+            switchToSlave.checkDataConsistency( masterClient, transactionIdStore, storeId,
+                    new URI( "cluster://localhost?serverId=1" ), false );
             fail( "Should have thrown " + MismatchingStoreIdException.class.getSimpleName() + " exception" );
         }
         catch ( MismatchingStoreIdException e )
@@ -154,7 +157,7 @@ public class SwitchToSlaveTest
         when( updatePuller.await( UpdatePuller.NEXT_TICKET, false ) ).thenReturn( false );
 
         // when
-        URI localhost = new URI( "127.0.0.1" );
+        URI localhost = new URI( "cluster://127.0.0.1?serverId=1" );
         URI uri = switchToSlave.switchToSlave( mock( LifeSupport.class ), localhost, localhost,
                 mock( CancellationRequest.class ) );
 
@@ -174,6 +177,7 @@ public class SwitchToSlaveTest
         when( master.getStoreId() ).thenReturn( new StoreId( 42, 42, 42, 42 ) );
         when( master.getHARole() ).thenReturn( HighAvailabilityModeSwitcher.MASTER );
         when( master.hasRole( eq( HighAvailabilityModeSwitcher.MASTER ) ) ).thenReturn( true );
+        when( master.getInstanceId() ).thenReturn( new InstanceId( 1 ) );
         when( clusterMembers.getMembers() ).thenReturn( asList( master ) );
 
         DependencyResolver resolver = mock( DependencyResolver.class );

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.test.ha;
 
-import org.junit.rules.ExternalResource;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 import org.neo4j.function.Predicate;
 import org.neo4j.graphdb.config.Setting;
@@ -38,8 +38,10 @@ import org.neo4j.test.ha.ClusterManager.Builder;
 import org.neo4j.test.ha.ClusterManager.ManagedCluster;
 
 import static java.util.Arrays.asList;
+
 import static org.neo4j.cluster.ClusterSettings.default_timeout;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_internal_log_level;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.ha.HaSettings.tx_push_factor;
 import static org.neo4j.test.ha.ClusterManager.allSeesAllAsAvailable;
@@ -60,6 +62,7 @@ public class ClusterRule extends ExternalResource
     {
         this.testDirectory = TargetDirectory.testDirForTest( testClass );
         config.putAll( stringMap(
+                store_internal_log_level.name(), "DEBUG",
                 default_timeout.name(), "1s",
                 tx_push_factor.name(), "0",
                 pagecache_memory.name(), "8m" ) );

--- a/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.ha;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
 
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.Transaction;


### PR DESCRIPTION
MemberIsAvailable/MemberIsUnavailable messages could arrive out of order if an instance is switching to master and another instance is elected as master (first unavailable, then available). This fixes so that messages are sent on the state switching thread, so the order is correct.

Also, ProtocolServer.msgLog was a GC root, causing OOMs. Clear on shutdown to fix.
