### PR TITLE
Log database startup failures in messages.log

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/InternalAbstractGraphDatabase.java
@@ -345,6 +345,7 @@ public abstract class InternalAbstractGraphDatabase
                 }
                 catch ( Throwable shutdownError )
                 {
+                    msgLog.error( "Failed to start database", error );
                     error = Exceptions.withSuppressed( shutdownError, error );
                 }
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/InternalAbstractGraphDatabaseTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/InternalAbstractGraphDatabaseTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.InternalAbstractGraphDatabase.Dependencies;
+import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
@@ -91,6 +92,7 @@ public class InternalAbstractGraphDatabaseTest
             @Override
             protected void create()
             {
+                msgLog = mock( StringLogger.class );
                 availabilityGuard = mock( AvailabilityGuard.class );
             }
 


### PR DESCRIPTION
Before this change database startup errors were logged only in console.log
