### PR TITLE
Query log rotation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -406,6 +406,10 @@ public abstract class GraphDatabaseSettings
             "provided query logging is enabled. Defaults to 0 seconds, that is all queries are logged.")
     public static final Setting<Long> log_queries_threshold = setting("dbms.querylog.threshold", DURATION, "0s");
 
+    @Description( "Specifies at which file size the query log will auto-rotate. ")
+    public static final Setting<Long> log_queries_rotation_threshold = setting("dbms.querylog.rotation.threshold",
+            BYTES, "20m", min( 1024 * 1024L ), max( Long.MAX_VALUE ) );
+
     @Description( "Specifies number of operations that batch inserter will try to group into one batch before " +
                   "flushing data into underlying storage.")
     @Internal

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.query;
 
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -29,9 +30,13 @@ import org.junit.runner.RunWith;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -39,118 +44,139 @@ import org.neo4j.helpers.Settings;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-@RunWith( Enclosed.class )
 public class QueryLoggerIT
 {
 
-    public static class ConfiguredCorrectly
+    @Rule
+    public final EphemeralFileSystemRule fileSystem = new EphemeralFileSystemRule();
+    @Rule
+    public final TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+    private GraphDatabaseBuilder databaseBuilder;
+    public static final String QUERY = "CREATE (n:Foo{bar:\"baz\"})";
+
+    @Before
+    public void setUp()
     {
-        @Rule
-        public TestRule ruleOrder()
-        {
-            return RuleChain.outerRule( fs ).around( db );
-        }
-
-        private final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
-        private final DatabaseRule db = new ImpermanentDatabaseRule()
-        {
-            @Override
-            protected GraphDatabaseFactory newFactory()
-            {
-                return ((TestGraphDatabaseFactory) super.newFactory()).setFileSystem( fs.get() );
-            }
-
-            @Override
-            protected GraphDatabaseBuilder newBuilder( GraphDatabaseFactory factory )
-            {
-                return super.newBuilder( factory )
-                        .setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE )
-                        .setConfig( GraphDatabaseSettings.log_queries_filename, logFilename.getPath() );
-            }
-        };
-
-        private File logFilename = new File( "target/test-data/impermanent-db/queries.log" );
-
-        @Test
-        public void shouldLogQuerySlowerThanThreshold() throws Exception
-        {
-            String QUERY = "CREATE (n:Foo{bar:\"baz\"})";
-            db.getGraphDatabaseService().execute( QUERY );
-
-            db.shutdown();
-
-            List<String> logLines = new ArrayList<>();
-            try ( BufferedReader reader = new BufferedReader( fs.get().openAsReader( logFilename, "UTF-8" ) ) )
-            {
-                for ( String line; (line = reader.readLine()) != null; )
-                {
-                    logLines.add( line );
-                }
-            }
-
-            assertEquals( 1, logLines.size() );
-            assertThat( logLines.get( 0 ), Matchers.endsWith( String.format( " ms: %s - %s",
-                    QueryEngineProvider.embeddedSession(), QUERY ) ) );
-        }
+        databaseBuilder = new TestGraphDatabaseFactory().setFileSystem( fileSystem.get() )
+                .newImpermanentDatabaseBuilder( testDirectory.graphDbDir().getAbsolutePath() );
     }
 
