### PR TITLE
Allow expressions in SKIP/LIMIT

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/SkipLimitAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/SkipLimitAcceptanceTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.{SyntaxException, NewPlannerTestSupport, ExecutionEngineFunSuite}
+
+class SkipLimitAcceptanceTest extends ExecutionEngineFunSuite {
+  test("SKIP should not allow identifiers") {
+    intercept[SyntaxException](execute("MATCH (n) RETURN n SKIP n.count"))
+  }
+
+  test("LIMIT should not allow identifiers") {
+    intercept[SyntaxException](execute("MATCH (n) RETURN n LIMIT n.count"))
+  }
+
+  test("SKIP with an expression that does not depend on identifiers should work") {
+    1 to 10 foreach { _ => createNode() }
+
+    val query = "MATCH (n) RETURN n SKIP toInt(rand()*9)"
+    val result = execute(query)
+
+    result.toList should not be empty
+  }
+
+  test("LIMIT with an expression that does not depend on identifiers should work") {
+    1 to 3 foreach { _ => createNode() }
+
+    val query = "MATCH (n) RETURN n LIMIT toInt(ceil(1.7))"
+    val result = execute(query)
+
+    result.toList should have size 2
+  }
+}

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -572,7 +572,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
         QueryShuffle(
           sortItems = Seq.empty,
           skip = None,
-          limit = Some(UnsignedDecimalIntegerLiteral("10")(pos)))))
+          limit = Some(SignedDecimalIntegerLiteral("10")(pos)))))
   }
 
   test("match n return n skip 10") {
@@ -587,7 +587,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
         projections = Map("n"->ident("n")),
         QueryShuffle(
           sortItems = Seq.empty,
-          skip = Some(UnsignedDecimalIntegerLiteral("10")(pos)),
+          skip = Some(SignedDecimalIntegerLiteral("10")(pos)),
           limit = None)))
   }
 
