### PR TITLE
ProcessRelationshipCountsDataStep tracks an unnecessary amount of data.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
@@ -42,8 +42,6 @@ import static org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory.relations
 
 public class CountsRecordState implements CountsAccessor, RecordState, CountsAccessor.Updater, CountsAccessor.IndexStatsUpdater
 {
-    /** Don't support these counts at the moment so don't compute them */
-    private static final boolean COMPUTE_DOUBLE_SIDED_RELATIONSHIP_COUNTS = false;
     private static final long DEFAULT_FIRST_VALUE = 0, DEFAULT_SECOND_VALUE = 0;
     private final Map<CountsKey, DoubleLongRegister> counts = new HashMap<>();
 
@@ -229,14 +227,6 @@ public class CountsRecordState implements CountsAccessor, RecordState, CountsAcc
         {
             incrementRelationshipCount( (int) startLabelId, ANY_RELATIONSHIP_TYPE, ANY_LABEL, 1 );
             incrementRelationshipCount( (int) startLabelId, type, ANY_LABEL, 1 );
-            if ( COMPUTE_DOUBLE_SIDED_RELATIONSHIP_COUNTS )
-            {
-                for ( long endLabelId : endLabels )
-                {
-                    incrementRelationshipCount( (int) startLabelId, ANY_RELATIONSHIP_TYPE, (int) endLabelId, 1 );
-                    incrementRelationshipCount( (int) startLabelId, type, (int) endLabelId, 1 );
-                }
-            }
         }
         for ( long endLabelId : endLabels )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessor.java
@@ -31,18 +31,21 @@ import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
  */
 public class RelationshipCountsProcessor implements RecordProcessor<RelationshipRecord>
 {
-    /** Don't support these counts at the moment so don't compute them */
-    private static final boolean COMPUTE_DOUBLE_SIDED_RELATIONSHIP_COUNTS = false;
     private final NodeLabelsCache nodeLabelCache;
-    // start node label id | relationship type | end node label id. Roughly 8Mb for 100,100,100
-    private final LongArray counts;
+    private final LongArray labelsCounts;
+    private final LongArray wildcardCounts;
+
     private int[] startScratch = new int[20], endScratch = new int[20]; // and grows on demand
     private final CountsAccessor.Updater countsUpdater;
     private final long anyLabel;
     private final long anyRelationshipType;
     private final NodeLabelsCache.Client client;
+    private final long itemsPerLabel;
     private final long itemsPerType;
-    private final long itemsPerStartLabel;
+
+    private final int START = 0;
+    private final int END = 1;
+    private final int SIDES = 2;
 
     public RelationshipCountsProcessor( NodeLabelsCache nodeLabelCache,
             int highLabelId, int highRelationshipTypeId, CountsAccessor.Updater countsUpdater,
@@ -55,28 +58,17 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
         // Make room for high id + 1 since we need that extra slot for the ANY counts
         this.anyLabel = highLabelId;
         this.anyRelationshipType = highRelationshipTypeId;
-        this.itemsPerType = anyLabel+1;
-        this.itemsPerStartLabel = (anyRelationshipType+1)*itemsPerType;
-        this.counts = cacheFactory.newLongArray( arrayIndex( highLabelId, highRelationshipTypeId, highLabelId )+1, 0 );
-    }
-
-    private long arrayIndex( long startLabel, long relationshipType, long endLabel )
-    {
-        return startLabel*itemsPerStartLabel + relationshipType*itemsPerType + endLabel;
-    }
-
-    private void increment( long startLabel, long relationshipType, long endLabel )
-    {
-        long index = arrayIndex( startLabel, relationshipType, endLabel );
-        counts.set( index, counts.get( index ) + 1 );
+        this.itemsPerType = anyLabel + 1;
+        this.itemsPerLabel = anyRelationshipType + 1;
+        this.labelsCounts = cacheFactory.newLongArray( sideSize() * SIDES, 0 );
+        this.wildcardCounts = cacheFactory.newLongArray( anyRelationshipType + 1, 0 );
     }
 
     public void process( long startNode, int type, long endNode )
     {
         // Below is logic duplication of CountsState#addRelationship
-
-        increment( anyLabel, anyRelationshipType, anyLabel );
-        increment( anyLabel, type, anyLabel );
+        increment( wildcardCounts, anyRelationshipType );
+        increment( wildcardCounts, type );
         startScratch = nodeLabelCache.get( client, startNode, startScratch );
         for ( int startNodeLabelId : startScratch )
         {
@@ -85,19 +77,8 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
                 break;
             }
 
-            increment( startNodeLabelId, anyRelationshipType, anyLabel );
-            increment( startNodeLabelId, type, anyLabel );
-            endScratch = nodeLabelCache.get( client, endNode, endScratch );
-            for ( int endNodeLabelId : endScratch )
-            {
-                if ( endNodeLabelId == -1 )
-                {   // We reached the end of it
-                    break;
-                }
-
-                increment( startNodeLabelId, anyRelationshipType, endNodeLabelId );
-                increment( startNodeLabelId, type, endNodeLabelId );
-            }
+            increment( labelsCounts, startNodeLabelId, anyRelationshipType, START );
+            increment( labelsCounts, startNodeLabelId, type, START );
         }
         endScratch = nodeLabelCache.get( client, endNode, endScratch );
         for ( int endNodeLabelId : endScratch )
@@ -107,8 +88,8 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
                 break;
             }
 
-            increment( anyLabel, anyRelationshipType, endNodeLabelId );
-            increment( anyLabel, type, endNodeLabelId );
+            increment( labelsCounts, endNodeLabelId, anyRelationshipType, END );
+            increment( labelsCounts, endNodeLabelId, type, END );
         }
     }
 
