### PR TITLE
Move Cypher URL check inside 2.2 SPI

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LoadCSVPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/LoadCSVPipe.scala
@@ -38,24 +38,21 @@ case class LoadCSVPipe(source: Pipe,
                   identifier: String,
                   fieldTerminator: Option[String])(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) {
-  private val protocolWhiteList: Seq[String] = Seq("file", "http", "https", "ftp")
 
-  protected def checkURL(urlString: String, context: QueryContext): URL = {
+  protected def getImportURL(urlString: String, context: QueryContext): URL = {
     val url: URL = try {
       new URL(urlString)
     } catch {
       case e: java.net.MalformedURLException =>
-        throw new LoadExternalResourceException(s"Invalid URL specified (${e.getMessage})", null)
+        throw new LoadExternalResourceException(s"Invalid URL '$urlString': ${e.getMessage}")
     }
 
-    val protocol = url.getProtocol
-    if (!protocolWhiteList.contains(protocol)) {
-      throw new LoadExternalResourceException(s"Unsupported URL protocol: $protocol", null)
+    context.getImportURL(url) match {
+      case Left(error) =>
+        throw new LoadExternalResourceException(s"Cannot load from URL '$urlString': $error")
+      case Right(urlToLoad) =>
+        urlToLoad
     }
-    if (url.getProtocol == "file" && !context.hasLocalFileAccess) {
-      throw new LoadExternalResourceException("Accessing local files not allowed by the configuration")
-    }
-    url
   }
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
@@ -64,7 +61,7 @@ case class LoadCSVPipe(source: Pipe,
 
     input.flatMap(context => {
       implicit val s = state
-      val url = checkURL(urlExpression(context).asInstanceOf[String], state.query)
+      val url = getImportURL(urlExpression(context).asInstanceOf[String], state.query)
 
       val iterator: Iterator[Array[String]] = state.resources.getCsvIterator(url, fieldTerminator)
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/DelegatingQueryContext.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.spi
 
+import java.net.URL
+
 import org.neo4j.graphdb.{Relationship, PropertyContainer, Direction, Node}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
@@ -105,7 +107,7 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
 
   def getRelTypeName(id: Int): String = singleDbHit(inner.getRelTypeName(id))
 
-  override def hasLocalFileAccess: Boolean = inner.hasLocalFileAccess
+  def getImportURL(url: URL): Either[String,URL] = inner.getImportURL(url)
 
   def relationshipStartNode(rel: Relationship) = inner.relationshipStartNode(rel)
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueryContext.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.spi
 
+import java.net.URL
+
 import org.neo4j.cypher.internal.compiler.v2_2.InternalQueryStatistics
 import org.neo4j.graphdb._
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
@@ -93,7 +95,7 @@ trait QueryContext extends TokenContext {
 
   def getOptStatistics: Option[InternalQueryStatistics] = None
 
-  def hasLocalFileAccess: Boolean = false
+  def getImportURL(url: URL): Either[String,URL]
 
   /**
    * This should not be used. We'll remove sooner (or later). Don't do it.

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContext.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compatibility
 
+import java.net.URL
+
 import org.neo4j.cypher.CypherExecutionException
 import org.neo4j.cypher.internal.compiler.v2_2.spi
 import org.neo4j.cypher.internal.compiler.v2_2.spi._
@@ -133,8 +135,8 @@ class ExceptionTranslatingQueryContext(inner: QueryContext) extends DelegatingQu
   override def commitAndRestartTx() =
     translateException(super.commitAndRestartTx())
 
-  override def hasLocalFileAccess =
-    translateException(super.hasLocalFileAccess)
+  override def getImportURL(url: URL): Either[String,URL] =
+    translateException(super.getImportURL(url))
 
   override def relationshipStartNode(rel: Relationship) =
     translateException(super.relationshipStartNode(rel))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LoadCsvAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LoadCsvAcceptanceTest.scala
@@ -290,14 +290,14 @@ class LoadCsvAcceptanceTest
     val exception = intercept[LoadExternalResourceException] {
       execute(s"LOAD CSV FROM 'morsecorba://sos' AS line CREATE (a {name:line[0]})")
     }
-    exception.getMessage should equal("Invalid URL specified (unknown protocol: morsecorba)")
+    exception.getMessage should equal("Invalid URL 'morsecorba://sos': unknown protocol: morsecorba")
   }
 
   test("should reject invalid URLs") {
     val exception = intercept[LoadExternalResourceException] {
       execute(s"LOAD CSV FROM 'foo.bar' AS line CREATE (a {name:line[0]})")
     }
-    exception.getMessage should equal("Invalid URL specified (no protocol: foo.bar)")
+    exception.getMessage should equal("Invalid URL 'foo.bar': no protocol: foo.bar")
   }
 
   private def ensureNoIllegalCharsInWindowsFilePath(filename: String) = {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/LabelActionTest.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2
 
+import java.net.URL
+
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Literal
 import org.neo4j.cypher.internal.compiler.v2_2.commands.values.{KeyToken, TokenType}
@@ -162,4 +164,6 @@ class SnitchingQueryContext extends QueryContext {
   def nodeGetDegree(node: Long, dir: Direction): Int = ???
 
   def nodeGetDegree(node: Long, dir: Direction, relTypeId: Int): Int = ???
+
+  def getImportURL(url: URL): Either[String,URL] = ???
 }


### PR DESCRIPTION
Back-ported from 6d37b9fd27b55d8aa015f219ded0a172b8e508da.

This refactoring ensures that the 2.2 cypher runtime will also delegate to the SPI for URL access checking, ensuring rules provided in Neo4j 2.3 will apply to URLs used by both the 2.2 and 2.3 cypher runtimes.

This should be null-merged into 2.3.
