### PR TITLE
Fix #4984 - UnsupportedOperationException on ResourceIterator::remove()

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/PipeExecutionResult.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/PipeExecutionResult.scala
@@ -100,7 +100,7 @@ class PipeExecutionResult(val result: ResultIterator,
   }
 
   private trait WrappingResourceIterator[T] extends ResourceIterator[T] {
-    def remove() { Collections.emptyIterator[T]().remove() }
+    def remove() { throw new UnsupportedOperationException("remove") }
     def close() { self.close() }
   }
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompiledExecutionResult.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/CompiledExecutionResult.scala
@@ -252,7 +252,7 @@ class CompiledExecutionResult(taskCloser: TaskCloser,
     new EntityNotFoundException("No column named '" + column + "' was found. Found: " + data.keys.mkString("(\"", "\", \"", "\")"))
 
   private trait WrappingResourceIterator[T] extends ResourceIterator[T] {
-    def remove() { Collections.emptyIterator[T]().remove() }
+    def remove() { throw new UnsupportedOperationException("remove") }
     def close() { self.close() }
   }
 


### PR DESCRIPTION
Throw UnsupportedOperationException instead of IllegalStateException on
ResourceIterator, constructed from Result::columnAs().

Collections.emptyIterator has correct behaviour, because it is always empty. But in our case - we have non-empty iterator and accordingly to javadoc, we should throw UOE.
