### PR TITLE
Send MemberIsUnavailable on executor thread

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServer.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ProtocolServer.java
@@ -30,19 +30,22 @@ import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.Listeners;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.Logging;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 /**
  * A ProtocolServer ties together the underlying StateMachines with an understanding of ones
  * own server address (me), and provides a proxy factory for creating clients to invoke the CSM.
  */
-public class ProtocolServer implements BindingNotifier
+public class ProtocolServer
+        extends LifecycleAdapter
+        implements BindingNotifier
 {
     private final InstanceId me;
     private URI boundAt;
     protected StateMachineProxyFactory proxyFactory;
     protected final StateMachines stateMachines;
     private Iterable<BindingListener> bindingListeners = Listeners.newListeners();
-    private final StringLogger msgLog;
+    private StringLogger msgLog;
 
     public ProtocolServer( InstanceId me, StateMachines stateMachines, Logging logging )
     {
@@ -53,6 +56,12 @@ public class ProtocolServer implements BindingNotifier
         StateMachineConversations conversations = new StateMachineConversations(me);
         proxyFactory = new StateMachineProxyFactory( stateMachines, conversations, me );
         stateMachines.addMessageProcessor( proxyFactory );
+    }
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+        msgLog = null;
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
@@ -251,16 +251,8 @@ public class HighAvailabilityModeSwitcher
                 switchToSlave();
                 break;
             case PENDING:
-                if ( event.getOldState().equals( HighAvailabilityMemberState.SLAVE ) )
-                {
-                    clusterMemberAvailability.memberIsUnavailable( SLAVE );
-                }
-                else if ( event.getOldState().equals( HighAvailabilityMemberState.MASTER ) )
-                {
-                    clusterMemberAvailability.memberIsUnavailable( MASTER );
-                }
 
-                switchToPending();
+                switchToPending( event.getOldState() );
                 break;
             default:
                 // do nothing
@@ -434,7 +426,7 @@ public class HighAvailabilityModeSwitcher
         }, cancellationHandle );
     }
 
-    private void switchToPending()
+    private void switchToPending( final HighAvailabilityMemberState oldState )
     {
         msgLog.info( "I am " + instanceId + ", moving to pending" );
 
@@ -447,6 +439,15 @@ public class HighAvailabilityModeSwitcher
                 {
                     msgLog.info( "Switch to pending cancelled on start." );
                     return;
+                }
+
+                if ( oldState.equals( HighAvailabilityMemberState.SLAVE ) )
+                {
+                    clusterMemberAvailability.memberIsUnavailable( SLAVE );
+                }
+                else if ( oldState.equals( HighAvailabilityMemberState.MASTER ) )
+                {
+                    clusterMemberAvailability.memberIsUnavailable( MASTER );
                 }
 
                 Listeners.notifyListeners( modeSwitchListeners, new Listeners.Notification<ModeSwitcher>()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -90,9 +90,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
 import static org.neo4j.helpers.collection.Iterables.filter;
 import static org.neo4j.helpers.collection.Iterables.single;
-import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.MASTER;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.getServerId;
-import static org.neo4j.kernel.ha.cluster.member.ClusterMembers.inRole;
+import static org.neo4j.kernel.ha.cluster.member.ClusterMembers.hasInstanceId;
 import static org.neo4j.kernel.impl.store.NeoStore.isStorePresent;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 
@@ -339,7 +338,7 @@ public class SwitchToSlave
         try
         {
             console.log( "Checking store consistency with master" );
-            checkMyStoreIdAndMastersStoreId( neoDataSource, masterIsOld );
+            checkMyStoreIdAndMastersStoreId( neoDataSource, masterIsOld, masterUri );
             checkDataConsistencyWithMaster( masterUri, masterClient, neoDataSource, txIdStore );
             console.log( "Store is consistent" );
         }
@@ -373,14 +372,18 @@ public class SwitchToSlave
         }
     }
 
