### PR TITLE
Reduce the grab size for the MemoryManager

### DIFF
--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
@@ -33,7 +33,7 @@ public final class MemoryManager
      * The amount of memory, in bytes, to grab in each Slab.
      */
     private static final long GRAB_SIZE = Integer.getInteger(
-            MemoryManager.class.getName() + ".GRAB_SIZE", 32 * 1024 * 1024 ); // 32 MiB
+            MemoryManager.class.getName() + ".GRAB_SIZE", 512 * 1024 ); // 512 KiB
 
     /**
      * The amount of memory that this memory manager can still allocate.


### PR DESCRIPTION
Experiments have shown that allocating 512 KiBs at a time, is the fastest way to go with the algorithm we have, when running on many-core hardware.
