### PR TITLE
Fix UDC memory collection on IBM JVMs

### DIFF
--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
@@ -274,7 +274,7 @@ public class DefaultUdcInformationCollector implements UdcInformationCollector
         {
             return ((OperatingSystemMXBean) operatingSystemMXBean).getTotalPhysicalMemorySize();
         }
-        catch ( NoClassDefFoundError e )
+        catch ( Throwable e )
         {
             // If not running on Oracle JDK
 


### PR DESCRIPTION
The code was expecting the IBM implementation to throw a NoClassDefFoundError when accessing the HotSpot specific OperatingSystemMXBean.
However, this was not the case. Instead, it was throwing a ClassCastException.
We now catch all Throwables to handle all cases.
