### PR TITLE
Log info about what triggered a check point and why

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -858,8 +858,8 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
         final StoreFlusher storeFlusher = new StoreFlusher(
                 neoStores, indexingService, labelScanStore, indexProviders );
 
-        final LogRotation logRotation = new LogRotationImpl( monitors.newMonitor( LogRotation.Monitor.class ),
-                logFile, kernelHealth, logProvider );
+        final LogRotation logRotation =
+                new LogRotationImpl( monitors.newMonitor( LogRotation.Monitor.class ), logFile, kernelHealth );
 
         final TransactionAppender appender = life.add( new BatchingTransactionAppender(
                 logFile, logRotation, transactionMetadataCache, metaDataStore, legacyIndexTransactionOrdering,

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -134,6 +134,7 @@ import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointThresholds;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointerImpl;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CountCommittedTransactionThreshold;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.TimeCheckPointThreshold;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
@@ -871,7 +872,8 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
                 new CountCommittedTransactionThreshold( txThreshold );
 
         long timeMillisThreshold = config.get( GraphDatabaseSettings.check_point_interval_time );
-        TimeCheckPointThreshold timeCheckPointThreshold = new TimeCheckPointThreshold( timeMillisThreshold, Clock.SYSTEM_CLOCK );
+        TimeCheckPointThreshold timeCheckPointThreshold =
+                new TimeCheckPointThreshold( timeMillisThreshold, Clock.SYSTEM_CLOCK );
 
         CheckPointThreshold threshold =
                 CheckPointThresholds.or( countCommittedTransactionThreshold, timeCheckPointThreshold );
@@ -1180,7 +1182,7 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
             {
                 try
                 {
-                    checkPointer.forceCheckPoint();
+                    checkPointer.forceCheckPoint( new SimpleTriggerInfo( "database shutdown" ) );
                 }
                 catch ( IOException e )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointScheduler.java
@@ -47,7 +47,7 @@ public class CheckPointScheduler extends LifecycleAdapter
                 {
                     return;
                 }
-                checkPointer.checkPointIfNeeded();
+                checkPointer.checkPointIfNeeded( new SimpleTriggerInfo( "scheduler" ) );
             }
             catch ( IOException e )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThreshold.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.transaction.log.checkpoint;
 
+import org.neo4j.function.Consumer;
+
 /**
  * A check point threshold provides information if a check point is required or not.
  */
@@ -35,9 +37,10 @@ public interface CheckPointThreshold
      * This method can be used for querying the threshold about the necessity of a check point.
      *
      * @param lastCommittedTransactionId the latest transaction committed id
+     * @param consumer will be called with the description about this threshold only if the return value is true
      * @return true is a check point is needed, false otherwise.
      */
-    boolean isCheckPointingNeeded( long lastCommittedTransactionId );
+    boolean isCheckPointingNeeded( long lastCommittedTransactionId, Consumer<String> consumer );
 
     /**
      * This method notifies the threshold that a check point has happened. This must be called every time a check point

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholds.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholds.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.transaction.log.checkpoint;
 
+import org.neo4j.function.Consumer;
+
 public class CheckPointThresholds
 {
     public static CheckPointThreshold or( final CheckPointThreshold... thresholds )
@@ -35,11 +37,11 @@ public class CheckPointThresholds
             }
 
             @Override
-            public boolean isCheckPointingNeeded( long transactionId )
+            public boolean isCheckPointingNeeded( long transactionId, Consumer<String> consumer )
             {
                 for ( CheckPointThreshold threshold : thresholds )
                 {
-                    if ( threshold.isCheckPointingNeeded( transactionId ) )
+                    if ( threshold.isCheckPointingNeeded( transactionId, consumer ) )
                     {
                         return true;
                     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointer.java
@@ -32,10 +32,12 @@ public interface CheckPointer
      *
      * This method does NOT handle concurrency since there should be only one check point thread running.
      *
+     * @param triggerInfo the info describing why check pointing has been triggered
+     * pending approval of the threshold check
      * @return the transaction id used for the check pointing or -1 if check pointing wasn't needed
      * @throws IOException if writing the check point fails
      */
-    long checkPointIfNeeded() throws IOException;
+    long checkPointIfNeeded( TriggerInfo triggerInfo ) throws IOException;
 
     /**
      * This method tries the write of a check point in the transaction log. If there is no running check pointing it
@@ -43,26 +45,20 @@ public interface CheckPointer
      *
      * It is mostly used for testing purpose and to force a check point when shutting down the database.
      *
+     * @param triggerInfo the info describing why check pointing has been triggered
      * @return the transaction id used for the check pointing
      * @throws IOException if writing the check point fails
      */
-    long tryCheckPoint() throws IOException;
+    long tryCheckPoint( TriggerInfo triggerInfo ) throws IOException;
 
     /**
      * This method forces the write of a check point in the transaction log.
      *
      * It is mostly used for testing purpose and to force a check point when shutting down the database.
      *
+     * @param triggerInfo the info describing why check pointing has been triggered
      * @return the transaction id used for the check pointing
      * @throws IOException if writing the check point fails
      */
-    long forceCheckPoint() throws IOException;
-
-    class PrintFormat
-    {
-        public static String prefix( long transactionId )
-        {
-            return "Check Pointing [" + transactionId + "]: ";
-        }
-    }
+    long forceCheckPoint( TriggerInfo triggerInfo ) throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/SimpleTriggerInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/SimpleTriggerInfo.java
@@ -19,38 +19,33 @@
  */
 package org.neo4j.kernel.impl.transaction.log.checkpoint;
 
-public class CountCommittedTransactionThreshold extends AbstractCheckPointThreshold
+/**
+ * Simple implementation of a trigger info taking in construction the name/description of what triggered the check point
+ * and offering the possibility to be enriched with a single optional extra description.
+ */
+public class SimpleTriggerInfo implements TriggerInfo
 {
-    private final int notificationThreshold;
+    private final String triggerName;
+    private String description;
 
-    private volatile long nextTransactionIdTarget;
-
-    public CountCommittedTransactionThreshold( int notificationThreshold )
+    public SimpleTriggerInfo( String triggerName )
     {
-        this.notificationThreshold = notificationThreshold;
+        assert triggerName != null;
+        this.triggerName = triggerName;
     }
 
     @Override
-    public void initialize( long transactionId )
+    public String describe( long transactionId )
     {
-        nextTransactionIdTarget = transactionId + notificationThreshold;
+        String info = description == null ? triggerName : triggerName + " for " + description;
+        return "Check Pointing triggered by " + info + " [" + transactionId + "]: ";
     }
 
     @Override
-    protected boolean thresholdReached( long lastCommittedTransactionId )
+    public void accept( String description )
     {
-        return lastCommittedTransactionId >= nextTransactionIdTarget;
-    }
-
-    @Override
-    protected String description()
-    {
-        return "tx count threshold";
-    }
-
-    @Override
-    public void checkPointHappened( long transactionId )
-    {
-        nextTransactionIdTarget = transactionId + notificationThreshold;
+        assert description != null;
+        assert this.description == null;
+        this.description = description;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/TimeCheckPointThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/TimeCheckPointThreshold.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.impl.transaction.log.checkpoint;
 
 import org.neo4j.helpers.Clock;
 
-public class TimeCheckPointThreshold implements CheckPointThreshold
+public class TimeCheckPointThreshold extends AbstractCheckPointThreshold
 {
     private volatile long lastCheckPointedTransactionId;
     private volatile long nextCheckPointTime;
@@ -44,10 +44,16 @@ public class TimeCheckPointThreshold implements CheckPointThreshold
     }
 
     @Override
-    public boolean isCheckPointingNeeded( long lastCommittedTransactionId )
+    protected boolean thresholdReached( long lastCommittedTransactionId )
     {
         return lastCommittedTransactionId > lastCheckPointedTransactionId &&
                clock.currentTimeMillis() >= nextCheckPointTime;
+    }
+
+    @Override
+    protected String description()
+    {
+        return "time threshold";
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/TriggerInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/TriggerInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.checkpoint;
+
+import org.neo4j.function.Consumer;
+
+/**
+ * A {@code TriggerInfo} contains the information about the events that are triggering a check point.
+ *
+ * The {@link org.neo4j.function.Consumer<String>#accept(String)} method can be used to enrich the description with
+ * extra information. As an example, when the events triggering the check point are conditionalized wrt to a threshold,
+ * thi can be used for adding the information about the threshold that actually allowed the check point to happen.
+ */
+public interface TriggerInfo extends Consumer<String>
+{
+    /**
+     * This method can be used to retrieve the actual human-readable description about the events that triggered the
+     * check point.
+     *
+     * @param transactionId the transaction id we are check pointing on
+     * @return the description of the events that triggered check pointing
+     */
+    String describe( long transactionId );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
@@ -47,12 +47,8 @@ public class LogPruningImpl implements LogPruning
         // and it's OK to skip pruning if another one is doing so right now.
         if ( pruneLock.tryLock() )
         {
-            Thread thread = Thread.currentThread();
-            String threadStr = "[" + thread.getId() + ":" + thread.getName() + "]";
             String prefix = "Log Rotation [" + upToVersion + "]: ";
-
-            msgLog.info( prefix + threadStr + " Starting log pruning." );
-
+            msgLog.info( prefix + " Starting log pruning." );
             try
             {
                 pruneStrategy.prune( upToVersion );
@@ -60,7 +56,7 @@ public class LogPruningImpl implements LogPruning
             finally
             {
                 pruneLock.unlock();
-                msgLog.info( prefix + threadStr + " Log pruning complete." );
+                msgLog.info( prefix + " Log pruning complete." );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningImpl.java
@@ -25,8 +25,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
-import static org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer.PrintFormat.prefix;
-
 /**
  * This class listens for rotations and does log pruning.
  */
@@ -51,8 +49,9 @@ public class LogPruningImpl implements LogPruning
         {
             Thread thread = Thread.currentThread();
             String threadStr = "[" + thread.getId() + ":" + thread.getName() + "]";
+            String prefix = "Log Rotation [" + upToVersion + "]: ";
 
-            msgLog.info( prefix( upToVersion ) + threadStr + " Starting log pruning." );
+            msgLog.info( prefix + threadStr + " Starting log pruning." );
 
             try
             {
@@ -61,9 +60,8 @@ public class LogPruningImpl implements LogPruning
             finally
             {
                 pruneLock.unlock();
+                msgLog.info( prefix + threadStr + " Log pruning complete." );
             }
-
-            msgLog.info( prefix( upToVersion ) + threadStr + " Log pruning complete." );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotation.java
@@ -63,12 +63,4 @@ public interface LogRotation
      * @throws IOException
      */
     void rotateLogFile() throws IOException;
-
-    class PrintFormat
-    {
-        public static String prefix( long currentVersion )
-        {
-            return "Log Rotation [" + currentVersion + "]: ";
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotationImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotationImpl.java
@@ -92,7 +92,7 @@ public class LogRotationImpl implements LogRotation
 
         monitor.startedRotating( currentVersion );
 
-        msgLog.info( PrintFormat.prefix( currentVersion ) + " Preparing new log file..." );
+        msgLog.info( "Log Rotation [" + currentVersion + "]: Preparing new log file...");
         logFile.rotate();
 
         monitor.finishedRotating( currentVersion );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotationImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotationImpl.java
@@ -25,8 +25,6 @@ import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.impl.transaction.log.LogFile;
 import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
 import org.neo4j.kernel.impl.transaction.tracing.LogRotateEvent;
-import org.neo4j.logging.Log;
-import org.neo4j.logging.LogProvider;
 
 /**
  * Default implementation of the LogRotation interface.
@@ -36,14 +34,12 @@ public class LogRotationImpl implements LogRotation
     private final LogRotation.Monitor monitor;
     private final LogFile logFile;
     private final KernelHealth kernelHealth;
-    private final Log msgLog;
 
-    public LogRotationImpl( Monitor monitor, LogFile logFile, KernelHealth kernelHealth, LogProvider logProvider )
+    public LogRotationImpl( Monitor monitor, LogFile logFile, KernelHealth kernelHealth )
     {
         this.monitor = monitor;
         this.logFile = logFile;
         this.kernelHealth = kernelHealth;
-        this.msgLog = logProvider.getLog( getClass() );
     }
 
     @Override
@@ -83,18 +79,13 @@ public class LogRotationImpl implements LogRotation
     private void doRotate() throws IOException
     {
         long currentVersion = logFile.currentLogVersion();
-
         /*
          * In order to rotate the current log file safely we need to assert that the kernel is still
          * at full health. In case of a panic this rotation will be aborted, which is the safest alternative.
          */
         kernelHealth.assertHealthy( IOException.class );
-
         monitor.startedRotating( currentVersion );
-
-        msgLog.info( "Log Rotation [" + currentVersion + "]: Preparing new log file...");
         logFile.rotate();
-
         monitor.finishedRotating( currentVersion );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
@@ -76,6 +76,7 @@ import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointerImpl;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CountCommittedTransactionThreshold;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.pruning.LogPruning;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.impl.transaction.log.rotation.StoreFlusher;
@@ -215,7 +216,7 @@ public class TransactionRepresentationCommitProcessIT
         completionLatch.await();
 
         // do checkpoint to catch up latest updates
-        checkPointer.forceCheckPoint();
+        checkPointer.forceCheckPoint( new SimpleTriggerInfo( "test" ) );
 
         // verify
         assertTrue( "All legacy index commands should be applied", legacyIndexTransactionOrdering.isEmpty() );
@@ -290,7 +291,7 @@ public class TransactionRepresentationCommitProcessIT
             {
                 try
                 {
-                    checkPointer.forceCheckPoint();
+                    checkPointer.forceCheckPoint( new SimpleTriggerInfo( "test" ) );
                     Thread.sleep( 10 );
                 }
                 catch ( Exception e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsRotationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsRotationTest.java
@@ -45,6 +45,8 @@ import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKey;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.TriggerInfo;
 import org.neo4j.kernel.lifecycle.Lifespan;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
@@ -182,7 +184,8 @@ public class CountsRotationTest
 
     private void checkPoint( GraphDatabaseAPI db ) throws IOException
     {
-        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+        TriggerInfo triggerInfo = new SimpleTriggerInfo( "test" );
+        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint( triggerInfo );
     }
 
     private final Label A = DynamicLabel.label( "A" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.test.TargetDirectory;
 
@@ -185,7 +186,9 @@ public class PartialTransactionFailureIT
                     tx.success();
                     latch.await();
                     db.getDependencyResolver().resolveDependency( LogRotation.class ).rotateLogFile();
-                    db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+                    db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint(
+                            new SimpleTriggerInfo( "test" )
+                    );
                 }
                 catch ( Exception ignore )
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/AbstractCheckPointThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/AbstractCheckPointThresholdTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.checkpoint;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.neo4j.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+
+public class AbstractCheckPointThresholdTest
+{
+    @Test
+    public void shouldCallConsumerProvidingTheDescriptionWhenThresholdIsTrue() throws Throwable
+    {
+        // Given
+        String description = "description";
+        AbstractCheckPointThreshold threshold = new TheAbstractCheckPointThreshold( true, description );
+
+        final AtomicReference<String> calledWith = new AtomicReference<>();
+        // When
+        threshold.isCheckPointingNeeded( 42, new Consumer<String>()
+        {
+            @Override
+            public void accept( String description )
+            {
+                calledWith.set( description );
+            }
+        } );
+
+        // Then
+        assertEquals( description, calledWith.get() );
+    }
+
+    @Test
+    public void shouldNotCallConsumerProvidingTheDescriptionWhenThresholdIsFalse() throws Throwable
+    {
+        // Given
+        AbstractCheckPointThreshold threshold = new TheAbstractCheckPointThreshold( false, null );
+
+        // When
+        threshold.isCheckPointingNeeded( 42, new Consumer<String>()
+        {
+            @Override
+            public void accept( String s )
+            {
+                throw new IllegalStateException( "nooooooooo!" );
+            }
+        } );
+
+        // Then
+        // should not throw
+    }
+
+    private static class TheAbstractCheckPointThreshold extends AbstractCheckPointThreshold
+    {
+        private final boolean reached;
+        private final String description;
+
+        public TheAbstractCheckPointThreshold( boolean reached, String description )
+        {
+            this.reached = reached;
+            this.description = description;
+        }
+
+        @Override
+        public void initialize( long transactionId )
+        {
+
+        }
+
+        @Override
+        public void checkPointHappened( long transactionId )
+        {
+
+        }
+
+        @Override
+        protected boolean thresholdReached( long lastCommittedTransactionId )
+        {
+            return reached;
+        }
+
+        @Override
+        protected String description()
+        {
+            return description;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointSchedulerTest.java
@@ -84,7 +84,7 @@ public class CheckPointSchedulerTest
         // then
         verify( jobScheduler, times( 2 ) ).schedule( eq( checkPoint ), any( Runnable.class ),
                 eq( 20l ), eq( TimeUnit.MILLISECONDS ) );
-        verify( checkPointer, times( 1 ) ).checkPointIfNeeded();
+        verify( checkPointer, times( 1 ) ).checkPointIfNeeded( any( TriggerInfo.class ) );
         assertEquals( scheduledJob, jobScheduler.getJob() );
     }
 
@@ -115,7 +115,7 @@ public class CheckPointSchedulerTest
         jobScheduler.runJob();
 
         // verify checkpoint was triggered
-        verify( checkPointer ).checkPointIfNeeded();
+        verify( checkPointer ).checkPointIfNeeded( any( TriggerInfo.class ) );
 
         // simulate scheduled run that was triggered just before stop
         scheduler.stop();
@@ -136,7 +136,7 @@ public class CheckPointSchedulerTest
         CheckPointer checkPointer = new CheckPointer()
         {
             @Override
-            public long checkPointIfNeeded() throws IOException
+            public long checkPointIfNeeded( TriggerInfo triggerInfo ) throws IOException
             {
                 checkPointerLatch.start();
                 checkPointerLatch.awaitFinish();
@@ -144,13 +144,13 @@ public class CheckPointSchedulerTest
             }
 
             @Override
-            public long tryCheckPoint() throws IOException
+            public long tryCheckPoint( TriggerInfo triggerInfo ) throws IOException
             {
                 throw new RuntimeException( "this should have not been called" );
             }
 
             @Override
-            public long forceCheckPoint() throws IOException
+            public long forceCheckPoint( TriggerInfo triggerInfo ) throws IOException
             {
                 throw new RuntimeException( "this should have not been called" );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CountCommittedTransactionThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CountCommittedTransactionThresholdTest.java
@@ -23,10 +23,14 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class CountCommittedTransactionThresholdTest
 {
-
+    private final TriggerInfo triggerInfo = mock( TriggerInfo.class );
     @Test
     public void checkPointIsNotNeededWhenThereAreNoTransactions() throws Throwable
     {
@@ -35,10 +39,11 @@ public class CountCommittedTransactionThresholdTest
         threshold.initialize( 2 );
 
         // when
-        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 2 );
+        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 2, triggerInfo );
 
         // then
         assertFalse( checkPointingNeeded );
+        verifyZeroInteractions( triggerInfo );
     }
 
     @Test
@@ -49,10 +54,11 @@ public class CountCommittedTransactionThresholdTest
         threshold.initialize( 2 );
 
         // when
-        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 3 );
+        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 3, triggerInfo );
 
         // then
         assertFalse( checkPointingNeeded );
+        verifyZeroInteractions( triggerInfo );
     }
 
     @Test
@@ -63,10 +69,11 @@ public class CountCommittedTransactionThresholdTest
         threshold.initialize( 2 );
 
         // when
-        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 4 );
+        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 4, triggerInfo );
 
         // then
         assertTrue( checkPointingNeeded );
+        verify( triggerInfo, times( 1 ) ).accept( threshold.description() );
     }
 
     @Test
@@ -78,10 +85,11 @@ public class CountCommittedTransactionThresholdTest
 
         // when
         threshold.checkPointHappened( 4 );
-        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 4 );
+        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 4, triggerInfo );
 
         // then
         assertFalse( checkPointingNeeded );
+        verifyZeroInteractions( triggerInfo );
     }
 
     @Test
@@ -94,10 +102,11 @@ public class CountCommittedTransactionThresholdTest
 
         // when
         threshold.checkPointHappened( 4 );
-        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 5 );
+        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 5, triggerInfo );
 
         // then
         assertFalse( checkPointingNeeded );
+        verifyZeroInteractions( triggerInfo );
     }
 
     @Test
@@ -109,9 +118,10 @@ public class CountCommittedTransactionThresholdTest
 
         // when
         threshold.checkPointHappened( 4 );
-        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 6 );
+        boolean checkPointingNeeded = threshold.isCheckPointingNeeded( 6, triggerInfo );
 
         // then
         assertTrue( checkPointingNeeded );
+        verify( triggerInfo, times( 1 ) ).accept( threshold.description() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/TestLogPruning.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/TestLogPruning.java
@@ -41,15 +41,16 @@ import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionCursor;
 import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadableVersionableLogChannel;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
-import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.TriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
 
@@ -199,8 +200,13 @@ public class TestLogPruning
             node.setProperty( "name", "a somewhat lengthy string of some sort, right?" );
             tx.success();
         }
+        checkPoint();
+    }
 
-        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+    private void checkPoint() throws IOException
+    {
+        TriggerInfo triggerInfo = new SimpleTriggerInfo( "test" );
+        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint( triggerInfo );
     }
 
     private int figureOutSampleTransactionSizeBytes() throws IOException

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/IndexCreationTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/IndexCreationTest.java
@@ -47,6 +47,7 @@ import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.transaction.log.ReadableVersionableLogChannel;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommand;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
@@ -132,7 +133,9 @@ public class IndexCreationTest
         PhysicalLogFile pLogFile = db.getDependencyResolver().resolveDependency( PhysicalLogFile.class );
         long version = ds.getCurrentLogVersion();
         db.getDependencyResolver().resolveDependency( LogRotation.class ).rotateLogFile();
-        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint(
+                new SimpleTriggerInfo( "test" )
+        );
 
         ReadableVersionableLogChannel logChannel = pLogFile.getReader( LogPosition.start( version ) );
 

--- a/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTests.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTests.java
@@ -45,6 +45,7 @@ import org.neo4j.kernel.api.impl.index.LuceneSchemaIndexProviderFactory;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.impl.transaction.log.rotation.StoreFlusher;
 import org.neo4j.test.TargetDirectory;
@@ -246,7 +247,9 @@ public class UniqueIndexRecoveryTests
     private void rotateLogAndCheckPoint() throws IOException
     {
         db.getDependencyResolver().resolveDependency( LogRotation.class ).rotateLogFile();
-        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint(
+                new SimpleTriggerInfo( "test" )
+        );
     }
 
     private void flushAll()

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexRecoveryIT.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.test.EphemeralFileSystemRule;
@@ -264,7 +265,9 @@ public class LuceneIndexRecoveryIT
     private void rotateLogsAndCheckPoint() throws IOException
     {
         db.getDependencyResolver().resolveDependency( LogRotation.class ).rotateLogFile();
-        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint(
+                new SimpleTriggerInfo( "test" )
+        );
     }
 
     private IndexDefinition createIndex( Label label )

--- a/community/neo4j/src/test/java/counts/RebuildCountsTest.java
+++ b/community/neo4j/src/test/java/counts/RebuildCountsTest.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -171,7 +172,7 @@ public class RebuildCountsTest
     private void rotateLog() throws IOException
     {
         ((GraphDatabaseAPI) db).getDependencyResolver()
-                               .resolveDependency( CheckPointer.class ).forceCheckPoint();
+                               .resolveDependency( CheckPointer.class ).forceCheckPoint( new SimpleTriggerInfo( "test" ) );
     }
 
     private FileSystemAbstraction crash()

--- a/community/neo4j/src/test/java/recovery/CountsStoreRecoveryTest.java
+++ b/community/neo4j/src/test/java/recovery/CountsStoreRecoveryTest.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -98,7 +99,9 @@ public class CountsStoreRecoveryTest
     private void checkPoint() throws IOException
     {
         ((GraphDatabaseAPI) db).getDependencyResolver()
-                               .resolveDependency( CheckPointer.class ).forceCheckPoint();
+                               .resolveDependency( CheckPointer.class ).forceCheckPoint(
+                new SimpleTriggerInfo( "test" )
+        );
     }
 
     private void crashAndRestart()

--- a/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.StoreFlusher;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -308,7 +309,9 @@ public class TestRecoveryScenarios
 
     private void checkPoint() throws IOException
     {
-        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint(
+                new SimpleTriggerInfo( "test" )
+        );
     }
 
     private void deleteNode( Node node )

--- a/community/neo4j/src/test/java/synchronization/TestConcurrentRotation.java
+++ b/community/neo4j/src/test/java/synchronization/TestConcurrentRotation.java
@@ -30,6 +30,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.test.AbstractSubProcessTestBase;
 import org.neo4j.test.subprocess.BreakPoint;
 import org.neo4j.test.subprocess.DebugInterface;
@@ -191,7 +192,9 @@ public class TestConcurrentRotation extends AbstractSubProcessTestBase
 
         private void checkPoint( GraphDatabaseAPI graphdb ) throws IOException
         {
-            graphdb.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+            graphdb.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint(
+                    new SimpleTriggerInfo( "test" )
+            );
         }
 
         private void setSuccess( GraphDatabaseAPI graphdb, boolean success )

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -67,6 +67,7 @@ import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.ReadOnlyTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
@@ -514,7 +515,9 @@ public class BackupServiceIT
     private void rotateAndCheckPoint( GraphDatabaseAPI db ) throws IOException
     {
         db.getDependencyResolver().resolveDependency( LogRotation.class ).rotateLogFile();
-        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint(
+                new SimpleTriggerInfo( "test" )
+        );
     }
 
     @Test

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceStressTestingBuilder.java
@@ -47,6 +47,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.DependenciesProxy;
@@ -315,7 +316,9 @@ public class BackupServiceStressTestingBuilder
         private void rotateLogAndCheckPoint( GraphDatabaseAPI db ) throws IOException
         {
             db.getDependencyResolver().resolveDependency( LogRotation.class ).rotateLogFile();
-            db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+            db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint(
+                    new SimpleTriggerInfo( "test" )
+            );
         }
 
         private static Label randomLabel()

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
@@ -32,6 +32,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 
 import static org.neo4j.com.RequestContext.anonymous;
 import static org.neo4j.io.fs.FileUtils.getMostCanonicalFile;
@@ -136,7 +137,7 @@ public class StoreCopyServer
         try
         {
             monitor.startTryCheckPoint();
-            long lastAppliedTransaction = checkPointer.tryCheckPoint();
+            long lastAppliedTransaction = checkPointer.tryCheckPoint( new SimpleTriggerInfo( "store copy" ) );
             monitor.finishTryCheckPoint();
             ByteBuffer temporaryBuffer = ByteBuffer.allocateDirect( (int) ByteUnit.mebiBytes( 1 ) );
 

--- a/enterprise/ha/src/test/java/slavetest/TestInstanceJoin.java
+++ b/enterprise/ha/src/test/java/slavetest/TestInstanceJoin.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.ha.UpdatePuller;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.tooling.GlobalGraphOperations;
@@ -132,7 +133,9 @@ public class TestInstanceJoin
 
     private void checkPoint( HighlyAvailableGraphDatabase db ) throws IOException
     {
-        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint();
+        db.getDependencyResolver().resolveDependency( CheckPointer.class ).forceCheckPoint(
+                new SimpleTriggerInfo( "test" )
+        );
     }
 
     private int nodesHavingProperty( HighlyAvailableGraphDatabase slave, String key, String value )


### PR DESCRIPTION
This change adds a way to log additional info about the event that
triggered a check point. In particular, it will add extra info about
which threshold triggered the check point and if the check pointing
was actually executed or not wrt tryCheckPoint.
