### PR TITLE
More merge docs, and add exists()

### DIFF
--- a/manual/cypher/cypher-docs/src/docs/dev/ql/merge/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/merge/index.asciidoc
@@ -38,6 +38,8 @@ include::merge-single-node-with-properties.asciidoc[]
 
 include::merge-single-node-specifying-both-label-and-property.asciidoc[]
 
+include::merge-single-node-derived-from-existing-node-property.asciidoc[]
+
 :leveloffset: 2
 
 == Use ON CREATE and ON MATCH ==

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -147,9 +147,15 @@ class WhereTest extends DocumentingTestBase {
   @Test def has_property() {
     testQuery(
       title = "Property exists",
-      text = "To only include nodes/relationships that have a property, use the `HAS()` function and just write out the identifier and the property you expect it to have.",
-      queryText = """match (n) where has(n.belt) return n""",
-      optionalResultExplanation = """"+Andres+" will be returned because he is the only one with a `belt` property.""",
+      text = "Use the `EXISTS()` function to only include nodes or relationships in which a property exists.",
+      queryText = """match (n) where exists(n.belt) return n""",
+      optionalResultExplanation =
+        """"+Andres+" will be returned because he is the only one with a `belt` property.
+          |
+          |[IMPORTANT]
+          |The `HAS()` function has been deprecated by `EXISTS()` and will be removed in a future release.
+          |
+        """.stripMargin,
       assertions = (p) => assertEquals(List(node("Andres")), p.columnAs[Node]("n").toList))
   }
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
@@ -84,7 +84,7 @@ Use comparison operators.
 MATCH n
 WHERE
 
-has(n.property)
+exists(n.property)
 
 RETURN n###
 
@@ -136,7 +136,7 @@ Check if something is `NULL`.
 MATCH n
 WHERE
 
-NOT has(n.property) OR n.property = {value}
+NOT exists(n.property) OR n.property = {value}
 
 RETURN n###
 
@@ -164,7 +164,7 @@ Properties may also be accessed using a dynamically computed property name.
 
 ###assertion=returns-one parameters=regex
 MATCH n
-WHERE HAS(n.property) AND
+WHERE EXISTS(n.property) AND
 
 n.property =~ "Tob.*"
 
@@ -194,7 +194,7 @@ Exclude matches to `(n)-[:KNOWS]->(m)` from the result.
 
 ###assertion=returns-one parameters=names
 MATCH n
-WHERE has(n.property) AND
+WHERE exists(n.property) AND
 
 n.property IN [{value1}, {value2}]
 


### PR DESCRIPTION
Spell out the different cases for merge with a node and a relationship.

Document exists().

Also added deprecation warnings for has() in the manual.
