### PR TITLE
Made slave update pulling use batch size config

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
@@ -89,8 +89,7 @@ public class HaSettings
             TxPushStrategy.class ), "fixed" );
 
     @Description( "Size of batches of transactions applied on slaves when pulling from master" )
-    public static final Setting<Integer> pull_apply_batch_size = setting( "ha.pull_apply_batch_size",
-            INTEGER, "100" );
+    public static final Setting<Integer> pull_apply_batch_size = setting( "ha.pull_apply_batch_size", INTEGER, "100" );
 
     public enum TxPushStrategy
     {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -161,7 +161,6 @@ import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKeys;
 
 import static java.lang.reflect.Proxy.newProxyInstance;
-import static org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker.DEFAULT_BATCH_SIZE;
 
 /**
  * This implementation of {@link org.neo4j.kernel.impl.factory.EditionModule} creates the implementations of services
@@ -199,7 +198,7 @@ public class HighlyAvailableEditionModule
 
         TransactionCommittingResponseUnpacker responseUnpacker = dependencies.satisfyDependency(
                 new TransactionCommittingResponseUnpacker( new DefaultUnpackerDependencies( dependencies ),
-                        DEFAULT_BATCH_SIZE ) );
+                        config.get( HaSettings.pull_apply_batch_size ) ) );
 
         Supplier<KernelAPI> kernelProvider = dependencies.provideDependency( KernelAPI.class );
 


### PR DESCRIPTION
Slave update pulling was hardcoded to 100. This commit makes it use dedicated HA setting - `ha.pull_apply_batch_size`.
