### PR TITLE
Uses highest committed transaction id as tx obligation to slaves

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
@@ -42,6 +42,7 @@ import org.neo4j.logging.LogProvider;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
 import static org.neo4j.kernel.impl.util.CappedOperation.time;
@@ -640,6 +641,13 @@ public class MetaDataStore extends AbstractStore implements TransactionIdStore, 
     {
         checkInitialized( lastCommittingTxField.get() );
         return lastCommittedTx.get();
+    }
+
+    @Override
+    public long getHighestCommittedTransactionId()
+    {
+        checkInitialized( lastCommittingTxField.get() );
+        return lastCommittedTx.getHighestOfferedNumber();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
@@ -24,9 +24,9 @@ import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.MetaDataStore.Position;
 import org.neo4j.kernel.impl.store.NeoStores;
 
-import static org.neo4j.kernel.impl.store.MetaDataStore.Position;
 import static org.neo4j.kernel.impl.store.MetaDataStore.getRecord;
 
 public class ReadOnlyTransactionIdStore implements TransactionIdStore
@@ -76,6 +76,12 @@ public class ReadOnlyTransactionIdStore implements TransactionIdStore
     public long[] getLastCommittedTransaction()
     {
         return new long[] {transactionId, transactionChecksum};
+    }
+
+    @Override
+    public long getHighestCommittedTransactionId()
+    {
+        return transactionId;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
@@ -74,6 +74,8 @@ public interface TransactionIdStore
      */
     long[] getLastCommittedTransaction();
 
+    long getHighestCommittedTransactionId();
+
     /**
      * Returns transaction information about transaction where the last upgrade was performed, i.e.
      * transaction id as well as checksum.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ArrayQueueOutOfOrderSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ArrayQueueOutOfOrderSequence.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import static java.lang.Math.max;
 import static java.lang.String.format;
 
 /**
@@ -30,6 +31,7 @@ public class ArrayQueueOutOfOrderSequence implements OutOfOrderSequence
     private volatile int version;
     // These don't need to be volatile, reading them is "guarded" by version access
     private long highestGapFreeNumber;
+    private volatile long highestOfferedNumber;
     private long[] highestGapFreeMeta;
     private final SequenceArray outOfOrderQueue;
     private long[] metaArray;
@@ -44,6 +46,7 @@ public class ArrayQueueOutOfOrderSequence implements OutOfOrderSequence
     @Override
     public synchronized boolean offer( long number, long[] meta )
     {
+        highestOfferedNumber = max( highestOfferedNumber, number );
         if ( highestGapFreeNumber + 1 == number )
         {
             version++;
@@ -98,6 +101,12 @@ public class ArrayQueueOutOfOrderSequence implements OutOfOrderSequence
     public long getHighestGapFreeNumber()
     {
         return highestGapFreeNumber;
+    }
+
+    @Override
+    public long getHighestOfferedNumber()
+    {
+        return highestOfferedNumber;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OutOfOrderSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OutOfOrderSequence.java
@@ -49,6 +49,11 @@ public interface OutOfOrderSequence
     long getHighestGapFreeNumber();
 
     /**
+     * @return the highest gap-free number, without its meta data.
+     */
+    long getHighestOfferedNumber();
+
+    /**
      * @return true if the pair number/meta data has been offered
      */
     boolean seen( long number, long[] meta );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/DeadSimpleTransactionIdStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/DeadSimpleTransactionIdStore.java
@@ -78,6 +78,12 @@ public class DeadSimpleTransactionIdStore implements TransactionIdStore
     }
 
     @Override
+    public long getHighestCommittedTransactionId()
+    {
+        return committedTransactionId.getHighestOfferedNumber();
+    }
+
+    @Override
     public long[] getUpgradeTransaction()
     {
         return new long[] {previouslyCommittedTxId, initialTransactionChecksum};

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponsePacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ResponsePacker.java
@@ -73,7 +73,7 @@ public class ResponsePacker
     public <T> Response<T> packTransactionObligationResponse( RequestContext context, T response )
     {
         return packTransactionObligationResponse( context, response,
-                transactionIdStore.getLastCommittedTransactionId() );
+                transactionIdStore.getHighestCommittedTransactionId() );
     }
 
     public <T> Response<T> packTransactionObligationResponse( RequestContext context, T response,


### PR DESCRIPTION
this requires a good commit description, but we'll probably revert this
commit anyway to refactor how getLastCommittedTransactionId() is used and
implemented as a whole, so that can wait.
