### PR TITLE
Import tool help/usage message should provide usage example

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -29,6 +29,7 @@ import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
+import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.configuration.Config;
@@ -128,7 +129,7 @@ public class ConsistencyCheckTool
             {
                 if ( recoveryChecker.recoveryNeededAt( new File( storeDir ) ) )
                 {
-                    systemError.print( lines(
+                    systemError.print( Strings.joinAsLines(
                             "Active logical log detected, this might be a source of inconsistencies.",
                             "Consider allowing the database to recover before running the consistency check.",
                             "Consistency checking will continue, abort if you wish to perform recovery first.",
@@ -154,7 +155,8 @@ public class ConsistencyCheckTool
         String storeDir = unprefixedArguments.get( 0 );
         if ( !new File( storeDir ).isDirectory() )
         {
-            throw new ToolFailureException( lines( String.format( "'%s' is not a directory", storeDir ) ) + usage() );
+            throw new ToolFailureException( Strings.joinAsLines( String.format( "'%s' is not a directory", storeDir ) ) +
+                                            usage() );
         }
         return storeDir;
     }
@@ -183,7 +185,7 @@ public class ConsistencyCheckTool
 
     private String usage()
     {
-        return lines(
+        return Strings.joinAsLines(
                 Args.jarUsage( getClass(), "[-propowner] [-recovery] [-config <neo4j.properties>] <storedir>" ),
                 "WHERE:   <storedir>         is the path to the store to check",
                 "         -recovery          to perform recovery on the store before checking",
@@ -192,15 +194,6 @@ public class ConsistencyCheckTool
         );
     }
 
-    private static String lines( String... content )
-    {
-        StringBuilder result = new StringBuilder();
-        for ( String line : content )
-        {
-            result.append( line ).append( System.getProperty( "line.separator" ) );
-        }
-        return result.toString();
-    }
 
     class ToolFailureException extends Exception
     {

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -33,6 +33,8 @@ import org.neo4j.function.Function;
 import org.neo4j.function.Function2;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.Args.Option;
+import org.neo4j.helpers.ArrayUtil;
+import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -62,10 +64,10 @@ import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitors;
 
 import static java.lang.System.out;
 import static java.nio.charset.Charset.defaultCharset;
-
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_dir;
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.Format.bytes;
+import static org.neo4j.helpers.Strings.TAB;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.util.Converters.withDefault;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.BAD_FILE_NAME;
@@ -168,7 +170,7 @@ public class ImportTool
                         + "nodes within the same group having the same id, the first encountered will be imported "
                         + "whereas consecutive such nodes will be skipped. "
                         + "Skipped nodes will be logged"
-                        + ", containing at most number of entites specified by " + BAD_TOLERANCE.key() + "." );
+                        + ", containing at most number of entities specified by " + BAD_TOLERANCE.key() + "." );
 
         private final String key;
         private final Object defaultValue;
@@ -259,7 +261,7 @@ public class ImportTool
     public static void main( String[] incomingArguments, boolean defaultSettingsSuitableForTests )
     {
         Args args = Args.parse( incomingArguments );
-        if ( asksForUsage( args ) )
+        if ( ArrayUtil.isEmpty( incomingArguments ) || asksForUsage( args ) )
         {
             printUsage( System.out );
             return;
@@ -513,13 +515,20 @@ public class ImportTool
                 + "See the chapter \"Import Tool\" in the Neo4j Manual for details on the CSV file format "
                 + "- a special kind of header is required.", 80 ) )
         {
-            out.println( "\t" + line );
+            out.println( TAB + line );
         }
         out.println( "Usage:" );
         for ( Options option : Options.values() )
         {
             option.printUsage( out );
         }
+
+        out.println( "Example:");
+        out.print( Strings.joinAsLines(
+                TAB + "bin/neo4j-import --into retail.db --id-type string --nodes:Customer customers.csv ",
+                TAB + "--nodes products.csv --nodes orders_header.csv,orders1.csv,orders2.csv ",
+                TAB + "--relationships:CONTAINS order_details.csv ",
+                TAB + "--relationships:ORDERED customer_orders_header.csv,orders1.csv,orders2.csv" ) );
     }
 
     private static boolean asksForUsage( Args args )

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -22,6 +22,7 @@ package org.neo4j.tooling;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
@@ -92,6 +93,20 @@ public class ImportToolTest
     @Rule
     public final Mute mute = Mute.mute( Mute.System.values() );
     private int dataIndex;
+
+    @Test
+    public void usageMessageIncludeExample() throws Exception
+    {
+        String output = executeImportAndCatchOutput( "?" );
+        assertTrue( "Usage message should include example section, but was:" + output, output.contains( "Example:" ) );
+    }
+
+    @Test
+    public void usageMessagePrintedOnEmptyInputParameters()
+    {
+        String output = executeImportAndCatchOutput();
+        assertTrue( "Output should include usage section, but was:" + output, output.contains( "Example:" ) );
+    }
 
     @Test
     public void shouldImportWithAsManyDefaultsAsAvailable() throws Exception
@@ -1093,6 +1108,23 @@ public class ImportToolTest
                 return line >= startingAt && line < endingAt;
             }
         };
+    }
+
+    private String executeImportAndCatchOutput(String... arguments)
+    {
+        PrintStream originalStream = System.out;
+        ByteArrayOutputStream outputStreamBuffer = new ByteArrayOutputStream();
+        PrintStream replacement = new PrintStream( outputStreamBuffer );
+        System.setOut( replacement );
+        try
+        {
+            importTool( arguments );
+            return new String( outputStreamBuffer.toByteArray() );
+        }
+        finally
+        {
+            System.setOut( originalStream );
+        }
     }
 
     private void importTool( String... arguments )

--- a/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
@@ -373,6 +373,16 @@ public abstract class ArrayUtil
     }
 
     /**
+     * Check if provided array is empty
+     * @param array - array to check
+     * @return true if array is null or empty
+     */
+    public static boolean isEmpty( Object[] array )
+    {
+        return array == null || (array.length == 0);
+    }
+
+    /**
      * Convert an array to a String using a custom delimiter.
      * 
      * @param items The array to convert

--- a/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
@@ -27,6 +27,9 @@ import java.util.Arrays;
  */
 public final class Strings
 {
+
+    public static final String TAB = "\t";
+
     private Strings()
     {
     }
@@ -144,6 +147,23 @@ public final class Strings
         }
         return builder.toString();
     }
