### PR TITLE
Revert the extraction of GlobalGraphOperations

### DIFF
--- a/community/consistency-check-legacy/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check-legacy/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -38,6 +33,11 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -60,7 +60,6 @@ import org.neo4j.test.RandomRule;
 import org.neo4j.test.Randoms;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Group;
@@ -74,7 +73,6 @@ import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
@@ -325,8 +323,6 @@ public class ParallelBatchImporterTest
     protected void verifyData( int nodeCount, int relationshipCount, GraphDatabaseService db, IdGroupDistribution groups,
             long nodeRandomSeed, long relationshipRandomSeed )
     {
-        GlobalGraphOperations globalOps = GlobalGraphOperations.at( db );
-
         // Read all nodes, relationships and properties ad verify against the input data.
         try ( InputIterator<InputNode> nodes = nodes( nodeRandomSeed, nodeCount, inputIdGenerator, groups ).iterator();
               InputIterator<InputRelationship> relationships = relationships( relationshipRandomSeed, relationshipCount,
@@ -334,7 +330,7 @@ public class ParallelBatchImporterTest
         {
             // Nodes
             Map<String,Node> nodeByInputId = new HashMap<>( nodeCount );
-            Iterator<Node> dbNodes = globalOps.getAllNodes().iterator();
+            Iterator<Node> dbNodes = db.getAllNodes().iterator();
             int verifiedNodes = 0;
             while ( nodes.hasNext() )
             {
@@ -349,7 +345,7 @@ public class ParallelBatchImporterTest
 
             // Relationships
             Map<String,Relationship> relationshipByName = new HashMap<>();
-            for ( Relationship relationship : globalOps.getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 relationshipByName.put( (String) relationship.getProperty( "id" ), relationship );
             }

--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -38,6 +33,11 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.ConsistencyCheckService.Result;
@@ -60,7 +60,6 @@ import org.neo4j.test.RandomRule;
 import org.neo4j.test.Randoms;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Group;
@@ -74,7 +73,6 @@ import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
@@ -325,8 +323,6 @@ public class ParallelBatchImporterTest
     protected void verifyData( int nodeCount, int relationshipCount, GraphDatabaseService db, IdGroupDistribution groups,
             long nodeRandomSeed, long relationshipRandomSeed )
     {
-        GlobalGraphOperations globalOps = GlobalGraphOperations.at( db );
-
         // Read all nodes, relationships and properties ad verify against the input data.
         try ( InputIterator<InputNode> nodes = nodes( nodeRandomSeed, nodeCount, inputIdGenerator, groups ).iterator();
               InputIterator<InputRelationship> relationships = relationships( relationshipRandomSeed, relationshipCount,
@@ -334,7 +330,7 @@ public class ParallelBatchImporterTest
         {
             // Nodes
             Map<String,Node> nodeByInputId = new HashMap<>( nodeCount );
-            Iterator<Node> dbNodes = globalOps.getAllNodes().iterator();
+            Iterator<Node> dbNodes = db.getAllNodes().iterator();
             int verifiedNodes = 0;
             while ( nodes.hasNext() )
             {
@@ -349,7 +345,7 @@ public class ParallelBatchImporterTest
 
             // Relationships
             Map<String,Relationship> relationshipByName = new HashMap<>();
-            for ( Relationship relationship : globalOps.getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 relationshipByName.put( (String) relationship.getProperty( "id" ), relationship );
             }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -24,7 +24,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 /**
  * @author mh
@@ -47,15 +46,13 @@ public class DatabaseSubGraph implements SubGraph
     @Override
     public Iterable<Node> getNodes()
     {
-        final GlobalGraphOperations operations = GlobalGraphOperations.at( gdb );
-        return operations.getAllNodes();
+        return gdb.getAllNodes();
     }
 
     @Override
     public Iterable<Relationship> getRelationships()
     {
-        final GlobalGraphOperations operations = GlobalGraphOperations.at( gdb );
-        return operations.getAllRelationships();
+        return gdb.getAllRelationships();
     }
 
     @Override

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v1_9/GDSBackedQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v1_9/GDSBackedQueryContext.scala
@@ -19,16 +19,17 @@
  */
 package org.neo4j.cypher.internal.spi.v1_9
 
-import org.neo4j.cypher.internal.compiler.v1_9.spi.{Operations, QueryContext}
-import org.neo4j.graphdb._
-import org.neo4j.graphdb.DynamicRelationshipType.withName
-import collection.JavaConverters._
-import java.lang.{Iterable=>JIterable}
-import org.neo4j.tooling.GlobalGraphOperations
+import java.lang.{Iterable => JIterable}
+
 import org.neo4j.cypher.EntityNotFoundException
+import org.neo4j.cypher.internal.compiler.v1_9.spi.{Operations, QueryContext}
+import org.neo4j.graphdb.DynamicRelationshipType.withName
+import org.neo4j.graphdb._
 import org.neo4j.kernel.GraphDatabaseAPI
-import org.neo4j.kernel.impl.core.{ThreadToStatementContextBridge, NodeManager}
 import org.neo4j.kernel.impl.api.KernelStatement
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
+
+import scala.collection.JavaConverters._
 
 class GDSBackedQueryContext(graph: GraphDatabaseService) extends QueryContext {
 
@@ -87,7 +88,7 @@ class GDSBackedQueryContext(graph: GraphDatabaseService) extends QueryContext {
         graph.index.forNodes(name).query(query).iterator().asScala
 
       def all: Iterator[Node] =
-        GlobalGraphOperations.at(graph).getAllNodes.iterator().asScala
+        graph.getAllNodes.iterator().asScala
 
       def isDeleted(node: Node): Boolean = {
         val nodeManager: ThreadToStatementContextBridge = graph.asInstanceOf[GraphDatabaseAPI].getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge])
@@ -134,7 +135,7 @@ class GDSBackedQueryContext(graph: GraphDatabaseService) extends QueryContext {
         graph.index.forRelationships(name).query(query).iterator().asScala
 
       def all: Iterator[Relationship] =
-        GlobalGraphOperations.at(graph).getAllRelationships.iterator().asScala
+        graph.getAllRelationships.iterator().asScala
 
       def isDeleted(rel: Relationship): Boolean = {
         val nodeManager: ThreadToStatementContextBridge = graph.asInstanceOf[GraphDatabaseAPI].getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge])

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
@@ -35,7 +35,6 @@ import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
 import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.impl.api.KernelStatement
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
-import org.neo4j.tooling.GlobalGraphOperations
 
 import scala.collection.JavaConverters._
 import scala.collection.{Iterator, mutable}
@@ -182,7 +181,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       case e: NotFoundException => throw new EntityNotFoundException(s"Node with id $id", e)
     }
 
-    def all: Iterator[Node] = GlobalGraphOperations.at(graph).getAllNodes.iterator().asScala
+    def all: Iterator[Node] = graph.getAllNodes.iterator().asScala
 
     def indexGet(name: String, key: String, value: Any): Iterator[Node] =
       graph.index.forNodes(name).get(key, value).iterator().asScala
@@ -223,7 +222,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     }
 
     def all: Iterator[Relationship] =
-      GlobalGraphOperations.at(graph).getAllRelationships.iterator().asScala
+      graph.getAllRelationships.iterator().asScala
 
     def indexGet(name: String, key: String, value: Any): Iterator[Relationship] =
       graph.index.forRelationships(name).get(key, value).iterator().asScala

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -332,7 +332,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       case e: NotFoundException => throw new EntityNotFoundException(s"Node with id $id", e)
     }
 
-    def all: Iterator[Node] = GlobalGraphOperations.at(graph).getAllNodes.iterator().asScala
+    def all: Iterator[Node] = graph.getAllNodes.iterator().asScala
 
     def indexGet(name: String, key: String, value: Any): Iterator[Node] =
       graph.index.forNodes(name).get(key, value).iterator().asScala
@@ -373,7 +373,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     }
 
     def all: Iterator[Relationship] =
-      GlobalGraphOperations.at(graph).getAllRelationships.iterator().asScala
+      graph.getAllRelationships.iterator().asScala
 
     def indexGet(name: String, key: String, value: Any): Iterator[Relationship] =
       graph.index.forRelationships(name).get(key, value).iterator().asScala

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/GraphDatabaseServiceExecuteTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/GraphDatabaseServiceExecuteTest.java
@@ -24,10 +24,8 @@ import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 
 public class GraphDatabaseServiceExecuteTest
@@ -40,7 +38,7 @@ public class GraphDatabaseServiceExecuteTest
         final int before, after;
         try ( Transaction tx = graphDb.beginTx() )
         {
-            before = count( GlobalGraphOperations.at( graphDb ).getAllNodes() );
+            before = count( graphDb.getAllNodes() );
             tx.success();
         }
 
@@ -50,7 +48,7 @@ public class GraphDatabaseServiceExecuteTest
         // then
         try ( Transaction tx = graphDb.beginTx() )
         {
-            after = count( GlobalGraphOperations.at( graphDb ).getAllNodes() );
+            after = count( graphDb.getAllNodes() );
             tx.success();
         }
         assertEquals( before + 1, after );

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -29,7 +29,6 @@ import org.neo4j.kernel.api.{DataWriteOperations, KernelAPI}
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 import org.neo4j.kernel.{GraphDatabaseAPI, monitoring}
 import org.neo4j.test.ImpermanentGraphDatabase
-import org.neo4j.tooling.GlobalGraphOperations
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
@@ -90,11 +89,11 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
   }
 
   def countNodes() = graph.inTx {
-    GlobalGraphOperations.at(graph).getAllNodes.asScala.size
+    graph.getAllNodes.asScala.size
   }
 
   def countRelationships() = graph.inTx {
-    GlobalGraphOperations.at(graph).getAllRelationships.asScala.size
+    graph.getAllRelationships.asScala.size
   }
 
   def createNode(): Node = createNode(Map[String, Any]())
@@ -131,13 +130,13 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
   def createNode(values: (String, Any)*): Node = createNode(values.toMap)
 
   def deleteAllEntities() = graph.inTx {
-    val relIterator = GlobalGraphOperations.at(graph).getAllRelationships.iterator()
+    val relIterator = graph.getAllRelationships.iterator()
 
     while (relIterator.hasNext) {
       relIterator.next().delete()
     }
 
-    val nodeIterator = GlobalGraphOperations.at(graph).getAllNodes.iterator()
+    val nodeIterator = graph.getAllNodes.iterator()
     while (nodeIterator.hasNext) {
       nodeIterator.next().delete()
     }
@@ -189,7 +188,7 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
     nodes.find(_.getProperty("name") == name).get
   }
 
-  def relType(name: String): RelationshipType = GlobalGraphOperations.at(graph).getAllRelationshipTypes.asScala.find(_.name() == name).get
+  def relType(name: String): RelationshipType = graph.getRelationshipTypes.asScala.find(_.name() == name).get
 
   def createNodes(names: String*): List[Node] = {
     nodes = names.map(x => createNode(Map("name" -> x))).toList

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
@@ -31,25 +31,25 @@ import scala.collection.JavaConverters._
 class MutatingIntegrationTest extends ExecutionEngineFunSuite with Assertions with QueryStatisticsTestSupport {
 
   test("create_a_single_node") {
-    val before = graph.inTx(GlobalGraphOperations.at(graph).getAllNodes.asScala.size)
+    val before = graph.inTx(graph.getAllNodes.asScala.size)
 
     val result = execute("create a")
 
     assertStats(result, nodesCreated = 1)
     graph.inTx {
-      GlobalGraphOperations.at(graph).getAllNodes.asScala should have size before + 1
+      graph.getAllNodes.asScala should have size before + 1
     }
   }
 
 
   test("create_a_single_node_with_props_and_return_it") {
-    val before = graph.inTx(GlobalGraphOperations.at(graph).getAllNodes.asScala.size)
+    val before = graph.inTx(graph.getAllNodes.asScala.size)
 
     val result = execute("create (a {name : 'Andres'}) return a")
 
     assertStats(result, nodesCreated = 1, propertiesSet = 1)
     graph.inTx {
-      GlobalGraphOperations.at(graph).getAllNodes.asScala should have size before + 1
+      graph.getAllNodes.asScala should have size before + 1
     }
 
     val list = result.toList
@@ -287,7 +287,7 @@ return distinct center""")
     execute("""start n=node(*) optional match n-[r]-() delete n,r""")
 
     graph.inTx {
-      GlobalGraphOperations.at(graph).getAllNodes.asScala shouldBe empty
+      graph.getAllNodes.asScala shouldBe empty
     }
   }
 
@@ -299,7 +299,7 @@ return distinct center""")
     execute("""match (n) where id(n) = 0 match p=n-->() delete p""")
 
     graph.inTx {
-      GlobalGraphOperations.at(graph).getAllNodes.asScala shouldBe empty
+      graph.getAllNodes.asScala shouldBe empty
     }
   }
 

--- a/community/graphviz/src/main/java/org/neo4j/walk/Walker.java
+++ b/community/graphviz/src/main/java/org/neo4j/walk/Walker.java
@@ -27,7 +27,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public abstract class Walker
 {
@@ -40,7 +39,7 @@ public abstract class Walker
             @Override
             public <R, E extends Throwable> R accept( Visitor<R, E> visitor ) throws E
             {
-                for ( Node node : GlobalGraphOperations.at( graphDb ).getAllNodes() )
+                for ( Node node : graphDb.getAllNodes() )
                 {
                     visitor.visitNode( node );
                     for ( Relationship edge : node.getRelationships( Direction.OUTGOING ) )

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.tooling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -32,6 +29,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -47,6 +48,8 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.ImportTool.Options;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.helpers.ArrayUtil.join;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
@@ -54,10 +57,6 @@ import static org.neo4j.io.fs.FileUtils.readTextFile;
 import static org.neo4j.io.fs.FileUtils.writeToFile;
 import static org.neo4j.tooling.GlobalGraphOperations.at;
 import static org.neo4j.tooling.ImportTool.MULTI_FILE_DELIMITER;
-
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Rule;
-import org.junit.Test;
 
 public class ImportToolDocIT
 {
@@ -623,7 +622,7 @@ public class ImportToolDocIT
             int nodeCount = count( at( db ).getAllNodes() ), relationshipCount = 0;
             assertEquals( 2, nodeCount );
 
-            for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 assertTrue( relationship.hasProperty( "roles" ) );
 
@@ -659,7 +658,7 @@ public class ImportToolDocIT
         {
             int nodeCount = count( at( db ).getAllNodes() ), relationshipCount = 0, sequelCount = 0;
             assertEquals( NODE_COUNT, nodeCount );
-            for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 assertTrue( relationship.hasProperty( "role" ) );
                 relationshipCount++;

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.tooling;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -33,6 +30,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.csv.reader.IllegalMultilineFieldException;
 import org.neo4j.function.IntPredicate;
@@ -59,6 +59,9 @@ import org.neo4j.unsafe.impl.batchimport.input.InputException;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Type;
 
+import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -66,11 +69,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import static java.lang.String.format;
-import static java.lang.System.currentTimeMillis;
-import static java.util.Arrays.asList;
-
 import static org.neo4j.function.IntPredicates.alwaysTrue;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
@@ -255,7 +253,7 @@ public class ImportToolTest
         try ( Transaction tx = db.beginTx() )
         {
             int nodeCount = 0;
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 assertTrue( node.hasProperty( "name" ) );
                 nodeCount++;
@@ -295,7 +293,7 @@ public class ImportToolTest
         try ( Transaction tx = db.beginTx() )
         {
             int nodeCount = 0;
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 assertTrue( node.hasProperty( "name" ) );
                 nodeCount++;
@@ -401,7 +399,7 @@ public class ImportToolTest
         GraphDatabaseService db = dbRule.getGraphDatabaseService();
         try ( Transaction tx = db.beginTx() )
         {
-            Iterator<Node> nodes = GlobalGraphOperations.at( db ).getAllNodes().iterator();
+            Iterator<Node> nodes = db.getAllNodes().iterator();
             Iterator<String> expectedIds = FilteringIterator.noDuplicates( nodeIds.iterator() );
             while ( expectedIds.hasNext() )
             {
@@ -614,7 +612,7 @@ public class ImportToolTest
         GraphDatabaseService db = dbRule.getGraphDatabaseService();
         try ( Transaction tx = db.beginTx() )
         {
-            Iterable<Node> allNodes = GlobalGraphOperations.at( db ).getAllNodes();
+            Iterable<Node> allNodes = db.getAllNodes();
             int anonymousCount = 0;
             for ( final String id : nodeIds )
             {
@@ -714,7 +712,7 @@ public class ImportToolTest
         GraphDatabaseService db = dbRule.getGraphDatabaseAPI();
         try ( Transaction tx = db.beginTx() )
         {
-            ResourceIterator<Node> allNodes = GlobalGraphOperations.at( db ).getAllNodes().iterator();
+            ResourceIterator<Node> allNodes = IteratorUtil.asResourceIterator( db.getAllNodes().iterator() );
             Node node = IteratorUtil.single( allNodes );
             allNodes.close();
 
@@ -738,7 +736,8 @@ public class ImportToolTest
         GraphDatabaseService graphDatabaseService = dbRule.getGraphDatabaseService();
         try ( Transaction tx = graphDatabaseService.beginTx() )
         {
-            ResourceIterator<Node> allNodes = GlobalGraphOperations.at( graphDatabaseService ).getAllNodes().iterator();
+            ResourceIterator<Node> allNodes = IteratorUtil.asResourceIterator(
+                    graphDatabaseService.getAllNodes().iterator() );
             assertFalse( "Expected database to be empty", allNodes.hasNext() );
             tx.success();
         }
@@ -762,7 +761,7 @@ public class ImportToolTest
         GraphDatabaseService db = dbRule.getGraphDatabaseAPI();
         try ( Transaction tx = db.beginTx() )
         {
-            Node node = single( GlobalGraphOperations.at( db ).getAllNodes() );
+            Node node = single( db.getAllNodes() );
             assertEquals( "three", single( node.getPropertyKeys() ) );
             tx.success();
         }
@@ -815,14 +814,14 @@ public class ImportToolTest
         try ( Transaction tx = db.beginTx() )
         {
             int nodeCount = 0, relationshipCount = 0;
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 assertTrue( node.hasProperty( "name" ) );
                 nodeAdditionalValidation.validate( node );
                 nodeCount++;
             }
             assertEquals( NODE_COUNT, nodeCount );
-            for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 assertTrue( relationship.hasProperty( "created" ) );
                 relationshipAdditionalValidation.validate( relationship );
@@ -871,7 +870,7 @@ public class ImportToolTest
         try ( Transaction tx = db.beginTx() )
         {
             Map<String,Node> nodes = new HashMap<>();
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 nodes.put( idOf( node ), node );
             }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -28,7 +28,6 @@ import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.kernel.EmbeddedGraphDatabase;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 /**
  * The main access point to a running Neo4j instance. The most common
@@ -92,10 +91,16 @@ public interface GraphDatabaseService
      * Returns all nodes in the graph.
      *
      * @return all nodes in the graph.
-     * @deprecated this operation can be found in {@link GlobalGraphOperations} instead.
      */
-    @Deprecated
+    // TODO: should be a ResourceIterable, but we probably can't change that until 3.0
     Iterable<Node> getAllNodes();
+
+    /**
+     * Returns all relationships in the graph.
+     *
+     * @return all relationships in the graph.
+     */
+    ResourceIterable<Relationship> getAllRelationships();
 
     /**
      * Returns all nodes having the label, and the wanted property value.
@@ -183,10 +188,56 @@ public interface GraphDatabaseService
      * space).
      *
      * @return all relationship types in the underlying store
-     * @deprecated this operation can be found in {@link GlobalGraphOperations} instead.
      */
-    @Deprecated
+    // TODO: should be a ResourceIterable, but we probably can't change that until 3.0
     Iterable<RelationshipType> getRelationshipTypes();
+
+    /**
+     * Returns all relationship types currently in use in the underlying store. Relationship types are
+     * added to the underlying store the first time they are used in a successfully committed
+     * {@link Node#createRelationshipTo node.createRelationshipTo(...)}. Note that this method is
+     * guaranteed to return all known relationship types, and it guarantees that it won't return
+     * "historic" relationship types that no longer have any relationships in the graph.
+     *
+     * @return all relationship types in use in the underlying store
+     */
+    ResourceIterable<RelationshipType> getAllRelationshipTypesInUse();
+
+    /**
+     * Returns all labels currently in the underlying store. Labels are added to the store the first time
+     * they are used. This method guarantees that it will return all labels currently in use. However,
+     * it may also return <i>more</i> than that (e.g. it can return "historic" labels that are no longer used).
+     *
+     * Please take care that the returned {@link ResourceIterable} is closed correctly and as soon as possible
+     * inside your transaction to avoid potential blocking of write operations.
+     *
+     * @return all labels in the underlying store.
+     */
+    ResourceIterable<Label> getAllLabels();
+
+    /**
+     * Returns all labels currently in use in the underlying store. Labels are added to the store the first time
+     * they are used. This method guarantees that it will return all labels currently in use by filtering out
+     * "historic" labels that are no longer used.
+     *
+     * Please take care that the returned {@link ResourceIterable} is closed correctly and as soon as possible
+     * inside your transaction to avoid potential blocking of write operations.
+     *
+     * @return all labels in use in the underlying store.
+     */
+    ResourceIterable<Label> getAllLabelsInUse();
+
+    /**
+     * Returns all property keys currently in the underlying store. This method guarantees that it will return all
+     * property keys currently in use. However, it may also return <i>more</i> than that (e.g. it can return "historic"
+     * labels that are no longer used).
+     *
+     * Please take care that the returned {@link ResourceIterable} is closed correctly and as soon as possible
+     * inside your transaction to avoid potential blocking of write operations.
+     *
+     * @return all property keys in the underlying store.
+     */
+    ResourceIterable<String> getAllPropertyKeys();
 
     /**
      * Use this method to check if the database is currently in a usable state.

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
@@ -617,14 +617,18 @@ public final class Iterables
         return list.toArray( (T[]) Array.newInstance( componentType, list.size() ) );
     }
 
-    public static <T> ResourceIterable<T> asResourceIterable( final Iterable<T> labels )
+    public static <T> ResourceIterable<T> asResourceIterable( final Iterable<T> iterable )
     {
+        if ( iterable instanceof ResourceIterable<?> )
+        {
+            return (ResourceIterable<T>) iterable;
+        }
         return new ResourceIterable<T>()
         {
             @Override
             public ResourceIterator<T> iterator()
             {
-                return asResourceIterator( labels.iterator() );
+                return asResourceIterator( iterable.iterator() );
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
@@ -1049,6 +1049,10 @@ public abstract class IteratorUtil
 
     public static <T> ResourceIterator<T> asResourceIterator( final Iterator<T> iterator )
     {
+        if ( iterator instanceof ResourceIterator<?> )
+        {
+            return (ResourceIterator<T>) iterator;
+        }
         return new WrappingResourceIterator<>( iterator );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/TokenRead.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/TokenRead.java
@@ -52,6 +52,9 @@ interface TokenRead
     /** Returns the labels currently stored in the database * */
     Iterator<Token> labelsGetAllTokens(); // TODO: Token is a store level concern, should not make it this far up the stack
 
+    /** Returns the relationship types currently stored in the database */
+    Iterator<Token> relationshipTypesGetAllTokens();
+
     int relationshipTypeGetForName( String relationshipTypeName );
 
     String relationshipTypeGetName( int relationshipTypeId ) throws RelationshipTypeIdNotFoundKernelException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -762,6 +762,13 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
+    public Iterator<Token> relationshipTypesGetAllTokens()
+    {
+        statement.assertOpen();
+        return tokenRead().relationshipTypesGetAllTokens( statement );
+    }
+
+    @Override
     public int relationshipTypeGetForName( String relationshipTypeName )
     {
         statement.assertOpen();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -1229,6 +1229,12 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
+    public Iterator<Token> relationshipTypesGetAllTokens( Statement state )
+    {
+        return storeLayer.relationshipTypeGetAllTokens();
+    }
+
+    @Override
     public int relationshipTypeGetForName( Statement state, String relationshipTypeName )
     {
         return storeLayer.relationshipTypeGetForName( relationshipTypeName );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/KeyReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/KeyReadOperations.java
@@ -55,6 +55,9 @@ public interface KeyReadOperations
     /** Returns the labels currently stored in the database **/
     Iterator<Token> labelsGetAllTokens( Statement state ); // TODO: Token is a store level concern, should not make it this far up the stack
 
+    /** Returns the relationship types currently stored in the database */
+    Iterator<Token> relationshipTypesGetAllTokens( Statement state );
+
     int relationshipTypeGetForName( Statement state, String relationshipTypeName );
 
     String relationshipTypeGetName( Statement state, int relationshipTypeId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -391,6 +391,12 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
+    public Iterator<Token> relationshipTypeGetAllTokens()
+    {
+        return diskLayer.relationshipTypeGetAllTokens();
+    }
+
+    @Override
     public int relationshipTypeGetForName( String relationshipTypeName )
     {
         return diskLayer.relationshipTypeGetForName( relationshipTypeName );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
@@ -526,6 +526,13 @@ public class DiskLayer implements StoreReadLayer
         return labelTokenHolder.getAllTokens().iterator();
     }
 
+    @SuppressWarnings( "unchecked" )
+    @Override
+    public Iterator<Token> relationshipTypeGetAllTokens()
+    {
+        return (Iterator)relationshipTokenHolder.getAllTokens().iterator();
+    }
+
     @Override
     public int relationshipTypeGetForName( String relationshipTypeName )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -128,6 +128,8 @@ public interface StoreReadLayer
 
     Iterator<Token> labelsGetAllTokens();
 
+    Iterator relationshipTypeGetAllTokens();
+
     int relationshipTypeGetForName( String relationshipTypeName );
 
     String relationshipTypeGetName( int relationshipTypeId ) throws RelationshipTypeIdNotFoundKernelException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/GraphDbStructureGuide.java
@@ -33,14 +33,13 @@ import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
-import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
+import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.String.format;
 import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
@@ -57,16 +56,14 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
         }
     };
 
-    private final GraphDatabaseAPI db;
+    private final GraphDatabaseService db;
     private final ThreadToStatementContextBridge bridge;
-    private final GlobalGraphOperations glops;
 
     public GraphDbStructureGuide( GraphDatabaseService graph )
     {
-        this.db = (GraphDatabaseAPI) graph;
-        DependencyResolver dependencyResolver = db.getDependencyResolver();
-        this.bridge = dependencyResolver.resolveDependency( ThreadToStatementContextBridge.class );
-        this.glops = GlobalGraphOperations.at( db );
+        this.db = graph;
+        DependencyResolver dependencies = ((GraphDatabaseAPI) graph).getDependencyResolver();
+        this.bridge = dependencies.resolveDependency( ThreadToStatementContextBridge.class );
     }
 
     public void accept( DbStructureVisitor visitor )
@@ -106,7 +103,7 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
 
     private void showLabels( ReadOperations read, DbStructureVisitor visitor )
     {
-        for ( Label label : glops.getAllLabels() )
+        for ( Label label : db.getAllLabels() )
         {
             int labelId = read.labelGetForName( label.name() );
             visitor.visitLabel( labelId, label.name() );
@@ -115,7 +112,7 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
 
     private void showPropertyKeys( ReadOperations read, DbStructureVisitor visitor )
     {
-        for ( String propertyKeyName : glops.getAllPropertyKeys() )
+        for ( String propertyKeyName : db.getAllPropertyKeys() )
         {
             int propertyKeyId = read.propertyKeyGetForName( propertyKeyName );
             visitor.visitPropertyKey( propertyKeyId, propertyKeyName );
@@ -124,7 +121,7 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
 
     private void showRelTypes( ReadOperations read, DbStructureVisitor visitor )
     {
-        for ( RelationshipType relType : glops.getAllRelationshipTypes() )
+        for ( RelationshipType relType : db.getRelationshipTypes() )
         {
             int relTypeId = read.relationshipTypeGetForName( relType.name() );
             visitor.visitRelationshipType( relTypeId, relType.name() );
@@ -206,7 +203,7 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
     private void showNodeCounts( ReadOperations read, DbStructureVisitor visitor )
     {
         visitor.visitAllNodesCount( read.countsForNode( ANY_LABEL ) );
-        for ( Label label : glops.getAllLabels() )
+        for ( Label label : db.getAllLabels() )
         {
             int labelId = read.labelGetForName( label.name() );
             visitor.visitNodeCount( labelId, label.name(), read.countsForNode( labelId ) );
@@ -218,7 +215,7 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
         noSide( read, visitor, WILDCARD_REL_TYPE, ANY_RELATIONSHIP_TYPE );
 
         // one label only
-        for ( Label label : glops.getAllLabels() )
+        for ( Label label : db.getAllLabels() )
         {
             int labelId = read.labelGetForName( label.name() );
 
@@ -227,12 +224,12 @@ public class GraphDbStructureGuide implements Visitable<DbStructureVisitor>
         }
 
         // fixed rel type
-        for ( RelationshipType relType : glops.getAllRelationshipTypes() )
+        for ( RelationshipType relType : db.getRelationshipTypes() )
         {
             int relTypeId = read.relationshipTypeGetForName( relType.name() );
             noSide( read, visitor, relType, relTypeId );
 
-            for ( Label label : glops.getAllLabels() )
+            for ( Label label : db.getAllLabels() )
             {
                 int labelId = read.labelGetForName( label.name() );
 

--- a/community/kernel/src/test/java/org/neo4j/graphdb/CreateAndDeleteNodesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/CreateAndDeleteNodesIT.java
@@ -23,7 +23,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.test.ImpermanentDatabaseRule;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public class CreateAndDeleteNodesIT
 {
@@ -56,12 +55,12 @@ public class CreateAndDeleteNodesIT
         // When
         try ( Transaction tx2 = dataBase.beginTx() )
         {
-            for ( Relationship r : GlobalGraphOperations.at( dataBase ).getAllRelationships() )
+            for ( Relationship r : dataBase.getAllRelationships() )
             {
                 r.delete();
             }
 
-            for ( Node n : GlobalGraphOperations.at( dataBase ).getAllNodes() )
+            for ( Node n : dataBase.getAllNodes() )
             {
                 n.delete();
             }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/FirstStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/FirstStartupIT.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.helpers.collection.Iterables.count;
@@ -44,13 +43,11 @@ public class FirstStartupIT
         // Then
         try(Transaction ignore = db.beginTx())
         {
-            GlobalGraphOperations global = GlobalGraphOperations.at( db );
-
-            assertEquals(0, count( global.getAllNodes() ));
-            assertEquals(0, count( global.getAllRelationships() ));
-            assertEquals(0, count( global.getAllRelationshipTypes() ));
-            assertEquals(0, count( global.getAllLabels() ));
-            assertEquals(0, count( global.getAllPropertyKeys() ));
+            assertEquals(0, count( db.getAllNodes() ));
+            assertEquals(0, count( db.getAllRelationships() ));
+            assertEquals(0, count( db.getRelationshipTypes() ));
+            assertEquals(0, count( db.getAllLabels() ));
+            assertEquals(0, count( db.getAllPropertyKeys() ));
         }
 
         db.shutdown();

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.graphdb;
 
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.cursor.Cursor;
 import org.neo4j.function.Consumer;
@@ -56,7 +56,6 @@ import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactoryState;
 import org.neo4j.test.impl.EphemeralIdGenerator;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
@@ -418,14 +417,13 @@ public class LabelsAcceptanceTest
     {
         // Given
         GraphDatabaseService db = dbRule.getGraphDatabaseService();
-        GlobalGraphOperations globalOps = GlobalGraphOperations.at( db );
         createNode( db, Labels.MY_LABEL, Labels.MY_OTHER_LABEL );
         List<Label> labels = null;
 
         // When
         try (Transaction tx = db.beginTx())
         {
-            labels = toList( globalOps.getAllLabels() );
+            labels = toList( db.getAllLabels() );
         }
 
         // Then
@@ -457,7 +455,7 @@ public class LabelsAcceptanceTest
         // WHEN
         try ( Transaction tx = db.beginTx() )
         {
-            for ( final Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( final Node node : db.getAllNodes() )
             {
                 node.removeLabel( label ); // remove Label ...
                 node.delete(); // ... and afterwards the node
@@ -468,7 +466,7 @@ public class LabelsAcceptanceTest
         // THEN
         try (Transaction transaction = db.beginTx())
         {
-            assertEquals( 0, count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+            assertEquals( 0, count( db.getAllNodes() ) );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/Neo4jConstraintsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/Neo4jConstraintsTest.java
@@ -27,7 +27,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,7 +47,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
         // long numNodesPre = getNodeManager().getNumberOfIdsInUse( Node.class
         // );
         // empty the DB instance
-        for ( Node node : GlobalGraphOperations.at( getGraphDb() ).getAllNodes() )
+        for ( Node node : getGraphDb().getAllNodes() )
         {
             for ( Relationship rel : node.getRelationships() )
             {
@@ -59,7 +58,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
         tx.success();
         tx.close();
         tx = getGraphDb().beginTx();
-        assertFalse( GlobalGraphOperations.at( getGraphDb() ).getAllNodes().iterator().hasNext() );
+        assertFalse( getGraphDb().getAllNodes().iterator().hasNext() );
         // TODO: this should be valid, fails right now!
         // assertEquals( 0, numNodesPost );
         tx.success();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
@@ -34,13 +34,11 @@ import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.PlaceboTransaction;
 import org.neo4j.kernel.PropertyTracker;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
 
 public class NodeManagerTest
@@ -128,7 +126,7 @@ public class NodeManagerTest
 
         // WHEN iterator is started
         Transaction transaction = db.beginTx();
-        Iterator<Node> allNodes = GlobalGraphOperations.at( db ).getAllNodes().iterator();
+        Iterator<Node> allNodes = db.getAllNodes().iterator();
         allNodes.next();
 
         // and WHEN another node is then added
@@ -165,7 +163,7 @@ public class NodeManagerTest
 
         // WHEN
         tx = db.beginTx();
-        Iterator<Relationship> allRelationships = GlobalGraphOperations.at( db ).getAllRelationships().iterator();
+        Iterator<Relationship> allRelationships = db.getAllRelationships().iterator();
 
         Thread thread = new Thread( new Runnable()
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
@@ -30,6 +26,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -51,14 +51,12 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
 import static org.neo4j.graphdb.Neo4jMatchers.inTx;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
@@ -172,7 +170,7 @@ public class TestCrashWithRebuildSlow
             // Verify that the data we didn't delete is still around
             int nameCount = 0;
             int relCount = 0;
-            for ( Node node : GlobalGraphOperations.at( newDb ).getAllNodes() )
+            for ( Node node : newDb.getAllNodes() )
             {
                 nameCount++;
                 assertThat( node, inTx( newDb, hasProperty( "name" ), true ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4j.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4j.java
@@ -36,7 +36,6 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -190,13 +189,13 @@ public class TestNeo4j extends AbstractNeo4jTestCase
         long highId = getIdGenerator( IdType.NODE ).getHighestPossibleIdInUse();
         if ( highId >= 0 && highId < 10000 )
         {
-            int count = IteratorUtil.count( GlobalGraphOperations.at( getGraphDb() ).getAllNodes() );
+            int count = IteratorUtil.count( getGraphDb().getAllNodes() );
             boolean found = false;
             Node newNode = getGraphDb().createNode();
             newTransaction();
             int oldCount = count;
             count = 0;
-            for ( Node node : GlobalGraphOperations.at( getGraphDb() ).getAllNodes() )
+            for ( Node node : getGraphDb().getAllNodes() )
             {
                 count++;
                 if ( node.equals( newNode ) )
@@ -208,14 +207,14 @@ public class TestNeo4j extends AbstractNeo4jTestCase
             assertEquals( count, oldCount + 1 );
 
             // Tests a bug in the "all nodes" iterator
-            Iterator<Node> allNodesIterator = GlobalGraphOperations.at( getGraphDb() ).getAllNodes().iterator();
+            Iterator<Node> allNodesIterator = getGraphDb().getAllNodes().iterator();
             assertNotNull( allNodesIterator.next() );
 
             newNode.delete();
             newTransaction();
             found = false;
             count = 0;
-            for ( Node node : GlobalGraphOperations.at( getGraphDb() ).getAllNodes() )
+            for ( Node node : getGraphDb().getAllNodes() )
             {
                 count++;
                 if ( node.equals( newNode ) )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -27,10 +31,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -53,7 +53,6 @@ import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.subprocess.BreakpointTrigger;
 import org.neo4j.test.subprocess.EnabledBreakpoints;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
@@ -157,7 +156,7 @@ public class IdGeneratorRebuildFailureEmulationTest
         try ( Transaction tx = graphdb.beginTx() )
         {
             int nodecount = 0;
-            for ( Node node : GlobalGraphOperations.at( graphdb ).getAllNodes() )
+            for ( Node node : graphdb.getAllNodes() )
             {
                 int propcount = readProperties( node );
                 int relcount = 0;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -33,6 +28,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -48,7 +48,6 @@ import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -56,7 +55,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.collection.IteratorUtil.lastOrNull;
 import static org.neo4j.io.fs.FileUtils.deleteRecursively;
@@ -676,7 +674,7 @@ public class IdGeneratorTest
 
         // Verify by loading everything from scratch
         tx = db.beginTx();
-        for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+        for ( Node node : db.getAllNodes() )
         {
             lastOrNull( node.getRelationships() );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
@@ -38,9 +38,10 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.test.GraphDefinition;
 import org.neo4j.test.GraphDescription;
-import org.neo4j.tooling.GlobalGraphOperations;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public abstract class TraversalTestBase extends AbstractNeo4jTestCase
 {
@@ -84,7 +85,7 @@ public abstract class TraversalTestBase extends AbstractNeo4jTestCase
 
     protected Node getNodeWithName( String name )
     {
-        for ( Node node : GlobalGraphOperations.at( getGraphDb() ).getAllNodes() )
+        for ( Node node : getGraphDb().getAllNodes() )
         {
             String nodeName = (String) node.getProperty( "name", null );
             if ( nodeName != null && nodeName.equals( name ) )

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
@@ -29,12 +29,10 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.test.GraphDatabaseServiceCleaner.cleanDatabaseContent;
 
 public class TestImpermanentGraphDatabase
@@ -98,7 +96,7 @@ public class TestImpermanentGraphDatabase
     private int nodeCount()
     {
         Transaction transaction = db.beginTx();
-        int count = IteratorUtil.count( GlobalGraphOperations.at( db ).getAllNodes() );
+        int count = IteratorUtil.count( db.getAllNodes() );
         transaction.close();
         return count;
     }

--- a/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
@@ -407,6 +407,36 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
     }
 
     @Override
+    public ResourceIterable<Relationship> getAllRelationships()
+    {
+        return database.getAllRelationships();
+    }
+
+    @Override
+    public ResourceIterable<RelationshipType> getAllRelationshipTypesInUse()
+    {
+        return database.getAllRelationshipTypesInUse();
+    }
+
+    @Override
+    public ResourceIterable<Label> getAllLabels()
+    {
+        return database.getAllLabels();
+    }
+
+    @Override
+    public ResourceIterable<Label> getAllLabelsInUse()
+    {
+        return database.getAllLabelsInUse();
+    }
+
+    @Override
+    public ResourceIterable<String> getAllPropertyKeys()
+    {
+        return database.getAllPropertyKeys();
+    }
+
+    @Override
     public ResourceIterator<Node> findNodes( Label label, String key, Object value )
     {
         return database.findNodes( label, key, value );

--- a/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
@@ -39,7 +39,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public class DbRepresentation implements Serializable
 {
@@ -57,7 +56,7 @@ public class DbRepresentation implements Serializable
         try ( Transaction ignore = db.beginTx() )
         {
             DbRepresentation result = new DbRepresentation();
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 NodeRep nodeRep = new NodeRep( db, node, includeIndexes );
                 result.nodes.put( node.getId(), nodeRep );

--- a/community/kernel/src/test/java/org/neo4j/test/EmbeddedDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/EmbeddedDatabaseRule.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.test;
 
-import org.junit.rules.TemporaryFolder;
-
 import java.io.File;
 import java.io.IOException;
+
+import org.junit.rules.TemporaryFolder;
 
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;

--- a/community/kernel/src/test/java/org/neo4j/test/GraphDatabaseServiceCleaner.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphDatabaseServiceCleaner.java
@@ -25,7 +25,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public class GraphDatabaseServiceCleaner
 {
@@ -52,12 +51,12 @@ public class GraphDatabaseServiceCleaner
 
         try ( Transaction tx = db.beginTx() )
         {
-            for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 relationship.delete();
             }
 
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 node.delete();
             }

--- a/community/kernel/src/test/java/org/neo4j/test/GraphDescription.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphDescription.java
@@ -39,11 +39,9 @@ import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.AutoIndexer;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.copyOfRange;
-
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.test.GraphDescription.PropType.ERROR;
 import static org.neo4j.test.GraphDescription.PropType.STRING;
@@ -307,7 +305,7 @@ public class GraphDescription implements GraphDefinition
         GraphDatabaseService db = nodes.values().iterator().next().getGraphDatabase();
         try ( Transaction tx = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 for ( Relationship rel : node.getRelationships() )
                     rel.delete();

--- a/community/kernel/src/test/java/org/neo4j/tooling/GlobalGraphOperationsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/tooling/GlobalGraphOperationsIT.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.tooling;
 
+import java.util.Collections;
+
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Collections;
 
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.DynamicLabel;
@@ -58,12 +58,10 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When
         try( Transaction _ = db.beginTx() )
         {
-            assertThat( toList( gg.getAllPropertyKeys() ), equalTo( asList( "myProperty" ) ) );
+            assertThat( toList( db.getAllPropertyKeys() ), equalTo( asList( "myProperty" ) ) );
         }
     }
 
@@ -88,12 +86,10 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When - Then
         try( Transaction ignored = db.beginTx() )
         {
-            assertThat( toSet( gg.getAllLabels() ), equalTo( toSet( asList( alive, dead ) ) ) );
+            assertThat( toSet( db.getAllLabels() ), equalTo( toSet( asList( alive, dead ) ) ) );
         }
     }
 
@@ -118,12 +114,10 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When - Then
         try( Transaction ignored = db.beginTx() )
         {
-            assertThat( toSet( gg.getAllLabelsInUse() ), equalTo( Collections.singleton( alive ) ) );
+            assertThat( toSet( db.getAllLabelsInUse() ), equalTo( Collections.singleton( alive ) ) );
         }
     }
 
@@ -148,8 +142,6 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When - Then
         try( Transaction ignored = db.beginTx() )
         {
@@ -160,7 +152,7 @@ public class GlobalGraphOperationsIT
                 {
                     return relationshipType.name();
                 }
-            }, gg.getAllRelationshipTypes() );
+            }, db.getRelationshipTypes() );
             assertThat( toSet( result ), equalTo( toSet( asList( alive.name(), dead.name() ) ) ) );
         }
     }
@@ -186,8 +178,6 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When - Then
         try( Transaction ignored = db.beginTx() )
         {
@@ -198,7 +188,7 @@ public class GlobalGraphOperationsIT
                 {
                     return relationshipType.name();
                 }
-            }, gg.getAllRelationshipTypesInUse() );
+            }, db.getAllRelationshipTypesInUse() );
             assertThat( toSet( result ) , equalTo( Collections.singleton( alive.name() ) ) );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input.csv;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
@@ -36,6 +33,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -57,7 +57,6 @@ import org.neo4j.kernel.impl.util.AutoCreatingHashMap;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 import org.neo4j.unsafe.impl.batchimport.Configuration.Default;
@@ -259,7 +258,7 @@ public class CsvInputBatchImportIT
         try ( Transaction tx = db.beginTx() )
         {
             // Verify nodes
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 String name = (String) node.getProperty( "name" );
                 String[] labels = expectedNodeNames.remove( name );
@@ -268,7 +267,7 @@ public class CsvInputBatchImportIT
             assertEquals( 0, expectedNodeNames.size() );
 
             // Verify relationships
-            for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 String startNodeName = (String) relationship.getStartNode().getProperty( "name" );
                 Map<String, Map<String, AtomicInteger>> inner = expectedRelationships.get( startNodeName );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.index.impl.lucene;
 
-import org.junit.Test;
-
 import java.io.File;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -30,7 +30,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -58,7 +57,7 @@ public class LuceneRecoveryIT
         {
             assertTrue( db.index().existsForNodes( "myIndex" ) );
             Index<Node> index = db.index().forNodes( "myIndex" );
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 for ( String key : node.getPropertyKeys() )
                 {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.kernel.impl.api.constraints;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.DynamicLabel;
@@ -40,7 +40,6 @@ import org.neo4j.kernel.impl.transaction.state.NeoStoresSupplier;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -119,7 +118,7 @@ public class ConstraintRecoveryIT
 
         try(Transaction tx = db.beginTx())
         {
-            assertEquals(2, Iterables.count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+            assertEquals(2, Iterables.count( db.getAllNodes() ) );
         }
 
         try(Transaction tx = db.beginTx())

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.harness;
 
-import org.apache.commons.io.FileUtils;
-import org.codehaus.jackson.JsonNode;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -40,12 +35,18 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.apache.commons.io.FileUtils;
+import org.codehaus.jackson.JsonNode;
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.harness.extensionpackage.MyUnmanagedExtension;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.configuration.ServerSettings;
@@ -54,7 +55,6 @@ import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.server.HTTP;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -181,8 +181,7 @@ public class InProcessBuilderTest
                 // Then
                 try ( Transaction tx = server.graph().beginTx() )
                 {
-                    ResourceIterable<Node> allNodes = GlobalGraphOperations.at(
-                            server.graph() ).getAllNodes();
+                    ResourceIterable<Node> allNodes = Iterables.asResourceIterable( server.graph().getAllNodes() );
 
                     assertTrue( IteratorUtil.count( allNodes ) > 0 );
 
@@ -198,7 +197,7 @@ public class InProcessBuilderTest
             {
                 try ( Transaction tx = db.beginTx() )
                 {
-                    assertEquals( 1, IteratorUtil.count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+                    assertEquals( 1, IteratorUtil.count( db.getAllNodes() ) );
                     tx.success();
                 }
             }

--- a/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
@@ -19,11 +19,11 @@
  */
 package recovery;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
@@ -33,7 +33,6 @@ import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.Runtime.getRuntime;
 import static java.lang.System.exit;
@@ -68,8 +67,7 @@ public class TestRecoveryMultipleDataSources
         // Then
         try ( Transaction ignored = db.beginTx() )
         {
-            assertEquals( MyRelTypes.TEST.name(),
-                    GlobalGraphOperations.at( db ).getAllRelationshipTypes().iterator().next().name() );
+            assertEquals( MyRelTypes.TEST.name(), db.getRelationshipTypes().iterator().next().name() );
         }
         finally
         {

--- a/community/neo4j/src/test/java/upgrade/DatabaseContentVerifier.java
+++ b/community/neo4j/src/test/java/upgrade/DatabaseContentVerifier.java
@@ -33,14 +33,12 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.store.PropertyType;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.makeLongArray;
@@ -64,7 +62,7 @@ public class DatabaseContentVerifier
         try ( Transaction tx = database.beginTx() )
         {
             int traversalCount = 0;
-            for ( Relationship rel : GlobalGraphOperations.at( database ).getAllRelationships() )
+            for ( Relationship rel : database.getAllRelationships() )
             {
                 traversalCount++;
                 verifyProperties( rel );
@@ -79,7 +77,7 @@ public class DatabaseContentVerifier
         int nodeCount = 0;
         try ( Transaction tx = database.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( database ).getAllNodes() )
+            for ( Node node : database.getAllNodes() )
             {
                 nodeCount++;
                 if ( node.getId() >= numberOfUnrelatedNodes )

--- a/community/server-examples/src/main/java/org/neo4j/examples/server/plugins/GetAll.java
+++ b/community/server-examples/src/main/java/org/neo4j/examples/server/plugins/GetAll.java
@@ -44,7 +44,7 @@ public class GetAll extends ServerPlugin
         ArrayList<Node> nodes = new ArrayList<>();
         try (Transaction tx = graphDb.beginTx())
         {
-            for ( Node node : GlobalGraphOperations.at( graphDb ).getAllNodes() )
+            for ( Node node : graphDb.getAllNodes() )
             {
                 nodes.add( node );
             }
@@ -60,7 +60,7 @@ public class GetAll extends ServerPlugin
         List<Relationship> rels = new ArrayList<>();
         try (Transaction tx = graphDb.beginTx())
         {
-            for ( Relationship rel : GlobalGraphOperations.at( graphDb ).getAllRelationships() )
+            for ( Relationship rel : graphDb.getAllRelationships() )
             {
                 rels.add( rel );
             }

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/CloneSubgraphPluginTest.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/CloneSubgraphPluginTest.java
@@ -45,7 +45,6 @@ import org.neo4j.server.rest.RestRequest;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.server.ExclusiveServerTestBase;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -192,8 +191,7 @@ public class CloneSubgraphPluginTest extends ExclusiveServerTestBase
         try ( Transaction tx = server.getDatabase().getGraph().beginTx() )
         {
             int count = 0;
-            for ( @SuppressWarnings("unused") Node node : GlobalGraphOperations.at( server.getDatabase().getGraph() )
-                                                                               .getAllNodes() )
+            for ( @SuppressWarnings("unused") Node node : server.getDatabase().getGraph().getAllNodes() )
             {
                 count++;
             }

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/NodeRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/NodeRepresentation.java
@@ -19,13 +19,12 @@
  */
 package org.neo4j.server.rest.repr;
 
+import java.util.Collection;
+
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.tooling.GlobalGraphOperations;
-
-import java.util.Collection;
 
 import static org.neo4j.helpers.collection.MapUtil.map;
 
@@ -163,7 +162,7 @@ public final class NodeRepresentation extends ObjectRepresentation implements Ex
         if ( writer.isInteractive() )
         {
             serializer.putList( "relationship_types", ListRepresentation.relationshipTypes(
-                    GlobalGraphOperations.at( node.getGraphDatabase() ).getAllRelationshipTypes() ) );
+                    node.getGraphDatabase().getRelationshipTypes() ) );
         }
         properties.done();
     }

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.server.rest.web;
 
-import com.sun.jersey.api.core.HttpContext;
-import org.apache.lucene.search.Sort;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import com.sun.jersey.api.core.HttpContext;
+import org.apache.lucene.search.Sort;
 
 import org.neo4j.function.Function;
 import org.neo4j.function.Predicate;
@@ -245,7 +245,7 @@ public class DatabaseActions
             {
                 return ValueRepresentation.string( key );
             }
-        }, GlobalGraphOperations.at( graphDb ).getAllPropertyKeys() ) );
+        }, graphDb.getAllPropertyKeys() ) );
 
         return new ListRepresentation( RepresentationType.STRING, propKeys );
     }
@@ -1457,8 +1457,7 @@ public class DatabaseActions
 
     public ListRepresentation getAllLabels( boolean inUse )
     {
-        GlobalGraphOperations operations = GlobalGraphOperations.at( graphDb );
-        ResourceIterable<Label> labels = inUse ? operations.getAllLabelsInUse() : operations.getAllLabels();
+        ResourceIterable<Label> labels = inUse ? graphDb.getAllLabelsInUse() : graphDb.getAllLabels();
         Collection<ValueRepresentation> labelNames = asSet( map( new Function<Label,ValueRepresentation>()
         {
             @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseMetadataService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseMetadataService.java
@@ -28,10 +28,10 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.rest.repr.RepresentationWriteHandler;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 @Path( "/relationship/types" )
 public class DatabaseMetadataService
@@ -50,10 +50,10 @@ public class DatabaseMetadataService
     {
         try
         {
-            GlobalGraphOperations operations = GlobalGraphOperations.at( database.getGraph() );
+            GraphDatabaseService db = database.getGraph();
             Iterable<RelationshipType> relationshipTypes = inUse
-                                                           ? operations.getAllRelationshipTypesInUse()
-                                                           : operations.getAllRelationshipTypes();
+                                                           ? db.getAllRelationshipTypesInUse()
+                                                           : db.getRelationshipTypes();
             return Response.ok()
                     .type( MediaType.APPLICATION_JSON )
                     .entity( generateJsonRepresentation( relationshipTypes ) )

--- a/community/server/src/test/java/org/dummy/web/service/DummyThirdPartyWebService.java
+++ b/community/server/src/test/java/org/dummy/web/service/DummyThirdPartyWebService.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.Response;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 @Path( "/" )
 public class DummyThirdPartyWebService
@@ -100,7 +99,7 @@ public class DummyThirdPartyWebService
     private int countNodesIn( GraphDatabaseService db )
     {
         int count = 0;
-        for ( @SuppressWarnings("unused") Node node : GlobalGraphOperations.at(db).getAllNodes() )
+        for ( @SuppressWarnings("unused") Node node : db.getAllNodes() )
         {
             count++;
         }

--- a/community/server/src/test/java/org/neo4j/server/NeoServerJAXRSDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerJAXRSDocIT.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.server;
 
+import java.net.URI;
+
 import org.dummy.web.service.DummyThirdPartyWebService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.net.URI;
 
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
@@ -37,7 +37,6 @@ import org.neo4j.server.helpers.UnitOfWork;
 import org.neo4j.server.rest.JaxRsResponse;
 import org.neo4j.server.rest.RestRequest;
 import org.neo4j.test.server.ExclusiveServerTestBase;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.server.helpers.FunctionalTestHelper.CLIENT;
@@ -111,9 +110,9 @@ public class NeoServerJAXRSDocIT extends ExclusiveServerTestBase
                     graph.createNode();
                 }
 
-                for ( Node n1 : GlobalGraphOperations.at(graph).getAllNodes() )
+                for ( Node n1 : graph.getAllNodes() )
                 {
-                    for ( Node n2 : GlobalGraphOperations.at(graph).getAllNodes() )
+                    for ( Node n2 : graph.getAllNodes() )
                     {
                         if ( n1.equals( n2 ) )
                         {

--- a/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
@@ -167,7 +167,7 @@ public class ServerHelper
 
         private void deleteAllNodesAndRelationships()
         {
-            Iterable<Node> allNodes = GlobalGraphOperations.at( db ).getAllNodes();
+            Iterable<Node> allNodes = db.getAllNodes();
             for ( Node n : allNodes )
             {
                 Iterable<Relationship> relationships = n.getRelationships();

--- a/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
@@ -769,7 +769,7 @@ public class BatchOperationDocIT extends AbstractRestFunctionalTestBase
         try ( Transaction tx = graphdb().beginTx() )
         {
             int count = 0;
-            for(Node node : GlobalGraphOperations.at(graphdb()).getAllNodes())
+            for(Node node : graphdb().getAllNodes())
             {
                 count++;
             }

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationDocIT.java
@@ -644,7 +644,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
     {
         try ( Transaction transaction = graphdb().beginTx() )
         {
-            return IteratorUtil.count( (Iterable) GlobalGraphOperations.at(graphdb()).getAllNodes() );
+            return IteratorUtil.count( (Iterable) graphdb().getAllNodes() );
         }
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
@@ -876,7 +876,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         try ( Transaction transaction = graphdb().beginTx() )
         {
             long count = 0;
-            for ( Node node : GlobalGraphOperations.at( graphdb() ).getAllNodes() )
+            for ( Node node : graphdb().getAllNodes() )
             {
                 Set<Label> nodeLabels = IteratorUtil.asSet( node.getLabels() );
                 if ( nodeLabels.containsAll( givenLabels ) )

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
@@ -29,6 +29,7 @@ import org.codehaus.jackson.JsonNode;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -36,11 +37,11 @@ import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.repr.util.RFC1123;
 import org.neo4j.test.server.HTTP;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
 
 /**
@@ -142,7 +143,7 @@ public class TransactionMatchers
         try ( Transaction ignore = graphdb.beginTx() )
         {
             long count = 0;
-            Iterator<Node> allNodes = GlobalGraphOperations.at( graphdb ).getAllNodes().iterator();
+            Iterator<Node> allNodes = graphdb.getAllNodes().iterator();
             while ( allNodes.hasNext() )
             {
                 allNodes.next();

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
@@ -744,7 +744,7 @@ public abstract class TransactionProvidingApp extends AbstractApp
             boolean looseFilters ) throws ShellException
     {
         Map<String, Direction> matches = new TreeMap<String, Direction>();
-        for ( RelationshipType type : GlobalGraphOperations.at( db ).getAllRelationshipTypes() )
+        for ( RelationshipType type : db.getRelationshipTypes() )
         {
             Direction direction = null;
             if ( filterMap == null || filterMap.isEmpty() )

--- a/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.shell;
 
-import org.junit.Test;
-
 import java.io.PrintWriter;
+
+import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Relationship;
@@ -33,7 +33,6 @@ import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.RemoteClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.System.lineSeparator;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -263,11 +262,10 @@ public class ShellDocTest
 
         try (Transaction tx = db.beginTx())
         {
-            assertEquals( 7, Iterables.count( GlobalGraphOperations.at( db ).getAllRelationships() ) );
-            assertEquals( 7, Iterables.count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+            assertEquals( 7, Iterables.count( db.getAllRelationships() ) );
+            assertEquals( 7, Iterables.count( db.getAllNodes() ) );
             boolean foundRootAndNeoRelationship = false;
-            for ( Relationship relationship : GlobalGraphOperations.at( db )
-                    .getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 if ( relationship.getType().name().equals( "ROOT" ) )
                 {

--- a/community/shell/src/test/java/org/neo4j/shell/TransactionSoakIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TransactionSoakIT.java
@@ -29,13 +29,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.SameJvmClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.helpers.collection.Iterables.count;
@@ -96,7 +96,7 @@ public class TransactionSoakIT
 
         try ( Transaction tx = db.beginTx() )
         {
-            long relationshipCount = count( GlobalGraphOperations.at( db ).getAllRelationships() );
+            long relationshipCount = count( db.getAllRelationships() );
             int expected = committerCount( testers );
     
             assertEquals( expected, relationshipCount );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/RebuildFromLogsTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/RebuildFromLogsTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.backup;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,6 +26,11 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -43,7 +43,6 @@ import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
@@ -160,7 +159,7 @@ public class RebuildFromLogsTest
                     @Override
                     void applyTx( GraphDatabaseService graphDb )
                     {
-                        for ( Node node : GlobalGraphOperations.at( graphDb ).getAllNodes() )
+                        for ( Node node : graphDb.getAllNodes() )
                         {
                             if ( "value".equals( node.getProperty( CREATE_NODE_WITH_PROPERTY.name(), null ) ) )
                             {
@@ -182,7 +181,7 @@ public class RebuildFromLogsTest
 
         private static Node firstNode( GraphDatabaseService graphDb )
         {
-            return Iterables.first( GlobalGraphOperations.at( graphDb ).getAllNodes() );
+            return Iterables.first( graphDb.getAllNodes() );
         }
 
         private final Transaction[] dependencies;

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.com.storecopy;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
@@ -36,7 +36,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.helpers.Service;
-import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
@@ -55,7 +55,6 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNotNull;
@@ -127,12 +126,10 @@ public class StoreCopyClientTest
 
         try ( Transaction tx = copy.beginTx() )
         {
-            GlobalGraphOperations globalOps = GlobalGraphOperations.at( copy );
-
-            long nodesCount = Iterables.count( globalOps.getAllNodesWithLabel( label( "BeforeCopyBegins" ) ) );
+            long nodesCount = IteratorUtil.count( copy.findNodes( label( "BeforeCopyBegins" ) ) );
             assertThat( nodesCount, equalTo( 1l ) );
 
-            assertThat( Iterables.single( globalOps.getAllNodesWithLabel( label( "BeforeCopyBegins" ) ) ).getId(),
+            assertThat( IteratorUtil.single( copy.findNodes( label( "BeforeCopyBegins" ) ) ).getId(),
                     equalTo( 0l ) );
 
             tx.success();
@@ -198,9 +195,7 @@ public class StoreCopyClientTest
 
         try ( Transaction tx = copy.beginTx() )
         {
-            GlobalGraphOperations globalOps = GlobalGraphOperations.at( copy );
-
-            long nodesCount = Iterables.count( globalOps.getAllNodesWithLabel( label( "BeforeCopyBegins" ) ) );
+            long nodesCount = IteratorUtil.count( copy.findNodes( label( "BeforeCopyBegins" ) ) );
             assertThat( nodesCount, equalTo( 0l ) );
 
             tx.success();

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ForeignStoreIdIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ForeignStoreIdIT.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.ha;
 
+import java.io.File;
+
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.io.File;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -31,7 +31,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -132,7 +131,7 @@ public class ForeignStoreIdIT
     {
         try ( Transaction transaction = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
                 if ( name.equals( node.getProperty( "name", null ) ) )
                     return node.getId();
             fail( "Didn't find node '" + name + "' in " + db );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.ha;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -49,7 +49,6 @@ import org.neo4j.kernel.lifecycle.LifeRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertFalse;
@@ -227,7 +226,7 @@ public class TestBranchedData
     {
         try ( Transaction tx = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 if ( nodeName.equals( node.getProperty( "name", null ) ) )
                 {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.kernel.api;
 
+import java.io.File;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-
-import java.io.File;
 
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -50,7 +50,6 @@ import org.neo4j.kernel.impl.coreapi.schema.RelationshipPropertyExistenceConstra
 import org.neo4j.kernel.impl.coreapi.schema.UniquenessConstraintDefinition;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterRule;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -58,7 +57,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.collection.Iterables.count;
@@ -157,7 +155,7 @@ public class ConstraintHaIT
         {
             try ( Transaction tx = db.beginTx() )
             {
-                for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+                for ( Relationship relationship : db.getAllRelationships() )
                 {
                     if ( relationship.isType( withName( type ) ) )
                     {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
@@ -33,10 +33,8 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.TransactionTemplate;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterRule;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 import static org.neo4j.kernel.configuration.Config.parseLongWithUnit;
 
@@ -115,7 +113,7 @@ public class BiggerThanLogTxIT
     {
         try ( Transaction tx = db.beginTx() )
         {
-            int count = count( GlobalGraphOperations.at( db ).getAllNodes() );
+            int count = count( db.getAllNodes() );
             tx.success();
             return count;
         }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.kernel.ha;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
@@ -58,13 +58,10 @@ import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.test.CleanupRule;
 import org.neo4j.test.RepeatRule;
 import org.neo4j.test.ha.ClusterRule;
-import org.neo4j.tooling.GlobalGraphOperations;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.neo4j.cluster.protocol.cluster.ClusterConfiguration.COORDINATOR;
 import static org.neo4j.function.Predicates.not;
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
@@ -253,7 +250,7 @@ public class ClusterTopologyChangesIT
     {
         try ( Transaction ignored = db.beginTx() )
         {
-            return Iterables.count( GlobalGraphOperations.at( db ).getAllNodes() );
+            return Iterables.count( db.getAllNodes() );
         }
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HardKillIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HardKillIT.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.kernel.ha;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.client.ClusterClient;
@@ -43,7 +43,6 @@ import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
 import org.neo4j.test.ProcessStreamHandler;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
@@ -138,7 +137,7 @@ public class HardKillIT
     {
         try ( Transaction transaction = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 if ( name.equals( node.getProperty( "name", null ) ) )
                 {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.kernel.ha;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -32,6 +26,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.neo4j.com.ComException;
 import org.neo4j.graphdb.ConstraintViolationException;
@@ -49,14 +49,11 @@ import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.OtherThreadRule;
 import org.neo4j.test.RepeatRule;
 import org.neo4j.test.ha.ClusterRule;
-import org.neo4j.tooling.GlobalGraphOperations;
 
+import static java.lang.String.format;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
-
-import static java.lang.String.format;
-
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.collection.IteratorUtil.loop;
@@ -539,7 +536,7 @@ public class PropertyConstraintsStressIT
         {
             try ( Transaction tx = db.beginTx() )
             {
-                for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+                for ( Relationship relationship : db.getAllRelationships() )
                 {
                     if ( relationship.getType().name().equals( type ) )
                     {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlavesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlavesIT.java
@@ -29,11 +29,9 @@ import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.ha.HaSettings.tx_push_factor;
 import static org.neo4j.kernel.impl.ha.ClusterManager.clusterOfSize;
@@ -74,7 +72,7 @@ public class HighAvailabilitySlavesIT
 
     private long getNodeByName( HighlyAvailableGraphDatabase db, String name )
     {
-        for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+        for ( Node node : db.getAllNodes() )
             if ( name.equals( node.getProperty( "name", null ) ) )
                 return node.getId();
         fail( "No node '" + name + "' found in " + db );

--- a/enterprise/ha/src/test/java/slavetest/TestInstanceJoin.java
+++ b/enterprise/ha/src/test/java/slavetest/TestInstanceJoin.java
@@ -19,11 +19,11 @@
  */
 package slavetest;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.Node;
@@ -35,7 +35,6 @@ import org.neo4j.kernel.ha.UpdatePuller;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
@@ -140,7 +139,7 @@ public class TestInstanceJoin
         try ( Transaction tx = slave.beginTx() )
         {
             int count = 0;
-            for ( Node node : GlobalGraphOperations.at( slave ).getAllNodes() )
+            for ( Node node : slave.getAllNodes() )
             {
                 if ( value.equals( node.getProperty( key, null ) ) )
                 {

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
@@ -26,7 +26,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
@@ -76,7 +75,7 @@ public class RelationshipPropertyExistenceConstraintCreationIT
     @Override
     void removeOffendingDataInRunningTx( GraphDatabaseService db )
     {
-        Iterable<Relationship> relationships = GlobalGraphOperations.at( db ).getAllRelationships();
+        Iterable<Relationship> relationships = db.getAllRelationships();
         for ( Relationship relationship : relationships )
         {
             relationship.delete();

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom19IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom19IT.java
@@ -19,16 +19,16 @@
  */
 package upgrade;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -60,24 +60,21 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
+import static java.lang.Integer.MAX_VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.kernel.impl.store.StoreFactory.SF_CREATE;
-import static upgrade.StoreMigratorTestUtil.buildClusterWithMasterDirIn;
-
-import static java.lang.Integer.MAX_VALUE;
-
 import static org.neo4j.consistency.store.StoreAssertions.assertConsistentStore;
 import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
 import static org.neo4j.graphdb.Neo4jMatchers.inTx;
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.kernel.impl.store.CommonAbstractStore.ALL_STORES_VERSION;
+import static org.neo4j.kernel.impl.store.StoreFactory.SF_CREATE;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.find19FormatHugeStoreDirectory;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.find19FormatStoreDirectory;
 import static org.neo4j.kernel.impl.storemigration.UpgradeConfiguration.ALLOW_UPGRADE;
+import static upgrade.StoreMigratorTestUtil.buildClusterWithMasterDirIn;
 
 public class StoreMigratorFrom19IT
 {
@@ -227,7 +224,7 @@ public class StoreMigratorFrom19IT
     {
         try ( Transaction tx = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 if ( name.equals( node.getProperty( "name", null ) ) )
                 {

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/test/server/ha/EnterpriseServerHelper.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/test/server/ha/EnterpriseServerHelper.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.test.server.ha;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
-
 import java.io.File;
 import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -32,7 +32,6 @@ import org.neo4j.server.enterprise.EnterpriseNeoServer;
 import org.neo4j.server.enterprise.helpers.EnterpriseServerBuilder;
 import org.neo4j.server.helpers.Transactor;
 import org.neo4j.server.helpers.UnitOfWork;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public class EnterpriseServerHelper
 {
@@ -56,7 +55,7 @@ public class EnterpriseServerHelper
 
             private void deleteAllNodesAndRelationships( final EnterpriseNeoServer server )
             {
-                Iterable<Node> allNodes = GlobalGraphOperations.at( server.getDatabase().getGraph() ).getAllNodes();
+                Iterable<Node> allNodes = server.getDatabase().getGraph().getAllNodes();
                 for ( Node n : allNodes )
                 {
                     Iterable<Relationship> relationships = n.getRelationships();

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.storeupgrade;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.FilenameFilter;
@@ -37,6 +31,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -72,7 +72,6 @@ import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.database.Database;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -443,7 +442,7 @@ public class StoreUpgradeIntegrationTest
         try ( Transaction ignored = db.beginTx() )
         {
             HashMap<Label,Long> counts = new HashMap<>();
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 for ( Label label : node.getLabels() )
                 {
@@ -491,7 +490,7 @@ public class StoreUpgradeIntegrationTest
         try ( Transaction ignored = db.beginTx() )
         {
             // count nodes
-            long nodeCount = count( GlobalGraphOperations.at( db ).getAllNodes() );
+            long nodeCount = count( db.getAllNodes() );
             assertThat( nodeCount, is( store.expectedNodeCount ) );
 
             // count indexes

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ArticleTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ArticleTest.scala
@@ -236,7 +236,7 @@ abstract class ArticleTest extends Assertions with DocumentationHelper {
         case (name, node) => name -> node.getId
       }.toMap
 
-      GlobalGraphOperations.at(db).getAllNodes.asScala.foreach((n) => {
+      db.getAllNodes.asScala.foreach((n) => {
         indexProperties(n, nodeIndex)
         n.getRelationships(Direction.OUTGOING).asScala.foreach(indexProperties(_, relIndex))
       })

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -468,7 +468,7 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
 
       setupQueries.foreach(engine.execute)
 
-      GlobalGraphOperations.at(db).getAllNodes.asScala.foreach((n) => {
+      db.getAllNodes.asScala.foreach((n) => {
         indexProperties(n, nodeIndex)
         n.getRelationships(Direction.OUTGOING).asScala.foreach(indexProperties(_, relIndex))
       })

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -23,8 +23,6 @@ import org.hamcrest.CoreMatchers._
 import org.junit.Assert._
 import org.junit.Test
 import org.neo4j.graphdb._
-import org.neo4j.kernel.GraphDatabaseAPI
-import org.neo4j.tooling.GlobalGraphOperations
 import org.neo4j.visualization.graphviz.{AsciiDocSimpleStyle, GraphStyle}
 
 import scala.collection.JavaConverters._
@@ -112,7 +110,7 @@ This is not recommended practice. See <<match-node-by-id>> for more information 
       queryText = """match (n) return n""",
       optionalResultExplanation = "Returns all the nodes in the database.",
       assertions = (p) => {
-        val allNodes: List[Node] = GlobalGraphOperations.at(db).getAllNodes.asScala.toList
+        val allNodes: List[Node] = db.getAllNodes.asScala.toList
 
         assertEquals(allNodes, p.columnAs[Node]("n").toList)
       }
@@ -126,7 +124,7 @@ This is not recommended practice. See <<match-node-by-id>> for more information 
       queryText = """match (a), (b) where id(a) = id(b) return a, b""",
       optionalResultExplanation = "Returns the combinations of the two nodes from the database.",
       assertions = (p) => {
-        val allNodes: List[Node] = GlobalGraphOperations.at(db).getAllNodes.asScala.toList
+        val allNodes: List[Node] = db.getAllNodes.asScala.toList
 
         assertEquals(allNodes, p.columnAs[Node]("a").toList)
       }


### PR DESCRIPTION
The GlobalGraphOperations class was a bad idea. This Change moves those operations back to GraphDatabaseService.
