### PR TITLE
Generate a dummy javadoc artifact for Cypher frontend module

### DIFF
--- a/community/cypher/frontend-2.3/pom.xml
+++ b/community/cypher/frontend-2.3/pom.xml
@@ -121,4 +121,39 @@
 
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>neo-full-build-with-javadoc</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>fullBuild</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-dummy-javadocs-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <excludes>
+                    <exclude>**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
The module is Scala-only and doesn't naturally produce any
javadocs. However Maven Central insists on all artifacts being
accompanies by javadocs.
