### PR TITLE
Updated packaged config files for the new cert-file properties

### DIFF
--- a/community/server/src/docs/ops/security.asciidoc
+++ b/community/server/src/docs/ops/security.asciidoc
@@ -61,10 +61,10 @@ To provide your own key and certificate, replace the generated key and certifica
 [source,properties]
 ----
 # Certificate location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.cert.location=ssl/snakeoil.cert
+dbms.security.tls_certificate_file=ssl/snakeoil.cert
 
 # Private key location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.key.location=ssl/snakeoil.key
+dbms.security.tls_key_file=ssl/snakeoil.key
 ----
 
 Note that the key should be unencrypted.

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-server-default.properties
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-server-default.properties
@@ -28,10 +28,10 @@ org.neo4j.server.webserver.port=7474
 org.neo4j.server.webserver.https.port=7473
 
 # Certificate location (auto generated if the file does not exist)
-# org.neo4j.server.webserver.https.cert.location=conf/ssl/snakeoil.cert
+# dbms.security.tls_certificate_file=conf/ssl/snakeoil.cert
 
 # Private key location (auto generated if the file does not exist)
-# org.neo4j.server.webserver.https.key.location=conf/ssl/snakeoil.key
+# dbms.security.tls_key_file=conf/ssl/snakeoil.key
 
 # Internally generated keystore (don't try to put your own
 # keystore there, it will get deleted when the server starts)

--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -51,8 +51,8 @@
     <org.neo4j.server.webserver.https.enabled>true</org.neo4j.server.webserver.https.enabled>
     <org.neo4j.webserver.https.port>7473</org.neo4j.webserver.https.port>
 
-    <org.neo4j.server.webserver.https.cert.location>conf/ssl/snakeoil.cert</org.neo4j.server.webserver.https.cert.location>
-    <org.neo4j.server.webserver.https.key.location>conf/ssl/snakeoil.key</org.neo4j.server.webserver.https.key.location>
+    <dbms.security.tls_certificate_file>conf/ssl/snakeoil.cert</dbms.security.tls_certificate_file>
+    <dbms.security.tls_key_file>conf/ssl/snakeoil.key</dbms.security.tls_key_file>
     <org.neo4j.server.webserver.https.keystore.location>data/keystore</org.neo4j.server.webserver.https.keystore.location>
     <org.neo4j.webservice.packages>org.neo4j.rest.web,org.neo4j.webadmin,org.neo4j.webadmin.backup,org.neo4j.webadmin.console,org.neo4j.webadmin.domain,org.neo4j.webadmin.parser,org.neo4j.webadmin.properties,org.neo4j.webadmin.resources,org.neo4j.webadmin.rest,org.neo4j.webadmin.rrd,org.neo4j.webadmin.task,org.neo4j.webadmin.utils</org.neo4j.webservice.packages>
     <org.neo4j.server.bundledir>system/lib</org.neo4j.server.bundledir>

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-server.properties
@@ -41,10 +41,10 @@ org.neo4j.server.webserver.https.enabled=#{org.neo4j.server.webserver.https.enab
 org.neo4j.server.webserver.https.port=#{org.neo4j.webserver.https.port}
 
 # Certificate location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.cert.location=#{org.neo4j.server.webserver.https.cert.location}
+dbms.security.tls_certificate_file=#{dbms.security.tls_certificate_file}
 
 # Private key location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.key.location=#{org.neo4j.server.webserver.https.key.location}
+dbms.security.tls_key_file=#{dbms.security.tls_key_file}
 
 # Internally generated keystore (don't try to put your own
 # keystore there, it will get deleted when the server starts)

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-server.properties
@@ -41,10 +41,10 @@ org.neo4j.server.webserver.https.enabled=#{org.neo4j.server.webserver.https.enab
 org.neo4j.server.webserver.https.port=#{org.neo4j.webserver.https.port}
 
 # Certificate location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.cert.location=#{org.neo4j.server.webserver.https.cert.location}
+dbms.security.tls_certificate_file=#{dbms.security.tls_certificate_file}
 
 # Private key location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.key.location=#{org.neo4j.server.webserver.https.key.location}
+dbms.security.tls_key_file=#{dbms.security.tls_key_file}
 
 # Internally generated keystore (don't try to put your own
 # keystore there, it will get deleted when the server starts)

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-server.properties
@@ -48,10 +48,10 @@ org.neo4j.server.webserver.https.enabled=#{org.neo4j.server.webserver.https.enab
 org.neo4j.server.webserver.https.port=#{org.neo4j.webserver.https.port}
 
 # Certificate location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.cert.location=#{org.neo4j.server.webserver.https.cert.location}
+dbms.security.tls_certificate_file=#{dbms.security.tls_certificate_file}
 
 # Private key location (auto generated if the file does not exist)
-org.neo4j.server.webserver.https.key.location=#{org.neo4j.server.webserver.https.key.location}
+dbms.security.tls_key_file=#{dbms.security.tls_key_file}
 
 # Internally generated keystore (don't try to put your own
 # keystore there, it will get deleted when the server starts)


### PR DESCRIPTION
When Neo with default starts up it complains about outdated cert-location properties. This should not happen with the built in config