@@ -612,7 +612,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
         QueryShuffle(
           sortItems = Seq.empty,
           skip = None,
-          limit = Some(UnsignedDecimalIntegerLiteral("1")(pos)))))
+          limit = Some(SignedDecimalIntegerLiteral("1")(pos)))))
 
     query.tail should not be empty
     query.tail.get.graph should equal(
@@ -657,7 +657,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     query.horizon should equal(
       RegularQueryProjection(
         Map("property" -> Property(Identifier("a")(pos), PropertyKeyName("prop")(pos))(pos)),
-        QueryShuffle(Seq.empty, None, Some(UnsignedDecimalIntegerLiteral("1")(pos)))
+        QueryShuffle(Seq.empty, None, Some(SignedDecimalIntegerLiteral("1")(pos)))
       )
     )
     val tailQg = query.tail.get
@@ -899,7 +899,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     val result = query.toString
 
     val expectation =
-      """PlannerQuery(QueryGraph(Set(PatternRelationship(IdName(r1),(IdName(  origin@7),IdName(c)),BOTH,List(RelTypeName(KNOWS), RelTypeName(WORKS_AT)),SimplePatternLength), PatternRelationship(IdName(r2),(IdName(c),IdName(  candidate@60)),BOTH,List(RelTypeName(KNOWS), RelTypeName(WORKS_AT)),SimplePatternLength)),Set(IdName(  origin@7), IdName(c), IdName(  candidate@60)),Set(),Selections(Set(Predicate(Set(IdName(r1), IdName(r2)),Not(Equals(Identifier(r1),Identifier(r2)))), Predicate(Set(IdName(  origin@7), IdName(  candidate@60)),Not(PatternExpression(RelationshipsPattern(RelationshipChain(NodePattern(Some(Identifier(  origin@7)),List(),None,false),RelationshipPattern(Some(Identifier(  UNNAMED143)),false,List(RelTypeName(KNOWS)),None,None,BOTH),NodePattern(Some(Identifier(  candidate@60)),List(),None,false)))))), Predicate(Set(IdName(r1), IdName(r2)),Equals(FunctionInvocation(FunctionName(type),false,Vector(Identifier(r1))),FunctionInvocation(FunctionName(type),false,Vector(Identifier(r2))))), Predicate(Set(IdName(  origin@7)),In(Property(Identifier(  origin@7),PropertyKeyName(name)),Collection(List(StringLiteral(Clark Kent))))))),List(),Set(),Set()),AggregatingQueryProjection(Map(  FRESHID178 -> Property(Identifier(  origin@7),PropertyKeyName(name)),   FRESHID204 -> Property(Identifier(  candidate@60),PropertyKeyName(name))),Map(  FRESHID223 -> FunctionInvocation(FunctionName(SUM),false,Vector(FunctionInvocation(FunctionName(ROUND),false,Vector(Add(Property(Identifier(r2),PropertyKeyName(weight)),Multiply(FunctionInvocation(FunctionName(COALESCE),false,Vector(Property(Identifier(r2),PropertyKeyName(activity)), SignedDecimalIntegerLiteral(0))),SignedDecimalIntegerLiteral(2)))))))),QueryShuffle(List(),None,None)),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(  FRESHID178), IdName(  FRESHID204), IdName(  FRESHID223)),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(  FRESHID178 -> Identifier(  FRESHID178),   FRESHID204 -> Identifier(  FRESHID204),   FRESHID223 -> Identifier(  FRESHID223)),QueryShuffle(List(DescSortItem(Identifier(  FRESHID223))),None,Some(UnsignedDecimalIntegerLiteral(10)))),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(  FRESHID178), IdName(  FRESHID204), IdName(  FRESHID223)),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(origin -> Identifier(  FRESHID178), candidate -> Identifier(  FRESHID204), boost -> Identifier(  FRESHID223)),QueryShuffle(List(),None,None)),None)))))""".stripMargin
+      """PlannerQuery(QueryGraph(Set(PatternRelationship(IdName(r1),(IdName(  origin@7),IdName(c)),BOTH,List(RelTypeName(KNOWS), RelTypeName(WORKS_AT)),SimplePatternLength), PatternRelationship(IdName(r2),(IdName(c),IdName(  candidate@60)),BOTH,List(RelTypeName(KNOWS), RelTypeName(WORKS_AT)),SimplePatternLength)),Set(IdName(  origin@7), IdName(c), IdName(  candidate@60)),Set(),Selections(Set(Predicate(Set(IdName(r1), IdName(r2)),Not(Equals(Identifier(r1),Identifier(r2)))), Predicate(Set(IdName(  origin@7), IdName(  candidate@60)),Not(PatternExpression(RelationshipsPattern(RelationshipChain(NodePattern(Some(Identifier(  origin@7)),List(),None,false),RelationshipPattern(Some(Identifier(  UNNAMED143)),false,List(RelTypeName(KNOWS)),None,None,BOTH),NodePattern(Some(Identifier(  candidate@60)),List(),None,false)))))), Predicate(Set(IdName(r1), IdName(r2)),Equals(FunctionInvocation(FunctionName(type),false,Vector(Identifier(r1))),FunctionInvocation(FunctionName(type),false,Vector(Identifier(r2))))), Predicate(Set(IdName(  origin@7)),In(Property(Identifier(  origin@7),PropertyKeyName(name)),Collection(List(StringLiteral(Clark Kent))))))),List(),Set(),Set()),AggregatingQueryProjection(Map(  FRESHID178 -> Property(Identifier(  origin@7),PropertyKeyName(name)),   FRESHID204 -> Property(Identifier(  candidate@60),PropertyKeyName(name))),Map(  FRESHID223 -> FunctionInvocation(FunctionName(SUM),false,Vector(FunctionInvocation(FunctionName(ROUND),false,Vector(Add(Property(Identifier(r2),PropertyKeyName(weight)),Multiply(FunctionInvocation(FunctionName(COALESCE),false,Vector(Property(Identifier(r2),PropertyKeyName(activity)), SignedDecimalIntegerLiteral(0))),SignedDecimalIntegerLiteral(2)))))))),QueryShuffle(List(),None,None)),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(  FRESHID178), IdName(  FRESHID204), IdName(  FRESHID223)),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(  FRESHID178 -> Identifier(  FRESHID178),   FRESHID204 -> Identifier(  FRESHID204),   FRESHID223 -> Identifier(  FRESHID223)),QueryShuffle(List(DescSortItem(Identifier(  FRESHID223))),None,Some(SignedDecimalIntegerLiteral(10)))),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(  FRESHID178), IdName(  FRESHID204), IdName(  FRESHID223)),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(origin -> Identifier(  FRESHID178), candidate -> Identifier(  FRESHID204), boost -> Identifier(  FRESHID223)),QueryShuffle(List(),None,None)),None)))))""".stripMargin
 
     result should equal(expectation)
   }
@@ -1044,7 +1044,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     val result = query.toString
 
     val expectation =
