### PR TITLE
Run `neo4j console` as a single process without forking the JVM subprocess

### DIFF
--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -1,12 +1,12 @@
-2.3-RC01
---------
+2.3.0-RC1
+---------
 o Generates a warning when a plan using LOAD CSV uses MATCH or MERGE on a large label without an index
 o Generates a warning when a plan using LOAD CSV also contains an EagerPipe
 o Introduce STARTS WITH, ENDS WITH and CONTAINS
 o ShortestPath no longer has a max limit of 15 steps
 o Generates a warning when using shortestPath without supplying an upper limit
 
-2.3-M03
+2.3.0-M03
 -------
 o SKIP/LIMIT now allows arbitrary expressions that does not depend on identifiers
 o Allow arbitrary expressions for URL in LOAD CSV
@@ -33,7 +33,7 @@ o ShortestPath should now return paths that fulfil any predicates enforced upon 
 o The str() function is now deprecated
 o Cypher queries will no longer be logged in messages.log
 
-2.3-M02
+2.3.0-M02
 -------
 o Removed support for Cypher version 2.0 and 2.1, as announced
 o Produces error or warning if a query cannot be solved using the specified planner
@@ -43,7 +43,7 @@ o Cypher now supports two new operators for string pattern matching: LIKE and IL
 o It is now possible to escape '_' and '%' in string literals using backslash (for use with LIKE)
 o Specifying a default Cypher planner in the settings now only applies to the default language version / parser
 
-2.3-M01
+2.3.0-M01
 -------
 o Added new warning mechanism. The first supported warning is generated for queries that contain a potentially
   unintended cartesian product

--- a/community/neo4j-harness/CHANGES.txt
+++ b/community/neo4j-harness/CHANGES.txt
@@ -1,5 +1,5 @@
-2.3-SNAPSHOT
-------------------------
+2.3.0-M01
+---------
 o expose GraphDatabaseService to be used in assertions
 o support fixtures based on Function<GraphDatabaseService,Void>
-o support running Neo4jRule/TestServerBuilder with a existing databse 
+o support running Neo4jRule/TestServerBuilder with a existing databse

--- a/community/shell/CHANGES.txt
+++ b/community/shell/CHANGES.txt
@@ -1,4 +1,4 @@
-2.3-M02
+2.3.0-M02
 -------
 o Print warnings and/or errors (as configured) from Cypher
 
@@ -217,4 +217,3 @@ o Improved the ls command with additional options.
 o Improved error reporting so non existing exception classes on client
   side still get the original exception message.
 o Fixed bug in the jLineConsole causing shell client to enter infinite loop.
-

