### PR TITLE
Add deprecated cache_type setting

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.graphdb.factory;
 
-import org.apache.commons.lang3.SystemUtils;
-
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 import java.util.List;
+
+import org.apache.commons.lang3.SystemUtils;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.kernel.configuration.ConfigurationMigrator;
@@ -70,6 +70,12 @@ public abstract class GraphDatabaseSettings
     @Description("Only allow read operations from this Neo4j instance. "
             + "This mode still requires write access to the directory for lock purposes.")
     public static final Setting<Boolean> read_only = setting( "read_only", BOOLEAN, FALSE );
+
+    @Deprecated
+    @Description( "The type of cache to use for nodes and relationships. " +
+                  "This configuration setting is no longer applicable from Neo4j 2.3. " +
+                  "Configuration has been simplified to only require tuning of the page cache." )
+    public static final Setting<String> cache_type = setting( "cache_type", STRING, "deprecated" );
 
     @Description("Print out the effective Neo4j configuration after startup.")
     public static final Setting<Boolean> dump_configuration = setting("dump_configuration", BOOLEAN, FALSE );

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.configuration;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.Settings;
 
@@ -206,6 +207,34 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
                 }
             }
         });
+
+        add( new SpecificPropertyMigration( "cache_type",
+                "The cache_type setting has been removed as of Neo4j 2.3. " +
+                "Configuration has been simplified to only require tuning of the page cache.")
+        {
+            @Override
+            public boolean appliesTo( Map<String,String> rawConfiguration )
+            {
+                String value = rawConfiguration.get( "cache_type" );
+                if ( value == null )
+                {
+                    // differentiate between the setting not being set, and it being set to null
+                    return rawConfiguration.containsKey( "cache_type" );
+                }
+                if ( GraphDatabaseSettings.cache_type.getDefaultValue().equals( value ) )
+                {
+                    // remove the default value, but don't issue a warning.
+                    rawConfiguration.remove( "cache_type" );
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public void setValueWithOldSetting( String value, Map<String,String> rawConfiguration )
+            {
+            }
+        } );
     }
 
     @Deprecated


### PR DESCRIPTION
This is useful for backwards compatibility with older versions of Neo4j. If the deprecated cache_type setting is used, Neo4j will log a warning.
