### PR TITLE
Ability to treat empty quoted strings as null in csv input

### DIFF
--- a/community/csv/CHANGES.txt
+++ b/community/csv/CHANGES.txt
@@ -1,3 +1,7 @@
+2.2.6
+-----
+o Ability to treat empty quoted strings as null
+
 2.2.5
 -----
 o Detects and uses BOM (byte-order mark) headers in input streams

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
@@ -39,6 +39,11 @@ public interface Configuration
      */
     boolean multilineFields();
 
+    /**
+     * @return {@code true} for treating empty strings, i.e. {@code ""} as null, instead of an empty string.
+     */
+    boolean emptyQuotedStringsAsNull();
+
     static int KB = 1024, MB = KB * KB;
 
     class Default implements Configuration
@@ -57,6 +62,12 @@ public interface Configuration
 
         @Override
         public boolean multilineFields()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean emptyQuotedStringsAsNull()
         {
             return false;
         }
@@ -89,6 +100,12 @@ public interface Configuration
         public boolean multilineFields()
         {
             return defaults.multilineFields();
+        }
+
+        @Override
+        public boolean emptyQuotedStringsAsNull()
+        {
+            return defaults.emptyQuotedStringsAsNull();
         }
     }
 }

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -83,13 +83,18 @@ public class Extractors
     private final Extractor<float[]> floatArray;
     private final Extractor<double[]> doubleArray;
 
+    public Extractors( char arrayDelimiter )
+    {
+        this( arrayDelimiter, Configuration.DEFAULT.emptyQuotedStringsAsNull() );
+    }
+
     /**
      * Why do we have a public constructor here and why isn't this class an enum?
      * It's because the array extractors can be configured with an array delimiter,
      * something that would be impossible otherwise. There's an equivalent {@link #valueOf(String)}
      * method to keep the feel of an enum.
      */
-    public Extractors( char arrayDelimiter )
+    public Extractors( char arrayDelimiter, boolean emptyStringsAsNull )
     {
         try
         {
@@ -105,7 +110,7 @@ public class Extractors
                 }
             }
 
-            add( string = new StringExtractor() );
+            add( string = new StringExtractor( emptyStringsAsNull ) );
             add( long_ = new LongExtractor() );
             add( int_ = new IntExtractor() );
             add( char_ = new CharExtractor() );
@@ -276,10 +281,12 @@ public class Extractors
     private static class StringExtractor extends AbstractSingleValueExtractor<String>
     {
         private String value;
+        private final boolean emptyStringsAsNull;
 
-        StringExtractor()
+        StringExtractor( boolean emptyStringsAsNull )
         {
             super( String.class.getSimpleName() );
+            this.emptyStringsAsNull = emptyStringsAsNull;
         }
 
         @Override
@@ -291,7 +298,7 @@ public class Extractors
         @Override
         protected boolean nullValue( int length, boolean skippedChars )
         {
-            return length == 0 && !skippedChars;
+            return length == 0 && (!skippedChars || emptyStringsAsNull);
         }
 
         @Override

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ExtractorsTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ExtractorsTest.java
@@ -25,6 +25,7 @@ import org.neo4j.csv.reader.Extractors.IntExtractor;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public class ExtractorsTest
@@ -205,6 +206,21 @@ public class ExtractorsTest
 
         // THEN
         assertEquals( "", extractor.value() );
+    }
+
+    @Test
+    public void shouldExtractNullForEmptyQuotedStringIfConfiguredTo() throws Exception
+    {
+        // GIVEN
+        Extractors extractors = new Extractors( ';', true );
+        Extractor<String> extractor = extractors.string();
+
+        // WHEN
+        extractor.extract( new char[0], 0, 0, true );
+        String extracted = extractor.value();
+
+        // THEN
+        assertNull( extracted );
     }
 
     private String toString( long[] values, char delimiter )

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/CSVResources.scala
@@ -41,6 +41,8 @@ object CSVResources {
     override def bufferSize(): Int = DEFAULT_BUFFER_SIZE
 
     override def multilineFields(): Boolean = true
+
+    override def emptyQuotedStringsAsNull(): Boolean = false
   }
 }
 

