### PR TITLE
Cleanup working directory on succesful runs of the backup stress test

### DIFF
--- a/stresstests/src/test/java/org/neo4j/backup/BackupServiceStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/backup/BackupServiceStressTesting.java
@@ -63,6 +63,8 @@ public class BackupServiceStressTesting
         int brokenStores = callable.call();
 
         assertEquals( 0, brokenStores );
+
+        FileUtils.deleteRecursively( new File( directory ) );
     }
 
     private static File ensureExists( File directory ) throws IOException


### PR DESCRIPTION
There is no reason to keep around stores for succesful runs, this fix
will make sure we don't use disk space in CI for useless data.
