### PR TITLE
Changed the default query replan threshold

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -1046,7 +1046,7 @@ order by a.COL1""")
     planningListener.planRequests.toSeq should equal(Seq(
       s"match (n:Person) return n"
     ))
-    (0 until 50).foreach { _ => createLabeledNode("Person") }
+    (0 until 100).foreach { _ => createLabeledNode("Person") }
     eengine.execute(s"match (n:Person) return n").toList
 
     //THEN

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -112,7 +112,7 @@ public abstract class GraphDatabaseSettings
                   " statistics used to create the plan has changed more than this value, " +
                   "the plan is considered stale and will be replanned. " +
                   "A value of 0 means always replan, and 1 means never replan." )
-    public static Setting<Double> query_statistics_divergence_threshold = setting( "dbms.cypher.statistics_divergence_threshold", DOUBLE, "0.1", min( 0.0 ), max( 1.0 ) );
+    public static Setting<Double> query_statistics_divergence_threshold = setting( "dbms.cypher.statistics_divergence_threshold", DOUBLE, "0.5", min( 0.0 ), max( 1.0 ) );
 
     @Description("The minimum lifetime of a query plan before a query is considered for replanning")
     public static Setting<Long> cypher_min_replan_interval = setting( "dbms.cypher.min_replan_interval", DURATION, "1s" );


### PR DESCRIPTION
On write-heavy benchmarks we have seen a regression caused by spending too much time planning.
This PR increases the threshold to get closer in behaviour to 2.0 where we essentially never
replanned.
