### PR TITLE
Special case for ORDER BY ... LIMIT 1

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -24,6 +24,7 @@ import org.neo4j.cypher._
 import org.neo4j.graphdb._
 
 import scala.collection.JavaConverters._
+import scala.util.Random
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TopPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/TopPipe.scala
@@ -23,7 +23,7 @@ import java.util.Comparator
 
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.commands.SortItem
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.Expression
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Literal, Expression}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments.{KeyExpressions, LegacyExpression}
 
 import scala.math._
@@ -32,12 +32,11 @@ import scala.math._
  * TopPipe is used when a query does a ORDER BY ... LIMIT query. Instead of ordering the whole result set and then
  * returning the matching top results, we only keep the top results in heap, which allows us to release memory earlier
  */
-case class TopPipe(source: Pipe, sortDescription: List[SortItem], countExpression: Expression)
-                  (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+abstract class TopPipe(source: Pipe, sortDescription: List[SortItem], estimatedCardinality: Option[Double])(implicit pipeMonitor: PipeMonitor)
   extends PipeWithSource(source, pipeMonitor) with Comparer with RonjaPipe with NoEffectsPipe {
 
   val sortItems = sortDescription.toArray
-  val sortItemsCount = sortItems.size
+  val sortItemsCount = sortItems.length
 
   type SortDataWithContext = (Array[Any],ExecutionContext)
 
@@ -59,10 +58,18 @@ case class TopPipe(source: Pipe, sortDescription: List[SortItem], countExpressio
   }
 
   def binarySearch(array: Array[SortDataWithContext], comparator: Comparator[SortDataWithContext])(key: SortDataWithContext) = {
-    java.util.Arrays.binarySearch(array.asInstanceOf[Array[SortDataWithContext]],key, comparator)
+    java.util.Arrays.binarySearch(array.asInstanceOf[Array[SortDataWithContext]], key, comparator)
   }
 
   def arrayEntry(ctx : ExecutionContext)(implicit qtx : QueryState) : SortDataWithContext = (sortItems.map(_(ctx)),ctx)
+
+
+  def symbols = source.symbols
+}
+
+
+case class TopNPipe(source: Pipe, sortDescription: List[SortItem], countExpression: Expression)
+(val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor) extends TopPipe(source, sortDescription, estimatedCardinality)(pipeMonitor) {
 
   protected def internalCreateResults(input:Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe
@@ -111,11 +118,59 @@ case class TopPipe(source: Pipe, sortDescription: List[SortItem], countExpressio
     }
   }
 
+  def dup(sources: List[Pipe]): Pipe = {
+    val (head :: Nil) = sources
+    copy(source = head)(estimatedCardinality)
+  }
+
+  def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+
   def planDescriptionWithoutCardinality =
     source.planDescription
       .andThen(this.id, "Top", identifiers, LegacyExpression(countExpression), KeyExpressions(sortDescription.map(_.expression)))
 
-  def symbols = source.symbols
+}
+
+/*
+ * Special case for when we only have one element, in this case it is no idea to store
+ * an array, instead just store a single value.
+ */
+case class Top1Pipe(source: Pipe, sortDescription: List[SortItem])
+                   (val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor) extends TopPipe(source, sortDescription, estimatedCardinality)(pipeMonitor) {
+
+  protected def internalCreateResults(input: Iterator[ExecutionContext],
+                                      state: QueryState): Iterator[ExecutionContext] = {
+    //register as parent so that stats are associated with this pipe
+    state.decorator.registerParentPipe(this)
+
+    implicit val s = state
+    if (input.isEmpty)
+      Iterator.empty
+    else if (sortDescription.isEmpty)
+      input
+    else {
+
+      val lessThan = new LessThanComparator(this)
+
+      val first = input.next()
+      var result = arrayEntry(first)
+
+      input.foreach {
+        ctx =>
+          val next = arrayEntry(ctx)
+          if (lessThan.compare(next, result) < 0) {
+            result = next
+          }
+      }
+      Iterator.single(result._2)
+    }
+  }
+
+  def planDescriptionWithoutCardinality =
+    source.planDescription
+      .andThen(this.id, "Top", identifiers, LegacyExpression(Literal(1)),
+        KeyExpressions(sortDescription.map(_.expression)))
+
 
   def dup(sources: List[Pipe]): Pipe = {
     val (head :: Nil) = sources
@@ -124,3 +179,5 @@ case class TopPipe(source: Pipe, sortDescription: List[SortItem], countExpressio
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
 }
+
+

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
@@ -181,8 +181,11 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
         case Limit(lhs, count) =>
           LimitPipe(buildPipe(lhs), buildExpression(count))()
 
+        case SortedLimit(lhs, SignedDecimalIntegerLiteral("1"), sortItems) =>
+          Top1Pipe(buildPipe(lhs), sortItems.map(_.asCommandSortItem).toList)()
+
         case SortedLimit(lhs, exp, sortItems) =>
-          TopPipe(buildPipe(lhs), sortItems.map(_.asCommandSortItem).toList, toCommandExpression(exp))()
+          TopNPipe(buildPipe(lhs), sortItems.map(_.asCommandSortItem).toList, toCommandExpression(exp))()
 
         // TODO: Maybe we shouldn't encode distinct as an empty aggregation.
         case Aggregation(Projection(source, expressions), groupingExpressions, aggregatingExpressions)


### PR DESCRIPTION
In the case where we have `LIMIT 1` we don't need to store
an array but can instead just store a single value. This gives
a small performance benefit for those particular cases.
