### PR TITLE
Fix neo4j start on lsof>=4.87

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -140,13 +140,18 @@ buildclasspath() {
 
 detectrunning() {
   if [ $DIST_OS = "solaris" ] ; then
-      ## SmartOS has a different lsof command line arguments
-      newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
+    ## SmartOS has a different lsof command line arguments
+    newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
   else
-      ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
-      ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
+    ## Handle different versions of lsof
+    LSOFVER=`lsof -v 2>&1 | grep revision | grep -v latest | cut -d: -f2 | tr -d ' ' | tr -d .`
+
+    if [ $LSOFVER -ge 487 ]; then
       newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep "p")
-      newpid=${newpid:1}
+    else
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
+    fi
+    newpid=${newpid:1}
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -145,7 +145,7 @@ detectrunning() {
   else
       ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
       ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
-      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep "p")
       newpid=${newpid:1}
   fi
 }


### PR DESCRIPTION
The neo4j startup script fails for distros using lsof version 4.87 or higher. Today this means atleast two (Arch Linux and Fedora). It has also entered [Debian unstable](http://metadata.ftp-master.debian.org/changelogs//main/l/lsof/lsof_4.89+dfsg-0.1_changelog).

Duplicates/Related:
#5443
#3414
#4505