+
+    /**
+     * Joining independent lines from provided elements into one line with {@link java.lang.System#lineSeparator} after
+     * each element
+     * @param elements - lines to join
+     * @return joined line
+     */
+    public static String joinAsLines( String... elements )
+    {
+        StringBuilder result = new StringBuilder();
+        for ( String line : elements )
+        {
+            result.append( line ).append( System.lineSeparator() );
+        }
+        return result.toString();
+    }
+
 
     public static void escape( Appendable output, String arg ) throws IOException
     {

--- a/community/kernel/src/test/java/org/neo4j/helpers/ArrayUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ArrayUtilTest.java
@@ -44,6 +44,14 @@ public class ArrayUtilTest
     }
 
     @Test
+    public void emptyArray()
+    {
+        assertTrue( ArrayUtil.isEmpty( null ) );
+        assertTrue( ArrayUtil.isEmpty( new String[] {} ) );
+        assertFalse( ArrayUtil.isEmpty( new Long[] { 1L } ) );
+    }
+
+    @Test
     public void shouldProduceUnionWhereFirstIsNull() throws Exception
     {
         // GIVEN

--- a/community/kernel/src/test/java/org/neo4j/helpers/StringsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/StringsTest.java
@@ -79,4 +79,11 @@ public class StringsTest
         assertEquals( "a\\bbc", Strings.escape( "a\bbc" ) );
         assertEquals( "a\\fbc", Strings.escape( "a\fbc" ) );
     }
+
+    @Test
+    public void testJoiningLines()
+    {
+        assertEquals( "a" + System.lineSeparator() + "b" + System.lineSeparator() + "c" + System.lineSeparator(),
+                Strings.joinAsLines( "a", "b", "c" ) );
+    }
 }


### PR DESCRIPTION
Update import tool help message to be printed out when no input parameters were provided.
Text updated to include usage example.
