### PR TITLE
Fixes exception about unordered label updates in batch importer

### DIFF
--- a/community/import-tool/CHANGES.txt
+++ b/community/import-tool/CHANGES.txt
@@ -1,3 +1,8 @@
+2.2.6
+-----
+o Stacktraces are printed for any unexpected exception, even if --stacktrace isn't supplied.
+  --stacktrace can still be used to print stack trace for known exceptions.
+
 2.2.5
 -----
 o No longer ignores --multiline-field option

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -444,23 +444,23 @@ public class ImportTool
      */
     private static RuntimeException andPrintError( String typeOfError, Exception e, boolean stackTrace )
     {
+        // List of common errors that can be explained to the user
         if ( e.getClass().equals( DuplicateInputIdException.class ) )
         {
-            System.err.println( "Duplicate input ids that would otherwise clash can be put into separate id space," +
+            printErrorMessage( "Duplicate input ids that would otherwise clash can be put into separate id space," +
                     " read more about how to use id spaces in the manual:" +
-                    manualReference( "import-tool-header-format.html#_id_spaces" ) );
+                    manualReference( "import-tool-header-format.html#_id_spaces" ), e, stackTrace );
         }
         else if ( e.getClass().equals( IllegalMultilineFieldException.class ) )
         {
-            System.err.println( "Detected field which spanned multiple lines for an import where " +
+            printErrorMessage( "Detected field which spanned multiple lines for an import where " +
                     Options.MULTILINE_FIELDS.argument() + "=false. If you know that your input data include " +
-                    "fields containing new-line characters then import with this option set to true." );
+                    "fields containing new-line characters then import with this option set to true.", e, stackTrace );
         }
-
-        System.err.println( typeOfError + ": " + e.getMessage() );
-        if ( stackTrace )
+        // Fallback to printing generic error and stack trace
+        else
         {
-            e.printStackTrace( System.err );
+            printErrorMessage( typeOfError + ": " + e.getMessage(), e, true );
         }
         System.err.println();
 
@@ -476,6 +476,15 @@ public class ImportTool
             }
         } );
         return launderedException( e ); // throw in order to have process exit with !0
+    }
+
+    private static void printErrorMessage( String string, Exception e, boolean stackTrace )
+    {
+        System.err.println( string );
+        if ( stackTrace )
+        {
+            e.printStackTrace( System.err );
+        }
     }
 
     private static Iterable<DataFactory<InputRelationship>>

--- a/community/kernel/CHANGES.txt
+++ b/community/kernel/CHANGES.txt
@@ -1,3 +1,9 @@
+2.2.6
+-----
+o Fixes an issue where label updates where supplied unordered during batch import
+  when deduplicating nodes. This issue could prevent any import containing duplicate
+  input ids from completing successfully.
+
 2.2.5
 -----
 o Adds timeout for log rotation

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/DuplicateInputIdException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/DuplicateInputIdException.java
@@ -21,11 +21,18 @@ package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
 
 import org.neo4j.unsafe.impl.batchimport.input.DataException;
 
+import static java.lang.String.format;
+
 public class DuplicateInputIdException extends DataException
 {
     public DuplicateInputIdException( Object id, String groupName, String sourceLocation1, String sourceLocation2 )
     {
-        super( "Id '" + id + "' is defined more than once in " + groupName + ", at least at " +
-                sourceLocation1 + " and " + sourceLocation2 );
+        super( message( id, groupName, sourceLocation1, sourceLocation2 ) );
+    }
+
+    public static String message( Object id, String groupName, String sourceLocation1, String sourceLocation2 )
+    {
+        return format( "Id '%s' is defined more than once in %s, at least at %s and %s",
+                id, groupName, sourceLocation1, sourceLocation2 );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
@@ -201,6 +201,14 @@ public class ParallelSort
          * @return {@code true} if {@code right} is greater than or equal to {@code pivot}.
          */
         boolean ge( long right, long pivot );
+
+        /**
+         * @param dataValue the data value in the used dataCache for a given tracker index.
+         * @return actual data value given the data value retrieved from the dataCache at a given index.
+         * This is exposed to be able to introduce an indirection while preparing the tracker indexes
+         * just like the other methods on this interface does.
+         */
+        long dataValue( long dataValue );
     }
 
     public static final Comparator DEFAULT = new Comparator()
@@ -215,6 +223,12 @@ public class ParallelSort
         public boolean ge( long right, long pivot )
         {
             return Utils.unsignedCompare( right, pivot, CompareType.GE );
+        }
+
+        @Override
+        public long dataValue( long dataValue )
+        {
+            return dataValue;
         }
     };
 
