### PR TITLE
HA member enters bad state unable to copy store from master

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StoreUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StoreUtil.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+
+import org.neo4j.io.fs.FileUtils;
+
+public class StoreUtil
+{
+    // Branched directories will end up in <dbStoreDir>/branched/<timestamp>/
+    public final static String BRANCH_SUBDIRECTORY = "branched";
+
+    public static void cleanStoreDir( File storeDir ) throws IOException
+    {
+        for ( File file : relevantDbFiles( storeDir ) )
+        {
+            FileUtils.deleteRecursively( file );
+        }
+    }
+
+    private static File[] relevantDbFiles( File storeDir )
+    {
+        if ( !storeDir.exists() )
+        {
+            return new File[0];
+        }
+
+        return storeDir.listFiles( new FileFilter()
+        {
+            @Override
+            public boolean accept( File file )
+            {
+                return !file.getName().startsWith( "metrics" ) && !file.getName().startsWith( "messages." ) &&
+                       !isBranchedDataRootDirectory( file );
+            }
+        } );
+    }
+
+    public static File newBranchedDataDir( File storeDir )
+    {
+        File result = getBranchedDataDirectory( storeDir, System.currentTimeMillis() );
+        result.mkdirs();
+        return result;
+    }
+
+    private static boolean isBranchedDataRootDirectory( File file )
+    {
+        return file.isDirectory() && file.getName().equals( BRANCH_SUBDIRECTORY );
+    }
+
+    public static boolean isBranchedDataDirectory( File file )
+    {
+        return file.isDirectory() && file.getParentFile().getName().equals( BRANCH_SUBDIRECTORY ) &&
+               isNumerical( file.getName() );
+    }
+
+    public static File getBranchedDataRootDirectory( File storeDir )
+    {
+        return new File( storeDir, BRANCH_SUBDIRECTORY );
+    }
+
+    public static File getBranchedDataDirectory( File storeDir, long timestamp )
+    {
+        return new File( getBranchedDataRootDirectory( storeDir ), "" + timestamp );
+    }
+
+    private static boolean isNumerical( String string )
+    {
+        for ( char c : string.toCharArray() )
+        {
+            if ( !Character.isDigit( c ) )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static void moveAwayDb( File storeDir, File branchedDataDir ) throws IOException
+    {
+        for ( File file : relevantDbFiles( storeDir ) )
+        {
+            FileUtils.moveFileToDirectory( file, branchedDataDir );
+        }
+    }
+}

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -164,7 +164,7 @@ public class StoreCopyClient
     private final FileSystemAbstraction fs;
     private final PageCache pageCache;
     private final Monitor monitor;
-    private boolean forensics;
+    private final boolean forensics;
 
     public StoreCopyClient( File storeDir, Config config, Iterable<KernelExtensionFactory<?>> kernelExtensions,
             LogProvider logProvider, FileSystemAbstraction fs,

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -360,6 +360,7 @@ public class StoreCopyClient
     {
         if ( cancellationRequest.cancellationRequested() )
         {
+            log.info( "Store copying was cancelled. Cleaning up temp-directories." );
             cleanDirectory( tempStore );
         }
     }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/BranchedDataMigrator.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.impl.util.StoreUtil;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 public class BranchedDataMigrator extends LifecycleAdapter
@@ -42,7 +43,7 @@ public class BranchedDataMigrator extends LifecycleAdapter
 
     private void migrateBranchedDataDirectoriesToRootDirectory()
     {
-        File branchedDir = BranchedDataPolicy.getBranchedDataRootDirectory( storeDir );
+        File branchedDir = StoreUtil.getBranchedDataRootDirectory( storeDir );
         branchedDir.mkdirs();
         for ( File oldBranchedDir : storeDir.listFiles() )
         {
@@ -62,7 +63,7 @@ public class BranchedDataMigrator extends LifecycleAdapter
                 continue;
             }
 
-            File targetDir = BranchedDataPolicy.getBranchedDataDirectory( storeDir, timestamp );
+            File targetDir = StoreUtil.getBranchedDataDirectory( storeDir, timestamp );
             try
             {
                 FileUtils.moveFile( oldBranchedDir, targetDir );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -497,6 +497,7 @@ public class SwitchToSlave
 
         if ( cancellationRequest.cancellationRequested() )
         {
+            msgLog.info( "Switch to slave cancelled, unable to start HA-communication" );
             return null;
         }
 
@@ -600,6 +601,7 @@ public class SwitchToSlave
 
     private void startServicesAgain() throws Throwable
     {
+        msgLog.debug( "Starting services again" );
         for ( Class<? extends Lifecycle> serviceClass : SERVICES_TO_RESTART_FOR_STORE_COPY )
         {
             resolver.resolveDependency( serviceClass ).start();
@@ -608,6 +610,7 @@ public class SwitchToSlave
 
     void stopServicesAndHandleBranchedStore( BranchedDataPolicy branchPolicy ) throws Throwable
     {
+        msgLog.debug( "Stopping services to handle branched store" );
         for ( int i = SERVICES_TO_RESTART_FOR_STORE_COPY.length - 1; i >= 0; i-- )
         {
             Class<? extends Lifecycle> serviceClass = SERVICES_TO_RESTART_FOR_STORE_COPY[i];

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/BranchedStoreBean.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/management/BranchedStoreBean.java
@@ -37,7 +37,8 @@ import org.neo4j.kernel.impl.store.MetaDataStore.Position;
 import org.neo4j.management.BranchedStore;
 import org.neo4j.management.BranchedStoreInfo;
 
-import static org.neo4j.kernel.ha.BranchedDataPolicy.getBranchedDataRootDirectory;
+import static org.neo4j.kernel.impl.util.StoreUtil.getBranchedDataRootDirectory;
+
 
 @Service.Implementation(ManagementBeanProvider.class)
 public final class BranchedStoreBean extends ManagementBeanProvider

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.ha;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
-
-import org.junit.Rule;
-import org.junit.Test;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -37,7 +37,6 @@ import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.NeoStoreDataSource;
-import org.neo4j.kernel.ha.BranchedDataPolicy;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.ha.ClusterManager;
@@ -45,6 +44,7 @@ import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
 import org.neo4j.kernel.impl.ha.ClusterManager.RepairKit;
 import org.neo4j.kernel.impl.logging.StoreLogService;
 import org.neo4j.kernel.impl.util.Listener;
+import org.neo4j.kernel.impl.util.StoreUtil;
 import org.neo4j.kernel.lifecycle.LifeRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
@@ -52,10 +52,8 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.String.format;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.helpers.SillyUtils.nonNull;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -90,7 +88,7 @@ public class TestBranchedData
             assertFalse( "directory branched-" + timestamp + " still exists.",
                     new File( dir, "branched-" + timestamp ).exists() );
             assertTrue( "directory " + timestamp + " is not there",
-                    BranchedDataPolicy.getBranchedDataDirectory( dir, timestamp ).exists() );
+                    StoreUtil.getBranchedDataDirectory( dir, timestamp ).exists() );
         }
     }
 


### PR DESCRIPTION
If an error occurs while copying files from the temporary directory
to the actual store directory, the slave can end up in a weird unrecoverable
state where the services aren't ever started.

By cleaning up the store directory if an error occurs, copyFromMaster will
be called again on subsequent attempts (it would not be called again
previously).

Then the copying can be retried, and if successful, the services will be started
again.

The PR also moves some code previously located in BranchedDataStore, to avoid
code duplication.
