### PR TITLE
Change isolateAggregation AST-rewriter to topDown

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/isolateAggregation.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/isolateAggregation.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.AggregationNameGenerator
-import org.neo4j.cypher.internal.compiler.v2_2.{replace, Rewriter, bottomUp}
+import org.neo4j.cypher.internal.compiler.v2_2.{replace, Rewriter, topDown}
 import org.neo4j.cypher.internal.helpers.Converge.iterateUntilConverged
 
 /**
@@ -83,7 +83,7 @@ case object isolateAggregation extends Rewriter {
           val pos = clause.position
           val withClause = With(distinct = false, ReturnItems(includeExisting = false, withReturnItems.toSeq)(pos), None, None, None, None)(pos)
 
-          val resultClause = clause.endoRewrite(bottomUp(Rewriter.lift {
+          val resultClause = clause.endoRewrite(topDown(Rewriter.lift {
             case e: Expression =>
               withReturnItems.collectFirst {
                 case AliasedReturnItem(expression, identifier) if e == expression => identifier.copyId

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/IsolateAggregationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/IsolateAggregationTest.scala
@@ -137,6 +137,19 @@ class IsolateAggregationTest extends CypherFunSuite with RewriteTest with AstCon
       "WITH 1 AS x, 2 AS y WITH sum(x) as `  AGGREGATION27`, y as y RETURN `  AGGREGATION27`*y AS a, `  AGGREGATION27`*y AS b")
   }
 
+  test("MATCH (a), (b) RETURN coalesce(a.prop, b.prop), b.prop, { x: count(b) }") {
+    assertRewrite(
+      """MATCH (a), (b)
+        |RETURN coalesce(a.prop, b.prop), b.prop, { x: count(b) }""".stripMargin,
+      """MATCH (a), (b)
+        |WITH coalesce(a.prop, b.prop) AS `  AGGREGATION22`,
+        |     b.prop AS `  AGGREGATION50`,
+        |     count(b) AS `  AGGREGATION61`
+        |RETURN `  AGGREGATION22` AS `coalesce(a.prop, b.prop)`,
+        |       `  AGGREGATION50` AS `b.prop`,
+        |       { x: `  AGGREGATION61` } AS `{ x: count(b) }`""".stripMargin)
+  }
+
   override protected def parseForRewriting(queryText: String) = {
     val mkException = new SyntaxExceptionCreator(queryText, Some(pos))
     super.parseForRewriting(queryText).endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/AggregationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/AggregationAcceptanceTest.scala
@@ -224,4 +224,22 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
     result.toList should equal(Seq(Map("name" -> "a", "others" -> Seq("c", "b"), "len" -> 1 )))
   }
 
+  test("should handle subexpression in aggregation also occuring as standalone expression with nested aggregation in a literal map") {
+    // There was a bug in the isolateAggregation AST rewriter that was triggered by this somewhat unusual case
+    val a = createLabeledNode("A")
+    val b = createLabeledNode(Map("prop" -> 42), "B")
+
+    val query =
+      """|MATCH (a:A), (b:B)
+         |RETURN
+         |coalesce(a.prop, b.prop) AS foo,
+         |b.prop AS bar,
+         |{
+         |    y: count(b)
+         |} AS baz""".stripMargin
+
+    val result = executeWithCostPlannerOnly(query)
+
+    result.toList should equal(List(Map("foo" -> 42, "bar" -> 42, "baz" -> Map("y" -> 1))))
+  }
 }


### PR DESCRIPTION
The isolateAggregation AST-rewriter works on clauses that has aggregations
but is not itself an aggregation. It moves aggregation expressions up into
a separate WITH clause and rewrites the clause to use those expressions by
identifiers.
Before it used to do the rewrite bottom-up, but that can cause a bug
where a subexpression E of an aggregation expression A is first rewritten
because that expression E also exists as a standalone expression that
is also being rewritten.
In this case the rewriter will subsequently fail to recognize the whole
aggregation expression A since a part of it was already rewritten,
and leave the AST in a partly rewritten state.
This results in that a semantic check on the rewritten AST can fail
because identifiers may not have been declared.
