### PR TITLE
Less eagerness when multiple merge statements

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/LabelAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/LabelAction.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.commands
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effect, Effects, WritesLabel}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{WritesNodesWithLabels, Effect, Effects}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CastSupport, CollectionSupport}
 import org.neo4j.cypher.internal.compiler.v2_3.mutation.{GraphElementPropertyFunctions, UpdateAction}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
@@ -38,7 +38,7 @@ case object LabelRemoveOp extends LabelOp
 case class LabelAction(entity: Expression, labelOp: LabelOp, labels: Seq[KeyToken])
   extends UpdateAction with GraphElementPropertyFunctions with CollectionSupport {
 
-  def localEffects(ignored: SymbolTable) = Effects(labels.map(l => WritesLabel(l.name)).toSet[Effect])
+  def localEffects(ignored: SymbolTable) = Effects(labels.map(l => WritesNodesWithLabels(l.name)).toSet[Effect])
 
   def children = labels.flatMap(_.children) :+ entity
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/StartItem.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/StartItem.scala
@@ -78,7 +78,7 @@ case class NodeByIndex(varName: String, idxName: String, key: Expression, expres
     Arguments.LegacyIndex(idxName),
     Arguments.LegacyExpression(key)))
   with ReadOnlyStartItem with NodeStartItemIdentifiers with Hint {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAllNodes)
 }
 
 case class NodeByIndexQuery(varName: String, idxName: String, query: Expression)
@@ -86,7 +86,7 @@ case class NodeByIndexQuery(varName: String, idxName: String, query: Expression)
     Arguments.LegacyExpression(query),
     Arguments.LegacyIndex(idxName)))
   with ReadOnlyStartItem with NodeStartItemIdentifiers with Hint {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAllNodes)
 }
 
 trait Hint
@@ -128,13 +128,13 @@ case class SchemaIndex(identifier: String, label: String, property: String, kind
 case class NodeById(varName: String, expression: Expression)
   extends StartItem(varName, Seq(Arguments.LegacyExpression(expression)))
   with ReadOnlyStartItem with NodeStartItemIdentifiers {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAllNodes)
 }
 
 case class NodeByIdOrEmpty(varName: String, expression: Expression)
   extends StartItem(varName, Seq(Arguments.LegacyExpression(expression)))
   with ReadOnlyStartItem with NodeStartItemIdentifiers {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAllNodes)
 }
 
 case class NodeByLabel(varName: String, label: String)
@@ -145,7 +145,7 @@ case class NodeByLabel(varName: String, label: String)
 
 case class AllNodes(columnName: String) extends StartItem(columnName, Seq.empty)
   with ReadOnlyStartItem with NodeStartItemIdentifiers {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAllNodes)
 }
 
 case class AllRelationships(columnName: String) extends StartItem(columnName, Seq.empty)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/StartItem.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/StartItem.scala
@@ -78,7 +78,7 @@ case class NodeByIndex(varName: String, idxName: String, key: Expression, expres
     Arguments.LegacyIndex(idxName),
     Arguments.LegacyExpression(key)))
   with ReadOnlyStartItem with NodeStartItemIdentifiers with Hint {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
 }
 
 case class NodeByIndexQuery(varName: String, idxName: String, query: Expression)
@@ -86,7 +86,7 @@ case class NodeByIndexQuery(varName: String, idxName: String, query: Expression)
     Arguments.LegacyExpression(query),
     Arguments.LegacyIndex(idxName)))
   with ReadOnlyStartItem with NodeStartItemIdentifiers with Hint {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
 }
 
 trait Hint
@@ -128,13 +128,13 @@ case class SchemaIndex(identifier: String, label: String, property: String, kind
 case class NodeById(varName: String, expression: Expression)
   extends StartItem(varName, Seq(Arguments.LegacyExpression(expression)))
   with ReadOnlyStartItem with NodeStartItemIdentifiers {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
 }
 
 case class NodeByIdOrEmpty(varName: String, expression: Expression)
   extends StartItem(varName, Seq(Arguments.LegacyExpression(expression)))
   with ReadOnlyStartItem with NodeStartItemIdentifiers {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
 }
 
 case class NodeByLabel(varName: String, label: String)
@@ -145,7 +145,7 @@ case class NodeByLabel(varName: String, label: String)
 
 case class AllNodes(columnName: String) extends StartItem(columnName, Seq.empty)
   with ReadOnlyStartItem with NodeStartItemIdentifiers {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsNodes)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
 }
 
 case class AllRelationships(columnName: String) extends StartItem(columnName, Seq.empty)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/StartItem.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/StartItem.scala
@@ -122,7 +122,7 @@ case class RangeQueryExpression[T](expression: T) extends QueryExpression[T] {
 case class SchemaIndex(identifier: String, label: String, property: String, kind: SchemaIndexKind, query: Option[QueryExpression[Expression]])
   extends StartItem(identifier, query.map(q => Arguments.LegacyExpression(q.expression)).toSeq :+ Arguments.Index(label, property))
   with ReadOnlyStartItem with Hint with NodeStartItemIdentifiers {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsLabel(label), ReadsNodeProperty(property))
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsNodesWithLabels(label), ReadsGivenNodeProperty(property))
 }
 
 case class NodeById(varName: String, expression: Expression)
@@ -140,7 +140,7 @@ case class NodeByIdOrEmpty(varName: String, expression: Expression)
 case class NodeByLabel(varName: String, label: String)
   extends StartItem(varName, Seq(Arguments.LabelName(label)))
   with ReadOnlyStartItem with Hint with NodeStartItemIdentifiers {
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsLabel(label))
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsNodesWithLabels(label))
 }
 
 case class AllNodes(columnName: String) extends StartItem(columnName, Seq.empty)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/LabelsFunction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/LabelsFunction.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.commands.expressions
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.Effects
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -51,5 +51,5 @@ case class LabelsFunction(nodeExpr: Expression) extends Expression {
     CTCollection(CTString)
   }
 
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
+  override def localEffects(symbols: SymbolTable) = Effects()
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/LabelsFunction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/LabelsFunction.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.commands.expressions
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsAnyLabel}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -51,5 +51,5 @@ case class LabelsFunction(nodeExpr: Expression) extends Expression {
     CTCollection(CTString)
   }
 
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyLabel)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes)
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ShortestPathExpression.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ShortestPathExpression.scala
@@ -22,12 +22,11 @@ package org.neo4j.cypher.internal.compiler.v2_3.commands.expressions
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.DirectionConverter.toGraphDb
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates._
-import org.neo4j.cypher.internal.compiler.v2_3.commands._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.{PathExtractor, Pattern, ShortestPath, SingleNode, _}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsAnyNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.SyntaxException
-import org.neo4j.cypher.internal.frontend.v2_3.ast.{Property, FunctionName, FunctionInvocation}
 import org.neo4j.cypher.internal.frontend.v2_3.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
 import org.neo4j.graphalgo.GraphAlgoFactory
@@ -92,8 +91,6 @@ case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates:
   def calculateType(symbols: SymbolTable) =  if (shortestPathPattern.single) CTPath else CTCollection(CTPath)
 
   def symbolTableDependencies = shortestPathPattern.symbolTableDependencies + shortestPathPattern.left.name + shortestPathPattern.right.name
-
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsNodes, ReadsRelationships)
 
   private def propertyExistsExpander(name: String) = new org.neo4j.function.Predicate[PropertyContainer] {
     override def test(t: PropertyContainer): Boolean = {
@@ -160,6 +157,7 @@ case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates:
     (predicate.symbolTableDependencies intersect pathIdentifiers).isEmpty
   }
 
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes, ReadsRelationships)
 }
 
 trait ShortestPathStrategy {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ShortestPathExpression.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ShortestPathExpression.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.DirectionConverter.toGraphDb
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.{PathExtractor, Pattern, ShortestPath, SingleNode, _}
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsAnyNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsAllNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.SyntaxException
@@ -157,7 +157,7 @@ case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates:
     (predicate.symbolTableDependencies intersect pathIdentifiers).isEmpty
   }
 
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsAnyNodes, ReadsRelationships)
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsAllNodes, ReadsRelationships)
 }
 
 trait ShortestPathStrategy {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/predicates/Predicate.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/predicates/Predicate.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.commands.predicates
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Expression, Literal}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsLabel}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsNodesWithLabels, Effects}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CastSupport, CollectionSupport, IsCollection}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -286,7 +286,7 @@ case class HasLabel(entity: Expression, label: KeyToken) extends Predicate {
 
   def containsIsNull = false
 
-  override def localEffects(symbols: SymbolTable) = Effects(ReadsLabel(label.name))
+  override def localEffects(symbols: SymbolTable) = Effects(ReadsNodesWithLabels(label.name))
 }
 
 case class CoercedPredicate(inner:Expression) extends Predicate with CollectionSupport {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/Effects.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/Effects.scala
@@ -44,11 +44,11 @@ case class Effects(effectsSet: Set[Effect] = Set.empty) {
   }.toSet[Effect])
 }
 
