### PR TITLE
Make prettifier handle DETACH DELETE.

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/prettifier/Prettifier.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/prettifier/Prettifier.scala
@@ -129,6 +129,7 @@ class PrettifierParser extends Parser with Base with Strings {
       keyword("USING SCAN") |
       keyword("USING JOIN ON") |
       keyword("OPTIONAL MATCH") |
+      keyword("DETACH DELETE") |
       keyword("START") |
       keyword("MATCH") |
       keyword("WHERE") |

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/prettifier/PrettifierTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/prettifier/PrettifierTest.scala
@@ -125,6 +125,12 @@ class PrettifierTest extends CypherFunSuite {
     )
   }
 
+  test("should not break after DETACH in DETACH DELETE") {
+    actual("MATCH (n) DETACH DELETE (n)") should equal(
+      expected("MATCH (n)%nDETACH DELETE (n)")
+    )
+  }
+
   test("should prettify and break USING PERIODIC COMMIT LOAD CSV") {
     actual("using periodic commit match () MATCH (n) LOAD CSV FROM \"f\" AS line return (n)") should equal(
       expected("USING PERIODIC COMMIT%nMATCH ()%nMATCH (n)%nLOAD CSV FROM \"f\" AS line%nRETURN (n)")


### PR DESCRIPTION
Current snapshat @ http://neo4j.com/docs/snapshot/query-delete.html#delete-delete-a-node-with-all-its-relationships:

![detach-before](https://cloud.githubusercontent.com/assets/1732305/10114026/5f0732ae-63eb-11e5-9a8c-fbc1f7d8e136.png)

Patched local build:

![detach-after](https://cloud.githubusercontent.com/assets/1732305/10114039/779e5cb6-63eb-11e5-8693-a9efd74c459a.png)
