### PR TITLE
Handles deleted dynamic label records in NodeRecord#toString

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
@@ -36,6 +36,7 @@ import static org.neo4j.kernel.impl.store.LabelIdArray.stripNodeId;
 import static org.neo4j.kernel.impl.store.NodeLabelsField.fieldPointsToDynamicRecordOfLabels;
 import static org.neo4j.kernel.impl.store.NodeLabelsField.firstDynamicLabelRecordId;
 import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsBody;
+import static org.neo4j.kernel.impl.store.NodeStore.getDynamicLabelsArrayFromHeavyRecords;
 import static org.neo4j.kernel.impl.store.PropertyType.ARRAY;
 
 public class DynamicNodeLabels implements NodeLabels
@@ -202,6 +203,6 @@ public class DynamicNodeLabels implements NodeLabels
             return format( "Dynamic(id:%d)", firstDynamicLabelRecordId( node.getLabelField() ) );
         }
         return format( "Dynamic(id:%d,[%s])", firstDynamicLabelRecordId( node.getLabelField() ),
-                Arrays.toString( NodeStore.getDynamicLabelsArrayFromHeavyRecords( node.getDynamicLabelRecords() ) ) );
+                Arrays.toString( getDynamicLabelsArrayFromHeavyRecords( node.getUsedDynamicLabelRecords() ) ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
@@ -20,12 +20,13 @@
 package org.neo4j.kernel.impl.store.record;
 
 import org.neo4j.helpers.CloneableInPublic;
+import org.neo4j.helpers.Predicate;
 
 public abstract class AbstractBaseRecord implements CloneableInPublic
 {
     private boolean inUse = false;
     private boolean created = false;
-    
+
     public abstract long getLongId();
 
     public final boolean inUse()
@@ -47,7 +48,7 @@ public abstract class AbstractBaseRecord implements CloneableInPublic
     {
         return created;
     }
-    
+
     @Override
     public int hashCode()
     {
@@ -72,10 +73,48 @@ public abstract class AbstractBaseRecord implements CloneableInPublic
             return false;
         return true;
     }
-    
+
     @Override
     public AbstractBaseRecord clone()
     {
         throw new UnsupportedOperationException();
+    }
+
+    @SuppressWarnings( "rawtypes" )
+    private static final Predicate IN_USE_FILTER = new Predicate<AbstractBaseRecord>()
+    {
+        @Override
+        public boolean accept( AbstractBaseRecord item )
+        {
+            return item.inUse();
+        }
+    };
+
+    @SuppressWarnings( "rawtypes" )
+    private static final Predicate NOT_IN_USE_FILTER = new Predicate<AbstractBaseRecord>()
+    {
+        @Override
+        public boolean accept( AbstractBaseRecord item )
+        {
+            return !item.inUse();
+        }
+    };
+
+    /**
+     * @return {@link Predicate filter} which only records that are {@link #inUse() in use} passes.
+     */
+    @SuppressWarnings( "unchecked" )
+    public static <RECORD extends AbstractBaseRecord> Predicate<RECORD> inUseFilter()
+    {
+        return IN_USE_FILTER;
+    }
+
+    /**
+     * @return {@link Predicate filter} which only records that are {@link #inUse() NOT in use} passes.
+     */
+    @SuppressWarnings( "unchecked" )
+    public static <RECORD extends AbstractBaseRecord> Predicate<RECORD> notInUseFilter()
+    {
+        return NOT_IN_USE_FILTER;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/NodeRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/NodeRecord.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.neo4j.helpers.Predicate;
-
 import static java.util.Collections.emptyList;
 
 import static org.neo4j.helpers.collection.Iterables.filter;
@@ -108,7 +106,12 @@ public class NodeRecord extends PrimitiveRecord
 
     public Iterable<DynamicRecord> getUsedDynamicLabelRecords()
     {
-        return filter( RECORDS_IN_USE, dynamicLabelRecords );
+        return filter( inUseFilter(), dynamicLabelRecords );
+    }
+
+    public Iterable<DynamicRecord> getUnusedDynamicLabelRecords()
+    {
+        return filter( notInUseFilter(), dynamicLabelRecords );
     }
 
     public boolean isDense()
@@ -162,15 +165,6 @@ public class NodeRecord extends PrimitiveRecord
         }
         return clone;
     }
-
-    private static final Predicate<DynamicRecord> RECORDS_IN_USE = new Predicate<DynamicRecord>()
-    {
-        @Override
-        public boolean accept( DynamicRecord item )
-        {
-            return item.inUse();
-        }
-    };
 
     public void copyFrom( NodeRecord from )
     {


### PR DESCRIPTION
deleted dynamic node label records would cause NPE when reading them from
log, printing them (i.e. calling toString()). Separating them out into its
own iterable from NodeRecord allows for proper toString() implementation.
