### PR TITLE
Allocate dirty memory during testing

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -101,7 +101,7 @@ the relevant Commercial Agreement.
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <argLine>-Xmx300m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data</argLine>
+          <argLine>-Xmx300m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
@@ -29,6 +29,9 @@ package org.neo4j.unsafe.impl.internal.dragons;
  */
 public final class MemoryManager
 {
+    /**
+     * The amount of memory, in bytes, to grab in each Slab.
+     */
     private static final long GRAB_SIZE = Integer.getInteger(
             MemoryManager.class.getName() + ".GRAB_SIZE", 32 * 1024 * 1024 ); // 32 MiB
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <logback-classic.version>1.1.2</logback-classic.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
     <hsqldb.version>2.3.2</hsqldb.version>
-    <test.runner.jvm.settings>-Xmx1G -XX:MaxPermSize=128M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data</test.runner.jvm.settings>
+    <test.runner.jvm.settings>-Xmx1G -XX:MaxPermSize=128M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true</test.runner.jvm.settings>
     <doclint-groups>reference</doclint-groups>
   </properties>
 


### PR DESCRIPTION
This way, we make sure that our code that works with native memory, does not assume that the memory we get from `UnsafeUtil.allocateMemory` is zeroed out for us.
