### PR TITLE
Increase timeouts on many page cache tests

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheTest.java
@@ -265,7 +265,7 @@ public class MuninnPageCacheTest extends PageCacheTest<MuninnPageCache>
         assertThat( buf.getLong(), is( y ) );
     }
 
-    @Test( timeout = 10000 )
+    @Test( timeout = SEMI_LONG_TIMEOUT_MILLIS )
     public void mustUnblockPageFaultersWhenEvictionGetsException() throws Exception
     {
         writeInitialDataTo( file( "a" ) );


### PR DESCRIPTION
Beucase they have become flaky, after they now also run on the real file system, where the latencies and variance are much higher.
