### PR TITLE
Use primitives in SelectivityCombiner

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombinerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/cardinality/SelectivityCombinerTest.scala
@@ -39,13 +39,15 @@ class SelectivityCombinerTest extends CypherFunSuite {
   test("ANDing together works as expected") {
     val selectivities = Seq(Selectivity.of(.1).get, Selectivity.of(.2).get, Selectivity.ONE)
 
-    IndependenceCombiner.andTogetherSelectivities(selectivities).get should equal(Selectivity.of(0.02).get)
+    val selectivity = IndependenceCombiner.andTogetherSelectivities(selectivities).get.factor
+    assert( selectivity === 0.02 +- 0.000000000000000002 )
   }
 
   test("ORing together works as expected") {
     val selectivities = Seq(Selectivity.of(.1).get, Selectivity.of(.2).get)
 
-    IndependenceCombiner.orTogetherSelectivities(selectivities).get should equal(Selectivity.of(0.28).get)
+    val selectivity = IndependenceCombiner.orTogetherSelectivities(selectivities).get.factor
+    assert( selectivity === 0.28 +- 0.000000000000000028 )
   }
 
 }


### PR DESCRIPTION
Using BigDecimal comes with quite a bit of overhead. Instead of using a naive formula with a data structure (BigDecimal) to maintain accuracy, this change introduces a formula for the same computation that maintains accuracy while using primitives for the computation. The algebraic transformation of the formula that makes this possible is included in a source code comment.

This fixes a regression in planner performance that stem from the fact that BigDecimal is slow for computation.
