### PR TITLE
Awaits uniqueness constraint indexes to fully populate during recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -35,7 +35,7 @@ import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.BiConsumer;
-import org.neo4j.helpers.Pair;
+import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
@@ -70,6 +70,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.Iterables.concatResourceIterators;
 import static org.neo4j.helpers.collection.Iterables.toList;
+import static org.neo4j.kernel.api.index.InternalIndexState.FAILED;
 import static org.neo4j.kernel.impl.api.index.IndexPopulationFailure.failure;
 
 /**
@@ -117,6 +118,8 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
         void populationCompleteOn( IndexDescriptor descriptor );
 
         void verifyDeferredConstraints();
+
+        void awaitingPopulationOfRecoveredIndex( long indexId, IndexDescriptor descriptor );
     }
 
     public static abstract class MonitorAdapter implements Monitor
@@ -138,8 +141,12 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
 
         @Override
         public void verifyDeferredConstraints()
-        {
-            // Do nothing
+        {   // Do nothing
+        }
+
+        @Override
+        public void awaitingPopulationOfRecoveredIndex( long indexId, IndexDescriptor descriptor )
+        {   // Do nothing
         }
     }
 
@@ -246,14 +253,14 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
 
     // Recovery semantics: This is to be called after init, and after the database has run recovery.
     @Override
-    public void start() throws IOException
+    public void start() throws Exception
     {
         state = State.STARTING;
 
         applyRecoveredUpdates();
         IndexMap indexMap = indexMapRef.indexMapSnapshot();
 
-        final Map<Long, Pair<IndexDescriptor, SchemaIndexProvider.Descriptor>> rebuildingDescriptors = new HashMap<>();
+        final Map<Long,RebuildingIndexDescriptor> rebuildingDescriptors = new HashMap<>();
 
         // Find all indexes that are not already online, do not require rebuilding, and create them
         indexMap.foreachIndexProxy( new BiConsumer<Long, IndexProxy>()
@@ -271,7 +278,8 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
                         break;
                     case POPULATING:
                         // Remember for rebuilding
-                        rebuildingDescriptors.put( indexId, Pair.of( descriptor, proxy.getProviderDescriptor() ) );
+                        rebuildingDescriptors.put( indexId, new RebuildingIndexDescriptor(
+                                descriptor, proxy.getProviderDescriptor(), proxy.config() ) );
                         break;
                     case FAILED:
                         // Don't do anything, the user needs to drop the index and re-create
@@ -281,15 +289,13 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
         } );
 
         // Drop placeholder proxies for indexes that need to be rebuilt
-        dropRecoveringIndexes( indexMap, rebuildingDescriptors );
+        dropRecoveringIndexes( indexMap, rebuildingDescriptors.keySet() );
 
         // Rebuild indexes by recreating and repopulating them
-        for ( Map.Entry<Long, Pair<IndexDescriptor, SchemaIndexProvider.Descriptor>> entry : rebuildingDescriptors.entrySet() )
+        for ( Map.Entry<Long,RebuildingIndexDescriptor> entry : rebuildingDescriptors.entrySet() )
         {
             long indexId = entry.getKey();
-            Pair<IndexDescriptor, SchemaIndexProvider.Descriptor> descriptors = entry.getValue();
-            IndexDescriptor indexDescriptor = descriptors.first();
-            SchemaIndexProvider.Descriptor providerDescriptor = descriptors.other();
+            RebuildingIndexDescriptor descriptors = entry.getValue();
 
             /*
              * Passing in "false" for unique here may seem surprising, and.. well, yes, it is, I was surprised too.
@@ -298,7 +304,7 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
              * they will get dropped as soon as recovery is completed by the constraint system.
              */
             IndexProxy proxy = proxySetup.createPopulatingIndexProxy(
-                    indexId, indexDescriptor, providerDescriptor, false, monitor );
+                    indexId, descriptors.getIndexDescriptor(), descriptors.getProviderDescriptor(), false, monitor );
             proxy.start();
             indexMap.putIndexProxy( indexId, proxy );
         }
@@ -308,7 +314,57 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
         samplingController.recoverIndexSamples();
         samplingController.start();
 
+        // So at this point we've started population of indexes that needs to be rebuilt in the background.
+        // Indexes backing uniqueness constraints are normally built within the transaction creating the constraint
+        // and so we shouldn't leave such indexes in a populating state after recovery.
+        // This is why we now go and wait for those indexes to be fully populated.
+        for ( Map.Entry<Long,RebuildingIndexDescriptor> entry : rebuildingDescriptors.entrySet() )
+        {
+            if ( !entry.getValue().getConfiguration().isUnique() )
+            {
+                // It's not a uniqueness constraint, so don't wait for it to be rebuilt
+                continue;
+            }
+
+            IndexProxy proxy;
+            try
+            {
+                proxy = getIndexProxy( entry.getKey().longValue() );
+            }
+            catch ( IndexNotFoundKernelException e )
+            {
+                throw new ThisShouldNotHappenError( "Mattias",
+                        "What? This index was seen during recovery just now, why isn't it available now?" );
+            }
+
+            monitor.awaitingPopulationOfRecoveredIndex( entry.getKey(), entry.getValue().getIndexDescriptor() );
+            awaitOnline( proxy );
+        }
+
         state = State.RUNNING;
