### PR TITLE
Use absolute URLs and load_csv_file_url_root in feature suite

### DIFF
--- a/community/cypher/compatibility-suite/src/test/resources/cypher/db/cineast/params.json
+++ b/community/cypher/compatibility-suite/src/test/resources/cypher/db/cineast/params.json
@@ -1,9 +1,9 @@
 {
-  "user_csv" : "file:User.csv",
-  "person_csv" : "file:Person.csv",
-  "movie_csv" : "file:Movie.csv",
-  "acts_in_csv" : "file:ACTS_IN.csv",
-  "directed_csv" : "file:DIRECTED.csv",
-  "friend_csv" : "file:FRIEND.csv",
-  "rated_csv" : "file:RATED.csv"
+  "user_csv" : "file:///User.csv",
+  "person_csv" : "file:///Person.csv",
+  "movie_csv" : "file:///Movie.csv",
+  "acts_in_csv" : "file:///ACTS_IN.csv",
+  "directed_csv" : "file:///DIRECTED.csv",
+  "friend_csv" : "file:///FRIEND.csv",
+  "rated_csv" : "file:///RATED.csv"
 }


### PR DESCRIPTION
Rather than using non-standard absolute URLs, we can now use absolute URLs and the `load_csv_file_url_root` setting to control where they are sourced from.

This resolves a windows issue when mapping those non-standard URLs to java Paths.
