### PR TITLE
Fixes numeric overflow for the AVG function

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/AvgFunction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/AvgFunction.scala
@@ -25,10 +25,8 @@ import org.neo4j.cypher.internal.compiler.v2_3.helpers.TypeSafeMathSupport
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.QueryState
 
 /**
- * AVG computation is calculated using cumulative moving average approach
- * with Kahan's summation algorithm:
+ * AVG computation is calculated using cumulative moving average approach:
  * https://en.wikipedia.org/wiki/Moving_average#Cumulative_moving_average
- * https://en.wikipedia.org/wiki/Kahan_summation_algorithm
  */
 class AvgFunction(val value: Expression)
   extends AggregationFunction

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/AvgFunction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/AvgFunction.scala
@@ -36,7 +36,7 @@ class AvgFunction(val value: Expression)
   def name = "AVG"
 
   private var count: Int = 0
-  private val sum = new KahanSum()
+  private val sum = new OverflowAwareSum()
 
   def result =
     if (count > 0) {
@@ -48,7 +48,7 @@ class AvgFunction(val value: Expression)
   def apply(data: ExecutionContext)(implicit state: QueryState) {
     actOnNumber(value(data), (number) => {
       count += 1
-      val next = (number.doubleValue() - sum.value) / count.toDouble
+      val next = divide(minus(number, sum.value), count.toDouble)
       sum.add(next)
     })
   }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/NumericExpressionOnly.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/NumericExpressionOnly.scala
@@ -36,6 +36,10 @@ trait NumericExpressionOnly {
     }
   }
 
+  /**
+   * Encapsulates Kahan's algorithm for summation with the error minimization:
+   * https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+   */
   class KahanSum {
     private var c = 0d
     var value = 0d

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/NumericExpressionOnly.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/NumericExpressionOnly.scala
@@ -35,4 +35,21 @@ trait NumericExpressionOnly {
         throw new CypherTypeException("%s(%s) can only handle numerical values, or null.".format(name, value))
     }
   }
+
+  class KahanSum {
+    private var c = 0d
+    var value = 0d
+
+    /**
+     * @param next  next number to add to the total sum
+     * @return      current value of the sum variable
+     */
+    def add(next: Number): Double = {
+      val y = next.doubleValue() - c
+      val t = value + y
+      c = (t - value) - y
+      value = t
+      value
+    }
+  }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/NumericExpressionOnly.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/NumericExpressionOnly.scala
@@ -35,25 +35,4 @@ trait NumericExpressionOnly {
         throw new CypherTypeException("%s(%s) can only handle numerical values, or null.".format(name, value))
     }
   }
-
-  /**
-   * Encapsulates Kahan's algorithm for summation with the error minimization:
-   * https://en.wikipedia.org/wiki/Kahan_summation_algorithm
-   */
-  class KahanSum {
-    private var c = 0d
-    var value = 0d
-
-    /**
-     * @param next  next number to add to the total sum
-     * @return      current value of the sum variable
-     */
-    def add(next: Number): Double = {
-      val y = next.doubleValue() - c
-      val t = value + y
-      c = (t - value) - y
-      value = t
-      value
-    }
-  }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/SumFunction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/SumFunction.scala
@@ -31,7 +31,7 @@ class SumFunction(val value: Expression)
 
   def name = "SUM"
 
-  private val sum = new KahanSum
+  private val sum = new OverflowAwareSum
 
   def result = sum.value
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/SumFunction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/SumFunction.scala
@@ -31,11 +31,13 @@ class SumFunction(val value: Expression)
 
   def name = "SUM"
 
