### PR TITLE
fix `neo4j start` works correctly

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -143,10 +143,7 @@ detectrunning() {
       ## SmartOS has a different lsof command line arguments
       newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
   else
-      ## This could be achieved with filtering using -sTCP:LISTEN but this option is not available
-      ## on lsof v4.78 which is the one bundled with some distros. So we have to do this grep below
-      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
-      newpid=${newpid:1}
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT | awk 'NR!=1 { print $2 }')
   fi
 }
 


### PR DESCRIPTION
`neo4j start` command for standalone can not work properly for my environment:

```
% lsof -v
lsof version information:
    revision: 4.89
    latest revision: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/
    latest FAQ: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/FAQ
    latest man page: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_man
    constructed: Tue Sep 1 21:31:14 JST 2015
    constructed by and on: portage@localhost
    compiler: x86_64-pc-linux-gnu-gcc
    compiler flags: -O2 -pipe -DHASNOTRPC -DHASNORPC_H -DHASIPv6 -DLINUXV=42000 -DGLIBCV=221 -DHASIPv6 -DNEEDS_NETINET_TCPH -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DHAS_STRFTIME -DLSOF_VSTR="4.2.0" -I/var/tmp/portage/sys-process/lsof-4.89/temp
    loader flags: -L./lib -llsof -O2 -pipe -Wl,-O1 -Wl,--as-needed
    system info: Linux localhost 4.1.6-aufs #2 SMP Mon Aug 24 10:33:20 JST 2015 x86_64 Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz GenuineIntel GNU/Linux
    Anyone can list all files.
    /dev warnings are disabled.
    Kernel ID check is disabled.
```

and `neo4j start` got following error message:

```
Starting Neo4j Server...WARNING: not changing user
process [24051]... waiting for server to be ready............. Failed to start within 120 seconds.
Neo4j Server failed to start, please check the logs for details.
If startup is blocked on a long recovery, use 'db/neo4j/development/bin/neo4j start-no-wait' to give the startup more time.
```
