### PR TITLE
Removed superfluous warning for index lookups

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/IndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/IndexSeekLeafPlanner.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
 import org.neo4j.cypher.internal.frontend.v2_3.ast._
-import org.neo4j.cypher.internal.frontend.v2_3.notification.IndexSeekUnfulfillableNotification
+import org.neo4j.cypher.internal.frontend.v2_3.notification.IndexLookupUnfulfillableNotification
 import org.neo4j.kernel.api.index.IndexDescriptor
 
 
@@ -70,7 +70,7 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner {
     }.flatten
 
     if (resultPlans.isEmpty) {
-      DynamicPropertyNotifier.process(findNonSeekableIdentifiers(predicates), IndexSeekUnfulfillableNotification, qg)
+      DynamicPropertyNotifier.process(findNonSeekableIdentifiers(predicates), IndexLookupUnfulfillableNotification, qg)
     }
 
     resultPlans

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/indexScanLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/steps/indexScanLeafPlanner.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_3.planner.logical.{LeafPlanner, LogicalPlanningContext}
 import org.neo4j.cypher.internal.frontend.v2_3.ast._
-import org.neo4j.cypher.internal.frontend.v2_3.notification.IndexScanUnfulfillableNotification
+import org.neo4j.cypher.internal.frontend.v2_3.notification.IndexLookupUnfulfillableNotification
 
 object indexScanLeafPlanner extends LeafPlanner {
   override def apply(qg: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] = {
@@ -55,7 +55,7 @@ object indexScanLeafPlanner extends LeafPlanner {
     }.flatten
 
     if (resultPlans.isEmpty) {
-      DynamicPropertyNotifier.process(findNonScannableIdentifiers(predicates), IndexScanUnfulfillableNotification, qg)
+      DynamicPropertyNotifier.process(findNonScannableIdentifiers(predicates), IndexLookupUnfulfillableNotification, qg)
     }
 
     resultPlans

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/JoinHintPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/JoinHintPlanningIntegrationTest.scala
@@ -38,7 +38,7 @@ import scala.util.Random
 class JoinHintPlanningIntegrationTest extends CypherFunSuite with PropertyChecks with LogicalPlanningTestSupport2 {
 
   val MinPatternLength = 2
-  val MaxPatternLength = 10
+  val MaxPatternLength = 8
   val NumberOfTestRuns = 100
   val MaxDiscardedInputs = 500
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -306,10 +306,8 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
       NotificationCode.JOIN_HINT_UNFULFILLABLE.notification(InputPosition.empty, NotificationDetail.Factory.joinKey(identifiers.asJava))
     case JoinHintUnsupportedNotification(identifiers) =>
       NotificationCode.JOIN_HINT_UNSUPPORTED.notification(InputPosition.empty, NotificationDetail.Factory.joinKey(identifiers.asJava))
-    case IndexSeekUnfulfillableNotification(labels) =>
-      NotificationCode.INDEX_SEEK_FOR_DYNAMIC_PROPERTY.notification(InputPosition.empty, NotificationDetail.Factory.indexSeekOrScan(labels.asJava))
-    case IndexScanUnfulfillableNotification(labels) =>
-      NotificationCode.INDEX_SCAN_FOR_DYNAMIC_PROPERTY.notification(InputPosition.empty, NotificationDetail.Factory.indexSeekOrScan(labels.asJava))
+    case IndexLookupUnfulfillableNotification(labels) =>
+      NotificationCode.INDEX_LOOKUP_FOR_DYNAMIC_PROPERTY.notification(InputPosition.empty, NotificationDetail.Factory.indexSeekOrScan(labels.asJava))
     case BareNodeSyntaxDeprecatedNotification(pos) =>
       NotificationCode.BARE_NODE_SYNTAX_DEPRECATED.notification(pos.asInputPosition)
     case EagerLoadCsvNotification =>

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -152,7 +152,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE n['key-' + n.name] = 'value' RETURN n")
 
-    result.notifications should equal(Set(IndexSeekUnfulfillableNotification(Set("Person")), IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   test("warn for unfulfillable index seek when using dynamic property lookup with explicit label check") {
@@ -160,7 +160,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n) WHERE n['key-' + n.name] = 'value' AND (n:Person) RETURN n")
 
-    result.notifications should equal(Set(IndexSeekUnfulfillableNotification(Set("Person")), IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   test("warn for unfulfillable index seek when using dynamic property lookup with a single label and negative predicate") {
@@ -176,7 +176,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE n['key-' + n.name] > 10 RETURN n")
 
-    result.notifications should equal(Set(IndexSeekUnfulfillableNotification(Set("Person")), IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   test("warn for unfulfillable index seek when using dynamic property lookup with range seek (reverse)") {
@@ -184,7 +184,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE 10 > n['key-' + n.name] RETURN n")
 
-    result.notifications should equal(Set(IndexSeekUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   test("warn for unfulfillable index seek when using dynamic property lookup with a single label and property existence check with exists") {
@@ -192,7 +192,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE exists(n['na' + 'me']) RETURN n")
 
-    result.notifications should equal(Set(IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   test("warn for unfulfillable index seek when using dynamic property lookup with a single label and property existence check with has") {
@@ -200,7 +200,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE has(n['na' + 'me']) RETURN n")
 
-    result.notifications should equal(Set(IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   ignore("warn for unfulfillable index seek when using dynamic property lookup with a single label and like") {
@@ -208,7 +208,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE n['key-' + n.name] LIKE 'Foo%' RETURN n")
 
-    result.notifications should equal(Set(IndexSeekUnfulfillableNotification(Set("Person")), IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   ignore("warn for unfulfillable index seek when using dynamic property lookup with a single label and like - suffix") {
@@ -216,7 +216,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE n['key-' + n.name] LIKE '%Foo' RETURN n")
 
-    result.notifications should equal(Set(IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   test("warn for unfulfillable index seek when using dynamic property lookup with a single label and regex") {
@@ -224,7 +224,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE n['key-' + n.name] =~ 'Foo*' RETURN n")
 
-    result.notifications should equal(Set(IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   test("warn for unfulfillable index seek when using dynamic property lookup with a single label and IN") {
@@ -232,7 +232,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE n['key-' + n.name] IN ['Foo', 'Bar'] RETURN n")
 
-    result.notifications should equal(Set(IndexSeekUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   test("warn for unfulfillable index seek when using dynamic property lookup with multiple labels") {
@@ -240,7 +240,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person:Foo) WHERE n['key-' + n.name] = 'value' RETURN n")
 
-    result.notifications should (contain(IndexSeekUnfulfillableNotification(Set("Person"))) and contain(IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should contain(IndexLookupUnfulfillableNotification(Set("Person")))
   }
 
   test("warn for unfulfillable index seek when using dynamic property lookup with multiple indexed labels") {
@@ -249,7 +249,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person:Jedi) WHERE n['key-' + n.name] = 'value' RETURN n")
 
-    result.notifications should equal(Set(IndexSeekUnfulfillableNotification(Set("Person", "Jedi")), IndexScanUnfulfillableNotification(Set("Person", "Jedi"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person", "Jedi"))))
   }
 
   test("should not warn when using dynamic property lookup with no labels") {
@@ -265,7 +265,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     val result = innerExecute("EXPLAIN MATCH (n:Person) WHERE n.name = 'Tobias' AND n['key-' + n.name] = 'value' RETURN n")
 
-    result.notifications should equal(Set(IndexSeekUnfulfillableNotification(Set("Person")), IndexScanUnfulfillableNotification(Set("Person"))))
+    result.notifications should equal(Set(IndexLookupUnfulfillableNotification(Set("Person"))))
   }
 
   test("should not warn when using dynamic property lookup with a label having no index") {

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
@@ -42,9 +42,7 @@ case class JoinHintUnfulfillableNotification(identified: Seq[String]) extends In
 
 case class JoinHintUnsupportedNotification(identified: Seq[String]) extends InternalNotification
 
-case class IndexSeekUnfulfillableNotification(labels: Set[String]) extends InternalNotification
-
-case class IndexScanUnfulfillableNotification(labels: Set[String]) extends InternalNotification
+case class IndexLookupUnfulfillableNotification(labels: Set[String]) extends InternalNotification
 
 case class BareNodeSyntaxDeprecatedNotification(position: InputPosition) extends InternalNotification
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -74,15 +74,10 @@ public enum NotificationCode
         Status.Statement.DeprecationWarning,
         "Using 'length' on anything that is not a path is deprecated, please use 'size' instead"
     ),
-    INDEX_SEEK_FOR_DYNAMIC_PROPERTY(
+    INDEX_LOOKUP_FOR_DYNAMIC_PROPERTY(
         SeverityLevel.WARNING,
         Status.Statement.DynamicPropertyWarning,
-        "Using a dynamic property makes it impossible to use an index seek for this query"
-    ),
-    INDEX_SCAN_FOR_DYNAMIC_PROPERTY(
-        SeverityLevel.WARNING,
-        Status.Statement.DynamicPropertyWarning,
-        "Using a dynamic property makes it impossible to use an index scan for this query"
+        "Using a dynamic property makes it impossible to use an index lookup for this query"
     ),
     BARE_NODE_SYNTAX_DEPRECATED(
         SeverityLevel.WARNING,


### PR DESCRIPTION
Previously we differentiated warnings for not being able to use index seeks and
index scans when using dynamic property lookup. This commit merges the
warnings into one.
Reduced a parameter to speed up long-running test.
