### PR TITLE
Doc: made example octal literal a valid octal

### DIFF
--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -8,7 +8,7 @@ An expression in Cypher can be:
 
 * A decimal (integer or double) literal: `13`, `-40000`, `3.14`, `6.022E23`.
 * A hexadecimal integer literal (starting with `0x`): `0x13zf`, `0xFC3A9`, `-0x66eff`.
-* An octal integer literal (starting with `0`): `01372`, `01278`, `-05671`.
+* An octal integer literal (starting with `0`): `01372`, `02127`, `-05671`.
 * A string literal: `"Hello"`, `'World'`.
 * A boolean literal:  `true`, `false`, `TRUE`, `FALSE`.
 * An identifier: `n`, `x`, `rel`, `myFancyIdentifier`, +\`A name with weird stuff in it[]!`+.


### PR DESCRIPTION
Minor fix to documentation.  We just started exploring Neo4j, thanks for the cool tool devs.
