### PR TITLE
Remove heartbeat message logging

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
@@ -101,7 +101,6 @@ public enum HeartbeatState
                                 break;
                             }
 
-                            context.getInternalLog( HeartbeatState.class ).debug( "Received " + state );
 
                             if ( state.getServer() == null )
                             {


### PR DESCRIPTION
Newly introduced checkpointing (on vector I/O steroids) will periodically try to flush data consuming as much IO as it would able to get, that will cause wait for any other IO related activities. And logging is one of them at this point.
To prevent scenarios when heartbeat message logging will be blocked for some time and will cause cluster fall to pieces - heartbeat message logging removed for now.