-      """PlannerQuery(QueryGraph(Set(PatternRelationship(IdName(r),(IdName(a1),IdName(b1)),OUTGOING,List(),SimplePatternLength)),Set(IdName(a1), IdName(b1)),Set(),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(r -> Identifier(r), a1 -> Identifier(a1)),QueryShuffle(List(),None,Some(UnsignedDecimalIntegerLiteral(1)))),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(r), IdName(a1)),Selections(Set()),List(QueryGraph(Set(PatternRelationship(IdName(r),(IdName(a1),IdName(b2)),INCOMING,List(),SimplePatternLength)),Set(IdName(a1), IdName(b2)),Set(IdName(r), IdName(a1)),Selections(Set()),List(),Set(),Set())),Set(),Set()),RegularQueryProjection(Map(a1 -> Identifier(a1), r -> Identifier(r), b2 -> Identifier(b2)),QueryShuffle(List(),None,None)),None)))""".stripMargin
+      """PlannerQuery(QueryGraph(Set(PatternRelationship(IdName(r),(IdName(a1),IdName(b1)),OUTGOING,List(),SimplePatternLength)),Set(IdName(a1), IdName(b1)),Set(),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(r -> Identifier(r), a1 -> Identifier(a1)),QueryShuffle(List(),None,Some(SignedDecimalIntegerLiteral(1)))),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(r), IdName(a1)),Selections(Set()),List(QueryGraph(Set(PatternRelationship(IdName(r),(IdName(a1),IdName(b2)),INCOMING,List(),SimplePatternLength)),Set(IdName(a1), IdName(b2)),Set(IdName(r), IdName(a1)),Selections(Set()),List(),Set(),Set())),Set(),Set()),RegularQueryProjection(Map(a1 -> Identifier(a1), r -> Identifier(r), b2 -> Identifier(b2)),QueryShuffle(List(),None,None)),None)))""".stripMargin
 
     result should equal(expectation)
   }
@@ -1057,7 +1057,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     val result = query.toString
 
     val expectation =
-      """PlannerQuery(QueryGraph(Set(PatternRelationship(IdName(r),(IdName(a1),IdName(b1)),OUTGOING,List(),SimplePatternLength)),Set(IdName(a1), IdName(b1)),Set(),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(r -> Identifier(r), a1 -> Identifier(a1)),QueryShuffle(List(),None,Some(UnsignedDecimalIntegerLiteral(1)))),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(r), IdName(a1)),Selections(Set()),List(QueryGraph(Set(PatternRelationship(IdName(r),(IdName(a2),IdName(b2)),INCOMING,List(),SimplePatternLength)),Set(IdName(a2), IdName(b2)),Set(IdName(r), IdName(a1)),Selections(Set(Predicate(Set(IdName(a1), IdName(a2)),Equals(Identifier(a1),Identifier(a2))))),List(),Set(),Set())),Set(),Set()),RegularQueryProjection(Map(a1 -> Identifier(a1), r -> Identifier(r), b2 -> Identifier(b2), a2 -> Identifier(a2)),QueryShuffle(List(),None,None)),None)))""".stripMargin
+      """PlannerQuery(QueryGraph(Set(PatternRelationship(IdName(r),(IdName(a1),IdName(b1)),OUTGOING,List(),SimplePatternLength)),Set(IdName(a1), IdName(b1)),Set(),Selections(Set()),List(),Set(),Set()),RegularQueryProjection(Map(r -> Identifier(r), a1 -> Identifier(a1)),QueryShuffle(List(),None,Some(SignedDecimalIntegerLiteral(1)))),Some(PlannerQuery(QueryGraph(Set(),Set(),Set(IdName(r), IdName(a1)),Selections(Set()),List(QueryGraph(Set(PatternRelationship(IdName(r),(IdName(a2),IdName(b2)),INCOMING,List(),SimplePatternLength)),Set(IdName(a2), IdName(b2)),Set(IdName(r), IdName(a1)),Selections(Set(Predicate(Set(IdName(a1), IdName(a2)),Equals(Identifier(a1),Identifier(a2))))),List(),Set(),Set())),Set(),Set()),RegularQueryProjection(Map(a1 -> Identifier(a1), r -> Identifier(r), b2 -> Identifier(b2), a2 -> Identifier(a2)),QueryShuffle(List(),None,None)),None)))""".stripMargin
 
     result should equal(expectation)
   }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/WithPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/WithPlanningIntegrationTest.scala
