### PR TITLE
Put libraries in the right location of packages

### DIFF
--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
@@ -30,7 +30,7 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/advanced</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>keep</lineEnding>
       <filtered>true</filtered>
       <excludes>
@@ -42,7 +42,7 @@
     <!-- password files -->
     <fileSet>
       <directory>src/main/distribution/text/advanced</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>unix</lineEnding>
       <filtered>true</filtered>
       <includes>
@@ -53,7 +53,7 @@
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>system/lib/*.jar</include>
         <include>lib/*.jar</include>
@@ -62,7 +62,7 @@
     <!-- filter and chmod 755 shell scripts -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
@@ -79,7 +79,7 @@
     <!--add MacOS *.plist installer files -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/resources</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
@@ -90,7 +90,7 @@
     <!-- upgrade text file -->
     <fileSet>
       <directory>target/upgrade</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <fileMode>0644</fileMode>
       <includes>
         <include>UPGRADE.txt</include>
@@ -110,7 +110,8 @@
         <include>org.neo4j:*</include>
         <include>jline:jline</include>
         <include>org.apache.lucene:lucene-core</include>
-        <include>org.scala-lang:scala-library</include>
+        <include>org.scala-lang:*</include>
+        <include>org.scala-lang.modules:*</include>
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
@@ -134,7 +135,8 @@
         <exclude>org.neo4j.doc:*</exclude>
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:lucene-core</exclude>
-        <exclude>org.scala-lang:scala-library</exclude>
+        <exclude>org.scala-lang:*</exclude>
+        <exclude>org.scala-lang.modules:*</exclude>
         <exclude>org.parboiled:*</exclude>
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>

--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-windows-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-windows-dist.xml
@@ -30,14 +30,14 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/advanced</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>dos</lineEnding>
       <filtered>true</filtered>
     </fileSet>
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>system/lib/*.jar</include>
         <include>lib/*.jar</include>
@@ -45,7 +45,7 @@
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>dos</lineEnding>
       <includes>
         <include>**/*.bat</include>
@@ -60,7 +60,7 @@
     <!-- Neo4j Powershell Modules -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>dos</lineEnding>
       <includes>
         <include>**/*.psd1</include>
@@ -72,7 +72,7 @@
     <!-- upgrade text file -->
     <fileSet>
       <directory>target/upgrade</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <fileMode>0644</fileMode>
       <lineEnding>dos</lineEnding>
       <includes>
@@ -99,7 +99,8 @@
         <include>org.neo4j:*</include>
         <include>jline:jline</include>
         <include>org.apache.lucene:lucene-core</include>
-        <include>org.scala-lang:scala-library</include>
+        <include>org.scala-lang:*</include>
+        <include>org.scala-lang.modules:*</include>
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
@@ -121,7 +122,8 @@
         <exclude>org.neo4j.doc:*</exclude>
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:lucene-core</exclude>
-        <exclude>org.scala-lang:scala-library</exclude>
+        <exclude>org.scala-lang:*</exclude>
+        <exclude>org.scala-lang.modules:*</exclude>
         <exclude>org.parboiled:*</exclude>
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -31,7 +31,7 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/community</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>keep</lineEnding>
       <filtered>true</filtered>
       <directoryMode>0755</directoryMode>
@@ -40,7 +40,7 @@
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>system/lib/*.jar</include>
         <include>lib/*.jar</include>
@@ -49,7 +49,7 @@
     <!-- filter and chmod 755 shell scripts -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
@@ -66,7 +66,7 @@
     <!--add MacOS *.plist installer files -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/resources</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
@@ -77,7 +77,7 @@
     <!-- upgrade text file -->
     <fileSet>
       <directory>target/upgrade</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <fileMode>0644</fileMode>
       <includes>
         <include>UPGRADE.txt</include>
@@ -97,7 +97,8 @@
         <include>org.neo4j:*</include>
         <include>jline:jline</include>
         <include>org.apache.lucene:lucene-core</include>
-        <include>org.scala-lang:scala-library</include>
+        <include>org.scala-lang:*</include>
+        <include>org.scala-lang.modules:*</include>
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
@@ -120,7 +121,8 @@
         <exclude>org.neo4j.doc:*</exclude>
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:lucene-core</exclude>
-        <exclude>org.scala-lang:scala-library</exclude>
+        <exclude>org.scala-lang:*</exclude>
+        <exclude>org.scala-lang.modules:*</exclude>
         <exclude>org.parboiled:*</exclude>
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
@@ -30,14 +30,14 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/community</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>dos</lineEnding>
       <filtered>true</filtered>
     </fileSet>
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>system/lib/*.jar</include>
         <include>lib/*.jar</include>
@@ -45,7 +45,7 @@
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>dos</lineEnding>
       <includes>
         <include>**/*.bat</include>
