### PR TITLE
Warnings for unavailable labels, relationship types, and properties

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherCompiler.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans.rewriter.Lo
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{CachedMetricsFactory, DefaultQueryPlanner, SimpleMetricsFactory}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.PlanContext
 import org.neo4j.cypher.internal.compiler.v2_3.tracing.rewriters.RewriterStepSequencer
-import org.neo4j.cypher.internal.frontend.v2_3.ast.{NodePattern, Statement}
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{LabelName, NodePattern, Statement}
 import org.neo4j.cypher.internal.frontend.v2_3.notification.{BareNodeSyntaxDeprecatedNotification, InternalNotification}
 import org.neo4j.cypher.internal.frontend.v2_3.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v2_3.{InputPosition, SemanticTable, inSequence}

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/checkForUnresolvedTokens.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/checkForUnresolvedTokens.scala
@@ -20,8 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v2_3.planner
 
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticTable
-import org.neo4j.cypher.internal.frontend.v2_3.ast.{RelTypeName, LabelName, Query}
-import org.neo4j.cypher.internal.frontend.v2_3.notification.{MissingRelTypeNotification, MissingLabelNotification, InternalNotification}
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{PropertyKeyName, RelTypeName, LabelName, Query}
+import org.neo4j.cypher.internal.frontend.v2_3.notification.{MissingPropertyNameNotification, MissingRelTypeNotification, MissingLabelNotification, InternalNotification}
 
 /**
  * Parses ast and looks for unresolved tokens
@@ -30,7 +30,8 @@ object checkForUnresolvedTokens extends ((Query, SemanticTable) => Seq[InternalN
 
   def apply(ast: Query, table: SemanticTable) = {
     def isEmptyLabel(label: String) = !table.resolvedLabelIds.contains(label)
-    def isEmptyRelType(label: String) = !table.resolvedRelTypeNames.contains(label)
+    def isEmptyRelType(relType: String) = !table.resolvedRelTypeNames.contains(relType)
+    def isEmptyPropertyName(name: String) = !table.resolvedPropertyKeyNames.contains(name)
 
     ast.treeFold(Seq.empty[InternalNotification]) {
 
@@ -39,6 +40,9 @@ object checkForUnresolvedTokens extends ((Query, SemanticTable) => Seq[InternalN
 
       case rel@RelTypeName(name) if isEmptyRelType(name) => (acc, children) => children(
         acc :+ MissingRelTypeNotification(rel.position, name))
+
+      case prop@PropertyKeyName(name) if isEmptyPropertyName(name) => (acc, children) => children(
+        acc :+ MissingPropertyNameNotification(prop.position, name))
 
     }
   }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/checkForUnresolvedTokens.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/checkForUnresolvedTokens.scala
@@ -20,8 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v2_3.planner
 
 import org.neo4j.cypher.internal.frontend.v2_3.SemanticTable
-import org.neo4j.cypher.internal.frontend.v2_3.ast.{LabelName, Query}
-import org.neo4j.cypher.internal.frontend.v2_3.notification.{MissingLabelNotification, InternalNotification}
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{RelTypeName, LabelName, Query}
+import org.neo4j.cypher.internal.frontend.v2_3.notification.{MissingRelTypeNotification, MissingLabelNotification, InternalNotification}
 
 /**
  * Parses ast and looks for unresolved tokens
@@ -29,11 +29,17 @@ import org.neo4j.cypher.internal.frontend.v2_3.notification.{MissingLabelNotific
 object checkForUnresolvedTokens extends ((Query, SemanticTable) => Seq[InternalNotification]) {
 
   def apply(ast: Query, table: SemanticTable) = {
-    def isEmptyLabel(label: String): Boolean = !table.resolvedLabelIds.contains(label)
+    def isEmptyLabel(label: String) = !table.resolvedLabelIds.contains(label)
+    def isEmptyRelType(label: String) = !table.resolvedRelTypeNames.contains(label)
 
     ast.treeFold(Seq.empty[InternalNotification]) {
+
       case label@LabelName(name) if isEmptyLabel(name) => (acc, children) => children(
         acc :+ MissingLabelNotification(label.position, name))
+
+      case rel@RelTypeName(name) if isEmptyRelType(name) => (acc, children) => children(
+        acc :+ MissingRelTypeNotification(rel.position, name))
+
     }
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/checkForUnresolvedTokens.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/checkForUnresolvedTokens.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner
+
+import org.neo4j.cypher.internal.frontend.v2_3.SemanticTable
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{LabelName, Query}
+import org.neo4j.cypher.internal.frontend.v2_3.notification.{MissingLabelNotification, InternalNotification}
+
+/**
+ * Parses ast and looks for unresolved tokens
+ */
+object checkForUnresolvedTokens extends ((Query, SemanticTable) => Seq[InternalNotification]) {
+
+  def apply(ast: Query, table: SemanticTable) = {
+    def isEmptyLabel(label: String): Boolean = !table.resolvedLabelIds.contains(label)
+
+    ast.treeFold(Seq.empty[InternalNotification]) {
+      case label@LabelName(name) if isEmptyLabel(name) => (acc, children) => children(
+        acc :+ MissingLabelNotification(label.position, name))
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/CheckForUnresolvedTokensTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/CheckForUnresolvedTokensTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v2_3.planner
+
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{Query, Statement, SingleQuery}
+import org.neo4j.cypher.internal.frontend.v2_3.notification.MissingLabelNotification
+import org.neo4j.cypher.internal.frontend.v2_3.{InputPosition, LabelId, SemanticTable}
+import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
+
+class CheckForUnresolvedTokensTest extends CypherFunSuite with AstRewritingTestSupport {
+
+  test("warn when missing label") {
+    //given
+    val semanticTable = new SemanticTable
+
+    //when
+    val ast = parse("MATCH (a:A)-->(b:B) RETURN *")
+
+    //then
+    checkForUnresolvedTokens(ast, semanticTable) should equal(Seq(
+      MissingLabelNotification(InputPosition(9, 1, 10), "A"),
+      MissingLabelNotification(InputPosition(17, 1, 18), "B")))
+  }
+
+  test("don't warn when labels are there") {
+    //given
+    val semanticTable = new SemanticTable
+    semanticTable.resolvedLabelIds.put("A", LabelId(42))
+    semanticTable.resolvedLabelIds.put("B", LabelId(84))
+
+    //when
+    val ast = parse("MATCH (a:A)-->(b:B) RETURN *")
+
+    //then
+    checkForUnresolvedTokens(ast, semanticTable) shouldBe empty
+  }
+
+  private def parse(query: String): Query = parser.parse(query) match {
+    case q: Query => q
+    case _ => fail("Must be a Query")
+  }
+
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -320,6 +320,8 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
       NotificationCode.MISSING_LABEL.notification(pos.asInputPosition, NotificationDetail.Factory.label(label))
     case MissingRelTypeNotification(pos, relType) =>
       NotificationCode.MISSING_REL_TYPE.notification(pos.asInputPosition, NotificationDetail.Factory.relationshipType(relType))
+    case MissingPropertyNameNotification(pos, name) =>
+      NotificationCode.MISSING_PROPERTY_NAME.notification(pos.asInputPosition, NotificationDetail.Factory.propertyName(name))
   }
 
   override def accept[EX <: Exception](visitor: ResultVisitor[EX]) = exceptionHandlerFor2_3.runSafely {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -316,6 +316,8 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
       NotificationCode.EAGER_LOAD_CSV.notification(InputPosition.empty)
     case LargeLabelWithLoadCsvNotification =>
       NotificationCode.LARGE_LABEL_LOAD_CSV.notification(InputPosition.empty)
+    case MissingLabelNotification(pos, label) =>
+      NotificationCode.MISSING_LABEL.notification(pos.asInputPosition, NotificationDetail.Factory.label(label))
   }
 
   override def accept[EX <: Exception](visitor: ResultVisitor[EX]) = exceptionHandlerFor2_3.runSafely {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -318,6 +318,8 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
       NotificationCode.LARGE_LABEL_LOAD_CSV.notification(InputPosition.empty)
     case MissingLabelNotification(pos, label) =>
       NotificationCode.MISSING_LABEL.notification(pos.asInputPosition, NotificationDetail.Factory.label(label))
+    case MissingRelTypeNotification(pos, relType) =>
+      NotificationCode.MISSING_REL_TYPE.notification(pos.asInputPosition, NotificationDetail.Factory.relationshipType(relType))
   }
 
   override def accept[EX <: Exception](visitor: ResultVisitor[EX]) = exceptionHandlerFor2_3.runSafely {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -333,11 +333,27 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
   }
 
   test("should warn for misspelled label") {
+    //given
     createLabeledNode("Person")
+
+    //when
     val resultMisspelled = innerExecute("EXPLAIN MATCH (n:Preson) RETURN n.name")
     val resultCorrectlySpelled = innerExecute("EXPLAIN MATCH (n:Person) RETURN n.name")
 
+    //then
     resultMisspelled.notifications should contain(MissingLabelNotification(InputPosition(9, 1, 10), "Preson"))
+    resultCorrectlySpelled.notifications shouldBe empty
+  }
+
+  test("should warn for misspelled relationship type") {
+    //given
+    relate(createNode(), createNode(), "R")
+
+    //when
+    val resultMisspelled = innerExecute("EXPLAIN MATCH ()-[r:r]->() RETURN r.prop")
+    val resultCorrectlySpelled = innerExecute("EXPLAIN MATCH ()-[r:R]->() RETURN r.prop")
+
+    resultMisspelled.notifications should contain(MissingRelTypeNotification(InputPosition(12, 1, 13), "r"))
     resultCorrectlySpelled.notifications shouldBe empty
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -332,4 +332,12 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     result.notifications should not contain LargeLabelWithLoadCsvNotification
   }
 
+  test("should warn for misspelled label") {
+    createLabeledNode("Person")
+    val resultMisspelled = innerExecute("EXPLAIN MATCH (n:Preson) RETURN n.name")
+    val resultCorrectlySpelled = innerExecute("EXPLAIN MATCH (n:Person) RETURN n.name")
+
+    resultMisspelled.notifications should contain(MissingLabelNotification(InputPosition(9, 1, 10), "Preson"))
+    resultCorrectlySpelled.notifications shouldBe empty
+  }
 }

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Clause.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Clause.scala
@@ -93,8 +93,6 @@ case class Match(optional: Boolean, pattern: Pattern, hints: Seq[UsingHint], whe
       case NodePattern(Some(id), _, _, _) => list => list + id
     })
 
-    def pickFirst(a: Identifier, b: Identifier) = if (a.position.offset < b.position.offset) a else b
-
     @tailrec
     def loop(compare: Set[Identifier], rest: Seq[Set[Identifier]], intermediateState: SemanticState): SemanticState = {
       val updatedState = rest.filter { o =>

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
@@ -55,3 +55,5 @@ case object LargeLabelWithLoadCsvNotification extends InternalNotification
 case class MissingLabelNotification(position: InputPosition, label: String) extends InternalNotification
 
 case class MissingRelTypeNotification(position: InputPosition, relType: String) extends InternalNotification
+
+case class MissingPropertyNameNotification(position: InputPosition, name: String) extends InternalNotification

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
@@ -53,3 +53,5 @@ case object EagerLoadCsvNotification extends InternalNotification
 case object LargeLabelWithLoadCsvNotification extends InternalNotification
 
 case class MissingLabelNotification(position: InputPosition, label: String) extends InternalNotification
+
+case class MissingRelTypeNotification(position: InputPosition, relType: String) extends InternalNotification

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
@@ -51,3 +51,5 @@ case class BareNodeSyntaxDeprecatedNotification(position: InputPosition) extends
 case object EagerLoadCsvNotification extends InternalNotification
 
 case object LargeLabelWithLoadCsvNotification extends InternalNotification
+
+case class MissingLabelNotification(position: InputPosition, label: String) extends InternalNotification

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -114,7 +114,14 @@ public enum NotificationCode
             Status.Statement.RelTypeMissingWarning,
             "One of the relationship types in your query is not available in the database, make sure you didn't " +
             "misspell it or that the label is available when you run this statement in your application"
-    );
+    ),
+    MISSING_PROPERTY_NAME(
+            SeverityLevel.WARNING,
+            Status.Statement.PropertyNameMissingWarning,
+            "One of the property names in your query is not available in the database, make sure you didn't " +
+            "misspell it or that the label is available when you run this statement in your application"
+    )
+    ;
 
     private final Status status;
     private final String description;

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -102,7 +102,12 @@ public enum NotificationCode
         Status.Statement.IndexMissingWarning,
         "Using LOAD CSV followed by a MATCH or MERGE that matches a non-indexed label will most likely " +
         "not perform well on large data sets. Please consider using a schema index."
-        )
+        ),
+    MISSING_LABEL(
+            SeverityLevel.WARNING,
+            Status.Statement.LabelMissingWarning,
+            "One of the labels in your query is not available in the database, make sure you didn't misspell it or that the label is available when you run this statement in your application"
+    )
     ;
 
     private final Status status;

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -106,9 +106,15 @@ public enum NotificationCode
     MISSING_LABEL(
             SeverityLevel.WARNING,
             Status.Statement.LabelMissingWarning,
-            "One of the labels in your query is not available in the database, make sure you didn't misspell it or that the label is available when you run this statement in your application"
-    )
-    ;
+            "One of the labels in your query is not available in the database, make sure you didn't " +
+            "misspell it or that the label is available when you run this statement in your application"
+    ),
+    MISSING_REL_TYPE(
+            SeverityLevel.WARNING,
+            Status.Statement.RelTypeMissingWarning,
+            "One of the relationship types in your query is not available in the database, make sure you didn't " +
+            "misspell it or that the label is available when you run this statement in your application"
+    );
 
     private final Status status;
     private final String description;

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
@@ -38,12 +38,17 @@ public interface NotificationDetail
 
         public static NotificationDetail label( final String labelName )
         {
-            return createNotificationDetail( "provided label", labelName, true );
+            return createNotificationDetail( "the missing label name is", labelName, true );
         }
 
         public static NotificationDetail relationshipType( final String relType )
         {
-            return createNotificationDetail( "provided relationship type", relType, true );
+            return createNotificationDetail( "the missing relationship type is", relType, true );
+        }
+
+        public static NotificationDetail propertyName( final String name )
+        {
+            return createNotificationDetail( "the missing property name is", name, true );
         }
 
         public static NotificationDetail joinKey( List<String> identifiers )

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
@@ -41,6 +41,11 @@ public interface NotificationDetail
             return createNotificationDetail( "provided label", labelName, true );
         }
 
