### PR TITLE
Forces sticky id generator mark to channel

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
@@ -482,6 +482,7 @@ public class IdGeneratorImpl implements IdGenerator
         buffer.put( STICKY_GENERATOR ).limit( 1 ).flip();
         fileChannel.position( 0 );
         fileChannel.write( buffer );
+        fileChannel.force( false );
     }
 
     private ByteBuffer readHeader() throws IOException


### PR DESCRIPTION
so that the mark is guaranteed to be visible, even if the jvm crashes.
This problem is hard to test, but could have been there all along, just
guarded by the store version trailers when they existed.