@@ -239,7 +253,7 @@ public class ParallelSort
         void incrementProgress( int diff )
         {
             threadLocalProgress += diff;
-            if ( threadLocalProgress == 10_000 /*reasonably big to dwarf passing a memory barrier*/ )
+            if ( threadLocalProgress >= 10_000 /*reasonably big to dwarf passing a memory barrier*/ )
             {   // Update the total progress
                 reportProgress();
             }
@@ -388,7 +402,7 @@ public class ParallelSort
         {
             for ( long i = 0; i <= highestSetIndex; i++ )
             {
-                int rIndex = radixCalculator.radixOf( dataCache.get( i ) );
+                int rIndex = radixCalculator.radixOf( comparator.dataValue( dataCache.get( i ) ) );
                 if ( rIndex > lowRadixRange && rIndex <= highRadixRange )
                 {
                     long trackerIndex = (rangeParams[0] + bucketIndex++);

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
@@ -31,16 +31,17 @@ import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.test.EphemeralFileSystemRule;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import static org.neo4j.unsafe.impl.batchimport.input.BadCollectorTest.InputRelationshipBuilder.inputRelationship;
 
 public class BadCollectorTest
 {
     public final @Rule EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
-    
+
     @Test
     public void shouldCollectBadRelationshipsEvenIfThresholdNeverReached() throws IOException
     {
@@ -185,6 +186,22 @@ public class BadCollectorTest
         }
     }
 
+    @Test
+    public void shouldProvideNodeIdsSorted() throws Exception
+    {
+        // GIVEN
+        BadCollector badCollector = new BadCollector( badOutputFile(), 10, BadCollector.DUPLICATE_NODES );
+        badCollector.collectDuplicateNode( "a", 10, "group", "source1", "source2" );
+        badCollector.collectDuplicateNode( "b", 8, "group", "source1", "source2" );
+        badCollector.collectDuplicateNode( "c", 12, "group", "source1", "source2" );
+
+        // WHEN
+        long[] nodeIds = PrimitiveLongCollections.asArray( badCollector.leftOverDuplicateNodesIds() );
+
+        // THEN
+        assertArrayEquals( new long[] {8, 10, 12}, nodeIds );
+    }
+
     private OutputStream badOutputFile() throws IOException
     {
         File badDataPath = new File( "/tmp/foo2" ).getAbsoluteFile();
@@ -195,15 +212,15 @@ public class BadCollectorTest
 
     static class InputRelationshipBuilder
     {
-        private String sourceDescription = "foo";
-        private int lineNumber = 1;
-        private int position = 1;
-        private Object[] properties = new Object[]{};
-        private long firstPropertyId = -1l;
-        private Object startNode = null;
-        private Object endNode = null;
-        private String friend = "FRIEND";
-        private int typeId = 1;
+        private final String sourceDescription = "foo";
+        private final int lineNumber = 1;
+        private final int position = 1;
+        private final Object[] properties = new Object[]{};
+        private final long firstPropertyId = -1l;
+        private final Object startNode = null;
+        private final Object endNode = null;
+        private final String friend = "FRIEND";
+        private final int typeId = 1;
 
         public static InputRelationshipBuilder inputRelationship()
         {


### PR DESCRIPTION
which might be thrown when deduplicating duplicate input ids.
Fixing this highlighted an issue where not all duplicate input ids were
collected. Also fixed an issue where less than specified threads were used
to sort the input id collisions before detecting duplicates, so
performance should be better for imports that see many duplicate input
ids.