-    public static class MissingLogQueryPathInConfiguration
+    @Test
+    public void shouldLogQuerySlowerThanThreshold() throws Exception
     {
-        @Rule
-        public TestRule ruleOrder()
+        final File logFilename = new File( testDirectory.graphDbDir(), "queries.log" );
+        GraphDatabaseService database = databaseBuilder.setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.log_queries_filename, logFilename.getPath() )
+                .newGraphDatabase();
+
+        executeQueryAndShutdown( database );
+
+        List<String> logLines = readAllLines( logFilename );
+        assertEquals( 1, logLines.size() );
+        assertThat( logLines.get( 0 ), Matchers.endsWith( String.format( " ms: %s - %s",
+                QueryEngineProvider.embeddedSession(), QUERY ) ) );
+    }
+
+    @Test
+    public void shouldSuppressQueryLoggingIfTheGivenPathIsNull() throws Exception
+    {
+        final File logFilename = new File( testDirectory.graphDbDir(), "messages.log" );
+        GraphDatabaseService database = databaseBuilder.setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE )
+                .newGraphDatabase();
+
+        executeQueryAndShutdown( database );
+
+        List<String> lines = readAllLines( logFilename );
+        boolean found = false;
+        for ( String line : lines )
         {
-            return RuleChain.outerRule( fs ).around( db );
+            if ( line.endsWith( GraphDatabaseSettings.log_queries.name() +
+                                " is enabled but no " +
+                                GraphDatabaseSettings.log_queries_filename.name() +
+                                " has not been provided in configuration, hence query logging is suppressed" ) )
+            {
+                found = true;
+            }
+        }
+        assertTrue( found );
+    }
+
+    @Test
+    public void disabledQueryLogging() throws IOException
+    {
+        final File logFilename = new File( testDirectory.graphDbDir(), "queries.log" );
+        GraphDatabaseService database = databaseBuilder.setConfig( GraphDatabaseSettings.log_queries, Settings.FALSE )
+                .setConfig( GraphDatabaseSettings.log_queries_filename, logFilename.getPath() )
+                .newGraphDatabase();
+
+        executeQueryAndShutdown( database );
+
+        List<String> lines = readAllLines( logFilename );
+        assertTrue( "Should not have any queries logged since query log is disabled", lines.isEmpty() );
+    }
+
+    @Test
+    public void queryLogRotation() throws Exception
+    {
+        final File logFilename = new File( testDirectory.graphDbDir(), "queries.log" );
+        final File shiftedLogFilename = new File( testDirectory.graphDbDir(), "queries.log.1" );
+        GraphDatabaseService database = databaseBuilder.setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.log_queries_filename, logFilename.getPath() )
+                .setConfig( GraphDatabaseSettings.log_queries_rotation_threshold, "1M" )
+                .newGraphDatabase();
+
+
+        String longQuery = createLongQuery();
+        database.execute( longQuery );
+        database.execute( longQuery );
+        // execute one more slow query which should go to new log file
+        database.execute( longQuery );
+        database.shutdown();
+
+        List<String> lines = readAllLines( logFilename );
+        assertEquals( 1, lines.size() );
+        List<String> shiftedLines = readAllLines( shiftedLogFilename );
+        assertEquals( 2, shiftedLines.size() );
+    }
+
+    private String createLongQuery()
+    {
+        String longIdentifier = getStringWithLenght( 1024 * 1024 );
+        return "CREATE (n:Foo{bar:\"" + longIdentifier + "\"})";
+    }
+
+    private String getStringWithLenght(int size)
+    {
+        char[] chars = new char[size];
+        Arrays.fill(chars, 'a');
+        return new String( chars );
+    }
+
+
+    private void executeQueryAndShutdown( GraphDatabaseService database )
+    {
+        database.execute( QUERY );
+        database.shutdown();
+    }
+
+    private List<String> readAllLines( File logFilename ) throws IOException
+    {
+        List<String> logLines = new ArrayList<>();
+        try ( BufferedReader reader = new BufferedReader( fileSystem.get().openAsReader( logFilename, "UTF-8" ) ) )
+        {
+            for ( String line; (line = reader.readLine()) != null; )
+            {
+                logLines.add( line );
+            }
         }
 
-        private final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
-        private final DatabaseRule db = new ImpermanentDatabaseRule()
-        {
-            @Override
-            protected GraphDatabaseFactory newFactory()
-            {
-                return ((TestGraphDatabaseFactory) super.newFactory()).setFileSystem( fs.get() );
-            }
-
-            @Override
-            protected GraphDatabaseBuilder newBuilder( GraphDatabaseFactory factory )
-            {
-                return super.newBuilder( factory )
-                        .setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE );
-            }
-        };
-
-        @Test
-        public void shouldSuppressQueryLoggingIfTheGivenPathIsNull() throws Exception
-        {
-
-            String QUERY = "CREATE (n:Foo{bar:\"baz\"})";
-            db.getGraphDatabaseService().execute( QUERY );
-
-            db.shutdown();
-
-            File messages = new File( "target/test-data/impermanent-db/messages.log" );
-            boolean found = false;
-            try ( BufferedReader reader = new BufferedReader( fs.get().openAsReader( messages, "UTF-8" ) ) )
-            {
-                for ( String line; (line = reader.readLine()) != null; )
-                {
-                    if ( line.endsWith( GraphDatabaseSettings.log_queries.name() +
-                                        " is enabled but no " +
-                                        GraphDatabaseSettings.log_queries_filename.name() +
-                                        " has not been provided in configuration, hence query logging is suppressed" ) )
-                    {
-                        found = true;
-                    }
-                }
-            }
-
-            assertTrue( found );
-        }
+        return logLines;
     }
 }


### PR DESCRIPTION
Add possibility to rotate query. Rotation threshold is specified by 'dbms.querylog.rotation.threshold' property.
By default rotation will happen each 20m.
