### PR TITLE
Reverses --experimental flag

### DIFF
--- a/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/checking/full/FullCheck.java
+++ b/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/checking/full/FullCheck.java
@@ -117,7 +117,8 @@ public class FullCheck
         final ConsistencyReporter reporter = new ConsistencyReporter( recordAccess, report );
         StoreProcessor processEverything = new StoreProcessor( decorator, reporter );
 
-        ProgressMonitorFactory.MultiPartBuilder progress = progressFactory.multipleParts( "Full consistency check" );
+        ProgressMonitorFactory.MultiPartBuilder progress = progressFactory.multipleParts(
+                "Full consistency check (legacy version)" );
 
         final StoreAccess nativeStores = directStoreAccess.nativeStores();
         try ( IndexAccessors indexes =

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -52,13 +52,13 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 public class ConsistencyCheckTool
 {
     // This to easily change this behaviour before/after releases
-    public static final boolean EXPERIMENTAL_BY_DEFAULT = true;
+    public static final boolean USE_LEGACY_BY_DEFAULT = false;
 
     static final String RECOVERY = "recovery";
     static final String CONFIG = "config";
     static final String PROP_OWNER = "propowner";
     static final String VERBOSE = "v";
-    static final String EXPERIMENTAL = "experimental";
+    static final String USE_LEGACY_CHECKER = "use-legacy-checker";
 
     // Use the ExitHandle from consistency-check-legacy so that ConsistencyCheckToolTest can properly
     // test everything with -experimental and w/o it.
@@ -95,8 +95,8 @@ public class ConsistencyCheckTool
 
     void run( String... args ) throws ToolFailureException, IOException
     {
-        Args arguments = Args.withFlags( RECOVERY, PROP_OWNER, VERBOSE, EXPERIMENTAL ).parse( args );
-        if ( !isExperimental( arguments ) )
+        Args arguments = Args.withFlags( RECOVERY, PROP_OWNER, VERBOSE, USE_LEGACY_CHECKER ).parse( args );
+        if ( useLegacyChecker( arguments ) )
         {
             // We want to actually use the legacy checker, so just go ahead and invoke that main instead,
             // this component depends on the old checker (w/ changed top-level package to not let all
@@ -159,9 +159,9 @@ public class ConsistencyCheckTool
         return arguments.getBoolean( VERBOSE, false, true );
     }
 
-    private boolean isExperimental( Args arguments )
+    private boolean useLegacyChecker( Args arguments )
     {
-        return arguments.getBoolean( EXPERIMENTAL, EXPERIMENTAL_BY_DEFAULT, true );
+        return arguments.getBoolean( USE_LEGACY_CHECKER, USE_LEGACY_BY_DEFAULT, true );
     }
 
     private void attemptRecoveryOrCheckStateOfLogicalLogs( Args arguments, File storeDir, Config tuningConfiguration )
@@ -232,15 +232,14 @@ public class ConsistencyCheckTool
     private String usage()
     {
         return joinAsLines(
-                jarUsage( getClass(), "[-propowner] [-recovery] [-config <neo4j.properties>] [-v] [-experimental] <storedir>" ),
-                "WHERE:   -propowner         also check property owner consistency (more time consuming)",
-                "         -recovery          to perform recovery on the store before checking",
-                "         -config <filename> is the location of an optional properties file",
-                "                            containing tuning parameters for the consistency check",
-                "         -v                 produce execution output",
-                "         -experimental      (ADVANCED) runs the new, experimental and potentially much faster",
-                "                            consistency checker (" + EXPERIMENTAL_BY_DEFAULT + " by default)",
-                "         <storedir>         is the path to the store to check"
+                jarUsage( getClass(), "[-propowner] [-recovery] [-config <neo4j.properties>] [-v] [-" + USE_LEGACY_CHECKER + "] <storedir>" ),
+                "WHERE:   -propowner          also check property owner consistency (more time consuming)",
+                "         -recovery           to perform recovery on the store before checking",
+                "         -config <filename>  is the location of an optional properties file",
+                "                             containing tuning parameters for the consistency check",
+                "         -v                  produce execution output",
+                "         -use-legacy-checker (ADVANCED) runs the legacyconsistency checker (" + USE_LEGACY_BY_DEFAULT + " by default)",
+                "         <storedir>          is the path to the store to check"
         );
     }
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
@@ -130,7 +130,7 @@ public class FullCheck
         final ConsistencyReporter reporter = new ConsistencyReporter( recordAccess, report, reportMonitor );
         StoreProcessor processEverything = new StoreProcessor( decorator, reporter, Stage.SEQUENTIAL_FORWARD, cacheAccess );
         ProgressMonitorFactory.MultiPartBuilder progress = progressFactory.multipleParts(
-                "Full Consistency Check (experimental version)" );
+                "Full Consistency Check" );
         final StoreAccess nativeStores = directStoreAccess.nativeStores();
         try ( IndexAccessors indexes =
                       new IndexAccessors( directStoreAccess.indexes(), nativeStores.getSchemaStore(), samplingConfig ) )

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
@@ -59,7 +59,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
@@ -67,7 +67,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-import static org.neo4j.consistency.ConsistencyCheckTool.EXPERIMENTAL;
+import static org.neo4j.consistency.ConsistencyCheckTool.USE_LEGACY_CHECKER;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.ArrayUtil.concat;
 import static org.neo4j.test.EphemeralFileSystemRule.shutdownDbAction;
@@ -75,28 +75,28 @@ import static org.neo4j.test.EphemeralFileSystemRule.shutdownDbAction;
 @RunWith( Parameterized.class )
 public class ConsistencyCheckToolTest
 {
-    private final boolean experimental;
+    private final boolean useLegacyChecker;
 
     @Parameters( name = "Experimental:{0}" )
     public static Collection<Object[]> data()
     {
         Collection<Object[]> data = new ArrayList<>();
-        data.add( new Object[] { Boolean.TRUE } );
         data.add( new Object[] { Boolean.FALSE } );
+        data.add( new Object[] { Boolean.TRUE } );
         return data;
     }
 
-    public ConsistencyCheckToolTest( boolean experimental )
+    public ConsistencyCheckToolTest( boolean useLegacyChecker )
     {
-        this.experimental = experimental;
+        this.useLegacyChecker = useLegacyChecker;
     }
 
     @Test
     public void runsConsistencyCheck() throws Exception
     {
         // given
-        assumeTrue( "This test runs with mocked ConsistencyCheckService, doesn't work with the legacy checker " +
-                "since it creates its own", experimental );
+        assumeFalse( "This test runs with mocked ConsistencyCheckService, doesn't work with the legacy checker " +
+                "since it creates its own", useLegacyChecker );
         File storeDir = storeDirectory.directory();
         String[] args = {storeDir.getPath()};
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
@@ -115,8 +115,8 @@ public class ConsistencyCheckToolTest
     public void appliesDefaultTuningConfigurationForConsistencyChecker() throws Exception
     {
         // given
-        assumeTrue( "This test runs with mocked ConsistencyCheckService, doesn't work with the legacy checker " +
-                "since it creates its own", experimental );
+        assumeFalse( "This test runs with mocked ConsistencyCheckService, doesn't work with the legacy checker " +
+                "since it creates its own", useLegacyChecker );
         File storeDir = storeDirectory.directory();
         String[] args = {storeDir.getPath()};
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
@@ -137,8 +137,8 @@ public class ConsistencyCheckToolTest
     public void passesOnConfigurationIfProvided() throws Exception
     {
         // given
-        assumeTrue( "This test runs with mocked ConsistencyCheckService, doesn't work with the legacy checker " +
-                "since it creates its own", experimental );
+        assumeFalse( "This test runs with mocked ConsistencyCheckService, doesn't work with the legacy checker " +
+                "since it creates its own", useLegacyChecker );
         File storeDir = storeDirectory.directory();
         File propertyFile = storeDirectory.file( "neo4j.properties" );
         Properties properties = new Properties();
@@ -300,7 +300,7 @@ public class ConsistencyCheckToolTest
 
     private String[] augment( String[] args )
     {
-        return concat( "-" + EXPERIMENTAL + "=" + experimental, args );
+        return concat( "-" + USE_LEGACY_CHECKER + "=" + useLegacyChecker, args );
     }
 
     private void runConsistencyCheckToolWith ( ConsistencyCheckService

--- a/community/kernel/src/test/java/org/neo4j/kernel/AvailabilityGuardTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/AvailabilityGuardTest.java
@@ -19,17 +19,15 @@
  */
 package org.neo4j.kernel;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.neo4j.helpers.TickingClock;
-import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.Log;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
-
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
@@ -37,6 +35,7 @@ import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
+
 import static org.neo4j.kernel.AvailabilityGuard.availabilityRequirement;
 
 public class AvailabilityGuardTest

--- a/enterprise/backup/src/main/java/org/neo4j/backup/ConsistencyCheck.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/ConsistencyCheck.java
@@ -49,7 +49,7 @@ enum ConsistencyCheck
                         FileSystemAbstraction fileSystem, PageCache pageCache, boolean verbose )
                         throws ConsistencyCheckFailedException
                 {
-                    ConsistencyCheck checker = ConsistencyCheckTool.EXPERIMENTAL_BY_DEFAULT ? EXPERIMENTAL : LEGACY;
+                    ConsistencyCheck checker = ConsistencyCheckTool.USE_LEGACY_BY_DEFAULT ? LEGACY : EXPERIMENTAL;
                     return checker.runFull( storeDir, tuningConfiguration, progressFactory, logProvider,
                             fileSystem, pageCache, verbose );
                 }


### PR DESCRIPTION
since it's going to be the default. It's now called --use-legacy-checker
instead which is much easier to understand.
