### PR TITLE
New operator MergeInto

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeIntoAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeIntoAcceptanceTest.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.ExecutionEngineFunSuite
+
+class MergeIntoAcceptanceTest extends ExecutionEngineFunSuite{
+
+  test("ON CREATE with update one property") {
+    //given
+    createNode("A")
+    createNode("B")
+
+    //when
+    val update = execute("""MATCH (a {name:'A'}), (b {name:'B'})
+      |MERGE (a)-[r:TYPE]->(b) ON CREATE SET r.name = 'foo'""".stripMargin)
+
+    //then
+    update should use("Merge(Into)")
+    val res = execute("MATCH ()-[r:TYPE]->() RETURN extract(key IN keys(r)| key + '->' + r[key]) as keyValue")
+    res.toList should equal(List(Map("keyValue" -> Seq("name->foo"))))
+  }
+
+  test("ON CREATE with deleting one property") {
+    //given
+    createNode("A")
+    createNode("B")
+
+    //when
+    val update = execute("""MATCH (a {name:'A'}), (b {name:'B'})
+                           |MERGE (a)-[r:TYPE]->(b) ON CREATE SET r.name = null""".stripMargin)
+
+    //then
+    update should use("Merge(Into)")
+    val res = execute("MATCH ()-[r:TYPE]->() RETURN extract(key IN keys(r)| key + '->' + r[key]) as keyValue")
+    res.toList should equal(List(Map("keyValue" -> Seq.empty)))
+  }
+
+  test("ON CREATE with update all properties from node") {
+    //given
+    createNode("A")
+    createNode("B")
+
+    //when
+    val update = execute("MATCH (a {name:'A'}), (b {name:'B'}) MERGE (a)-[r:TYPE]->(b) ON CREATE SET r = a")
+
+    //then
+    update should use("Merge(Into)")
+    val res = execute("MATCH ()-[r:TYPE]->() RETURN extract(key IN keys(r)| key + '->' + r[key]) as keyValue")
+    res.toList should equal(List(Map("keyValue" -> Seq("name->A"))))
+  }
+
+  test("ON MATCH with update all properties from node") {
+    //note the props here should be overwritten with ON MATCH
+    relate(createNode("A"), createNode("B"), "TYPE", Map("foo" -> "bar"))
+
+    //when
+    val update = execute("MATCH (a {name:'A'}), (b {name:'B'}) MERGE (a)-[r:TYPE]->(b) ON MATCH SET r = a")
+
+    //then
+    update should use("Merge(Into)")
+    val res = execute("MATCH ()-[r:TYPE]->() RETURN extract(key IN keys(r)| key + '->' + r[key]) as keyValue")
+    res.toList should equal(List(Map("keyValue" -> Seq("name->A"))))
+  }
+
+  test("ON CREATE with update properties from literal map") {
+    //given
+    createNode("A")
+    createNode("B")
+
+    //when
+    val update = execute("""MATCH (a {name:'A'}), (b {name:'B'})
+      |MERGE (a)-[r:TYPE]->(b) ON CREATE SET r += {foo: 'bar', bar: 'baz'}""".stripMargin)
+
+    //then
+    update should use("Merge(Into)")
+    val res = execute("MATCH ()-[r:TYPE]->() RETURN extract(key IN keys(r)| key + '->' + r[key]) as keyValue")
+    res.toList should equal(List(Map("keyValue" -> Seq("foo->bar", "bar->baz"))))
+  }
+
+
+  test("ON MATCH with update properties from literal map") {
+    //given
+    relate(createNode("A"), createNode("B"), "TYPE", Map("foo" -> "bar"))
+
+    //when
+    val update = execute("""MATCH (a {name:'A'}), (b {name:'B'})
+                           |MERGE (a)-[r:TYPE]->(b) ON MATCH SET r += {foo: 'baz', bar: 'baz'}""".stripMargin)
+
+    //then
+    update should use("Merge(Into)")
+    val res = execute("MATCH ()-[r:TYPE]->() RETURN extract(key IN keys(r)| key + '->' + r[key]) as keyValue")
+    res.toList should equal(List(Map("keyValue" -> Seq("foo->baz", "bar->baz"))))
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/LabelAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/LabelAction.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{WritesNodesWithLabels, Effect, Effects}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{CastSupport, CollectionSupport}
-import org.neo4j.cypher.internal.compiler.v2_3.mutation.{GraphElementPropertyFunctions, UpdateAction}
+import org.neo4j.cypher.internal.compiler.v2_3.mutation.{SetAction}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.graphdb.Node
@@ -36,7 +36,7 @@ case object LabelRemoveOp extends LabelOp
 
 //TODO: Should take single label
 case class LabelAction(entity: Expression, labelOp: LabelOp, labels: Seq[KeyToken])
-  extends UpdateAction with GraphElementPropertyFunctions with CollectionSupport {
+  extends SetAction with CollectionSupport {
 
   def localEffects(ignored: SymbolTable) = Effects(labels.map(l => WritesNodesWithLabels(l.name)).toSet[Effect])
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/MergeAst.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/MergeAst.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.predicates.{Equals, HasLabel}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.TokenType.PropertyKey
-import org.neo4j.cypher.internal.compiler.v2_3.mutation.{MergeNodeAction, MergePatternAction, PropertySetAction, UpdateAction}
+import org.neo4j.cypher.internal.compiler.v2_3.mutation.{SetAction, MergeNodeAction, MergePatternAction, PropertySetAction, UpdateAction}
 import org.neo4j.cypher.internal.frontend.v2_3.PatternException
 
 case class MergeAst(patterns: Seq[AbstractPattern],
@@ -71,9 +71,9 @@ case class MergeAst(patterns: Seq[AbstractPattern],
     if (!matches.exists(_.isInstanceOf[RelatedTo]))
       None
     else
-      Some(MergePatternAction(matches, create ++ getActionsFor(On.Create), getActionsFor(On.Match)))
+      Some(MergePatternAction(matches, create, getActionsFor(On.Create), getActionsFor(On.Match)))
 
-  private def getActionsFor(action:Action): Seq[UpdateAction] = onActions.collect {
+  private def getActionsFor(action:Action): Seq[SetAction] = onActions.collect {
     case p if p.verb == action => p.set
   }.flatten
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/LegacyExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/LegacyExecutablePlanBuilder.scala
@@ -176,6 +176,7 @@ The Neo4j Team""")
   private def updates = new Phase {
     def myBuilders: Seq[PlanBuilder] = Seq(
       new NamedPathBuilder,
+      new MergeIntoBuilder,
       new MergePatternBuilder(prepare andThen matching),
       new UpdateActionBuilder
     )

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/MergeIntoBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/MergeIntoBuilder.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.executionplan.builders
+
+import org.neo4j.cypher.internal.compiler.v2_3.commands.RelatedTo
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
+import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{KeyToken, UnresolvedProperty}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ExecutionPlanInProgress, PlanBuilder}
+import org.neo4j.cypher.internal.compiler.v2_3.mutation.MergePatternAction
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.{MergeIntoPipe, PipeMonitor}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
+
+class MergeIntoBuilder extends PlanBuilder {
+  override def canWorkWith(plan: ExecutionPlanInProgress, ctx: PlanContext)(implicit pipeMonitor: PipeMonitor) =
+    plan.query.updates.exists {
+      case Unsolved(merge@MergePatternAction(_, _, _, _, _, _)) => canWorkWith(merge, plan.pipe.symbols)
+      case _ => false
+    }
+
+  override def apply(plan: ExecutionPlanInProgress, ctx: PlanContext)(implicit pipeMonitor: PipeMonitor) = {
+    val (relatedTo, queryToken, merge)= plan.query.updates.collectFirst {
+      case token@Unsolved(merge@MergePatternAction(_, _, _, _, _, _)) if canWorkWith(merge, plan.pipe.symbols) =>
+        (merge.patterns.head.asInstanceOf[RelatedTo], token, merge)
+    }.get
+
+    val props: Map[KeyToken, Expression] = relatedTo.properties.map {
+      case (key, value) => resolve(ctx)(key) -> value
+    }.toMap
+
+    val mergePipe = MergeIntoPipe(plan.pipe, relatedTo.left.name,
+      relatedTo.relName, relatedTo.right.name, relatedTo.direction,
+      relatedTo.relTypes.head, props, merge.onCreate, merge.onMatch)()
+
+    //mark as solved
+    val newUpdates = plan.query.updates.replace(queryToken, queryToken.solve)
+
+    plan.copy(
+      pipe = mergePipe,
+      query = plan.query.copy(updates = newUpdates),
+      isUpdating = true
+    )
+  }
+
+  private def resolve(ctx: PlanContext)(key: String) = UnresolvedProperty(key).resolve(ctx)
+
+  private def canWorkWith(m: MergePatternAction, s: SymbolTable): Boolean =
+    m.patterns.size == 1 &&
+      m.patterns.forall {
+        case r: RelatedTo => s.hasIdentifierNamed(r.left.name) && s.hasIdentifierNamed(r.right.name)
+        case _ => false
+      }
+}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/MergePatternBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/MergePatternBuilder.scala
@@ -45,7 +45,7 @@ case class MergePatternBuilder(matching: Phase) extends PlanBuilder with Collect
 
   def apply(plan: ExecutionPlanInProgress, ctx: PlanContext)(implicit pipeMonitor: PipeMonitor): ExecutionPlanInProgress = {
     def prepareMergeAction(symbols: SymbolTable, originalMerge: MergePatternAction): (SymbolTable, MergePatternAction) = {
-      val (newSymbols,updateActions) = MergePatternBuilder.createActions(symbols, originalMerge.actions)
+      val (newSymbols,updateActions) = MergePatternBuilder.createActions(symbols, originalMerge.actions ++ originalMerge.onCreate)
       val matchPipe = solveMatchQuery(symbols, originalMerge).pipe
       val preparedMerge = originalMerge.copy(maybeMatchPipe = Some(matchPipe), maybeUpdateActions = Some(updateActions))
       (newSymbols, preparedMerge)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MapPropertySetAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/MapPropertySetAction.scala
@@ -33,7 +33,7 @@ import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 import scala.collection.Map
 
 case class MapPropertySetAction(element: Expression, mapExpression: Expression, removeOtherProps:Boolean)
-  extends UpdateAction with GraphElementPropertyFunctions with MapSupport {
+  extends SetAction with MapSupport {
 
   def exec(context: ExecutionContext, state: QueryState) = {
     val qtx = state.query
@@ -98,7 +98,7 @@ case class MapPropertySetAction(element: Expression, mapExpression: Expression, 
 
   def children = Seq(element, mapExpression)
 
-  def rewrite(f: (Expression) => Expression) = MapPropertySetAction(element.rewrite(f), mapExpression.rewrite(f), removeOtherProps)
+  def rewrite(f: (Expression) => Expression): MapPropertySetAction = MapPropertySetAction(element.rewrite(f), mapExpression.rewrite(f), removeOtherProps)
 
   def symbolTableDependencies = element.symbolTableDependencies ++ mapExpression.symbolTableDependencies
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/PropertySetAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/PropertySetAction.scala
@@ -27,8 +27,8 @@ import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.graphdb.{Node, Relationship}
 import org.neo4j.helpers.ThisShouldNotHappenError
 
-case class PropertySetAction(prop: Property, e: Expression)
-  extends UpdateAction with GraphElementPropertyFunctions {
+case class PropertySetAction(prop: Property, valueExpression: Expression)
+  extends SetAction {
 
   val Property(mapExpr, propertyKey) = prop
 
@@ -47,7 +47,7 @@ case class PropertySetAction(prop: Property, e: Expression)
         case _ => throw new ThisShouldNotHappenError("Stefan", "This should be a node or a relationship")
       }
 
-      makeValueNeoSafe(e(context)) match {
+      makeValueNeoSafe(valueExpression(context)) match {
         case null => propertyKey.getOptId(qtx).foreach(ops.removeProperty(id, _))
         case value => ops.setProperty(id, propertyKey.getOrCreateId(qtx), value)
       }
@@ -58,9 +58,9 @@ case class PropertySetAction(prop: Property, e: Expression)
 
   def identifiers = Nil
 
-  def children = Seq(prop, e)
+  def children = Seq(prop, valueExpression)
 
-  def rewrite(f: (Expression) => Expression): UpdateAction = PropertySetAction(prop, e.rewrite(f))
+  def rewrite(f: (Expression) => Expression): PropertySetAction = PropertySetAction(prop, valueExpression.rewrite(f))
 
-  def symbolTableDependencies = prop.symbolTableDependencies ++ e.symbolTableDependencies
+  def symbolTableDependencies = prop.symbolTableDependencies ++ valueExpression.symbolTableDependencies
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/SetAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/SetAction.scala
@@ -17,21 +17,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v2_3
+package org.neo4j.cypher.internal.compiler.v2_3.mutation
 
-import org.neo4j.cypher.internal.compiler.v2_3.mutation.SetAction
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
 
-case class OnAction(verb: Action, set: Seq[SetAction])
-
-trait Action
-
-object On {
-
-  case object Create extends Action
-
-  case object Match extends Action
-
+trait SetAction extends UpdateAction with GraphElementPropertyFunctions {
+  def rewrite(f: (Expression) => Expression): SetAction
 }
-
-
-

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExecuteUpdateCommandsPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExecuteUpdateCommandsPipe.scala
@@ -91,7 +91,7 @@ trait NoLushEntityCreation {
       Seq(NamedExpectation(key, props, Seq.empty)) ++ extractIfEntity(from) ++ extractIfEntity(to)
     case CreateUniqueAction(links@_*) =>
       links.flatMap(l => Seq(l.start, l.end, l.rel))
-    case MergePatternAction(_, _, _, Some(updates), _) =>
+    case MergePatternAction(_, _, _, _, Some(updates), _) =>
       updates.flatMap(extractEntities)
     case _ =>
       Seq()

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipe.scala
@@ -129,4 +129,3 @@ case class LoadCSVPipe(source: Pipe,
     copy(source = head)
   }
 }
-

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
@@ -46,6 +46,8 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
 
   def createRelationship(start: Node, end: Node, relType: String): Relationship = singleDbHit(inner.createRelationship(start, end, relType))
 
+  override def createRelationship(start: Long, end: Long, relType: Int): Relationship = singleDbHit(inner.createRelationship(start, end, relType))
+
   def getOrCreateRelTypeId(relTypeName: String): Int = singleDbHit(inner.getOrCreateRelTypeId(relTypeName))
 
   def getLabelsForNode(node: Long): Iterator[Int] = singleDbHit(inner.getLabelsForNode(node))

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
@@ -49,6 +49,8 @@ trait QueryContext extends TokenContext {
 
   def createRelationship(start: Node, end: Node, relType: String): Relationship
 
+  def createRelationship(start: Long, end: Long, relType: Int): Relationship
+
   def getOrCreateRelTypeId(relTypeName: String): Int
 
   def getRelationshipsForIds(node: Node, dir: SemanticDirection, types: Option[Seq[Int]]): Iterator[Relationship]

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/UpdateCountingQueryContext.scala
@@ -78,6 +78,11 @@ class UpdateCountingQueryContext(inner: QueryContext) extends DelegatingQueryCon
     inner.createRelationship(start, end, relType)
   }
 
+  override def createRelationship(start: Long, end: Long, relType: Int) = {
+    relationshipsCreated.increase()
+    inner.createRelationship(start, end, relType)
+  }
+
   override def removeLabelsFromNode(node: Long, labelIds: Iterator[Int]): Int = {
     val removed = inner.removeLabelsFromNode(node, labelIds)
     labelsRemoved.increase(removed)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/PartiallySolvedQueryTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/PartiallySolvedQueryTest.scala
@@ -125,5 +125,5 @@ class PartiallySolvedQueryTest extends CypherFunSuite {
 
   private def mergeNode(name: String) = MergeNodeAction(name, Map.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, None)
 
-  private def mergePattern(pattern: Pattern) = MergePatternAction(Seq(pattern), Seq.empty, Seq.empty)
+  private def mergePattern(pattern: Pattern) = MergePatternAction(Seq(pattern), Seq.empty, Seq.empty, Seq.empty)
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/MergeIntoBuilderTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/MergeIntoBuilderTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.executionplan.builders
+
+import org.neo4j.cypher.internal.compiler.v2_3.commands.{RelatedTo, AllNodes}
+import org.neo4j.cypher.internal.compiler.v2_3.mutation.{MergePatternAction}
+import org.neo4j.cypher.internal.compiler.v2_3.pipes.MergeIntoPipe
+import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
+import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
+
+class MergeIntoBuilderTest extends BuilderTest {
+  override def builder = new MergeIntoBuilder
+  context = mock[PlanContext]
+
+  test("should not take on a plan without MERGE between two nodes") {
+    val q = newQuery(start = Seq(AllNodes("x")))
+
+    assertRejects(q)
+  }
+
+  test("should not take on a plan MERGE between two nodes when the nodes have not yet been bound") {
+
+    val r = RelatedTo("a", "b", "r", "T", SemanticDirection.OUTGOING)
+    val mergeP = MergePatternAction(patterns = Seq(r), actions = Seq.empty, Seq.empty, Seq.empty)
+
+    val q = newQuery(
+      start = Seq(AllNodes("a"), AllNodes("b")),
+      updates = Seq(mergeP)
+    )
+
+    val p = createPipe(nodes = Seq("a"))
+
+    assertRejects(p, q)
+  }
+
+  test("should take on a plan MERGE between two nodes when the nodes have not yet been bound") {
+
+    val r = RelatedTo("a", "b", "r", "T", SemanticDirection.OUTGOING)
+    val mergeP = MergePatternAction(patterns = Seq(r), actions = Seq.empty, Seq.empty, Seq.empty)
+
+    val q = newQuery(
+      start = Seq(AllNodes("a"), AllNodes("b")),
+      updates = Seq(mergeP)
+    )
+
+    val p = createPipe(nodes = Seq("a", "b"))
+
+    val result = assertAccepts(p, q).pipe
+
+    result should equal (MergeIntoPipe(p, "a", "r", "b", SemanticDirection.OUTGOING, "T", Map.empty, Seq.empty, Seq.empty)())
+  }
+
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipeTest.scala
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.pipes
+
+import org.mockito.Matchers.{any => mockAny, eq => mockEq}
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.mockito.Mockito.{mock => jmock}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
+import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
+import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
+import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
+import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection.{INCOMING, OUTGOING}
+import org.neo4j.cypher.internal.frontend.v2_3.symbols._
+import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.DynamicRelationshipType.withName
+import org.neo4j.graphdb.{Node, Relationship}
+
+import scala.collection
+
+class MergeIntoPipeTest extends CypherFunSuite {
+
+  implicit val monitor = mock[PipeMonitor]
+  val node_a = newMockedNode(1)
+  val node_b = newMockedNode(2)
+  val node_c = newMockedNode(3)
+  val node_d = newMockedNode(4)
+  val rel_a_A_b = newMockedRelationship(1, node_a, node_b, "A")
+  val rel_a_A_c = newMockedRelationship(1, node_a, node_c, "A")
+  val rel_a_B_c = newMockedRelationship(2, node_a, node_c, "B")
+  val rel_a_C_d = newMockedRelationship(3, node_a, node_d, "C")
+  val rel_a_D_a = newMockedRelationship(4, node_a, node_a, "D")
+
+  setupMockingInQueryContext()
+
+  test("should create a relationship when no-one exists between two nodes") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+
+    setUpRelNodesWithoutRelationships(node_a, node_b)
+    setUpCreationOfRelationship(node_a, node_b, rel_a_A_b)
+
+    val left = newMockedPipe("a", 
+      row("a" -> node_a, "b" -> node_b))
+
+    // when
+    val result = createPipeAndRun(query, left, OUTGOING, "A", Map.empty)
+
+    // then
+    val (single :: Nil) = result
+    single.m("a") should equal(node_a)
+    single.m("b") should equal(node_b)
+    single.m("r") should equal(rel_a_A_b)
+  }
+
+  test("should find a matching relationship between two nodes - neither dense") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+
+    markAsNotDense(node_a)
+    markAsNotDense(node_b)
+    setupRelationshipFromNode(node_a, OUTGOING, rel_a_A_b, rel_a_A_c)
+    setupRelationshipFromNode(node_a, OUTGOING, rel_a_B_c)
+    val left = newMockedPipe("a",
+      row("a" -> node_a, "b" -> node_b))
+
+    // when
+    val result = createPipeAndRun(query, left, OUTGOING, "A", Map.empty)
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+  }
+
+  test("should find a matching relationship between two nodes - node_a is dense") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+
+    markAsDense(node_a, 2)
+    markAsNotDense(node_b)
+    setupRelationshipFromNode(node_b, INCOMING, rel_a_A_b)
+    val left = newMockedPipe("a",
+      row("a" -> node_a, "b" -> node_b))
+
+    // when
+    val result = createPipeAndRun(query, left, OUTGOING, "A", Map.empty)
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+  }
+
+  test("should find a matching relationship between two nodes - node_b is dense") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+
+    markAsNotDense(node_a)
+    markAsDense(node_b, 2)
+    setupRelationshipFromNode(node_a, OUTGOING, rel_a_A_b)
+    val left = newMockedPipe("a",
+      row("a" -> node_a, "b" -> node_b))
+
+    // when
+    val result = createPipeAndRun(query, left, OUTGOING, "A", Map.empty)
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+  }
+
+  test("should find a matching relationship between two nodes - both are dense node_a has lower degree") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+
+    markAsDense(node_a, 1)
+    markAsDense(node_b, 2)
+    setupRelationshipFromNode(node_a, OUTGOING, rel_a_A_b)
+    val left = newMockedPipe("a",
+      row("a" -> node_a, "b" -> node_b))
+
+    // when
+    val result = createPipeAndRun(query, left, OUTGOING, "A", Map.empty)
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+  }
+
+  test("should find a matching relationship between two nodes - both are dense node_b has lower degree") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+
+    markAsDense(node_a, 2)
+    markAsDense(node_b, 1)
+    setupRelationshipFromNode(node_b, INCOMING, rel_a_A_b)
+    val left = newMockedPipe("a",
+      row("a" -> node_a, "b" -> node_b))
+
+    // when
+    val result = createPipeAndRun(query, left, OUTGOING, "A", Map.empty)
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+  }
+
+  test("should find a matching relationship between two nodes - both are dense node_a has no matching rel degree zero") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+
+    markAsDense(node_a, 0)
+    markAsDense(node_b, 1)
+    val left = newMockedPipe("a",
+      row("a" -> node_a, "b" -> node_b))
+    setUpCreationOfRelationship(node_a, node_b, rel_a_A_b)
+
+    // when
+    val result = createPipeAndRun(query, left, OUTGOING, "A", Map.empty)
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+  }
+
+  /*
+  correct type, wrong rel-properties
+  matching type and single prop
+  matching type and multiple props
+  
+  execute on create set
+  execute on merge set
+   */
+  private def createPipeAndRun(query: QueryContext, left: Pipe, dir: SemanticDirection = OUTGOING, relType: String, relProperties: Map[String, Expression]): List[ExecutionContext] =
+    MergeIntoPipe(left, "a", "r", "b", dir, relType, relProperties)().createResults(QueryStateHelper.emptyWith(query)).toList
+
+  private def setupRelationshipFromNode(startNode: Node, dir: SemanticDirection, rels: Relationship*)(implicit query: QueryContext) {
+    val typeId = rels.head.getType.name().hashCode
+    when(query.getRelationshipsForIds(startNode, dir, Some(Seq(typeId)))).thenReturn(rels.toIterator)
+  }
+
+  private def markAsNotDense(node: Node)(implicit query: QueryContext) {
+    when(query.nodeIsDense(mockEq(node.getId))).thenReturn(false)
+  }
+
+  private def markAsDense(node: Node, degree: Int)(implicit query: QueryContext) {
+    when(query.nodeIsDense(mockEq(node.getId))).thenReturn(true)
+    when(query.nodeGetDegree(mockEq(node.getId), mockAny(), mockAny())).thenReturn(degree)
+  }
+
+  //
+
+
+  //  test("should return no relationships for types that have not been defined yet") {
+  //    // given
+  //    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Seq.empty)))).thenAnswer(
+  //      new Answer[Iterator[Relationship]] {
+  //        override def answer(invocationOnMock: InvocationOnMock) = Iterator.empty
+  //      })
+  //    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Seq(1, 2))))).thenAnswer(
+  //      new Answer[Iterator[Relationship]] {
+  //        override def answer(invocationOnMock: InvocationOnMock) = Iterator(relationship1, relationship2)
+  //      })
+  //    when(query.nodeGetDegree(any(), any(), any())).thenReturn(1)
+  //
+  //    val pipe = ExpandIntoPipe(newMockedPipe("a", row("a"-> startNode, "b" -> endNode1)), "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes(Seq("FOO", "BAR")))()
+  //
+  //    // when
+  //    when(query.getOptRelTypeId("FOO")).thenReturn(None)
+  //    when(query.getOptRelTypeId("BAR")).thenReturn(None)
+  //    val result1 = pipe.createResults(queryState).toList
+  //
+  //    // when
+  //    when(query.getOptRelTypeId("FOO")).thenReturn(Some(1))
+  //    when(query.getOptRelTypeId("BAR")).thenReturn(Some(2))
+  //    val result2 = pipe.createResults(queryState).toList
+  //
+  //    // then
+  //    result1 should be(empty)
+  //    result2 should not be empty
+  //  }
+  //
+  //  test("should support expand between two nodes with multiple relationships") {
+  //    // given
+  //    setUpRelMockingInQueryContext(relationship1, relationship2, relationship3)
+  //    val left = newMockedPipe("a",
+  //      row("a" -> startNode, "b" -> endNode1),
+  //      row("a" -> startNode, "b" -> endNode2)
+  //    )
+  //
+  //    // when
+  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
+  //
+  //    // then
+  //    val (first :: second :: Nil) = result
+  //    first.m should equal(Map("a" -> startNode, "r" -> relationship1, "b" -> endNode1))
+  //    second.m should equal(Map("a" -> startNode, "r" -> relationship2, "b" -> endNode2))
+  //  }
+  //
+  //  test("should support expand between two nodes with multiple relationships and self loops") {
+  //    // given
+  //    setUpRelMockingInQueryContext(relationship1, selfRelationship, relationship3)
+  //    val left = newMockedPipe("a",
+  //      row("a" -> startNode, "b" -> endNode1),
+  //      row("a" -> startNode, "b" -> startNode)
+  //    )
+  //
+  //    // when
+  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
+  //
+  //    // then
+  //    val (first :: second :: Nil) = result
+  //    first.m should equal(Map("a" -> startNode, "r" -> relationship1, "b" -> endNode1))
+  //    second.m should equal(Map("a" -> startNode, "r" -> selfRelationship, "b" -> startNode))
+  //  }
+  //
+  //  test("given empty input, should return empty output") {
+  //    // given
+  //    setUpRelMockingInQueryContext()
+  //    val left = newMockedPipe("a", row("a" -> null, "b" -> null))
+  //
+  //    // when
+  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
+  //
+  //    // then
+  //    result should be (empty)
+  //  }
+  //
+  //  test("given a null start point, returns an empty iterator") {
+  //    // given
+  //    setUpRelMockingInQueryContext(relationship1)
+  //    val left = newMockedPipe("a",
+  //      row("a" -> null, "b" -> endNode1))
+  //
+  //    // when
+  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
+  //
+  //    // then
+  //    result shouldBe empty
+  //  }
+  //
+  //  test("given a null end point, returns an empty iterator") {
+  //    // given
+  //    setUpRelMockingInQueryContext(relationship1)
+  //    val left = newMockedPipe("a",
+  //      row("a" -> startNode, "b" -> null))
+  //
+  //    // when
+  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
+  //
+  //    // then
+  //    result shouldBe empty
+  //  }
+  //
+  //  test("issue 4692 should respect relationship direction") {
+  //    // Given
+  //    val node0 = newMockedNode(0)
+  //    val node1 = newMockedNode(1)
+  //    val rel0 = newMockedRelationship(0, node0, node1)
+  //    val rel1 = newMockedRelationship(1, node1, node0)
+  //
+  //    setUpRelMockingInQueryContext(rel0, rel1)
+  //
+  //    val source = newMockedPipe(
+  //      Map("n" -> CTNode, "r2" -> CTRelationship, "k" -> CTNode),
+  //      row("n" -> node1, "r2" -> rel1, "k" -> node0),
+  //      row("n" -> node0, "r2" -> rel0, "k" -> node1))
+  //
+  //    // When
+  //    val results = ExpandIntoPipe(source, "n", "r1", "k", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
+  //
+  //    // Then
+  //    results should contain theSameElementsAs List(
+  //      Map("n" -> node1, "k" -> node0, "r1" -> rel1, "r2" -> rel1),
+  //      Map("n" -> node0, "k" -> node1, "r1" -> rel0, "r2" -> rel0))
+  //  }
+  //
+  //  test("should work for bidirectional relationships") {
+  //    // Given
+  //    val node0 = newMockedNode(0)
+  //    val node1 = newMockedNode(1)
+  //    val rel0 = newMockedRelationship(0, node0, node1)
+  //    val rel1 = newMockedRelationship(1, node1, node0)
+  //
+  //    setUpRelMockingInQueryContext(rel0, rel1)
+  //
+  //    val source = newMockedPipe(
+  //      Map("n" -> CTNode, "r2" -> CTRelationship, "k" -> CTNode),
+  //      row("n" -> node1, "r2" -> rel1, "k" -> node0),
+  //      row("n" -> node0, "r2" -> rel0, "k" -> node1))
+  //
+  //    // When
+  //    val results = ExpandIntoPipe(source, "n", "r1", "k", SemanticDirection.BOTH, LazyTypes.empty)().createResults(queryState).toList
+  //
+  //    // Then
+  //    results should contain theSameElementsAs List(
+  //      Map("n" -> node1, "k" -> node0, "r1" -> rel0, "r2" -> rel1),
+  //      Map("n" -> node1, "k" -> node0, "r1" -> rel1, "r2" -> rel1),
+  //      Map("n" -> node0, "k" -> node1, "r1" -> rel1, "r2" -> rel0),
+  //      Map("n" -> node0, "k" -> node1, "r1" -> rel0, "r2" -> rel0))
+  //
+  //    // relationships should be cached after the first call
+  //    verify(query, times(1)).getRelationshipsForIds(any(), mockEq(SemanticDirection.BOTH), mockEq(None))
+  //  }
+
+  private def row(values: (String, Any)*) = ExecutionContext.from(values: _*)
+
+  //  private def setUpRelMockingInQueryContext(rels: Relationship*) {
+  //    val relsByStartNode = rels.groupBy(_.getStartNode)
+  //    val relsByEndNode = rels.groupBy(_.getEndNode)
+  //    val relsByNode = (relsByStartNode.keySet ++ relsByEndNode.keySet).map {
+  //      n => n -> (relsByStartNode.getOrElse(n, Seq.empty) ++ relsByEndNode.getOrElse(n, Seq.empty))
+  //    }.toMap
+  //
+  //    setUpRelLookupMocking(SemanticDirection.OUTGOING, relsByStartNode)
+  //    setUpRelLookupMocking(SemanticDirection.INCOMING, relsByEndNode)
+  //    setUpRelLookupMocking(SemanticDirection.BOTH, relsByNode)
+  //  }
+
+  private def setUpRelNodesWithoutRelationships(nodes: Node*)(implicit query: QueryContext) {
+    nodes.foreach { node =>
+      when(query.getRelationshipsForIds(mockEq(node), mockAny(), mockAny())).thenReturn(Iterator.empty)
+    }
+  }
+
+  private def setUpCreationOfRelationship(from: Node, to: Node, rel: Relationship)(implicit query: QueryContext) {
+    when(query.createRelationship(from.getId, to.getId, rel.getType.name().hashCode)).thenReturn(rel)
+  }
+
+  //  private def setUpRelLookupMocking(direction: SemanticDirection, relsByNode: Map[Node, Seq[Relationship]]) {
+  //    relsByNode.foreach {
+  //      case (node, rels) =>
+  //        rels.groupBy(_.getType).foreach { case (relType, relsByType) =>
+  //
+  //          when(query.getRelationshipsForIds(node, direction, mockEq(Some(Seq(relType.name().hashCode()))))).thenAnswer(
+  //            new Answer[Iterator[Relationship]] {
+  //              def answer(invocation: InvocationOnMock) = relsByType.iterator
+  //            })
+  //          when(query.nodeGetDegree(node.getId, direction, relType.hashCode())).thenReturn(relsByType.size)
+  //        }
+  //        when(query.nodeGetDegree(node.getId, direction)).thenReturn(rels.size)
+  //    }
+  //  }
+
+  private def newMockedNode(id: Int) = {
+    val node = mock[Node]
+    when(node.getId).thenReturn(id)
+    node
+  }
+
+  private def setupMockingInQueryContext(): QueryContext = {
+    val query = jmock(classOf[QueryContext], Mockito.RETURNS_SMART_NULLS)
+    when(query.getOrCreateRelTypeId(mockAny(classOf[String]))).thenAnswer(new Answer[Int] {
+      override def answer(invocationOnMock: InvocationOnMock): Int = {
+        val arguments = invocationOnMock.getArguments
+        val head = arguments.head
+        head.asInstanceOf[String].hashCode
+      }
+    })
+    query
+  }
+
+  private def newMockedRelationship(id: Int, startNode: Node, endNode: Node, typ: String): Relationship = {
+    val relationship = mock[Relationship]
+    when(relationship.getId).thenReturn(id)
+    when(relationship.getStartNode).thenReturn(startNode)
+    when(relationship.getEndNode).thenReturn(endNode)
+    when(relationship.getOtherNode(startNode)).thenReturn(endNode)
+    when(relationship.getOtherNode(endNode)).thenReturn(startNode)
+    when(relationship.getType).thenReturn(withName(typ))
+    relationship
+  }
+
+  private def newMockedPipe(node: String, rows: ExecutionContext*): Pipe = {
+    newMockedPipe(Map(node -> CTNode), rows: _*)
+  }
+
+  private def newMockedPipe(symbols: Map[String, CypherType], rows: ExecutionContext*): Pipe = {
+    val pipe = mock[Pipe]
+
+    when(pipe.sources).thenReturn(Seq.empty)
+    when(pipe.symbols).thenReturn(SymbolTable(symbols))
+    when(pipe.createResults(mockAny())).thenAnswer(new Answer[Iterator[ExecutionContext]] {
+      def answer(invocation: InvocationOnMock) = rows.iterator
+    })
+
+    pipe
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipeTest.scala
@@ -21,14 +21,12 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 
 import org.mockito.Matchers.{any => mockAny, eq => mockEq}
 import org.mockito.Mockito
-import org.mockito.Mockito._
-import org.mockito.Mockito.{mock => jmock}
+import org.mockito.Mockito.{mock => jmock, _}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Literal, Expression}
-import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken.Unresolved
-import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{TokenType, KeyToken}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Expression, Literal}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{KeyToken, TokenType}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{Operations, QueryContext}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
@@ -37,8 +35,6 @@ import org.neo4j.cypher.internal.frontend.v2_3.symbols._
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.DynamicRelationshipType.withName
 import org.neo4j.graphdb.{Node, Relationship}
-
-import scala.collection
 
 class MergeIntoPipeTest extends CypherFunSuite {
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipeTest.scala
@@ -26,8 +26,10 @@ import org.mockito.Mockito.{mock => jmock}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
-import org.neo4j.cypher.internal.compiler.v2_3.spi.QueryContext
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Literal, Expression}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.values.KeyToken.Unresolved
+import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{TokenType, KeyToken}
+import org.neo4j.cypher.internal.compiler.v2_3.spi.{Operations, QueryContext}
 import org.neo4j.cypher.internal.compiler.v2_3.symbols.SymbolTable
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection.{INCOMING, OUTGOING}
@@ -46,10 +48,11 @@ class MergeIntoPipeTest extends CypherFunSuite {
   val node_c = newMockedNode(3)
   val node_d = newMockedNode(4)
   val rel_a_A_b = newMockedRelationship(1, node_a, node_b, "A")
-  val rel_a_A_c = newMockedRelationship(1, node_a, node_c, "A")
-  val rel_a_B_c = newMockedRelationship(2, node_a, node_c, "B")
-  val rel_a_C_d = newMockedRelationship(3, node_a, node_d, "C")
-  val rel_a_D_a = newMockedRelationship(4, node_a, node_a, "D")
+  val rel_a_A_b2 = newMockedRelationship(2, node_a, node_b, "A")
+  val rel_a_A_c = newMockedRelationship(3, node_a, node_c, "A")
+  val rel_a_B_c = newMockedRelationship(4, node_a, node_c, "B")
+  val rel_a_C_d = newMockedRelationship(5, node_a, node_d, "C")
+  val rel_a_D_a = newMockedRelationship(6, node_a, node_a, "D")
 
   setupMockingInQueryContext()
 
@@ -57,10 +60,10 @@ class MergeIntoPipeTest extends CypherFunSuite {
     // given
     implicit val query = setupMockingInQueryContext()
 
-    setUpRelNodesWithoutRelationships(node_a, node_b)
+    setUpNodesWithoutRelationships(node_a, node_b)
     setUpCreationOfRelationship(node_a, node_b, rel_a_A_b)
 
-    val left = newMockedPipe("a", 
+    val left = newMockedPipe("a",
       row("a" -> node_a, "b" -> node_b))
 
     // when
@@ -182,16 +185,98 @@ class MergeIntoPipeTest extends CypherFunSuite {
     single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
   }
 
-  /*
-  correct type, wrong rel-properties
-  matching type and single prop
-  matching type and multiple props
-  
-  execute on create set
-  execute on merge set
-   */
-  private def createPipeAndRun(query: QueryContext, left: Pipe, dir: SemanticDirection = OUTGOING, relType: String, relProperties: Map[String, Expression]): List[ExecutionContext] =
-    MergeIntoPipe(left, "a", "r", "b", dir, relType, relProperties)().createResults(QueryStateHelper.emptyWith(query)).toList
+  test("should find a matching relationship between two nodes with no matching properties") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+    markAsNotDense(node_a)
+    markAsNotDense(node_b)
+
+    // when
+    setupRelationshipFromNode(node_a, INCOMING, rel_a_A_b)
+    when(query.relationshipOps.getProperty(1, "key".hashCode())).thenReturn(null, Seq.empty: _*)
+    when(query.relationshipOps.getProperty(1, "foo".hashCode())).thenReturn(null, Seq.empty: _*)
+    setUpCreationOfRelationship(node_a, node_b, rel_a_A_b2)
+
+    val left = newMockedPipe("a", row("a" -> node_a, "b" -> node_b))
+    val result = createPipeAndRun(query, left, INCOMING, "A", Map("key" -> Literal(42),
+      "foo" -> Literal("bar")))
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b2, "b" -> node_b))
+    verify(query.relationshipOps).setProperty(2, "key".hashCode(), 42)
+    verify(query.relationshipOps).setProperty(2, "foo".hashCode(), "bar")
+  }
+
+  test("should find a matching relationship between two nodes with matching properties") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+    markAsNotDense(node_a)
+    markAsNotDense(node_b)
+
+    // when
+    setupRelationshipFromNode(node_a, INCOMING, rel_a_A_b)
+    when(query.relationshipOps.getProperty(1, "key".hashCode())).thenReturn(42, Seq.empty: _*)
+    when(query.relationshipOps.getProperty(1, "foo".hashCode())).thenReturn("bar", Seq.empty: _*)
+
+    val left = newMockedPipe("a", row("a" -> node_a, "b" -> node_b))
+    val result = createPipeAndRun(query, left, INCOMING, "A", Map("key" -> Literal(42),
+      "foo" -> Literal("bar")))
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+    verify(query.relationshipOps).getProperty(1, "key".hashCode())
+    verify(query.relationshipOps).getProperty(1, "foo".hashCode())
+    verifyNoMoreInteractions(query.relationshipOps)
+  }
+
+  test("should set properties on create") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+    markAsNotDense(node_a)
+    markAsNotDense(node_b)
+    setUpNodesWithoutRelationships(node_a, node_b)
+    setUpCreationOfRelationship(node_a, node_b, rel_a_A_b)
+
+    // when
+    val left = newMockedPipe("a", row("a" -> node_a, "b" -> node_b))
+    val result = createPipeAndRun(query, left, INCOMING, "A", relProperties = Map.empty,
+      onCreateProperties = Map("key" -> Literal(42), "foo" -> Literal("bar")))
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+    verify(query.relationshipOps).setProperty(rel_a_A_b.getId, "key".hashCode(), 42)
+    verify(query.relationshipOps).setProperty(rel_a_A_b.getId, "foo".hashCode(), "bar")
+  }
+
+  test("should set properties on match") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+    markAsNotDense(node_a)
+    markAsNotDense(node_b)
+    setupRelationshipFromNode(node_a, INCOMING, rel_a_A_b)
+
+    // when
+    val left = newMockedPipe("a", row("a" -> node_a, "b" -> node_b))
+    val result = createPipeAndRun(query, left, INCOMING, "A", relProperties = Map.empty,
+      onCreateProperties = Map.empty, onMatchProperties = Map("key" -> Literal(42), "foo" -> Literal("bar")))
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+    verify(query.relationshipOps).setProperty(rel_a_A_b.getId, "key".hashCode(), 42)
+    verify(query.relationshipOps).setProperty(rel_a_A_b.getId, "foo".hashCode(), "bar")
+  }
+
+  private def createPipeAndRun(query: QueryContext, left: Pipe, dir: SemanticDirection = OUTGOING, relType: String,
+                               relProperties: Map[String, Expression], onCreateProperties: Map[String, Expression] = Map.empty, onMatchProperties: Map[String, Expression] = Map.empty): List[ExecutionContext] = {
+    val f: PartialFunction[(String, Expression), (KeyToken, Expression)] = {
+      case (k, v) => KeyToken.Resolved(k, k.hashCode, TokenType.PropertyKey) -> v
+    }
+    MergeIntoPipe(left, "a", "r", "b", dir, relType, relProperties.map(f), onCreateProperties.map(f), onMatchProperties.map(f))().createResults(QueryStateHelper.emptyWith(query)).toList
+  }
 
   private def setupRelationshipFromNode(startNode: Node, dir: SemanticDirection, rels: Relationship*)(implicit query: QueryContext) {
     val typeId = rels.head.getType.name().hashCode
@@ -207,176 +292,9 @@ class MergeIntoPipeTest extends CypherFunSuite {
     when(query.nodeGetDegree(mockEq(node.getId), mockAny(), mockAny())).thenReturn(degree)
   }
 
-  //
-
-
-  //  test("should return no relationships for types that have not been defined yet") {
-  //    // given
-  //    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Seq.empty)))).thenAnswer(
-  //      new Answer[Iterator[Relationship]] {
-  //        override def answer(invocationOnMock: InvocationOnMock) = Iterator.empty
-  //      })
-  //    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Seq(1, 2))))).thenAnswer(
-  //      new Answer[Iterator[Relationship]] {
-  //        override def answer(invocationOnMock: InvocationOnMock) = Iterator(relationship1, relationship2)
-  //      })
-  //    when(query.nodeGetDegree(any(), any(), any())).thenReturn(1)
-  //
-  //    val pipe = ExpandIntoPipe(newMockedPipe("a", row("a"-> startNode, "b" -> endNode1)), "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes(Seq("FOO", "BAR")))()
-  //
-  //    // when
-  //    when(query.getOptRelTypeId("FOO")).thenReturn(None)
-  //    when(query.getOptRelTypeId("BAR")).thenReturn(None)
-  //    val result1 = pipe.createResults(queryState).toList
-  //
-  //    // when
-  //    when(query.getOptRelTypeId("FOO")).thenReturn(Some(1))
-  //    when(query.getOptRelTypeId("BAR")).thenReturn(Some(2))
-  //    val result2 = pipe.createResults(queryState).toList
-  //
-  //    // then
-  //    result1 should be(empty)
-  //    result2 should not be empty
-  //  }
-  //
-  //  test("should support expand between two nodes with multiple relationships") {
-  //    // given
-  //    setUpRelMockingInQueryContext(relationship1, relationship2, relationship3)
-  //    val left = newMockedPipe("a",
-  //      row("a" -> startNode, "b" -> endNode1),
-  //      row("a" -> startNode, "b" -> endNode2)
-  //    )
-  //
-  //    // when
-  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
-  //
-  //    // then
-  //    val (first :: second :: Nil) = result
-  //    first.m should equal(Map("a" -> startNode, "r" -> relationship1, "b" -> endNode1))
-  //    second.m should equal(Map("a" -> startNode, "r" -> relationship2, "b" -> endNode2))
-  //  }
-  //
-  //  test("should support expand between two nodes with multiple relationships and self loops") {
-  //    // given
-  //    setUpRelMockingInQueryContext(relationship1, selfRelationship, relationship3)
-  //    val left = newMockedPipe("a",
-  //      row("a" -> startNode, "b" -> endNode1),
-  //      row("a" -> startNode, "b" -> startNode)
-  //    )
-  //
-  //    // when
-  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
-  //
-  //    // then
-  //    val (first :: second :: Nil) = result
-  //    first.m should equal(Map("a" -> startNode, "r" -> relationship1, "b" -> endNode1))
-  //    second.m should equal(Map("a" -> startNode, "r" -> selfRelationship, "b" -> startNode))
-  //  }
-  //
-  //  test("given empty input, should return empty output") {
-  //    // given
-  //    setUpRelMockingInQueryContext()
-  //    val left = newMockedPipe("a", row("a" -> null, "b" -> null))
-  //
-  //    // when
-  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
-  //
-  //    // then
-  //    result should be (empty)
-  //  }
-  //
-  //  test("given a null start point, returns an empty iterator") {
-  //    // given
-  //    setUpRelMockingInQueryContext(relationship1)
-  //    val left = newMockedPipe("a",
-  //      row("a" -> null, "b" -> endNode1))
-  //
-  //    // when
-  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
-  //
-  //    // then
-  //    result shouldBe empty
-  //  }
-  //
-  //  test("given a null end point, returns an empty iterator") {
-  //    // given
-  //    setUpRelMockingInQueryContext(relationship1)
-  //    val left = newMockedPipe("a",
-  //      row("a" -> startNode, "b" -> null))
-  //
-  //    // when
-  //    val result = ExpandIntoPipe(left, "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
-  //
-  //    // then
-  //    result shouldBe empty
-  //  }
-  //
-  //  test("issue 4692 should respect relationship direction") {
-  //    // Given
-  //    val node0 = newMockedNode(0)
-  //    val node1 = newMockedNode(1)
-  //    val rel0 = newMockedRelationship(0, node0, node1)
-  //    val rel1 = newMockedRelationship(1, node1, node0)
-  //
-  //    setUpRelMockingInQueryContext(rel0, rel1)
-  //
-  //    val source = newMockedPipe(
-  //      Map("n" -> CTNode, "r2" -> CTRelationship, "k" -> CTNode),
-  //      row("n" -> node1, "r2" -> rel1, "k" -> node0),
-  //      row("n" -> node0, "r2" -> rel0, "k" -> node1))
-  //
-  //    // When
-  //    val results = ExpandIntoPipe(source, "n", "r1", "k", SemanticDirection.OUTGOING, LazyTypes.empty)().createResults(queryState).toList
-  //
-  //    // Then
-  //    results should contain theSameElementsAs List(
-  //      Map("n" -> node1, "k" -> node0, "r1" -> rel1, "r2" -> rel1),
-  //      Map("n" -> node0, "k" -> node1, "r1" -> rel0, "r2" -> rel0))
-  //  }
-  //
-  //  test("should work for bidirectional relationships") {
-  //    // Given
-  //    val node0 = newMockedNode(0)
-  //    val node1 = newMockedNode(1)
-  //    val rel0 = newMockedRelationship(0, node0, node1)
-  //    val rel1 = newMockedRelationship(1, node1, node0)
-  //
-  //    setUpRelMockingInQueryContext(rel0, rel1)
-  //
-  //    val source = newMockedPipe(
-  //      Map("n" -> CTNode, "r2" -> CTRelationship, "k" -> CTNode),
-  //      row("n" -> node1, "r2" -> rel1, "k" -> node0),
-  //      row("n" -> node0, "r2" -> rel0, "k" -> node1))
-  //
-  //    // When
-  //    val results = ExpandIntoPipe(source, "n", "r1", "k", SemanticDirection.BOTH, LazyTypes.empty)().createResults(queryState).toList
-  //
-  //    // Then
-  //    results should contain theSameElementsAs List(
-  //      Map("n" -> node1, "k" -> node0, "r1" -> rel0, "r2" -> rel1),
-  //      Map("n" -> node1, "k" -> node0, "r1" -> rel1, "r2" -> rel1),
-  //      Map("n" -> node0, "k" -> node1, "r1" -> rel1, "r2" -> rel0),
-  //      Map("n" -> node0, "k" -> node1, "r1" -> rel0, "r2" -> rel0))
-  //
-  //    // relationships should be cached after the first call
-  //    verify(query, times(1)).getRelationshipsForIds(any(), mockEq(SemanticDirection.BOTH), mockEq(None))
-  //  }
-
   private def row(values: (String, Any)*) = ExecutionContext.from(values: _*)
 
-  //  private def setUpRelMockingInQueryContext(rels: Relationship*) {
-  //    val relsByStartNode = rels.groupBy(_.getStartNode)
-  //    val relsByEndNode = rels.groupBy(_.getEndNode)
-  //    val relsByNode = (relsByStartNode.keySet ++ relsByEndNode.keySet).map {
-  //      n => n -> (relsByStartNode.getOrElse(n, Seq.empty) ++ relsByEndNode.getOrElse(n, Seq.empty))
-  //    }.toMap
-  //
-  //    setUpRelLookupMocking(SemanticDirection.OUTGOING, relsByStartNode)
-  //    setUpRelLookupMocking(SemanticDirection.INCOMING, relsByEndNode)
-  //    setUpRelLookupMocking(SemanticDirection.BOTH, relsByNode)
-  //  }
-
-  private def setUpRelNodesWithoutRelationships(nodes: Node*)(implicit query: QueryContext) {
+  private def setUpNodesWithoutRelationships(nodes: Node*)(implicit query: QueryContext) {
     nodes.foreach { node =>
       when(query.getRelationshipsForIds(mockEq(node), mockAny(), mockAny())).thenReturn(Iterator.empty)
     }
@@ -386,23 +304,9 @@ class MergeIntoPipeTest extends CypherFunSuite {
     when(query.createRelationship(from.getId, to.getId, rel.getType.name().hashCode)).thenReturn(rel)
   }
 
-  //  private def setUpRelLookupMocking(direction: SemanticDirection, relsByNode: Map[Node, Seq[Relationship]]) {
-  //    relsByNode.foreach {
-  //      case (node, rels) =>
-  //        rels.groupBy(_.getType).foreach { case (relType, relsByType) =>
-  //
-  //          when(query.getRelationshipsForIds(node, direction, mockEq(Some(Seq(relType.name().hashCode()))))).thenAnswer(
-  //            new Answer[Iterator[Relationship]] {
-  //              def answer(invocation: InvocationOnMock) = relsByType.iterator
-  //            })
-  //          when(query.nodeGetDegree(node.getId, direction, relType.hashCode())).thenReturn(relsByType.size)
-  //        }
-  //        when(query.nodeGetDegree(node.getId, direction)).thenReturn(rels.size)
-  //    }
-  //  }
-
   private def newMockedNode(id: Int) = {
     val node = mock[Node]
+    when(node.toString).thenReturn(id.toString)
     when(node.getId).thenReturn(id)
     node
   }
@@ -416,6 +320,10 @@ class MergeIntoPipeTest extends CypherFunSuite {
         head.asInstanceOf[String].hashCode
       }
     })
+
+    val mockOperationsRelationship = mock[Operations[Relationship]]
+    when(query.relationshipOps).thenReturn(mockOperationsRelationship)
+
     query
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -115,6 +115,11 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   def createRelationship(start: Node, end: Node, relType: String) =
     start.createRelationshipTo(end, withName(relType))
 
+  def createRelationship(start: Long, end: Long, relType: Int) = {
+    val relId = statement.dataWriteOperations().relationshipCreate(relType, start, end)
+    relationshipOps.getById(relId)
+  }
+
   def getOrCreateRelTypeId(relTypeName: String): Int =
     statement.tokenWriteOperations().relationshipTypeGetOrCreateForName(relTypeName)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
@@ -185,4 +185,5 @@ class SnitchingQueryContext extends QueryContext {
   override def variableLengthPathExpand(node: PatternNode, realNode: Node, minHops: Option[Int], maxHops: Option[Int], direction: SemanticDirection, relTypes: Seq[String]): Iterator[Path] = ???
 
   def getImportURL(url: URL): Either[String,URL] = ???
+  override def createRelationship(start: Long, end: Long, relType: Int) = ???
 }

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/SetItem.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/SetItem.scala
@@ -24,21 +24,23 @@ import org.neo4j.cypher.internal.frontend.v2_3.{InputPosition, SemanticCheckable
 
 sealed trait SetItem extends ASTNode with ASTPhrase with SemanticCheckable
 
-case class SetPropertyItem(property: Property, expression: Expression)(val position: InputPosition) extends SetItem {
-  def semanticCheck =
-    property.semanticCheck(Expression.SemanticContext.Simple) chain
-    expression.semanticCheck(Expression.SemanticContext.Simple) chain
-    property.map.expectType(CTNode.covariant | CTRelationship.covariant)
-}
-
 case class SetLabelItem(expression: Expression, labels: Seq[LabelName])(val position: InputPosition) extends SetItem {
   def semanticCheck =
     expression.semanticCheck(Expression.SemanticContext.Simple) chain
     expression.expectType(CTNode.covariant)
 }
 
+sealed trait SetProperty extends SetItem
+
+case class SetPropertyItem(property: Property, expression: Expression)(val position: InputPosition) extends SetProperty {
+  def semanticCheck =
+    property.semanticCheck(Expression.SemanticContext.Simple) chain
+      expression.semanticCheck(Expression.SemanticContext.Simple) chain
+      property.map.expectType(CTNode.covariant | CTRelationship.covariant)
+}
+
 case class SetExactPropertiesFromMapItem(identifier: Identifier, expression: Expression)
-                                        (val position: InputPosition) extends SetItem {
+                                        (val position: InputPosition) extends SetProperty {
   def semanticCheck =
     identifier.semanticCheck(Expression.SemanticContext.Simple) chain
     identifier.expectType(CTNode.covariant | CTRelationship.covariant) chain
@@ -47,7 +49,7 @@ case class SetExactPropertiesFromMapItem(identifier: Identifier, expression: Exp
 }
 
 case class SetIncludingPropertiesFromMapItem(identifier: Identifier, expression: Expression)
-                                        (val position: InputPosition) extends SetItem {
+                                        (val position: InputPosition) extends SetProperty {
   def semanticCheck =
     identifier.semanticCheck(Expression.SemanticContext.Simple) chain
     identifier.expectType(CTNode.covariant | CTRelationship.covariant) chain

--- a/manual/cypher/cypher-docs/src/docs/dev/execution-plan-groups/update.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/execution-plan-groups/update.asciidoc
@@ -9,3 +9,4 @@ These operators are used in queries that update the graph.
 include::../ql/query-plan/constraint-operation.asciidoc[]
 include::../ql/query-plan/empty-result.asciidoc[]
 include::../ql/query-plan/update-graph.asciidoc[]
+include::../ql/query-plan/merge-into.asciidoc[]

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -158,6 +158,16 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
     )
   }
 
+  @Test def mergeInto() {
+    profileQuery(
+      title = "Merge Into",
+      text =
+        """When both the start and end node have already been found, merge-into is used to find all connecting relationships or creating a new relationship between the two nodes.""".stripMargin,
+      queryText = """MATCH (p:Person {name: "me"}), (f:Person {name: "Andres"}) MERGE (p)-[:FRIENDS_WITH]->(f)""",
+      assertions = (p) => assertThat(p.executionPlanDescription().toString, containsString("Merge(Into)"))
+    )
+  }
+
   @Test def emptyResult() {
     profileQuery(
       title = "Empty Result",


### PR DESCRIPTION
Whenever we do `MERGE (a)-[:R]->(b)` when both `a` and `b` are already known we can do `MergeInto` instead, i.e. either find all the connecting relationships or create the relationship.