@@ -60,7 +60,7 @@
     <!-- Neo4j Powershell Modules -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>dos</lineEnding>
       <includes>
         <include>**/*.psd1</include>
@@ -72,7 +72,7 @@
     <!-- upgrade text file -->
     <fileSet>
       <directory>target/upgrade</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <fileMode>0644</fileMode>
       <lineEnding>dos</lineEnding>
       <includes>
@@ -98,7 +98,8 @@
         <include>org.neo4j:*</include>
         <include>jline:jline</include>
         <include>org.apache.lucene:lucene-core</include>
-        <include>org.scala-lang:scala-library</include>
+        <include>org.scala-lang:*</include>
+        <include>org.scala-lang.modules:*</include>
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
@@ -119,7 +120,8 @@
         <exclude>org.neo4j.doc:*</exclude>
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:lucene-core</exclude>
-        <exclude>org.scala-lang:scala-library</exclude>
+        <exclude>org.scala-lang:*</exclude>
+        <exclude>org.scala-lang.modules:*</exclude>
         <exclude>org.parboiled:*</exclude>
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
@@ -30,7 +30,7 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/enterprise</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>keep</lineEnding>
       <filtered>true</filtered>
       <excludes>
@@ -42,7 +42,7 @@
     <!-- password files -->
     <fileSet>
       <directory>src/main/distribution/text/enterprise</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>unix</lineEnding>
       <filtered>true</filtered>
       <includes>
@@ -53,7 +53,7 @@
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>system/lib/*.jar</include>
         <include>lib/*.jar</include>
@@ -63,7 +63,7 @@
     <!-- filter and chmod 755 shell scripts -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <excludes>
@@ -77,7 +77,7 @@
     <!--add MacOS *.plist installer files -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/resources</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>unix</lineEnding>
       <fileMode>0755</fileMode>
       <filtered>true</filtered>
@@ -85,7 +85,7 @@
     <!-- upgrade text file -->
     <fileSet>
       <directory>target/upgrade</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <fileMode>0644</fileMode>
       <includes>
         <include>UPGRADE.txt</include>
@@ -106,11 +106,16 @@
         <include>jline:jline</include>
         <include>org.apache.lucene:lucene-core</include>
         <include>io.netty:netty</include>
-        <include>org.scala-lang:scala-library</include>
+        <include>org.scala-lang:*</include>
+        <include>org.scala-lang.modules:*</include>
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>net.sf.opencsv:opencsv</include>
         <include>org.apache.commons:commons-lang3</include>
+        <include>io.dropwizard.metrics:*</include>
+        <include>info.ganglia.gmetric4j:gmetric4j</include>
+        <include>org.acplt:oncrpc</include>
+        <include>org.slf4j:slf4j-api</include>
       </includes>
       <excludes>
         <exclude>*:pom:*</exclude>
@@ -132,12 +137,17 @@
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:lucene-core</exclude>
         <exclude>io.netty:netty</exclude>
-        <exclude>org.scala-lang:scala-library</exclude>
+        <exclude>org.scala-lang:*</exclude>
+        <exclude>org.scala-lang.modules:*</exclude>
         <exclude>org.parboiled:*</exclude>
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
         <exclude>net.sf.opencsv:opencsv</exclude>
         <exclude>org.apache.commons:commons-lang3</exclude>
+        <exclude>io.dropwizard.metrics:*</exclude>
+        <exclude>info.ganglia.gmetric4j:gmetric4j</exclude>
+        <exclude>org.acplt:oncrpc</exclude>
+        <exclude>org.slf4j:slf4j-api</exclude>
       </excludes>
     </dependencySet>
  </dependencySets>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
@@ -30,14 +30,14 @@
     <!-- filter plain text -->
     <fileSet>
       <directory>src/main/distribution/text/enterprise</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>dos</lineEnding>
       <filtered>true</filtered>
     </fileSet>
     <!-- non-maven jars -->
     <fileSet>
       <directory>src/main/distribution/binary</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <includes>
         <include>system/lib/*.jar</include>
         <include>lib/*.jar</include>
@@ -45,7 +45,7 @@
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>dos</lineEnding>
       <includes>
         <include>**/*.bat</include>
