### PR TITLE
Security improvements to file URL access in `LOAD CSV`

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipe.scala
@@ -41,24 +41,21 @@ case class LoadCSVPipe(source: Pipe,
                   identifier: String,
                   fieldTerminator: Option[String])(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) {
-  private val protocolWhiteList: Seq[String] = Seq("file", "http", "https", "ftp")
 
-  protected def checkURL(urlString: String, context: QueryContext): URL = {
+  protected def getImportURL(urlString: String, context: QueryContext): URL = {
     val url: URL = try {
       new URL(urlString)
     } catch {
       case e: java.net.MalformedURLException =>
-        throw new LoadExternalResourceException(s"Invalid URL specified (${e.getMessage})", null)
+        throw new LoadExternalResourceException(s"Invalid URL '$urlString': ${e.getMessage}")
     }
 
-    val protocol = url.getProtocol
-    if (!protocolWhiteList.contains(protocol)) {
-      throw new LoadExternalResourceException(s"Unsupported URL protocol: $protocol", null)
+    context.getImportURL(url) match {
+      case Left(error) =>
+        throw new LoadExternalResourceException(s"Cannot load from URL '$urlString': $error")
+      case Right(urlToLoad) =>
+        urlToLoad
     }
-    if (url.getProtocol == "file" && !context.hasLocalFileAccess) {
-      throw new LoadExternalResourceException("Accessing local files not allowed by the configuration")
-    }
-    url
   }
 
   //Uses an ArrayBackedMap to store header-to-values mapping
@@ -104,7 +101,7 @@ case class LoadCSVPipe(source: Pipe,
 
     input.flatMap(context => {
       implicit val s = state
-      val url = checkURL(urlExpression(context).asInstanceOf[String], state.query)
+      val url = getImportURL(urlExpression(context).asInstanceOf[String], state.query)
 
       val iterator: Iterator[Array[String]] = state.resources.getCsvIterator(url, fieldTerminator)
       format match {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/DelegatingQueryContext.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.spi
 
+import java.net.URL
+
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
 import org.neo4j.graphdb.{Path, Relationship, PropertyContainer, Node}
@@ -119,7 +121,7 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
 
   def getRelTypeName(id: Int): String = singleDbHit(inner.getRelTypeName(id))
 
-  override def hasLocalFileAccess: Boolean = inner.hasLocalFileAccess
+  def getImportURL(url: URL): Either[String,URL] = inner.getImportURL(url)
 
   def relationshipStartNode(rel: Relationship) = inner.relationshipStartNode(rel)
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/QueryContext.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.spi
 
+import java.net.URL
+
 import org.neo4j.cypher.internal.compiler.v2_3.InternalQueryStatistics
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
@@ -107,7 +109,7 @@ trait QueryContext extends TokenContext {
 
   def getOptStatistics: Option[InternalQueryStatistics] = None
 
-  def hasLocalFileAccess: Boolean = false
+  def getImportURL(url: URL): Either[String,URL]
 
   /**
    * This should not be used. We'll remove sooner (or later). Don't do it.

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipeTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.pipes
+
+import java.net.{URI, URL}
+import java.nio.file.Paths
+
+import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
+import org.neo4j.cypher.internal.frontend.v2_3.symbols.CTNumber
+import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
+
+class LoadCSVPipeTest extends CypherFunSuite with PipeTestSupport {
+
+  test("should map unix path") {
+    val url = new URL("file:///tmp/data/import.csv")
+
+    val path = Paths.get(url.toURI)
+    path.toAbsolutePath should equal( Paths.get("/tmp", "data", "import.csv") )
+  }
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compatibility
 
+import java.net.URL
+
 import org.neo4j.cypher.internal.compiler.v2_3.spi
 import org.neo4j.cypher.internal.compiler.v2_3.spi._
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticDirection
@@ -146,8 +148,8 @@ class ExceptionTranslatingQueryContextFor2_3(inner: QueryContext) extends Delega
   override def commitAndRestartTx() =
     translateException(super.commitAndRestartTx())
 
-  override def hasLocalFileAccess =
-    translateException(super.hasLocalFileAccess)
+  override def getImportURL(url: URL) =
+    translateException(super.getImportURL(url))
 
   override def relationshipStartNode(rel: Relationship) =
     translateException(super.relationshipStartNode(rel))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
@@ -291,7 +291,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
 
   override def hasLocalFileAccess: Boolean = graph match {
     case db: GraphDatabaseAPI => db.getDependencyResolver.resolveDependency(classOf[Config]).get(GraphDatabaseSettings.allow_file_urls)
-    case _ => true
+    case _ => false
   }
 
   def relationshipStartNode(rel: Relationship) = rel.getStartNode

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/LabelActionTest.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3
 
+import java.net.URL
+
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Literal
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{KeyToken, TokenType}
@@ -181,4 +183,6 @@ class SnitchingQueryContext extends QueryContext {
 
   // Legacy dependency between kernel and compiler
   override def variableLengthPathExpand(node: PatternNode, realNode: Node, minHops: Option[Int], maxHops: Option[Int], direction: SemanticDirection, relTypes: Seq[String]): Iterator[Path] = ???
+
+  def getImportURL(url: URL): Either[String,URL] = ???
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContextTest.scala
@@ -109,9 +109,9 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     val context = new TransactionBoundQueryContext(graph, tx, isTopLevelTx = true, stmt)
 
     // THEN
-    context.getImportURL(new URL("http://localhost:7474/data.csv")) should equal (Left(new URL("http://localhost:7474/data.csv")))
-    context.getImportURL(new URL("file:///tmp/foo/data.csv")) should equal (Left(new URL("file:///tmp/foo/data.csv")))
-    context.getImportURL(new URL("jar:file:/tmp/blah.jar!/tmp/foo/data.csv")) should equal (Right("loading resources via protocol 'jar' is not permitted"))
+    context.getImportURL(new URL("http://localhost:7474/data.csv")) should equal (Right(new URL("http://localhost:7474/data.csv")))
+    context.getImportURL(new URL("file:///tmp/foo/data.csv")) should equal (Right(new URL("file:///tmp/foo/data.csv")))
+    context.getImportURL(new URL("jar:file:/tmp/blah.jar!/tmp/foo/data.csv")) should equal (Left("loading resources via protocol 'jar' is not permitted"))
 
     tx.success()
     tx.finish()
@@ -126,8 +126,8 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     val context = new TransactionBoundQueryContext(graph, tx, isTopLevelTx = true, stmt)
 
     // THEN
-    context.getImportURL(new URL("http://localhost:7474/data.csv")) should equal (Left(new URL("http://localhost:7474/data.csv")))
-    context.getImportURL(new URL("file:///tmp/foo/data.csv")) should equal (Right("configuration property 'allow_file_urls' is false"))
+    context.getImportURL(new URL("http://localhost:7474/data.csv")) should equal (Right(new URL("http://localhost:7474/data.csv")))
+    context.getImportURL(new URL("file:///tmp/foo/data.csv")) should equal (Left("configuration property 'allow_file_urls' is false"))
 
     tx.success()
     tx.finish()

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.graphdb.security.URLAccessRule;
 import org.neo4j.logging.LogProvider;
 
 import static java.util.Arrays.asList;
@@ -179,8 +180,14 @@ public class GraphDatabaseFactory
         return this;
     }
 
+    public GraphDatabaseFactory addURLAccessRule( String protocol, URLAccessRule rule )
+    {
+        getCurrentState().addURLAccessRule( protocol, rule );
+        return this;
+    }
+
     public GraphDatabaseFactory setUserLogProvider( LogProvider userLogProvider )
-   {
+    {
         getCurrentState().setUserLogProvider( userLogProvider );
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
@@ -20,11 +20,14 @@
 package org.neo4j.graphdb.factory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.neo4j.helpers.Service;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.graphdb.security.URLAccessRule;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
 
@@ -36,6 +39,7 @@ public class GraphDatabaseFactoryState
     private final List<KernelExtensionFactory<?>> kernelExtensions;
     private Monitors monitors;
     private LogProvider userLogProvider;
+    private Map<String,URLAccessRule> urlAccessRules;
 
     public GraphDatabaseFactoryState() {
         settingsClasses = new ArrayList<>();
@@ -45,12 +49,14 @@ public class GraphDatabaseFactoryState
         {
             kernelExtensions.add( factory );
         }
+        urlAccessRules = new HashMap<>();
     }
 
     public GraphDatabaseFactoryState( GraphDatabaseFactoryState previous )
     {
         settingsClasses = new ArrayList<>( previous.settingsClasses );
         kernelExtensions = new ArrayList<>( previous.kernelExtensions );
+        urlAccessRules = new HashMap<>( previous.urlAccessRules );
         monitors = previous.monitors;
         monitors = previous.monitors;
         userLogProvider = previous.userLogProvider;
@@ -75,6 +81,11 @@ public class GraphDatabaseFactoryState
         }
     }
 
+    public void addURLAccessRule( String protocol, URLAccessRule rule )
+    {
+        urlAccessRules.put( protocol, rule );
+    }
+
     public void setUserLogProvider( LogProvider userLogProvider )
     {
         this.userLogProvider = userLogProvider;
@@ -91,6 +102,7 @@ public class GraphDatabaseFactoryState
                 monitors(monitors).
                 userLogProvider(userLogProvider).
                 settingsClasses(settingsClasses).
+                urlAccessRules( urlAccessRules ).
                 kernelExtensions(kernelExtensions);
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -144,6 +144,10 @@ public abstract class GraphDatabaseSettings
                   + "value to `false` will cause Neo4j to fail `LOAD CSV` clauses that load data from the file system." )
     public static Setting<Boolean> allow_file_urls = setting( "allow_file_urls", BOOLEAN, TRUE );
 
+    @Description( "Sets the root directory for file URLs used with the Cypher `LOAD CSV` clause. This must be set to a single "
+                  + "directory, restricting access to only those files within that directory and its subdirectories." )
+    public static Setting<File> load_csv_file_url_root = setting( "dbms.security.load_csv_file_url_root", PATH, NO_DEFAULT );
+
     @Deprecated
     @Obsoleted( "This is no longer used" )
     @Description("The directory where the database files are located.")

--- a/community/kernel/src/main/java/org/neo4j/graphdb/security/URLAccessRule.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/security/URLAccessRule.java
@@ -17,40 +17,26 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel;
+package org.neo4j.graphdb.security;
 
 import java.net.URL;
 
-import org.neo4j.graphdb.DependencyResolver;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.security.URLAccessValidationError;
 
 /**
- * This API can be used to get access to services.
- *
- * @deprecated This will be moved to internal packages in the next major release.
+ * A rule to evaluate if Neo4j is permitted to reach out to the specified URL (e.g. when using {@code LOAD CSV} in Cypher).
  */
-@Deprecated
-public interface GraphDatabaseAPI extends GraphDatabaseService
+public interface URLAccessRule
 {
     /**
-     * Look up database components for direct access.
-     * Usage of this method is generally an indication of architectural error.
-     */
-    DependencyResolver getDependencyResolver();
-
-    /** Provides the unique id assigned to this database. */
-    StoreId storeId();
-
-    /**
-     * Validate whether this database instance is permitted to reach out to the specified URL (e.g. when using {@code LOAD CSV} in Cypher).
+     * Validate this rule against the specified URL and configuration, and throw a {@link URLAccessValidationError}
+     * if the URL is not permitted for access.
      *
+     * @param gdb the current graph database
      * @param url the URL being validated
      * @return an updated URL that should be used for accessing the resource
+     * @throws URLAccessValidationError thrown if the url does not pass the validation rule
      */
-    URL validateURLAccess( URL url ) throws URLAccessValidationError;
-
-    @Deprecated
-    String getStoreDir();
+    URL validate( GraphDatabaseAPI gdb, URL url ) throws URLAccessValidationError;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseDependencies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseDependencies.java
@@ -21,13 +21,18 @@ package org.neo4j.kernel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.neo4j.helpers.Service;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
+import org.neo4j.kernel.impl.security.URLAccessRules;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.graphdb.security.URLAccessRule;
 import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.collection.Iterables.addAll;
@@ -38,7 +43,7 @@ public class GraphDatabaseDependencies implements GraphDatabaseFacadeFactory.Dep
     public static GraphDatabaseDependencies newDependencies( GraphDatabaseFacadeFactory.Dependencies deps )
     {
         return new GraphDatabaseDependencies( deps.monitors(), deps.userLogProvider(),
-                toList( deps.settingsClasses() ), toList( deps.kernelExtensions() ), toList( deps.executionEngines() ) );
+                toList( deps.settingsClasses() ), toList( deps.kernelExtensions() ), deps.urlAccessRules(), toList( deps.executionEngines() ) );
     }
 
     public static GraphDatabaseDependencies newDependencies()
@@ -48,14 +53,24 @@ public class GraphDatabaseDependencies implements GraphDatabaseFacadeFactory.Dep
         {
             kernelExtensions.add( factory );
         }
+
+        Map<String,URLAccessRule> urlAccessRules = new HashMap<>();
+        urlAccessRules.put( "http", URLAccessRules.alwaysPermitted() );
+        urlAccessRules.put( "https", URLAccessRules.alwaysPermitted() );
+        urlAccessRules.put( "ftp", URLAccessRules.alwaysPermitted() );
+        urlAccessRules.put( "file", URLAccessRules.fileAccess() );
+
+        List<QueryEngineProvider> queryEngineProviders = toList( Service.load( QueryEngineProvider.class ) );
+
         return new GraphDatabaseDependencies( null, null, new ArrayList<Class<?>>(), kernelExtensions,
-                toList( Service.load( QueryEngineProvider.class ) ) );
+                urlAccessRules, queryEngineProviders );
     }
 
     private final Monitors monitors;
     private final LogProvider userLogProvider;
     private final List<Class<?>> settingsClasses;
     private final List<KernelExtensionFactory<?>> kernelExtensions;
+    private final Map<String,URLAccessRule> urlAccessRules;
     private final List<QueryEngineProvider> queryEngineProviders;
 
     private GraphDatabaseDependencies(
@@ -63,12 +78,14 @@ public class GraphDatabaseDependencies implements GraphDatabaseFacadeFactory.Dep
             LogProvider userLogProvider,
             List<Class<?>> settingsClasses,
             List<KernelExtensionFactory<?>> kernelExtensions,
+            Map<String,URLAccessRule> urlAccessRules,
             List<QueryEngineProvider> queryEngineProviders )
     {
         this.monitors = monitors;
         this.userLogProvider = userLogProvider;
         this.settingsClasses = settingsClasses;
         this.kernelExtensions = kernelExtensions;
+        this.urlAccessRules = Collections.unmodifiableMap( urlAccessRules );
         this.queryEngineProviders = queryEngineProviders;
     }
 
@@ -76,39 +93,47 @@ public class GraphDatabaseDependencies implements GraphDatabaseFacadeFactory.Dep
     public GraphDatabaseDependencies monitors( Monitors monitors )
     {
         return new GraphDatabaseDependencies( monitors, userLogProvider, settingsClasses, kernelExtensions,
-                queryEngineProviders );
+                urlAccessRules, queryEngineProviders );
     }
 
     public GraphDatabaseDependencies userLogProvider( LogProvider userLogProvider )
     {
         return new GraphDatabaseDependencies( monitors, userLogProvider, settingsClasses, kernelExtensions,
-                queryEngineProviders );
+                urlAccessRules, queryEngineProviders );
     }
 
     public GraphDatabaseDependencies settingsClasses( List<Class<?>> settingsClasses )
     {
         return new GraphDatabaseDependencies( monitors, userLogProvider, settingsClasses, kernelExtensions,
-                queryEngineProviders );
+                urlAccessRules, queryEngineProviders );
     }
 
     public GraphDatabaseDependencies settingsClasses( Class<?>... settingsClass )
     {
         settingsClasses.addAll( Arrays.asList( settingsClass ) );
         return new GraphDatabaseDependencies( monitors, userLogProvider, settingsClasses, kernelExtensions,
-                queryEngineProviders );
+                urlAccessRules, queryEngineProviders );
     }
 
     public GraphDatabaseDependencies kernelExtensions( Iterable<KernelExtensionFactory<?>> kernelExtensions )
     {
         return new GraphDatabaseDependencies( monitors, userLogProvider, settingsClasses,
                 addAll( new ArrayList<KernelExtensionFactory<?>>(), kernelExtensions ),
-                queryEngineProviders );
+                urlAccessRules, queryEngineProviders );
+    }
+
+    public GraphDatabaseDependencies urlAccessRules( Map<String,URLAccessRule> urlAccessRules )
+    {
+        final HashMap<String,URLAccessRule> newUrlAccessRules = new HashMap<>( this.urlAccessRules );
+        newUrlAccessRules.putAll( urlAccessRules );
+        return new GraphDatabaseDependencies( monitors, userLogProvider, settingsClasses, kernelExtensions,
+                newUrlAccessRules, queryEngineProviders );
     }
 
     public GraphDatabaseDependencies queryEngineProviders( Iterable<QueryEngineProvider> queryEngineProviders )
     {
         return new GraphDatabaseDependencies( monitors, userLogProvider, settingsClasses, kernelExtensions,
-                addAll( this.queryEngineProviders, queryEngineProviders ) );
+                urlAccessRules, addAll( new ArrayList<>( this.queryEngineProviders ), queryEngineProviders ) );
     }
 
     // Dependencies implementation
