### PR TITLE
Allow custom Accept-Headers with HTTP utility

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/rest/HtmlDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/HtmlDocIT.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.Response.Status;
 import org.neo4j.server.helpers.FunctionalTestHelper;
 import org.neo4j.server.rest.domain.GraphDbHelper;
 import org.neo4j.server.rest.domain.RelationshipDirection;
+import org.neo4j.test.server.HTTP;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -90,6 +91,13 @@ public class HtmlDocIT extends AbstractRestFunctionalTestBase
         assertEquals(Status.OK.getStatusCode(), response.getStatus());
         assertValidHtml( response.getEntity() );
         response.close();
+    }
+
+    @Test
+    public void shouldGetRootWithHTTP() {
+        HTTP.Response response = HTTP.withHeaders("Accept", MediaType.TEXT_HTML).GET(functionalTestHelper.dataUri());
+        assertEquals(Status.OK.getStatusCode(), response.status());
+        assertValidHtml( response.rawContent() );
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/test/server/HTTP.java
+++ b/community/server/src/test/java/org/neo4j/test/server/HTTP.java
@@ -142,8 +142,8 @@ public class HTTP
         public Builder withHeaders( Map<String, String> newHeaders )
         {
             HashMap<String, String> combined = new HashMap<>();
-            combined.putAll( newHeaders );
             combined.putAll( headers );
+            combined.putAll( newHeaders );
             return new Builder( combined, baseUri );
         }
 


### PR DESCRIPTION
The previous implementation always overwrote the new setting with existing ones.
And the default existing setting in the `BUILDER` root for `Accept` was `application/json`.
