### PR TITLE
Remove hidden upper limit in shortestPath

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -2213,6 +2213,21 @@ return b
     result.toList should equal(List(Map("n" -> start, "m" -> end)))
   }
 
+  test("should be able to do varlength matches of sizes larger that 15 hops") {
+    //given
+    //({prop: "bar"})-[:R]->({prop: "bar"})…-[:R]->({prop: "foo"})
+    val start = createNode(Map("prop" -> "start"))
+    val end = createNode(Map("prop" -> "end"))
+    val nodes = start +: (for (i <- 1 to 15) yield createNode(Map("prop" -> "bar"))) :+ end
+    nodes.sliding(2).foreach {
+      case Seq(node1, node2) => relate(node1, node2, "R")
+    }
+
+    val result = executeWithAllPlanners("MATCH (n {prop: 'start'})-[:R*]->(m {prop: 'end'}) RETURN m")
+
+    result.toList should equal(List(Map("m" -> end)))
+  }
+
   /**
    * Append identifier to keys and transform value arrays to lists
    */

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -432,6 +432,22 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
 
+
+  test("should be able to do find shortest paths longer than 15 hops") {
+    //given
+    //({prop: "bar"})-[:R]->({prop: "bar"})…-[:R]->({prop: "foo"})
+    val start = createNode(Map("prop" -> "start"))
+    val end = createNode(Map("prop" -> "end"))
+    val nodes = start +: (for (i <- 1 to 15) yield createNode(Map("prop" -> "bar"))) :+ end
+    nodes.sliding(2).foreach {
+      case Seq(node1, node2) => relate(node1, node2, "R")
+    }
+
+    val result = executeWithAllPlanners("MATCH p = shortestPath((n {prop: 'start'})-[:R*]->(m {prop: 'end'})) RETURN length(p) AS l")
+
+    result.toList should equal(List(Map("l" -> 16)))
+  }
+
   def shortestPathModel(): Map[String, Node] = {
     val nodes = Map[String, Node](
       "source" -> createLabeledNode(Map("name" -> "x"), "X"),

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ShortestPathExpression.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/ShortestPathExpression.scala
@@ -56,9 +56,9 @@ case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates:
     val expander: Expander = addPredicates(ctx, makeRelationshipTypeExpander())
     val shortestPathPredicate = createShortestPathPredicate(ctx, predicates)
     val shortestPathStrategy = if (shortestPathPattern.single)
-      new SingleShortestPathStrategy(expander, shortestPathPattern.allowZeroLength, shortestPathPattern.maxDepth.getOrElse(15), shortestPathPredicate)
+      new SingleShortestPathStrategy(expander, shortestPathPattern.allowZeroLength, shortestPathPattern.maxDepth.getOrElse(Int.MaxValue), shortestPathPredicate)
     else
-      new AllShortestPathsStrategy(expander, shortestPathPattern.allowZeroLength, shortestPathPattern.maxDepth.getOrElse(15), shortestPathPredicate)
+      new AllShortestPathsStrategy(expander, shortestPathPattern.allowZeroLength, shortestPathPattern.maxDepth.getOrElse(Int.MaxValue), shortestPathPredicate)
 
     shortestPathStrategy.findResult(start, end)
   }
@@ -77,7 +77,7 @@ case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates:
   }
 
   private def getEndPoint(m: Map[String, Any], start: SingleNode): Node = m.getOrElse(start.name,
-    throw new SyntaxException(s"To find a shortest path, both ends of the path need to be provided. Couldn't find `${start}`")).asInstanceOf[Node]
+    throw new SyntaxException(s"To find a shortest path, both ends of the path need to be provided. Couldn't find `$start`")).asInstanceOf[Node]
 
   private def anyStartpointsContainNull(m: Map[String, Any]): Boolean =
     m(shortestPathPattern.left.name) == null || m(shortestPathPattern.right.name) == null

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -320,6 +320,8 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
       NotificationCode.MISSING_REL_TYPE.notification(pos.asInputPosition, NotificationDetail.Factory.relationshipType(relType))
     case MissingPropertyNameNotification(pos, name) =>
       NotificationCode.MISSING_PROPERTY_NAME.notification(pos.asInputPosition, NotificationDetail.Factory.propertyName(name))
+    case UnboundedShortestPathNotification(pos) =>
+      NotificationCode.UNBOUNDED_SHORTEST_PATH.notification(pos.asInputPosition)
   }
 
   override def accept[EX <: Exception](visitor: ResultVisitor[EX]) = exceptionHandlerFor2_3.runSafely {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -368,4 +368,10 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     resultMisspelled.notifications should contain(MissingPropertyNameNotification(InputPosition(18, 1, 19), "propp"))
     resultCorrectlySpelled.notifications shouldBe empty
   }
+
+  test("should warn about unbounded shortest path") {
+    val res = innerExecute("EXPLAIN MATCH p = shortestPath((n)-[*]->(m)) RETURN m")
+
+    res.notifications should contain (UnboundedShortestPathNotification(InputPosition(26, 1, 27)))
+  }
 }

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/notification/InternalNotification.scala
@@ -55,3 +55,5 @@ case class MissingLabelNotification(position: InputPosition, label: String) exte
 case class MissingRelTypeNotification(position: InputPosition, relType: String) extends InternalNotification
 
 case class MissingPropertyNameNotification(position: InputPosition, name: String) extends InternalNotification
+
+case class UnboundedShortestPathNotification(position: InputPosition) extends InternalNotification

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -115,6 +115,12 @@ public enum NotificationCode
             Status.Statement.PropertyNameMissingWarning,
             "One of the property names in your query is not available in the database, make sure you didn't " +
             "misspell it or that the label is available when you run this statement in your application"
+    ),
+    UNBOUNDED_SHORTEST_PATH(
+            SeverityLevel.WARNING,
+            Status.Statement.UnboundedPatternWarning,
+            "Using shortest path with an unbounded pattern will likely result in long execution times. " +
+            "It is recommended to use an upper limit to the number of node hops in your pattern."
     )
     ;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -172,7 +172,8 @@ public interface Status
         IndexMissingWarning( ClientNotification, "Adding a schema index may speed up this query." ),
         LabelMissingWarning( ClientNotification, "The provided label is not in the database." ),
         RelTypeMissingWarning( ClientNotification, "The provided relationship type is not in the database." ),
-        PropertyNameMissingWarning( ClientNotification, "The provided property name is not in the database" );
+        PropertyNameMissingWarning( ClientNotification, "The provided property name is not in the database" ),
+        UnboundedPatternWarning( ClientNotification, "The provided pattern is unbounded, consider adding an upper limit to the number of node hops."  );
 
         private final Code code;
 


### PR DESCRIPTION
`shortestPath` when provided with a unbounded pattern will use an upper limit
of 15 hops. This PR removes this limit and instead provides a warning when using
`shortestPath` with an unbounded pattern.
