### PR TITLE
Ensures console ERROR messages gets logged to the console

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/logging/ConsoleLogger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/logging/ConsoleLogger.java
@@ -94,7 +94,7 @@ public class ConsoleLogger
      */
     public void error( String message )
     {
-        realLogger.error( message );
+        realLogger.error( message, null, true, CONSOLE_MARK );
     }
 
     /**

--- a/community/kernel/src/test/java/org/neo4j/kernel/logging/ConsoleLoggerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/logging/ConsoleLoggerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.logging;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.util.StringLogger;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.kernel.logging.LogMarker.CONSOLE_MARK;
+
+public class ConsoleLoggerTest
+{
+    @Test
+    public void shouldAddConsoleMarkToInfo() throws Exception
+    {
+        // GIVEN
+        StringLogger realLogger = mock( StringLogger.class );
+        ConsoleLogger logger = new ConsoleLogger( realLogger );
+
+        // WHEN
+        logger.log( "A1" );
+        logger.log( "A%d", 2 );
+
+        // THEN
+        verify( realLogger ).info( eq( "A1" ), any( Throwable.class ), anyBoolean(), eq( CONSOLE_MARK ) );
+        verify( realLogger ).info( eq( "A2" ), any( Throwable.class ), anyBoolean(), eq( CONSOLE_MARK ) );
+    }
+
+    @Test
+    public void shouldAddConsoleMarkToWarn() throws Exception
+    {
+        // GIVEN
+        StringLogger realLogger = mock( StringLogger.class );
+        ConsoleLogger logger = new ConsoleLogger( realLogger );
+        Exception cause = new RuntimeException( "cause" );
+
+        // WHEN
+        logger.warn( "A1" );
+        logger.warn( "A%d", 2 );
+        logger.warn( "A3", cause );
+
+        // THEN
+        verify( realLogger ).warn( eq( "A1" ), any( Throwable.class ), anyBoolean(), eq( CONSOLE_MARK ) );
+        verify( realLogger ).warn( eq( "A2" ), any( Throwable.class ), anyBoolean(), eq( CONSOLE_MARK ) );
+        verify( realLogger ).warn( eq( "A3" ), eq( cause ), anyBoolean(), eq( CONSOLE_MARK ) );
+    }
+
+    @Test
+    public void shouldAddConsoleMarkToError() throws Exception
+    {
+        // GIVEN
+        StringLogger realLogger = mock( StringLogger.class );
+        ConsoleLogger logger = new ConsoleLogger( realLogger );
+        Exception cause = new RuntimeException( "cause" );
+
+        // WHEN
+        logger.error( "A1" );
+        logger.error( "A%d", 2 );
+        logger.error( "A3", cause );
+
+        // THEN
+        verify( realLogger ).error( eq( "A1" ), any( Throwable.class ), anyBoolean(), eq( CONSOLE_MARK ) );
+        verify( realLogger ).error( eq( "A2" ), any( Throwable.class ), anyBoolean(), eq( CONSOLE_MARK ) );
+        verify( realLogger ).error( eq( "A3" ), eq( cause ), anyBoolean(), eq( CONSOLE_MARK ) );
+    }
+}

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/custom-logback.xml
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/custom-logback.xml
@@ -33,7 +33,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.neo4j" level="all">
+  <logger name="org.neo4j">
     <appender-ref ref="CONSOLE"/>
   </logger>
 

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/custom-logback.xml
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/custom-logback.xml
@@ -33,7 +33,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.neo4j" level="all">
+  <logger name="org.neo4j">
     <appender-ref ref="CONSOLE"/>
   </logger>
 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/custom-logback.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/custom-logback.xml
@@ -48,7 +48,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.neo4j" level="all">
+  <logger name="org.neo4j">
     <appender-ref ref="CONSOLE"/>
   </logger>
 


### PR DESCRIPTION
Problem was that a CONSOLE_MARK was missing in the error log method call
which made error messages not end up int the console.

This commit also reverts commit 0bd00980404864021c09f2de9d391c40a884e0c4
which tried to fix this problem earlier, but ended up setting the default
log level for everything to DEBUG instead.