+    }
+
+    /**
+     * Polls the {@link IndexProxy#getState() state of the index} and waits for it to be either
+     * {@link InternalIndexState#ONLINE}, in which case the wait is over, or {@link InternalIndexState#FAILED},
+     * in which an exception is thrown.
+     */
+    private void awaitOnline( IndexProxy proxy ) throws InterruptedException
+    {
+        while ( true )
+        {
+            switch ( proxy.getState() )
+            {
+            case ONLINE: return;
+            case FAILED: throw new IllegalStateException( "Index entered " + FAILED +
+                    " state while recovery waited for it to be fully populated" );
+            case POPULATING:
+                // Sleep a short while and look at state again the next loop iteration
+                Thread.sleep( 10 );
+                break;
+            default: throw new IllegalStateException( proxy.getState().name() );
+            }
+        }
     }
 
     @Override
@@ -701,11 +757,10 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
         }
     }
 
-    private void dropRecoveringIndexes(
-        IndexMap indexMap, Map<Long, Pair<IndexDescriptor,SchemaIndexProvider.Descriptor>> recoveringIndexes )
+    private void dropRecoveringIndexes( IndexMap indexMap, Iterable<Long> indexesToRebuild )
             throws IOException
     {
-        for ( long indexId : recoveringIndexes.keySet() )
+        for ( long indexId : indexesToRebuild )
         {
             IndexProxy indexProxy = indexMap.removeIndexProxy( indexId );
             indexProxy.drop();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RebuildingIndexDescriptor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RebuildingIndexDescriptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.neo4j.kernel.api.index.IndexConfiguration;
+import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.index.SchemaIndexProvider.Descriptor;
+
+/**
+ * Small class for holding a bunch of information about an index that we need to rebuild during recovery.
+ */
+public class RebuildingIndexDescriptor
+{
+    private final IndexDescriptor indexDescriptor;
+    private final Descriptor providerDescriptor;
+    private final IndexConfiguration configuration;
+
+    RebuildingIndexDescriptor( IndexDescriptor indexDescriptor, SchemaIndexProvider.Descriptor providerDescriptor,
+            IndexConfiguration configuration )
+    {
+        this.indexDescriptor = indexDescriptor;
+        this.providerDescriptor = providerDescriptor;
+        this.configuration = configuration;
+    }
+
+    public IndexDescriptor getIndexDescriptor()
+    {
+        return indexDescriptor;
+    }
+
+    public Descriptor getProviderDescriptor()
+    {
+        return providerDescriptor;
+    }
+
+    public IndexConfiguration getConfiguration()
+    {
+        return configuration;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
@@ -43,19 +43,19 @@ import org.neo4j.kernel.api.index.NodePropertyUpdate;
  * <ol>
  * <li>Begin a transaction T, which will be the "parent" transaction in this process</li>
  * <li>Execute a mini transaction Tt which will create the index rule to start the index population</li>
- * <li>Sit and wait for the index to be built</li>
- * <li>Execute yet another mini transaction Tu which will create the constraint rule and connect the two</li>
+ * <li>In T: Sit and wait for the index to be built</li>
+ * <li>In T: Create the constraint rule and connect the two</li>
  * </ol>
  *
  * The fully populated index flips to a tentative index. The reason for that is to guard for incoming transactions
  * that gets applied.
  * Such incoming transactions have potentially been verified on another instance with a slightly dated view
- * of the schema and has furthermore made it through some additional checks on this instance since the constraint
- * transaction Tu hasn't yet committed. Transaction data gets applied to the neo store first and the index second, so at
+ * of the schema and has furthermore made it through some additional checks on this instance since transaction T
+ * hasn't yet fully committed. Transaction data gets applied to the neo store first and the index second, so at
  * the point where the applying transaction sees that it violates the constraint it has already modified the store and
- * cannot back out. However the constraint transaction T (and specifically Tu) can. So a violated constraint while
+ * cannot back out. However the constraint transaction T can. So a violated constraint while
  * in tentative mode does not fail the transaction violating the constraint, but keeps the failure around and will
- * eventually fail Tu, and in extension T.
+ * eventually fail T instead.
  */
 public class TentativeConstraintIndexProxy extends AbstractDelegatingIndexProxy
 {


### PR DESCRIPTION
before returning from the GDS constructor. Previous there was this
mismatch where a newly created uniqueness constraint, after a crash, would
have to be rebuilt from scratch. This is done after the store has
recovered, so that's fine. However the usualt semantics of creating a
uniqneness constraint is that the transaction creating it waits for it to
be fully populated before returning. This added waiting mimics that
behaviour for recovery. Without it recovery could be considered completed
while uniquness constraint indexes were still being populated in the
background.
