### PR TITLE
Force which node the rule planner will expand a merge pattern from

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/SimplePatternMatcherBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/SimplePatternMatcherBuilder.scala
@@ -85,7 +85,10 @@ class SimplePatternMatcherBuilder(pattern: PatternGraph,
   def getMatches(ctx: ExecutionContext, state: QueryState) = {
     val (patternNodes, patternRels) = setAssociations(ctx)
     val validPredicates = predicates.filter(p => p.symbolDependenciesMet(symbolTable))
-    val startPoint = patternNodes.values.find(_.getAssociation != null).get
+    // We sort the patternNodes here to always start at the lexicographically smaller identifier
+    // This is suboptimal and will be superseded by a better planner
+    val values = patternNodes.values.toList.sortBy(pn => pn.toString)
+    val startPoint = values.find(_.getAssociation != null).get
 
     val incomingRels: Set[Relationship] = ctx.collect {
       case (k, r: Relationship) if identifiersInClause.contains(k) => r

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/DelegatingQueryContext.scala
@@ -114,6 +114,8 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
   def nodeGetDegree(node: Long, dir: Direction): Int = singleDbHit(inner.nodeGetDegree(node, dir))
 
   def nodeGetDegree(node: Long, dir: Direction, relTypeId: Int): Int = singleDbHit(inner.nodeGetDegree(node, dir, relTypeId))
+
+  override def isLabelSetOnNode(label: Int, node: Long): Boolean = getLabelsForNode(node).contains(label)
 }
 
 class DelegatingOperations[T <: PropertyContainer](protected val inner: Operations[T]) extends Operations[T] {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueryContext.scala
@@ -53,7 +53,7 @@ trait QueryContext extends TokenContext {
 
   def getLabelsForNode(node: Long): Iterator[Int]
 
-  def isLabelSetOnNode(label: Int, node: Long): Boolean = getLabelsForNode(node).toIterator.contains(label)
+  def isLabelSetOnNode(label: Int, node: Long): Boolean
 
   def setLabelsOnNode(node: Long, labelIds: Iterator[Int]): Int
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LabelActionTest.scala
@@ -162,4 +162,6 @@ class SnitchingQueryContext extends QueryContext {
   def nodeGetDegree(node: Long, dir: Direction): Int = ???
 
   def nodeGetDegree(node: Long, dir: Direction, relTypeId: Int): Int = ???
+
+  override def isLabelSetOnNode(label: Int, node: Long): Boolean = ???
 }

--- a/community/cypher/docs/cypher-docs/src/docs/dev/ql/merge/index.asciidoc
+++ b/community/cypher/docs/cypher-docs/src/docs/dev/ql/merge/index.asciidoc
@@ -23,6 +23,10 @@ If there are multiple matches, they will all be passed on to later stages of the
 The last part of +MERGE+ is the +ON CREATE+ and +ON MATCH+.
 These allow a query to express additional changes to the properties of a node or relationship, depending on if the element was ++MATCH++ed in the database or if it was ++CREATE++d.
 
+The rule planner expands a `MERGE` pattern from the end point that has the identifier with the lowest lexicographical order.
+This means that it might choose a suboptimal expansion path, expanding from a node with a higher degree.
+The pattern `MERGE (a:A)-[:R]->(b:B)` will always expand from `a` to `b`, so if it is known that `b` nodes are a better choice for start point, renaming identifiers could improve performance.
+
 The following graph is used for the examples below:
 
 .Graph


### PR DESCRIPTION
Previously, a merge pattern would always be expanded from the node which had an identifier that was returned first by a Map.values call. This order is not well defined. From now on identifiers are sorted in ascending lexicographical order and the first bound one is picked.
