### PR TITLE
Prevent concurrent rotations of count store.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -50,7 +50,6 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.register.Register;
 
 import static java.lang.String.format;
-
 import static org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory.indexSampleKey;
 import static org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory.indexStatisticsKey;
 import static org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory.nodeKey;
@@ -138,15 +137,6 @@ public class CountsTracker extends AbstractKeyValueStore<CountsKey>
             }
         } );
         return this;
-    }
-
-    /**
-     * @param txId the lowest transaction id that must be included in the snapshot created by the rotation.
-     * @return the highest transaction id that was included in the snapshot created by the rotation.
-     */
-    public long rotate( long txId ) throws IOException
-    {
-        return prepareRotation( txId ).rotate();
     }
 
     public long txId()

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/ArrayEncoderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/ArrayEncoderTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 import org.neo4j.function.Function;
 import org.neo4j.helpers.ArrayUtil;
-import org.neo4j.test.ThreadingRule;
+import org.neo4j.test.ExecutorRule;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 public class ArrayEncoderTest
 {
     @Rule
-    public final ThreadingRule threads = new ThreadingRule();
+    public final ExecutorRule threads = new ExecutorRule();
 
 
     private static final Character[] base64chars = new Character[]{

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/RelationshipCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/RelationshipCountsTest.java
@@ -40,7 +40,7 @@ import org.neo4j.test.Barrier;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.ImpermanentDatabaseRule;
 import org.neo4j.test.NamedFunction;
-import org.neo4j.test.ThreadingRule;
+import org.neo4j.test.ExecutorRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.graphdb.DynamicLabel.label;
@@ -48,8 +48,10 @@ import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
 public class RelationshipCountsTest
 {
-    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
-    public final @Rule ThreadingRule threading = new ThreadingRule();
+    @Rule
+    public final DatabaseRule db = new ImpermanentDatabaseRule();
+    @Rule
+    public final ExecutorRule executorRule = new ExecutorRule();
 
     @Test
     public void shouldReportNumberOfRelationshipsInAnEmptyGraph() throws Exception
@@ -126,7 +128,7 @@ public class RelationshipCountsTest
         GraphDatabaseService graphDb = db.getGraphDatabaseService();
         final Barrier.Control barrier = new Barrier.Control();
         long before = numberOfRelationships();
-        Future<Long> tx = threading.execute( new NamedFunction<GraphDatabaseService, Long>( "create-relationships" )
+        Future<Long> tx = executorRule.execute( new NamedFunction<GraphDatabaseService, Long>( "create-relationships" )
         {
             @Override
             public Long apply( GraphDatabaseService graphDb )
@@ -175,7 +177,7 @@ public class RelationshipCountsTest
         }
         final Barrier.Control barrier = new Barrier.Control();
         long before = numberOfRelationships();
-        Future<Long> tx = threading.execute( new NamedFunction<GraphDatabaseService, Long>( "create-relationships" )
+        Future<Long> tx = executorRule.execute( new NamedFunction<GraphDatabaseService, Long>( "create-relationships" )
         {
             @Override
             public Long apply( GraphDatabaseService graphDb )

--- a/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.ImpermanentDatabaseRule;
-import org.neo4j.test.ThreadingRule;
+import org.neo4j.test.ExecutorRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -46,7 +46,7 @@ public class ConstraintIndexConcurrencyTest
     @Rule
     public final DatabaseRule db = new ImpermanentDatabaseRule();
     @Rule
-    public final ThreadingRule threads = new ThreadingRule();
+    public final ExecutorRule executorRule = new ExecutorRule();
 
     @Test
     public void shouldNotAllowConcurrentViolationOfConstraint() throws Exception
@@ -79,7 +79,7 @@ public class ConstraintIndexConcurrencyTest
                     "The value is irrelevant, we just want to perform some sort of lookup against this index" );
 
             // then let another thread come in and create a node
-            threads.execute( createNode( label, propertyKey, conflictingValue ), graphDb ).get();
+            executorRule.execute( createNode( label, propertyKey, conflictingValue ), graphDb ).get();
 
             // before we create a node with the same property ourselves - using the same statement that we have
             // already used for lookup against that very same index

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.neo4j.function.Function;
 import org.neo4j.kernel.impl.locking.Locks;
-import org.neo4j.test.ThreadingRule;
+import org.neo4j.test.ExecutorRule;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -49,7 +49,7 @@ public class ConversationTest
     @InjectMocks
     private Conversation conversation;
     @Rule
-    public ThreadingRule threadingRule = new ThreadingRule();
+    public ExecutorRule executorRule = new ExecutorRule();
 
     @Test
     public void stopAlreadyClosedConversationDoNotTouchLocks()
@@ -103,10 +103,10 @@ public class ConversationTest
             }
         } ).when( client ).close();
 
-        threadingRule.execute( stopConversation(), conversation );
+        executorRule.execute( stopConversation(), conversation );
 
         stopReadyLatch.await();
-        threadingRule.execute( closeConversation(), conversation );
+        executorRule.execute( closeConversation(), conversation );
 
         long raceStartTime = System.currentTimeMillis();
         stopLatch.countDown();

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintVerificationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyExistenceConstraintVerificationIT.java
@@ -45,7 +45,7 @@ import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.impl.api.OperationsFacade;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ThreadingRule;
+import org.neo4j.test.ExecutorRule;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -57,7 +57,7 @@ import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.kernel.impl.api.integrationtest.PropertyExistenceConstraintVerificationIT.NodePropertyExistenceExistenceConstrainVerificationIT;
 import static org.neo4j.kernel.impl.api.integrationtest.PropertyExistenceConstraintVerificationIT.RelationshipPropertyExistenceExistenceConstrainVerificationIT;
-import static org.neo4j.test.ThreadingRule.waitingWhileIn;
+import static org.neo4j.test.ExecutorRule.waitingWhileIn;
 
 @RunWith( Suite.class )
 @SuiteClasses( {
@@ -147,7 +147,7 @@ public class PropertyExistenceConstraintVerificationIT
         @Rule
         public final DatabaseRule db = new EnterpriseDatabaseRule();
         @Rule
-        public final ThreadingRule thread = new ThreadingRule();
+        public final ExecutorRule executorRule = new ExecutorRule();
 
         abstract void createConstraint( DatabaseRule db, String key, String property );
 
@@ -199,7 +199,7 @@ public class PropertyExistenceConstraintVerificationIT
                 {
                     createConstraint( db, KEY, PROPERTY );
 
-                    nodeCreation = thread.executeAndAwait( createOffender(), null,
+                    nodeCreation = executorRule.executeAndAwait( createOffender(), null,
                             waitingWhileIn( OperationsFacade.class, offenderCreationMethodName() ), 5, SECONDS );
 
                     tx.success();
@@ -233,7 +233,7 @@ public class PropertyExistenceConstraintVerificationIT
                 {
                     createOffender( db, KEY );
 
-                    constraintCreation = thread.executeAndAwait( createConstraint(), null,
+                    constraintCreation = executorRule.executeAndAwait( createConstraint(), null,
                             waitingWhileIn( OperationsFacade.class, constraintCreationMethodName() ), 5, SECONDS );
 
                     tx.success();
@@ -292,11 +292,9 @@ public class PropertyExistenceConstraintVerificationIT
                 {
                     try ( Transaction tx = db.beginTx() )
                     {
-                        System.out.println("creating constraint");
                         createConstraint( db, KEY, PROPERTY );
                         tx.success();
                     }
-                    System.out.println("constraint created");
                     return null;
                 }
             };


### PR DESCRIPTION
Introduce separate count store rotation lock to prevent cases
when count store rotation failed when called from different threads.
Now those threads will execute rotation in sequential order.
From now on clients should use rotate method to perform count store rotation.

Reshape threading rule: rename, add support for Callable, cleanup.
