### PR TITLE
Do not use toList where toVector is a better option

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndex.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ContainerIndex.scala
@@ -38,7 +38,7 @@ with CollectionSupport {
 
       case IsCollection(collection) =>
         var idx = CastSupport.castOrFail[Number](index(ctx)).intValue()
-        val collectionValue = collection.toList
+        val collectionValue = collection.toVector
 
         if (idx < 0)
           idx = collectionValue.size + idx


### PR DESCRIPTION
We overuse List in the code base, Vectors are better in all cases except
for doing updates at the head. In some cases we use List when doing random access
and `size` operations which is clearly wrong, in some cases it is not as clear-cut
but we should prefer Vectors in most cases.
