### PR TITLE
Do several retries on lock file deletion and throw actual file deletion exception

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/fs/FileLock.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileLock.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
 
 public abstract class FileLock
 {
@@ -186,9 +187,9 @@ public abstract class FileLock
                 }
                 finally
                 {
-                    if ( !lockFile.delete() )
+                    if (!FileUtils.deleteFile( lockFile ))
                     {
-                        throw new IOException( "Couldn't delete lock file " + lockFile.getAbsolutePath() );
+                        Files.delete(lockFile.toPath());
                     }
                 }
             }


### PR DESCRIPTION
In case if fail to delete a file actual exception should help us to find a root cause.
