### PR TITLE
Make MERGE print start point in plan description

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/MergePatternAction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/MergePatternAction.scala
@@ -19,12 +19,14 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.mutation
 
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.Argument
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.{MergePattern, UpdateActionName}
 import org.neo4j.cypher.internal.compiler.v2_2.{InvalidSemanticsException, InternalException, ExecutionContext}
 import org.neo4j.cypher.internal.compiler.v2_2.commands._
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan._
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.PropertySupport
-import org.neo4j.cypher.internal.compiler.v2_2.pipes.{Pipe, QueryState}
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.{MatchPipe, Pipe, QueryState}
 import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 import org.neo4j.graphdb.Node
 import org.neo4j.helpers.ThisShouldNotHappenError
@@ -135,6 +137,15 @@ case class MergePatternAction(patterns: Seq[Pattern],
   }
 
   override def updateSymbols(symbol: SymbolTable): SymbolTable = symbol.add(identifiers.toMap)
+
+  override def arguments: Seq[Argument] = {
+    val startPoint: Option[String] = maybeMatchPipe.map {
+      case m: MatchPipe => m.mergeStartPoint
+      case _ => ""
+    }
+    Seq(MergePattern(startPoint.getOrElse("")))
+  }
+
 }
 
 object MergePatternAction {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/MatchPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/MatchPipe.scala
@@ -51,6 +51,8 @@ case class MatchPipe(source: Pipe,
   override def planDescription =
     source.planDescription.andThen(this, matchingContext.builder.name, identifiers)
 
+  def mergeStartPoint = matchingContext.builder.startPoint
+
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
     copy(source = head)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/MatchingContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/MatchingContext.scala
@@ -65,7 +65,8 @@ class MatchingContext(boundIdentifiers: SymbolTable,
 }
 
 trait MatcherBuilder {
-  def name:String
+  def name: String
+  def startPoint: String
   def getMatches(sourceRow: ExecutionContext, state: QueryState): Traversable[ExecutionContext]
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/PatternMatchingBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/PatternMatchingBuilder.scala
@@ -109,5 +109,7 @@ class PatternMatchingBuilder(patternGraph: PatternGraph,
   }
 
   def name = "PatternMatcher"
+
+  override def startPoint: String = ""
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/SimplePatternMatcherBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/SimplePatternMatcherBuilder.scala
@@ -20,14 +20,14 @@
 package org.neo4j.cypher.internal.compiler.v2_2.pipes.matching
 
 import org.neo4j.cypher.internal.compiler.v2_2._
-import commands.Predicate
-import pipes.QueryState
-import symbols._
-import org.neo4j.graphdb.{Relationship, Node, DynamicRelationshipType}
-import org.neo4j.graphmatching.{PatternMatcher => SimplePatternMatcher, PatternNode => SimplePatternNode,
-PatternRelationship => SimplePatternRelationship, PatternMatch}
-import collection.{immutable, Map}
-import collection.JavaConverters._
+import org.neo4j.cypher.internal.compiler.v2_2.commands.Predicate
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.QueryState
+import org.neo4j.cypher.internal.compiler.v2_2.symbols._
+import org.neo4j.graphdb.{DynamicRelationshipType, Node, Relationship}
+import org.neo4j.graphmatching.{PatternMatch, PatternMatcher => SimplePatternMatcher, PatternNode => SimplePatternNode, PatternRelationship => SimplePatternRelationship}
+
+import scala.collection.JavaConverters._
+import scala.collection.{Map, immutable}
 
 class SimplePatternMatcherBuilder(pattern: PatternGraph,
                                   predicates: Seq[Predicate],
@@ -35,16 +35,15 @@ class SimplePatternMatcherBuilder(pattern: PatternGraph,
                                   identifiersInClause: Set[String]) extends MatcherBuilder {
   def createPatternNodes: immutable.Map[String, SimplePatternNode] = {
     pattern.patternNodes.map {
-      case (key, pn) => {
+      case (key, pn) =>
         key -> {
           new SimplePatternNode(pn.key)
         }
-      }
     }
   }
 
   def createPatternRels(patternNodes:immutable.Map[String, SimplePatternNode]):immutable.Map[String, SimplePatternRelationship]  = pattern.patternRels.map {
-    case (key, pr) => {
+    case (key, pr) =>
       val start = patternNodes(pr.startNode.key)
       val end = patternNodes(pr.endNode.key)
 
@@ -59,7 +58,6 @@ class SimplePatternMatcherBuilder(pattern: PatternGraph,
       patternRel.setLabel(pr.key)
 
       key -> patternRel
-    }
   }
 
   def setAssociations(sourceRow: Map[String, Any]): (immutable.Map[String, SimplePatternNode], immutable.Map[String, SimplePatternRelationship]) = {
@@ -124,6 +122,8 @@ class SimplePatternMatcherBuilder(pattern: PatternGraph,
   }
 
   def name = "SimplePatternMatcher"
+
+  override def startPoint: String = pattern.patternNodes.values.head.key
 }
 
 object SimplePatternMatcherBuilder {

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/InternalPlanDescription.scala
@@ -76,6 +76,7 @@ object InternalPlanDescription {
     case class ColumnsLeft(value: Seq[String]) extends Argument
     case class LegacyExpression(value: commands.expressions.Expression) extends Argument
     case class UpdateActionName(value: String) extends Argument
+    case class MergePattern(startPoint: String) extends Argument
     case class LegacyIndex(value: String) extends Argument
     case class Index(label: String, property: String) extends Argument
     case class LabelName(label: String) extends Argument

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -34,6 +34,7 @@ object PlanDescriptionArgumentSerializer {
       case ColumnsLeft(columns) => s"keep columns ${columns.mkString(SEPARATOR)}"
       case LegacyExpression(expr) => removeGeneratedNames(expr.toString)
       case UpdateActionName(action) => action
+      case MergePattern(startPoint) => s"MergePattern($startPoint)"
       case LegacyIndex(index) => index
       case Index(label, property) => s":$label($property)"
       case LabelName(label) => s":$label"

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExplainAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExplainAcceptanceTest.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher
 
+import org.neo4j.cypher.internal.compiler.v2_2.planDescription.InternalPlanDescription.Arguments.MergePattern
+
 class ExplainAcceptanceTest extends ExecutionEngineFunSuite {
   test("normal query is marked as such") {
     createNode()
@@ -34,5 +36,15 @@ class ExplainAcceptanceTest extends ExecutionEngineFunSuite {
 
     result.planDescriptionRequested should equal(true)
     result should be(empty)
+  }
+
+  test("should report which node the merge starts from") {
+    val query = "EXPLAIN MERGE (first)-[:PIZZA]->(second)"
+
+    val result = execute(query)
+    val plan = result.executionPlanDescription()
+    result.close()
+
+    plan.toString should include(MergePattern("second").toString)
   }
 }


### PR DESCRIPTION
The idea behind this is to give feedback as to the order on which MERGE
starts its traversal when matching. Choosing a startpoint of lower
cardinality is preferred, and this change provides the user with
information that together with domain knowledge can tune MERGE queries
towards becoming more performant.
