### PR TITLE
Don't pre-zero freshly allocated memory.

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPage.java
@@ -415,7 +415,6 @@ final class MuninnPage extends StampedLock implements Page
         if ( pointer == 0 )
         {
             pointer = memoryManager.allocateAligned( size() );
-            UnsafeUtil.setMemory( pointer, size(), MuninnPageCache.ZERO_BYTE );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
@@ -127,7 +127,7 @@ public class ConfiguringPageCacheFactory
     public void dumpConfiguration()
     {
         int cachePageSize = calculatePageSize( config, swapperFactory );
-        int maxPages = calculateMaxPages( config, cachePageSize );
+        long maxPages = calculateMaxPages( config, cachePageSize );
         long totalPhysicalMemory = totalPhysicalMemory();
         String totalPhysicalMemMb = totalPhysicalMemory == -1? "?" : "" + totalPhysicalMemory / 1024 / 1024;
         long maxVmUsageMb = Runtime.getRuntime().maxMemory() / 1024 / 1024;

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
@@ -29,7 +29,8 @@ package org.neo4j.unsafe.impl.internal.dragons;
  */
 public final class MemoryManager
 {
-    private static final long GRAB_SIZE = 32 * 1024 * 1024; // 32 MiB
+    private static final long GRAB_SIZE = Integer.getInteger(
+            MemoryManager.class.getName() + ".GRAB_SIZE", 32 * 1024 * 1024 ); // 32 MiB
 
     /**
      * The amount of memory that this memory manager can still allocate.


### PR DESCRIPTION
This is safe because it will always be overwritten or zeroed out when we page fault.

This _might_ improve performance on high-mem and NUMA systems. Needs testing.
