### PR TITLE
Transactions are rolled back on client error

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -400,7 +400,7 @@ public interface Status
     public enum Classification
     {
         /** The Client sent a bad request - changing the request might yield a successful outcome. */
-        ClientError( TransactionEffect.NONE,
+        ClientError( TransactionEffect.ROLLBACK,
                 "The Client sent a bad request - changing the request might yield a successful outcome." ),
         /** The database failed to service the request. */
         DatabaseError( TransactionEffect.ROLLBACK,


### PR DESCRIPTION
REST API transactions are not supposed to commit after client error
(missing query parameter, etc.). They were not doing the commit even before
this change, instead transaction was simply marked for termination and commit
failed. This change makes it more pretty. Now transactions will rollback once
they encounter client error.

**Note:** I'd like to forward merge this PR myself and add couple more tests for notifications in 2.3
