### PR TITLE
Page cache cursor unclaimed check made explicit

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
@@ -62,12 +62,14 @@ final class MuninnReadPageCursor extends MuninnPageCursor
         return true;
     }
 
+    @Override
     protected void lockPage( MuninnPage page )
     {
         lockStamp = page.tryOptimisticRead();
         optimisticLock = true;
     }
 
+    @Override
     protected void unlockPage( MuninnPage page )
     {
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnWritePageCursor.java
@@ -61,11 +61,13 @@ final class MuninnWritePageCursor extends MuninnPageCursor
         return true;
     }
 
+    @Override
     protected void lockPage( MuninnPage page )
     {
         lockStamp = page.writeLock();
     }
 
+    @Override
     protected void unlockPage( MuninnPage page )
     {
         page.unlockWrite( lockStamp );


### PR DESCRIPTION
Previously this check was an assertion and thus was not executed in many cases.
This commit makes it explicit so we would catch more incorrect usages or page cache cursors at runtime.
Check is guarded by a static final boolean flag obtained from system property.
So if `ThreadLocal#get()` appears to be very heavy, this additional check could be turned off.
