### PR TITLE
Client errors do not cause transaction rollback

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ExplainExecutionResult.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ExplainExecutionResult.scala
@@ -54,7 +54,7 @@ case class ExplainExecutionResult(closer: TaskCloser, columns: List[String],
 
   def executionType = explained(queryType)
 
-  def close() { closer.close(success = true) }
+  def close() { closer.close() }
 
   def next() = Iterator.empty.next()
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -19,11 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.executionplan
 
-import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.pipes._
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v2_2.spi.{CSVResources, QueryContext}
-import org.neo4j.cypher.internal.compiler.v2_2.ExplainMode
+import org.neo4j.cypher.internal.compiler.v2_2.{ExplainMode, _}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.QueryExecutionType.QueryType
 
@@ -70,7 +69,7 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: Lis
       }
       catch {
         case (t: Throwable) =>
-          taskCloser.close(success = false)
+          taskCloser.closeFailed(t)
           throw t
       }
     }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/DelegatingQueryContext.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.spi
 
-import org.neo4j.graphdb.{Relationship, PropertyContainer, Direction, Node}
+import org.neo4j.graphdb.{Direction, Node, PropertyContainer, Relationship}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
 class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
@@ -34,8 +34,8 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
   def setLabelsOnNode(node: Long, labelIds: Iterator[Int]): Int =
     singleDbHit(inner.setLabelsOnNode(node, labelIds))
 