@@ -134,6 +159,12 @@ public class GraphDatabaseDependencies implements GraphDatabaseFacadeFactory.Dep
     public Iterable<KernelExtensionFactory<?>> kernelExtensions()
     {
         return kernelExtensions;
+    }
+
+    @Override
+    public Map<String,URLAccessRule> urlAccessRules()
+    {
+        return urlAccessRules;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.factory;
 
 import java.io.File;
+import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 
@@ -81,6 +82,7 @@ import org.neo4j.kernel.impl.traversal.BidirectionalTraversalDescriptionImpl;
 import org.neo4j.kernel.impl.traversal.MonoDirectionalTraversalDescription;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleException;
+import org.neo4j.kernel.security.URLAccessValidationError;
 import org.neo4j.logging.Log;
 import org.neo4j.tooling.GlobalGraphOperations;
 
@@ -549,6 +551,12 @@ public class GraphDatabaseFacade
     public StoreId storeId()
     {
         return storeId.get();
+    }
+
+    @Override
+    public URL validateURLAccess( URL url ) throws URLAccessValidationError
+    {
+        return platformModule.urlAccessRule.validate( this, url );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.graphdb.security.URLAccessRule;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.Logger;
 
@@ -69,6 +70,8 @@ public abstract class GraphDatabaseFacadeFactory
         Iterable<Class<?>> settingsClasses();
 
         Iterable<KernelExtensionFactory<?>> kernelExtensions();
+
+        Map<String,URLAccessRule> urlAccessRules();
 
         Iterable<QueryEngineProvider> executionEngines();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -45,6 +45,7 @@ import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.StoreLogService;
 import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 import org.neo4j.kernel.impl.pagecache.PageCacheLifecycle;
+import org.neo4j.kernel.impl.security.URLAccessRules;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.impl.transaction.TransactionCounters;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
@@ -56,6 +57,7 @@ import org.neo4j.kernel.info.JvmMetadataRepository;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
+import org.neo4j.graphdb.security.URLAccessRule;
 import org.neo4j.logging.Level;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -93,6 +95,8 @@ public class PlatformModule
     public final DataSourceManager dataSourceManager;
 
     public final KernelExtensions kernelExtensions;
+
+    public final URLAccessRule urlAccessRule;
 
     public final JobScheduler jobScheduler;
 
@@ -183,6 +187,8 @@ public class PlatformModule
                 externalDependencies.kernelExtensions(),
                 dependencies,
                 UnsatisfiedDependencyStrategies.fail() ) );
