### PR TITLE
Fixes an issue where .id files wouldn't be rebuilt during recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplicationMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplicationMode.java
@@ -49,8 +49,7 @@ public enum TransactionApplicationMode
      * a recovered transaction may have already been applied previously to the store.
      */
     RECOVERY(
-            true,  // id tracking needed because of the cases when we will free ids of entities that was created as
-                   // part of recovery with ids that potentially higher then current highId
+            false, // id tracking not needed because id generators will be rebuilt after recovery anyway
             false, // during recovery there's not really a cache to invalidate so don't bother
             true   // extra care needs to be taken to ensure idempotency since this transaction
                     // may have been applied previously

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
@@ -67,7 +67,7 @@ import static org.neo4j.io.fs.FileUtils.truncateFile;
 public class IdGeneratorImpl implements IdGenerator
 {
     // sticky(byte), nextFreeId(long)
-    private static final int HEADER_SIZE = 9;
+    public static final int HEADER_SIZE = 9;
 
     // if sticky the id generator wasn't closed properly so it has to be
     // rebuilt (go through the node, relationship, property, rel type etc files)
@@ -427,9 +427,9 @@ public class IdGeneratorImpl implements IdGenerator
     /**
      * Creates a new id generator.
      *
-     * @param fileName
-     *            The name of the id generator
-     * @param throwIfFileExists
+     * @param fileName The name of the id generator
+     * @param throwIfFileExists if {@code true} will cause an {@link UnderlyingStorageException} to be thrown if
+     * the file already exists. if {@code false} will truncate the file writing the header in it.
      */
     public static void createGenerator( FileSystemAbstraction fs, File fileName, long highId,
                                         boolean throwIfFileExists )
@@ -448,15 +448,14 @@ public class IdGeneratorImpl implements IdGenerator
             throw new IllegalStateException( "Can't create IdGeneratorFile["
                 + fileName + "], file already exists" );
         }
-        try
+        try ( StoreChannel channel = fs.create( fileName ) )
         {
-            StoreChannel channel = fs.create( fileName );
             // write the header
+            channel.truncate( 0 );
             ByteBuffer buffer = ByteBuffer.allocate( HEADER_SIZE );
             buffer.put( CLEAN_GENERATOR ).putLong( highId ).flip();
             channel.write( buffer );
             channel.force( false );
-            channel.close();
         }
         catch ( IOException e )
         {
@@ -472,7 +471,7 @@ public class IdGeneratorImpl implements IdGenerator
         {
             fileChannel = fs.open( file, "rw" );
             ByteBuffer buffer = readHeader();
-            markAsSticky( buffer );
+            markAsSticky( fileChannel, buffer );
 
             fileChannel.position( HEADER_SIZE );
             maxReadPosition = fileChannel.size();
@@ -486,7 +485,11 @@ public class IdGeneratorImpl implements IdGenerator
         }
     }
 
-    private void markAsSticky( ByteBuffer buffer ) throws IOException
+    /**
+     * Made available for testing purposes.
+     * Marks an id generator as sticky, i.e. not cleanly shut down.
+     */
+    public static void markAsSticky( StoreChannel fileChannel, ByteBuffer buffer ) throws IOException
     {
         buffer.clear();
         buffer.put( STICKY_GENERATOR ).limit( 1 ).flip();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
@@ -1,0 +1,88 @@
+package org.neo4j.kernel.impl.store;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.storemigration.StoreFile;
+import org.neo4j.kernel.impl.storemigration.StoreFileType;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.PageCacheRule;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import static org.neo4j.kernel.impl.store.StoreFactory.SF_CREATE;
+import static org.neo4j.kernel.impl.store.StoreFactory.SF_LAZY;
+import static org.neo4j.kernel.impl.store.id.IdGeneratorImpl.HEADER_SIZE;
+import static org.neo4j.kernel.impl.store.id.IdGeneratorImpl.markAsSticky;
+
+public class FreeIdsAfterRecoveryTest
+{
+    @Rule
+    public final TargetDirectory.TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+    @Rule
+    public final PageCacheRule pageCacheRule = new PageCacheRule();
+    private final FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
+
+    @Test
+    public void shouldCompletelyRebuildIdGeneratorsAfterCrash() throws Exception
+    {
+        // GIVEN
+        StoreFactory storeFactory = new StoreFactory( fs, directory.directory(), pageCacheRule.getPageCache( fs ),
+                NullLogProvider.getInstance() );
+        long highId;
+        try ( NeoStores stores = storeFactory.openNeoStores( SF_LAZY | SF_CREATE ) )
+        {
+            // a node store with a "high" node
+            NodeStore nodeStore = stores.getNodeStore();
+            nodeStore.setHighId( 20 );
+            nodeStore.updateRecord( node( nodeStore.nextId() ) );
+            highId = nodeStore.getHighId();
+        }
+
+        // populating its .id file with a bunch of ids
+        File nodeIdFile = new File( directory.directory(), StoreFile.NODE_STORE.fileName( StoreFileType.ID ) );
+        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fs, nodeIdFile, 10, 10_000, false, highId );
+        for ( long id = 0; id < 15; id++ )
+        {
+            idGenerator.freeId( id );
+        }
+        idGenerator.close();
+        // marking as sticky to simulate a crash
+        try ( StoreChannel channel = fs.open( nodeIdFile, "rw" ) )
+        {
+            markAsSticky( channel, ByteBuffer.allocate( HEADER_SIZE ) );
+        }
+
+        // WHEN
+        try ( NeoStores stores = storeFactory.openNeoStores( SF_LAZY | SF_CREATE ) )
+        {
+            NodeStore nodeStore = stores.getNodeStore();
+            assertFalse( nodeStore.getStoreOk() );
+
+            // simulating what recovery does
+            nodeStore.deleteIdGenerator();
+            // recovery happens here...
+            nodeStore.makeStoreOk();
+
+            // THEN
+            assertEquals( highId, nodeStore.nextId() );
+        }
+    }
+
+    private NodeRecord node( long nextId )
+    {
+        NodeRecord node = new NodeRecord( nextId );
+        node.setInUse( true );
+        return node;
+    }
+}


### PR DESCRIPTION
problem being that an .id file marked as sticky (i.e. non-clean shutdown)
would flag a !storeOk during startup. Recovery would then call
deleteIdGenerator(), followed by makeStoreOk(), which rebuilds the id
generator from scratch. That sounds safe, right? Nuh-uh.
- deleteIdGenerator() would only delete to the id generator's delete()
  method if the id generator was actually started, otherwise it would
  think that rebuildIdGenerator() would take care of rebuilding the id
  generator, as the name hints.
- rebuildIdGenerator() would use IdGeneratorImpl.createGenerator in the
  belief that it would recreate the id file if "false" was passed in for
  "throwIfFileExists", but it wouldn't

This commit makes sure that IdGeneratorImpl.createGenerator deletes the
file before creating a new one, if that flag is false.

There are tons of accidental complexity associated with id generator files
currently, which is why bugs like these sneak in and are hard to shake out
with the various testing we do. This must change within a near future if
we don't want to get caught off guard again.
