### PR TITLE
:play remote guides

### DIFF
--- a/community/browser/app/index.jade
+++ b/community/browser/app/index.jade
@@ -187,6 +187,7 @@ html(class="no-js", lang="en", ng-app="neo4jApp", ng-controller="MainCtrl")
     script(src='scripts/controllers/Frame.js')
     script(src='scripts/controllers/FrameNotification.js')
     script(src='scripts/directives/cypherHint.js')
+    script(src='scripts/directives/playSrc.js')
     script(src='lib/helpers.js')
     script(src='lib/serializer.js')
     //endbuild

--- a/community/browser/app/scripts/directives/playSrc.coffee
+++ b/community/browser/app/scripts/directives/playSrc.coffee
@@ -1,0 +1,33 @@
+###!
+Copyright (c) 2002-2015 "Neo Technology,"
+Network Engine for Objects in Lund AB [http://neotechnology.com]
+
+This file is part of Neo4j.
+
+Neo4j is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###
+
+'use strict';
+
+angular.module('neo4jApp.directives')
+  .directive('playSrc', ['$compile', '$rootScope', 'Utils', ($compile, $rootScope, Utils) ->
+    (scope, element, attrs) ->
+      unbind = scope.$watch 'frame.response', (response) ->
+        return unless response
+        if response.is_remote
+          response.contents = Utils.cleanHTML response.contents
+        element.html(response.contents)
+        $compile(element.contents())(scope)
+        unbind()
+  ])

--- a/community/browser/app/scripts/init/commandInterpreters.coffee
+++ b/community/browser/app/scripts/init/commandInterpreters.coffee
@@ -116,17 +116,29 @@ angular.module('neo4jApp')
       type: 'play'
       templateUrl: 'views/frame-guide.html'
       matches: "#{cmdchar}play"
-      exec: ['$http', ($http) ->
+      exec: ['$http', '$rootScope', 'Utils', ($http, $rootScope, Utils) ->
         step_number = 1
         (input, q) ->
-          topic = topicalize(input[('play'.length+1)..]) or 'start'
-          url = "content/guides/#{topic}.html"
+          clean_url = input[('play'.length+1)..].trim()
+          is_remote = no
+          if /^https?:\/\//i.test(clean_url)
+            is_remote = yes
+            url = input[('play'.length+2)..]
+            host = url.match(/^(https?:\/\/[^\/]+)/)[1]
+            host_ok = Utils.hostIsAllowed host, $rootScope.kernel['dbms.browser.remote_content_hostname_whitelist'], $rootScope.neo4j.enterpriseEdition
+          else
+            topic = topicalize(clean_url) or 'start'
+            url = "content/guides/#{topic}.html"
+          if is_remote and not host_ok
+            q.reject({page: url, contents: '', is_remote: is_remote, errors: [{code: "0", message: "Requested host is not whitelisted in dbms.browser.remote_content_hostname_whitelist."}]})  
+            return q.promise
           $http.get(url)
           .then(
-            ->
-              q.resolve(page: url)
+            (res) ->
+              q.resolve({contents:res.data, page: url, is_remote: is_remote})
           ,
             (r)->
+              r.is_remote = is_remote
               q.reject(r)
           )
           q.promise

--- a/community/browser/app/scripts/services/Frame.coffee
+++ b/community/browser/app/scripts/services/Frame.coffee
@@ -119,8 +119,12 @@ angular.module('neo4jApp.services')
             #This happens for HTTP status error codes
             result = {errors:[{code: "HTTP Status: #{result.status}", message: "HTTP Status: #{result.status} - #{result.statusText}"}]} if result.status
 
+            #This happens on remote requests when no 'Access-Control-Allow-Origin' is present.
+            if result.is_remote and result.status is 0
+              result = {errors: [{code: 0, message: "No 'Access-Control-Allow-Origin' header is present on the requested resource and can therefore not be played."}]}
+
             errors = result.errors[0]
-            @errorText = errors.code
+            @errorText = "#{errors.code}"
             @detailedErrorText = errors.message
 
           resetError: =>

--- a/community/browser/app/views/frame-guide.jade
+++ b/community/browser/app/views/frame-guide.jade
@@ -2,11 +2,12 @@ div(fullscreen)
   .outer
     include partials/frame-common-actions
     .inner
-      .view-result.help(ng-hide='frame.hasErrors', ng-include = 'frame.response.page')
+      .view-result.help(ng-hide='frame.hasErrors')
+        .play(play-src)
       .view-result-error.help(ng-show='frame.hasErrors')
         pre No such topic to play.
-      .status-bar(ng-class='{error: frame.hasErrors, loading: frame.isLoading}', ng-show="frame.errorText")
+      .status-bar(ng-class='{error: frame.hasErrors, loading: frame.isLoading}', ng-show="frame.errorText.length")
         .status(ng-hide='frame.isLoading')
           span(ng-show='frame.hasErrors')
             .fa.fa-exclamation-triangle.icon-warning-sign &nbsp;
-          | Not found
+          | {{ frame.detailedErrorText }}

--- a/community/browser/lib/helpers.coffee
+++ b/community/browser/lib/helpers.coffee
@@ -109,3 +109,18 @@ class neo.helpers
         "'": '&#39;'
         "/": '&#x2F;'
       String(string).replace(/[&<>"'\/]/g, (s) -> entityMap[s])
+
+    @cleanHTML = (string) ->
+      @stripNGAttributes @stripScripts string
+
+    @stripScripts = (string = '') ->
+      string = string.replace(/(\s+(on[^\s=]+)[^\s=]*\s*=\s*("[^"]*"|'[^']*'|[\w\-.:]+\s*))/ig, '')
+      string.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*(<\/script>)?/gi, '')
+
+    @stripNGAttributes = (string = '') ->
+      string.replace(/(\s+(ng|data|x)[^\s=]*\s*=\s*("[^"]*"|'[^']*'|[\w\-.:]+\s*))/ig, '')
+
+    @hostIsAllowed = (hostname, whitelist, is_enterprise) ->
+      return true if is_enterprise and (not whitelist or whitelist is '*')
+      whitelisted_hosts = if is_enterprise then whitelist.split(",") else ['http://guides.neo4j.com', 'https://guides.neo4j.com', 'http://localhost', 'https://localhost']
+      hostname in whitelisted_hosts

--- a/community/browser/test/spec/other/utils.coffee
+++ b/community/browser/test/spec/other/utils.coffee
@@ -51,3 +51,76 @@ describe 'Utils: firstWord', () ->
           still extractable
           """
     expect(Utils.firstWord text).toBe 'alone'
+
+  it 'should strip element "onX" attributes', ->
+    text = '<a href="" onclick="alert(1) " onLoad="alert(2)">x</a>'
+    expect(Utils.stripScripts text).toBe '<a href="">x</a>'
+
+  it 'should strip script tags', ->
+    text = 'hello<script>alert(1)</script>'
+    expect(Utils.stripScripts text).toBe 'hello'
+
+    text = 'hello<script src="xxx">'
+    expect(Utils.stripScripts text).toBe 'hello'
+
+    text = 'hello<script src="xxx" />'
+    expect(Utils.stripScripts text).toBe 'hello'
+
+    text = 'hello<script type="text/html">alert(1)</script>xxx<script> alert(3)</script  >'
+    expect(Utils.stripScripts text).toBe 'helloxxx'
+
+  it 'should strip ng attributes', ->
+    text = '<p ng-show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p ng_show="false " style="color:red">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p style="color:red">x</p>'
+
+    text = '<p data-ng-show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p data-ng_show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p data_ng_show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p ng:show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p data-ng:show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p data:ng:show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p x-ng-show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p x-ng_show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p x_ng_show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+    text = '<p x-ng:show="false">x</p>'
+    expect(Utils.stripNGAttributes text).toBe '<p>x</p>'
+
+  it 'should strip both script tags, onX anf ng-x attributes', ->
+    text = 'hello<script>alert(1)</script> <p onclick="alert(1)" ng-show=\'false\'>xxx</p>'
+    expect(Utils.cleanHTML text).toBe 'hello <p>xxx</p>'
+
+  it 'should respect whitelist for enterprise edition', ->
+    host = 'http://first.com'
+    whitelist = 'http://second.com,http://third.com'
+    expect(Utils.hostIsAllowed host, '*', yes).toBe yes
+    expect(Utils.hostIsAllowed host, host, yes).toBe yes
+    expect(Utils.hostIsAllowed host, whitelist, yes).toBe no
+
+  it 'should ignore whitelist for non enterprise editions', ->
+    host = 'http://first.com'
+    whitelist = 'http://second.com,http://third.com'
+    expect(Utils.hostIsAllowed host, '*', no).toBe no
+    expect(Utils.hostIsAllowed host, host, no).toBe no
+    expect(Utils.hostIsAllowed host, whitelist, no).toBe no
+    expect(Utils.hostIsAllowed 'http://guides.neo4j.com', whitelist, no).toBe yes

--- a/community/server/src/docs/ops/server-configuration.asciidoc
+++ b/community/server/src/docs/ops/server-configuration.asciidoc
@@ -178,6 +178,20 @@ This line is already present and needs uncommenting.
 Note also that logging is not directed to console.
 You will find the logging statements in _data/log/ne4j-gc.log_ or whatever directory you set the option to.
 
+=== Whitelist for remote guides in Browser ===
+
+The Browser can `:play` guides from remote locations. You can specify a whitelist of hosts from where the Browser will be allowed to fetch content from.
+
+In the _conf/neo4j-server.properties_ file:
+
+[source,properties]
+----
+# To allow default hosts
+dbms.browser.remote_content_hostname_whitelist="http://guides.neo4j.com,https://guides.neo4j.com,http://localhost,https://localhost"
+
+# To allow all hosts (enterprise edition only)
+dbms.browser.remote_content_hostname_whitelist="*"
+----
 
 === Disabling console types in Webadmin ===
 

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
@@ -33,12 +33,15 @@ public interface EnterpriseServerSettings
 {
     @Description( "Configure the Neo4j Browser to time out logged in users after this idle period. " +
                   "Setting this to 0 indicates no limit." )
-    Setting<Long> browser_credentialTimeout = setting("dbms.browser.credential_timeout", DURATION, "0");
+    Setting<Long> browser_credentialTimeout = setting( "dbms.browser.credential_timeout", DURATION, "0" );
 
     @Description( "Configure the Neo4j Browser to store or not store user credentials." )
-    Setting<Boolean> browser_storeCredentials = setting("dbms.browser.store_credentials", BOOLEAN, TRUE);
+    Setting<Boolean> browser_storeCredentials = setting( "dbms.browser.store_credentials", BOOLEAN, TRUE );
 
     @Description( "Configure the operating mode of the database - 'SINGLE' for stand-alone operation or 'HA'" +
                   "for operating as a member in a cluster." )
     Setting<String> mode = setting( "org.neo4j.server.database.mode", STRING, "SINGLE" );
+
+    @Description( "Whitelist of hosts for the Neo4j Browser to be allowed to fetch content from." )
+    Setting<String> browser_remoteContentHostnameWhitelist = setting( "dbms.browser.remote_content_hostname_whitelist", STRING, "http://guides.neo4j.com,https://guides.neo4j.com,http://localhost,https://localhost" );
 }

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-server.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-server.properties
@@ -90,4 +90,14 @@ org.neo4j.server.http.log.config=conf/neo4j-http-logging.xml
 # - commented out, will default to the database data directory.
 org.neo4j.server.webadmin.rrdb.location=data/rrd
 
+
+#*****************************************************************
+# Neo4j Browser configuration
+#*****************************************************************
+
+# Whitelist of hosts for the Neo4j Browser to be allowed to fetch content from.
+# Set to '*' to allow all hosts.
+dbms.browser.remote_content_hostname_whitelist=#{dbms.browser.remote_content_hostname_whitelist}
+
+
 #{config.neo4j-server.additional}


### PR DESCRIPTION
- Reads whitelist of hosts from server dbms.browser.remote_content_hostname_whitelist config.
- If no whitelist available, play guides from any source. (Enterprise edition only)
- Strip out onX attributes and <script> tags.
