### PR TITLE
Restored test removed by mistake

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/constraints/StandardConstraintSemantics.java
@@ -36,6 +36,8 @@ import org.neo4j.kernel.impl.store.record.UniquePropertyConstraintRule;
 
 public class StandardConstraintSemantics implements ConstraintSemantics
 {
+    public static final String ERROR_MESSAGE = "Property existence constraint requires Neo4j Enterprise Edition";
+
     @Override
     public void validateNodePropertyExistenceConstraint( Cursor<NodeItem> allNodes, int label, int propertyKey )
             throws CreateConstraintFailureException
@@ -63,14 +65,13 @@ public class StandardConstraintSemantics implements ConstraintSemantics
     protected PropertyConstraint readNonStandardConstraint( PropertyConstraintRule rule )
     {
         // When opening a store in Community Edition that contains a Property Existence Constraint
-        throw new IllegalStateException( "Property existence constraint requires Neo4j Enterprise Edition");
+        throw new IllegalStateException( ERROR_MESSAGE );
     }
 
     private CreateConstraintFailureException propertyExistenceConstraintsNotAllowed( PropertyConstraint constraint )
     {
         // When creating a Property Existence Constraint in Community Edition
-        return new CreateConstraintFailureException( constraint, new IllegalStateException(
-                "Property existence constraint requires Neo4j Enterprise Edition" ) );
+        return new CreateConstraintFailureException( constraint, new IllegalStateException( ERROR_MESSAGE ) );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/SchemaHelper.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/SchemaHelper.java
@@ -41,7 +41,6 @@ public final class SchemaHelper
     public static void createIndex( GraphDatabaseService db, String label, String property )
     {
         db.execute( String.format( "CREATE INDEX ON :`%s`(`%s`)", label, property ) );
-        awaitIndexes( db );
     }
 
     public static void createUniquenessConstraint( GraphDatabaseService db, Label label, String property )
@@ -52,7 +51,6 @@ public final class SchemaHelper
     public static void createUniquenessConstraint( GraphDatabaseService db, String label, String property )
     {
         db.execute( String.format( "CREATE CONSTRAINT ON (n:`%s`) ASSERT n.`%s` IS UNIQUE", label, property ) );
-        awaitIndexes( db );
     }
 
     public static void createNodePropertyExistenceConstraint( GraphDatabaseService db, Label label, String property )
@@ -76,7 +74,7 @@ public final class SchemaHelper
         db.execute( String.format( "CREATE CONSTRAINT ON ()-[r:`%s`]-() ASSERT exists(r.`%s`)", type, property ) );
     }
 
-    private static void awaitIndexes( GraphDatabaseService db )
+    public static void awaitIndexes( GraphDatabaseService db )
     {
         try ( Transaction tx = db.beginTx() )
         {

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/SchemaWithPECAcceptanceTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/SchemaWithPECAcceptanceTest.java
@@ -121,6 +121,7 @@ public class SchemaWithPECAcceptanceTest
     private ConstraintDefinition createUniquenessConstraint( Label label, String propertyKey )
     {
         SchemaHelper.createUniquenessConstraint( db, label, propertyKey );
+        SchemaHelper.awaitIndexes( db );
         return new UniquenessConstraintDefinition( mock( InternalSchemaActions.class ), label, propertyKey );
     }
 

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
@@ -24,8 +24,13 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.helpers.Exceptions;
+import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
 import org.neo4j.test.TargetDirectory;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.neo4j.test.TargetDirectory.testDirForTest;
 
@@ -58,7 +63,9 @@ public class StartupConstraintSemanticsTest
         // then
         catch ( Exception e )
         {
-            e.printStackTrace();
+            Throwable error = Exceptions.rootCause( e );
+            assertThat( error, instanceOf( IllegalStateException.class ) );
+            assertEquals( StandardConstraintSemantics.ERROR_MESSAGE, error.getMessage() );
         }
         finally
         {

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.kernel.impl.api.integrationtest;
 
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransientTransactionFailureException;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema;
@@ -46,6 +47,7 @@ import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchConstraintException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -82,7 +84,6 @@ public abstract class AbstractConstraintCreationIT<Constraint extends PropertyCo
 
     abstract void removeOffendingDataInRunningTx( GraphDatabaseService db );
 
-
     @Before
     public void createKeys() throws Exception
     {
@@ -90,6 +91,15 @@ public abstract class AbstractConstraintCreationIT<Constraint extends PropertyCo
         this.typeId = initializeLabelOrRelType( statement, KEY );
         this.propertyKeyId = statement.propertyKeyGetOrCreateForName( PROP );
         commit();
+    }
+
+    @Override
+    protected GraphDatabaseService createGraphDatabase( EphemeralFileSystemAbstraction fs )
+    {
+        return new TestEnterpriseGraphDatabaseFactory()
+                .setFileSystem( fs )
+                .newImpermanentDatabaseBuilder()
+                .newGraphDatabase();
     }
 
     @Test

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
@@ -19,15 +19,14 @@
  */
 package org.neo4j.kernel.impl.api.integrationtest;
 
-import java.util.Iterator;
-
 import org.junit.Test;
+
+import java.util.Iterator;
 
 import org.neo4j.SchemaHelper;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
@@ -36,7 +35,6 @@ import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
 import org.neo4j.kernel.api.exceptions.schema.NoSuchConstraintException;
-import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -48,15 +46,6 @@ import static org.neo4j.helpers.collection.IteratorUtil.single;
 public class NodePropertyExistenceConstraintCreationIT
         extends AbstractConstraintCreationIT<NodePropertyExistenceConstraint>
 {
-    @Override
-    protected GraphDatabaseService createGraphDatabase( EphemeralFileSystemAbstraction fs )
-    {
-        return new TestEnterpriseGraphDatabaseFactory()
-                .setFileSystem( fs )
-                .newImpermanentDatabaseBuilder()
-                .newGraphDatabase();
-    }
-
     @Override
     int initializeLabelOrRelType( SchemaWriteOperations writeOps, String name ) throws KernelException
     {

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
@@ -23,11 +23,9 @@ import org.neo4j.SchemaHelper;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
@@ -35,15 +33,6 @@ import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 public class RelationshipPropertyExistenceConstraintCreationIT
         extends AbstractConstraintCreationIT<RelationshipPropertyExistenceConstraint>
 {
-    @Override
-    protected GraphDatabaseService createGraphDatabase( EphemeralFileSystemAbstraction fs )
-    {
-        return new TestEnterpriseGraphDatabaseFactory()
-                .setFileSystem( fs )
-                .newImpermanentDatabaseBuilder()
-                .newGraphDatabase();
-    }
-
     @Override
     int initializeLabelOrRelType( SchemaWriteOperations writeOps, String name ) throws KernelException
     {

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.integrationtest;
+
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import org.neo4j.SchemaHelper;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.SchemaWriteOperations;
+import org.neo4j.kernel.api.StatementTokenNameLookup;
+import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
+import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
+import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
+import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
+import org.neo4j.kernel.api.exceptions.schema.DropConstraintFailureException;
+import org.neo4j.kernel.api.exceptions.schema.NoSuchConstraintException;
+import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.impl.store.SchemaStorage;
+import org.neo4j.kernel.impl.store.record.IndexRule;
+import org.neo4j.kernel.impl.store.record.UniquePropertyConstraintRule;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+
+public class UniquenessConstraintCreationIT extends AbstractConstraintCreationIT<UniquenessConstraint>
+{
+    private static final String DUPLICATED_VALUE = "apa";
+
+    @Override
+    int initializeLabelOrRelType( SchemaWriteOperations writeOps, String name ) throws KernelException
+    {
+        return writeOps.labelGetOrCreateForName( KEY );
+    }
+
+    @Override
+    UniquenessConstraint createConstraint( SchemaWriteOperations writeOps, int type, int property ) throws Exception
+    {
+        return writeOps.uniquePropertyConstraintCreate( type, property );
+    }
+
+    @Override
+    void createConstraintInRunningTx( GraphDatabaseService db, String type, String property )
+    {
+        SchemaHelper.createUniquenessConstraint( db, type, property );
+    }
+
+    @Override
+    UniquenessConstraint newConstraintObject( int type, int property )
+    {
+        return new UniquenessConstraint( type, property );
+    }
+
+    @Override
+    void dropConstraint( SchemaWriteOperations writeOps, UniquenessConstraint constraint ) throws Exception
+    {
+        writeOps.constraintDrop( constraint );
+    }
+
+    @Override
+    void createOffendingDataInRunningTx( GraphDatabaseService db )
+    {
+        db.createNode( label( KEY ) ).setProperty( PROP, DUPLICATED_VALUE );
+        db.createNode( label( KEY ) ).setProperty( PROP, DUPLICATED_VALUE );
+    }
+
+    @Override
+    void removeOffendingDataInRunningTx( GraphDatabaseService db )
+    {
+        try ( ResourceIterator<Node> nodes = db.findNodes( label( KEY ), PROP, DUPLICATED_VALUE ) )
+        {
+            while ( nodes.hasNext() )
+            {
+                nodes.next().delete();
+            }
+        }
+    }
+
+    @Test
+    public void shouldAbortConstraintCreationWhenDuplicatesExist() throws Exception
+    {
+        // given
+        long node1, node2;
+        int foo, name;
+        {
+            DataWriteOperations statement = dataWriteOperationsInNewTransaction();
+            // name is not unique for Foo in the existing data
+
+            foo = statement.labelGetOrCreateForName( "Foo" );
+            name = statement.propertyKeyGetOrCreateForName( "name" );
+
+            long node = statement.nodeCreate();
+            node1 = node;
+            statement.nodeAddLabel( node, foo );
+            statement.nodeSetProperty( node, Property.stringProperty( name, "foo" ) );
+
+            node = statement.nodeCreate();
+            statement.nodeAddLabel( node, foo );
+            node2 = node;
+            statement.nodeSetProperty( node, Property.stringProperty( name, "foo" ) );
+            commit();
+        }
+
+        // when
+        try
+        {
+            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            statement.uniquePropertyConstraintCreate( foo, name );
+
+            fail( "expected exception" );
+        }
+        // then
+        catch ( CreateConstraintFailureException ex )
+        {
+            assertEquals( new UniquenessConstraint( foo, name ), ex.constraint() );
+            Throwable cause = ex.getCause();
+            assertThat( cause, instanceOf( ConstraintVerificationFailedKernelException.class ) );
+
+            String expectedMessage = String.format(
+                    "Multiple nodes with label `%s` have property `%s` = '%s':%n  node(%d)%n  node(%d)",
+                    "Foo", "name", "foo", node1, node2 );
+            String actualMessage = userMessage( (ConstraintVerificationFailedKernelException) cause );
+            assertEquals( expectedMessage, actualMessage );
+        }
+    }
+
+    @Test
+    public void shouldCreateAnIndexToGoAlongWithAUniquePropertyConstraint() throws Exception
+    {
+        // when
+        {
+            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            statement.uniquePropertyConstraintCreate( typeId, propertyKeyId );
+            commit();
+        }
+
+        // then
+        {
+            ReadOperations statement = readOperationsInNewTransaction();
+            assertEquals( asSet( new IndexDescriptor( typeId, propertyKeyId ) ),
+                    asSet( statement.uniqueIndexesGetAll() ) );
+        }
+    }
+
+    @Test
+    public void shouldDropCreatedConstraintIndexWhenRollingBackConstraintCreation() throws Exception
+    {
+        // given
+        {
+            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            statement.uniquePropertyConstraintCreate( typeId, propertyKeyId );
+            assertEquals( asSet( new IndexDescriptor( typeId, propertyKeyId ) ),
+                    asSet( statement.uniqueIndexesGetAll() ) );
+        }
+
+        // when
+        rollback();
+
+        // then
+        {
+            ReadOperations statement = readOperationsInNewTransaction();
+            assertEquals( emptySetOf( IndexDescriptor.class ), asSet( statement.uniqueIndexesGetAll() ) );
+            commit();
+        }
+    }
+
+    @Test
+    public void shouldNotDropUniquePropertyConstraintThatDoesNotExistWhenThereIsAPropertyExistenceConstraint()
+            throws Exception
+    {
+        // given
+        NodePropertyExistenceConstraint constraint;
+        {
+            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            constraint = statement.nodePropertyExistenceConstraintCreate( typeId, propertyKeyId );
+            commit();
+        }
+
+        // when
+        try
+        {
+            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            statement.constraintDrop( new UniquenessConstraint( constraint.label(), constraint.propertyKey() ) );
+
+            fail( "expected exception" );
+        }
+        // then
+        catch ( DropConstraintFailureException e )
+        {
+            assertThat( e.getCause(), instanceOf( NoSuchConstraintException.class ) );
+        }
+        finally
+        {
+            rollback();
+        }
+
+        // then
+        {
+            ReadOperations statement = readOperationsInNewTransaction();
+
+            Iterator<NodePropertyConstraint> constraints =
+                    statement.constraintsGetForLabelAndPropertyKey( typeId, propertyKeyId );
+
+            assertEquals( constraint, single( constraints ) );
+        }
+    }
+
+    @Test
+    public void committedConstraintRuleShouldCrossReferenceTheCorrespondingIndexRule() throws Exception
+    {
+        // when
+        SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+        statement.uniquePropertyConstraintCreate( typeId, propertyKeyId );
+        commit();
+
+        // then
+        SchemaStorage schema = new SchemaStorage( neoStore().getSchemaStore() );
+        IndexRule indexRule = schema.indexRule( typeId, propertyKeyId );
+        UniquePropertyConstraintRule constraintRule = schema.uniquenessConstraint( typeId, propertyKeyId );
+        assertEquals( constraintRule.getId(), indexRule.getOwningConstraint().longValue() );
+        assertEquals( indexRule.getId(), constraintRule.getOwnedIndex() );
+    }
+
+    @Test
+    public void shouldDropConstraintIndexWhenDroppingConstraint() throws Exception
+    {
+        // given
+        UniquenessConstraint constraint;
+        {
+            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            constraint = statement.uniquePropertyConstraintCreate( typeId, propertyKeyId );
+            assertEquals( asSet( new IndexDescriptor( typeId, propertyKeyId ) ),
+                    asSet( statement.uniqueIndexesGetAll() ) );
+            commit();
+        }
+
+        // when
+        {
+            SchemaWriteOperations statement = schemaWriteOperationsInNewTransaction();
+            statement.constraintDrop( constraint );
+            commit();
+        }
+
+        // then
+        {
+            ReadOperations statement = readOperationsInNewTransaction();
+            assertEquals( emptySetOf( IndexDescriptor.class ), asSet( statement.uniqueIndexesGetAll() ) );
+            commit();
+        }
+    }
+
+    private String userMessage( ConstraintVerificationFailedKernelException cause )
+            throws TransactionFailureException
+    {
+        StatementTokenNameLookup lookup = new StatementTokenNameLookup( readOperationsInNewTransaction() );
+        String actualMessage = cause.getUserMessage( lookup );
+        commit();
+        return actualMessage;
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerSchemaWithPECTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerSchemaWithPECTest.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.kernel.impl.api.store;
 
-import java.util.Set;
-
 import org.junit.Test;
+
+import java.util.Set;
 
 import org.neo4j.SchemaHelper;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -55,6 +55,8 @@ public class DiskLayerSchemaWithPECTest extends DiskLayerTest
         SchemaHelper.createNodePropertyExistenceConstraint( db, label2, propertyKey );
         SchemaHelper.createRelPropertyExistenceConstraint( db, relType1, propertyKey );
 
+        SchemaHelper.awaitIndexes( db );
+
         // When
         Set<PropertyConstraint> constraints = asSet( disk.constraintsGetAll() );
 
@@ -79,6 +81,8 @@ public class DiskLayerSchemaWithPECTest extends DiskLayerTest
 
         SchemaHelper.createUniquenessConstraint( db, label1, propertyKey );
 
+        SchemaHelper.awaitIndexes( db );
+
         // When
         Set<NodePropertyConstraint> constraints = asSet( disk.constraintsGetForLabel( labelId( label1 ) ) );
 
@@ -99,6 +103,8 @@ public class DiskLayerSchemaWithPECTest extends DiskLayerTest
 
         SchemaHelper.createNodePropertyExistenceConstraint( db, label1, propertyKey );
         SchemaHelper.createNodePropertyExistenceConstraint( db, label2, propertyKey );
+
+        SchemaHelper.awaitIndexes( db );
 
         // When
         Set<NodePropertyConstraint> constraints = asSet(

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/TestPECListing.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/TestPECListing.java
@@ -143,6 +143,8 @@ public class TestPECListing extends AbstractShellTest
         SchemaHelper.createNodePropertyExistenceConstraint( db, label, "name" );
         SchemaHelper.createRelPropertyExistenceConstraint( db, relType, "since" );
 
+        SchemaHelper.awaitIndexes( db );
+
         // THEN
         executeCommand( "schema",
                 "Indexes",


### PR DESCRIPTION
UniquenessConstraintCreationIT was deleted my mistake during PEC restructuring.
This commit restores it and makes some small cleanup in PEC related tests.