--- a/packaging/standalone/CHANGES.txt
+++ b/packaging/standalone/CHANGES.txt
@@ -1,3 +1,7 @@
+2.3.0-RC1
+---------
+o Neo4j console does not fork a subprocess on Linux, enabling easier process management
+
 2.3.0-M03
 ---------
 o Adds a Windows PowerShell for managing a Neo4j server

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -268,7 +268,7 @@ console() {
     buildclasspath
     checkandrepairenv
 
-    "$JAVACMD" -cp "${CLASSPATH}" $JAVA_OPTS \
+    exec "$JAVACMD" -cp "${CLASSPATH}" $JAVA_OPTS \
         -Dneo4j.home="${NEO4J_HOME}" -Dneo4j.instance="${NEO4J_INSTANCE}" \
         -Dfile.encoding=UTF-8 \
         #{neo4j.mainClass}

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
@@ -15,6 +15,9 @@ o New drawer for :config settings
 o :play remote guides
 o Handle 403 responses from server
 
+Packaging:
+o Neo4j console does not fork a subprocess on Linux, enabling easier process management
+
 2.3.0-M03
 ---------
 

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
@@ -1,7 +1,7 @@
 For Release Notes, see http://neo4j.com/release-notes/neo4j-#{project.version}/
 
-2.3-RC01
--------
+2.3.0-RC1
+---------
 
 Cypher:
 o Generates a warning when a plan using LOAD CSV uses MATCH or MERGE on a large label without an index
@@ -15,8 +15,8 @@ o New drawer for :config settings
 o :play remote guides
 o Handle 403 responses from server
 
-2.3-M03
--------
+2.3.0-M03
+---------
 
 Cypher:
 o Allow arbitrary expressions for URL in LOAD CSV
@@ -74,8 +74,8 @@ o Deprecate webadmin
 o When disconnected from database, check for connection every two seconds
 o Show server edition on :play start frame
 
-2.3-M02
--------
+2.3.0-M02
+---------
 
 Cypher:
 o Removed support for Cypher version 2.0 and 2.1, as announced
@@ -96,8 +96,8 @@ Browser:
 o Code view of Cypher request frames. It displays info about the frame requests
   made to the REST API.
 
-2.3-M01
--------
+2.3.0-M01
+---------
 
 Cypher:
 o Added new warning mechanism. The first supported warning is generated for queries that contain a potentially

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
@@ -15,6 +15,9 @@ o New drawer for :config settings
 o :play remote guides
 o Handle 403 responses from server
 
+Packaging:
+o Neo4j console does not fork a subprocess on Linux, enabling easier process management
+
 2.3.0-M03
 ---------
 

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
@@ -1,7 +1,7 @@
 For Release Notes, see http://neo4j.com/release-notes/neo4j-#{project.version}/
 
-2.3-RC01
--------
+2.3.0-RC1
+---------
 
 Cypher:
 o Generates a warning when a plan using LOAD CSV uses MATCH or MERGE on a large label without an index
@@ -15,8 +15,8 @@ o New drawer for :config settings
 o :play remote guides
 o Handle 403 responses from server
 
-2.3-M03
--------
+2.3.0-M03
+---------
 
 Cypher:
 o Allow arbitrary expressions for URL in LOAD CSV
@@ -74,8 +74,8 @@ o Deprecate webadmin
 o When disconnected from database, check for connection every two seconds
 o Show server edition on :play start frame
 
-2.3-M02
--------
+2.3.0-M02
+---------
 
 Cypher:
 o Removed support for Cypher version 2.0 and 2.1, as announced
@@ -96,8 +96,8 @@ Browser:
 o Code view of Cypher request frames. It displays info about the frame requests
   made to the REST API.
 
-2.3-M01
--------
+2.3.0-M01
+---------
 
 Cypher:
 o Added new warning mechanism. The first supported warning is generated for queries that contain a potentially

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
@@ -16,6 +16,9 @@ o :play remote guides
 o Handle 403 responses from server
 o Add config to control outgoing connections
 
+Packaging:
+o Neo4j console does not fork a subprocess on Linux, enabling easier process management
+
 2.3.0-M03
 ---------
 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
@@ -1,7 +1,7 @@
 For Release Notes, see http://neo4j.com/release-notes/neo4j-#{project.version}/
 
-2.3-RC01
--------
+2.3.0-RC1
+---------
 
 Cypher:
 o Generates a warning when a plan using LOAD CSV uses MATCH or MERGE on a large label without an index
@@ -16,8 +16,8 @@ o :play remote guides
 o Handle 403 responses from server
 o Add config to control outgoing connections
 
-2.3-M03
--------
+2.3.0-M03
+---------
 
 Cluster:
 o Fixes bad assumption about all messages containing instance ID
@@ -83,8 +83,8 @@ o Deprecate webadmin
 o When disconnected from database, check for connection every two seconds
 o Show server edition on :play start frame
 
-2.3-M02
--------
+2.3.0-M02
+---------
 
 Cypher:
 o Removed support for Cypher version 2.0 and 2.1, as announced
@@ -105,8 +105,8 @@ Browser:
 o Code view of Cypher request frames. It displays info about the frame requests
   made to the REST API.
 
-2.3-M01
--------
+2.3.0-M01
+---------
 
 Cypher:
 o Added new warning mechanism. The first supported warning is generated for queries that contain a potentially


### PR DESCRIPTION
This is required for Docker support in 2.3.0.