-    private void checkMyStoreIdAndMastersStoreId( NeoStoreDataSource neoDataSource, boolean masterIsOld )
+    private void checkMyStoreIdAndMastersStoreId( NeoStoreDataSource neoDataSource, boolean masterIsOld, URI masterUri )
     {
         if ( !masterIsOld )
         {
             StoreId myStoreId = neoDataSource.getStoreId();
 
             ClusterMembers clusterMembers = resolver.resolveDependency( ClusterMembers.class );
-            ClusterMember master = single( filter( inRole( MASTER ), clusterMembers.getMembers() ) );
+
+            ClusterMember master = single(
+                    filter( hasInstanceId( HighAvailabilityModeSwitcher.getServerId( masterUri ) ),
+                            clusterMembers.getMembers() ) );
+
             StoreId masterStoreId = master.getStoreId();
 
             if ( !myStoreId.equals( masterStoreId ) )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
@@ -65,6 +65,18 @@ public class ClusterMembers
         };
     }
 
+    public static Predicate<ClusterMember> hasInstanceId( final InstanceId instanceId )
+    {
+        return new Predicate<ClusterMember>()
+        {
+            @Override
+            public boolean accept( ClusterMember item )
+            {
+                return item.getInstanceId().equals( instanceId );
+            }
+        };
+    }
+
     private final Map<InstanceId, ClusterMember> members = new CopyOnWriteHashMap<>();
 
     public ClusterMembers( Cluster cluster, Heartbeat heartbeat, ClusterMemberEvents events, InstanceId me )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.ha.cluster;
 
-import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -36,6 +31,11 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
@@ -91,6 +91,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.MASTER;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.SLAVE;
 
@@ -736,7 +737,7 @@ public class HighAvailabilityMemberStateMachineTest
         public void switchToSlave( InstanceId me )
         {
             InstanceId someOneElseThanMyself = new InstanceId( me.toIntegerIndex() + 1 );
-            listener.memberIsAvailable( "master", someOneElseThanMyself, URI.create( "http://127.0.0.1:2390" ), null );
+            listener.memberIsAvailable( "master", someOneElseThanMyself, URI.create( "cluster://127.0.0.1:2390?serverId=2" ), null );
             listener.memberIsAvailable( "slave", me, null, null );
         }
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.backup.OnlineBackupKernelExtension;
+import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.com.Response;
 import org.neo4j.com.monitor.RequestMonitor;
@@ -110,7 +111,7 @@ public class SwitchToSlaveTest
         // When
         try
         {
-            switchToSlave.checkDataConsistency( masterClient, neoStoreDataSource, null, false );
+            switchToSlave.checkDataConsistency( masterClient, neoStoreDataSource, new URI("cluster://localhost?serverId=1"), false );
             fail( "Should have thrown " + MismatchingStoreIdException.class.getSimpleName() + " exception" );
         }
         catch ( MismatchingStoreIdException e )
@@ -193,13 +194,14 @@ public class SwitchToSlaveTest
 
         verify( updatePuller ).tryPullUpdates();
         verify( communicationLife ).add( pullerScheduler );
-        verify( jobScheduler ).scheduleRecurring( eq(JobScheduler.Group.pullUpdates), any(Runnable.class), eq( 10l ),
+        verify( jobScheduler ).scheduleRecurring( eq( JobScheduler.Group.pullUpdates ), any( Runnable.class ),
+                eq( 10l ),
                 eq( 10l ), eq( TimeUnit.MILLISECONDS ) );
     }
 
     private URI getLocalhostUri() throws URISyntaxException
     {
-        return new URI( "127.0.0.1" );
+        return new URI( "cluster://127.0.0.1?serverId=1" );
     }
 
     @SuppressWarnings( "unchecked" )
@@ -271,6 +273,7 @@ public class SwitchToSlaveTest
         when( master.getStoreId() ).thenReturn( storeId );
         when( master.getHARole() ).thenReturn( HighAvailabilityModeSwitcher.MASTER );
         when( master.hasRole( eq( HighAvailabilityModeSwitcher.MASTER ) ) ).thenReturn( true );
+        when( master.getInstanceId() ).thenReturn( new InstanceId(1) );
         when( clusterMembers.getMembers() ).thenReturn( Collections.singleton( master ) );
         when( resolver.resolveDependency( ClusterMembers.class ) ).thenReturn( clusterMembers );
 

--- a/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.ha;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.io.File;
-import java.io.IOException;
 
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.Transaction;


### PR DESCRIPTION
MemberIsAvailable/MemberIsUnavailable messages could arrive out of order if an instance is switching to master and another instance is elected as master (first unavailable, then available). This fixes so that messages are sent on the state switching thread, so the order is correct.

Also, ProtocolServer.msgLog was a GC root, causing OOMs. Clear on shutdown to fix.

Do not forward merge this!
