### PR TITLE
Remove MaxPermSize flag from test options, README.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -26,7 +26,7 @@ NOTE: This GitHub repository contains mixed GPL and AGPL code. Our Community edi
 
 == Dependencies ==
 
-Neo4j is built using http://maven.apache.org/[Apache Maven] version 3.0.x and a recent version of http://www.oracle.com/technetwork/java/javase/downloads/index.html[Java 7]. Bash and Make is also required. Note that maven needs more memory than the standard configuration, this can be achieved with `export MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=128m"`.
+Neo4j is built using http://maven.apache.org/[Apache Maven] version 3.0.x and a recent version of http://www.oracle.com/technetwork/java/javase/downloads/index.html[Java 8]. Bash and Make is also required. Note that maven needs more memory than the standard configuration, this can be achieved with `export MAVEN_OPTS="-Xmx512m"`.
 
 The Neo4j Browser module is built using http://nodejs.org[Node.js]. For skipping that part of the build, see below. Building the manual requires Python, graphviz and make.
 
@@ -44,7 +44,7 @@ If you don't plan to build the browser (for example by using -DskipBrowser), the
 
 === With apt-get on Ubuntu ===
 
-  sudo apt-get install graphviz maven nodejs-legacy npm make openjdk-7-jdk devscripts debhelper rpm
+  sudo apt-get install graphviz maven nodejs-legacy npm make openjdk-8-jdk devscripts debhelper rpm
 
 == Building Neo4j ==
 
@@ -58,7 +58,7 @@ If you don't plan to build the browser (for example by using -DskipBrowser), the
 * When building on Windows, use `-Dlicensing.skip` to avoid problems related to line endings.
 * The license header check can be skipped by appending the following to the command line: `-Dlicense.skip=true`.
 * If you are running into problems building on Windows you can try building Neo4j in a Ubuntu virtual machine.
-* You may need to increase the memory available to Maven: `export MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=256m"`.
+* You may need to increase the memory available to Maven: `export MAVEN_OPTS="-Xmx512m"`.
 
 == Running Neo4j ==
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <logback-classic.version>1.1.2</logback-classic.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
     <hsqldb.version>2.3.2</hsqldb.version>
-    <test.runner.jvm.settings>-Xmx1G -XX:MaxPermSize=128M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data</test.runner.jvm.settings>
+    <test.runner.jvm.settings>-Xmx1G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data</test.runner.jvm.settings>
     <doclint-groups>reference</doclint-groups>
     <neo4j.java.version>1.8</neo4j.java.version>
   </properties>


### PR DESCRIPTION
This memory area is not a separate area in the JVM anymore. With
JDK 8 this flag has no effect besides issuing a warning. Also
updates build instructions in README to use JDK8.
