### PR TITLE
Make it possible to build from a git-worktree checkout

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -131,6 +131,8 @@ the relevant Commercial Agreement.
         <artifactId>git-commit-id-plugin</artifactId>
         <configuration>
           <dotGitDirectory>${git.directory}</dotGitDirectory>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <useNativeGit>true</useNativeGit>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@ public class ComponentVersion extends Version
         <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
-          <version>2.1.5</version>
+          <version>2.1.13</version>
           <executions>
             <execution>
               <id>generate-git-hash</id>


### PR DESCRIPTION
This is a back-port from 2.3.
