### PR TITLE
Move Bolt dependencies from `lib` to `system/lib`.

### DIFF
--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-unix-dist.xml
@@ -121,6 +121,8 @@
         <exclude>*:pom:*</exclude>
         <exclude>org.neo4j:neo4j-advanced:jar</exclude>
         <exclude>org.neo4j:neo4j</exclude>
+        <!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+        <exclude>org.neo4j:neo4j-bolt*</exclude>
       </excludes>
     </dependencySet>
     <dependencySet>
@@ -143,6 +145,17 @@
         <exclude>net.sf.opencsv:opencsv</exclude>
         <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
+    </dependencySet>
+    <dependencySet><!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+      <outputDirectory>system/lib</outputDirectory>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0755</fileMode>
+      <unpack>false</unpack>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useStrictFiltering>true</useStrictFiltering>
+      <includes>
+        <include>org.neo4j:neo4j-bolt*</include>
+      </includes>
     </dependencySet>
  </dependencySets>
 

--- a/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-windows-dist.xml
+++ b/packaging/standalone/standalone-advanced/src/main/assemblies/advanced-windows-dist.xml
@@ -110,6 +110,8 @@
         <exclude>*:pom:*</exclude>
         <exclude>org.neo4j:neo4j-advanced:jar</exclude>
         <exclude>org.neo4j:neo4j</exclude>
+        <!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+        <exclude>org.neo4j:neo4j-bolt*</exclude>
       </excludes>
     </dependencySet>
     <dependencySet>
@@ -130,6 +132,17 @@
         <exclude>net.sf.opencsv:opencsv</exclude>
         <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
+    </dependencySet>
+    <dependencySet><!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+      <outputDirectory>system/lib</outputDirectory>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0755</fileMode>
+      <unpack>false</unpack>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useStrictFiltering>true</useStrictFiltering>
+      <includes>
+        <include>org.neo4j:neo4j-bolt*</include>
+      </includes>
     </dependencySet>
   </dependencySets>
 </assembly>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -107,6 +107,8 @@
       <excludes>
         <exclude>*:pom:*</exclude>
         <exclude>org.neo4j:neo4j:jar</exclude>
+        <!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+        <exclude>org.neo4j:neo4j-bolt*</exclude>
       </excludes>
     </dependencySet>
     <dependencySet>
@@ -129,6 +131,17 @@
         <exclude>net.sf.opencsv:opencsv</exclude>
         <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
+    </dependencySet>
+    <dependencySet><!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+      <outputDirectory>system/lib</outputDirectory>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0755</fileMode>
+      <unpack>false</unpack>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useStrictFiltering>true</useStrictFiltering>
+      <includes>
+        <include>org.neo4j:neo4j-bolt*</include>
+      </includes>
     </dependencySet>
  </dependencySets>
 

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
@@ -108,6 +108,8 @@
       <excludes>
         <exclude>*:pom:*</exclude>
         <exclude>org.neo4j:neo4j:jar</exclude>
+        <!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+        <exclude>org.neo4j:neo4j-bolt*</exclude>
       </excludes>
     </dependencySet>
     <dependencySet>
@@ -128,6 +130,17 @@
         <exclude>net.sf.opencsv:opencsv</exclude>
         <exclude>org.apache.commons:commons-lang3</exclude>
       </excludes>
+    </dependencySet>
+    <dependencySet><!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+      <outputDirectory>system/lib</outputDirectory>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0755</fileMode>
+      <unpack>false</unpack>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useStrictFiltering>true</useStrictFiltering>
+      <includes>
+        <include>org.neo4j:neo4j-bolt*</include>
+      </includes>
     </dependencySet>
   </dependencySets>
 

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
@@ -122,6 +122,8 @@
         <exclude>org.neo4j:neo4j-enterprise:jar</exclude>
         <exclude>org.neo4j:neo4j-advanced</exclude>
         <exclude>org.neo4j:neo4j</exclude>
+        <!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+        <exclude>org.neo4j:neo4j-bolt*</exclude>
       </excludes>
     </dependencySet>
     <dependencySet>
@@ -149,6 +151,17 @@
         <exclude>org.acplt:oncrpc</exclude>
         <exclude>org.slf4j:slf4j-api</exclude>
       </excludes>
+    </dependencySet>
+    <dependencySet><!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+      <outputDirectory>system/lib</outputDirectory>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0755</fileMode>
+      <unpack>false</unpack>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useStrictFiltering>true</useStrictFiltering>
+      <includes>
+        <include>org.neo4j:neo4j-bolt*</include>
+      </includes>
     </dependencySet>
  </dependencySets>
 

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
@@ -111,6 +111,8 @@
         <exclude>org.neo4j:neo4j-enterprise:jar</exclude>
         <exclude>org.neo4j:neo4j-advanced</exclude>
         <exclude>org.neo4j:neo4j</exclude>
+        <!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+        <exclude>org.neo4j:neo4j-bolt*</exclude>
       </excludes>
     </dependencySet>
     <dependencySet>
@@ -136,6 +138,17 @@
         <exclude>org.acplt:oncrpc</exclude>
         <exclude>org.slf4j:slf4j-api</exclude>
       </excludes>
+    </dependencySet>
+    <dependencySet><!-- Temporary move bolt to system/lib - to be removed entirely as a dependency in 2.3.1 -->
+      <outputDirectory>system/lib</outputDirectory>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0755</fileMode>
+      <unpack>false</unpack>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useStrictFiltering>true</useStrictFiltering>
+      <includes>
+        <include>org.neo4j:neo4j-bolt*</include>
+      </includes>
     </dependencySet>
   </dependencySets>
 


### PR DESCRIPTION
`lib/` is documented to only contain Neo4j Embedded jars, in a manner that
people can point their IDEs to that folder to add Neo4j to their java
classpaths.

Thus, Bolt should've been under `system/lib` to begin with, and if we keep
it in `lib` in 2.3 it causes issues for users that do not use Dependency
Management.

Because we are so late in the 2.3 release cycle, this does
not actually remove the Bolt dependency from the 2.3 server,
as that is considered too invasive (it would require code changes to the Server).
Once 2.3 is out, it is expected we simply remove the Bolt dependency entirely
 from Neo4j Server 2.3.x.