+
+        urlAccessRule = dependencies.satisfyDependency( URLAccessRules.combined( externalDependencies.urlAccessRules() ) );
 
         publishPlatformInfo( dependencies.resolveDependency( UsageData.class ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/security/FileURLAccessRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/security/FileURLAccessRule.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.security;
+
+import java.net.URL;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.graphdb.security.URLAccessRule;
+import org.neo4j.kernel.security.URLAccessValidationError;
+
+class FileURLAccessRule implements URLAccessRule
+{
+    @Override
+    public URL validate( GraphDatabaseAPI gdb, URL url ) throws URLAccessValidationError
+    {
+        if ( !( url.getAuthority() == null || url.getAuthority().equals("") ) )
+        {
+            throw new URLAccessValidationError( "file URL may not contain an authority section (i.e. it should be 'file:///')" );
+        }
+
+        if ( !( url.getQuery() == null || url.getQuery().equals("") ) )
+        {
+            throw new URLAccessValidationError( "file URL may not contain a query component" );
+        }
+
+        final Config config = gdb.getDependencyResolver().resolveDependency( Config.class );
+        if ( !config.get( GraphDatabaseSettings.allow_file_urls ) )
+        {
+            throw new URLAccessValidationError( "configuration property '" + GraphDatabaseSettings.allow_file_urls.name() + "' is false" );
+        }
+        return url;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/security/URLAccessRules.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/security/URLAccessRules.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.security;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.graphdb.security.URLAccessRule;
+import org.neo4j.kernel.security.URLAccessValidationError;
+
+public class URLAccessRules
+{
+    private static final URLAccessRule ALWAYS_PERMITTED = new URLAccessRule()
+    {
+        @Override
+        public URL validate( GraphDatabaseAPI gdb, URL url )
+        {
+            return url;
+        }
+    };
+
+    public static URLAccessRule alwaysPermitted()
+    {
+        return ALWAYS_PERMITTED;
+    }
+
+    private static final URLAccessRule FILE_ACCESS = new FileURLAccessRule();
+
+    public static URLAccessRule fileAccess()
+    {
+        return FILE_ACCESS;
+    }
+
+    public static URLAccessRule combined( final Map<String,URLAccessRule> urlAccessRules )
+    {
+        return new URLAccessRule()
+        {
+            @Override
+            public URL validate( GraphDatabaseAPI gdb, URL url ) throws URLAccessValidationError
+            {
+                String protocol = url.getProtocol();
+                URLAccessRule protocolRule = urlAccessRules.get( protocol );
+                if ( protocolRule == null )
+                {
+                    throw new URLAccessValidationError( "loading resources via protocol '" + protocol + "' is not permitted" );
+                }
+                return protocolRule.validate( gdb, url );
+            }
+        };
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/security/URLAccessValidationError.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/security/URLAccessValidationError.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.security;
+
+/**
+ * An access validation error indicating why a URL cannot be accessed by a Neo4j graph database instance.
+ */
+public class URLAccessValidationError extends Exception
+{
+    public URLAccessValidationError( String message )
+    {
+        super( message );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/security/FileURLAccessRuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/security/FileURLAccessRuleTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.security;
+
+import org.junit.Test;
+
+import java.net.URL;
+
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.security.URLAccessValidationError;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FileURLAccessRuleTest
+{
+    @Test
+    public void shouldThrowWhenFileURLContainsAuthority() throws Exception
+    {
+        try
+        {
+            URLAccessRules.fileAccess().validate( mock( GraphDatabaseAPI.class ), new URL( "file://foo/bar/baz" ) );
+            fail( "expected exception not thrown " );
+        }
+        catch ( URLAccessValidationError error )
+        {
+            assertThat( error.getMessage(), equalTo( "file URL may not contain an authority section (i.e. it should be 'file:///')" ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenFileURLContainsQuery() throws Exception
+    {
+        try
+        {
+            URLAccessRules.fileAccess().validate( mock( GraphDatabaseAPI.class ), new URL( "file:///bar/baz?q=foo" ) );
+            fail( "expected exception not thrown " );
+        }
+        catch ( URLAccessValidationError error )
+        {
+            assertThat( error.getMessage(), equalTo( "file URL may not contain a query component" ) );
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenFileAccessIsDisabled() throws Exception
+    {
+        final URL url = new URL( "file:///bar/baz.csv" );
+        final GraphDatabaseAPI gdb = mock( GraphDatabaseAPI.class );
+        final DependencyResolver mockResolver = mock( DependencyResolver.class );
+        when( gdb.getDependencyResolver() ).thenReturn( mockResolver );
+        final Config config = new Config( MapUtil.stringMap( GraphDatabaseSettings.allow_file_urls.name(), "false" ) );
+        when( mockResolver.resolveDependency( eq( Config.class ) ) ).thenReturn( config );
+
+        try
+        {
+            URLAccessRules.fileAccess().validate( gdb, url );
+            fail( "expected exception not thrown " );
+        }
+        catch ( URLAccessValidationError error )
+        {
+            assertThat( error.getMessage(), equalTo( "configuration property 'allow_file_urls' is false" ) );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/security/FileURLAccessRuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/security/FileURLAccessRuleTest.java
@@ -87,4 +87,18 @@ public class FileURLAccessRuleTest
             assertThat( error.getMessage(), equalTo( "configuration property 'allow_file_urls' is false" ) );
         }
     }
+
+    @Test
+    public void shouldAdjustURLToWithinImportDirectory() throws Exception
+    {
+        final URL url = new URL( "file:///bar/baz.csv" );
+        final GraphDatabaseAPI gdb = mock( GraphDatabaseAPI.class );
+        final DependencyResolver mockResolver = mock( DependencyResolver.class );
+        when( gdb.getDependencyResolver() ).thenReturn( mockResolver );
+        final Config config = new Config( MapUtil.stringMap( GraphDatabaseSettings.load_csv_file_url_root.name(), "/var/lib/neo4j/import" ) );
+        when( mockResolver.resolveDependency( eq( Config.class ) ) ).thenReturn( config );
+
+        URL accessURL = URLAccessRules.fileAccess().validate( gdb, url );
+        assertThat( accessURL, equalTo( new URL( "file:///var/lib/neo4j/import/bar/baz.csv" ) ) );
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
@@ -21,6 +21,7 @@ package org.neo4j.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Map;
 
 import org.neo4j.function.Consumer;
@@ -54,6 +55,7 @@ import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.security.URLAccessValidationError;
 
 public abstract class DatabaseRule extends ExternalResource implements GraphDatabaseAPI
 {
@@ -378,6 +380,12 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
     public File getStoreDirFile()
     {
         return new File( getStoreDir() );
+    }
+
+    @Override
+    public URL validateURLAccess( URL url ) throws URLAccessValidationError
+    {
+        return database.validateURLAccess( url );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentDatabaseRule.java
@@ -19,8 +19,11 @@
  */
 package org.neo4j.test;
 
+import java.net.URL;
+
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.kernel.security.URLAccessValidationError;
 import org.neo4j.logging.LogProvider;
 
 /**

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -36,6 +36,7 @@ import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.impl.logging.AbstractLogService;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.graphdb.security.URLAccessRule;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
@@ -134,6 +135,12 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
     public TestGraphDatabaseFactory addKernelExtension( KernelExtensionFactory<?> newKernelExtension )
     {
         return (TestGraphDatabaseFactory) super.addKernelExtension( newKernelExtension );
+    }
+
+    @Override
+    public TestGraphDatabaseFactory addURLAccessRule( String protocol, URLAccessRule rule )
+    {
+        return (TestGraphDatabaseFactory) super.addURLAccessRule( protocol, rule );
     }
 
     public GraphDatabaseBuilder newImpermanentDatabaseBuilder( final File storeDir )

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
@@ -20,6 +20,7 @@
 package org.neo4j.shell.kernel;
 
 import java.io.Serializable;
+import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +60,7 @@ import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.traversal.OldTraverserWrapper;
+import org.neo4j.kernel.security.URLAccessValidationError;
 
 public class ReadOnlyGraphDatabaseProxy implements GraphDatabaseService, GraphDatabaseAPI, IndexManager
 {
@@ -1010,6 +1012,12 @@ public class ReadOnlyGraphDatabaseProxy implements GraphDatabaseService, GraphDa
     public StoreId storeId()
     {
         return actual.storeId();
+    }
+
+    @Override
+    public URL validateURLAccess( URL url ) throws URLAccessValidationError
+    {
+        return actual.validateURLAccess( url );
     }
 
     @Override

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -21,6 +21,9 @@
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
 
+# Set the root directory for use with file URLs (`file:///`) in LOAD CSV.
+dbms.security.load_csv_file_url_root=data/import
+
 # Keep logical logs, helps debugging but uses more disk space, enabled for
 # legacy reasons To limit space needed to store historical logs use values such
 # as: "7 days" or "100M size" instead of "true".

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/data/import/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/data/import/README.txt
@@ -1,0 +1,7 @@
+#{product.fullname} Import Data
+=======================================
+
+Files placed into this directory are accessible using file URLs (`file:///`)
+with the `LOAD CSV` clause in Cypher. If the location of this directory needs
+to be changed, this can be achieved by altering the database configuration
+property `dbms.security.load_csv_file_url_root`.

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -21,6 +21,9 @@
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
 
+# Set the root directory for use with file URLs (`file:///`) in LOAD CSV.
+dbms.security.load_csv_file_url_root=data/import
+
 # Keep logical logs, helps debugging but uses more disk space, enabled for
 # legacy reasons To limit space needed to store historical logs use values such
 # as: "7 days" or "100M size" instead of "true".

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/data/import/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/data/import/README.txt
@@ -1,0 +1,7 @@
+#{product.fullname} Import Data
+=======================================
+
+Files placed into this directory are accessible using file URLs (`file:///`)
+with the `LOAD CSV` clause in Cypher. If the location of this directory needs
+to be changed, this can be achieved by altering the database configuration
+property `dbms.security.load_csv_file_url_root`.

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -21,6 +21,9 @@
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
 
+# Set the root directory for use with file URLs (`file:///`) in LOAD CSV.
+dbms.security.load_csv_file_url_root=data/import
+
 # Keep logical logs, helps debugging but uses more disk space, enabled for
 # legacy reasons To limit space needed to store historical logs use values such
 # as: "7 days" or "100M size" instead of "true".

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/data/import/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/data/import/README.txt
@@ -1,0 +1,7 @@
+#{product.fullname} Import Data
+=======================================
+
+Files placed into this directory are accessible using file URLs (`file:///`)
+with the `LOAD CSV` clause in Cypher. If the location of this directory needs
+to be changed, this can be achieved by altering the database configuration
+property `dbms.security.load_csv_file_url_root`.


### PR DESCRIPTION
Add `dbms.security.load_csv_file_url_root` setting, which restricts file URLs used with `LOAD CSV` to be within the specified directory, such that the URL is resolved relative to that root directory (similarly to a chroot).

There is currently no default for the setting, which allows file URLs to access any local file. For neo4j-server, the default configuration files explicitly set this to `data/import`, so new deployments will be
restricted by default (e.g. `file:///foo.csv` will refer to `data/import/foo.csv`). The `data/import` directory has also been added to the server packaging.

For Neo4j 3.0, a default should be added to this property, so all deployments are made safe by default.

Additionally, this PR introduces an [embedded API for setting URL access rules](https://github.com/neo4j/neo4j/commit/040117bdc35b330396df647647ca317fb6f5fb10#diff-d68a25b513aea36d3689582e4e1a9967R338), allowing support for additional protocols to be enabled at runtime (via custom `URLStreamHandlers`). This replaces #5321.