-object AllWriteEffects extends Effects(Set(WritesAnyNodes, WritesRelationships, WritesAnyNodeProperty, WritesAnyRelationshipProperty)) {
+object AllWriteEffects extends Effects(Set(WritesAnyNode, WritesRelationships, WritesAnyNodeProperty, WritesAnyRelationshipProperty)) {
   override def toString = "AllWriteEffects"
 }
 
-object AllReadEffects extends Effects(Set(ReadsAnyNodes, ReadsRelationships, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty)) {
+object AllReadEffects extends Effects(Set(ReadsAllNodes, ReadsRelationships, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty)) {
   override def toString = "AllReadEffects"
 }
 
@@ -131,8 +131,12 @@ protected trait WriteEffect extends Effect {
 
 trait ReadsNodes extends ReadEffect
 
-case object ReadsAnyNodes extends ReadsNodes {
-  override def toWriteEffect = WritesAnyNodes
+case object ReadsAllNodes extends ReadsNodes {
+  override def toWriteEffect = WritesAnyNode
+}
+
+case object ReadsRelationshipBoundNodes extends ReadsNodes {
+  override def toWriteEffect = WritesRelationshipBoundNodes
 }
 
 case class ReadsNodesWithLabels(labels: Set[String]) extends ReadsNodes {
@@ -145,7 +149,9 @@ object ReadsNodesWithLabels {
 
 trait WritesNodes extends WriteEffect
 
-case object WritesAnyNodes extends WritesNodes
+case object WritesAnyNode extends WritesNodes
+
+case object WritesRelationshipBoundNodes extends WritesNodes
 
 object WritesNodesWithLabels {
   def apply(labels: String*): WritesNodesWithLabels = WritesNodesWithLabels(labels.toSet)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/Effects.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/Effects.scala
@@ -44,11 +44,11 @@ case class Effects(effectsSet: Set[Effect] = Set.empty) {
   }.toSet[Effect])
 }
 
-object AllWriteEffects extends Effects(Set(WritesNodes, WritesRelationships, WritesAnyLabel, WritesAnyNodeProperty, WritesAnyRelationshipProperty)) {
+object AllWriteEffects extends Effects(Set(WritesAnyNodes, WritesRelationships, WritesAnyLabel, WritesAnyNodeProperty, WritesAnyRelationshipProperty)) {
   override def toString = "AllWriteEffects"
 }
 
-object AllReadEffects extends Effects(Set(ReadsNodes, ReadsRelationships, ReadsAnyLabel, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty)) {
+object AllReadEffects extends Effects(Set(ReadsAnyNodes, ReadsRelationships, ReadsAnyLabel, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty)) {
   override def toString = "AllReadEffects"
 }
 
@@ -129,11 +129,29 @@ protected trait WriteEffect extends Effect {
   override def writes = true
 }
 
-case object ReadsNodes extends ReadEffect {
-  override def toWriteEffect = WritesNodes
+trait ReadsNodes extends ReadEffect
+
+case object ReadsAnyNodes extends ReadsNodes {
+  override def toWriteEffect = WritesAnyNodes
 }
 
-case object WritesNodes extends WriteEffect
+case class ReadsNodesWithLabels(labels: Set[String]) extends ReadsNodes {
+  override def toWriteEffect = WritesNodesWithLabels(labels)
+}
+
+object ReadsNodesWithLabels {
+  def apply(label: String*): ReadsNodesWithLabels = ReadsNodesWithLabels(label.toSet)
+}
+
+trait WritesNodes extends WriteEffect
+
+case object WritesAnyNodes extends WritesNodes
+
+object WritesNodesWithLabels {
+  def apply(labels: String*): WritesNodesWithLabels = WritesNodesWithLabels(labels.toSet)
+}
+
+case class WritesNodesWithLabels(labels: Set[String]) extends WritesNodes
 
 case class ReadsNodeProperty(propertyName: String) extends ReadEffect {
   override def toString = s"${super.toString} '$propertyName'"

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/Effects.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/Effects.scala
@@ -38,17 +38,17 @@ case class Effects(effectsSet: Set[Effect] = Set.empty) {
 
   def writes() = effectsSet.exists(_.writes)
 
-  def toWriteEffects() = Effects(effectsSet.map {
+  def toWriteEffects = Effects(effectsSet.map {
     case e: ReadEffect => e.toWriteEffect
     case e: WriteEffect => e
   }.toSet[Effect])
 }
 
-object AllWriteEffects extends Effects(Set(WritesAnyNodes, WritesRelationships, WritesAnyLabel, WritesAnyNodeProperty, WritesAnyRelationshipProperty)) {
+object AllWriteEffects extends Effects(Set(WritesAnyNodes, WritesRelationships, WritesAnyNodeProperty, WritesAnyRelationshipProperty)) {
   override def toString = "AllWriteEffects"
 }
 
-object AllReadEffects extends Effects(Set(ReadsAnyNodes, ReadsRelationships, ReadsAnyLabel, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty)) {
+object AllReadEffects extends Effects(Set(ReadsAnyNodes, ReadsRelationships, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty)) {
   override def toString = "AllReadEffects"
 }
 
@@ -63,8 +63,8 @@ object Effects {
   def propertyRead(expression: Expression, symbols: SymbolTable)(propertyKey: String) = {
     (expression match {
       case i: Identifier => symbols.identifiers.get(i.entityName).map {
-        case _: NodeType => Effects(ReadsNodeProperty(propertyKey))
-        case _: RelationshipType => Effects(ReadsRelationshipProperty(propertyKey))
+        case _: NodeType => Effects(ReadsGivenNodeProperty(propertyKey))
+        case _: RelationshipType => Effects(ReadsGivenRelationshipProperty(propertyKey))
         case _ => Effects()
       }
       case _ => None
@@ -74,8 +74,8 @@ object Effects {
   def propertyWrite(expression: Expression, symbols: SymbolTable)(propertyKey: String) =
     (expression match {
       case i: Identifier => symbols.identifiers.get(i.entityName).map {
-        case _: NodeType => Effects(WritesNodeProperty(propertyKey))
-        case _: RelationshipType => Effects(WritesRelationshipProperty(propertyKey))
+        case _: NodeType => Effects(WritesGivenNodeProperty(propertyKey))
+        case _: RelationshipType => Effects(WritesGivenRelationshipProperty(propertyKey))
         case _ => Effects()
       }
       case _ => None
@@ -153,43 +153,27 @@ object WritesNodesWithLabels {
 
 case class WritesNodesWithLabels(labels: Set[String]) extends WritesNodes
 
-case class ReadsNodeProperty(propertyName: String) extends ReadEffect {
+trait ReadsNodeProperty extends ReadEffect
+
+case class ReadsGivenNodeProperty(propertyName: String) extends ReadsNodeProperty {
   override def toString = s"${super.toString} '$propertyName'"
 
-  override def toWriteEffect = WritesNodeProperty(propertyName)
+  override def toWriteEffect = WritesGivenNodeProperty(propertyName)
 }
 
-object ReadsAnyNodeProperty extends ReadsNodeProperty("") {
-  override def toWriteEffect: WritesNodeProperty = WritesAnyNodeProperty
+object ReadsAnyNodeProperty extends ReadsNodeProperty {
+  override def toWriteEffect = WritesAnyNodeProperty
 
   override def toString = this.getClass.getSimpleName
 }
 
-case class WritesNodeProperty(propertyName: String) extends WriteEffect {
+trait WritesNodeProperty extends WriteEffect
+
+case class WritesGivenNodeProperty(propertyName: String) extends WritesNodeProperty {
   override def toString = s"${super.toString} '$propertyName'"
 }
 
-object WritesAnyNodeProperty extends WritesNodeProperty("") {
-  override def toString = this.getClass.getSimpleName
-}
-
-case class ReadsLabel(labelName: String) extends ReadEffect {
-  override def toString = s"${super.toString} '$labelName'"
-
-  override def toWriteEffect = WritesLabel(labelName)
-}
-
-object ReadsAnyLabel extends ReadsLabel("") {
-  override def toWriteEffect: WritesLabel = WritesAnyLabel
-
-  override def toString = this.getClass.getSimpleName
-}
-
-case class WritesLabel(labelName: String) extends WriteEffect {
-  override def toString = s"${super.toString} '$labelName'"
-}
-
-object WritesAnyLabel extends WritesLabel("") {
+object WritesAnyNodeProperty extends WritesNodeProperty {
   override def toString = this.getClass.getSimpleName
 }
 
@@ -199,22 +183,26 @@ case object ReadsRelationships extends ReadEffect {
 
 case object WritesRelationships extends WriteEffect
 
-case class ReadsRelationshipProperty(propertyName: String) extends ReadEffect {
+trait ReadsRelationshipProperty extends ReadEffect
+
+case class ReadsGivenRelationshipProperty(propertyName: String) extends ReadsRelationshipProperty {
   override def toString = s"${super.toString} '$propertyName'"
 
-  override def toWriteEffect = WritesRelationshipProperty(propertyName)
+  override def toWriteEffect = WritesGivenRelationshipProperty(propertyName)
 }
 
-case class WritesRelationshipProperty(propertyName: String) extends WriteEffect {
-  override def toString = s"${super.toString} '$propertyName'"
-}
-
-object ReadsAnyRelationshipProperty extends ReadsRelationshipProperty("") {
-  override def toWriteEffect: WritesRelationshipProperty = WritesAnyRelationshipProperty
+object ReadsAnyRelationshipProperty extends ReadsRelationshipProperty {
+  override def toWriteEffect = WritesAnyRelationshipProperty
 
   override def toString = this.getClass.getSimpleName
 }
 
-object WritesAnyRelationshipProperty extends WritesRelationshipProperty("") {
+trait WritesRelationshipProperty extends WriteEffect
+
+case class WritesGivenRelationshipProperty(propertyName: String) extends WritesRelationshipProperty {
+  override def toString = s"${super.toString} '$propertyName'"
+}
+
+object WritesAnyRelationshipProperty extends WritesRelationshipProperty {
   override def toString = this.getClass.getSimpleName
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/addEagernessIfNecessary.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/addEagernessIfNecessary.scala
@@ -58,8 +58,8 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
     val toWrites = to.effectsSet.collect {
       case writes: WritesNodes => writes
     }
-    (fromWrites.contains(WritesAnyNodes) && toWrites.nonEmpty && toReads.nonEmpty) ||
-    (fromWrites.nonEmpty && toWrites.nonEmpty && toReads.contains(ReadsAnyNodes)) ||
+    (fromWrites.contains(WritesAnyNode) && toWrites.nonEmpty && toReads.nonEmpty) ||
+    (fromWrites.nonEmpty && toWrites.nonEmpty && toReads.contains(ReadsAllNodes)) ||
       (nodeLabelOverlap(toReads, fromWrites) && toWrites.nonEmpty)
   }
 
@@ -72,8 +72,7 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
       case writes: WritesNodes => writes
     }
 
-    (fromReads.nonEmpty && toWrites.contains(WritesAnyNodes)) ||
-    (fromReads.contains(ReadsAnyNodes) && toWrites.nonEmpty) ||
+    (fromReads.nonEmpty && toWrites.contains(WritesAnyNode)) ||
       nodeLabelOverlap(fromReads, toWrites)
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/CreateNode.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/CreateNode.scala
@@ -37,7 +37,7 @@ case class CreateNode(key: String, properties: Map[String, Expression], labels: 
   with CollectionSupport {
 
   def localEffects(symbols: SymbolTable) = {
-    val writeEffects = if (labels.isEmpty) Effects(WritesAnyNodes) else Effects(WritesNodesWithLabels(labels.map(_.name).toSet))
+    val writeEffects = if (labels.isEmpty) Effects(WritesAnyNode) else Effects(WritesNodesWithLabels(labels.map(_.name).toSet))
     val propertyEffects = properties.values.foldLeft(Effects())(_ | _.effects(symbols))
     val labelEffects = Effects(labels.map(kt => WritesNodesWithLabels(kt.name)).toSet[Effect])
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/CreateNode.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/CreateNode.scala
@@ -39,7 +39,7 @@ case class CreateNode(key: String, properties: Map[String, Expression], labels: 
   def localEffects(symbols: SymbolTable) = {
     val writeEffects = if (labels.isEmpty) Effects(WritesAnyNodes) else Effects(WritesNodesWithLabels(labels.map(_.name).toSet))
     val propertyEffects = properties.values.foldLeft(Effects())(_ | _.effects(symbols))
-    val labelEffects = Effects(labels.map(kt => WritesLabel(kt.name)).toSet[Effect])
+    val labelEffects = Effects(labels.map(kt => WritesNodesWithLabels(kt.name)).toSet[Effect])
 
     writeEffects | propertyEffects | labelEffects
   }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/CreateNode.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/CreateNode.scala
@@ -37,10 +37,11 @@ case class CreateNode(key: String, properties: Map[String, Expression], labels: 
   with CollectionSupport {
 
   def localEffects(symbols: SymbolTable) = {
+    val writeEffects = if (labels.isEmpty) Effects(WritesAnyNodes) else Effects(WritesNodesWithLabels(labels.map(_.name).toSet))
     val propertyEffects = properties.values.foldLeft(Effects())(_ | _.effects(symbols))
     val labelEffects = Effects(labels.map(kt => WritesLabel(kt.name)).toSet[Effect])
 
-    Effects(WritesNodes) | propertyEffects | labelEffects
+    writeEffects | propertyEffects | labelEffects
   }
 
   def exec(context: ExecutionContext, state: QueryState): Iterator[ExecutionContext] = {
@@ -54,7 +55,7 @@ case class CreateNode(key: String, properties: Map[String, Expression], labels: 
 
       val queryCtx = state.query
       val labelIds = labels.map(_.getOrCreateId(state.query))
-      if (labelIds.size > 0)
+      if (labelIds.nonEmpty)
         queryCtx.setLabelsOnNode(node.getId, labelIds.iterator)
 
       val newContext = context.newWith(key -> node)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/DeleteEntityAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/DeleteEntityAction.scala
@@ -73,7 +73,7 @@ case class DeleteEntityAction(elementToDelete: Expression, forced: Boolean)
 
   def localEffects(symbols: SymbolTable) = elementToDelete match {
     case i: Identifier => symbols.identifiers(i.entityName) match {
-      case _: NodeType         => Effects(WritesAnyNodes, WritesAnyNodes, WritesAnyNodeProperty)
+      case _: NodeType         => Effects(WritesAnyNode, WritesAnyNode, WritesAnyNodeProperty)
       case _: RelationshipType => Effects(WritesRelationships, WritesAnyRelationshipProperty)
       case _                   => Effects()
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/DeleteEntityAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/DeleteEntityAction.scala
@@ -73,7 +73,7 @@ case class DeleteEntityAction(elementToDelete: Expression, forced: Boolean)
 
   def localEffects(symbols: SymbolTable) = elementToDelete match {
     case i: Identifier => symbols.identifiers(i.entityName) match {
-      case _: NodeType         => Effects(WritesAnyNodes, WritesAnyLabel, WritesAnyNodeProperty)
+      case _: NodeType         => Effects(WritesAnyNodes, WritesAnyNodes, WritesAnyNodeProperty)
       case _: RelationshipType => Effects(WritesRelationships, WritesAnyRelationshipProperty)
       case _                   => Effects()
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/DeleteEntityAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/DeleteEntityAction.scala
@@ -73,7 +73,7 @@ case class DeleteEntityAction(elementToDelete: Expression, forced: Boolean)
 
   def localEffects(symbols: SymbolTable) = elementToDelete match {
     case i: Identifier => symbols.identifiers(i.entityName) match {
-      case _: NodeType         => Effects(WritesNodes, WritesAnyLabel, WritesAnyNodeProperty)
+      case _: NodeType         => Effects(WritesAnyNodes, WritesAnyLabel, WritesAnyNodeProperty)
       case _: RelationshipType => Effects(WritesRelationships, WritesAnyRelationshipProperty)
       case _                   => Effects()
     }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MergeNodeAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MergeNodeAction.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, WritesAnyNodes, WritesNodesWithLabels, ReadsNodesWithLabels, Effects, ReadsNodes, WritesNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, WritesAnyNode, WritesNodesWithLabels, ReadsNodesWithLabels, Effects}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.PropertySupport
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.{EntityProducer, QueryState}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.Argument
@@ -171,7 +171,7 @@ case class MergeNodeAction(identifier: String,
       ++ onMatch.flatMap(_.symbolTableDependencies)).toSet - identifier
 
   def localEffects(symbols: SymbolTable) =
-    if (labels.isEmpty) Effects(WritesAnyNodes, ReadsAnyNodes)
+    if (labels.isEmpty) Effects(WritesAnyNode, ReadsAllNodes)
     else Effects(ReadsNodesWithLabels(labels.map(_.name).toSet), WritesNodesWithLabels(labels.map(_.name).toSet))
 
   override def updateSymbols(symbol: SymbolTable): SymbolTable = symbol.add(identifiers.toMap)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MergeNodeAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MergeNodeAction.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, WritesNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, WritesAnyNodes, WritesNodesWithLabels, ReadsNodesWithLabels, Effects, ReadsNodes, WritesNodes}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.PropertySupport
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.{EntityProducer, QueryState}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.Argument
@@ -170,7 +170,9 @@ case class MergeNodeAction(identifier: String,
       ++ onCreate.flatMap(_.symbolTableDependencies)
       ++ onMatch.flatMap(_.symbolTableDependencies)).toSet - identifier
 
-  def localEffects(symbols: SymbolTable) = Effects(WritesNodes, ReadsNodes)
+  def localEffects(symbols: SymbolTable) =
+    if (labels.isEmpty) Effects(WritesAnyNodes, ReadsAnyNodes)
+    else Effects(ReadsNodesWithLabels(labels.map(_.name).toSet), WritesNodesWithLabels(labels.map(_.name).toSet))
 
   override def updateSymbols(symbol: SymbolTable): SymbolTable = symbol.add(identifiers.toMap)
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MergePatternAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MergePatternAction.scala
@@ -116,7 +116,7 @@ case class MergePatternAction(patterns: Seq[Pattern],
 
   private def readEffects(symbols: SymbolTable): Effects = {
     val collect: Seq[Effect] = identifiers.collect {
-      case (k, CTNode) if !symbols.hasIdentifierNamed(k) => ReadsNodes
+      case (k, CTNode) if !symbols.hasIdentifierNamed(k) => ReadsAnyNodes
       case (k, CTRelationship) if !symbols.hasIdentifierNamed(k) => ReadsRelationships
     }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MergePatternAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MergePatternAction.scala
@@ -116,7 +116,7 @@ case class MergePatternAction(patterns: Seq[Pattern],
 
   private def readEffects(symbols: SymbolTable): Effects = {
     val collect: Seq[Effect] = identifiers.collect {
-      case (k, CTNode) if !symbols.hasIdentifierNamed(k) => ReadsAnyNodes
+      case (k, CTNode) if !symbols.hasIdentifierNamed(k) => ReadsAllNodes
       case (k, CTRelationship) if !symbols.hasIdentifierNamed(k) => ReadsRelationships
     }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/UpdateAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/UpdateAction.scala
@@ -47,9 +47,9 @@ trait UpdateAction extends TypeSafe with AstNode[UpdateAction] {
     val collector = new EffectsCollector(localEffects(symbols), self, symbols)
     visitFirst {
       case (effectful: pipes.Effectful) => collector.register(effectful)
-        .withEffects(effectful.localEffects.toWriteEffects())
+        .withEffects(effectful.localEffects.toWriteEffects)
       case (effectfulAst: EffectfulAstNode[_]) => collector.register(effectfulAst)
-        .withEffects(effectfulAst.localEffects(updateSymbols(symbols)).toWriteEffects())
+        .withEffects(effectfulAst.localEffects(updateSymbols(symbols)).toWriteEffects)
       case (update: UpdateAction) =>
         val oldSymbols = collector.symbols(update)
         collector

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/AllNodesScanPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/AllNodesScanPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -41,7 +41,7 @@ case class AllNodesScanPipe(ident: String)(val estimatedCardinality: Option[Doub
 
   override def monitor = pipeMonitor
 
-  override def localEffects: Effects = Effects(ReadsAnyNodes)
+  override def localEffects: Effects = Effects(ReadsAllNodes)
 
   def dup(sources: List[Pipe]): Pipe = {
     require(sources.isEmpty)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/AllNodesScanPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/AllNodesScanPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -41,7 +41,7 @@ case class AllNodesScanPipe(ident: String)(val estimatedCardinality: Option[Doub
 
   override def monitor = pipeMonitor
 
-  override def localEffects: Effects = Effects(ReadsNodes)
+  override def localEffects: Effects = Effects(ReadsAnyNodes)
 
   def dup(sources: List[Pipe]): Pipe = {
     require(sources.isEmpty)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/DirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/DirectedRelationshipByIdSeekPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.CollectionSupport
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
@@ -64,7 +64,7 @@ case class DirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs, 
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAllNodes, ReadsRelationships)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/DirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/DirectedRelationshipByIdSeekPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.CollectionSupport
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
@@ -64,7 +64,7 @@ case class DirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs, 
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandAllPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -63,7 +63,7 @@ case class ExpandAllPipe(source: Pipe,
 
   val symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
 
-  override def localEffects = Effects(ReadsNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandAllPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -63,7 +63,7 @@ case class ExpandAllPipe(source: Pipe,
 
   val symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
 
-  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAllNodes, ReadsRelationships)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandIntoPipe.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 import java.util.concurrent.ThreadLocalRandom
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
@@ -158,7 +158,7 @@ case class ExpandIntoPipe(source: Pipe,
 
   val symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
 
-  override def localEffects = Effects(ReadsNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandIntoPipe.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 import java.util.concurrent.ThreadLocalRandom
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
@@ -158,7 +158,7 @@ case class ExpandIntoPipe(source: Pipe,
 
   val symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
 
-  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAllNodes, ReadsRelationships)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (source :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeByIdSeekPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CollectionSupport, IsCollection}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -82,7 +82,7 @@ case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: SeekArgs)
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsAnyNodes)
+  override def localEffects = Effects(ReadsAllNodes)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeByIdSeekPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CollectionSupport, IsCollection}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -82,7 +82,7 @@ case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: SeekArgs)
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsNodes)
+  override def localEffects = Effects(ReadsAnyNodes)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeByLabelScanPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeByLabelScanPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsNodesWithLabels, Effects, ReadsLabel}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodesWithLabels}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.LabelName
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -58,7 +58,7 @@ case class NodeByLabelScanPipe(ident: String, label: LazyLabel)
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsNodesWithLabels(label.name), ReadsLabel(label.name))
+  override def localEffects = Effects(ReadsNodesWithLabels(label.name))
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeByLabelScanPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeByLabelScanPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsLabel}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsNodesWithLabels, Effects, ReadsLabel}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.LabelName
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -58,7 +58,7 @@ case class NodeByLabelScanPipe(ident: String, label: LazyLabel)
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsLabel(label.name))
+  override def localEffects = Effects(ReadsNodesWithLabels(label.name), ReadsLabel(label.name))
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexScanPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexScanPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsLabel, ReadsNodeProperty, ReadsNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsNodesWithLabels, Effects, ReadsLabel, ReadsNodeProperty, ReadsNodes}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.Index
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -61,7 +61,7 @@ case class NodeIndexScanPipe(ident: String,
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsNodes, ReadsLabel(label.name), ReadsNodeProperty(propertyKey.name))
+  override def localEffects = Effects(ReadsNodesWithLabels(label.name), ReadsLabel(label.name), ReadsNodeProperty(propertyKey.name))
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexScanPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexScanPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsNodesWithLabels, Effects, ReadsLabel, ReadsNodeProperty, ReadsNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsGivenNodeProperty, ReadsNodesWithLabels}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.Index
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -61,7 +61,7 @@ case class NodeIndexScanPipe(ident: String,
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsNodesWithLabels(label.name), ReadsLabel(label.name), ReadsNodeProperty(propertyKey.name))
+  override def localEffects = Effects(ReadsNodesWithLabels(label.name), ReadsGivenNodeProperty(propertyKey.name))
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipe.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Expression, InequalitySeekRangeExpression, PrefixSeekRangeExpression}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.{QueryExpression, RangeQueryExpression, indexQuery}
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsLabel, ReadsNodeProperty, ReadsNodesWithLabels}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsGivenNodeProperty, ReadsNodesWithLabels}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{Index, InequalityIndex, PrefixIndex}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -94,7 +94,7 @@ case class NodeIndexSeekPipe(ident: String,
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsNodesWithLabels(label.name), ReadsLabel(label.name), ReadsNodeProperty(propertyKey.name))
+  override def localEffects = Effects(ReadsNodesWithLabels(label.name), ReadsGivenNodeProperty(propertyKey.name))
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/NodeIndexSeekPipe.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Expression, InequalitySeekRangeExpression, PrefixSeekRangeExpression}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.{QueryExpression, RangeQueryExpression, indexQuery}
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsLabel, ReadsNodeProperty, ReadsNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsLabel, ReadsNodeProperty, ReadsNodesWithLabels}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{Index, InequalityIndex, PrefixIndex}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -94,7 +94,7 @@ case class NodeIndexSeekPipe(ident: String,
 
   def sources: Seq[Pipe] = Seq.empty
 
-  override def localEffects = Effects(ReadsNodes, ReadsLabel(label.name), ReadsNodeProperty(propertyKey.name))
+  override def localEffects = Effects(ReadsNodesWithLabels(label.name), ReadsLabel(label.name), ReadsNodeProperty(propertyKey.name))
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/OptionalExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/OptionalExpandAllPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -80,7 +80,7 @@ case class OptionalExpandAllPipe(source: Pipe, fromName: String, relName: String
     copy(source = head)(estimatedCardinality)
   }
 
-  override def localEffects = predicate.effects(symbols) | Effects(ReadsNodes, ReadsRelationships)
+  override def localEffects = predicate.effects(symbols) | Effects(ReadsAnyNodes, ReadsRelationships)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/OptionalExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/OptionalExpandAllPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -80,7 +80,7 @@ case class OptionalExpandAllPipe(source: Pipe, fromName: String, relName: String
     copy(source = head)(estimatedCardinality)
   }
 
-  override def localEffects = predicate.effects(symbols) | Effects(ReadsAnyNodes, ReadsRelationships)
+  override def localEffects = predicate.effects(symbols) | Effects(ReadsAllNodes, ReadsRelationships)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/OptionalExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/OptionalExpandIntoPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -104,7 +104,7 @@ case class OptionalExpandIntoPipe(source: Pipe, fromName: String, relName: Strin
     copy(source = head)(estimatedCardinality)
   }
 
-  override def localEffects = predicate.effects(symbols) | Effects(ReadsAnyNodes, ReadsRelationships)
+  override def localEffects = predicate.effects(symbols) | Effects(ReadsAllNodes, ReadsRelationships)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/OptionalExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/OptionalExpandIntoPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -104,7 +104,7 @@ case class OptionalExpandIntoPipe(source: Pipe, fromName: String, relName: Strin
     copy(source = head)(estimatedCardinality)
   }
 
-  override def localEffects = predicate.effects(symbols) | Effects(ReadsNodes, ReadsRelationships)
+  override def localEffects = predicate.effects(symbols) | Effects(ReadsAnyNodes, ReadsRelationships)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ProjectEndpointsPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ProjectEndpointsPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.CollectionSupport
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.KeyNames
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
@@ -39,7 +39,7 @@ case class ProjectEndpointsPipe(source: Pipe, relName: String,
   val symbols: SymbolTable =
     source.symbols.add(start, CTNode).add(end, CTNode)
 
-  override val localEffects = if (!startInScope || !endInScope) Effects(ReadsNodes) else Effects()
+  override val localEffects = if (!startInScope || !endInScope) Effects(ReadsAnyNodes) else Effects()
 
   type Projector = (ExecutionContext) => Iterator[ExecutionContext]
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ProjectEndpointsPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ProjectEndpointsPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.CollectionSupport
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.KeyNames
 import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
@@ -39,7 +39,7 @@ case class ProjectEndpointsPipe(source: Pipe, relName: String,
   val symbols: SymbolTable =
     source.symbols.add(start, CTNode).add(end, CTNode)
 
-  override val localEffects = if (!startInScope || !endInScope) Effects(ReadsAnyNodes) else Effects()
+  override val localEffects = if (!startInScope || !endInScope) Effects(ReadsAllNodes) else Effects()
 
   type Projector = (ExecutionContext) => Iterator[ExecutionContext]
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ShortestPathPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ShortestPathPipe.scala
@@ -24,6 +24,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.ShortestPathExpression
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CastSupport, CollectionSupport}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.LegacyExpression
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -74,7 +75,7 @@ case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, pre
     copy(source = head)(estimatedCardinality)
   }
 
-  override def localEffects = Effects(ReadsNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ShortestPathPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ShortestPathPipe.scala
@@ -23,8 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.ShortestPathExpression
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.Predicate
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CastSupport, CollectionSupport}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.LegacyExpression
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -75,7 +74,7 @@ case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, pre
     copy(source = head)(estimatedCardinality)
   }
 
-  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAllNodes, ReadsRelationships)
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/StartPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/StartPipe.scala
@@ -46,7 +46,7 @@ sealed abstract class StartPipe[T <: PropertyContainer](source: Pipe,
       .andThen(this.id, s"${createSource.producerType}", identifiers, createSource.arguments: _*)
 }
 
-case class NodeStartPipe(source: Pipe, name: String, createSource: EntityProducer[Node], itemEffects: Effects = Effects(ReadsAnyNodes))(val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+case class NodeStartPipe(source: Pipe, name: String, createSource: EntityProducer[Node], itemEffects: Effects = Effects(ReadsAllNodes))(val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends StartPipe[Node](source, name, createSource, pipeMonitor) {
   def identifierType = CTNode
   override def localEffects = itemEffects

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/StartPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/StartPipe.scala
@@ -46,7 +46,7 @@ sealed abstract class StartPipe[T <: PropertyContainer](source: Pipe,
       .andThen(this.id, s"${createSource.producerType}", identifiers, createSource.arguments: _*)
 }
 
-case class NodeStartPipe(source: Pipe, name: String, createSource: EntityProducer[Node], itemEffects: Effects = Effects(ReadsNodes))(val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+case class NodeStartPipe(source: Pipe, name: String, createSource: EntityProducer[Node], itemEffects: Effects = Effects(ReadsAnyNodes))(val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
   extends StartPipe[Node](source, name, createSource, pipeMonitor) {
   def identifierType = CTNode
   override def localEffects = itemEffects

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TraversalMatchPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TraversalMatchPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.{Trail, TraversalMatcher}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.KeyNames
 
@@ -52,7 +52,7 @@ case class TraversalMatchPipe(source: Pipe, matcher: TraversalMatcher, trail: Tr
   def planDescription =
     source.planDescription.andThen(this.id, "TraversalMatcher", identifiers, KeyNames(trail.pathDescription))
 
-  override def localEffects = trail.predicates.flatten.foldLeft(Effects(ReadsAnyNodes, ReadsRelationships))(_ | _.effects(symbols))
+  override def localEffects = trail.predicates.flatten.foldLeft(Effects(ReadsAllNodes, ReadsRelationships))(_ | _.effects(symbols))
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TraversalMatchPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TraversalMatchPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.{Trail, TraversalMatcher}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.KeyNames
 
@@ -52,7 +52,7 @@ case class TraversalMatchPipe(source: Pipe, matcher: TraversalMatcher, trail: Tr
   def planDescription =
     source.planDescription.andThen(this.id, "TraversalMatcher", identifiers, KeyNames(trail.pathDescription))
 
-  override def localEffects = trail.predicates.flatten.foldLeft(Effects(ReadsNodes, ReadsRelationships))(_ | _.effects(symbols))
+  override def localEffects = trail.predicates.flatten.foldLeft(Effects(ReadsAnyNodes, ReadsRelationships))(_ | _.effects(symbols))
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/UndirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/UndirectedRelationshipByIdSeekPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.CollectionSupport
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -53,7 +53,7 @@ case class UndirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs
     this
   }
 
-  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAllNodes, ReadsRelationships)
 
   def sources: Seq[Pipe] = Seq.empty
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/UndirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/UndirectedRelationshipByIdSeekPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.CollectionSupport
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
@@ -53,7 +53,7 @@ case class UndirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs
     this
   }
 
-  override def localEffects = Effects(ReadsNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
 
   def sources: Seq[Pipe] = Seq.empty
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/VarLengthExpandPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -105,7 +105,7 @@ case class VarLengthExpandPipe(source: Pipe,
 
   def symbols = source.symbols.add(toName, CTNode).add(relName, CTCollection(CTRelationship))
 
-  override def localEffects = Effects(ReadsNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/VarLengthExpandPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAnyNodes, Effects, ReadsNodes, ReadsRelationships}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ReadsAllNodes, Effects, ReadsRelationships}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression
 import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection, InternalException}
 import org.neo4j.cypher.internal.frontend.v2_3.symbols._
@@ -105,7 +105,7 @@ case class VarLengthExpandPipe(source: Pipe,
 
   def symbols = source.symbols.add(toName, CTNode).add(relName, CTCollection(CTRelationship))
 
-  override def localEffects = Effects(ReadsAnyNodes, ReadsRelationships)
+  override def localEffects = Effects(ReadsAllNodes, ReadsRelationships)
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/AddEagernessIfNecessaryTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/AddEagernessIfNecessaryTest.scala
@@ -93,26 +93,26 @@ class AddEagernessIfNecessaryTest extends CypherFunSuite {
   }
 
   test("READS PROP -> WRITES PROP needs eagerness"){
-    testThatGoingFrom(Effects(ReadsNodeProperty("foo")))
-      .to(Effects(WritesNodeProperty("foo")))
+    testThatGoingFrom(Effects(ReadsGivenNodeProperty("foo")))
+      .to(Effects(WritesGivenNodeProperty("foo")))
       .doesIntroduceEagerness()
   }
 
   test("WRITES PROP -> READS PROP does not need eagerness") {
-    testThatGoingFrom(Effects(WritesNodeProperty("foo")))
-      .to(Effects(ReadsNodeProperty("foo")))
+    testThatGoingFrom(Effects(WritesGivenNodeProperty("foo")))
+      .to(Effects(ReadsGivenNodeProperty("foo")))
       .doesNotIntroduceEagerness()
   }
 
   test("READS ALL PROPS -> WRITES PROP needs eagerness") {
     testThatGoingFrom(Effects(ReadsAnyNodeProperty))
-      .to(Effects(WritesNodeProperty("bar")))
+      .to(Effects(WritesGivenNodeProperty("bar")))
       .doesIntroduceEagerness()
   }
 
   test("WRITES ALL PROPS -> READS PROP does not need eagerness") {
     testThatGoingFrom(Effects(WritesAnyNodeProperty))
-      .to(Effects(ReadsNodeProperty("foo")))
+      .to(Effects(ReadsGivenNodeProperty("foo")))
       .doesNotIntroduceEagerness()
   }
 
@@ -129,26 +129,26 @@ class AddEagernessIfNecessaryTest extends CypherFunSuite {
   }
 
   test("READS LABEL -> WRITES LABEL needs eagerness") {
-    testThatGoingFrom(Effects(ReadsLabel("foo")))
-      .to(Effects(WritesLabel("foo")))
+    testThatGoingFrom(Effects(ReadsNodesWithLabels("foo")))
+      .to(Effects(WritesNodesWithLabels("foo")))
       .doesIntroduceEagerness()
   }
 
   test("WRITES LABEL -> READS LABEL does not need eagerness") {
-    testThatGoingFrom(Effects(WritesLabel("foo")))
-      .to(Effects(ReadsLabel("foo")))
+    testThatGoingFrom(Effects(WritesNodesWithLabels("foo")))
+      .to(Effects(ReadsNodesWithLabels("foo")))
       .doesNotIntroduceEagerness()
   }
 
   test("READS ALL LABELS -> WRITES LABEL needs eagerness") {
-    testThatGoingFrom(Effects(ReadsAnyLabel))
-      .to(Effects(WritesLabel("foo")))
+    testThatGoingFrom(Effects(ReadsAnyNodes))
+      .to(Effects(WritesNodesWithLabels("foo")))
       .doesIntroduceEagerness()
   }
 
   test("WRITES ALL LABELS -> READS LABEL does not need eagerness") {
-    testThatGoingFrom(Effects(WritesAnyLabel))
-      .to(Effects(ReadsLabel("foo")))
+    testThatGoingFrom(Effects(WritesAnyNodes))
+      .to(Effects(ReadsNodesWithLabels("foo")))
       .doesNotIntroduceEagerness()
   }
 
@@ -164,8 +164,8 @@ class AddEagernessIfNecessaryTest extends CypherFunSuite {
   }
 
   test("ReadsLabel with matching label should introduce eagerness") {
-    testThatGoingFrom(Effects(ReadsLabel("Folder"), WritesRelationships, WritesAnyNodes))
-      .to(Effects(WritesLabel("Folder"), WritesAnyNodes, WritesRelationships))
+    testThatGoingFrom(Effects(ReadsNodesWithLabels("Folder"), WritesRelationships, WritesAnyNodes))
+      .to(Effects(WritesNodesWithLabels("Folder"), WritesAnyNodes, WritesRelationships))
       .doesIntroduceEagerness()
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/EffectsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/EffectsTest.scala
@@ -32,16 +32,16 @@ class EffectsTest extends CypherFunSuite {
 
   test("logical AND works for write effects") {
     val first = AllWriteEffects
-    val second = Effects(WritesRelationships, ReadsRelationships, WritesLabel("foo"), WritesNodes)
+    val second = Effects(WritesRelationships, ReadsRelationships, WritesLabel("foo"), WritesAnyNodes)
 
-    (first & second) should be(Effects(WritesRelationships, WritesNodes))
+    (first & second) should be(Effects(WritesRelationships, WritesAnyNodes))
   }
 
   test("logical AND works for read effects") {
     val first = AllReadEffects
-    val second = Effects(ReadsNodes, ReadsAnyNodeProperty, WritesNodeProperty("bar"))
+    val second = Effects(ReadsAnyNodes, ReadsAnyNodeProperty, WritesNodeProperty("bar"))
 
-    (first & second) should be(Effects(ReadsNodes, ReadsAnyNodeProperty))
+    (first & second) should be(Effects(ReadsAnyNodes, ReadsAnyNodeProperty))
   }
 
   test("logical AND considers equal property names") {
@@ -52,25 +52,25 @@ class EffectsTest extends CypherFunSuite {
   }
 
   test("logical AND considers equal label names") {
-    val first = Effects(ReadsNodes, ReadsLabel("bar"))
+    val first = Effects(ReadsAnyNodes, ReadsLabel("bar"))
     val second = Effects(ReadsLabel("bar"))
 
     (first & second).effectsSet should contain only ReadsLabel("bar")
   }
 
   test("logical OR works") {
-    val first = Effects(WritesRelationships, WritesNodes, ReadsLabel("foo"))
+    val first = Effects(WritesRelationships, WritesAnyNodes, ReadsLabel("foo"))
     val second = Effects(ReadsLabel("foo"), WritesNodeProperty("bar"))
 
-    (first | second) should be(Effects(WritesRelationships, WritesNodes, ReadsLabel("foo"), WritesNodeProperty("bar")))
+    (first | second) should be(Effects(WritesRelationships, WritesAnyNodes, ReadsLabel("foo"), WritesNodeProperty("bar")))
   }
 
   test("logical OR works for write effects") {
     val first = AllWriteEffects
-    val second = Effects(WritesRelationships, ReadsRelationships, ReadsNodes)
+    val second = Effects(WritesRelationships, ReadsRelationships, ReadsAnyNodes)
 
     val expected = Effects(
-      WritesNodes, WritesRelationships, WritesAnyLabel, WritesAnyNodeProperty, WritesAnyRelationshipProperty, ReadsRelationships, ReadsNodes
+      WritesAnyNodes, WritesRelationships, WritesAnyLabel, WritesAnyNodeProperty, WritesAnyRelationshipProperty, ReadsRelationships, ReadsAnyNodes
     )
 
     (first | second) should be(expected)
@@ -81,23 +81,23 @@ class EffectsTest extends CypherFunSuite {
     val second = Effects(ReadsNodeProperty("foo"), WritesNodeProperty("bar"))
 
     val expected = Effects(
-      ReadsNodes, ReadsRelationships, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty, ReadsAnyLabel, ReadsNodeProperty("foo"), WritesNodeProperty("bar")
+      ReadsAnyNodes, ReadsRelationships, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty, ReadsAnyLabel, ReadsNodeProperty("foo"), WritesNodeProperty("bar")
     )
 
     (first | second) should be(expected)
   }
 
   test("logical OR considers equal property names") {
-    val first = Effects(WritesNodes, ReadsNodeProperty("foo"))
+    val first = Effects(WritesAnyNodes, ReadsNodeProperty("foo"))
     val second = Effects(ReadsNodeProperty("foo"))
 
-    (first | second) should be(Effects(WritesNodes, ReadsNodeProperty("foo")))
+    (first | second) should be(Effects(WritesAnyNodes, ReadsNodeProperty("foo")))
   }
 
   test("logical OR considers equal label names") {
-    val first = Effects(WritesNodes, ReadsLabel("bar"))
+    val first = Effects(WritesAnyNodes, ReadsLabel("bar"))
     val second = Effects(ReadsLabel("bar"))
 
-    (first | second) should be(Effects(WritesNodes, ReadsLabel("bar")))
+    (first | second) should be(Effects(WritesAnyNodes, ReadsLabel("bar")))
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/EffectsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/EffectsTest.scala
@@ -24,45 +24,45 @@ import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
 class EffectsTest extends CypherFunSuite {
 
   test("logical AND works") {
-    val first = Effects(WritesRelationships, ReadsNodeProperty("2"))
-    val second = Effects(WritesRelationships, WritesNodeProperty("2"))
+    val first = Effects(WritesRelationships, ReadsGivenNodeProperty("2"))
+    val second = Effects(WritesRelationships, WritesGivenNodeProperty("2"))
 
     (first & second) should be(Effects(WritesRelationships))
   }
 
   test("logical AND works for write effects") {
     val first = AllWriteEffects
-    val second = Effects(WritesRelationships, ReadsRelationships, WritesLabel("foo"), WritesAnyNodes)
+    val second = Effects(WritesRelationships, ReadsRelationships, WritesNodesWithLabels("foo"), WritesAnyNodes)
 
     (first & second) should be(Effects(WritesRelationships, WritesAnyNodes))
   }
 
   test("logical AND works for read effects") {
     val first = AllReadEffects
-    val second = Effects(ReadsAnyNodes, ReadsAnyNodeProperty, WritesNodeProperty("bar"))
+    val second = Effects(ReadsAnyNodes, ReadsAnyNodeProperty, WritesGivenNodeProperty("bar"))
 
     (first & second) should be(Effects(ReadsAnyNodes, ReadsAnyNodeProperty))
   }
 
   test("logical AND considers equal property names") {
-    val first = Effects(WritesRelationships, ReadsNodeProperty("foo"))
-    val second = Effects(ReadsNodeProperty("foo"))
+    val first = Effects(WritesRelationships, ReadsGivenNodeProperty("foo"))
+    val second = Effects(ReadsGivenNodeProperty("foo"))
 
-    (first & second).effectsSet should contain only ReadsNodeProperty("foo")
+    (first & second).effectsSet should contain only ReadsGivenNodeProperty("foo")
   }
 
   test("logical AND considers equal label names") {
-    val first = Effects(ReadsAnyNodes, ReadsLabel("bar"))
-    val second = Effects(ReadsLabel("bar"))
+    val first = Effects(ReadsAnyNodes, ReadsNodesWithLabels("bar"))
+    val second = Effects(ReadsNodesWithLabels("bar"))
 
-    (first & second).effectsSet should contain only ReadsLabel("bar")
+    (first & second).effectsSet should contain only ReadsNodesWithLabels("bar")
   }
 
   test("logical OR works") {
-    val first = Effects(WritesRelationships, WritesAnyNodes, ReadsLabel("foo"))
-    val second = Effects(ReadsLabel("foo"), WritesNodeProperty("bar"))
+    val first = Effects(WritesRelationships, WritesAnyNodes, ReadsNodesWithLabels("foo"))
+    val second = Effects(ReadsNodesWithLabels("foo"), WritesGivenNodeProperty("bar"))
 
-    (first | second) should be(Effects(WritesRelationships, WritesAnyNodes, ReadsLabel("foo"), WritesNodeProperty("bar")))
+    (first | second) should be(Effects(WritesRelationships, WritesAnyNodes, ReadsNodesWithLabels("foo"), WritesGivenNodeProperty("bar")))
   }
 
   test("logical OR works for write effects") {
@@ -70,7 +70,7 @@ class EffectsTest extends CypherFunSuite {
     val second = Effects(WritesRelationships, ReadsRelationships, ReadsAnyNodes)
 
     val expected = Effects(
-      WritesAnyNodes, WritesRelationships, WritesAnyLabel, WritesAnyNodeProperty, WritesAnyRelationshipProperty, ReadsRelationships, ReadsAnyNodes
+      WritesAnyNodes, WritesRelationships, WritesAnyNodes, WritesAnyNodeProperty, WritesAnyRelationshipProperty, ReadsRelationships, ReadsAnyNodes
     )
 
     (first | second) should be(expected)
@@ -78,26 +78,26 @@ class EffectsTest extends CypherFunSuite {
 
   test("logical OR works for read effects") {
     val first = AllReadEffects
-    val second = Effects(ReadsNodeProperty("foo"), WritesNodeProperty("bar"))
+    val second = Effects(ReadsGivenNodeProperty("foo"), WritesGivenNodeProperty("bar"))
 
     val expected = Effects(
-      ReadsAnyNodes, ReadsRelationships, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty, ReadsAnyLabel, ReadsNodeProperty("foo"), WritesNodeProperty("bar")
+      ReadsAnyNodes, ReadsRelationships, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty, ReadsAnyNodes, ReadsGivenNodeProperty("foo"), WritesGivenNodeProperty("bar")
     )
 
     (first | second) should be(expected)
   }
 
   test("logical OR considers equal property names") {
-    val first = Effects(WritesAnyNodes, ReadsNodeProperty("foo"))
-    val second = Effects(ReadsNodeProperty("foo"))
+    val first = Effects(WritesAnyNodes, ReadsGivenNodeProperty("foo"))
+    val second = Effects(ReadsGivenNodeProperty("foo"))
 
-    (first | second) should be(Effects(WritesAnyNodes, ReadsNodeProperty("foo")))
+    (first | second) should be(Effects(WritesAnyNodes, ReadsGivenNodeProperty("foo")))
   }
 
   test("logical OR considers equal label names") {
-    val first = Effects(WritesAnyNodes, ReadsLabel("bar"))
-    val second = Effects(ReadsLabel("bar"))
+    val first = Effects(WritesAnyNodes, ReadsNodesWithLabels("bar"))
+    val second = Effects(ReadsNodesWithLabels("bar"))
 
-    (first | second) should be(Effects(WritesAnyNodes, ReadsLabel("bar")))
+    (first | second) should be(Effects(WritesAnyNodes, ReadsNodesWithLabels("bar")))
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/EffectsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/EffectsTest.scala
@@ -32,16 +32,16 @@ class EffectsTest extends CypherFunSuite {
 
   test("logical AND works for write effects") {
     val first = AllWriteEffects
-    val second = Effects(WritesRelationships, ReadsRelationships, WritesNodesWithLabels("foo"), WritesAnyNodes)
+    val second = Effects(WritesRelationships, ReadsRelationships, WritesNodesWithLabels("foo"), WritesAnyNode)
 
-    (first & second) should be(Effects(WritesRelationships, WritesAnyNodes))
+    (first & second) should be(Effects(WritesRelationships, WritesAnyNode))
   }
 
   test("logical AND works for read effects") {
     val first = AllReadEffects
-    val second = Effects(ReadsAnyNodes, ReadsAnyNodeProperty, WritesGivenNodeProperty("bar"))
+    val second = Effects(ReadsAllNodes, ReadsAnyNodeProperty, WritesGivenNodeProperty("bar"))
 
-    (first & second) should be(Effects(ReadsAnyNodes, ReadsAnyNodeProperty))
+    (first & second) should be(Effects(ReadsAllNodes, ReadsAnyNodeProperty))
   }
 
   test("logical AND considers equal property names") {
@@ -52,25 +52,25 @@ class EffectsTest extends CypherFunSuite {
   }
 
   test("logical AND considers equal label names") {
-    val first = Effects(ReadsAnyNodes, ReadsNodesWithLabels("bar"))
+    val first = Effects(ReadsAllNodes, ReadsNodesWithLabels("bar"))
     val second = Effects(ReadsNodesWithLabels("bar"))
 
     (first & second).effectsSet should contain only ReadsNodesWithLabels("bar")
   }
 
   test("logical OR works") {
-    val first = Effects(WritesRelationships, WritesAnyNodes, ReadsNodesWithLabels("foo"))
+    val first = Effects(WritesRelationships, WritesAnyNode, ReadsNodesWithLabels("foo"))
     val second = Effects(ReadsNodesWithLabels("foo"), WritesGivenNodeProperty("bar"))
 
-    (first | second) should be(Effects(WritesRelationships, WritesAnyNodes, ReadsNodesWithLabels("foo"), WritesGivenNodeProperty("bar")))
+    (first | second) should be(Effects(WritesRelationships, WritesAnyNode, ReadsNodesWithLabels("foo"), WritesGivenNodeProperty("bar")))
   }
 
   test("logical OR works for write effects") {
     val first = AllWriteEffects
-    val second = Effects(WritesRelationships, ReadsRelationships, ReadsAnyNodes)
+    val second = Effects(WritesRelationships, ReadsRelationships, ReadsAllNodes)
 
     val expected = Effects(
-      WritesAnyNodes, WritesRelationships, WritesAnyNodes, WritesAnyNodeProperty, WritesAnyRelationshipProperty, ReadsRelationships, ReadsAnyNodes
+      WritesAnyNode, WritesRelationships, WritesAnyNode, WritesAnyNodeProperty, WritesAnyRelationshipProperty, ReadsRelationships, ReadsAllNodes
     )
 
     (first | second) should be(expected)
@@ -81,23 +81,23 @@ class EffectsTest extends CypherFunSuite {
     val second = Effects(ReadsGivenNodeProperty("foo"), WritesGivenNodeProperty("bar"))
 
     val expected = Effects(
-      ReadsAnyNodes, ReadsRelationships, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty, ReadsAnyNodes, ReadsGivenNodeProperty("foo"), WritesGivenNodeProperty("bar")
+      ReadsAllNodes, ReadsRelationships, ReadsAnyNodeProperty, ReadsAnyRelationshipProperty, ReadsAllNodes, ReadsGivenNodeProperty("foo"), WritesGivenNodeProperty("bar")
     )
 
     (first | second) should be(expected)
   }
 
   test("logical OR considers equal property names") {
-    val first = Effects(WritesAnyNodes, ReadsGivenNodeProperty("foo"))
+    val first = Effects(WritesAnyNode, ReadsGivenNodeProperty("foo"))
     val second = Effects(ReadsGivenNodeProperty("foo"))
 
-    (first | second) should be(Effects(WritesAnyNodes, ReadsGivenNodeProperty("foo")))
+    (first | second) should be(Effects(WritesAnyNode, ReadsGivenNodeProperty("foo")))
   }
 
   test("logical OR considers equal label names") {
-    val first = Effects(WritesAnyNodes, ReadsNodesWithLabels("bar"))
+    val first = Effects(WritesAnyNode, ReadsNodesWithLabels("bar"))
     val second = Effects(ReadsNodesWithLabels("bar"))
 
-    (first | second) should be(Effects(WritesAnyNodes, ReadsNodesWithLabels("bar")))
+    (first | second) should be(Effects(WritesAnyNode, ReadsNodesWithLabels("bar")))
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/UpdateActionEffectfulTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/UpdateActionEffectfulTest.scala
@@ -37,14 +37,14 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
     val inner = PropertySetAction(Property(Identifier("a"), PropertyKey("x")), Literal(1))
     val given = MergeNodeAction("a", Map.empty, Seq.empty, Seq.empty, Seq(inner), Seq.empty, None)
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesGivenNodeProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAllNodes, WritesAnyNode, WritesGivenNodeProperty("x")))
   }
 
   test("correctly computes MergeNodeAction's effects for relationship property write") {
     val inner = PropertySetAction(Property(Identifier("a"), PropertyKey("x")), Literal(1))
     val given = MergeNodeAction("b", Map.empty, Seq.empty, Seq.empty, Seq(inner), Seq.empty, None)
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTRelationship))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesGivenRelationshipProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTRelationship))) should equal(Effects(ReadsAllNodes, WritesAnyNode, WritesGivenRelationshipProperty("x")))
   }
 
   test("correctly computes MergeNodeAction's effects when inside Foreach") {
@@ -52,7 +52,7 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
     val merge = MergeNodeAction("a", Map.empty, Seq.empty, Seq.empty, Seq(inner), Seq.empty, None)
     val given = ForeachAction(Literal(Seq.empty), "k", Seq(merge))
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesGivenNodeProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAllNodes, WritesAnyNode, WritesGivenNodeProperty("x")))
   }
 
   test("correctly computes CreateNode's effects when inside Foreach") {
@@ -60,7 +60,7 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
     val create = CreateNode("a", Map.empty, Seq.empty)
     val given = ForeachAction(Literal(Seq.empty), "k", Seq(create, propertySet))
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(WritesAnyNodes, WritesGivenNodeProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(WritesAnyNode, WritesGivenNodeProperty("x")))
   }
 
   test("MATCH (a) SET a:Foo RETURN a") {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/UpdateActionEffectfulTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/UpdateActionEffectfulTest.scala
@@ -37,14 +37,14 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
     val inner = PropertySetAction(Property(Identifier("a"), PropertyKey("x")), Literal(1))
     val given = MergeNodeAction("a", Map.empty, Seq.empty, Seq.empty, Seq(inner), Seq.empty, None)
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesNodeProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesGivenNodeProperty("x")))
   }
 
   test("correctly computes MergeNodeAction's effects for relationship property write") {
     val inner = PropertySetAction(Property(Identifier("a"), PropertyKey("x")), Literal(1))
     val given = MergeNodeAction("b", Map.empty, Seq.empty, Seq.empty, Seq(inner), Seq.empty, None)
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTRelationship))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesRelationshipProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTRelationship))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesGivenRelationshipProperty("x")))
   }
 
   test("correctly computes MergeNodeAction's effects when inside Foreach") {
@@ -52,7 +52,7 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
     val merge = MergeNodeAction("a", Map.empty, Seq.empty, Seq.empty, Seq(inner), Seq.empty, None)
     val given = ForeachAction(Literal(Seq.empty), "k", Seq(merge))
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesNodeProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesGivenNodeProperty("x")))
   }
 
   test("correctly computes CreateNode's effects when inside Foreach") {
@@ -60,7 +60,7 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
     val create = CreateNode("a", Map.empty, Seq.empty)
     val given = ForeachAction(Literal(Seq.empty), "k", Seq(create, propertySet))
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(WritesAnyNodes, WritesNodeProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(WritesAnyNodes, WritesGivenNodeProperty("x")))
   }
 
   test("MATCH (a) SET a:Foo RETURN a") {
@@ -70,7 +70,7 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
       case query: Query =>
         query.tail.get.updatedCommands match {
           case Seq(setAction) =>
-            setAction.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(WritesLabel("Foo")))
+            setAction.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(WritesNodesWithLabels("Foo")))
         }
     }
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/UpdateActionEffectfulTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/UpdateActionEffectfulTest.scala
@@ -37,14 +37,14 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
     val inner = PropertySetAction(Property(Identifier("a"), PropertyKey("x")), Literal(1))
     val given = MergeNodeAction("a", Map.empty, Seq.empty, Seq.empty, Seq(inner), Seq.empty, None)
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsNodes, WritesNodes, WritesNodeProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesNodeProperty("x")))
   }
 
   test("correctly computes MergeNodeAction's effects for relationship property write") {
     val inner = PropertySetAction(Property(Identifier("a"), PropertyKey("x")), Literal(1))
     val given = MergeNodeAction("b", Map.empty, Seq.empty, Seq.empty, Seq(inner), Seq.empty, None)
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTRelationship))) should equal(Effects(ReadsNodes, WritesNodes, WritesRelationshipProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTRelationship))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesRelationshipProperty("x")))
   }
 
   test("correctly computes MergeNodeAction's effects when inside Foreach") {
@@ -52,7 +52,7 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
     val merge = MergeNodeAction("a", Map.empty, Seq.empty, Seq.empty, Seq(inner), Seq.empty, None)
     val given = ForeachAction(Literal(Seq.empty), "k", Seq(merge))
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsNodes, WritesNodes, WritesNodeProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(ReadsAnyNodes, WritesAnyNodes, WritesNodeProperty("x")))
   }
 
   test("correctly computes CreateNode's effects when inside Foreach") {
@@ -60,7 +60,7 @@ class UpdateActionEffectfulTest extends CypherFunSuite {
     val create = CreateNode("a", Map.empty, Seq.empty)
     val given = ForeachAction(Literal(Seq.empty), "k", Seq(create, propertySet))
 
-    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(WritesNodes, WritesNodeProperty("x")))
+    given.effects(SymbolTable(Map("a" -> symbols.CTNode))) should equal(Effects(WritesAnyNodes, WritesNodeProperty("x")))
   }
 
   test("MATCH (a) SET a:Foo RETURN a") {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/PipeEffectsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/PipeEffectsTest.scala
@@ -42,7 +42,7 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
     -> Effects(),
 
     ExecuteUpdateCommandsPipe(SingleRowPipe(), Seq(CreateNode("n", Map.empty, Seq.empty)))
-    -> Effects(WritesAnyNodes),
+    -> Effects(WritesAnyNode),
 
     ExecuteUpdateCommandsPipe(SingleRowPipe(), Seq(CreateRelationship("r", RelationshipEndpoint("a"), RelationshipEndpoint("b"), "TYPE", Map.empty)))
     -> Effects(WritesRelationships),
@@ -50,13 +50,13 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
     ExecuteUpdateCommandsPipe(SingleRowPipe(), Seq(
       CreateNode("n", Map.empty, Seq.empty),
       CreateRelationship("r", RelationshipEndpoint("a"), RelationshipEndpoint("b"), "TYPE", Map.empty)))
-    -> Effects(WritesAnyNodes, WritesRelationships),
+    -> Effects(WritesAnyNode, WritesRelationships),
 
     ExecuteUpdateCommandsPipe(SingleRowPipe(), Seq(MergeNodeAction("n", Map.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, None)))
-      -> Effects(ReadsAnyNodes, WritesAnyNodes),
+      -> Effects(ReadsAllNodes, WritesAnyNode),
 
     NodeStartPipe(SingleRowPipe(), "n", mock[EntityProducer[Node]])()
-      -> Effects(ReadsAnyNodes),
+      -> Effects(ReadsAllNodes),
 
     LoadCSVPipe(SingleRowPipe(), null, Literal("apa"), "line", None)
       -> Effects(),
@@ -76,7 +76,7 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
     {
       val trail: Trail = mock[Trail]
       when(trail.predicates).thenReturn(Seq.empty)
-      TraversalMatchPipe(SingleRowPipe(), mock[TraversalMatcher], trail) -> Effects(ReadsAnyNodes, ReadsRelationships)
+      TraversalMatchPipe(SingleRowPipe(), mock[TraversalMatcher], trail) -> Effects(ReadsAllNodes, ReadsRelationships)
     },
 
     SlicePipe(SingleRowPipe(), Some(Literal(10)), None)
@@ -95,13 +95,13 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
       -> Effects(),
 
     DistinctPipe(NodeStartPipe(SingleRowPipe(), "n", mock[EntityProducer[Node]])(), Map.empty)()
-      -> Effects(ReadsAnyNodes),
+      -> Effects(ReadsAllNodes),
 
     DistinctPipe(SingleRowPipe(), Map.empty)()
       -> Effects(),
 
     OptionalMatchPipe(SingleRowPipe(), NodeStartPipe(SingleRowPipe(), "n", mock[EntityProducer[Node]])(), SymbolTable())
-      -> Effects(ReadsAnyNodes)
+      -> Effects(ReadsAllNodes)
   )
 
   EFFECTS.foreach { case (pipe: Pipe, effects: Effects) =>

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/PipeEffectsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/PipeEffectsTest.scala
@@ -42,7 +42,7 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
     -> Effects(),
 
     ExecuteUpdateCommandsPipe(SingleRowPipe(), Seq(CreateNode("n", Map.empty, Seq.empty)))
-    -> Effects(WritesNodes),
+    -> Effects(WritesAnyNodes),
 
     ExecuteUpdateCommandsPipe(SingleRowPipe(), Seq(CreateRelationship("r", RelationshipEndpoint("a"), RelationshipEndpoint("b"), "TYPE", Map.empty)))
     -> Effects(WritesRelationships),
@@ -50,13 +50,13 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
     ExecuteUpdateCommandsPipe(SingleRowPipe(), Seq(
       CreateNode("n", Map.empty, Seq.empty),
       CreateRelationship("r", RelationshipEndpoint("a"), RelationshipEndpoint("b"), "TYPE", Map.empty)))
-    -> Effects(WritesNodes, WritesRelationships),
+    -> Effects(WritesAnyNodes, WritesRelationships),
 
     ExecuteUpdateCommandsPipe(SingleRowPipe(), Seq(MergeNodeAction("n", Map.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, None)))
-      -> Effects(ReadsNodes, WritesNodes),
+      -> Effects(ReadsAnyNodes, WritesAnyNodes),
 
     NodeStartPipe(SingleRowPipe(), "n", mock[EntityProducer[Node]])()
-      -> Effects(ReadsNodes),
+      -> Effects(ReadsAnyNodes),
 
     LoadCSVPipe(SingleRowPipe(), null, Literal("apa"), "line", None)
       -> Effects(),
@@ -76,7 +76,7 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
     {
       val trail: Trail = mock[Trail]
       when(trail.predicates).thenReturn(Seq.empty)
-      TraversalMatchPipe(SingleRowPipe(), mock[TraversalMatcher], trail) -> Effects(ReadsNodes, ReadsRelationships)
+      TraversalMatchPipe(SingleRowPipe(), mock[TraversalMatcher], trail) -> Effects(ReadsAnyNodes, ReadsRelationships)
     },
 
     SlicePipe(SingleRowPipe(), Some(Literal(10)), None)
@@ -95,13 +95,13 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
       -> Effects(),
 
     DistinctPipe(NodeStartPipe(SingleRowPipe(), "n", mock[EntityProducer[Node]])(), Map.empty)()
-      -> Effects(ReadsNodes),
+      -> Effects(ReadsAnyNodes),
 
     DistinctPipe(SingleRowPipe(), Map.empty)()
       -> Effects(),
 
     OptionalMatchPipe(SingleRowPipe(), NodeStartPipe(SingleRowPipe(), "n", mock[EntityProducer[Node]])(), SymbolTable())
-      -> Effects(ReadsNodes)
+      -> Effects(ReadsAnyNodes)
   )
 
   EFFECTS.foreach { case (pipe: Pipe, effects: Effects) =>

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/PipeEffectsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/PipeEffectsTest.scala
@@ -68,7 +68,7 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
       -> Effects(),
 
     FilterPipe(SingleRowPipe(), HasLabel(Identifier("a"), UnresolvedLabel("Apa")))()
-      -> Effects(ReadsLabel("Apa")),
+      -> Effects(ReadsNodesWithLabels("Apa")),
 
     ColumnFilterPipe(SingleRowPipe(), Seq(ReturnItem(Literal(42), "a")))
       -> Effects(),

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/ProfilerTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.profiler
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{NestedPipeExpression, ProjectedPath}
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{Effects, WritesNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{WritesAnyNodes, Effects, WritesNodes}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes._
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{Argument, InternalPlanDescription}
@@ -207,7 +207,7 @@ case class ProfilerTestPipe(source: Pipe, name: String, rows: Int, dbAccess: Int
     (0 until rows).map(x => ExecutionContext.empty).toIterator
   }
 
-  def localEffects: Effects = Effects(WritesNodes)
+  def localEffects: Effects = Effects(WritesAnyNodes)
 
   def symbols: SymbolTable = SymbolTable()
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/profiler/ProfilerTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_3.profiler
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{NestedPipeExpression, ProjectedPath}
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{WritesAnyNodes, Effects, WritesNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{WritesAnyNode, Effects, WritesNodes}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes._
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{Argument, InternalPlanDescription}
@@ -207,7 +207,7 @@ case class ProfilerTestPipe(source: Pipe, name: String, rows: Int, dbAccess: Int
     (0 until rows).map(x => ExecutionContext.empty).toIterator
   }
 
-  def localEffects: Effects = Effects(WritesAnyNodes)
+  def localEffects: Effects = Effects(WritesAnyNode)
 
   def symbols: SymbolTable = SymbolTable()
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
@@ -598,6 +598,30 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     assertNumberOfEagerness(query, 0)
   }
 
+  test("should not be eager when merging on two different labels") {
+    val query = "MERGE(:L1) MERGE(p:L2) ON CREATE SET p.name = 'Blaine'"
+
+    assertNumberOfEagerness(query, 0)
+  }
+
+  test("should be eager when merging on the same label") {
+    val query = "MERGE(:L1) MERGE(p:L1) ON CREATE SET p.name = 'Blaine'"
+
+    assertNumberOfEagerness(query, 1)
+  }
+
+  test("should be eager when only one merge has labels") {
+    val query = "MERGE() MERGE(p: Person) ON CREATE SET p.name = 'Blaine'"
+
+    assertNumberOfEagerness(query, 1)
+  }
+
+  test("should be eager when no merge has labels") {
+    val query = "MERGE() MERGE(p) ON CREATE SET p.name = 'Blaine'"
+
+    assertNumberOfEagerness(query, 1)
+  }
+
   private def assertNumberOfEagerness(query: String, expectedEagerCount: Int) {
     val q = if (query.contains("EXPLAIN")) query else "EXPLAIN " + query
     val result = execute(q)


### PR DESCRIPTION
Queries of the type `MERGE (a:A) MERGE (b:B) ON CREATE SET a.prop="foo"` does not need to be eager
