### PR TITLE
Improves TxPushStrategyConfigIT.twoRoundRobin, removing flakyness

### DIFF
--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
@@ -69,23 +69,19 @@ public class TxPushStrategyConfigIT
     @Test
     public void twoRoundRobin() throws Exception
     {
-        startCluster( 5, 2, "round_robin" );
+        startCluster( 4, 2, "round_robin" );
 
         createTransactionOnMaster();
         assertLastTransactions( lastTx( FIRST_SLAVE, BASE_TX_ID + 1 ), lastTx( SECOND_SLAVE, BASE_TX_ID + 1 ),
-                lastTx( THIRD_SLAVE, BASE_TX_ID ), lastTx( FOURTH_SLAVE, BASE_TX_ID ) );
+                lastTx( THIRD_SLAVE, BASE_TX_ID ) );
 
         createTransactionOnMaster();
         assertLastTransactions( lastTx( FIRST_SLAVE, BASE_TX_ID + 1 ), lastTx( SECOND_SLAVE, BASE_TX_ID + 2 ),
-                lastTx( THIRD_SLAVE, BASE_TX_ID + 2 ), lastTx( FOURTH_SLAVE, BASE_TX_ID ) );
+                lastTx( THIRD_SLAVE, BASE_TX_ID + 2 ) );
 
         createTransactionOnMaster();
-        assertLastTransactions( lastTx( FIRST_SLAVE, BASE_TX_ID + 1 ), lastTx( SECOND_SLAVE, BASE_TX_ID + 2 ),
-                lastTx( THIRD_SLAVE, BASE_TX_ID + 3 ), lastTx( FOURTH_SLAVE, BASE_TX_ID + 3 ) );
-
-        createTransactionOnMaster();
-        assertLastTransactions( lastTx( FIRST_SLAVE, BASE_TX_ID + 4 ), lastTx( SECOND_SLAVE, BASE_TX_ID + 2 ),
-                lastTx( THIRD_SLAVE, BASE_TX_ID + 3 ), lastTx( FOURTH_SLAVE, BASE_TX_ID + 4 ) );
+        assertLastTransactions( lastTx( FIRST_SLAVE, BASE_TX_ID + 3 ), lastTx( SECOND_SLAVE, BASE_TX_ID + 2 ),
+                lastTx( THIRD_SLAVE, BASE_TX_ID + 3 ) );
     }
 
     @Test


### PR DESCRIPTION
The test tries to verify behaviour when pushing to two slaves with
 a round robing algorithm. To that end, it used a cluster of five
 instances. This lead to performance issues in a single jvm in our
 CI, leading to consistent failures of the cluster to form properly
 because of GC issues.
This change reduces the instance count to 4, which seems to work for
 another test in the same test case. The same behaviour is still
 verified equally thoroughly.
