### PR TITLE
Fixes issues around .id files and recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1012,6 +1012,16 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
                 return PhysicalLogFile.openForVersion( logFiles, fileSystemAbstraction,
                         recoveryVersion );
             }
+
+            @Override
+            public void recoveryRequired()
+            {
+                // This method will be called before recovery actually starts and so will ensure that
+                // each store is aware that recovery will be performed. At this point all the stores have
+                // already started btw.
+                // Go and read more at {@link CommonAbstractStore#recoveryRequired()}
+                neoStore.deleteIdGenerators();
+            }
         }, recoveryMonitor );
 
         life.add( recovery );

--- a/community/kernel/src/main/java/org/neo4j/kernel/Recovery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/Recovery.java
@@ -44,9 +44,14 @@ public class Recovery extends LifecycleAdapter
     public interface SPI
     {
         void forceEverything();
+
         long getCurrentLogVersion();
+
         Visitor<LogVersionedStoreChannel, IOException> getRecoverer();
+
         LogVersionedStoreChannel getLogFile( long recoveryVersion ) throws IOException;
+
+        void recoveryRequired();
     }
 
     private final SPI spi;
@@ -68,6 +73,7 @@ public class Recovery extends LifecycleAdapter
         {
             if ( LogRecoveryCheck.recoveryRequired( toRecover ) )
             {   // There's already data in here, which means recovery will need to be performed.
+                spi.recoveryRequired();
                 monitor.recoveryRequired( toRecover.getVersion() );
                 spi.getRecoverer().visit( toRecover );
                 recoveredLog = true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -893,6 +893,24 @@ public abstract class CommonAbstractStore implements IdSequence, AutoCloseable
         visitor.visit( this );
     }
 
+    /**
+     * Called from the part of the code that starts the {@link NeoStore} and friends, together with any
+     * existing transaction log, seeing that there are transactions to recover. Now, this shouldn't be
+     * needed because the state of the id generator _should_ reflect this fact, but turns out that,
+     * given HA and the nature of the .id files being like orphans to the rest of the store, we just
+     * can't trust that to be true. If we happen to have id generators open during recovery we delegate
+     * {@link #freeId(long)} calls to {@link IdGenerator#freeId(long)} and since the id generator is most likely
+     * out of date w/ regards to high id, it may very well blow up.
+     */
+    final void deleteIdGenerator()
+    {
+        if ( idGenerator != null )
+        {
+            idGenerator.delete();
+            idGenerator = null;
+        }
+    }
+
     @Override
     public String toString()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
@@ -1020,4 +1020,17 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
             }
         } );
     }
+
+    public void deleteIdGenerators()
+    {
+        visitStore( new Visitor<CommonAbstractStore,RuntimeException>()
+        {
+            @Override
+            public boolean visit( CommonAbstractStore store ) throws RuntimeException
+            {
+                store.deleteIdGenerator();
+                return false;
+            }
+        } );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGenerator.java
@@ -32,10 +32,16 @@ public interface IdGenerator extends IdSequence
     void freeId( long id );
 
     /**
-     * Closes the id generator.
+     * Closes the id generator, marking it as clean.
      */
     void close();
     long getNumberOfIdsInUse();
     long getDefragCount();
+
+    /**
+     * Closes the id generator as dirty and deletes it right after closed. This operation is safe, in the sense
+     * that the id generator file is closed but not marked as clean. This has the net result that a crash in the
+     * middle will still leave the file marked as dirty so it will be deleted on the next open call.
+     */
     void delete();
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingIdGeneratorFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingIdGeneratorFactory.java
@@ -24,9 +24,9 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
 import org.neo4j.kernel.impl.store.id.IdRange;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
@@ -32,6 +32,7 @@ import org.neo4j.test.EphemeralFileSystemRule;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -134,6 +135,35 @@ public class IdGeneratorImplTest
         {
             // THEN Good
         }
+    }
+
+    @Test
+    public void shouldDeleteIfOpen() throws Exception
+    {
+        // GIVEN
+        IdGeneratorImpl.createGenerator( fsr.get(), file );
+        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, 42 );
+
+        // WHEN
+        idGenerator.delete();
+
+        // THEN
+        assertFalse( fsr.get().fileExists( file ) );
+    }
+
+    @Test
+    public void shouldDeleteIfClosed() throws Exception
+    {
+        // GIVEN
+        IdGeneratorImpl.createGenerator( fsr.get(), file );
+        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, 42 );
+        idGenerator.close();
+
+        // WHEN
+        idGenerator.delete();
+
+        // THEN
+        assertFalse( fsr.get().fileExists( file ) );
     }
 
     public static void main( String[] args )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersionTest.java