@@ -123,36 +104,63 @@ public class RelationshipCountsProcessor implements RecordProcessor<Relationship
     @Override
     public void done()
     {
-        long index = 0;
-        for ( int startNodeLabelId = 0; startNodeLabelId <= anyLabel; startNodeLabelId++ )
+        for ( int wildcardType = 0; wildcardType <= anyRelationshipType; wildcardType++ )
+        {
+            int type = wildcardType == anyRelationshipType ? ReadOperations.ANY_RELATIONSHIP_TYPE : wildcardType;
+            long count = wildcardCounts.get( wildcardType );
+            countsUpdater.incrementRelationshipCount( ReadOperations.ANY_LABEL, type, ReadOperations
+                    .ANY_LABEL, count );
+        }
+
+
+        for ( int labelId = 0; labelId < anyLabel; labelId++ )
         {
             for ( int typeId = 0; typeId <= anyRelationshipType; typeId++ )
             {
-                for ( int endNodeLabelId = 0; endNodeLabelId <= anyLabel; endNodeLabelId++, index++ )
-                {
-                    if ( !COMPUTE_DOUBLE_SIDED_RELATIONSHIP_COUNTS )
-                    {
-                        if ( startNodeLabelId != anyLabel && endNodeLabelId != anyLabel )
-                        {
-                            continue;
-                        }
-                    }
-                    int startLabel = startNodeLabelId == anyLabel ? ReadOperations.ANY_LABEL : startNodeLabelId;
-                    int type = typeId == anyRelationshipType ? ReadOperations.ANY_RELATIONSHIP_TYPE : typeId;
-                    int endLabel = endNodeLabelId == anyLabel ? ReadOperations.ANY_LABEL : endNodeLabelId;
-                    long count = counts.get( index );
-                    countsUpdater.incrementRelationshipCount( startLabel, type, endLabel, count );
-                }
+
+                long startCount = labelsCounts.get( arrayIndex( labelId, typeId, START ) );
+                long endCount = labelsCounts.get( arrayIndex( labelId, typeId, END ) );
+                int type = typeId == anyRelationshipType ? ReadOperations.ANY_RELATIONSHIP_TYPE : typeId;
+
+                countsUpdater.incrementRelationshipCount( labelId, type, ReadOperations.ANY_LABEL, startCount );
+                countsUpdater.incrementRelationshipCount( ReadOperations.ANY_LABEL, type, labelId, endCount );
             }
         }
     }
 
     public void addCountsFrom( RelationshipCountsProcessor from )
     {
-        long length = counts.length();
+        mergeCounts( labelsCounts, from.labelsCounts );
+        mergeCounts( wildcardCounts, from.wildcardCounts );
+    }
+
+    private void mergeCounts( LongArray destination, LongArray part )
+    {
+        long length = destination.length();
         for ( long i = 0; i < length; i++ )
         {
-            counts.set( i, counts.get( i ) + from.counts.get( i ) );
+            destination.set( i, destination.get( i ) + part.get( i ) );
         }
+    }
+
+    private long arrayIndex( long labelId, long relationshipTypeId, long side )
+    {
+        return (side * sideSize()) + (labelId * itemsPerLabel + relationshipTypeId);
+    }
+
+    private long sideSize()
+    {
+        return itemsPerType * itemsPerLabel;
+    }
+
+    private void increment( LongArray counts, long labelId, long relationshipTypeId, long side )
+    {
+        long index = arrayIndex( labelId, relationshipTypeId, side );
+        increment( counts, index );
+    }
+
+    private void increment( LongArray counts, long index )
+    {
+        counts.set( index, counts.get( index ) + 1 );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
@@ -33,7 +33,7 @@ public class Utils
     {
         if ( value > Integer.MAX_VALUE )
         {
-            throw new UnsupportedOperationException( "Not supported a.t.m" );
+            throw new ArithmeticException( getOverflowMessage( value, Integer.class ) );
         }
         return (int) value;
     }
@@ -42,7 +42,7 @@ public class Utils
     {
         if ( value > Short.MAX_VALUE )
         {
-            throw new UnsupportedOperationException( "Not supported a.t.m" );
+            throw new ArithmeticException( getOverflowMessage( value, Short.class ) );
         }
         return (short) value;
     }
@@ -51,7 +51,7 @@ public class Utils
     {
         if ( value > Byte.MAX_VALUE )
         {
-            throw new UnsupportedOperationException( "Not supported a.t.m" );
+            throw new ArithmeticException( getOverflowMessage( value, Byte.class ) );
         }
         return (byte) value;
     }
@@ -191,6 +191,11 @@ public class Utils
                 into[t--] = into[i--];
             }
         }