@@ -31,7 +31,7 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
       Projection(
         Limit(
           AllNodesScan("a", Set.empty)(solved),
-          UnsignedDecimalIntegerLiteral("1")(pos)
+          SignedDecimalIntegerLiteral("1")(pos)
         )(solved),
         Map[String, Expression]("b" -> SignedDecimalIntegerLiteral("1") _)
       )(solved)
@@ -46,62 +46,62 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
 
     resultText should equal(
       // oh perty where art thou!?
-      "Limit(Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll),UnsignedDecimalIntegerLiteral(1))")
+      "Limit(Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),SignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll),SignedDecimalIntegerLiteral(1))")
   }
 
   test("should build plans with WITH and selections") {
     val result = planFor("MATCH (a) WITH a LIMIT 1 MATCH (a)-[r1]->(b) WHERE r1.prop = 42 RETURN r1").plan
 
     result.toString should equal(
-      "Selection(Vector(In(Property(Identifier(r1),PropertyKeyName(prop)),Collection(List(SignedDecimalIntegerLiteral(42))))),Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Expand(Argument(Set(IdName(a))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll)))")
+      "Selection(Vector(In(Property(Identifier(r1),PropertyKeyName(prop)),Collection(List(SignedDecimalIntegerLiteral(42))))),Apply(Limit(AllNodesScan(IdName(a),Set()),SignedDecimalIntegerLiteral(1)),Expand(Argument(Set(IdName(a))),IdName(a),OUTGOING,List(),IdName(b),IdName(r1),ExpandAll)))")
   }
 
   test("should build plans for two matches separated by WITH") {
     val result = planFor("MATCH (a) WITH a LIMIT 1 MATCH (a)-[r]->(b) RETURN b").plan
 
     result.toString should equal(
-      "Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),UnsignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r),ExpandAll)")
+      "Expand(Apply(Limit(AllNodesScan(IdName(a),Set()),SignedDecimalIntegerLiteral(1)),Argument(Set(IdName(a)))),IdName(a),OUTGOING,List(),IdName(b),IdName(r),ExpandAll)")
   }
 
   test("should build plans that project endpoints of re-matched directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH r LIMIT 1 MATCH (u)-[r]->(v) RETURN r").plan
 
     plan.toString should equal(
-      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(r))),IdName(r),IdName(u),false,IdName(v),false,None,true,SimplePatternLength))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),SignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(r))),IdName(r),IdName(u),false,IdName(v),false,None,true,SimplePatternLength))")
   }
 
   test("should build plans that project endpoints of re-matched reversed directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH r AS r, a AS a LIMIT 1 MATCH (b2)<-[r]-(a) RETURN r").plan
 
     plan.toString should equal(
-      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),SignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength))")
   }
 
   test("should build plans that verify endpoints of re-matched directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH * LIMIT 1 MATCH (a)-[r]->(b) RETURN r").plan
 
     plan.toString should equal(
-      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(b), IdName(r))),IdName(r),IdName(a),true,IdName(b),true,None,true,SimplePatternLength))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),SignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(b), IdName(r))),IdName(r),IdName(a),true,IdName(b),true,None,true,SimplePatternLength))")
   }
 
   test("should build plans that project and verify endpoints of re-matched directed relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH a AS a, r AS r LIMIT 1 MATCH (a)-[r]->(b2) RETURN r").plan
 
     plan.toString should equal(
-      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),SignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,SimplePatternLength))")
   }
 
   test("should build plans that project and verify endpoints of re-matched undirected relationship arguments") {
     val plan = planFor("MATCH (a)-[r]->(b) WITH a AS a, r AS r LIMIT 1 MATCH (a)-[r]-(b2) RETURN r").plan
 
     plan.toString should equal(
-      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,false,SimplePatternLength))")
+      "Apply(Limit(Expand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,List(),IdName(a),IdName(r),ExpandAll),SignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,false,SimplePatternLength))")
   }
 
   test("should build plans that project and verify endpoints of re-matched directed var length relationship arguments") {
     val plan = planFor("MATCH (a)-[r*]->(b) WITH a AS a, r AS r LIMIT 1 MATCH (a)-[r*]->(b2) RETURN r").plan
 
     plan.toString should equal(
-      "Apply(Limit(VarExpand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,OUTGOING,List(),IdName(a),IdName(r),VarPatternLength(1,None),ExpandAll,Vector()),UnsignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,VarPatternLength(1,None)))")
+      "Apply(Limit(VarExpand(AllNodesScan(IdName(b),Set()),IdName(b),INCOMING,OUTGOING,List(),IdName(a),IdName(r),VarPatternLength(1,None),ExpandAll,Vector()),SignedDecimalIntegerLiteral(1)),ProjectEndpoints(Argument(Set(IdName(a), IdName(r))),IdName(r),IdName(a),true,IdName(b2),false,None,true,VarPatternLength(1,None)))")
   }
 }

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -2,6 +2,7 @@
 -------
 
 Cypher:
