### PR TITLE
Do not leak tx state for neo store records across transactions

### DIFF
--- a/community/kernel/CHANGES.txt
+++ b/community/kernel/CHANGES.txt
@@ -1,5 +1,6 @@
 2.2.6
 -----
+o Fixes #4415 - not leaking tx state containing neo store records across transactions
 o Fixes an issue where label updates where supplied unordered during batch import
   when deduplicating nodes. This issue could prevent any import containing duplicate
   input ids from completing successfully.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -109,6 +109,8 @@ public class TransactionRecordState implements RecordState
 
     public void clear()
     {
+        // no point in caching neostore record changes since they are rare, let's simply make sure they are cleared
+        neoStoreRecord = null;
         context.clear();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
@@ -47,6 +47,7 @@ import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -278,6 +279,54 @@ public class TestGraphProperties
         db = (GraphDatabaseAPI) factory.newImpermanentDatabase();
         assertFalse( graphProperties.equals( properties( db ) ) );
         db.shutdown();
+    }
+
+    @Test
+    public void shouldBeAbleToCreateLongGraphPropertyChainsAndReadTheCorrectNextPointerFromTheStore()
+    {
+        GraphDatabaseService database = new TestGraphDatabaseFactory().newImpermanentDatabase();
+
+        PropertyContainer graphProperties = properties( (GraphDatabaseAPI) database );
+
+        try ( Transaction tx = database.beginTx() )
+        {
+            graphProperties.setProperty( "a", new String[]{"A", "B", "C", "D", "E"} );
+            graphProperties.setProperty( "b", true );
+            graphProperties.setProperty( "c", "C" );
+            tx.success();
+        }
+
+        try ( Transaction tx = database.beginTx() )
+        {
+            graphProperties.setProperty( "d", new String[]{"A", "F"} );
+            graphProperties.setProperty( "e", true );
+            graphProperties.setProperty( "f", "F" );
+            tx.success();
+        }
+
+        try ( Transaction tx = database.beginTx() )
+        {
+            graphProperties.setProperty( "g", new String[]{"F"} );
+            graphProperties.setProperty( "h", false );
+            graphProperties.setProperty( "i", "I" );
+            tx.success();
+        }
+
+        try ( Transaction tx = database.beginTx() )
+        {
+            assertArrayEquals( new String[]{"A", "B", "C", "D", "E"}, (String[]) graphProperties.getProperty( "a" ) );
+            assertTrue( (boolean) graphProperties.getProperty( "b" ) );
+            assertEquals( "C", graphProperties.getProperty( "c" ) );
+
+            assertArrayEquals( new String[]{"A", "F"}, (String[]) graphProperties.getProperty( "d" ) );
+            assertTrue( (boolean) graphProperties.getProperty( "e" ) );
+            assertEquals( "F", graphProperties.getProperty( "f" ) );
+
+            assertArrayEquals( new String[]{"F"}, (String[]) graphProperties.getProperty( "g" ) );
+            assertFalse( (boolean) graphProperties.getProperty( "h" ) );
+            assertEquals( "I", graphProperties.getProperty( "i" ) );
+            tx.success();
+        }
     }
 
     private static class State

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/CHANGES.txt
@@ -10,6 +10,7 @@ o MERGE now prints its start point in the plan description
 o Cypher queries will no longer be logged in messages.log
 
 Kernel:
+o Fixes #4415 - not leaking tx state containing neo store records across transactions
 o Fixes an issue where label updates where supplied unordered during batch import
   when deduplicating nodes. This issue could prevent any import containing duplicate
   input ids from completing successfully.
@@ -244,7 +245,7 @@ o Fixed race condition when taking a uniqueness constraint ONLINE which could le
   that would violate the constraint, to be committed.
 o Added ability to scan index in addition to scanning node store
 o Fixed issue where importer IdMapper collision detection would use excessive memory
-o Performance improvements to importer, specifically around preparing IdMapper  
+o Performance improvements to importer, specifically around preparing IdMapper
 
 Server:
 o Fixed issue with 4xx HTTP response codes not including proper ClientError status

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/CHANGES.txt
@@ -10,6 +10,7 @@ o MERGE now prints its start point in the plan description
 o Cypher queries will no longer be logged in messages.log
 
 Kernel:
+o Fixes #4415 - not leaking tx state containing neo store records across transactions
 o Fixes an issue where label updates where supplied unordered during batch import
   when deduplicating nodes. This issue could prevent any import containing duplicate
   input ids from completing successfully.
@@ -245,7 +246,7 @@ o Fixed race condition when taking a uniqueness constraint ONLINE which could le
   that would violate the constraint, to be committed.
 o Added ability to scan index in addition to scanning node store
 o Fixed issue where importer IdMapper collision detection would use excessive memory
-o Performance improvements to importer, specifically around preparing IdMapper  
+o Performance improvements to importer, specifically around preparing IdMapper
 
 Server:
 o Fixed issue with 4xx HTTP response codes not including proper ClientError status

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/CHANGES.txt
@@ -10,6 +10,7 @@ o MERGE now prints its start point in the plan description
 o Cypher queries will no longer be logged in messages.log
 
 Kernel:
+o Fixes #4415 - not leaking tx state containing neo store records across transactions
 o Fixes an issue where label updates where supplied unordered during batch import
   when deduplicating nodes. This issue could prevent any import containing duplicate
   input ids from completing successfully.
@@ -289,7 +290,7 @@ o Fixed race condition when taking a uniqueness constraint ONLINE which could le
   that would violate the constraint, to be committed.
 o Added ability to scan index in addition to scanning node store
 o Fixed issue where importer IdMapper collision detection would use excessive memory
-o Performance improvements to importer, specifically around preparing IdMapper  
+o Performance improvements to importer, specifically around preparing IdMapper
 
 Server:
 o Fixed issue with 4xx HTTP response codes not including proper ClientError status
@@ -299,7 +300,7 @@ o HTTP responses containing errors in the form of server stack traces now do so
 HA:
 o Fixes a GC problem where memory could be indefinitely and unnecessarily kept after role switch
 o Properly resets the "health" state after a kernel panic has been handled
-  
+
 2.2.0
 -----
 Browser:


### PR DESCRIPTION
This was causing to read from tx state wrong records instead the
correct ones from disk and hence failing in adding new graph
properties to the database

Fixes issue #4415
