### PR TITLE
HAS is deprecated in favour of EXISTS.

### DIFF
--- a/manual/contents/src/reference/deprecations.asciidoc
+++ b/manual/contents/src/reference/deprecations.asciidoc
@@ -21,3 +21,7 @@ For more information, see <<powershell>>.
 `STR()` function::
 The `STR()` function is deprecated from Neo4j version 2.3 and onwards.
 It may be removed in a future major release.
+
+`HAS()` function::
+The `HAS()` function is deprecated from Neo4j version 2.3 and onwards. Please use `EXISTS()` instead. It will be
+removed in a future major release.

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -127,9 +127,15 @@ class WhereTest extends DocumentingTestBase {
   @Test def has_property() {
     testQuery(
       title = "Property exists",
-      text = "To only include nodes/relationships that have a property, use the `HAS()` function and just write out the identifier and the property you expect it to have.",
-      queryText = """match (n) where has(n.belt) return n""",
-      optionalResultExplanation = """"+Andres+" will be returned because he is the only one with a `belt` property.""",
+      text = "Use the `EXISTS()` function to only include nodes or relationships in which a property exists.",
+      queryText = """match (n) where exists(n.belt) return n""",
+      optionalResultExplanation =
+        """"+Andres+" will be returned because he is the only one with a `belt` property.
+          |
+          |[IMPORTANT]
+          |The `HAS()` function has been deprecated by `EXISTS()` and will be removed in a future release.
+          |
+        """.stripMargin,
       assertions = (p) => assertEquals(List(node("Andres")), p.columnAs[Node]("n").toList))
   }
 

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -133,7 +133,7 @@ class WhereTest extends DocumentingTestBase {
         """"+Andres+" will be returned because he is the only one with a `belt` property.
           |
           |[IMPORTANT]
-          |The `HAS()` function has been deprecated by `EXISTS()` and will be removed in a future release.
+          |The `HAS()` function has been superseded by `EXISTS()` and will be removed in a future release.
           |
         """.stripMargin,
       assertions = (p) => assertEquals(List(node("Andres")), p.columnAs[Node]("n").toList))

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
@@ -84,7 +84,7 @@ Use comparison operators.
 MATCH n
 WHERE
 
-has(n.property)
+exists(n.property)
 
 RETURN n###
 
@@ -136,7 +136,7 @@ Check if something is `NULL`.
 MATCH n
 WHERE
 
-NOT has(n.property) OR n.property = {value}
+NOT exists(n.property) OR n.property = {value}
 
 RETURN n###
 
@@ -176,7 +176,7 @@ String pattern matching.
 
 ###assertion=returns-one parameters=regex
 MATCH n
-WHERE HAS(n.property) AND
+WHERE EXISTS(n.property) AND
 
 n.property =~ "Tob.*"
 
@@ -206,7 +206,7 @@ Exclude matches to `(n)-[:KNOWS]->(m)` from the result.
 
 ###assertion=returns-one parameters=names
 MATCH n
-WHERE has(n.property) AND
+WHERE exists(n.property) AND
 
 n.property IN [{value1}, {value2}]
 


### PR DESCRIPTION
Add the `exists(n.prop)` predicate to the documentation, and remove the references to `has(n.prop)` which is a deprecated syntax.

Also, mark `has` as deprecated in the manual and give a warning about using it.