+        public static NotificationDetail relationshipType( final String relType )
+        {
+            return createNotificationDetail( "provided relationship type", relType, true );
+        }
+
         public static NotificationDetail joinKey( List<String> identifiers )
         {
             boolean singular = identifiers.size() == 1;

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationDetail.java
@@ -28,12 +28,17 @@ public interface NotificationDetail
 
     String value();
 
-    public final static class Factory
+    final class Factory
     {
         public static NotificationDetail index( final String labelName, final String propertyKeyName )
         {
             return createNotificationDetail( "hinted index",
                     String.format( "index on :%s(%s)", labelName, propertyKeyName ), true );
+        }
+
+        public static NotificationDetail label( final String labelName )
+        {
+            return createNotificationDetail( "provided label", labelName, true );
         }
 
         public static NotificationDetail joinKey( List<String> identifiers )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -170,7 +170,8 @@ public interface Status
                                          "which forces all dependent data to be materialized in main memory " +
                                          "before proceeding"),
         IndexMissingWarning( ClientNotification, "Adding a schema index may speed up this query." ),
-        LabelMissingWarning( ClientNotification, "The provided label is not in the database."  );
+        LabelMissingWarning( ClientNotification, "The provided label is not in the database." ),
+        RelTypeMissingWarning( ClientNotification, "The provided relationship type is not in the database." );
 
         private final Code code;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -169,7 +169,8 @@ public interface Status
         EagerWarning(ClientNotification, "The execution plan for this query contains the Eager operator, " +
                                          "which forces all dependent data to be materialized in main memory " +
                                          "before proceeding"),
-        IndexMissingWarning( ClientNotification, "Adding a schema index may speed up this query." );
+        IndexMissingWarning( ClientNotification, "Adding a schema index may speed up this query." ),
+        LabelMissingWarning( ClientNotification, "The provided label is not in the database."  );
 
         private final Code code;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -171,7 +171,8 @@ public interface Status
                                          "before proceeding"),
         IndexMissingWarning( ClientNotification, "Adding a schema index may speed up this query." ),
         LabelMissingWarning( ClientNotification, "The provided label is not in the database." ),
-        RelTypeMissingWarning( ClientNotification, "The provided relationship type is not in the database." );
+        RelTypeMissingWarning( ClientNotification, "The provided relationship type is not in the database." ),
+        PropertyNameMissingWarning( ClientNotification, "The provided property name is not in the database" );
 
         private final Code code;
 


### PR DESCRIPTION
When user provides missing (or misspelled) labels, relationship types, and/or properties there is now a warning in the browser.
