### PR TITLE
Fix neo4j start with lsof>=4.87

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -140,13 +140,18 @@ buildclasspath() {
 
 detectrunning() {
   if [ $DIST_OS = "solaris" ] ; then
-      ## SmartOS has a different lsof command line arguments
-      newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
+    ## SmartOS has a different lsof command line arguments
+    newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
   else
-      ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
-      ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
+    ## Handle different versions of lsof
+    LSOFVER=`lsof -v 2>&1 | grep revision | grep -v latest | cut -d: -f2 | tr -d ' ' | tr -d .`
+
+    if [ $LSOFVER -ge 487 ]; then
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep "p")
+    else
       newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
-      newpid=${newpid:1}
+    fi
+    newpid=${newpid:1}
   fi
 }
 


### PR DESCRIPTION
Retargeting this for 2.3 as discussed in #5445 

In summary: this allows the script to start on distros/containers which ship newer versions of `lsof`, such as Arch Linux, Fedora, and Debian Unstable. Ideally we want to remove the dependency on `lsof` in 3.0 completely.

Issues related to this:
#5443
#3414
#4505