@@ -33,7 +33,6 @@ public class LogEntryVersionTest
             // GIVEN
             byte code = version.byteCode();
             byte logHeaderFormatVersion = version.logHeaderFormatVersion();
-            System.out.println( "trying " + code +  ", " + logHeaderFormatVersion );
 
             // WHEN
             LogEntryVersion selectedVersion = LogEntryVersion.byVersion( code, logHeaderFormatVersion );

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.ext.udc.impl;
 
+import org.junit.Test;
+
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.junit.Test;
 
 import org.neo4j.ext.udc.UdcConstants;
 import org.neo4j.graphdb.DependencyResolver;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.kernel.ha.id;
 
-import java.io.File;
-
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
@@ -33,9 +34,10 @@ import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdRange;
 import org.neo4j.kernel.logging.DevNullLoggingService;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -52,7 +54,7 @@ public class HaIdGeneratorFactoryTest
         IdAllocation firstResult = new IdAllocation( new IdRange( new long[]{}, 42, 123 ), 123, 0 );
         Response<IdAllocation> response = response( firstResult );
         when( master.allocateIds( any( RequestContext.class ), any( IdType.class ) ) ).thenReturn( response );
-        
+
         // WHEN
         IdGenerator gen = switchToSlave();
 
@@ -72,7 +74,7 @@ public class HaIdGeneratorFactoryTest
         IdAllocation secondResult = new IdAllocation( new IdRange( new long[]{}, 1042, 223 ), 1042 + 223, 0 );
         Response<IdAllocation> response = response( firstResult, secondResult );
         when( master.allocateIds( any( RequestContext.class ), any( IdType.class ) ) ).thenReturn( response );
-        
+
         // WHEN
         IdGenerator gen = switchToSlave();
 
@@ -152,12 +154,47 @@ public class HaIdGeneratorFactoryTest
         // THEN
         assertEquals ( highIdFromUpdatedRecord, gen.getHighId() );
     }
-    
+
+    @Test
+    public void shouldDeleteIdGeneratorsAsPartOfSwitchingToSlave() throws Exception
+    {
+        // GIVEN we're in master mode. We do that to allow HaIdGeneratorFactory to open id generators at all
+        fac.switchToMaster();
+        File idFile = new File( "my.id" );
+        // ... opening an id generator as master
+        fac.create( fs, idFile, 10 );
+        IdGenerator idGenerator = fac.open( fs, idFile, 10, IdType.NODE, 10 );
+        assertTrue( fs.fileExists( idFile ) );
+        idGenerator.close();
+
+        // WHEN switching to slave
+        fac.switchToSlave();
+
+        // THEN the .id file underneath should be deleted
+        assertFalse( "Id file should've been deleted by now", fs.fileExists( idFile ) );
+    }
+
+    @Test
+    public void shouldDeleteIdGeneratorsAsPartOfOpenAfterSwitchingToSlave() throws Exception
+    {
+        // GIVEN we're in master mode. We do that to allow HaIdGeneratorFactory to open id generators at all
+        fac.switchToSlave();
+        File idFile = new File( "my.id" );
+        // ... opening an id generator as master
+        fac.create( fs, idFile, 10 );
+
+        // WHEN
+        IdGenerator idGenerator = fac.open( fs, idFile, 10, IdType.NODE, 10 );
+
+        // THEN
+        assertFalse( "Id file should've been deleted by now", fs.fileExists( idFile ) );
+    }
+
     private Master master;
     private DelegateInvocationHandler<Master> masterDelegate;
     private EphemeralFileSystemAbstraction fs;
     private HaIdGeneratorFactory fac;
-    
+
     @Before
     public void before()
     {
@@ -167,7 +204,7 @@ public class HaIdGeneratorFactoryTest
         fac  = new HaIdGeneratorFactory( masterDelegate, new DevNullLoggingService(),
                 mock( RequestContextFactory.class ) );
     }
-    
+
     @SuppressWarnings( "unchecked" )
     private Response<IdAllocation> response( IdAllocation firstValue, IdAllocation... additionalValues )
     {


### PR DESCRIPTION
- ensures .id files are never in clean state after an unclean shutdown
  more specifically deletes them when switching to slave, instead of just
  closing them.
- ensures .id files are deleted and corresponding id generators closed
  before recovery starts.
