### PR TITLE
need neo4j-server test-jar for testing extensions.

### DIFF
--- a/community/server-examples/src/docs/dev/server-testing.asciidoc
+++ b/community/server-examples/src/docs/dev/server-testing.asciidoc
@@ -12,6 +12,13 @@ You can access this toolkit by adding the following test dependency to your proj
    <version>{neo4j-version}</version>
    <scope>test</scope>
 </dependency>
+<dependency>
+   <groupId>org.neo4j.app</groupId>
+   <artifactId>neo4j-server</artifactId>
+   <version>{neo4j-version}</version>
+   <type>test-jar</type>
+   <scope>test</scope>
+</dependency>
 --------
 
 The test toolkit provides a mechanism to start a Neo4j instance with custom configuration and with extensions of your choice.


### PR DESCRIPTION
see #5524 - `org.neo4j.app:neo4j-server` test jar provides the class `org.neo4j.test.server.HTTP`.
