### PR TITLE
Allow upgrade from older store formats without id files

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyTokenStoreHighIdReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/LegacyTokenStoreHighIdReader.java
@@ -19,20 +19,9 @@
  */
 package org.neo4j.kernel.impl.storemigration.legacystore;
 
-import java.io.Closeable;
 import java.io.File;
-import java.io.IOException;
 
-public interface LegacyStore extends Closeable
+public interface LegacyTokenStoreHighIdReader
 {
-    File getStorageFileName();
-
-    @Override
-    void close() throws IOException;
-
-    LegacyNodeStoreReader getNodeStoreReader();
-
-    LegacyRelationshipStoreReader getRelStoreReader();
-
-    boolean hasTokenStore( String tokenStoreName );
+    long findHighIdBackwards( File storeFile, String storeName );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v19/Legacy19Store.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v19/Legacy19Store.java
@@ -25,16 +25,22 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.neo4j.function.Predicate;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.impl.store.CommonAbstractStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyNodeStoreReader;
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyRelationshipStoreReader;
 import org.neo4j.kernel.impl.storemigration.legacystore.LegacyStore;
+import org.neo4j.kernel.impl.storemigration.legacystore.LegacyTokenStoreHighIdReader;
 import org.neo4j.kernel.impl.storemigration.legacystore.v20.Legacy20RelationshipStoreReader;
 
 /**
@@ -45,9 +51,14 @@ import org.neo4j.kernel.impl.storemigration.legacystore.v20.Legacy20Relationship
  * <p>
  * {@link #LEGACY_VERSION} marks which version it's able to read.
  */
-public class Legacy19Store implements LegacyStore
+public class Legacy19Store implements LegacyStore, LegacyTokenStoreHighIdReader
 {
     public static final String LEGACY_VERSION = "v0.A.0";
+
+    // always one for token stores
+    private static final int bytesRequiredToDetermineInUse = 1;
+    // always zero for token stores
+    private static final int lowestHighId = 0;
 
     private final File storageFileName;
     private final Collection<Closeable> allStoreReaders = new ArrayList<>();
@@ -55,8 +66,21 @@ public class Legacy19Store implements LegacyStore
     private Legacy19PropertyIndexStoreReader propertyIndexReader;
     private Legacy19PropertyStoreReader propertyStoreReader;
     private LegacyRelationshipStoreReader relStoreReader;
-
     private final FileSystemAbstraction fs;
+    private final Predicate<ByteBuffer> isRecordInUse = new Predicate<ByteBuffer>()
+    {
+        @Override
+        public boolean test( ByteBuffer byteBuffer )
+        {
+            byte inUseByte = byteBuffer.get();
+            return inUseByte != Record.IN_USE.byteValue() && inUseByte != Record.NOT_IN_USE.byteValue();
+        }
+    };
+    private final Map<String,Integer> recordSizes = new HashMap<>( 2 );
+    {
+        recordSizes.put( StoreFactory.PROPERTY_KEY_TOKEN_STORE_NAME, 9 );
+        recordSizes.put( StoreFactory.RELATIONSHIP_TYPE_TOKEN_STORE_NAME, 5 );
+    }
 
     public Legacy19Store( FileSystemAbstraction fs, File storageFileName ) throws IOException
     {
@@ -128,6 +152,12 @@ public class Legacy19Store implements LegacyStore
         return relStoreReader;
     }
 
+    @Override
+    public boolean hasTokenStore( String tokenStoreName )
+    {
+        return recordSizes.containsKey( tokenStoreName );
+    }
+
     public Legacy19PropertyIndexStoreReader getPropertyIndexReader()
     {
         return propertyIndexReader;
@@ -151,5 +181,36 @@ public class Legacy19Store implements LegacyStore
             throw new RuntimeException( e );
         }
         buffer.flip();
+    }
+
+    @Override
+    public long findHighIdBackwards( File storeFile, String storeName )
+    {
+        int recordSize = recordSizes.get( storeName );
+        try ( StoreChannel fileChannel = fs.open( storeFile, "r" ) )
+        {
+            long fileSize = fileChannel.size();
+            long highId = fileSize / recordSize;
+            ByteBuffer byteBuffer = ByteBuffer.allocate( bytesRequiredToDetermineInUse );
+            for ( long i = highId; i >= 0; i-- )
+            {
+                fileChannel.position( i * recordSize );
+                if ( fileChannel.read( byteBuffer ) > 0 )
+                {
+                    byteBuffer.flip();
+                    boolean isInUse = isRecordInUse.test( byteBuffer );
+                    byteBuffer.clear();
+                    if ( isInUse )
+                    {
+                        return i + 1;
+                    }
+                }
+            }
+            return lowestHighId;
+        }
+        catch ( IOException e )
+        {
+            throw new UnderlyingStorageException( "Unable to rebuild id generator " + storeFile, e );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/Legacy21Store.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/Legacy21Store.java
@@ -83,4 +83,10 @@ public class Legacy21Store implements LegacyStore
         // not needed
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean hasTokenStore( String tokenStoreName )
+    {
+        return true;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v22/Legacy22Store.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v22/Legacy22Store.java
@@ -84,4 +84,10 @@ public class Legacy22Store implements LegacyStore
         // not needed
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean hasTokenStore( String tokenStoreName )
+    {
+        return true;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
@@ -57,7 +57,8 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
         this.anyRelationshipType = highRelationshipTypeId;
         this.itemsPerType = anyLabel+1;
         this.itemsPerStartLabel = (anyRelationshipType+1)*itemsPerType;
-        this.counts = cacheFactory.newLongArray( arrayIndex( highLabelId, highRelationshipTypeId, highLabelId )+1, 0 );
+        long length = arrayIndex( highLabelId, highRelationshipTypeId, highLabelId ) + 1;
+        this.counts = cacheFactory.newLongArray( length, 0 );
     }
 
     private long arrayIndex( long startLabel, long relationshipType, long endLabel )

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -27,6 +27,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -158,7 +159,44 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
-            builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
+            GraphDatabaseService db = builder.newGraphDatabase();
+            try
+            {
+                checkInstance( store, (GraphDatabaseAPI) db );
+
+            }
+            finally
+            {
+                db.shutdown();
+            }
+
+            assertConsistentStore( dir );
+        }
+
+        @Test
+        public void shouldBeAbleToUpgradeAStoreWithoutIdFilesAsBackups() throws Throwable
+        {
+            File dir = store.prepareDirectory( testDir.graphDbDir() );
+
+            // remove id files
+            File[] idFiles = dir.listFiles( new FilenameFilter()
+            {
+                @Override
+                public boolean accept( File dir, String name )
+                {
+
+                    return name.endsWith( ".id" );
+                }
+            } );
+
+            for ( File idFile : idFiles )
+            {
+                assertTrue( idFile.delete() );
+            }
+
+            GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
+            GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
+            builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
             GraphDatabaseService db = builder.newGraphDatabase();
             try
             {
@@ -218,7 +256,6 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
-            builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             GraphDatabaseService db = builder.newGraphDatabase();
             try
             {
@@ -275,7 +312,6 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
-            builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             try
             {
                 GraphDatabaseService db = builder.newGraphDatabase();


### PR DESCRIPTION
Store backup does not copy id files, hence in order to allow migration
from a backup we cannot rely on having id files.  This change will
make sure we can recompute the missing high ids before migration.