@@ -55,7 +55,7 @@
     <!-- Neo4j Powershell Modules -->
     <fileSet>
       <directory>${project.parent.basedir}/src/main/distribution/shell-scripts</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <lineEnding>dos</lineEnding>
       <includes>
         <include>**/*.psd1</include>
@@ -67,7 +67,7 @@
     <!-- upgrade text file -->
     <fileSet>
       <directory>target/upgrade</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory></outputDirectory>
       <fileMode>0644</fileMode>
       <lineEnding>dos</lineEnding>
       <includes>
@@ -96,10 +96,15 @@
         <include>org.apache.lucene:lucene-core</include>
         <include>io.netty:netty</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
-        <include>org.scala-lang:scala-library</include>
+        <include>org.scala-lang:*</include>
+        <include>org.scala-lang.modules:*</include>
         <include>org.parboiled:*</include>
         <include>net.sf.opencsv:opencsv</include>
         <include>org.apache.commons:commons-lang3</include>
+        <include>io.dropwizard.metrics:*</include>
+        <include>info.ganglia.gmetric4j:gmetric4j</include>
+        <include>org.acplt:oncrpc</include>
+        <include>org.slf4j:slf4j-api</include>
       </includes>
       <excludes>
         <exclude>*:pom:*</exclude>
@@ -119,12 +124,17 @@
         <exclude>jline:jline</exclude>
         <exclude>org.apache.lucene:lucene-core</exclude>
         <exclude>io.netty:netty</exclude>
-        <exclude>org.scala-lang:scala-library</exclude>
+        <exclude>org.scala-lang:*</exclude>
+        <exclude>org.scala-lang.modules:*</exclude>
         <exclude>org.parboiled:*</exclude>
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>
         <exclude>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</exclude>
         <exclude>net.sf.opencsv:opencsv</exclude>
         <exclude>org.apache.commons:commons-lang3</exclude>
+        <exclude>io.dropwizard.metrics:*</exclude>
+        <exclude>info.ganglia.gmetric4j:gmetric4j</exclude>
+        <exclude>org.acplt:oncrpc</exclude>
+        <exclude>org.slf4j:slf4j-api</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
     <logback-classic.version>1.1.2</logback-classic.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
     <hsqldb.version>2.3.2</hsqldb.version>
-    <metrics.version>3.1.2</metrics.version>
     <test.runner.jvm.settings>-Xmx1G -XX:MaxPermSize=128M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data</test.runner.jvm.settings>
     <doclint-groups>reference</doclint-groups>
   </properties>
@@ -729,17 +728,17 @@
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
-        <version>${metrics.version}</version>
+        <version>3.1.2</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-graphite</artifactId>
-        <version>${metrics.version}</version>
+        <version>3.1.2</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-ganglia</artifactId>
-        <version>${metrics.version}</version>
+        <version>3.1.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- Put all Scala libraries in lib/.
- Put the dependencies of neo4j-metrics in lib/.
  slf4j-api is one such transitive dependecy, so it got moved.
- Clean up of assembly descriptors to avoid warnings.
- Don't use a property for metrics.version.
  It caused strange issues with Maven.
