### PR TITLE
Release transaction state on close()

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/LegacyIndexTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/LegacyIndexTransactionState.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.impl.transaction.state.RecordState;
  */
 public interface LegacyIndexTransactionState extends RecordState
 {
-    void initialize();
+    void clear();
 
     LegacyIndex nodeChanges( String indexName ) throws LegacyIndexNotFoundKernelException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingLegacyIndexTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingLegacyIndexTransactionState.java
@@ -42,9 +42,9 @@ class CachingLegacyIndexTransactionState implements LegacyIndexTransactionState
     }
 
     @Override
-    public void initialize()
+    public void clear()
     {
-        txState.initialize();
+        txState.clear();
         if ( nodeLegacyIndexChanges != null && !nodeLegacyIndexChanges.isEmpty() )
         {
             nodeLegacyIndexChanges.clear();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
@@ -147,7 +147,7 @@ public class CountsRecordState implements CountsAccessor, RecordState, CountsAcc
     /**
      * Set this counter up to a pristine state, as if it had just been initialized.
      */
-    public void initialize()
+    public void clear()
     {
         if ( !counts.isEmpty() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -210,17 +210,12 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         assert locks != null : "This transaction has been disposed off, it should not be used.";
         this.terminated = closing = closed = failure = success = false;
         this.transactionType = TransactionType.ANY;
-        this.hooksState = null;
         this.beforeHookInvoked = false;
-        this.txState = null; // TODO: Implement txState.clear() instead, to re-use data structures
-        this.legacyIndexTransactionState.initialize();
         this.recordState.initialize( lastCommittedTx );
-        this.counts.initialize();
         this.startTimeMillis = clock.currentTimeMillis();
         this.lastTransactionIdWhenStarted = lastCommittedTx;
         this.transactionEvent = tracer.beginTransaction();
         assert transactionEvent != null: "transactionEvent was null!";
-        this.closeListener = null;
         return this;
     }
 
@@ -442,6 +437,12 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                 transactionEvent.setReadOnly( txState == null || !txState.hasChanges() );
                 transactionEvent.close();
                 transactionEvent = null;
+                legacyIndexTransactionState.clear();
+                recordState.clear();
+                counts.clear();
+                txState = null;
+                hooksState = null;
+                closeListener = null;
             }
             finally
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionStateImpl.java
@@ -244,7 +244,7 @@ public class LegacyIndexTransactionStateImpl implements LegacyIndexTransactionSt
 
     /** Set this data structure to it's initial state, allowing it to be re-used as if it had just been new'ed up. */
     @Override
-    public void initialize()
+    public void clear()
     {
         if ( !transactions.isEmpty() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionContext.java
@@ -141,7 +141,7 @@ public class NeoStoreTransactionContext
         locker.setLockClient( locksClient );
     }
 
-    public void initialize()
+    public void clear()
     {
         recordChangeSet.close();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -104,8 +104,12 @@ public class TransactionRecordState implements RecordState
     public void initialize( long lastCommittedTxWhenTransactionStarted )
     {
         this.lastCommittedTxWhenTransactionStarted = lastCommittedTxWhenTransactionStarted;
-        context.initialize();
         prepared = false;
+    }
+
+    public void clear()
+    {
+        context.clear();
     }
 
     @Override


### PR DESCRIPTION
If we are to pool KernelTransaction objects, we should clear the state of it as early as possible (in the close method), rather than just before we reuse it. Otherwise we run the risk of unnecessarily tenuring the objects that we then clear away, with negative effects on garbage collection performance.
