### PR TITLE
Force elect a demoted node if it is the only option. 

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/BiasedWinnerStrategy.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/BiasedWinnerStrategy.java
@@ -40,12 +40,12 @@ public class BiasedWinnerStrategy implements WinnerStrategy
         this.nodePromoted = nodePromoted;
     }
 
-    public static BiasedWinnerStrategy promotion(ClusterContext clusterContext, InstanceId biasedNode)
+    public static BiasedWinnerStrategy promotion( ClusterContext clusterContext, InstanceId biasedNode )
     {
         return new BiasedWinnerStrategy( clusterContext, biasedNode, true );
     }
 
-    public static BiasedWinnerStrategy demotion(ClusterContext clusterContext, InstanceId biasedNode)
+    public static BiasedWinnerStrategy demotion( ClusterContext clusterContext, InstanceId biasedNode )
     {
         return new BiasedWinnerStrategy( clusterContext, biasedNode, false );
     }
@@ -55,9 +55,9 @@ public class BiasedWinnerStrategy implements WinnerStrategy
     {
         List<Vote> eligibleVotes = ElectionContextImpl.removeBlankVotes( votes );
 
-        moveMostSuitableCandidatesToTop(eligibleVotes);
+        moveMostSuitableCandidatesToTop( eligibleVotes );
 
-        logElectionOutcome(votes, eligibleVotes);
+        logElectionOutcome( votes, eligibleVotes );
 
         for ( Vote vote : eligibleVotes )
         {
@@ -66,6 +66,12 @@ public class BiasedWinnerStrategy implements WinnerStrategy
             {
                 return vote.getSuggestedNode();
             }
+        }
+
+        // None were chosen - try again, without considering promotions or demotions
+        for ( Vote vote : eligibleVotes )
+        {
+            return vote.getSuggestedNode();
         }
 
         return null;

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
@@ -40,7 +40,7 @@ import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.test.TargetDirectory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.fromXml;
@@ -73,7 +73,6 @@ public class TestSlaveOnlyCluster
 
             cluster.await( allSeesAllAsAvailable() );
 
-            clusterManager.getDefaultCluster().await( ClusterManager.allSeesAllAsAvailable() );
             long nodeId = createNodeWithPropertyOn( cluster.getAnySlave(), PROPERTY, VALUE );
 
             try ( Transaction ignore = master.beginTx() )


### PR DESCRIPTION
If a demoted node is the only choice in an election, for example in a cluster where all other nodes are slave-only instances, then the demoted node needs to be chosen, or the cluster will just stop.
