### PR TITLE
Moved the MemoryManager from the io module to the unsafe module and make it public

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
@@ -29,6 +29,7 @@ import org.neo4j.io.pagecache.tracing.EvictionEvent;
 import org.neo4j.io.pagecache.tracing.FlushEvent;
 import org.neo4j.io.pagecache.tracing.FlushEventOpportunity;
 import org.neo4j.io.pagecache.tracing.PageFaultEvent;
+import org.neo4j.unsafe.impl.internal.dragons.MemoryManager;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 import static java.lang.String.format;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -40,6 +40,7 @@ import org.neo4j.io.pagecache.tracing.FlushEventOpportunity;
 import org.neo4j.io.pagecache.tracing.MajorFlushEvent;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.PageFaultEvent;
+import org.neo4j.unsafe.impl.internal.dragons.MemoryManager;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 /**

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
@@ -17,9 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.io.pagecache.impl.muninn;
-
-import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
+package org.neo4j.unsafe.impl.internal.dragons;
 
 /**
  * The memory manager is simple: it only allocates memory, until it itself is finalizable and frees it all in one go.
@@ -29,7 +27,7 @@ import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
  *
  * The memory manager assumes that the memory claimed from it is evenly divisible in units of pages.
  */
-final class MemoryManager
+public final class MemoryManager
 {
     private static final long GRAB_SIZE = 32 * 1024 * 1024; // 32 MiB
 

--- a/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManagerTest.java
+++ b/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManagerTest.java
@@ -17,15 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.io.pagecache.impl.muninn;
+package org.neo4j.unsafe.impl.internal.dragons;
 
 import org.junit.Test;
 
-import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
-
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class MemoryManagerTest
 {


### PR DESCRIPTION
Because the page cache might not be the only thing that is interested in allocating alligned memory.
