### PR TITLE
Break the circular dependency in licensecheck-config

### DIFF
--- a/community/licensecheck-config/pom.xml
+++ b/community/licensecheck-config/pom.xml
@@ -19,6 +19,7 @@
     <short-name>licenses</short-name>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <licensing.phase>none</licensing.phase>
   </properties>
 
   <scm>


### PR DESCRIPTION
It makes no sense to run the licensecheck plugin for this module anyhow.