-  def close(success: Boolean) {
-    inner.close(success)
+  def close(failure: Option[Throwable]) {
+    inner.close(failure)
   }
 
   def createNode(): Node = singleDbHit(inner.createNode())

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueryContext.scala
@@ -73,7 +73,7 @@ trait QueryContext extends TokenContext {
 
   def isTopLevelTx: Boolean
 
-  def close(success: Boolean)
+  def close(failure: Option[Throwable])
 
   def exactIndexSearch(index: IndexDescriptor, value: Any): Iterator[Node]
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ExplainExecutionResultTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ExplainExecutionResultTest.scala
@@ -33,19 +33,19 @@ class ExplainExecutionResultTest extends CypherFunSuite {
   test("should call taskCloser close on close") {
     result.close()
 
-    Mockito.verify(closer, Mockito.times(1)).close(success = true)
+    Mockito.verify(closer, Mockito.times(1)).close()
   }
 
   test("should call taskCloser close on close from java wrapper") {
     result.javaIterator.close()
 
-    Mockito.verify(closer, Mockito.times(1)).close(success = true)
+    Mockito.verify(closer, Mockito.times(1)).close()
   }
 
   test("should call taskCloser close on close from java columns wrapper") {
     result.javaColumnAs("something").close()
 
-    Mockito.verify(closer, Mockito.times(1)).close(success = true)
+    Mockito.verify(closer, Mockito.times(1)).close()
   }
 
   override protected def beforeEach() { Mockito.reset(closer) }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/TaskCloserTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/TaskCloserTest.scala
@@ -34,7 +34,7 @@ class TaskCloserTest extends CypherFunSuite with BeforeAndAfter {
 
   test("cleanUp call methods") {
     taskCloser.addTask(closingTask)
-    taskCloser.close(success = true)
+    taskCloser.close()
 
     ran should equal(true)
     outcome should equal(true)
@@ -44,7 +44,7 @@ class TaskCloserTest extends CypherFunSuite with BeforeAndAfter {
     outcome = true
 
     taskCloser.addTask(closingTask)
-    taskCloser.close(success = false)
+    taskCloser.closeFailed(new RuntimeException)
 
     ran should equal(true)
     outcome should equal(false)
@@ -54,7 +54,7 @@ class TaskCloserTest extends CypherFunSuite with BeforeAndAfter {
     taskCloser.addTask(_ => throw new Exception("oh noes"))
     taskCloser.addTask(closingTask)
 
-    intercept[Exception](taskCloser.close(success = true))
+    intercept[Exception](taskCloser.close())
 
     ran should equal(true)
     outcome should equal(true)
@@ -65,7 +65,7 @@ class TaskCloserTest extends CypherFunSuite with BeforeAndAfter {
     taskCloser.addTask(_ => throw expected)
     taskCloser.addTask(_ => throw new Exception)
 
-    val ex = intercept[Exception](taskCloser.close(success = true))
+    val ex = intercept[Exception](taskCloser.close())
 
     ex should equal(expected)
   }
@@ -74,23 +74,23 @@ class TaskCloserTest extends CypherFunSuite with BeforeAndAfter {
     val expected = new Exception("oh noes")
     taskCloser.addTask(closingTask)
 
-    taskCloser.close(success = true)
+    taskCloser.close()
     ran = false
-    taskCloser.close(success = true)
+    taskCloser.close()
 
     // If we close the closer twice, it should only run this once
-    ran should not equal(true)
+    ran should not equal true
   }
 
   test("cleanup without any cleanups does not fail") {
-    taskCloser.close(success = true)
+    taskCloser.close()
 
     ran should equal(false)
   }
 
-  private def closingTask(success:Boolean) = {
+  private def closingTask(failure: Option[Throwable]) = {
     ran = true
-    outcome = success
+    outcome = failure.isEmpty
   }
 
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResourcesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResourcesTest.scala
@@ -20,8 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v2_2.spi
 
 import java.net.URL
-import org.mockito.Mockito._
+
 import org.mockito.Matchers._
+import org.mockito.Mockito._
 import org.neo4j.cypher.internal.commons.{CreateTempFileTestSupport, CypherFunSuite}
 import org.neo4j.cypher.internal.compiler.v2_2.TaskCloser
 
@@ -129,7 +130,7 @@ class CSVResourcesTest extends CypherFunSuite with CreateTempFileTestSupport {
     resources.getCsvIterator(new URL(url))
 
     // then
-    verify(cleaner, times(1)).addTask(any(classOf[Boolean => Unit]))
+    verify(cleaner, times(1)).addTask(any(classOf[TaskCloser.Task]))
   }
 
   test("should accept and use a custom field terminator") {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
@@ -21,10 +21,11 @@ package org.neo4j.cypher
 
 import java.util.{Map => JavaMap}
 
+import org.neo4j.cypher.internal.compatibility.exceptionHandlerFor2_2
+import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.LRUCache
 import org.neo4j.cypher.internal.compiler.v2_2.parser.ParserMonitor
 import org.neo4j.cypher.internal.compiler.v2_2.prettifier.Prettifier
-import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.{CypherCompiler, _}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.config.Setting
@@ -165,11 +166,11 @@ class ExecutionEngine(graph: GraphDatabaseService, logger: StringLogger = String
         }.next()
       }
       catch {
-        case (t: Throwable) =>
+        case error: Throwable =>
+          exceptionHandlerFor2_2.handle(error, isTopLevelTx, tx)
           kernelStatement.close()
-          tx.failure()
           tx.close()
-          throw t
+          throw error
       }
 
       if (touched) {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContext.scala
@@ -31,8 +31,8 @@ class ExceptionTranslatingQueryContext(inner: QueryContext) extends DelegatingQu
   override def setLabelsOnNode(node: Long, labelIds: Iterator[Int]): Int =
     translateException(super.setLabelsOnNode(node, labelIds))
 
-  override def close(success: Boolean) =
-    translateException(super.close(success))
+  override def close(failure: Option[Throwable]) =
+    translateException(super.close(failure))
 
   override def createNode(): Node =
     translateException(super.createNode())

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/exceptionHandlerFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/exceptionHandlerFor2_2.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility
+
+import org.neo4j.cypher.internal.compiler.v2_2.spi.MapToPublicExceptions
+import org.neo4j.cypher.internal.compiler.v2_2.{CypherException => InternalCypherException}
+import org.neo4j.cypher.{ArithmeticException, CypherException => ExternalCypherException, CypherTypeException, EntityNotFoundException, FailedIndexException, HintException, IncomparableValuesException, IndexHintException, InternalException, InvalidArgumentException, InvalidSemanticsException, LabelScanHintException, LoadCsvStatusWrapCypherException, LoadExternalResourceException, MergeConstraintConflictException, NodeStillHasRelationshipsException, ParameterNotFoundException, ParameterWrongTypeException, PatternException, PeriodicCommitInOpenTransactionException, ProfilerStatisticsNotReadyException, SyntaxException, UniquePathNotUniqueException, UnknownLabelException, _}
+import org.neo4j.graphdb.Transaction
+
+object exceptionHandlerFor2_2 extends MapToPublicExceptions[ExternalCypherException] {
+  def syntaxException(message: String, query: String, offset: Option[Int]) = new SyntaxException(message, query, offset)
+
+  def arithmeticException(message: String, cause: Throwable) = new ArithmeticException(message, cause)
+
+  def profilerStatisticsNotReadyException() = new ProfilerStatisticsNotReadyException()
+
+  def incomparableValuesException(lhs: String, rhs: String) = new IncomparableValuesException(lhs, rhs)
+
+  def unknownLabelException(s: String) = new UnknownLabelException(s)
+
+  def patternException(message: String) = new PatternException(message)
+
+  def invalidArgumentException(message: String, cause: Throwable) = new InvalidArgumentException(message, cause)
+
+  def mergeConstraintConflictException(message: String) = new MergeConstraintConflictException(message)
+
+  def internalException(message: String) = new InternalException(message)
+
+  def missingConstraintException() = new MissingConstraintException
+
+  def loadCsvStatusWrapCypherException(extraInfo: String, cause: InternalCypherException) =
+    new LoadCsvStatusWrapCypherException(extraInfo, cause.mapToPublic(exceptionHandlerFor2_2))
+
+  def loadExternalResourceException(message: String, cause: Throwable) = new LoadExternalResourceException(message, cause)
+
+  def parameterNotFoundException(message: String, cause: Throwable) = new ParameterNotFoundException(message, cause)
+
+  def uniquePathNotUniqueException(message: String) = new UniquePathNotUniqueException(message)
+
+  def entityNotFoundException(message: String, cause: Throwable) = new EntityNotFoundException(message, cause)
+
+  def cypherTypeException(message: String, cause: Throwable) = new CypherTypeException(message, cause)
+
+  def hintException(message: String): ExternalCypherException = new HintException(message)
+
+  def labelScanHintException(identifier: String, label: String, message: String) = new LabelScanHintException(identifier, label, message)
+
+  def invalidSemanticException(message: String) = new InvalidSemanticsException(message)
+
+  def parameterWrongTypeException(message: String, cause: Throwable) = new ParameterWrongTypeException(message, cause)
+
+  def outOfBoundsException(message: String) = new OutOfBoundsException(message)
+
+  def nodeStillHasRelationshipsException(nodeId: Long, cause: Throwable) = new NodeStillHasRelationshipsException(nodeId, cause)
+
+  def indexHintException(identifier: String, label: String, property: String, message: String) = new IndexHintException(identifier, label, property, message)
+
+  def periodicCommitInOpenTransactionException() = new PeriodicCommitInOpenTransactionException
+
+  def failedIndexException(indexName: String) = new FailedIndexException(indexName)
+
+  def runSafely[T](body: => T)(implicit errorHandler: Throwable => Unit = (_) => ()) = {
+    try {
+      body
+    }
+    catch {
+      case e: InternalCypherException =>
+        errorHandler(e)
+        throw e.mapToPublic(exceptionHandlerFor2_2)
+      case e: Throwable =>
+        errorHandler(e)
+        throw e
+    }
+  }
+
+  /**
+   * Marks given transaction as successful or failed depending on the exception type and transaction type.
+   *
+   * If transaction is [[org.neo4j.kernel.TopLevelTransaction]] than it is marked as failed right away because it is
+   * either a manually started transaction (via [[ExecutionEngine]],
+   * [[org.neo4j.graphdb.GraphDatabaseService#beginTx()]], etc.) or a periodic commit transaction.
+   *
+   * If transaction is [[org.neo4j.kernel.PlaceboTransaction]] that it is marked as failed only if given exception
+   * requires rollback.
+   *
+   * @see [[org.neo4j.kernel.api.exceptions.Status.Classification]]
+   *
+   * @param error failure that occurred during transaction execution
+   * @param isTopLevelTx marker if given transaction is either [[org.neo4j.kernel.TopLevelTransaction]]
+   *                     or [[org.neo4j.kernel.PlaceboTransaction]]
+   * @param tx current transaction that had execution failure
+   */
+  def handle(error: Throwable, isTopLevelTx: Boolean, tx: Transaction) = {
+    if (isTopLevelTx)
+      tx.failure()
+    else
+      error match {
+        case e: InternalCypherException if shouldNotRollback(e) =>
+          tx.success()
+        case e: ExternalCypherException if shouldNotRollback(e) =>
+          tx.success()
+        case _ =>
+          tx.failure()
+      }
+  }
+
+  private def shouldNotRollback(e: InternalCypherException): Boolean = shouldNotRollback(e.mapToPublic(this))
+
+  private def shouldNotRollback(e: ExternalCypherException): Boolean = !e.status.code().classification().rollbackTransaction()
+}
+

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LabelActionTest.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Literal
 import org.neo4j.cypher.internal.compiler.v2_2.commands.values.{KeyToken, TokenType}
 import org.neo4j.cypher.internal.compiler.v2_2.commands.{LabelAction, LabelSetOp}
 import org.neo4j.cypher.internal.compiler.v2_2.spi.{IdempotentResult, LockingQueryContext, QueryContext}
-import org.neo4j.graphdb.{Relationship, Direction, Node}
+import org.neo4j.graphdb.{Direction, Node, Relationship}
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.kernel.api.index.IndexDescriptor
 
@@ -87,7 +87,7 @@ class SnitchingQueryContext extends QueryContext {
 
   def getLabelsForNode(node: Node) = Seq(12L)
 
-  def close(success: Boolean) {???}
+  def close(failure: Option[Throwable]) {???}
 
   def createNode() = ???
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/MutationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/MutationTest.scala
@@ -19,13 +19,14 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2
 
-import commands.expressions.{Expression, Literal}
-import mutation.{RelationshipEndpoint, CreateRelationship, CreateNode, DeleteEntityAction}
-import symbols._
-import org.neo4j.cypher.{ExecutionEngineFunSuite}
+import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Expression, Literal}
+import org.neo4j.cypher.internal.compiler.v2_2.mutation.{CreateNode, CreateRelationship, DeleteEntityAction, RelationshipEndpoint}
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.{ExecuteUpdateCommandsPipe, PipeMonitor, QueryState, SingleRowPipe}
+import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 import org.neo4j.graphdb.{Node, NotFoundException}
-import collection.mutable.{Map => MutableMap}
-import org.neo4j.cypher.internal.compiler.v2_2.pipes.{PipeMonitor, QueryState, ExecuteUpdateCommandsPipe, SingleRowPipe}
+
+import scala.collection.mutable.{Map => MutableMap}
 
 class MutationTest extends ExecutionEngineFunSuite {
 
@@ -132,7 +133,7 @@ class MutationTest extends ExecutionEngineFunSuite {
     val state = createQueryState
     createNodePipe.createResults(state).toList
 
-    state.query.close(success = true)
+    state.query.close(None)
     tx.close()
 
     intercept[NotFoundException](graph.inTx(graph.getNodeById(node_id)))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContextTest.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.spi.v2_2
 
+import org.mockito.Mockito._
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.helpers.DynamicIterable
 import org.neo4j.graphdb._
-import org.mockito.Mockito._
 import org.neo4j.kernel.api._
-import org.neo4j.kernel.impl.api.{StatementOperationParts, KernelTransactionImplementation, KernelStatement}
+import org.neo4j.kernel.impl.api.{KernelStatement, KernelTransactionImplementation}
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 import org.neo4j.test.ImpermanentGraphDatabase
 
@@ -47,7 +47,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     val context = new TransactionBoundQueryContext(graph, outerTx, isTopLevelTx = true, statement)
 
     // WHEN
-    context.close(success = true)
+    context.close(None)
 
     // THEN
     verify (outerTx).success ()
@@ -61,7 +61,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     val context = new TransactionBoundQueryContext(graph, outerTx, isTopLevelTx = true, statement)
 
     // WHEN
-    context.close(success = false)
+    context.close(Some(new RuntimeException))
 
     // THEN
     verify (outerTx).failure ()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/IntegrityValidator.java
@@ -84,7 +84,7 @@ public class IntegrityValidator
             }
             catch ( ConstraintVerificationFailedKernelException e )
             {
-                throw new TransactionFailureException( Status.Transaction.ValidationFailed, e, "Index valiation failed" );
+                throw new TransactionFailureException( Status.Transaction.ValidationFailed, e, "Index validation failed" );
             }
             catch ( IndexNotFoundKernelException | IndexPopulationFailedKernelException e )
             {

--- a/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.server.rest;
 
+import org.junit.Before;
+import org.junit.Rule;
+
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-
 import javax.ws.rs.core.Response.Status;
 
-import org.junit.Before;
-import org.junit.Rule;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -129,7 +129,7 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
         return server().getDatabase().getGraph();
     }
     
-    protected String getDataUri()
+    protected static String getDataUri()
     {
         return "http://localhost:7474/db/data/";
     }
@@ -162,6 +162,21 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
     protected String postRelationshipIndexUri( String indexName )
     {
         return getDataUri() + PATH_RELATIONSHIP_INDEX + "/" + indexName;
+    }
+
+    protected String txUri()
+    {
+        return getDataUri() + "transaction";
+    }
+
+    protected static String txCommitUri()
+    {
+        return getDataUri() + "transaction/commit";
+    }
+
+    protected String txUri( long txId )
+    {
+        return getDataUri() + "transaction/" + txId;
     }
 
     protected Node getNode( String name )

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ClientErrorIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ClientErrorIT.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.transactional.integration;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
+import org.neo4j.server.rest.domain.JsonParseException;
+import org.neo4j.test.server.HTTP;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.containsNoErrors;
+import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.hasErrors;
+import static org.neo4j.test.server.HTTP.POST;
+import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
+
+@RunWith( Parameterized.class )
+public class ClientErrorIT extends AbstractRestFunctionalTestBase
+{
+    private static final int UNIQUE_ISBN = 12345;
+
+    @Parameterized.Parameter( 0 )
+    public String query;
+
+    @Parameterized.Parameter( 1 )
+    public Status errorStatus;
+
+    @Parameterized.Parameters( name = "{0} should cause {1}" )
+    public static List<Object[]> queriesWithStatuses()
+    {
+        return Arrays.asList(
+                new Object[]{
+                        "Not a valid query",
+                        Status.Statement.InvalidSyntax
+                },
+                new Object[]{
+                        "RETURN {foo}",
+                        Status.Statement.ParameterMissing
+                },
+                new Object[]{
+                        "MATCH (n) WITH n.prop AS n2 RETURN n2.prop",
+                        Status.Statement.InvalidType
+                },
+                new Object[]{
+                        "CYPHER 1.9 EXPLAIN MATCH n RETURN n",
+                        Status.Statement.InvalidArguments
+                },
+                new Object[]{
+                        "RETURN 10 / 0",
+                        Status.Statement.ArithmeticError
+                },
+                new Object[]{
+                        "CREATE INDEX ON :Person(name)",
+                        Status.Transaction.InvalidType
+                },
+                new Object[]{
+                        "CREATE (n:``)",
+                        Status.Schema.IllegalTokenName
+                },
+                new Object[]{
+                        "CREATE (b:Book {isbn: " + UNIQUE_ISBN + "})",
+                        Status.Schema.ConstraintViolation
+                }
+        );
+    }
+
+    @BeforeClass
+    public static void prepareDatabase()
+    {
+        POST( txCommitUri(), quotedJson(
+                "{'statements': [{'statement': 'CREATE INDEX ON :Book(name)'}]}" ) );
+
+        POST( txCommitUri(), quotedJson(
+                "{'statements': [{'statement': 'CREATE CONSTRAINT ON (b:Book) ASSERT b.isbn IS UNIQUE'}]}" ) );
+
+        POST( txCommitUri(), quotedJson(
+                "{'statements': [{'statement': 'CREATE (b:Book {isbn: " + UNIQUE_ISBN + "})'}]}" ) );
+    }
+
+    @Test
+    public void clientErrorShouldNotRollbackTheTransaction() throws JsonParseException
+    {
+        // Given
+        HTTP.Response first = POST( txUri(), quotedJson( "{'statements': [{'statement': 'CREATE (n {prop : 1})'}]}" ) );
+        assertThat( first.status(), is( 201 ) );
+        assertThat( first, containsNoErrors() );
+        long txId = extractTxId( first );
+
+        // When
+        HTTP.Response second = POST( txUri( txId ),
+                quotedJson( "{'statements': [{'statement': '" + query + "'}]}" ) );
+        assertThat( second.status(), is( 200 ) );
+        assertThat( second, hasErrors( errorStatus ) );
+
+        HTTP.Response third = POST( txUri(), quotedJson( "{'statements': [{'statement': 'CREATE ()'}]}" ) );
+        assertThat( third.status(), is( 201 ) );
+        assertThat( third, containsNoErrors() );
+
+        // Then
+        HTTP.Response commit = POST( first.stringFromContent( "commit" ) );
+        assertThat( commit.status(), is( 200 ) );
+        assertThat( commit, containsNoErrors() );
+    }
+
+    private static long extractTxId( HTTP.Response response )
+    {
+        int lastSlash = response.location().lastIndexOf( "/" );
+        String txIdString = response.location().substring( lastSlash + 1 );
+        return Long.parseLong( txIdString );
+    }
+}

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionErrorIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionErrorIT.java
@@ -19,12 +19,13 @@
  */
 package org.neo4j.server.rest.transactional.integration;
 
+import org.codehaus.jackson.JsonNode;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 
-import org.codehaus.jackson.JsonNode;
-import org.junit.Test;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
 import org.neo4j.test.server.HTTP;
@@ -32,7 +33,7 @@ import org.neo4j.test.server.HTTP;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.kernel.api.exceptions.Status.Request.InvalidFormat;
 import static org.neo4j.kernel.api.exceptions.Status.Statement.InvalidSyntax;
 import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.containsNoStackTraces;
@@ -117,19 +118,8 @@ public class TransactionErrorIT extends AbstractRestFunctionalTestBase
         }
     }
 
-    private String txUri()
-    {
-        return getDataUri() + "transaction";
-    }
-
-    private String txCommitUri()
-    {
-        return getDataUri() + "transaction/commit";
-    }
-
     private long countNodes()
     {
         return TransactionMatchers.countNodes( graphdb() );
     }
-
 }


### PR DESCRIPTION
Client errors are not supposed to cause transaction rollbacks in REST API. This property is expected because client error does not modify database state and is something like misspelled query or missing query parameter.

This, however, was not true and client errors in Cypher queries made transactions to effectively rollback by marking them as failed. Such transaction seemed to be fine and accepted new statements but was never able to commit.

This PR makes marking of transactions as failed selective and dependent on the type of received exception. If exception has classification `ClientError` than transaction will be marked as failed only if it a top level transaction. If transaction is a placebo one (used as part of a big top level transaction started from REST API) than it would not be marked as failed to not fail the parent top level transaction.