+o SKIP/LIMIT now allows arbitrary expressions that does not depend on identifiers
 o Allow arbitrary expressions for URL in LOAD CSV
 o Added reverse function for reversing strings
 o Unfulfillable index hints (e.g. on non-existing indices) will now produce a warning or throw an error as configured

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -526,6 +526,26 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
       "o not defined (line 1, column 25 (offset: 24))")
   }
 
+  test("not allowed to refer to identifiers in SKIP")(
+    executeAndEnsureError("MATCH n RETURN n SKIP n.count",
+                          "It is not allowed to refer to identifiers in SKIP (line 1, column 23 (offset: 22))")
+  )
+
+  test("only allowed to use positive integer literals in SKIP") (
+    executeAndEnsureError("MATCH n RETURN n SKIP -1",
+                          "Invalid input '-1' is not a valid value, must be a positive integer (line 1, column 23 (offset: 22))")
+  )
+
+  test("not allowed to refer to identifiers in LIMIT")(
+    executeAndEnsureError("MATCH n RETURN n LIMIT n.count",
+                          "It is not allowed to refer to identifiers in LIMIT (line 1, column 24 (offset: 23))")
+  )
+
+  test("only allowed to use positive integer literals in LIMIT") (
+    executeAndEnsureError("MATCH n RETURN n LIMIT 1.7",
+                          "Invalid input '1.7' is not a valid value, must be a positive integer (line 1, column 24 (offset: 23))")
+  )
+
   def executeAndEnsureError(query: String, expected: String) {
     import org.neo4j.cypher.internal.frontend.v2_3.helpers.StringHelper._
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SyntaxExceptionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SyntaxExceptionTest.scala
@@ -67,7 +67,7 @@ class SyntaxExceptionTest extends ExecutionEngineFunSuite {
   test("shouldComplainAboutWholeNumbers") {
     test(
       "match (s) where id(s) = 0 return s limit -1",
-      "Invalid input '-': expected whitespace, comment, an unsigned integer or a parameter (line 1, column 42)"
+      "Invalid input '-1' is not a valid value, must be a positive integer (line 1, column 42 (offset: 41))"
     )
   }
 

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Limit.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Limit.scala
@@ -19,16 +19,8 @@
  */
 package org.neo4j.cypher.internal.frontend.v2_3.ast
 
-import org.neo4j.cypher.internal.frontend.v2_3.{SemanticCheckable, InputPosition}
-import org.neo4j.cypher.internal.frontend.v2_3.symbols._
+import org.neo4j.cypher.internal.frontend.v2_3.InputPosition
 
-case class Limit(expression: Expression)(val position: InputPosition) extends ASTNode with ASTSlicingPhrase with SemanticCheckable {
-
-  def dependencies = expression.dependencies
-
-  def semanticCheck =
-    expression.semanticCheck(Expression.SemanticContext.Simple) chain
-    expression.expectType(CTInteger.covariant)
+case class Limit(expression: Expression)(val position: InputPosition) extends ASTNode with ASTSlicingPhrase {
+  override def name = "LIMIT" // ASTSlicingPhrase name
 }
-
-

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Skip.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Skip.scala
@@ -19,15 +19,9 @@
  */
 package org.neo4j.cypher.internal.frontend.v2_3.ast
 
-import org.neo4j.cypher.internal.frontend.v2_3.{SemanticCheckable, InputPosition}
-import org.neo4j.cypher.internal.frontend.v2_3.symbols._
+import org.neo4j.cypher.internal.frontend.v2_3.InputPosition
 
-case class Skip(expression: Expression)(val position: InputPosition) extends ASTNode with ASTSlicingPhrase with SemanticCheckable {
-
-  def dependencies = expression.dependencies
-
-  def semanticCheck =
-    expression.semanticCheck(Expression.SemanticContext.Simple) chain
-    expression.expectType(CTInteger.covariant)
+case class Skip(expression: Expression)(val position: InputPosition) extends ASTNode with ASTSlicingPhrase {
+  override def name = "SKIP" // ASTSlicingPhrase name
 }
 

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/Clauses.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/parser/Clauses.scala
@@ -161,10 +161,10 @@ trait Clauses extends Parser
   )
 
   private def Skip: Rule1[ast.Skip] = rule("SKIP") {
-    group(keyword("SKIP") ~~ (UnsignedIntegerLiteral | Parameter)) ~~>> (ast.Skip(_))
+    group(keyword("SKIP") ~~ Expression) ~~>> (ast.Skip(_))
   }
 
   private def Limit: Rule1[ast.Limit] = rule("LIMIT") {
-    group(keyword("LIMIT") ~~ (UnsignedIntegerLiteral | Parameter)) ~~>> (ast.Limit(_))
+    group(keyword("LIMIT") ~~ Expression) ~~>> (ast.Limit(_))
   }
 }

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/limit/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/limit/index.asciidoc
@@ -4,7 +4,10 @@
 [abstract]
 `LIMIT` constrains the number of rows in the output.
 
+`LIMIT` accepts any expression that evaluates to a positive integer -- however the expression cannot refer to nodes or relationships.
+
 .Graph
 include::includes/cypher-limit-graph.asciidoc[]
 
 include::return-first-part.asciidoc[]
+include::return-first-from-expression.asciidoc[]

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/skip/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/skip/index.asciidoc
@@ -6,11 +6,12 @@
 
 By using `SKIP`, the result set will get trimmed from the top.
 Please note that no guarantees are made on the order of the result unless the query specifies the `ORDER BY` clause.
+`SKIP` accepts any expression that evaluates to a positive integer -- however the expression cannot refer to nodes or relationships.
 
 .Graph
 include::includes/cypher-skip-graph.asciidoc[]
 
 include::skip-first-three.asciidoc[]
-
 include::return-middle-two.asciidoc[]
+include::skip-first-from-expression.asciidoc[]
 

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/LimitTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/LimitTest.scala
@@ -19,11 +19,10 @@
  */
 package org.neo4j.cypher.docgen
 
-import org.neo4j.graphdb.Node
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
-import org.neo4j.visualization.graphviz.GraphStyle
-import org.neo4j.visualization.graphviz.AsciiDocSimpleStyle
+import org.neo4j.graphdb.Node
+import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
 class LimitTest extends DocumentingTestBase with SoftReset {
   override def graphDescription = List("A KNOWS B", "A KNOWS C", "A KNOWS D", "A KNOWS E")
@@ -41,5 +40,15 @@ class LimitTest extends DocumentingTestBase with SoftReset {
         optionalResultExplanation = "The top three items are returned by the example query.",
         assertions = (p) => assertEquals(List(node("A"), node("B"), node("C")), p.columnAs[Node]("n").toList))
     }
+
+  @Test def returnFromExpression() {
+    testQuery(
+      title = "Return first from expression",
+      text = "Limit accepts any expression that evaluates to a positive integer as long as it is not referring to any external identifiers:",
+      queryText = "match (n) return n order by n.name limit toInt(3 * rand()) + 1",
+      parameters = Map("p" -> 12),
+      optionalResultExplanation = "Returns one to three top items",
+      assertions = (p) => assertTrue(p.columnAs[Node]("n").nonEmpty))
+  }
 }
 

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SkipTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SkipTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.docgen
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 import org.neo4j.graphdb.Node
 import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
@@ -48,6 +48,15 @@ class SkipTest extends DocumentingTestBase {
       queryText = "match (n) return n order by n.name skip 1 limit 2",
       optionalResultExplanation = "Two nodes from the middle are returned.",
       assertions = (p) => assertEquals(List(node("B"), node("C")), p.columnAs[Node]("n").toList))
+  }
+
+  @Test def returnFromExpression() {
+    testQuery(
+      title = "Skip first from expression",
+      text = "Skip accepts any expression that evaluates to a positive integer as long as it is not referring to any external identifiers:",
+      queryText = "match (n) return n order by n.name skip toInt(3*rand()) + 1",
+      optionalResultExplanation = "The first three nodes are skipped, and only the last two are returned in the result.",
+      assertions = (p) => assertTrue(p.columnAs[Node]("n").nonEmpty))
   }
 }
 


### PR DESCRIPTION
- Changed parser so expressions are allowed in SKIP/LIMIT
- Added semantic check that fails if the expression depends on identifiers
- Added semantic check that fails if literals are not positive integers
