### PR TITLE
Properly handle selectivities when many labels

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/HardcodedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/HardcodedGraphStatistics.scala
@@ -27,10 +27,10 @@ case object HardcodedGraphStatistics extends HardcodedGraphStatisticsValues
 
 class HardcodedGraphStatisticsValues extends GraphStatistics {
   val NODES_CARDINALITY = Cardinality(10000)
-  val NODES_WITH_LABEL_SELECTIVITY = Selectivity(0.2)
+  val NODES_WITH_LABEL_SELECTIVITY = Selectivity.of(0.2).get
   val NODES_WITH_LABEL_CARDINALITY = NODES_CARDINALITY * NODES_WITH_LABEL_SELECTIVITY
   val RELATIONSHIPS_CARDINALITY = Cardinality(50000)
-  val INDEX_SELECTIVITY = Selectivity(.02)
+  val INDEX_SELECTIVITY = Selectivity.of(.02).get
 
   def indexSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
     Some(INDEX_SELECTIVITY)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/StatisticsBackedCardinalityModel.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/StatisticsBackedCardinalityModel.scala
@@ -49,7 +49,7 @@ class StatisticsBackedCardinalityModel(queryGraphCardinalityModel: QueryGraphCar
 
     // Distinct
     case projection: AggregatingQueryProjection if projection.aggregationExpressions.isEmpty =>
-      in * Selectivity(0.95)
+      in * Selectivity.of(0.95).get
 
     // Aggregates
     case _: AggregatingQueryProjection =>

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombiner.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombiner.scala
@@ -49,7 +49,7 @@ case object IndependenceCombiner extends SelectivityCombiner {
   }
 
   private def fromBigDecimal(bigDecimal: math.BigDecimal): Selectivity = {
-    Selectivity(bigDecimal.doubleValue())
+    Selectivity.of(bigDecimal.doubleValue()).get
   }
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModel.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModel.scala
@@ -107,6 +107,6 @@ case class AssumeIndependenceQueryGraphCardinalityModel(stats: GraphStatistics, 
 
     val selectivity = combiner.andTogetherSelectivities(expressionSelectivities ++ patternSelectivities.flatten)
 
-    (selectivity.getOrElse(Selectivity(1)), numberOfZeroZeroRels)
+    (selectivity.getOrElse(Selectivity.ONE), numberOfZeroZeroRels)
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/GraphStatistics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/GraphStatistics.scala
@@ -23,13 +23,13 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.{Cardinality, Sel
 import org.neo4j.cypher.internal.compiler.v2_2.{LabelId, PropertyKeyId, RelTypeId}
 
 object GraphStatistics {
-  val DEFAULT_RANGE_SELECTIVITY          = Selectivity(0.3)
-  val DEFAULT_PREDICATE_SELECTIVITY      = Selectivity(0.75)
-  val DEFAULT_EQUALITY_SELECTIVITY       = Selectivity(0.1)
+  val DEFAULT_RANGE_SELECTIVITY          = Selectivity.of(0.3).get
+  val DEFAULT_PREDICATE_SELECTIVITY      = Selectivity.of(0.75).get
+  val DEFAULT_EQUALITY_SELECTIVITY       = Selectivity.of(0.1).get
   val DEFAULT_NUMBER_OF_ID_LOOKUPS       = Cardinality(25)
   val DEFAULT_NUMBER_OF_INDEX_LOOKUPS    = Cardinality(25)
   val DEFAULT_LIMIT_CARDINALITY          = Cardinality(75)
-  val DEFAULT_REL_UNIQUENESS_SELECTIVITY = Selectivity(1.0 - 1 / 100 /*rel-cardinality*/)
+  val DEFAULT_REL_UNIQUENESS_SELECTIVITY = Selectivity.of(1.0 - 1.0 / 100 /*rel-cardinality*/).get
 }
 
 trait GraphStatistics {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueriedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueriedGraphStatistics.scala
@@ -100,9 +100,9 @@ class QueriedGraphStatistics(graph: GraphDatabaseService, queryContext: QueryCon
       }
 
       if (values.isEmpty)
-        Some(Selectivity(0)) // Avoids division by zero
+        Some(Selectivity.ZERO) // Avoids division by zero
       else
-        Some(Selectivity(1.0 / values.size))
+        Selectivity.of(1.0 / values.size)
     }
   }
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/DbStructureGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/DbStructureGraphStatistics.scala
@@ -41,6 +41,6 @@ class DbStructureGraphStatistics(lookup: DbStructureLookup) extends GraphStatist
    */
   override def indexSelectivity( label: LabelId, property: PropertyKeyId ): Option[Selectivity] = {
     val result = lookup.indexSelectivity( label.id, property.id )
-    if (result.isNaN) None else Some(Selectivity(result))
+    Selectivity.of(result)
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/MetricsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/MetricsTest.scala
@@ -24,15 +24,15 @@ import org.neo4j.cypher.internal.commons.CypherFunSuite
 class MetricsTest extends CypherFunSuite {
 
   test("negating a selectivity behaves as expected") {
-    Selectivity(.1).negate should not equal Selectivity.ONE
-    Selectivity(5.6e-17).negate should not equal Selectivity.ONE
-    Selectivity(1e-300).negate should not equal Selectivity.ONE
+    Selectivity.of(.1).get.negate should not equal Selectivity.ONE
+    Selectivity.of(5.6e-17).get.negate should not equal Selectivity.ONE
+    Selectivity.of(1e-300).get.negate should not equal Selectivity.ONE
 
     Selectivity.ZERO.negate should equal(Selectivity.ONE)
-    Selectivity(0).negate should equal(Selectivity.ONE)
+    Selectivity.ZERO.negate should equal(Selectivity.ONE)
 
     Selectivity.ONE.negate should equal(Selectivity.ZERO)
-    Selectivity(1).negate should equal(Selectivity.ZERO)
+    Selectivity.ONE.negate should equal(Selectivity.ZERO)
 
     Selectivity.CLOSEST_TO_ONE.negate should not equal Selectivity.ONE
   }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/StatisticsBackedCardinalityModelTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/StatisticsBackedCardinalityModelTest.scala
@@ -89,7 +89,7 @@ class StatisticsBackedCardinalityModelTest extends CypherFunSuite with LogicalPl
 
   test("aggregations should never increase cardinality") {
     givenPattern("MATCH (a:Person)-[:REL]->() WITH a, count(*) as c MATCH (a)-[:REL]->()").
-      withGraphNodes(1).
+      withGraphNodes(allNodes).
       withLabel('Person -> .1).
       withRelationshipCardinality('Person -> 'REL -> 'Person -> .5).
       shouldHavePlannerQueryCardinality(produceCardinalityModel)(2.5)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/CardinalityTestHelper.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/CardinalityTestHelper.scala
@@ -41,9 +41,9 @@ trait CardinalityTestHelper extends QueryGraphProducer with CardinalityCustomMat
 
   def combiner: SelectivityCombiner = IndependenceCombiner
 
-  def not(number: Double) = Selectivity(number).negate.factor
-  def and(numbers: Double*) = combiner.andTogetherSelectivities(numbers.map(Selectivity.apply)).get.factor
-  def or(numbers: Double*) = combiner.orTogetherSelectivities(numbers.map(Selectivity.apply)).get.factor
+  def not(number: Double) = Selectivity.of(number).getOrElse(Selectivity.ONE).negate.factor
+  def and(numbers: Double*) = combiner.andTogetherSelectivities(numbers.map(Selectivity.of(_).getOrElse(Selectivity.ONE))).get.factor
+  def or(numbers: Double*) = combiner.orTogetherSelectivities(numbers.map(Selectivity.of(_).getOrElse(Selectivity.ONE))).get.factor
 
   def degree(above: Double, below: Double) = above / below
 
@@ -139,9 +139,9 @@ trait CardinalityTestHelper extends QueryGraphProducer with CardinalityCustomMat
           (labelName, propertyName) match {
             case (Some(lName), Some(pName)) =>
               val selectivity = knownIndexSelectivity.get((lName, pName))
-              selectivity.map(Selectivity.apply)
+              selectivity.map(Selectivity.of(_).getOrElse(Selectivity.ONE))
 
-            case _ => Some(Selectivity(0))
+            case _ => Some(Selectivity.ZERO)
           }
         }
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/ExpressionSelectivityCalculatorTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/ExpressionSelectivityCalculatorTest.scala
@@ -39,7 +39,7 @@ class ExpressionSelectivityCalculatorTest extends CypherFunSuite with AstConstru
 
     val stats = mock[GraphStatistics]
     Mockito.when(stats.nodesWithLabelCardinality(None)).thenReturn(1000.0)
-    Mockito.when(stats.indexSelectivity(LabelId(0), PropertyKeyId(0))).thenReturn(Some(Selectivity(0.1d)))
+    Mockito.when(stats.indexSelectivity(LabelId(0), PropertyKeyId(0))).thenReturn(Selectivity.of(0.1d))
 
     val calculator = ExpressionSelectivityCalculator(stats, IndependenceCombiner)
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/NodeCardinalityEstimatorTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/NodeCardinalityEstimatorTest.scala
@@ -44,8 +44,8 @@ class NodeCardinalityEstimatorTest extends CypherFunSuite with LogicalPlanningTe
   val hasAnimalOnA: Expression = HasLabels(ident("a"), Seq(LabelName("Animal")_))_
   val hasPersonOnB: Expression = HasLabels(ident("b"), Seq(LabelName("Person")_))_
 
-  val personSelectivity = Selectivity(0.5)
-  val animalSelectivity = Selectivity(0.1)
+  val personSelectivity = Selectivity.of(0.5).get
+  val animalSelectivity = Selectivity.of(0.1).get
 
   test("should estimate node labels") {
     when( selectivityEstimator.apply(hasPersonOnA ) ).thenReturn( personSelectivity )
@@ -106,8 +106,8 @@ class NodeCardinalityEstimatorTest extends CypherFunSuite with LogicalPlanningTe
     val pred1 = mock[Expression]
     val pred2 = mock[Expression]
 
-    when( selectivityEstimator.apply( pred1 ) ).thenReturn( Selectivity( 0.5d ) )
-    when( selectivityEstimator.apply( pred2 ) ).thenReturn( Selectivity( 0.25d ) )
+    when( selectivityEstimator.apply( pred1 ) ).thenReturn( Selectivity.of( 0.5d ).get )
+    when( selectivityEstimator.apply( pred2 ) ).thenReturn( Selectivity.of( 0.25d ).get )
 
     val qg = QueryGraph
       .empty
@@ -122,7 +122,7 @@ class NodeCardinalityEstimatorTest extends CypherFunSuite with LogicalPlanningTe
     val (estimates, used) = estimator(qg)
 
     estimates should equal(Map(
-      IdName("a") -> allNodes * Selectivity( 0.5d ),
+      IdName("a") -> allNodes * Selectivity.of( 0.5d ).get,
       IdName("b") -> allNodes
     ))
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombinerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombinerTest.scala
@@ -25,27 +25,27 @@ import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Selectivity
 class SelectivityCombinerTest extends CypherFunSuite {
 
   test("should not lose precision for intermediate numbers") {
-    val selectivities = Seq(Selectivity(1e-10), Selectivity(2e-10))
+    val selectivities = Seq(Selectivity.of(1e-10).get, Selectivity.of(2e-10).get)
 
-    IndependenceCombiner.orTogetherSelectivities(selectivities).get should not equal Selectivity(0)
+    IndependenceCombiner.orTogetherSelectivities(selectivities).get should not equal Selectivity.ZERO
   }
 
   test("should not lose precision for small numbers") {
-    val selectivities = Seq(Selectivity(1e-100), Selectivity(2e-100), Selectivity(1e-300))
+    val selectivities = Seq(Selectivity.of(1e-100).get, Selectivity.of(2e-100).get, Selectivity.of(1e-300).get)
 
-    IndependenceCombiner.orTogetherSelectivities(selectivities).get should not equal Selectivity(0)
+    IndependenceCombiner.orTogetherSelectivities(selectivities).get should not equal Selectivity.ZERO
   }
 
   test("ANDing together works as expected") {
-    val selectivities = Seq(Selectivity(.1), Selectivity(.2), Selectivity.ONE)
+    val selectivities = Seq(Selectivity.of(.1).get, Selectivity.of(.2).get, Selectivity.ONE)
 
-    IndependenceCombiner.andTogetherSelectivities(selectivities).get should equal(Selectivity(0.02))
+    IndependenceCombiner.andTogetherSelectivities(selectivities).get should equal(Selectivity.of(0.02).get)
   }
 
   test("ORing together works as expected") {
-    val selectivities = Seq(Selectivity(.1), Selectivity(.2))
+    val selectivities = Seq(Selectivity.of(.1).get, Selectivity.of(.2).get)
 
-    IndependenceCombiner.orTogetherSelectivities(selectivities).get should equal(Selectivity(0.28))
+    IndependenceCombiner.orTogetherSelectivities(selectivities).get should equal(Selectivity.of(0.28).get)
   }
 
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModelTest.scala
@@ -121,8 +121,8 @@ class AssumeIndependenceQueryGraphCardinalityModelTest extends RandomizedCardina
       "MATCH (a:A:B)-->()"
         -> {
         val maxRelCount = N * N * Asel * Bsel
-        val A_relSelectivity = A_STAR_STAR / maxRelCount
-        val B_relSelectivity = B_STAR_STAR / maxRelCount
+        val A_relSelectivity = math.min(A_STAR_STAR / maxRelCount, 1.0)
+        val B_relSelectivity = math.min(B_STAR_STAR / maxRelCount, 1.0)
         val relSelectivity = A_relSelectivity * B_relSelectivity
         A * B * relSelectivity
       },
@@ -132,7 +132,7 @@ class AssumeIndependenceQueryGraphCardinalityModelTest extends RandomizedCardina
         val patternNodeCrossProduct = N * N
         val labelSelectivity = Asel * Bsel
         val maxRelCount = patternNodeCrossProduct * labelSelectivity
-        val relSelectivity = (A_T1_B + A_T2_B) / maxRelCount - (A_T1_B / maxRelCount) * (A_T2_B / maxRelCount)
+        val relSelectivity = or(A_T1_B / maxRelCount, A_T2_B / maxRelCount)
         patternNodeCrossProduct * labelSelectivity * relSelectivity
       },
 
@@ -153,8 +153,8 @@ class AssumeIndependenceQueryGraphCardinalityModelTest extends RandomizedCardina
         val patternNodeCrossProduct = N * N
         val labelSelectivity = Asel * Dsel
         val maxRelCount = patternNodeCrossProduct * labelSelectivity
-        val relSelectivityT1 = (A_T1_STAR / maxRelCount) * (D_T1_STAR / maxRelCount)
-        val relSelectivityT2 = (A_T2_STAR / maxRelCount) * (D_T2_STAR / maxRelCount)
+        val relSelectivityT1 = and(A_T1_STAR / maxRelCount, D_T1_STAR / maxRelCount)
+        val relSelectivityT2 = and(A_T2_STAR / maxRelCount, D_T2_STAR / maxRelCount)
         val relSelectivity = or(relSelectivityT1, relSelectivityT2)
         patternNodeCrossProduct * labelSelectivity * relSelectivity
       },
@@ -168,8 +168,8 @@ class AssumeIndependenceQueryGraphCardinalityModelTest extends RandomizedCardina
         val patternNodeCrossProduct = N * N
         val labelSelectivity = Asel * Bsel * Csel * Dsel
         val maxRelCount = patternNodeCrossProduct * labelSelectivity
-        val relSelT1 = (A_T1_C / maxRelCount) * (A_T1_D / maxRelCount) * (B_T1_C / maxRelCount) * (B_T1_D / maxRelCount)
-        val relSelT2 = (A_T2_C / maxRelCount) * (A_T2_D / maxRelCount) * (B_T2_C / maxRelCount) * (B_T2_D / maxRelCount)
+        val relSelT1 = and(A_T1_C / maxRelCount, A_T1_D / maxRelCount, B_T1_C / maxRelCount, B_T1_D / maxRelCount)
+        val relSelT2 = and(A_T2_C / maxRelCount, A_T2_D / maxRelCount, B_T2_C / maxRelCount, B_T2_D / maxRelCount)
         val relSelectivity = or(relSelT1, relSelT2)
         patternNodeCrossProduct * labelSelectivity * relSelectivity
       },

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/GraphStatisticsSnapshotTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/GraphStatisticsSnapshotTest.scala
@@ -35,7 +35,7 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
       Cardinality(relTypeId.fold(5000)(_.id * 10) * FACTOR)
 
     def indexSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
-      Some(1.0 / ((property.id + 1) * FACTOR))
+      Selectivity.of(1.0 / ((property.id + 1) * FACTOR))
   }
 
   test("records queries and its observed values") {

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -1,5 +1,6 @@
 2.2.6
 -----
+o Fixes #5336 - Properly handle matching on multiple labels
 o Fixes #5195 - USING INDEX hints breaks some queries
 
 2.2.5

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MatchAcceptanceTest.scala
@@ -2282,4 +2282,17 @@ return b
       Map("p" -> PathImpl(b, r2, a, r1, b)))
   }
 
+  test("should be able to match on nodes with MANY labels") {
+    //given
+    val start = createLabeledNode('A' to 'M' map(_.toString):_* )
+    val end = createLabeledNode('U' to 'Z' map(_.toString):_* )
+    relate(start, end, "REL")
+
+    //when
+    val result = executeWithAllPlanners("match (n:A:B:C:D:E:F:G:H:I:J:K:L:M)-[:REL]->(m:Z:Y:X:W:V:U) return n,m")
+
+    //then
+    result.toList should equal(List(Map("n" -> start, "m" -> end)))
+  }
+
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueriedGraphStatisticsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/QueriedGraphStatisticsTest.scala
@@ -104,7 +104,7 @@ class QueriedGraphStatisticsTest extends CypherFunSuite with GraphDatabaseTestSu
       val xLabel = LabelId(qtx.getLabelId("X"))
       val pkId = PropertyKeyId(qtx.getPropertyKeyId("age"))
 
-      stats.indexSelectivity(xLabel, pkId) should equal(Some(Selectivity(1.0/3.0)))
+      stats.indexSelectivity(xLabel, pkId) should equal(Selectivity.of(1.0/3.0))
     }
   }
 
@@ -116,7 +116,7 @@ class QueriedGraphStatisticsTest extends CypherFunSuite with GraphDatabaseTestSu
       val xLabel = LabelId(qtx.getLabelId("X"))
       val pkId = PropertyKeyId(qtx.getPropertyKeyId("age"))
 
-      stats.indexSelectivity(xLabel, pkId) should equal(Some(Selectivity(1.0/4.0)))
+      stats.indexSelectivity(xLabel, pkId) should equal(Selectivity.of(1.0/4.0))
     }
   }
 


### PR DESCRIPTION
Because of the independency assumption we could end up in situations with
label selectivities larger than 1.0, and completely blow up when having
many labels.

Fixes #5336