--- a/community/import-tool/CHANGES.txt
+++ b/community/import-tool/CHANGES.txt
@@ -2,6 +2,8 @@
 -----
 o Stacktraces are printed for any unexpected exception, even if --stacktrace isn't supplied.
   --stacktrace can still be used to print stack trace for known exceptions.
+o Adds --ignore-empty-strings for ignoring empty quoted strings, instead of those values
+  ending up as properties with empty string values
 
 2.2.5
 -----

--- a/community/kernel/src/main/java/org/neo4j/helpers/Args.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Args.java
@@ -252,7 +252,15 @@ public class Args
     public Boolean getBoolean( String key, Boolean defaultValue )
     {
         String value = getSingleOptionOrNull( key );
-        return value != null ? Boolean.parseBoolean( value ) : defaultValue;
+
+        // Apparently this condition must be split like this, instead of as an elvis operator,
+        // because defaultValue will, in that case, be evaluated as a primitive boolean and
+        // a NullPointerException will insue. Odd.
+        if ( value != null )
+        {
+            return Boolean.parseBoolean( value );
+        }
+        return defaultValue;
     }
 
     public Boolean getBoolean( String key, Boolean defaultValueIfNotFound,
@@ -496,7 +504,7 @@ public class Args
      * An option can be specified multiple times; this method will allow interpreting all values for
      * the given key, returning a {@link Collection}. This is the only means of extracting multiple values
      * for any given option. All other methods revolve around zero or one value for an option.
-     * 
+     *
      * @param key Key of the option
      * @param defaultValue Default value value of the option
      * @param converter Converter to use
@@ -523,7 +531,7 @@ public class Args
      * for any given option. All other methods revolve around zero or one value for an option.
      * This is also the only means of extracting metadata about a options. Metadata can be supplied as part
      * of the option key, like --my-option:Metadata "my value".
-     * 
+     *
      * @param key Key of the option
      * @param defaultValue Default value value of the option
      * @param converter Converter to use

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -260,7 +260,7 @@ public class DataFactories
             {
                 headerSeeker = headerCharSeekerFactory.open( dataSeeker, config );
                 Mark mark = new Mark();
-                Extractors extractors = new Extractors( config.arrayDelimiter() );
+                Extractors extractors = new Extractors( config.arrayDelimiter(), config.emptyQuotedStringsAsNull() );
                 Extractor<?> idExtractor = idType.extractor( extractors );
                 int delimiter = config.delimiter();
                 List<Header.Entry> columns = new ArrayList<>();

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -749,6 +749,34 @@ public class CsvInputTest
         }
     }
 
+    @Test
+    public void shouldTreatEmptyQuotedStringsAsNullIfConfiguredTo() throws Exception
+    {
+        // GIVEN
+        Iterable<DataFactory<InputNode>> data = DataFactories.nodeData( CsvInputTest.<InputNode>data(
+                ":ID,one,two,three\n" +
+                "1,\"\",,value" ) );
+        Configuration config = new Configuration.Overriden( COMMAS )
+        {
+            @Override
+            public boolean emptyQuotedStringsAsNull()
+            {
+                return true;
+            }
+        };
+        Input input = new CsvInput( data, defaultFormatNodeFileHeader(),
+                null, null, IdType.INTEGER, config, badCollector( 0 ) );
+
+        // WHEN
+        try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
+        {
+            InputNode node = nodes.next();
+            // THEN
+            assertNode( node, 1L, properties( "three", "value" ), labels() );
+            assertFalse( nodes.hasNext() );
+        }
+    }
+
     private Configuration customConfig( final char delimiter, final char arrayDelimiter, final char quote )
     {
         return new Configuration.Default()


### PR DESCRIPTION
to the import tool. This is useful if input contains quoted empty values
which should not be set as empty properties on the nodes/relationships,
rather ignored.