+    }
+
+    private static String getOverflowMessage( long value, Class clazz )
+    {
+        return "Value " + value + " is too big to be represented as " + clazz.getName();
     }
 
     private Utils()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -66,7 +66,7 @@ public interface NumberArrayFactory
     /**
      * Implements the dynamic array methods, because they are the same in most implementations.
      */
-    public static abstract class Adapter implements NumberArrayFactory
+    abstract class Adapter implements NumberArrayFactory
     {
         @Override
         public IntArray newDynamicIntArray( long chunkSize, int defaultValue )
@@ -84,7 +84,7 @@ public interface NumberArrayFactory
     /**
      * Puts arrays inside the heap.
      */
-    public static final NumberArrayFactory HEAP = new Adapter()
+    NumberArrayFactory HEAP = new Adapter()
     {
         @Override
         public IntArray newIntArray( long length, int defaultValue )
@@ -108,7 +108,7 @@ public interface NumberArrayFactory
     /**
      * Puts arrays off-heap, using unsafe calls.
      */
-    public static final NumberArrayFactory OFF_HEAP = new Adapter()
+    NumberArrayFactory OFF_HEAP = new Adapter()
     {
         @Override
         public IntArray newIntArray( long length, int defaultValue )
@@ -134,7 +134,7 @@ public interface NumberArrayFactory
      * array off-heap, then inside heap. If all else fails a dynamic array is returned with a smaller chunk size
      * so that collectively the whole array will fit in memory available on the machine.
      */
-    public static class Auto extends Adapter
+    class Auto extends Adapter
     {
         private final NumberArrayFactory[] candidates;
 
@@ -191,7 +191,7 @@ public interface NumberArrayFactory
      * ({@link #newLongArray(long, long)} and {@link #newIntArray(long, int)} into smaller chunks where
      * some can live on heap and some off heap.
      */
-    public static final NumberArrayFactory CHUNKED_FIXED_SIZE = new Adapter()
+    NumberArrayFactory CHUNKED_FIXED_SIZE = new Adapter()
     {
         private final NumberArrayFactory delegate = new Auto( OFF_HEAP, HEAP );
 
@@ -244,5 +244,5 @@ public interface NumberArrayFactory
     /**
      * {@link Auto} factory which uses JVM stats for gathering information about available memory.
      */
-    public static final NumberArrayFactory AUTO = new Auto( OFF_HEAP, HEAP, CHUNKED_FIXED_SIZE );
+    NumberArrayFactory AUTO = new Auto( OFF_HEAP, HEAP, CHUNKED_FIXED_SIZE );
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
@@ -168,7 +168,6 @@ public class CountsComputerTest
         {
             CountsTracker store = life.add( createCountsTracker() );
             assertEquals( BASE_TX_ID + 1 + 1 + 1 + 1 + 1, store.txId() );
-//            assertEquals( 11, store.totalRecordsStored() ); // we do not support yet (label,type,label) counts
             assertEquals( 9, store.totalEntriesStored() );
             assertEquals( 2, get( store, nodeKey( -1 ) ) );
             assertEquals( 1, get( store, nodeKey( 0 ) ) );
@@ -177,7 +176,6 @@ public class CountsComputerTest
             assertEquals( 0, get( store, nodeKey( 3 ) ) );
             assertEquals( 0, get( store, relationshipKey( -1, 0, -1 ) ) );
             assertEquals( 1, get( store, relationshipKey( -1, 1, -1 ) ) );
-//            assertEquals( 1, get( store, relationshipKey( 1, 1, 0 ) ) ); // we do not support yet (label,type,label) counts
         }
     }
 
@@ -205,7 +203,6 @@ public class CountsComputerTest
         {
             CountsTracker store = life.add( createCountsTracker() );
             assertEquals( BASE_TX_ID + 1 + 1 + 1 + 1 + 1 + 1, store.txId() );
-//            assertEquals( 15, store.totalRecordsStored() ); // we do not support yet (label,type,label) counts
             assertEquals( 13, store.totalEntriesStored() );
             assertEquals( 4, get( store, nodeKey( -1 ) ) );
             assertEquals( 1, get( store, nodeKey( 0 ) ) );
@@ -216,8 +213,6 @@ public class CountsComputerTest
             assertEquals( 1, get( store, relationshipKey( -1, 0, -1 ) ) );
             assertEquals( 1, get( store, relationshipKey( -1, 1, -1 ) ) );
             assertEquals( 0, get( store, relationshipKey( -1, 2, -1 ) ) );
-//            assertEquals( 1, get( store, relationshipKey( 0, 0, 2 ) ) ); // we do not support yet (label,type,label) counts
-//            assertEquals( 0, get( store, relationshipKey( 2, 0, 0 ) ) ); // we do not support yet (label,type,label) counts
             assertEquals( 1, get( store, relationshipKey( -1, 1, 1 ) ) );
             assertEquals( 0, get( store, relationshipKey( -1, 0, 1 ) ) );
         }
@@ -250,7 +245,6 @@ public class CountsComputerTest
             CountsTracker store = life.add( createCountsTracker() );
             assertEquals( BASE_TX_ID + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1, store.txId() );
             assertEquals( 22, store.totalEntriesStored() );
-//            assertEquals( 30, store.totalRecordsStored() ); // we do not support yet (label,type,label) counts
             assertEquals( 3, get( store, nodeKey( -1 ) ) );
             assertEquals( 1, get( store, nodeKey( 0 ) ) );
             assertEquals( 1, get( store, nodeKey( 1 ) ) );
@@ -262,11 +256,8 @@ public class CountsComputerTest
             assertEquals( 1, get( store, relationshipKey( -1, 2, -1 ) ) );
             assertEquals( 1, get( store, relationshipKey( -1, 3, -1 ) ) );
             assertEquals( 0, get( store, relationshipKey( -1, 4, -1 ) ) );
-//            assertEquals( 1, get( store, relationshipKey( 0, 2, 2 ) ) ); // we do not support yet (label,type,label) counts
-//            assertEquals( 0, get( store, relationshipKey( 2, 0, 0 ) ) ); // we do not support yet (label,type,label) counts
             assertEquals( 1, get( store, relationshipKey( -1, 1, 1 ) ) );
             assertEquals( 2, get( store, relationshipKey( -1, -1, 1 ) ) );
-//            assertEquals( 0, get( store, relationshipKey( 1, -1, 2 ) ) ); // we do not support yet (label,type,label) counts
             assertEquals( 3, get( store, relationshipKey( 0, -1, -1 ) ) );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,6 +43,10 @@ import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
 
 public class UtilsTest
 {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     @Test
     public void shouldDetectCollisions() throws Exception
     {
@@ -53,6 +59,24 @@ public class UtilsTest
 
         // THEN
         assertTrue( collides );
+    }
+
+    @Test
+    public void failSafeCastLongToIntOnOverflow()
+    {
+        expectedException.expect( ArithmeticException.class );
+        expectedException.expectMessage( "Value 2147483648 is too big to be represented as java.lang.Integer" );
+
+        Utils.safeCastLongToInt( Integer.MAX_VALUE + 1l );
+    }
+
+    @Test
+    public void failSafeCastLongToShortOnOverflow()
+    {
+        expectedException.expect( ArithmeticException.class );
+        expectedException.expectMessage( "Value 32768 is too big to be represented as java.lang.Short" );
+
+        Utils.safeCastLongToShort( Short.MAX_VALUE + 1l );
     }
 
     @Test


### PR DESCRIPTION
Remove evaluation of relationships counts for label - type - label
since those are not used and evaluation of those cause out of memory for some customers during counters array allocation.
Update error message for overflows in Utils, that can happen during conversion to lower number type.
