### PR TITLE
Query log rotation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -465,8 +465,17 @@ public abstract class GraphDatabaseSettings
     public static final Setting<File> log_queries_filename = setting("dbms.querylog.filename", PATH, NO_DEFAULT );
 
     @Description("If the execution of query takes more time than this threshold, the query is logged - " +
-            "provided query logging is enabled. Defaults to 0 seconds, that is all queries are logged.")
+                 "provided query logging is enabled. Defaults to 0 seconds, that is all queries are logged.")
     public static final Setting<Long> log_queries_threshold = setting("dbms.querylog.threshold", DURATION, "0s");
+
+    @Description( "Specifies at which file size the query log will auto-rotate. " +
+                  "`0` means that no rotation will automatically occur based on file size." )
+    public static final Setting<Long> log_queries_rotation_threshold = setting("dbms.querylog.rotation.threshold",
+            BYTES, "20m",  min( 0L ), max( Long.MAX_VALUE ) );
+
+    @Description( "Maximum number of history files for the query log." )
+    public static final Setting<Integer> log_queries_max_archives = setting( "dbms.querylog.max_archives", INTEGER,
+            "7", min( 1 ) );
 
     @Description( "Specifies number of operations that batch inserter will try to group into one batch before " +
                   "flushing data into underlying storage.")

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -132,6 +132,11 @@ public interface JobScheduler extends Lifecycle
         public static final Group internalLogRotation = new Group( "InternalLogRotation", POOLED );
 
         /**
+         * Rotates query logs
+         */
+        public static final Group queryLogRotation = new Group( "queryLogRotation", POOLED );
+
+        /**
          * Checkpoint and store flush
          */
         public static final Group checkPoint = new Group( "CheckPoint", POOLED );


### PR DESCRIPTION
Add possibility to rotate query. Rotation threshold is specified by 'dbms.querylog.rotation.threshold' property
and maximum number of history files to keep by 'dbms.querylog.max_archives'.
By default rotation will happen each 20m and we will keep 7 files.
