### PR TITLE
Import tool help/usage message should provide usage example

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -29,6 +29,7 @@ import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
+import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -124,7 +125,7 @@ public class ConsistencyCheckTool
             {
                 if ( new RecoveryRequiredChecker( fs, pageCache ).isRecoveryRequiredAt( storeDir ) )
                 {
-                    systemError.print( lines(
+                    systemError.print( Strings.joinAsLines(
                             "Active logical log detected, this might be a source of inconsistencies.",
                             "Consider allowing the database to recover before running the consistency check.",
                             "Consistency checking will continue, abort if you wish to perform recovery first.",
@@ -150,7 +151,8 @@ public class ConsistencyCheckTool
         File storeDir = new File( unprefixedArguments.get( 0 ) );
         if ( !storeDir.isDirectory() )
         {
-            throw new ToolFailureException( lines( String.format( "'%s' is not a directory", storeDir ) ) + usage() );
+            throw new ToolFailureException(
+                    Strings.joinAsLines( String.format( "'%s' is not a directory", storeDir ) ) + usage() );
         }
         return storeDir;
     }
@@ -178,23 +180,13 @@ public class ConsistencyCheckTool
 
     private String usage()
     {
-        return lines(
+        return Strings.joinAsLines(
                 Args.jarUsage( getClass(), "[-propowner] [-recovery] [-config <neo4j.properties>] <storedir>" ),
                 "WHERE:   <storedir>         is the path to the store to check",
                 "         -recovery          to perform recovery on the store before checking",
                 "         <neo4j.properties> is the location of an optional properties file",
                 "                            containing tuning parameters for the consistency check"
         );
-    }
-
-    private static String lines( String... content )
-    {
-        StringBuilder result = new StringBuilder();
-        for ( String line : content )
-        {
-            result.append( line ).append( System.lineSeparator() );
-        }
-        return result.toString();
     }
 
     class ToolFailureException extends Exception

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -33,6 +33,8 @@ import org.neo4j.function.BiFunction;
 import org.neo4j.function.Function;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.Args.Option;
+import org.neo4j.helpers.ArrayUtil;
+import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -64,6 +66,7 @@ import static java.nio.charset.Charset.defaultCharset;
 
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.Format.bytes;
+import static org.neo4j.helpers.Strings.TAB;
 import static org.neo4j.kernel.impl.util.Converters.withDefault;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.BAD_FILE_NAME;
 import static org.neo4j.unsafe.impl.batchimport.cache.AvailableMemoryCalculator.RUNTIME;
@@ -259,7 +262,7 @@ public class ImportTool
     public static void main( String[] incomingArguments, boolean defaultSettingsSuitableForTests ) throws IOException
     {
         Args args = Args.parse( incomingArguments );
-        if ( asksForUsage( args ) )
+        if ( ArrayUtil.isEmpty( incomingArguments ) || asksForUsage( args ) )
         {
             printUsage( System.out );
             return;
@@ -533,6 +536,13 @@ public class ImportTool
         {
             option.printUsage( out );
         }
+
+        out.println( "Example:");
+        out.print( Strings.joinAsLines(
+                TAB + "bin/neo4j-import --into retail.db --id-type string --nodes:Customer customers.csv ",
+                TAB + "--nodes products.csv --nodes orders_header.csv,orders1.csv,orders2.csv ",
+                TAB + "--relationships:CONTAINS order_details.csv ",
+                TAB + "--relationships:ORDERED customer_orders_header.csv,orders1.csv,orders2.csv" ) );
     }
 
     private static boolean asksForUsage( Args args )

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -97,6 +97,24 @@ public class ImportToolTest
     private int dataIndex;
 
     @Test
+    public void usageMessageIncludeExample() throws Exception
+    {
+        SuppressOutput.Voice outputVoice = suppressOutput.getOutputVoice();
+        importTool( "?" );
+        assertTrue( "Usage message should include example section, but was:" + outputVoice,
+                outputVoice.containsMessage( "Example:" ) );
+    }
+
+    @Test
+    public void usageMessagePrintedOnEmptyInputParameters() throws Exception
+    {
+        SuppressOutput.Voice outputVoice = suppressOutput.getOutputVoice();
+        importTool();
+        assertTrue( "Output should include usage section, but was:" + outputVoice,
+                outputVoice.containsMessage( "Example:" ) );
+    }
+
+    @Test
     public void shouldImportWithAsManyDefaultsAsAvailable() throws Exception
     {
         // GIVEN
@@ -637,7 +655,7 @@ public class ImportToolTest
     @Test
     public void shouldPrintReferenceLinkOnDataImportErrors() throws Exception
     {
-        shouldPrintReferenceLinkAsPartOfErrorMessage(nodeIds(),
+        shouldPrintReferenceLinkAsPartOfErrorMessage( nodeIds(),
                 IteratorUtil.iterator( new RelationshipDataLine( "1", "", "type", "name" ) ),
                 "Relationship missing mandatory field 'END_ID', read more about relationship " +
                 "format in the manual:  http://neo4j.com/docs/" + Version.getKernelVersion() +
@@ -952,7 +970,7 @@ public class ImportToolTest
 
     private String randomName()
     {
-        int length = random.nextInt( 10 )+5;
+        int length = random.nextInt( 10 ) + 5;
         StringBuilder builder = new StringBuilder();
         for ( int i = 0; i < length; i++ )
         {
@@ -962,13 +980,13 @@ public class ImportToolTest
     }
 
     private File relationshipData( boolean includeHeader, Configuration config, List<String> nodeIds,
-                                   IntPredicate linePredicate, boolean specifyType ) throws Exception
+            IntPredicate linePredicate, boolean specifyType ) throws Exception
     {
         return relationshipData( includeHeader, config, nodeIds, linePredicate, specifyType, Charset.defaultCharset() );
     }
 
     private File relationshipData( boolean includeHeader, Configuration config, List<String> nodeIds,
-                                   IntPredicate linePredicate, boolean specifyType, Charset encoding ) throws Exception
+            IntPredicate linePredicate, boolean specifyType, Charset encoding ) throws Exception
     {
         return relationshipData( includeHeader, config, randomRelationships( nodeIds ), linePredicate,
                 specifyType, encoding );
@@ -1065,7 +1083,7 @@ public class ImportToolTest
         public String toString()
         {
             return "RelationshipDataLine [startNodeId=" + startNodeId + ", endNodeId=" + endNodeId + ", type=" + type
-                    + ", name=" + name + "]";
+                   + ", name=" + name + "]";
         }
     }
 
@@ -1093,11 +1111,11 @@ public class ImportToolTest
             if ( linePredicate.test( i ) )
             {
                 writer.println( entry.startNodeId +
-                        delimiter + entry.endNodeId +
-                        (specifyType ? (delimiter + entry.type) : "") +
-                        delimiter + currentTimeMillis() +
-                        delimiter + (entry.name != null ? entry.name : "")
-                        );
+                                delimiter + entry.endNodeId +
+                                (specifyType ? (delimiter + entry.type) : "") +
+                                delimiter + currentTimeMillis() +
+                                delimiter + (entry.name != null ? entry.name : "")
+                );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ArrayUtil.java
@@ -373,6 +373,16 @@ public abstract class ArrayUtil
     }
 
     /**
+     * Check if provided array is empty
+     * @param array - array to check
+     * @return true if array is null or empty
+     */
+    public static boolean isEmpty( Object[] array )
+    {
+        return (array == null) || (array.length == 0);
+    }
+
+    /**
      * Convert an array to a String using a custom delimiter.
      * 
      * @param items The array to convert

--- a/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Strings.java
@@ -148,6 +148,22 @@ public final class Strings
         return builder.toString();
     }
 
+    /**
+     * Joining independent lines from provided elements into one line with {@link java.lang.System#lineSeparator} after
+     * each element
+     * @param elements - lines to join
+     * @return joined line
+     */
+    public static String joinAsLines( String... elements )
+    {
+        StringBuilder result = new StringBuilder();
+        for ( String line : elements )
+        {
+            result.append( line ).append( System.lineSeparator() );
+        }
+        return result.toString();
+    }
+
     public static void escape( Appendable output, String arg ) throws IOException
     {
         int len = arg.length();

--- a/community/kernel/src/test/java/org/neo4j/helpers/ArrayUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ArrayUtilTest.java
@@ -82,6 +82,14 @@ public class ArrayUtilTest
     }
 
     @Test
+    public void emptyArray()
+    {
+        assertTrue( ArrayUtil.isEmpty( null ) );
+        assertTrue( ArrayUtil.isEmpty( new String[] {} ) );
+        assertFalse( ArrayUtil.isEmpty( new Long[] { 1L } ) );
+    }
+
+    @Test
     public void shouldConcatOneAndMany() throws Exception
     {
         // WHEN

--- a/community/kernel/src/test/java/org/neo4j/helpers/StringsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/StringsTest.java
@@ -79,4 +79,11 @@ public class StringsTest
         assertEquals( "a\\bbc", Strings.escape( "a\bbc" ) );
         assertEquals( "a\\fbc", Strings.escape( "a\fbc" ) );
     }
+
+    @Test
+    public void testJoiningLines()
+    {
+        assertEquals( "a" + System.lineSeparator() + "b" + System.lineSeparator() + "c" + System.lineSeparator(),
+                Strings.joinAsLines( "a", "b", "c" ) );
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/SuppressOutput.java
+++ b/community/kernel/src/test/java/org/neo4j/test/SuppressOutput.java
@@ -249,6 +249,12 @@ public final class SuppressOutput implements TestRule
             return voiceStream.toString().contains( message );
         }
 
+        @Override
+        public String toString()
+        {
+            return voiceStream.toString();
+        }
+
         abstract void restore( boolean failure ) throws IOException;
     }
 


### PR DESCRIPTION
Update import tool help message to be printed out when no input parameters were provided.
Text updated to include usage example.
