### PR TITLE
Update layout and content of Cypher Refcard

### DIFF
--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AggregationTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AggregationTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.docgen.RefcardTest
 class AggregationTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Aggregation"
-  val css = "general c3-3 c4-2 c5-4 c6-6"
+  val css = "general c3-3 c4-3 c5-4 c6-6"
   override val linkId = "query-aggregation"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CaseTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CaseTest.scala
@@ -27,7 +27,7 @@ class CaseTest extends RefcardTest with QueryStatisticsTestSupport {
   def graphDescription = List(
     "A KNOWS B")
   val title = "CASE"
-  val css = "general c2-1 c3-3 c4-3 c5-4 c6-1"
+  val css = "general c2-1 c3-3 c4-2 c5-3 c6-1"
   override val linkId = "cypher-expressions"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionPredicatesTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionPredicatesTest.scala
@@ -52,7 +52,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 WITH nodes(path) as coll, n, m
 WHERE
 
-all(x IN coll WHERE has(x.property))
+all(x IN coll WHERE exists(x.property))
 
 RETURN n,m###
 
@@ -64,7 +64,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 WITH nodes(path) as coll, n, m
 WHERE
 
-any(x IN coll WHERE has(x.property))
+any(x IN coll WHERE exists(x.property))
 
 RETURN n,m###
 
@@ -76,7 +76,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 WITH nodes(path) as coll, n, m
 WHERE
 
-none(x IN coll WHERE has(x.property))
+none(x IN coll WHERE exists(x.property))
 
 RETURN n,m###
 
@@ -88,7 +88,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 WITH nodes(path) as coll, n, m
 WHERE
 
-single(x IN coll WHERE has(x.property))
+single(x IN coll WHERE exists(x.property))
 
 RETURN n,m###
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class CollectionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A KNOWS B")
   val title = "Collections"
-  val css = "general c2-2 c3-1 c4-3 c5-2 c6-2"
+  val css = "general c2-2 c3-1 c4-3 c5-2 c6-4"
   override val linkId = "syntax-collections"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
@@ -27,7 +27,7 @@ import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
 class ConstraintTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A:Person KNOWS B:Person")
   val title = "CONSTRAINT"
-  val css = "write c2-2 c4-4 c5-5 c6-3"
+  val css = "write c2-2 c4-4 c5-5 c6-4"
   override val linkId = "query-constraints"
 
   override protected def newTestGraphDatabaseFactory() = new TestEnterpriseGraphDatabaseFactory()

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateUniqueTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateUniqueTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class CreateUniqueTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT LINK A", "A LINK B", "B LINK C", "C LINK ROOT")
   val title = "CREATE UNIQUE"
-  val css = "col carddeprecation c2-1 c3-2 c4-4 c5-4 c6-6"
+  val css = "col carddeprecation c2-1 c3-3 c4-4 c5-4 c6-6"
   override val linkId = "query-create-unique"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/FunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/FunctionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class FunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Functions"
-  val css = "general c2-2 c3-2 c4-2 c5-3 c6-4"
+  val css = "general c2-2 c3-2 c4-2 c5-3 c6-5"
   override val linkId = "query-function"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ImportTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ImportTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class ImportTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List()
   val title = "Import"
-  val css = "write c2-1 c4-4 c5-5 c6-2"
+  val css = "write c2-1 c4-4 c5-4 c6-3"
   override val linkId = "cypherdoc-importing-csv-files-with-cypher"
 
   implicit var csvFilesDir: File = createDir(dir, "csv")

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.docgen.RefcardTest
 class LabelsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A:Person KNOWS ROOT")
   val title = "Labels"
-  val css = "general c2-1 c3-2 c4-2 c5-3 c6-4"
+  val css = "general c2-1 c3-2 c4-2 c5-3 c6-2"
   override val linkId = "cypherdoc-labels-constraints-and-indexes"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MathematicalFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MathematicalFunctionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class MathematicalFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A")
   val title = "Mathematical Functions"
-  val css = "general c2-1 c3-2 c4-1 c5-1 c6-5"
+  val css = "general c2-1 c3-2 c4-1 c5-2 c6-5"
   override val linkId = "query-functions-mathematical"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class PatternsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A:Person:Swedish KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Patterns"
-  val css = "general c2-2 c3-2 c6-4"
+  val css = "general c2-2 c3-2 c6-2"
   override val linkId = "introduction-pattern"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class PredicatesTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A:Person KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Predicates"
-  val css = "general c2-2 c3-3 c4-2 c5-2 c6-4"
+  val css = "general c2-2 c3-3 c4-2 c5-1 c6-4"
   override val linkId = "query-where"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -172,7 +172,7 @@ n.property CONTAINS "goodie"
 
 RETURN n###
 
-String pattern matching.
+String matching.
 
 ###assertion=returns-one parameters=regex
 MATCH n

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RelationshipFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RelationshipFunctionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class RelationshipFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Relationship Functions"
-  val css = "general c2-2 c3-1 c4-2 c5-4 c6-5"
+  val css = "general c2-2 c3-2 c4-2 c5-4 c6-6"
   override val linkId = "query-functions-scalar"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StartTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StartTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class StartTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT LINK A", "A LINK B", "B LINK C", "C LINK ROOT")
   val title = "START"
-  val css = "col carddeprecation c2-1 c3-2 c4-4 c5-4 c6-6"
+  val css = "col carddeprecation c2-1 c3-3 c4-4 c5-4 c6-6"
   override def indexProps: List[String] = List("value", "name", "key")
   override val linkId = "query-start"
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StringFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StringFunctionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class StringFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "String Functions"
-  val css = "general c2-2 c3-2 c4-1 c5-3 c6-5"
+  val css = "general c2-1 c3-2 c4-1 c5-3 c6-5"
   override val linkId = "query-functions-string"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UnionTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/UnionTest.scala
@@ -27,7 +27,7 @@ class UnionTest extends RefcardTest with QueryStatisticsTestSupport {
   def graphDescription = List(
     "A KNOWS B", "A LOVES B")
   val title = "UNION"
-  val css = "read c2-2 c3-2 c4-2 c5-4 c6-2"
+  val css = "read c2-2 c3-2 c4-2 c5-2 c6-2"
   override val linkId = "query-union"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/refcard/src/cypher-refcard.asciidoc
+++ b/manual/refcard/src/cypher-refcard.asciidoc
@@ -93,7 +93,7 @@ include::{sources}/import.asciidoc[]
 | String             | `+`
 | Collection         | `+`, `IN`, `[x]`, `[x .. y]`
 | Regular Expression | `=~`
-| String pattern matching | `LIKE`, `ILIKE`
+| String matching    | `STARTS WITH`, `ENDS WITH`, `CONTAINS`
 |===
 
 ++++
@@ -156,7 +156,7 @@ include::{sources}/create-unique.asciidoc[]
 
 
 ++++
-<div class="col cardperformance c2-2 c3-3 c5-3 c6-6"><div class="blk">
+<div class="col cardperformance c2-2 c3-3 c5-4 c6-6"><div class="blk">
 ++++
 
 [options="header", cols="a"]


### PR DESCRIPTION
- Update the different layouts.
- Remove LIKE and ILIKE.
- Use exists() consistently.