-  var result: Any = 0
+  private val sum = new KahanSum
+
+  def result = sum.value
 
   def apply(data: ExecutionContext)(implicit state: QueryState) {
     actOnNumber(value(data), (number) => {
-      result = plus(result, number)
+      sum.add(number)
     })
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/AvgFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/AvgFunctionTest.scala
@@ -19,12 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.pipes.aggregation
 
-import java.math.MathContext
-
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
-
-import scala.util.Random
 
 class AvgFunctionTest extends CypherFunSuite with AggregateTest {
   def createAggregator(inner: Expression) = new AvgFunction(inner)

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/AvgFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/AvgFunctionTest.scala
@@ -19,8 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.pipes.aggregation
 
+import java.math.MathContext
+
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
+
+import scala.util.Random
 
 class AvgFunctionTest extends CypherFunSuite with AggregateTest {
   def createAggregator(inner: Expression) = new AvgFunction(inner)
@@ -65,5 +69,17 @@ class AvgFunctionTest extends CypherFunSuite with AggregateTest {
     val result = aggregateOn(3, null, 6)
 
      result should equal(4.5)
+  }
+
+  test("noOverflowOnLongListOfLargeNumbers") {
+    val result = aggregateOn(Long.MaxValue / 2, Long.MaxValue / 2, Long.MaxValue / 2)
+
+      result should equal(Long.MaxValue / 2)
+  }
+
+  test("onEmpty") {
+    val result = aggregateOn()
+
+      Option(result) should be (None)
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/SumFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/SumFunctionTest.scala
@@ -30,7 +30,7 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
     val result = aggregateOn(1)
 
     result should equal(1)
-    result shouldBe a [java.lang.Double]
+    result shouldBe a [java.lang.Integer]
   }
 
   test("singleValueOfDecimalReturnsDecimal") {
@@ -51,24 +51,39 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
     val result = aggregateOn(1.byteValue(), 1.shortValue())
 
     result should equal(2)
-    result shouldBe a [java.lang.Double]
+    result shouldBe a [java.lang.Integer]
   }
 
   test("noNumbersEqualsZero") {
     val result = aggregateOn()
 
     result should equal(0)
-    result shouldBe a [java.lang.Double]
+    result shouldBe a [java.lang.Integer]
   }
 
   test("nullDoesNotChangeTheSum") {
     val result = aggregateOn(1, null)
 
     result should equal(1)
-    result shouldBe a [java.lang.Double]
+    result shouldBe a [java.lang.Integer]
   }
 
   test("noNumberValuesThrowAnException") {
     intercept[CypherTypeException](aggregateOn(1, "wut"))
+  }
+
+  test("intOverflowTransformsSumToLong") {
+    val halfInt= Int.MaxValue
+    val result = aggregateOn(halfInt, halfInt, halfInt)
+    val expected = 3L * halfInt
+    result should equal(expected)
+  }
+
+  test("typesArentUnnecessaryWidened") {
+    val thirdOfMaxInt: Int = Int.MaxValue / 3
+    val result = aggregateOn(thirdOfMaxInt, thirdOfMaxInt)
+    val expected = thirdOfMaxInt + thirdOfMaxInt
+    result should equal(expected)
+    result shouldBe a [java.lang.Integer]
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/SumFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/aggregation/SumFunctionTest.scala
@@ -30,7 +30,7 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
     val result = aggregateOn(1)
 
     result should equal(1)
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Double]
   }
 
   test("singleValueOfDecimalReturnsDecimal") {
@@ -51,21 +51,21 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
     val result = aggregateOn(1.byteValue(), 1.shortValue())
 
     result should equal(2)
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Double]
   }
 
   test("noNumbersEqualsZero") {
     val result = aggregateOn()
 
     result should equal(0)
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Double]
   }
 
   test("nullDoesNotChangeTheSum") {
     val result = aggregateOn(1, null)
 
     result should equal(1)
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Double]
   }
 
   test("noNumberValuesThrowAnException") {


### PR DESCRIPTION
Uses algorithm from https://en.wikipedia.org/wiki/Moving_average#Cumulative_moving_average.

I noticed this when I tried to run some statistics on my working dataset to find an appropriate block size (BTW, is it sensible to search for optimization possibilities in this direction?). 

Nodes have `attributes` property, which is basically a serialized map. It's length varies, but on average it's something like 175-200 characters, and the count of nodes is `14983680`, so the overflow happens:

```
scala> res5 * 175
res6: Int = -1672823296

scala> BigInt(res5) * 175
res7: scala.math.BigInt = 2622144000
```

Here's the screenshot that demonstrates the issue:

![Issue](https://i.imgur.com/ie8t8Lk.png)

As it's shown, `BigInt` could be used in order to not complicate the algorithm, but since CMA algorithm works, I decided to go with it.
