### PR TITLE
Log the first heartbeat after a series of missed

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/CursorPool.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/CursorPool.java
@@ -19,10 +19,11 @@
  */
 package org.neo4j.io.pagecache.impl.muninn;
 
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+
 final class CursorPool
 {
-    private static boolean disableCursorPooling = Boolean.getBoolean(
-            "org.neo4j.io.pagecache.impl.muninn.CursorPool.disableCursorPooling" );
+    private static boolean disableCursorPooling = flag( CursorPool.class, "disableCursorPooling", false );
 
     private final ThreadLocal<MuninnReadPageCursor> readCursorCache = new MuninnReadPageCursorThreadLocal();
     private final ThreadLocal<MuninnWritePageCursor> writeCursorCache = new MuninnWritePageCursorThreadLocal();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -43,6 +43,8 @@ import org.neo4j.io.pagecache.tracing.PageFaultEvent;
 import org.neo4j.unsafe.impl.internal.dragons.MemoryManager;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+
 /**
  * The Muninn {@link org.neo4j.io.pagecache.PageCache page cache} implementation.
  * <pre>
@@ -95,7 +97,7 @@ import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 public class MuninnPageCache implements PageCache
 {
     public static final byte ZERO_BYTE =
-            (byte) (Boolean.getBoolean( "org.neo4j.io.pagecache.impl.muninn.MuninnPage.brandedZeroByte" )? 0x0F : 0);
+            (byte) (flag( MuninnPageCache.class, "brandedZeroByte", false ) ? 0x0f : 0);
 
     // Keep this many pages free and ready for use in faulting.
     // This will be truncated to be no more than half of the number of pages

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
@@ -29,6 +29,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.io.pagecache.PageSwapper;
 
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.packageFlag;
+
 /**
  * The default PageCacheTracer implementation, that just increments counters.
  */
@@ -41,8 +43,7 @@ public class DefaultPageCacheTracer implements PageCacheTracer
         try
         {
             // A hidden setting to have pin/unpin monitoring enabled from the start by default.
-            boolean alwaysEnabled = Boolean.getBoolean(
-                    "org.neo4j.io.pagecache.tracing.tracePinUnpin" );
+            boolean alwaysEnabled = packageFlag( DefaultPageCacheTracer.class, "tracePinUnpin", false );
 
             MethodType type = MethodType.methodType( PinEvent.class );
             MethodHandles.Lookup lookup = MethodHandles.lookup();

--- a/community/kernel/src/main/java/org/neo4j/helpers/Service.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Service.java
@@ -35,6 +35,8 @@ import java.util.Set;
 
 import org.neo4j.helpers.collection.PrefetchingIterator;
 
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+
 /**
  * A utility for locating services. This implements the same functionality as <a
  * href="http://java.sun.com/javase/6/docs/api/java/util/ServiceLoader.html">
@@ -117,7 +119,7 @@ public abstract class Service
      * Enabling this is useful for debugging why services aren't loaded where you would expect them to.
      */
     private static final boolean printServiceLoaderStackTraces =
-            Boolean.getBoolean( "org.neo4j.helpers.Service.printServiceLoaderStackTraces" );
+            flag( Service.class, "printServiceLoaderStackTraces", false );
 
     /**
      * Designates that a class implements the specified service and should be

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueWriter.java
@@ -29,6 +29,8 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+
 class KeyValueWriter implements Closeable
 {
     private final MetadataCollector metadata;
@@ -245,7 +247,7 @@ class KeyValueWriter implements Closeable
     static abstract class Writer
     {
         private static final boolean WRITE_TO_PAGE_CACHE =
-                Boolean.getBoolean( KeyValueWriter.class.getName() + ".WRITE_TO_PAGE_CACHE" );
+                flag( KeyValueWriter.class, "WRITE_TO_PAGE_CACHE", false );
 
         abstract void write( byte[] data ) throws IOException;
 

--- a/community/logging/src/main/java/org/neo4j/logging/async/AsyncLog.java
+++ b/community/logging/src/main/java/org/neo4j/logging/async/AsyncLog.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.logging.async;
+
+import org.neo4j.concurrent.AsyncEventSender;
+import org.neo4j.function.Consumer;
+import org.neo4j.logging.AbstractLog;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.Logger;
+
+import static java.util.Objects.requireNonNull;
+import static org.neo4j.logging.async.AsyncLogEvent.bulkLogEvent;
+import static org.neo4j.logging.async.AsyncLogEvent.logEvent;
+
+public class AsyncLog extends AbstractLog
+{
+    private final Log log;
+    private final AsyncEventSender<AsyncLogEvent> events;
+
+    public AsyncLog( AsyncEventSender<AsyncLogEvent> events, Log log )
+    {
+        this.log = requireNonNull( log, "Log" );
+        this.events = requireNonNull( events, "AsyncEventSender<AsyncLogEvent>" );
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return log.isDebugEnabled();
+    }
+
+    @Override
+    public Logger debugLogger()
+    {
+        return new AsyncLogger( events, log.debugLogger() );
+    }
+
+    @Override
+    public Logger infoLogger()
+    {
+        return new AsyncLogger( events, log.infoLogger() );
+    }
+
+    @Override
+    public Logger warnLogger()
+    {
+        return new AsyncLogger( events, log.warnLogger() );
+    }
+
+    @Override
+    public Logger errorLogger()
+    {
+        return new AsyncLogger( events, log.errorLogger() );
+    }
+
+    @Override
+    public void bulk( Consumer<Log> consumer )
+    {
+        events.send( bulkLogEvent( log, consumer ) );
+    }
+
+    private static class AsyncLogger implements Logger
+    {
+        private final Logger logger;
+        private final AsyncEventSender<AsyncLogEvent> events;
+
+        AsyncLogger( AsyncEventSender<AsyncLogEvent> events, Logger logger )
+        {
+            this.logger = requireNonNull( logger, "Logger" );
+            this.events = events;
+        }
+
+        @Override
+        public void log( String message )
+        {
+            events.send( logEvent( logger, message ) );
+        }
+
+        @Override
+        public void log( String message, Throwable throwable )
+        {
+            events.send( logEvent( logger, message, throwable ) );
+        }
+
+        @Override
+        public void log( String format, Object... arguments )
+        {
+            events.send( logEvent( logger, format, arguments ) );
+        }
+
+        @Override
+        public void bulk( Consumer<Logger> consumer )
+        {
+            events.send( bulkLogEvent( logger, consumer ) );
+        }
+    }
+}

--- a/community/logging/src/main/java/org/neo4j/logging/async/AsyncLogEvent.java
+++ b/community/logging/src/main/java/org/neo4j/logging/async/AsyncLogEvent.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.logging.async;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.neo4j.concurrent.AsyncEvent;
+import org.neo4j.function.Consumer;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.Logger;
+
+import static java.util.Objects.requireNonNull;
+
+public final class AsyncLogEvent extends AsyncEvent
+{
+    static AsyncLogEvent logEvent( Logger logger, String message )
+    {
+        return new AsyncLogEvent( logger, requireNonNull( message, "message" ), null );
+    }
+
+    static AsyncLogEvent logEvent( Logger logger, String message, Throwable throwable )
+    {
+        return new AsyncLogEvent( logger, requireNonNull( message, "message" ),
+                requireNonNull( throwable, "Throwable" ) );
+    }
+
+    static AsyncLogEvent logEvent( Logger logger, String format, Object... arguments )
+    {
+        return new AsyncLogEvent( logger, requireNonNull( format, "format" ),
+                arguments == null ? new Object[0] : arguments );
+    }
+
+    static AsyncLogEvent bulkLogEvent( Log log, final Consumer<Log> consumer )
+    {
+        requireNonNull( consumer, "Consumer<Log>" );
+        return new AsyncLogEvent( log, null, new BulkLogger()
+        {
+            @Override
+            void process( long timestamp, Object target )
+            {
+                consumer.accept( (Log) target ); // TODO: include timestamp!
+            }
+
+            @Override
+            public String toString()
+            {
+                return "Log.bulkLog( " + consumer + " )";
+            }
+        } );
+    }
+
+    static AsyncLogEvent bulkLogEvent( Logger logger, final Consumer<Logger> consumer )
+    {
+        requireNonNull( consumer, "Consumer<Logger>" );
+        return new AsyncLogEvent( logger, null, new BulkLogger()
+        {
+            @Override
+            void process( long timestamp, Object target )
+            {
+                consumer.accept( (Logger) target ); // TODO: include timestamp!
+            }
+
+            @Override
+            public String toString()
+            {
+                return "Logger.bulkLog( " + consumer + " )";
+            }
+        } );
+    }
+
+    @SuppressWarnings( "StringEquality" )
+    public void process()
+    {
+        if ( parameter == null )
+        {
+            ((Logger) target).log( "[AsyncLog @ " + timestamp() + "]  " + message );
+        }
+        else if ( parameter instanceof Throwable )
+        {
+            ((Logger) target).log( "[AsyncLog @ " + timestamp() + "]  " + message, (Throwable) parameter );
+        }
+        else if ( parameter instanceof Object[] )
+        {
+            ((Logger) target).log( "[AsyncLog @ " + timestamp() + "]  " + message, (Object[]) parameter );
+        }
+        else if ( parameter instanceof BulkLogger )
+        {
+            ((BulkLogger) parameter).process( timestamp, target );
+        }
+    }
+
+    private final long timestamp;
+    private final Object target;
+    private final String message;
+    private final Object parameter;
+
+    private AsyncLogEvent( Object target, String message, Object parameter )
+    {
+        this.target = target;
+        this.message = message;
+        this.parameter = parameter;
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    @Override
+    public String toString()
+    {
+        if ( parameter == null )
+        {
+            return "log( @ " + timestamp() + ": \"" + message + "\" )";
+        }
+        if ( parameter instanceof Throwable )
+        {
+            return "log( @ " + timestamp() + ": \"" + message + "\", " + parameter + " )";
+        }
+        if ( parameter instanceof Object[] )
+        {
+            return "log( @ " + timestamp() + ": \"" + message + "\", " +
+                   Arrays.toString( (Object[]) parameter ) + " )";
+        }
+        if ( parameter instanceof BulkLogger )
+        {
+            return parameter.toString();
+        }
+        return super.toString();
+    }
+
+    private String timestamp()
+    {
+        return TIMESTAMP.format( timestamp );
+    }
+
+    private static abstract class BulkLogger
+    {
+        abstract void process( long timestamp, Object target );
+    }
+
+    private static final ThreadLocalFormat TIMESTAMP = new ThreadLocalFormat();
+
+    private static class ThreadLocalFormat extends ThreadLocal<DateFormat>
+    {
+        String format( long timestamp )
+        {
+            return get().format( new Date( timestamp ) );
+        }
+
+        @Override
+        protected DateFormat initialValue()
+        {
+            SimpleDateFormat format = new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss.SSSZ" );
+            format.setTimeZone( TimeZone.getTimeZone( "UTC" ) );
+            return format;
+        }
+    }
+}
+

--- a/community/logging/src/main/java/org/neo4j/logging/async/AsyncLogProvider.java
+++ b/community/logging/src/main/java/org/neo4j/logging/async/AsyncLogProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.logging.async;
+
+import org.neo4j.concurrent.AsyncEventSender;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+public class AsyncLogProvider implements LogProvider
+{
+    private final LogProvider provider;
+    private final AsyncEventSender<AsyncLogEvent> events;
+
+    public AsyncLogProvider( AsyncEventSender<AsyncLogEvent> events, LogProvider provider )
+    {
+        this.provider = provider;
+        this.events = events;
+    }
+
+    @Override
+    public Log getLog( Class loggingClass )
+    {
+        return new AsyncLog( events, provider.getLog( loggingClass ) );
+    }
+
+    @Override
+    public Log getLog( String name )
+    {
+        return new AsyncLog( events, provider.getLog( name ) );
+    }
+}

--- a/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
+++ b/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.logging;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.StringDescription;
-import org.neo4j.function.Consumer;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,6 +26,12 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+
+import org.neo4j.function.Consumer;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -315,7 +316,12 @@ public class AssertableLogProvider extends AbstractLogProvider<Log>
 
         public LogMatcher debug( String format, Object... arguments )
         {
-            return new LogMatcher( contextMatcher, DEBUG_LEVEL_MATCHER, equalTo( format ), arrayContaining( ensureMatchers( arguments ) ), NULL_THROWABLE_MATCHER );
+            return debug( equalTo( format ), arguments );
+        }
+
+        public LogMatcher debug( Matcher<String> format, Object... arguments )
+        {
+            return new LogMatcher( contextMatcher, DEBUG_LEVEL_MATCHER, format, arrayContaining( ensureMatchers( arguments ) ), NULL_THROWABLE_MATCHER );
         }
 
         public LogMatcher info( String message )
@@ -335,7 +341,12 @@ public class AssertableLogProvider extends AbstractLogProvider<Log>
 
         public LogMatcher info( String format, Object... arguments )
         {
-            return new LogMatcher( contextMatcher, INFO_LEVEL_MATCHER, equalTo( format ), arrayContaining( ensureMatchers( arguments ) ), NULL_THROWABLE_MATCHER );
+            return info( equalTo( format ), arguments );
+        }
+
+        public LogMatcher info( Matcher<String> format, Object... arguments )
+        {
+            return new LogMatcher( contextMatcher, INFO_LEVEL_MATCHER, format, arrayContaining( ensureMatchers( arguments ) ), NULL_THROWABLE_MATCHER );
         }
 
         public LogMatcher warn( String message )
@@ -355,7 +366,12 @@ public class AssertableLogProvider extends AbstractLogProvider<Log>
 
         public LogMatcher warn( String format, Object... arguments )
         {
-            return new LogMatcher( contextMatcher, WARN_LEVEL_MATCHER, equalTo( format ), arrayContaining( ensureMatchers( arguments ) ), NULL_THROWABLE_MATCHER );
+            return warn( equalTo( format ), arguments );
+        }
+
+        public LogMatcher warn( Matcher<String> format, Object... arguments )
+        {
+            return new LogMatcher( contextMatcher, WARN_LEVEL_MATCHER, format, arrayContaining( ensureMatchers( arguments ) ), NULL_THROWABLE_MATCHER );
         }
 
         public LogMatcher error( String message )
@@ -375,7 +391,12 @@ public class AssertableLogProvider extends AbstractLogProvider<Log>
 
         public LogMatcher error( String format, Object... arguments )
         {
-            return new LogMatcher( contextMatcher, ERROR_LEVEL_MATCHER, equalTo( format ), arrayContaining( ensureMatchers( arguments ) ), NULL_THROWABLE_MATCHER );
+            return error( equalTo( format ), arguments );
+        }
+
+        public LogMatcher error( Matcher<String> format, Object... arguments )
+        {
+            return new LogMatcher( contextMatcher, ERROR_LEVEL_MATCHER, format, arrayContaining( ensureMatchers( arguments ) ), NULL_THROWABLE_MATCHER );
         }
 
         @SuppressWarnings( "unchecked" )

--- a/community/logging/src/test/java/org/neo4j/logging/async/AsyncLogTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/async/AsyncLogTest.java
@@ -1,0 +1,535 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.logging.async;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.neo4j.concurrent.AsyncEventSender;
+import org.neo4j.function.Consumer;
+import org.neo4j.logging.AbstractLog;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.Logger;
+
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.neo4j.logging.AssertableLogProvider.inLog;
+
+@RunWith( Parameterized.class )
+public class AsyncLogTest
+{
+    @Parameterized.Parameters( name = "{0} {1}.log({2})" )
+    public static Iterable<Object[]> parameters()
+    {
+        List<Object[]> parameters = new ArrayList<>();
+        for ( Invocation invocation : Invocation.values() )
+        {
+            for ( Level level : Level.values() )
+            {
+                for ( Style style : Style.values() )
+                {
+                    parameters.add( new Object[]{invocation, level, style} );
+                }
+            }
+        }
+        return parameters;
+    }
+
+    @SuppressWarnings( "ThrowableInstanceNeverThrown" )
+    private final Throwable exception = new Exception();
+    private final Invocation invocation;
+    private final Level level;
+    private final Style style;
+
+    public AsyncLogTest( Invocation invocation, Level level, Style style )
+    {
+        this.invocation = invocation;
+        this.level = level;
+        this.style = style;
+    }
+
+    @Test
+    public void shouldLogAsynchronously() throws Exception
+    {
+        // given
+        AssertableLogProvider logging = new AssertableLogProvider();
+        Log log = logging.getLog( getClass() );
+        DeferredSender events = new DeferredSender();
+        AsyncLog asyncLog = new AsyncLog( events, log );
+
+        // when
+        log( invocation.decorate( asyncLog ) );
+        // then
+        logging.assertNoLoggingOccurred();
+
+        // when
+        events.process();
+        // then
+        MatcherBuilder matcherBuilder = new MatcherBuilder( inLog( getClass() ) );
+        log( matcherBuilder );
+        logging.assertExactly( matcherBuilder.matcher() );
+    }
+
+    private void log( Log log )
+    {
+        style.invoke( this, level.logger( log ) );
+    }
+
+    enum Invocation
+    {
+        DIRECT
+                {
+                    @Override
+                    Log decorate( Log log )
+                    {
+                        return new DirectLog( log );
+                    }
+                },
+        INDIRECT
+                {
+                    @Override
+                    Log decorate( Log log )
+                    {
+                        return log;
+                    }
+                };
+
+        abstract Log decorate( Log log );
+    }
+
+    enum Level
+    {
+        DEBUG
+                {
+                    @Override
+                    Logger logger( Log log )
+                    {
+                        return log.debugLogger();
+                    }
+                },
+        INFO
+                {
+                    @Override
+                    Logger logger( Log log )
+                    {
+                        return log.infoLogger();
+                    }
+                },
+        WARN
+                {
+                    @Override
+                    Logger logger( Log log )
+                    {
+                        return log.warnLogger();
+                    }
+                },
+        ERROR
+                {
+                    @Override
+                    Logger logger( Log log )
+                    {
+                        return log.errorLogger();
+                    }
+                };
+
+        abstract Logger logger( Log log );
+    }
+
+    enum Style
+    {
+        MESSAGE
+                {
+                    @Override
+                    void invoke( AsyncLogTest state, Logger logger )
+                    {
+                        logger.log( "a message" );
+                    }
+
+                    @Override
+                    public String toString()
+                    {
+                        return " <message> ";
+                    }
+                },
+        THROWABLE
+                {
+                    @Override
+                    void invoke( AsyncLogTest state, Logger logger )
+                    {
+                        logger.log( "an exception", state.exception );
+                    }
+
+                    @Override
+                    public String toString()
+                    {
+                        return " <message>, <exception> ";
+                    }
+                },
+        FORMAT
+                {
+                    @Override
+                    void invoke( AsyncLogTest state, Logger logger )
+                    {
+                        logger.log( "a %s message", "formatted" );
+                    }
+
+                    @Override
+                    public String toString()
+                    {
+                        return " <format>, <parameters...> ";
+                    }
+                };
+
+        abstract void invoke( AsyncLogTest state, Logger logger );
+    }
+
+    static class DeferredSender implements AsyncEventSender<AsyncLogEvent>
+    {
+        private final List<AsyncLogEvent> events = new ArrayList<>();
+
+        @Override
+        public void send( AsyncLogEvent event )
+        {
+            events.add( event );
+        }
+
+        public void process()
+        {
+            for ( AsyncLogEvent event : events )
+            {
+                event.process();
+            }
+            events.clear();
+        }
+    }
+
+    static class DirectLog extends AbstractLog
+    {
+        final Log log;
+
+        DirectLog( Log log )
+        {
+            this.log = log;
+        }
+
+        @Override
+        public boolean isDebugEnabled()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void bulk( Consumer<Log> consumer )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Logger debugLogger()
+        {
+            return new Logger()
+            {
+                @Override
+                public void log( String message )
+                {
+                    log.debug( message );
+                }
+
+                @Override
+                public void log( String message, Throwable throwable )
+                {
+                    log.debug( message, throwable );
+                }
+
+                @Override
+                public void log( String format, Object... arguments )
+                {
+                    log.debug( format, arguments );
+                }
+
+                @Override
+                public void bulk( Consumer<Logger> consumer )
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        @Override
+        public Logger infoLogger()
+        {
+            return new Logger()
+            {
+                @Override
+                public void log( String message )
+                {
+                    log.info( message );
+                }
+
+                @Override
+                public void log( String message, Throwable throwable )
+                {
+                    log.info( message, throwable );
+                }
+
+                @Override
+                public void log( String format, Object... arguments )
+                {
+                    log.info( format, arguments );
+                }
+
+                @Override
+                public void bulk( Consumer<Logger> consumer )
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        @Override
+        public Logger warnLogger()
+        {
+            return new Logger()
+            {
+                @Override
+                public void log( String message )
+                {
+                    log.warn( message );
+                }
+
+                @Override
+                public void log( String message, Throwable throwable )
+                {
+                    log.warn( message, throwable );
+                }
+
+                @Override
+                public void log( String format, Object... arguments )
+                {
+                    log.warn( format, arguments );
+                }
+
+                @Override
+                public void bulk( Consumer<Logger> consumer )
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        @Override
+        public Logger errorLogger()
+        {
+            return new Logger()
+            {
+                @Override
+                public void log( String message )
+                {
+                    log.error( message );
+                }
+
+                @Override
+                public void log( String message, Throwable throwable )
+                {
+                    log.error( message, throwable );
+                }
+
+                @Override
+                public void log( String format, Object... arguments )
+                {
+                    log.error( format, arguments );
+                }
+
+                @Override
+                public void bulk( Consumer<Logger> consumer )
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+    }
+
+    static class MatcherBuilder extends AbstractLog
+    {
+        private final AssertableLogProvider.LogMatcherBuilder builder;
+        private AssertableLogProvider.LogMatcher matcher;
+
+        public MatcherBuilder( AssertableLogProvider.LogMatcherBuilder builder )
+        {
+            this.builder = builder;
+        }
+
+        public AssertableLogProvider.LogMatcher matcher()
+        {
+            return requireNonNull( matcher, "invalid use, no matcher built" );
+        }
+
+        @Override
+        public boolean isDebugEnabled()
+        {
+            return true;
+        }
+
+        @Override
+        public void bulk( Consumer<Log> consumer )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Logger debugLogger()
+        {
+            return new Logger()
+            {
+                @Override
+                public void log( String message )
+                {
+                    matcher = builder.debug( messageMatcher( message ) );
+                }
+
+                @Override
+                public void log( String message, Throwable throwable )
+                {
+                    matcher = builder.debug( messageMatcher( message ), sameInstance( throwable ) );
+                }
+
+                @Override
+                public void log( String format, Object... arguments )
+                {
+                    matcher = builder.debug( messageMatcher( format ), arguments );
+                }
+
+                @Override
+                public void bulk( Consumer<Logger> consumer )
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        @Override
+        public Logger infoLogger()
+        {
+            return new Logger()
+            {
+                @Override
+                public void log( String message )
+                {
+                    matcher = builder.info( messageMatcher( message ) );
+                }
+
+                @Override
+                public void log( String message, Throwable throwable )
+                {
+                    matcher = builder.info( messageMatcher( message ), sameInstance( throwable ) );
+                }
+
+                @Override
+                public void log( String format, Object... arguments )
+                {
+                    matcher = builder.info( messageMatcher( format ), arguments );
+                }
+
+                @Override
+                public void bulk( Consumer<Logger> consumer )
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        @Override
+        public Logger warnLogger()
+        {
+            return new Logger()
+            {
+                @Override
+                public void log( String message )
+                {
+                    matcher = builder.warn( messageMatcher( message ) );
+                }
+
+                @Override
+                public void log( String message, Throwable throwable )
+                {
+                    matcher = builder.warn( messageMatcher( message ), sameInstance( throwable ) );
+                }
+
+                @Override
+                public void log( String format, Object... arguments )
+                {
+                    matcher = builder.warn( messageMatcher( format ), arguments );
+                }
+
+                @Override
+                public void bulk( Consumer<Logger> consumer )
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        @Override
+        public Logger errorLogger()
+        {
+            return new Logger()
+            {
+                @Override
+                public void log( String message )
+                {
+                    matcher = builder.error( messageMatcher( message ) );
+                }
+
+                @Override
+                public void log( String message, Throwable throwable )
+                {
+                    matcher = builder.error( messageMatcher( message ), sameInstance( throwable ) );
+                }
+
+                @Override
+                public void log( String format, Object... arguments )
+                {
+                    matcher = builder.error( messageMatcher( format ), arguments );
+                }
+
+                @Override
+                public void bulk( Consumer<Logger> consumer )
+                {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
+
+        private Matcher<String> messageMatcher( String message )
+        {
+            return allOf( startsWith( "[AsyncLog @ " ), endsWith( "]  " + message ) );
+        }
+    }
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEvent.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+/**
+ * The base-class for events that can be processed with an {@link AsyncEvents} processor.
+ */
+public abstract class AsyncEvent
+{
+    volatile AsyncEvent next;
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEventSender.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEventSender.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+/**
+ * An end-point of sorts, through which events can be sent or queued up for background processing.
+ *
+ * @param <T> The type of {@code AsyncEvent} objects this {@code AsyncEventSender} and process.
+ */
+public interface AsyncEventSender<T extends AsyncEvent>
+{
+    /**
+     * Send the given event to a background thread for processing.
+     *
+     * @param event The event that needs to be processed in the background.
+     */
+    void send( T event );
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEvents.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncEvents.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.LockSupport;
+
+import org.neo4j.function.Consumer;
+
+/**
+ * {@code AsyncEvents} is a mechanism for queueing up events to be processed asynchronously in a background thread.
+ *
+ * The {@code AsyncEvents} object implements {@link Runnable}, so it can be passed to a thread pool, or given to a
+ * dedicated thread. The runnable will then occupy a thread and dedicate it to background processing of events, until
+ * the {@code AsyncEvents} is {@link AsyncEvents#shutdown()}.
+ *
+ * If events are sent to an {@code AsyncEvents} that has been shut down, then those events will be processed in the
+ * foreground as a fall-back.
+ *
+ * Note, however, that no events are processed until the background thread is started.
+ *
+ * The {@code AsyncEvents} is given a {@link Consumer} of the specified event type upon construction, and will use it
+ * for doing the actual processing of events once they have been collected.
+ *
+ * @param <T> The type of events the {@code AsyncEvents} will process.
+ */
+public class AsyncEvents<T extends AsyncEvent> implements AsyncEventSender<T>, Runnable
+{
+    public interface Monitor
+    {
+        void eventCount( long count );
+
+        Monitor NONE = new Monitor()
+        {
+            @Override
+            public void eventCount( long count )
+            {
+            }
+        };
+    }
+
+    // TODO use VarHandles in Java 9
+    private static final AtomicReferenceFieldUpdater<AsyncEvents,AsyncEvent> STACK =
+            AtomicReferenceFieldUpdater.newUpdater( AsyncEvents.class, AsyncEvent.class, "stack" );
+    private static final Sentinel END_SENTINEL = new Sentinel( "END" );
+    private static final Sentinel SHUTDOWN_SENTINEL = new Sentinel( "SHUTDOWN" );
+
+    private final Consumer<T> eventConsumer;
+    private final Monitor monitor;
+    private final BinaryLatch startupLatch, shutdownLatch;
+
+    @SuppressWarnings( {"unused", "FieldCanBeLocal"} )
+    private volatile AsyncEvent stack; // Accessed via AtomicReferenceFieldUpdater
+    private volatile Thread backgroundThread;
+    private volatile boolean shutdown;
+
+    /**
+     * Construct a new {@code AsyncEvents} instance, that will use the given consumer to process the events.
+     *
+     * @param eventConsumer The {@link Consumer} used for processing the events that are sent in.
+     */
+    public AsyncEvents( Consumer<T> eventConsumer, Monitor monitor )
+    {
+        this.eventConsumer = eventConsumer;
+        this.monitor = monitor;
+        this.startupLatch = new BinaryLatch();
+        this.shutdownLatch = new BinaryLatch();
+        this.stack = END_SENTINEL;
+    }
+
+    @Override
+    public void send( T event )
+    {
+        AsyncEvent prev = STACK.getAndSet( this, event );
+        assert prev != null;
+        event.next = prev;
+        if ( prev == END_SENTINEL )
+        {
+            LockSupport.unpark( backgroundThread );
+        }
+        else if ( prev == SHUTDOWN_SENTINEL )
+        {
+            AsyncEvent events = STACK.getAndSet( this, SHUTDOWN_SENTINEL );
+            process( events );
+        }
+    }
+
+    @Override
+    public void run()
+    {
+        assert backgroundThread == null : "A thread is already running " + backgroundThread;
+        backgroundThread = Thread.currentThread();
+        startupLatch.release();
+
+        try
+        {
+            do
+            {
+                AsyncEvent events = STACK.getAndSet( this, END_SENTINEL );
+                process( events );
+                if ( stack == END_SENTINEL && !shutdown )
+                {
+                    LockSupport.park( this );
+                }
+            }
+            while ( !shutdown );
+
+            AsyncEvent events = STACK.getAndSet( this, SHUTDOWN_SENTINEL );
+            process( events );
+        }
+        finally
+        {
+            backgroundThread = null;
+            shutdownLatch.release();
+        }
+    }
+
+    private void process( AsyncEvent events )
+    {
+        events = reverseAndStripEndMark( events );
+        Consumer<T> consumer = this.eventConsumer;
+
+        while ( events != null )
+        {
+            @SuppressWarnings( "unchecked" )
+            T event = (T) events;
+            consumer.accept( event );
+            events = events.next;
+        }
+    }
+
+    private AsyncEvent reverseAndStripEndMark( AsyncEvent events )
+    {
+        AsyncEvent result = null;
+        long count = 0;
+        while ( events != END_SENTINEL && events != SHUTDOWN_SENTINEL )
+        {
+            AsyncEvent next;
+            do
+            {
+                next = events.next;
+            }
+            while ( next == null );
+            events.next = result;
+            result = events;
+            events = next;
+            count++;
+        }
+        if ( count > 0 )
+        {
+            monitor.eventCount( count );
+        }
+        return result;
+    }
+
+    /**
+     * Initiate the shut down process of this {@code AsyncEvents} instance.
+     *
+     * This call does not block or otherwise wait for the background thread to terminate.
+     */
+    public void shutdown()
+    {
+        assert backgroundThread != null : "Already shut down";
+        shutdown = true;
+        LockSupport.unpark( backgroundThread );
+    }
+
+    public void awaitStartup()
+    {
+        startupLatch.await();
+    }
+
+    public void awaitTermination() throws InterruptedException
+    {
+        shutdownLatch.await();
+    }
+
+    private static class Sentinel extends AsyncEvent
+    {
+        private final String str;
+
+        Sentinel( String identifier )
+        {
+            this.str = "AsyncEvent/Sentinel[" + identifier + "]";
+        }
+
+        @Override
+        public String toString()
+        {
+            return str;
+        }
+    }
+}

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/AsyncEventsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/AsyncEventsTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.function.Consumer;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+public class AsyncEventsTest
+{
+    private ExecutorService executor;
+
+    @Before
+    public void setUp()
+    {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @After
+    public void tearDown()
+    {
+        executor.shutdown();
+    }
+
+    class Event extends AsyncEvent
+    {
+        Thread processedBy;
+    }
+
+    class EventConsumer implements Consumer<Event>
+    {
+        final BlockingQueue<Event> eventsProcessed = new LinkedBlockingQueue<>();
+
+        @Override
+        public void accept( Event event )
+        {
+            event.processedBy = Thread.currentThread();
+            eventsProcessed.offer( event );
+        }
+
+        public Event poll( long timeout, TimeUnit unit ) throws InterruptedException
+        {
+            return eventsProcessed.poll( timeout, unit );
+        }
+    }
+
+    @Test
+    public void eventsMustBeProcessedByBackgroundThread() throws Exception
+    {
+        EventConsumer consumer = new EventConsumer();
+
+        AsyncEvents<Event> asyncEvents = new AsyncEvents<>( consumer, AsyncEvents.Monitor.NONE );
+        executor.submit( asyncEvents );
+
+        Event firstSentEvent = new Event();
+        asyncEvents.send( firstSentEvent );
+        Event firstProcessedEvent = consumer.poll( 10, TimeUnit.SECONDS );
+
+        Event secondSentEvent = new Event();
+        asyncEvents.send( secondSentEvent );
+        Event secondProcessedEvent = consumer.poll( 10, TimeUnit.SECONDS );
+
+        asyncEvents.shutdown();
+
+        assertThat( firstProcessedEvent, is( firstSentEvent ) );
+        assertThat( secondProcessedEvent, is( secondSentEvent ) );
+    }
+
+    @Test
+    public void mustNotProcessEventInSameThreadWhenNotShutDown() throws Exception
+    {
+        EventConsumer consumer = new EventConsumer();
+
+        AsyncEvents<Event> asyncEvents = new AsyncEvents<>( consumer, AsyncEvents.Monitor.NONE );
+        executor.submit( asyncEvents );
+
+        asyncEvents.send( new Event() );
+
+        Thread processingThread = consumer.poll( 10, TimeUnit.SECONDS ).processedBy;
+        asyncEvents.shutdown();
+
+        assertThat( processingThread, is( not( Thread.currentThread() ) ) );
+    }
+
+    @Test( timeout = 10000 )
+    public void mustProcessEventsDirectlyWhenShutDown() throws Exception
+    {
+        EventConsumer consumer = new EventConsumer();
+
+        AsyncEvents<Event> asyncEvents = new AsyncEvents<>( consumer, AsyncEvents.Monitor.NONE );
+        executor.submit( asyncEvents );
+
+        asyncEvents.send( new Event() );
+        Thread threadForFirstEvent = consumer.poll( 10, TimeUnit.SECONDS ).processedBy;
+        asyncEvents.shutdown();
+
+        assertThat( threadForFirstEvent, is( not( Thread.currentThread() ) ) );
+
+        Thread threadForSubsequentEvents;
+        do
+        {
+            asyncEvents.send( new Event() );
+            threadForSubsequentEvents = consumer.poll( 10, TimeUnit.SECONDS ).processedBy;
+        }
+        while ( threadForSubsequentEvents != Thread.currentThread() );
+    }
+
+    @Test( timeout = 10000 )
+    public void concurrentlyPublishedEventsMustAllBeProcessed() throws Exception
+    {
+        EventConsumer consumer = new EventConsumer();
+        final CountDownLatch startLatch = new CountDownLatch( 1 );
+        final int threads = 10;
+        final int iterations = 10_000;
+        final AsyncEvents<Event> asyncEvents = new AsyncEvents<>( consumer, AsyncEvents.Monitor.NONE );
+        executor.submit( asyncEvents );
+
+        ExecutorService threadPool = Executors.newFixedThreadPool( threads );
+        Runnable runner = new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                try
+                {
+                    startLatch.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    throw new RuntimeException( e );
+                }
+
+                for ( int i = 0; i < iterations; i++ )
+                {
+                    asyncEvents.send( new Event() );
+                }
+            }
+        };
+        for ( int i = 0; i < threads; i++ )
+        {
+            threadPool.submit( runner );
+        }
+        startLatch.countDown();
+
+        Thread thisThread = Thread.currentThread();
+        int eventCount = threads * iterations;
+        try
+        {
+            for ( int i = 0; i < eventCount; i++ )
+            {
+                Event event = consumer.poll( 1, TimeUnit.SECONDS );
+                assertThat( event.processedBy, is( not( thisThread ) ) );
+            }
+        }
+        finally
+        {
+            asyncEvents.shutdown();
+        }
+    }
+
+    @Test
+    public void awaitingShutdownMustBlockUntilAllMessagesHaveBeenProcessed() throws Exception
+    {
+        final Event specialShutdownObservedEvent = new Event();
+        final CountDownLatch awaitStartLatch = new CountDownLatch( 1 );
+        final EventConsumer consumer = new EventConsumer();
+        final AsyncEvents<Event> asyncEvents = new AsyncEvents<>( consumer, AsyncEvents.Monitor.NONE );
+        executor.submit( asyncEvents );
+
+        // Wait for the background thread to start processing events
+        do
+        {
+            asyncEvents.send( new Event() );
+        }
+        while ( consumer.eventsProcessed.take().processedBy == Thread.currentThread() );
+
+        // Start a thread that awaits the termination
+        Future<?> awaitShutdownFuture = executor.submit( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                awaitStartLatch.countDown();
+                try
+                {
+                    asyncEvents.awaitTermination();
+                }
+                catch ( InterruptedException e )
+                {
+                    throw new RuntimeException( e );
+                }
+                consumer.eventsProcessed.offer( specialShutdownObservedEvent );
+            }
+        } );
+
+        awaitStartLatch.await();
+
+        // Send 5 events
+        asyncEvents.send( new Event() );
+        asyncEvents.send( new Event() );
+        asyncEvents.send( new Event() );
+        asyncEvents.send( new Event() );
+        asyncEvents.send( new Event() );
+
+        // Observe 5 events processed
+        assertThat( consumer.eventsProcessed.take(), is( notNullValue() ) );
+        assertThat( consumer.eventsProcessed.take(), is( notNullValue() ) );
+        assertThat( consumer.eventsProcessed.take(), is( notNullValue() ) );
+        assertThat( consumer.eventsProcessed.take(), is( notNullValue() ) );
+        assertThat( consumer.eventsProcessed.take(), is( notNullValue() ) );
+
+        // Observe no events left
+        assertThat( consumer.eventsProcessed.poll( 20, TimeUnit.MILLISECONDS ), is( nullValue() ) );
+
+        // Shutdown and await termination
+        asyncEvents.shutdown();
+        awaitShutdownFuture.get();
+
+        // Observe termination
+        assertThat( consumer.eventsProcessed.take(), sameInstance( specialShutdownObservedEvent ) );
+    }
+}

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/FeatureToggles.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/FeatureToggles.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.internal.dragons;
+
+/**
+ * Feature toggles are used for features that are possible to configure, but where the configuration is always fixed in
+ * a production system.
+ *
+ * Typical use cases for feature toggles are features that are integrated into the code base for integration and
+ * testing purposes, but are not ready for inclusion in the finished product yet, or features that are always on or has
+ * a fixed configured value in the finished product, but can assume a different configuration or be turned off in some
+ * test.
+ *
+ * Feature toggles are passed to the JVM through {@linkplain System#getProperty(String) system properties}, and
+ * expected to be looked up from a static context, a {@code static final} fields of the class the toggle controls.
+ *
+ * All methods in this class returns the default value if the system property has not been assigned, or if the value of
+ * the system property cannot be interpreted as a value of the expected type.
+ *
+ * For features that the user is ever expected to touch, feature toggles is the wrong abstraction!
+ */
+public class FeatureToggles
+{
+    /**
+     * Get the value of a {@code boolean} system property.
+     *
+     * The absolute name of the system property is computed based on the provided class and local name.
+     *
+     * @param location the class that owns the flag.
+     * @param name the local name of the flag.
+     * @param defaultValue the default value of the flag if the system property is not assigned.
+     * @return the parsed value of the system property, or the default value.
+     */
+    public static boolean flag( Class<?> location, String name, boolean defaultValue )
+    {
+        return booleanProperty( name( location, name ), defaultValue );
+    }
+
+    /**
+     * Get the value of a {@code boolean} system property.
+     *
+     * The absolute name of the system property is computed based on the package of the provided class and local name.
+     *
+     * @param location a class in the package that owns the flag.
+     * @param name the local name of the flag.
+     * @param defaultValue the default value of the flag if the system property is not assigned.
+     * @return the parsed value of the system property, or the default value.
+     */
+    public static boolean packageFlag( Class<?> location, String name, boolean defaultValue )
+    {
+        return booleanProperty( name( location.getPackage(), name ), defaultValue );
+    }
+
+    /**
+     * Get the value of a {@code long} system property.
+     *
+     * The absolute name of the system property is computed based on the provided class and local name.
+     *
+     * @param location the class that owns the flag.
+     * @param name the local name of the flag.
+     * @param defaultValue the default value of the flag if the system property is not assigned.
+     * @return the parsed value of the system property, or the default value.
+     */
+    public static long getLong( Class<?> location, String name, long defaultValue )
+    {
+        return Long.getLong( name( location, name ), defaultValue );
+    }
+
+    /**
+     * Get the value of a {@code int} system property.
+     *
+     * The absolute name of the system property is computed based on the provided class and local name.
+     *
+     * @param location the class that owns the flag.
+     * @param name the local name of the flag.
+     * @param defaultValue the default value of the flag if the system property is not assigned.
+     * @return the parsed value of the system property, or the default value.
+     */
+    public static int getInteger( Class<?> location, String name, int defaultValue )
+    {
+        return Integer.getInteger( name( location, name ), defaultValue );
+    }
+
+    /**
+     * Get the value of a {@code enum} system property.
+     *
+     * The absolute name of the system property is computed based on the provided class and local name.
+     *
+     * @param location the class that owns the flag.
+     * @param name the local name of the flag.
+     * @param defaultValue the default value of the flag if the system property is not assigned.
+     * @param <E> the enum value type.
+     * @return the parsed value of the system property, or the default value.
+     */
+    public static <E extends Enum<E>> E flag( Class<?> location, String name, E defaultValue )
+    {
+        return enumProperty( defaultValue.getDeclaringClass(), name( location, name ), defaultValue );
+    }
+
+    /**
+     * Helps creating a JVM parameter for setting a {@code boolean} feature toggle.
+     *
+     * @param location the class that owns the flag.
+     * @param name the local name of the flag.
+     * @param value the value to assign to the feature toggle.
+     * @return the parameter to pass to the command line of the forked JVM.
+     */
+    public static String toggle( Class<?> location, String name, boolean value )
+    {
+        return toggle( name( location, name ), Boolean.toString( value ) );
+    }
+
+    /**
+     * Helps creating a JVM parameter for setting a {@code long} or {@code int} feature toggle.
+     *
+     * @param location the class that owns the flag.
+     * @param name the local name of the flag.
+     * @param value the value to assign to the feature toggle.
+     * @return the parameter to pass to the command line of the forked JVM.
+     */
+    public static String toggle( Class<?> location, String name, long value )
+    {
+        return toggle( name( location, name ), Long.toString( value ) );
+    }
+
+    /**
+     * Helps creating a JVM parameter for setting an {@code enum} feature toggle.
+     *
+     * @param location the class that owns the flag.
+     * @param name the local name of the flag.
+     * @param value the value to assign to the feature toggle.
+     * @return the parameter to pass to the command line of the forked JVM.
+     */
+    public static String toggle( Class<?> location, String name, Enum<?> value )
+    {
+        return toggle( name( location, name ), value.name() );
+    }
+
+    // <implementation>
+
+    private static String toggle( String key, String value )
+    {
+        return "-D" + key + "=" + value;
+    }
+
+    private FeatureToggles()
+    {
+    }
+
+    private static String name( Class<?> location, String name )
+    {
+        return location.getCanonicalName() + "." + name;
+    }
+
+    private static String name( Package location, String name )
+    {
+        return location.getName() + "." + name;
+    }
+
+    private static boolean booleanProperty( String flag, boolean defaultValue )
+    {
+        return parseBoolean( System.getProperty( flag ), defaultValue );
+    }
+
+    private static boolean parseBoolean( String value, boolean defaultValue )
+    {
+        return defaultValue ? !"false".equalsIgnoreCase( value ) : "true".equalsIgnoreCase( value );
+    }
+
+    private static <E extends Enum<E>> E enumProperty( Class<E> enumClass, String name, E defaultValue )
+    {
+        try
+        {
+            return Enum.valueOf( enumClass, System.getProperty( name, defaultValue.name() ) );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            return defaultValue;
+        }
+    }
+}

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/MemoryManager.java
@@ -32,8 +32,7 @@ public final class MemoryManager
     /**
      * The amount of memory, in bytes, to grab in each Slab.
      */
-    private static final long GRAB_SIZE = Integer.getInteger(
-            MemoryManager.class.getName() + ".GRAB_SIZE", 512 * 1024 ); // 512 KiB
+    private static final long GRAB_SIZE = FeatureToggles.getInteger( MemoryManager.class, "GRAB_SIZE", 512 * 1024 ); // 512 KiB
 
     /**
      * The amount of memory that this memory manager can still allocate.

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
@@ -32,6 +32,8 @@ import java.nio.ByteOrder;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+
 /**
  * Always check that the Unsafe utilities are available with the {@link UnsafeUtil#assertHasUnsafe} method, before
  * calling any of the other methods.
@@ -48,7 +50,7 @@ public final class UnsafeUtil
      * Enabling this feature will make sure that the allocated memory is full of random data, such that we can test
      * and verify that our code does not assume that memory is clean when allocated.
      */
-    private static final boolean DIRTY_MEMORY = Boolean.getBoolean( UnsafeUtil.class.getName() + ".DIRTY_MEMORY" );
+    private static final boolean DIRTY_MEMORY = flag( UnsafeUtil.class, "DIRTY_MEMORY", false );
 
     private static final Unsafe unsafe;
     private static final MethodHandle getAndAddInt;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.cluster.client;
 
-import org.jboss.netty.logging.InternalLoggerFactory;
-
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -28,6 +26,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+
+import org.jboss.netty.logging.InternalLoggerFactory;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.ExecutorLifecycleAdapter;
@@ -88,9 +88,8 @@ public class ClusterClientModule
     public ClusterClientModule( LifeSupport life, Dependencies dependencies, final Monitors monitors,
             final Config config, LogService logService, ElectionCredentialsProvider electionCredentialsProvider )
     {
-        final LogProvider internalLogProvider = logService.getInternalLogProvider();
-
-        InternalLoggerFactory.setDefaultFactory( new NettyLoggerFactory( internalLogProvider ) );
+        final LogProvider logging = logService.getInternalLogProvider();
+        InternalLoggerFactory.setDefaultFactory( new NettyLoggerFactory( logging ) );
 
         TimeoutStrategy timeoutStrategy = new MessageTimeoutStrategy(
                 new FixedTimeoutStrategy( config.get( ClusterSettings.default_timeout ) ) )
@@ -105,8 +104,9 @@ public class ClusterClientModule
                 .timeout( ClusterMessage.leaveTimedout, config.get( ClusterSettings.leave_timeout ) )
                 .timeout( ElectionMessage.electionTimeout, config.get( ClusterSettings.election_timeout ) );
 
-        MultiPaxosServerFactory protocolServerFactory = new MultiPaxosServerFactory( new ClusterConfiguration( config.get( ClusterSettings.cluster_name ),
-                internalLogProvider ), logService, monitors.newMonitor( StateMachines.Monitor.class ));
+        MultiPaxosServerFactory protocolServerFactory = new MultiPaxosServerFactory(
+                new ClusterConfiguration( config.get( ClusterSettings.cluster_name ), logging ),
+                logging, monitors.newMonitor( StateMachines.Monitor.class ) );
 
         NetworkReceiver receiver = dependencies.satisfyDependency( new NetworkReceiver( monitors.newMonitor( NetworkReceiver.Monitor.class ),
                 new NetworkReceiver.Configuration()
@@ -128,7 +128,7 @@ public class ClusterClientModule
             {
                 return config.get( ClusterSettings.instance_name );
             }
-        }, internalLogProvider ));
+        }, logging ));
 
         final ObjectInputStreamFactory objectInputStreamFactory = new ObjectStreamFactory();
         final ObjectOutputStreamFactory objectOutputStreamFactory = new ObjectStreamFactory();
@@ -143,7 +143,7 @@ public class ClusterClientModule
                 server.listeningAt( me );
                 if ( logger == null )
                 {
-                    logger = new StateTransitionLogger( internalLogProvider,
+                    logger = new StateTransitionLogger( logging,
                             new AtomicBroadcastSerializer( objectInputStreamFactory, objectOutputStreamFactory ) );
                     server.addStateTransitionListener( logger );
                 }
@@ -152,13 +152,13 @@ public class ClusterClientModule
             @Override
             public void channelOpened( URI to )
             {
-                internalLogProvider.getLog( NetworkReceiver.class ).info( to + " connected to me at " + server.boundAt() );
+                logging.getLog( NetworkReceiver.class ).info( to + " connected to me at " + server.boundAt() );
             }
 
             @Override
             public void channelClosed( URI to )
             {
-                internalLogProvider.getLog( NetworkReceiver.class ).info( to + " disconnected from me at " + server
+                logging.getLog( NetworkReceiver.class ).info( to + " disconnected from me at " + server
                         .boundAt() );
             }
         } );
@@ -177,7 +177,7 @@ public class ClusterClientModule
             {
                 return config.get( ClusterSettings.cluster_server ).getPort();
             }
-        }, receiver, internalLogProvider ));
+        }, receiver, logging ));
 
         ExecutorLifecycleAdapter stateMachineExecutor = new ExecutorLifecycleAdapter( new Factory<ExecutorService>()
         {
@@ -250,13 +250,13 @@ public class ClusterClientModule
         }
 
         @Override
-        public void init() throws Throwable
+        public void init()
         {
             server.getTimeouts().tick( System.currentTimeMillis() );
         }
 
         @Override
-        public void start() throws Throwable
+        public void start()
         {
             scheduler = Executors.newSingleThreadScheduledExecutor(
                     daemon( "timeout-clusterClient", monitors.newMonitor( NamedThreadFactory.Monitor.class ) ) );
@@ -274,16 +274,15 @@ public class ClusterClientModule
         }
 
         @Override
-        public void stop() throws Throwable
+        public void stop()
         {
             tickFuture.cancel( true );
             scheduler.shutdownNow();
         }
 
         @Override
-        public void shutdown() throws Throwable
+        public void shutdown()
         {
         }
     }
-
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
@@ -36,6 +36,7 @@ import org.neo4j.cluster.ProtocolServer;
 import org.neo4j.cluster.StateMachines;
 import org.neo4j.cluster.com.NetworkReceiver;
 import org.neo4j.cluster.com.NetworkSender;
+import org.neo4j.cluster.logging.AsyncLogging;
 import org.neo4j.cluster.logging.NettyLoggerFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.AtomicBroadcastSerializer;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
@@ -88,7 +89,7 @@ public class ClusterClientModule
     public ClusterClientModule( LifeSupport life, Dependencies dependencies, final Monitors monitors,
             final Config config, LogService logService, ElectionCredentialsProvider electionCredentialsProvider )
     {
-        final LogProvider logging = logService.getInternalLogProvider();
+        final LogProvider logging = AsyncLogging.provider( life, logService.getInternalLogProvider() );
         InternalLoggerFactory.setDefaultFactory( new NettyLoggerFactory( logging ) );
 
         TimeoutStrategy timeoutStrategy = new MessageTimeoutStrategy(

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/message/Message.java
@@ -70,14 +70,22 @@ public class Message<MESSAGETYPE extends MessageType>
     public static <MESSAGETYPE extends MessageType> Message<MESSAGETYPE> timeout( MESSAGETYPE message,
                                                                                   Message<?> causedBy, Object payload )
     {
-        return causedBy.copyHeadersTo( new Message<MESSAGETYPE>( message, payload ), Message.CONVERSATION_ID,
-                Message.CREATED_BY );
+        Message<MESSAGETYPE> timeout = causedBy.copyHeadersTo( new Message<>( message, payload ),
+                Message.CONVERSATION_ID, Message.CREATED_BY );
+        int timeoutCount = 0;
+        if ( causedBy.hasHeader( TIMEOUT_COUNT ) )
+        {
+            timeoutCount = Integer.parseInt( causedBy.getHeader( TIMEOUT_COUNT ) ) + 1;
+        }
+        timeout.setHeader( TIMEOUT_COUNT, "" + timeoutCount );
+        return timeout;
     }
 
 
     // Standard headers
     public static final String CONVERSATION_ID = "conversation-id";
     public static final String CREATED_BY = "created-by";
+    public static final String TIMEOUT_COUNT = "timeout-count";
     public static final String FROM = "from";
     public static final String TO = "to";
     public static final String INSTANCE_ID = "instance-id";

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/logging/AsyncLogging.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/logging/AsyncLogging.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster.logging;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.neo4j.concurrent.AsyncEventSender;
+import org.neo4j.concurrent.AsyncEvents;
+import org.neo4j.function.Consumer;
+import org.neo4j.helpers.NamedThreadFactory;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.logging.async.AsyncLogEvent;
+import org.neo4j.logging.async.AsyncLogProvider;
+
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+
+public class AsyncLogging extends LifecycleAdapter implements Consumer<AsyncLogEvent>, AsyncEvents.Monitor
+{
+    private static final boolean ENABLED = flag( AsyncLogging.class, "ENABLED", true );
+
+    public static LogProvider provider( LifeSupport life, LogProvider provider )
+    {
+        if ( ENABLED )
+        {
+            if ( provider instanceof NullLogProvider )
+            {
+                return provider;
+            }
+            return new AsyncLogProvider( life.add(
+                    new AsyncLogging( provider.getLog( AsyncLogging.class ) ) ).eventSender(), provider );
+        }
+        else
+        {
+            return provider;
+        }
+    }
+
+    private final Log metaLog;
+    private final AsyncEvents<AsyncLogEvent> events;
+    private long highCount;
+    private ExecutorService executor;
+
+    AsyncLogging( Log metaLog )
+    {
+        this.metaLog = metaLog;
+        this.events = new AsyncEvents<>( this, this );
+    }
+
+    @Override
+    public void accept( AsyncLogEvent event )
+    {
+        event.process();
+    }
+
+    @Override
+    public void start()
+    {
+        highCount = 0;
+        executor = Executors.newSingleThreadExecutor( new NamedThreadFactory( getClass().getSimpleName() ) );
+        executor.submit( events );
+        events.awaitStartup();
+    }
+
+    @Override
+    public void stop() throws InterruptedException
+    {
+        events.shutdown();
+        executor.shutdown();
+        events.awaitTermination();
+    }
+
+    @Override
+    public void eventCount( long count )
+    {
+        if ( metaLog.isDebugEnabled() )
+        {
+            if ( count > highCount )
+            {
+                metaLog.debug( "High mark increasing from %d to %d events", highCount, count );
+                highCount = count;
+            }
+        }
+    }
+
+    AsyncEventSender<AsyncLogEvent> eventSender()
+    {
+        return events;
+    }
+}

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/logging/NettyLoggerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/logging/NettyLoggerFactory.java
@@ -43,23 +43,13 @@ public class NettyLoggerFactory
     @Override
     public InternalLogger newInstance( String name )
     {
-        Class<?> clazz;
-        try
-        {
-            clazz = getClass().getClassLoader().loadClass( name );
-        }
-        catch ( ClassNotFoundException e )
-        {
-            clazz = getClass();
-        }
-
-        final Log log = logProvider.getLog( clazz );
+        final Log log = logProvider.getLog( name );
         return new AbstractInternalLogger()
         {
             @Override
             public boolean isDebugEnabled()
             {
-                return false;
+                return log.isDebugEnabled();
             }
 
             @Override
@@ -83,7 +73,7 @@ public class NettyLoggerFactory
             @Override
             public boolean isEnabled( InternalLogLevel level )
             {
-                return true;
+                return level != InternalLogLevel.DEBUG || isDebugEnabled();
             }
 
             @Override

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/LoggingContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/LoggingContext.java
@@ -17,22 +17,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
+package org.neo4j.cluster.protocol;
 
-import org.neo4j.cluster.protocol.ConfigurationContext;
-import org.neo4j.cluster.protocol.LoggingContext;
-import org.neo4j.cluster.protocol.TimeoutsContext;
-import org.neo4j.cluster.protocol.atomicbroadcast.AtomicBroadcastListener;
-import org.neo4j.cluster.protocol.atomicbroadcast.Payload;
+import org.neo4j.logging.Log;
 
-/**
- * Context for AtomicBroadcast statemachine.
- */
-public interface AtomicBroadcastContext
-    extends TimeoutsContext, ConfigurationContext, LoggingContext
+public interface LoggingContext
 {
-    void addAtomicBroadcastListener( AtomicBroadcastListener listener );
-    void removeAtomicBroadcastListener( AtomicBroadcastListener listener );
-    void receive( final Payload value );
-    boolean hasQuorum();
+    Log getLog( Class<?> loggingClass );
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/TimeoutsContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/TimeoutsContext.java
@@ -26,5 +26,7 @@ public interface TimeoutsContext
 {
     void setTimeout( Object key, Message<? extends MessageType> timeoutMessage );
 
-    void cancelTimeout( Object key );
+    Message<? extends MessageType> cancelTimeout( Object key );
+
+    long getTimeoutFor( Message<? extends MessageType> timeoutMessage );
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorContext.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
 
-import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.cluster.protocol.LoggingContext;
 
 /**
  * Context used by AcceptorState
  */
 public interface AcceptorContext
-    extends LogService
+    extends LoggingContext
 {
     AcceptorInstance getAcceptorInstance( InstanceId instanceId );
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AcceptorState.java
@@ -85,7 +85,7 @@ public enum AcceptorState
                             else
                             {
                                 // Optimization - explicit reject
-                                context.getInternalLog( AcceptorState.class ).debug("Rejecting prepare from "
+                                context.getLog( AcceptorState.class ).debug("Rejecting prepare from "
                                         + message.getHeader( Message.FROM ) + " for instance "
                                         + message.getHeader( InstanceId.INSTANCE ) + " and ballot "
                                         + incomingState.getBallot() + " (i had a prepare state ballot = "
@@ -116,7 +116,7 @@ public enum AcceptorState
                             }
                             else
                             {
-                                context.getInternalLog( AcceptorState.class ).debug( "Reject " + instanceId
+                                context.getLog( AcceptorState.class ).debug( "Reject " + instanceId
                                         + " accept ballot:" + acceptState.getBallot() + " actual ballot:" +
                                         instance.getBallot() );
                                 outgoing.offer( message.copyHeadersTo( Message.respond( ProposerMessage

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastState.java
@@ -153,7 +153,7 @@ public enum AtomicBroadcastState
                             }
                             else
                             {
-                                context.getInternalLog( AtomicBroadcastState.class )
+                                context.getLog( AtomicBroadcastState.class )
                                        .warn( "No quorum and therefor dropping broadcast msg: " + message.getPayload() );
                             }
                             break;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/BiasedWinnerStrategy.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/BiasedWinnerStrategy.java
@@ -93,7 +93,7 @@ public class BiasedWinnerStrategy implements WinnerStrategy
         String electionOutcome =
                 String.format( "Election: received votes %s, eligible votes %s (Instance #%s has been %s)",
                         votes, eligibleVotes, biasedNode, nodePromoted ? "promoted" : "demoted" );
-        electionContext.getInternalLog( getClass() ).debug( electionOutcome );
+        electionContext.getLog( getClass() ).debug( electionOutcome );
     }
 
     private boolean winnerIsBiasedInstance( Vote vote )

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerContext.java
@@ -20,15 +20,15 @@
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
 
 import org.neo4j.cluster.protocol.ConfigurationContext;
+import org.neo4j.cluster.protocol.LoggingContext;
 import org.neo4j.cluster.protocol.TimeoutsContext;
 import org.neo4j.cluster.protocol.atomicbroadcast.AtomicBroadcastSerializer;
-import org.neo4j.kernel.impl.logging.LogService;
 
 /**
  * Context for the Learner Paxos state machine.
  */
 public interface LearnerContext
-    extends TimeoutsContext, LogService, ConfigurationContext
+    extends TimeoutsContext, LoggingContext, ConfigurationContext
 {
     long getLastDeliveredInstanceId();
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerState.java
@@ -72,7 +72,7 @@ public enum LearnerState
                             InstanceId instanceId = new InstanceId( message );
                             PaxosInstance instance = context.getPaxosInstance( instanceId );
 
-                            Log log = context.getInternalLog( getClass() );
+                            Log log = context.getLog( getClass() );
 
                             // Skip if we already know about this
                             if ( instanceId.getId() <= context.getLastDeliveredInstanceId() )
@@ -143,14 +143,14 @@ public enum LearnerState
                                 else
                                 {
                                     // Found hole - we're waiting for this to be filled, i.e. timeout already set
-                                    context.getInternalLog( LearnerState.class ).debug( "*** HOLE! WAITING " +
+                                    context.getLog( LearnerState.class ).debug( "*** HOLE! WAITING " +
                                             "FOR " + (context.getLastDeliveredInstanceId() + 1) );
                                 }
                             }
                             else
                             {
                                 // Found hole - we're waiting for this to be filled, i.e. timeout already set
-                                context.getInternalLog( LearnerState.class ).debug( "*** GOT " + instanceId
+                                context.getLog( LearnerState.class ).debug( "*** GOT " + instanceId
                                         + ", WAITING FOR " + (context.getLastDeliveredInstanceId() + 1) );
 
                                 context.setTimeout( "learn", Message.timeout( LearnerMessage.learnTimedout,

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerContext.java
@@ -24,15 +24,15 @@ import java.util.List;
 
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.protocol.ConfigurationContext;
+import org.neo4j.cluster.protocol.LoggingContext;
 import org.neo4j.cluster.protocol.TimeoutsContext;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
-import org.neo4j.kernel.impl.logging.LogService;
 
 /**
  * Context used by {@link ProposerState} state machine.
  */
 public interface ProposerContext
-    extends TimeoutsContext, LogService, ConfigurationContext
+    extends TimeoutsContext, LoggingContext, ConfigurationContext
 {
     InstanceId newInstanceId( );
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerState.java
@@ -79,7 +79,7 @@ public enum ProposerState
                             ProposerMessage.RejectPrepare rejectPropose = message.getPayload();
                             org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId instanceId = new org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId( message );
                             PaxosInstance instance = context.getPaxosInstance( instanceId );
-                            context.getInternalLog( ProposerState.class ).debug( "Propose for instance " + instance
+                            context.getLog( ProposerState.class ).debug( "Propose for instance " + instance
                                     + " rejected from " + message.getHeader( Message.FROM ) + " with ballot "
                                     + rejectPropose.getBallot() );
 
@@ -93,7 +93,7 @@ public enum ProposerState
                                 }
 
                                 instance.phase1Timeout( ballot );
-                                context.getInternalLog( ProposerState.class ).debug(
+                                context.getLog( ProposerState.class ).debug(
                                         "Reproposing instance " + instance + " at ballot " + instance.ballot
                                                 + " after rejectPrepare" );
                                 for ( URI acceptor : instance.getAcceptors() )
@@ -122,7 +122,7 @@ public enum ProposerState
                             {
                                 if ( instance.ballot > 10000 )
                                 {
-                                    context.getInternalLog( ProposerState.class ).warn( "Propose failed due to phase 1 " +
+                                    context.getLog( ProposerState.class ).warn( "Propose failed due to phase 1 " +
                                             "timeout" );
 
                                     // Fail this propose
@@ -155,7 +155,7 @@ public enum ProposerState
                             {
                                 // Retry
                                 Message oldMessage = context.unbookInstance( instance.id );
-                                context.getInternalLog( getClass() ).debug( "Retrying instance " + instance.id +
+                                context.getLog( getClass() ).debug( "Retrying instance " + instance.id +
                                         " with message " + message.getPayload() +
                                         ". Previous instance was " + oldMessage );
                                 outgoing.offer( Message.internal( ProposerMessage.propose, message.getPayload() ) );
@@ -257,7 +257,7 @@ public enum ProposerState
                                 {
                                     context.cancelTimeout( instanceId );
 
-                                    context.getInternalLog( ProposerState.class ).warn( "Accept rejected:" +
+                                    context.getLog( ProposerState.class ).warn( "Accept rejected:" +
                                             instance.state );
 
                                     if ( instance.clientValue )
@@ -375,7 +375,7 @@ public enum ProposerState
                                     if ( context.hasPendingValues() && context.canBookInstance() )
                                     {
                                         Message proposeMessage = context.popPendingValue();
-                                        context.getInternalLog( ProposerState.class ).debug( "Restarting "
+                                        context.getLog( ProposerState.class ).debug( "Restarting "
                                                 + proposeMessage + " booked:"
                                                 + context.nrOfBookedInstances() );
                                         outgoing.offer( proposeMessage );
@@ -383,7 +383,7 @@ public enum ProposerState
                                 }
                             } else
                             {
-                                context.getInternalLog( ProposerState.class ).debug( "Instance receiving an accepted is in the wrong state:"+instance );
+                                context.getLog( ProposerState.class ).debug( "Instance receiving an accepted is in the wrong state:"+instance );
                             }
                             break;
                         }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
@@ -91,9 +91,15 @@ class AbstractContextImpl
     }
 
     @Override
-    public void cancelTimeout( Object key )
+    public long getTimeoutFor( Message<? extends MessageType> timeoutMessage )
     {
-        timeouts.cancelTimeout( key );
+        return timeouts.getTimeoutFor( timeoutMessage );
+    }
+
+    @Override
+    public Message<? extends MessageType> cancelTimeout( Object key )
+    {
+        return timeouts.cancelTimeout( key );
     }
 
     // ConfigurationContext

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
@@ -31,8 +31,8 @@ import org.neo4j.cluster.protocol.LoggingContext;
 import org.neo4j.cluster.protocol.TimeoutsContext;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.collection.Iterables.limit;
 import static org.neo4j.helpers.collection.Iterables.toList;
@@ -46,15 +46,15 @@ class AbstractContextImpl
 {
     protected final org.neo4j.cluster.InstanceId me;
     protected final CommonContextState commonState;
-    protected final LogService logService;
+    protected final LogProvider logProvider;
     protected final Timeouts timeouts;
 
     AbstractContextImpl( InstanceId me, CommonContextState commonState,
-            LogService logService, Timeouts timeouts )
+            LogProvider logProvider, Timeouts timeouts )
     {
         this.me = me;
         this.commonState = commonState;
-        this.logService = logService;
+        this.logProvider = logProvider;
         this.timeouts = timeouts;
     }
 
@@ -62,7 +62,7 @@ class AbstractContextImpl
     @Override
     public Log getLog( Class loggingClass )
     {
-        return logService.getInternalLog( loggingClass );
+        return logProvider.getLog( loggingClass );
     }
 
     // TimeoutsContext

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
@@ -27,12 +27,12 @@ import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageType;
 import org.neo4j.cluster.protocol.ConfigurationContext;
+import org.neo4j.cluster.protocol.LoggingContext;
 import org.neo4j.cluster.protocol.TimeoutsContext;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.Log;
-import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.collection.Iterables.limit;
 import static org.neo4j.helpers.collection.Iterables.toList;
@@ -42,16 +42,15 @@ import static org.neo4j.helpers.collection.Iterables.toList;
  * various generally useful information, and provides access to logging.
  */
 class AbstractContextImpl
-        implements TimeoutsContext, LogService, ConfigurationContext
+        implements TimeoutsContext, LoggingContext, ConfigurationContext
 {
     protected final org.neo4j.cluster.InstanceId me;
     protected final CommonContextState commonState;
     protected final LogService logService;
     protected final Timeouts timeouts;
 
-    AbstractContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState,
-                         LogService logService,
-                         Timeouts timeouts )
+    AbstractContextImpl( InstanceId me, CommonContextState commonState,
+            LogService logService, Timeouts timeouts )
     {
         this.me = me;
         this.commonState = commonState;
@@ -59,26 +58,9 @@ class AbstractContextImpl
         this.timeouts = timeouts;
     }
 
+    // LoggingContext
     @Override
-    public LogProvider getUserLogProvider()
-    {
-        return logService.getUserLogProvider();
-    }
-
-    @Override
-    public Log getUserLog( Class loggingClass )
-    {
-        return logService.getUserLog( loggingClass );
-    }
-
-    @Override
-    public LogProvider getInternalLogProvider()
-    {
-        return logService.getInternalLogProvider();
-    }
-
-    @Override
-    public Log getInternalLog( Class loggingClass )
+    public Log getLog( Class loggingClass )
     {
         return logService.getInternalLog( loggingClass );
     }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AcceptorContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AcceptorContextImpl.java
@@ -25,7 +25,7 @@ import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AcceptorInstanceSto
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AcceptorState;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.LogProvider;
 
 /**
  * Context for the {@link AcceptorState} distributed state machine.
@@ -39,10 +39,10 @@ class AcceptorContextImpl
     private final AcceptorInstanceStore instanceStore;
 
     AcceptorContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState,
-            LogService logService,
+            LogProvider logging,
             Timeouts timeouts, AcceptorInstanceStore instanceStore)
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.instanceStore = instanceStore;
     }
 
@@ -70,10 +70,10 @@ class AcceptorContextImpl
         instanceStore.clear();
     }
 
-    public AcceptorContextImpl snapshot( CommonContextState commonStateSnapshot, LogService logService, Timeouts timeouts,
+    public AcceptorContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging, Timeouts timeouts,
                                          AcceptorInstanceStore instanceStore )
     {
-        return new AcceptorContextImpl( me, commonStateSnapshot, logService, timeouts, instanceStore );
+        return new AcceptorContextImpl( me, commonStateSnapshot, logging, timeouts, instanceStore );
     }
 
     @Override

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AtomicBroadcastContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AtomicBroadcastContextImpl.java
@@ -30,7 +30,7 @@ import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.cluster.util.Quorums;
 import org.neo4j.helpers.Listeners;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.LogProvider;
 
 /**
  * Context for {@link AtomicBroadcastState} state machine.
@@ -46,10 +46,10 @@ class AtomicBroadcastContextImpl
     private final HeartbeatContext heartbeatContext;
 
     AtomicBroadcastContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState,
-                                LogService logService,
+                                LogProvider logging,
                                 Timeouts timeouts, Executor executor, HeartbeatContext heartbeatContext  )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.executor = executor;
         this.heartbeatContext = heartbeatContext;
     }
@@ -79,10 +79,10 @@ class AtomicBroadcastContextImpl
         } );
     }
 
-    public AtomicBroadcastContextImpl snapshot( CommonContextState commonStateSnapshot, LogService logService,
+    public AtomicBroadcastContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging,
                                                 Timeouts timeouts, Executor executor, HeartbeatContext heartbeatContext )
     {
-        return new AtomicBroadcastContextImpl( me, commonStateSnapshot, logService, timeouts, executor, heartbeatContext );
+        return new AtomicBroadcastContextImpl( me, commonStateSnapshot, logging, timeouts, executor, heartbeatContext );
     }
 
     @Override

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
@@ -41,7 +41,7 @@ import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.Listeners;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.Predicates.in;
 import static org.neo4j.helpers.Predicates.not;
@@ -74,13 +74,13 @@ class ClusterContextImpl
     private long electorVersion;
     private InstanceId lastElector;
 
-    ClusterContextImpl( InstanceId me, CommonContextState commonState, LogService logService,
+    ClusterContextImpl( InstanceId me, CommonContextState commonState, LogProvider logging,
                         Timeouts timeouts, Executor executor,
                         ObjectOutputStreamFactory objectOutputStreamFactory,
                         ObjectInputStreamFactory objectInputStreamFactory,
                         LearnerContext learnerContext, HeartbeatContext heartbeatContext )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.executor = executor;
         this.objectOutputStreamFactory = objectOutputStreamFactory;
         this.objectInputStreamFactory = objectInputStreamFactory;
@@ -112,14 +112,14 @@ class ClusterContextImpl
         }
     }
 
-    private ClusterContextImpl( InstanceId me, CommonContextState commonState, LogService logService, Timeouts timeouts,
+    private ClusterContextImpl( InstanceId me, CommonContextState commonState, LogProvider logging, Timeouts timeouts,
                         Iterable<URI> joiningInstances, ClusterMessage.ConfigurationResponseState
             joinDeniedConfigurationResponseState, Executor executor,
                         ObjectOutputStreamFactory objectOutputStreamFactory,
                         ObjectInputStreamFactory objectInputStreamFactory, LearnerContext learnerContext,
                         HeartbeatContext heartbeatContext )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.joiningInstances = joiningInstances;
         this.joinDeniedConfigurationResponseState = joinDeniedConfigurationResponseState;
         this.executor = executor;
@@ -171,7 +171,7 @@ class ClusterContextImpl
     @Override
     public void created( String name )
     {
-        commonState.setConfiguration( new ClusterConfiguration( name, logService.getInternalLogProvider(),
+        commonState.setConfiguration( new ClusterConfiguration( name, logProvider,
                 Collections.singleton( commonState.boundAt() ) ) );
         joined();
     }
@@ -462,13 +462,13 @@ class ClusterContextImpl
         return learnerContext.getLastDeliveredInstanceId();
     }
 
-    public ClusterContextImpl snapshot( CommonContextState commonStateSnapshot, LogService logService, Timeouts timeouts,
+    public ClusterContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging, Timeouts timeouts,
                                         Executor executor, ObjectOutputStreamFactory objectOutputStreamFactory,
                                         ObjectInputStreamFactory objectInputStreamFactory,
                                         LearnerContextImpl snapshotLearnerContext,
                                         HeartbeatContextImpl snapshotHeartbeatContext )
     {
-        return new ClusterContextImpl( me, commonStateSnapshot, logService, timeouts,
+        return new ClusterContextImpl( me, commonStateSnapshot, logging, timeouts,
                 joiningInstances == null ? null : new ArrayList<>(toList(joiningInstances)),
                 joinDeniedConfigurationResponseState == null ? null : joinDeniedConfigurationResponseState.snapshot(),
                 executor, objectOutputStreamFactory, objectInputStreamFactory, snapshotLearnerContext,

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
@@ -274,7 +274,7 @@ class ClusterContextImpl
         {
             if ( electorId.equals( getMyId() ) )
             {
-                getInternalLog( getClass() ).debug( "I elected instance " + instanceId + " for role "
+                getLog( getClass() ).debug( "I elected instance " + instanceId + " for role "
                         + roleName + " at version " + version );
                 if ( version < electorVersion )
                 {
@@ -283,14 +283,14 @@ class ClusterContextImpl
             }
             else if ( electorId.equals( lastElector ) && ( version < electorVersion && version > 1 ) )
             {
-                getInternalLog( getClass() ).warn( "Election result for role " + roleName +
+                getLog( getClass() ).warn( "Election result for role " + roleName +
                         " received from elector instance " + electorId + " with version " + version +
                         ". I had version " + electorVersion + " for elector " + lastElector );
                 return;
             }
             else
             {
-                getInternalLog( getClass() ).debug( "Setting elector to " + electorId + " and its version to " + version );
+                getLog( getClass() ).debug( "Setting elector to " + electorId + " and its version to " + version );
             }
 
             this.electorVersion = version;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ElectionContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ElectionContextImpl.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context;
 
-import static org.neo4j.cluster.util.Quorums.isQuorum;
-import static org.neo4j.helpers.collection.Iterables.filter;
-import static org.neo4j.helpers.collection.Iterables.map;
-import static org.neo4j.helpers.collection.Iterables.toList;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,6 +43,11 @@ import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.function.Function;
 import org.neo4j.function.Predicate;
 import org.neo4j.kernel.impl.logging.LogService;
+
+import static org.neo4j.cluster.util.Quorums.isQuorum;
+import static org.neo4j.helpers.collection.Iterables.filter;
+import static org.neo4j.helpers.collection.Iterables.map;
+import static org.neo4j.helpers.collection.Iterables.toList;
 
 public class ElectionContextImpl
         extends AbstractContextImpl
@@ -156,7 +156,7 @@ public class ElectionContextImpl
     @Override
     public void startElectionProcess( String role )
     {
-        clusterContext.getInternalLog( getClass() ).info( "Doing elections for role " + role );
+        clusterContext.getLog( getClass() ).info( "Doing elections for role " + role );
         if ( !clusterContext.getMyId().equals( clusterContext.getLastElector() ) )
         {
             clusterContext.setLastElector( clusterContext.getMyId() );
@@ -174,7 +174,7 @@ public class ElectionContextImpl
                 Collections.sort( filteredVoteList );
                 Collections.reverse( filteredVoteList );
 
-                clusterContext.getInternalLog( getClass() ).debug( "Election started with " + voteList +
+                clusterContext.getLog( getClass() ).debug( "Election started with " + voteList +
                         ", ended up with " + filteredVoteList );
 
                 // Elect this highest voted instance

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ElectionContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ElectionContextImpl.java
@@ -42,7 +42,7 @@ import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.function.Function;
 import org.neo4j.function.Predicate;
-import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.cluster.util.Quorums.isQuorum;
 import static org.neo4j.helpers.collection.Iterables.filter;
@@ -61,11 +61,11 @@ public class ElectionContextImpl
     private final ElectionCredentialsProvider electionCredentialsProvider;
 
     ElectionContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState,
-                         LogService logService,
+                         LogProvider logging,
                          Timeouts timeouts, Iterable<ElectionRole> roles, ClusterContext clusterContext,
                          HeartbeatContext heartbeatContext, ElectionCredentialsProvider electionCredentialsProvider )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.electionCredentialsProvider = electionCredentialsProvider;
         this.roles = new ArrayList<>(toList(roles));
         this.elections = new HashMap<>();
@@ -75,11 +75,11 @@ public class ElectionContextImpl
         heartbeatContext.addHeartbeatListener( this );
     }
 
-    ElectionContextImpl( InstanceId me, CommonContextState commonState, LogService logService, Timeouts timeouts,
+    ElectionContextImpl( InstanceId me, CommonContextState commonState, LogProvider logging, Timeouts timeouts,
                          ClusterContext clusterContext, HeartbeatContext heartbeatContext, List<ElectionRole> roles,
                          Map<String, Election> elections, ElectionCredentialsProvider electionCredentialsProvider )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.clusterContext = clusterContext;
         this.heartbeatContext = heartbeatContext;
         this.roles = roles;
@@ -342,7 +342,7 @@ public class ElectionContextImpl
         return heartbeatContext.getFailed();
     }
 
-    public ElectionContextImpl snapshot( CommonContextState commonStateSnapshot, LogService logService, Timeouts timeouts,
+    public ElectionContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging, Timeouts timeouts,
                                          ClusterContextImpl snapshotClusterContext,
                                          HeartbeatContextImpl snapshotHeartbeatContext,
                                          ElectionCredentialsProvider credentialsProvider )
@@ -354,7 +354,7 @@ public class ElectionContextImpl
             electionsSnapshot.put( election.getKey(), election.getValue().snapshot() );
         }
 
-        return new ElectionContextImpl( me, commonStateSnapshot, logService, timeouts, snapshotClusterContext,
+        return new ElectionContextImpl( me, commonStateSnapshot, logging, timeouts, snapshotClusterContext,
                 snapshotHeartbeatContext, new ArrayList<>(roles), electionsSnapshot, credentialsProvider );
     }
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
@@ -37,7 +37,7 @@ import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.function.Predicate;
 import org.neo4j.helpers.Listeners;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.helpers.collection.Iterables.toList;
 
@@ -56,18 +56,18 @@ class HeartbeatContextImpl
     private ClusterContext clusterContext;
     private LearnerContext learnerContext;
 
-    HeartbeatContextImpl( InstanceId me, CommonContextState commonState, LogService logService,
+    HeartbeatContextImpl( InstanceId me, CommonContextState commonState, LogProvider logging,
                           Timeouts timeouts, Executor executor )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.executor = executor;
     }
 
-    private HeartbeatContextImpl( InstanceId me, CommonContextState commonState, LogService logService, Timeouts timeouts,
+    private HeartbeatContextImpl( InstanceId me, CommonContextState commonState, LogProvider logging, Timeouts timeouts,
                           Set<InstanceId> failed, Map<InstanceId, Set<InstanceId>> nodeSuspicions,
                           Iterable<HeartbeatListener> heartBeatListeners, Executor executor)
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.failed = failed;
         this.nodeSuspicions = nodeSuspicions;
         this.heartBeatListeners = heartBeatListeners;
@@ -317,10 +317,10 @@ class HeartbeatContextImpl
         return learnerContext.getLastLearnedInstanceId();
     }
 
-    public HeartbeatContextImpl snapshot( CommonContextState commonStateSnapshot, LogService logService, Timeouts timeouts,
+    public HeartbeatContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging, Timeouts timeouts,
                                           Executor executor )
     {
-        return new HeartbeatContextImpl( me, commonStateSnapshot, logService, timeouts, new HashSet<>(failed),
+        return new HeartbeatContextImpl( me, commonStateSnapshot, logging, timeouts, new HashSet<>(failed),
                 new HashMap<>(nodeSuspicions), new ArrayList<>(toList(heartBeatListeners)), executor );
     }
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
@@ -97,7 +97,7 @@ class HeartbeatContextImpl
 
         if ( !isFailed( node ) && failed.remove( node ) )
         {
-            getInternalLog( HeartbeatContext.class ).info( "Notifying listeners that instance " + node + " is alive" );
+            getLog( HeartbeatContext.class ).info( "Notifying listeners that instance " + node + " is alive" );
             Listeners.notifyListeners( heartBeatListeners, executor, new Listeners.Notification<HeartbeatListener>()
             {
                 @Override
@@ -120,12 +120,12 @@ class HeartbeatContextImpl
         {
             serverSuspicions.add( node );
 
-            getInternalLog( HeartbeatContext.class ).info( getMyId() + "(me) is now suspecting " + node );
+            getLog( HeartbeatContext.class ).info( getMyId() + "(me) is now suspecting " + node );
         }
 
         if ( isFailed( node ) && !failed.contains( node ) )
         {
-            getInternalLog( HeartbeatContext.class ).info( "Notifying listeners that instance " + node + " is failed" );
+            getLog( HeartbeatContext.class ).info( "Notifying listeners that instance " + node + " is failed" );
             failed.add( node );
             Listeners.notifyListeners( heartBeatListeners, executor, new Listeners.Notification<HeartbeatListener>()
             {
@@ -144,7 +144,7 @@ class HeartbeatContextImpl
         // A failed instance might suspect instances which are alive so ignore it
         if ( isFailed( from ) )
         {
-            getInternalLog( HeartbeatContext.class ).info(
+            getLog( HeartbeatContext.class ).info(
                     "Ignoring suspicions from failed instance " + from + ": " + Iterables.toString( suspicions, "," ) );
             return;
         }
@@ -158,7 +158,7 @@ class HeartbeatContextImpl
             InstanceId currentSuspicion = suspicionsIterator.next();
             if ( !suspicions.contains( currentSuspicion ) )
             {
-                getInternalLog( HeartbeatContext.class ).info( from + " is no longer suspecting " + currentSuspicion );
+                getLog( HeartbeatContext.class ).info( from + " is no longer suspecting " + currentSuspicion );
                 suspicionsIterator.remove();
             }
         }
@@ -168,7 +168,7 @@ class HeartbeatContextImpl
         {
             if ( !serverSuspicions.contains( suspicion ) )
             {
-                getInternalLog( HeartbeatContext.class ).info( from + " is now suspecting " + suspicion );
+                getLog( HeartbeatContext.class ).info( from + " is now suspecting " + suspicion );
                 serverSuspicions.add( suspicion );
             }
         }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImpl.java
@@ -30,8 +30,8 @@ import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.PaxosInstance;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.PaxosInstanceStore;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.util.CappedOperation;
+import org.neo4j.logging.LogProvider;
 
 class LearnerContextImpl
         extends AbstractContextImpl
@@ -63,14 +63,14 @@ class LearnerContextImpl
     private final PaxosInstanceStore paxosInstances;
 
     LearnerContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState,
-                        LogService logService,
+                        LogProvider logging,
                         Timeouts timeouts, PaxosInstanceStore paxosInstances,
                         AcceptorInstanceStore instanceStore,
                         ObjectInputStreamFactory objectInputStreamFactory,
                         ObjectOutputStreamFactory objectOutputStreamFactory,
                         HeartbeatContext heartbeatContext )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.heartbeatContext = heartbeatContext;
         this.instanceStore = instanceStore;
         this.objectInputStreamFactory = objectInputStreamFactory;
@@ -78,13 +78,13 @@ class LearnerContextImpl
         this.paxosInstances = paxosInstances;
     }
 
-    private LearnerContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState, LogService logService,
+    private LearnerContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState, LogProvider logging,
                                 Timeouts timeouts, long lastDeliveredInstanceId, long lastLearnedInstanceId,
                                 HeartbeatContext heartbeatContext,
                         AcceptorInstanceStore instanceStore, ObjectInputStreamFactory objectInputStreamFactory,
                         ObjectOutputStreamFactory objectOutputStreamFactory, PaxosInstanceStore paxosInstances )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.lastDeliveredInstanceId = lastDeliveredInstanceId;
         this.lastLearnedInstanceId = lastLearnedInstanceId;
         this.heartbeatContext = heartbeatContext;
@@ -186,12 +186,12 @@ class LearnerContextImpl
         learnMissLogging.event( instanceId );
     }
 
-    public LearnerContextImpl snapshot( CommonContextState commonStateSnapshot, LogService logService, Timeouts timeouts,
+    public LearnerContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging, Timeouts timeouts,
                                         PaxosInstanceStore paxosInstancesSnapshot, AcceptorInstanceStore instanceStore,
                                         ObjectInputStreamFactory objectInputStreamFactory, ObjectOutputStreamFactory
             objectOutputStreamFactory, HeartbeatContextImpl snapshotHeartbeatContext )
     {
-        return new LearnerContextImpl( me, commonStateSnapshot, logService, timeouts, lastDeliveredInstanceId,
+        return new LearnerContextImpl( me, commonStateSnapshot, logging, timeouts, lastDeliveredInstanceId,
                 lastLearnedInstanceId, snapshotHeartbeatContext, instanceStore, objectInputStreamFactory,
                 objectOutputStreamFactory, paxosInstancesSnapshot );
     }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImpl.java
@@ -49,7 +49,7 @@ class LearnerContextImpl
                 @Override
                 protected void triggered( InstanceId instanceId )
                 {
-                    getInternalLog( LearnerState.class ).warn( "Did not have learned value for Paxos instance "
+                    getLog( LearnerState.class ).warn( "Did not have learned value for Paxos instance "
                             + instanceId + ". This generally indicates that this instance has missed too many " +
                             "cluster events and is failing to catch up. If this error does not resolve soon it " +
                             "may become necessary to restart this cluster member so normal operation can resume.");

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/MultiPaxosContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/MultiPaxosContext.java
@@ -36,7 +36,7 @@ import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.ElectionRole;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.LogProvider;
 
 /**
  * Context that implements all the context interfaces used by the Paxos state machines.
@@ -60,7 +60,7 @@ public class MultiPaxosContext
                               Iterable<ElectionRole> roles,
                               ClusterConfiguration configuration,
                               Executor executor,
-                              LogService logService,
+                              LogProvider logging,
                               ObjectInputStreamFactory objectInputStreamFactory,
                               ObjectOutputStreamFactory objectOutputStreamFactory,
                               AcceptorInstanceStore instanceStore,
@@ -70,13 +70,13 @@ public class MultiPaxosContext
         commonState = new CommonContextState(configuration);
         paxosInstances = new PaxosInstanceStore();
 
-        heartbeatContext = new HeartbeatContextImpl(me, commonState, logService, timeouts, executor );
-        learnerContext = new LearnerContextImpl(me, commonState, logService, timeouts, paxosInstances, instanceStore, objectInputStreamFactory, objectOutputStreamFactory, heartbeatContext );
-        clusterContext = new ClusterContextImpl(me, commonState, logService, timeouts, executor, objectOutputStreamFactory, objectInputStreamFactory, learnerContext, heartbeatContext );
-        electionContext = new ElectionContextImpl( me, commonState, logService, timeouts, roles, clusterContext, heartbeatContext, electionCredentialsProvider );
-        proposerContext = new ProposerContextImpl(me, commonState, logService, timeouts, paxosInstances );
-        acceptorContext = new AcceptorContextImpl(me, commonState, logService, timeouts, instanceStore );
-        atomicBroadcastContext = new AtomicBroadcastContextImpl(me, commonState, logService, timeouts, executor, heartbeatContext );
+        heartbeatContext = new HeartbeatContextImpl(me, commonState, logging, timeouts, executor );
+        learnerContext = new LearnerContextImpl(me, commonState, logging, timeouts, paxosInstances, instanceStore, objectInputStreamFactory, objectOutputStreamFactory, heartbeatContext );
+        clusterContext = new ClusterContextImpl(me, commonState, logging, timeouts, executor, objectOutputStreamFactory, objectInputStreamFactory, learnerContext, heartbeatContext );
+        electionContext = new ElectionContextImpl( me, commonState, logging, timeouts, roles, clusterContext, heartbeatContext, electionCredentialsProvider );
+        proposerContext = new ProposerContextImpl(me, commonState, logging, timeouts, paxosInstances );
+        acceptorContext = new AcceptorContextImpl(me, commonState, logging, timeouts, instanceStore );
+        atomicBroadcastContext = new AtomicBroadcastContextImpl(me, commonState, logging, timeouts, executor, heartbeatContext );
 
         heartbeatContext.setCircularDependencies( clusterContext, learnerContext );
     }
@@ -135,32 +135,32 @@ public class MultiPaxosContext
 
     /** Create a state snapshot. The snapshot will not duplicate services, and expects the caller to duplicate
      * {@link AcceptorInstanceStore}, since that is externally provided.  */
-    public MultiPaxosContext snapshot(LogService logService, Timeouts timeouts, Executor executor,
+    public MultiPaxosContext snapshot(LogProvider logging, Timeouts timeouts, Executor executor,
                                       AcceptorInstanceStore instanceStore,
                                       ObjectInputStreamFactory objectInputStreamFactory,
                                       ObjectOutputStreamFactory objectOutputStreamFactory,
                                       ElectionCredentialsProvider electionCredentialsProvider)
     {
-        CommonContextState commonStateSnapshot = commonState.snapshot(logService.getInternalLog( ClusterConfiguration.class ) );
+        CommonContextState commonStateSnapshot = commonState.snapshot( logging.getLog( ClusterConfiguration.class ) );
         PaxosInstanceStore paxosInstancesSnapshot = paxosInstances.snapshot();
 
         HeartbeatContextImpl snapshotHeartbeatContext =
-                heartbeatContext.snapshot( commonStateSnapshot, logService, timeouts, executor );
+                heartbeatContext.snapshot( commonStateSnapshot, logging, timeouts, executor );
         LearnerContextImpl snapshotLearnerContext =
-                learnerContext.snapshot( commonStateSnapshot, logService, timeouts, paxosInstancesSnapshot, instanceStore,
+                learnerContext.snapshot( commonStateSnapshot, logging, timeouts, paxosInstancesSnapshot, instanceStore,
                         objectInputStreamFactory, objectOutputStreamFactory, snapshotHeartbeatContext );
         ClusterContextImpl snapshotClusterContext =
-                clusterContext.snapshot( commonStateSnapshot, logService, timeouts, executor, objectOutputStreamFactory,
+                clusterContext.snapshot( commonStateSnapshot, logging, timeouts, executor, objectOutputStreamFactory,
                         objectInputStreamFactory, snapshotLearnerContext, snapshotHeartbeatContext );
         ElectionContextImpl snapshotElectionContext =
-                electionContext.snapshot( commonStateSnapshot, logService, timeouts, snapshotClusterContext,
+                electionContext.snapshot( commonStateSnapshot, logging, timeouts, snapshotClusterContext,
                         snapshotHeartbeatContext, electionCredentialsProvider );
         ProposerContextImpl snapshotProposerContext =
-                proposerContext.snapshot( commonStateSnapshot, logService, timeouts, paxosInstancesSnapshot );
+                proposerContext.snapshot( commonStateSnapshot, logging, timeouts, paxosInstancesSnapshot );
         AcceptorContextImpl snapshotAcceptorContext =
-                acceptorContext.snapshot( commonStateSnapshot, logService, timeouts, instanceStore );
+                acceptorContext.snapshot( commonStateSnapshot, logging, timeouts, instanceStore );
         AtomicBroadcastContextImpl snapshotAtomicBroadcastContext =
-                atomicBroadcastContext.snapshot( commonStateSnapshot, logService, timeouts, executor, snapshotHeartbeatContext );
+                atomicBroadcastContext.snapshot( commonStateSnapshot, logging, timeouts, executor, snapshotHeartbeatContext );
 
         snapshotHeartbeatContext.setCircularDependencies( snapshotClusterContext, snapshotLearnerContext );
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImpl.java
@@ -34,7 +34,7 @@ import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ProposerContext;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ProposerMessage;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.LogProvider;
 
 class ProposerContextImpl
         extends AbstractContextImpl
@@ -49,20 +49,20 @@ class ProposerContextImpl
     private final PaxosInstanceStore paxosInstances;
 
     ProposerContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState,
-                         LogService logService,
+                         LogProvider logging,
                          Timeouts timeouts, PaxosInstanceStore paxosInstances )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.paxosInstances = paxosInstances;
         pendingValues = new LinkedList<>(  );
         bookedInstances = new HashMap<>();
     }
 
-    private ProposerContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState, LogService logService,
+    private ProposerContextImpl( org.neo4j.cluster.InstanceId me, CommonContextState commonState, LogProvider logging,
                                  Timeouts timeouts, Deque<Message> pendingValues,
                                  Map<InstanceId, Message> bookedInstances, PaxosInstanceStore paxosInstances )
     {
-        super( me, commonState, logService, timeouts );
+        super( me, commonState, logging, timeouts );
         this.pendingValues = pendingValues;
         this.bookedInstances = bookedInstances;
         this.paxosInstances = paxosInstances;
@@ -211,10 +211,10 @@ class ProposerContextImpl
         }
     }
 
-    public ProposerContextImpl snapshot( CommonContextState commonStateSnapshot, LogService logService, Timeouts timeouts,
+    public ProposerContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging, Timeouts timeouts,
                                          PaxosInstanceStore paxosInstancesSnapshot )
     {
-        return new ProposerContextImpl( me, commonStateSnapshot, logService, timeouts, new LinkedList<>( pendingValues ),
+        return new ProposerContextImpl( me, commonStateSnapshot, logging, timeouts, new LinkedList<>( pendingValues ),
                 new HashMap<>(bookedInstances), paxosInstancesSnapshot );
     }
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImpl.java
@@ -180,7 +180,7 @@ class ProposerContextImpl
                 {
                     instance.getAcceptors().remove( commonState.configuration().getMembers().get( value.getJoin()));
 
-                    getInternalLog( ProposerContext.class ).debug( "For booked instance " + instance +
+                    getLog( ProposerContext.class ).debug( "For booked instance " + instance +
                             " removed gone member "
                             + commonState.configuration().getMembers().get( value.getJoin() )
                             + " added joining member " +
@@ -200,7 +200,7 @@ class ProposerContextImpl
                 PaxosInstance instance = paxosInstances.getPaxosInstance( instanceId );
                 if ( instance.getAcceptors() != null )
                 {
-                    getInternalLog( ProposerContext.class ).debug( "For booked instance " + instance +
+                    getLog( ProposerContext.class ).debug( "For booked instance " + instance +
                             " removed leaving member "
                             + value.getLeave() + " (at URI " +
                             commonState.configuration().getMembers().get( value.getLeave() )

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
@@ -25,11 +25,11 @@ import java.util.Map;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.ConfigurationContext;
+import org.neo4j.cluster.protocol.LoggingContext;
 import org.neo4j.cluster.protocol.TimeoutsContext;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage.ConfigurationResponseState;
-import org.neo4j.kernel.impl.logging.LogService;
 
 /**
  * Represents the context necessary for cluster operations. Includes instance membership calls, election
@@ -39,7 +39,7 @@ import org.neo4j.kernel.impl.logging.LogService;
  * @see ClusterState
  */
 public interface ClusterContext
-    extends LogService, TimeoutsContext, ConfigurationContext
+    extends LoggingContext, TimeoutsContext, ConfigurationContext
 {
     public static final int NO_ELECTOR_VERSION = -1;
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
@@ -74,7 +74,7 @@ public enum ClusterState
                         case create:
                         {
                             String name = message.getPayload();
-                            context.getInternalLog( ClusterState.class ).info( "Creating cluster: " + name );
+                            context.getLog( ClusterState.class ).info( "Creating cluster: " + name );
                             context.created( name );
                             return entered;
                         }
@@ -134,10 +134,10 @@ public enum ClusterState
 
                             ClusterMessage.ConfigurationResponseState state = message.getPayload();
 
-                            context.getInternalLog( ClusterState.class ).info( "Joining cluster " + state.getClusterName() );
+                            context.getLog( ClusterState.class ).info( "Joining cluster " + state.getClusterName() );
                             if ( !context.getConfiguration().getName().equals( state.getClusterName() ) )
                             {
-                                context.getInternalLog( ClusterState.class ).warn( "Joined cluster name is different than " +
+                                context.getLog( ClusterState.class ).warn( "Joined cluster name is different than " +
                                         "the one configured. Expected " + context.getConfiguration().getName() +
                                         ", got " + state.getClusterName() + "." );
                             }
@@ -150,7 +150,7 @@ public enum ClusterState
                             if ( !memberList.containsKey( context.getMyId() ) ||
                                     !memberList.get( context.getMyId() ).equals( context.boundAt() ) )
                             {
-                                context.getInternalLog( ClusterState.class ).info( String.format( "%s joining:%s, " +
+                                context.getLog( ClusterState.class ).info( String.format( "%s joining:%s, " +
                                         "last delivered:%d", context.getMyId().toString(),
                                         context.getConfiguration().toString(),
                                         state.getLatestReceivedInstanceId().getId() ) );
@@ -171,7 +171,7 @@ public enum ClusterState
                                             Message.FROM ) ), newState ) );
                                 }
 
-                                context.getInternalLog( ClusterState.class ).debug( "Setup join timeout for " + message
+                                context.getLog( ClusterState.class ).debug( "Setup join timeout for " + message
                                         .getHeader( Message.CONVERSATION_ID ) );
                                 context.setTimeout( "join", timeout( ClusterMessage.joiningTimeout, message,
                                         new URI( message.getHeader( Message.FROM ) ) ) );
@@ -359,7 +359,7 @@ public enum ClusterState
 
                         case joiningTimeout:
                         {
-                            context.getInternalLog( ClusterState.class ).info( "Join timeout for " + message.getHeader(
+                            context.getLog( ClusterState.class ).info( "Join timeout for " + message.getHeader(
                                     Message.CONVERSATION_ID ) );
 
                             if ( context.hasJoinBeenDenied() )
@@ -440,11 +440,11 @@ public enum ClusterState
                             {
                                 if(otherInstanceJoiningWithSameId)
                                 {
-                                    context.getInternalLog( ClusterState.class ).info( "Denying entry to instance " + joiningId + " because another instance is currently joining with the same id.");
+                                    context.getLog( ClusterState.class ).info( "Denying entry to instance " + joiningId + " because another instance is currently joining with the same id.");
                                 }
                                 else
                                 {
-                                    context.getInternalLog( ClusterState.class ).info( "Denying entry to instance " + joiningId + " because that instance is already in the cluster.");
+                                    context.getLog( ClusterState.class ).info( "Denying entry to instance " + joiningId + " because that instance is already in the cluster.");
                                 }
                                 outgoing.offer( message.copyHeadersTo( respond( ClusterMessage.joinDenied, message,
                                         new ClusterMessage.ConfigurationResponseState( context.getConfiguration()
@@ -477,7 +477,7 @@ public enum ClusterState
                             List<URI> nodeList = new ArrayList<URI>( context.getConfiguration().getMemberURIs() );
                             if ( nodeList.size() == 1 )
                             {
-                                context.getInternalLog( ClusterState.class ).info( "Shutting down cluster: " + context
+                                context.getLog( ClusterState.class ).info( "Shutting down cluster: " + context
                                         .getConfiguration().getName() );
                                 context.left();
 
@@ -486,7 +486,7 @@ public enum ClusterState
                             }
                             else
                             {
-                                context.getInternalLog( ClusterState.class ).info( "Leaving:" + nodeList );
+                                context.getLog( ClusterState.class ).info( "Leaving:" + nodeList );
 
                                 ClusterMessage.ConfigurationChangeState newState = new ClusterMessage
                                         .ConfigurationChangeState();
@@ -536,7 +536,7 @@ public enum ClusterState
 
                         case leaveTimedout:
                         {
-                            context.getInternalLog( ClusterState.class ).warn( "Failed to leave. Cluster may consider this" +
+                            context.getLog( ClusterState.class ).warn( "Failed to leave. Cluster may consider this" +
                                     " instance still a member" );
                             context.left();
                             return start;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionContext.java
@@ -25,15 +25,15 @@ import java.util.Set;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.ConfigurationContext;
+import org.neo4j.cluster.protocol.LoggingContext;
 import org.neo4j.cluster.protocol.TimeoutsContext;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
-import org.neo4j.kernel.impl.logging.LogService;
 
 /**
  * Context used by {@link ElectionState}.
  */
 public interface ElectionContext
-    extends TimeoutsContext, LogService, ConfigurationContext
+    extends TimeoutsContext, LoggingContext, ConfigurationContext
 {
 
     void created();
@@ -58,7 +58,7 @@ public interface ElectionContext
 
     void startPromotionProcess( String role, final InstanceId promoteNode );
 
-    public boolean voted( String role, InstanceId suggestedNode, Comparable<Object> suggestionCredentials,
+    boolean voted( String role, InstanceId suggestedNode, Comparable<Object> suggestionCredentials,
                        long electionVersion );
 
     InstanceId getElectionWinner( String role );
@@ -87,13 +87,13 @@ public interface ElectionContext
 
     boolean hasCurrentlyElectedVoted( String role, InstanceId currentElected );
 
-    public Set<InstanceId> getFailed();
+    Set<InstanceId> getFailed();
 
-    public ClusterMessage.VersionedConfigurationStateChange newConfigurationStateChange();
+    ClusterMessage.VersionedConfigurationStateChange newConfigurationStateChange();
 
-    public VoteRequest voteRequestForRole( ElectionRole role );
+    VoteRequest voteRequestForRole( ElectionRole role );
 
-    public class VoteRequest implements Serializable
+    class VoteRequest implements Serializable
     {
         private static final long serialVersionUID = -715604979485263049L;
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
@@ -78,7 +78,7 @@ public enum ElectionState
                 )
                         throws Throwable
                 {
-                    Log log = context.getInternalLog( ElectionState.class );
+                    Log log = context.getLog( ElectionState.class );
                     switch ( message.getMessageType() )
                     {
                         case demote:
@@ -160,7 +160,7 @@ public enum ElectionState
                                         String roleName = role.getName();
                                         if ( !context.isElectionProcessInProgress( roleName ) )
                                         {
-                                            context.getInternalLog(ElectionState.class).debug(
+                                            context.getLog( ElectionState.class ).debug(
                                                     "Starting election process for role " + roleName );
 
                                             context.startElectionProcess( roleName );

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContext.java
@@ -24,14 +24,14 @@ import java.util.Set;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.ConfigurationContext;
+import org.neo4j.cluster.protocol.LoggingContext;
 import org.neo4j.cluster.protocol.TimeoutsContext;
-import org.neo4j.kernel.impl.logging.LogService;
 
 /**
  * Context used by the {@link HeartbeatState} state machine.
  */
 public interface HeartbeatContext
-    extends TimeoutsContext, ConfigurationContext, LogService
+    extends TimeoutsContext, ConfigurationContext, LoggingContext
 {
     void started();
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
+import org.neo4j.cluster.com.message.MessageType;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.LearnerMessage;
 import org.neo4j.cluster.statemachine.State;
 
@@ -122,11 +123,7 @@ public enum HeartbeatState
                                 }
                             }
 
-                            context.cancelTimeout( HeartbeatMessage.i_am_alive + "-" +
-                                    state.getServer() );
-                            context.setTimeout( HeartbeatMessage.i_am_alive + "-" +
-                                    state.getServer(), timeout( HeartbeatMessage.timed_out, message, state
-                                    .getServer() ) );
+                            resetTimeout( context, message, state );
 
                             // Check if this server knows something that we don't
                             if ( message.hasHeader( "last-learned" ) )
@@ -266,6 +263,25 @@ public enum HeartbeatState
                     }
 
                     return this;
+                }
+
+                private void resetTimeout( HeartbeatContext context, Message<HeartbeatMessage> message,
+                        HeartbeatMessage.IAmAliveState state )
+                {
+                    String key = HeartbeatMessage.i_am_alive + "-" + state.getServer();
+                    Message<? extends MessageType> oldTimeout = context.cancelTimeout( key );
+                    if ( oldTimeout != null && oldTimeout.hasHeader( Message.TIMEOUT_COUNT ) )
+                    {
+                        int timeoutCount = Integer.parseInt( oldTimeout.getHeader( Message.TIMEOUT_COUNT ) );
+                        if ( timeoutCount > 0 )
+                        {
+                            long timeout = context.getTimeoutFor( oldTimeout );
+                            context.getInternalLog( HeartbeatState.class ).debug(
+                                    "Received " + state + " after missing " + timeoutCount +
+                                    " (" + timeout * timeoutCount + "ms)" );
+                        }
+                    }
+                    context.setTimeout( key, timeout( HeartbeatMessage.timed_out, message, state.getServer() ) );
                 }
             }
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
@@ -153,7 +153,7 @@ public enum HeartbeatState
                         {
 
                             InstanceId server = message.getPayload();
-                            context.getInternalLog( HeartbeatState.class )
+                            context.getLog( HeartbeatState.class )
                                     .debug( "Received timed out for server " + server );
                             // Check if this node is no longer a part of the cluster
                             if ( context.getMembers().containsKey( server ) )
@@ -227,7 +227,7 @@ public enum HeartbeatState
                         case suspicions:
                         {
                             HeartbeatMessage.SuspicionsState suspicions = message.getPayload();
-                            context.getInternalLog( HeartbeatState.class )
+                            context.getLog( HeartbeatState.class )
                                     .debug( "Received suspicions as " + suspicions );
 
                             InstanceId fromId = new InstanceId(Integer.parseInt(message.getHeader( Message.INSTANCE_ID )));
@@ -245,7 +245,7 @@ public enum HeartbeatState
 
                         case leave:
                         {
-                            context.getInternalLog( HeartbeatState.class ).debug( "Received leave" );
+                            context.getLog( HeartbeatState.class ).debug( "Received leave" );
                             return start;
                         }
 
@@ -276,7 +276,7 @@ public enum HeartbeatState
                         if ( timeoutCount > 0 )
                         {
                             long timeout = context.getTimeoutFor( oldTimeout );
-                            context.getInternalLog( HeartbeatState.class ).debug(
+                            context.getLog( HeartbeatState.class ).debug(
                                     "Received " + state + " after missing " + timeoutCount +
                                     " (" + timeout * timeoutCount + "ms)" );
                         }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/TimeoutStrategy.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/TimeoutStrategy.java
@@ -26,6 +26,9 @@ import org.neo4j.cluster.com.message.Message;
  */
 public interface TimeoutStrategy
 {
+    /**
+     * @return the timeout (in milliseconds) for the given message.
+     */
     long timeoutFor( Message message );
 
     void timeoutTriggered( Message timeoutMessage );

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/Timeouts.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/timeout/Timeouts.java
@@ -72,19 +72,26 @@ public class Timeouts implements MessageSource
         timeouts.put( key, new Timeout( timeoutAt, timeoutMessage ) );
     }
 
+    public long getTimeoutFor( Message<? extends MessageType> timeoutMessage )
+    {
+        return timeoutStrategy.timeoutFor( timeoutMessage );
+    }
+
     /**
      * Cancel a timeout corresponding to a particular key. Use the same key
      * that was used to set it up.
      *
      * @param key
      */
-    public void cancelTimeout( Object key )
+    public Message<? extends MessageType> cancelTimeout( Object key )
     {
         Timeout timeout = timeouts.remove( key );
         if ( timeout != null )
         {
             timeoutStrategy.timeoutCancelled( timeout.timeoutMessage );
+            return timeout.getTimeoutMessage();
         }
+        return null;
     }
 
     /**

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/NetworkMock.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/NetworkMock.java
@@ -90,7 +90,7 @@ public class NetworkMock
 
     protected TestProtocolServer newTestProtocolServer( int serverId, URI serverUri )
     {
-        ProtocolServerFactory protocolServerFactory = new MultiPaxosServerFactory( new ClusterConfiguration( "default", logService.getInternalLogProvider() ), logService, monitors.newMonitor( StateMachines.Monitor.class ) );
+        ProtocolServerFactory protocolServerFactory = new MultiPaxosServerFactory( new ClusterConfiguration( "default", logService.getInternalLogProvider() ), logService.getInternalLogProvider(), monitors.newMonitor( StateMachines.Monitor.class ) );
 
         ServerIdElectionCredentialsProvider electionCredentialsProvider = new ServerIdElectionCredentialsProvider();
         electionCredentialsProvider.listeningAt( serverUri );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/logging/AsyncLoggingTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/logging/AsyncLoggingTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cluster.logging;
+
+import org.junit.Test;
+
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.async.AsyncLogProvider;
+
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.neo4j.logging.AssertableLogProvider.inLog;
+
+public class AsyncLoggingTest
+{
+    @Test
+    public void shouldLogMessages() throws Exception
+    {
+        // given
+        AssertableLogProvider logs = new AssertableLogProvider();
+        AsyncLogging logging = new AsyncLogging( logs.getLog( "meta" ) );
+
+        // when
+        logging.start();
+        try
+        {
+            new AsyncLogProvider( logging.eventSender(), logs ).getLog( "test" ).info( "hello" );
+        }
+        finally
+        {
+            logging.stop();
+        }
+        // then
+        logs.assertExactly( inLog( "test" ).info( endsWith( "hello" ) ) );
+    }
+
+    @Test
+    public void shouldLogWhenLoggingThreadStarts() throws Exception
+    {
+        // given
+        AssertableLogProvider logs = new AssertableLogProvider();
+        AsyncLogging logging = new AsyncLogging( logs.getLog( "meta" ) );
+
+        // when
+        new AsyncLogProvider( logging.eventSender(), logs ).getLog( "test" ).info( "hello" );
+
+        // then
+        logs.assertNoLoggingOccurred();
+
+        // when
+        logging.start();
+        logging.stop();
+
+        // then
+        logs.assertExactly( inLog( "test" ).info( endsWith( "hello" ) ) );
+    }
+}

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/AtomicBroadcastStateTest.java
@@ -51,7 +51,7 @@ public class AtomicBroadcastStateTest
         InstanceId coordinator = id( 1 );
         when( context.getCoordinator() ).thenReturn( coordinator );
         when( context.getUriForId( coordinator ) ).thenReturn( uri( 1 ) );
-        when( context.getInternalLog( AtomicBroadcastState.class ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( AtomicBroadcastState.class ) ).thenReturn( NullLog.getInstance() );
 
         final List<Message<?>> messages = new ArrayList<>( 1 );
         MessageHolder outgoing = new MessageHolder()
@@ -76,7 +76,7 @@ public class AtomicBroadcastStateTest
         AtomicBroadcastContext context = mock( AtomicBroadcastContext.class );
         when( context.hasQuorum() ).thenReturn( false );
         when( context.getCoordinator() ).thenReturn( null );
-        when( context.getInternalLog( AtomicBroadcastState.class ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( AtomicBroadcastState.class ) ).thenReturn( NullLog.getInstance() );
 
         final List<Message<?>> messages = new ArrayList<>( 1 );
         MessageHolder outgoing = new MessageHolder()

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosContextTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.concurrent.Executor;
 
 import org.junit.Test;
+
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context.MultiPaxosContext;
@@ -31,13 +32,12 @@ import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.ElectionRole;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.logging.NullLogProvider;
 
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class MultiPaxosContextTest
 {
@@ -49,7 +49,7 @@ public class MultiPaxosContextTest
         MultiPaxosContext ctx = new MultiPaxosContext( new InstanceId( 1 ),
                 Collections.<ElectionRole>emptyList(),
                 mock( ClusterConfiguration.class ), mock( Executor.class ),
-                NullLogService.getInstance(), new ObjectStreamFactory(),
+                NullLogProvider.getInstance(), new ObjectStreamFactory(),
                 new ObjectStreamFactory(), mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class) );
 
@@ -79,11 +79,11 @@ public class MultiPaxosContextTest
         MultiPaxosContext ctx = new MultiPaxosContext( new InstanceId( 1 ),
                 Collections.<ElectionRole>emptyList(),
                 clusterConfig, executor,
-                NullLogService.getInstance(), objStream,
+                NullLogProvider.getInstance(), objStream,
                 objStream, acceptorInstances, timeouts, electionCredentials );
 
         // When
-        MultiPaxosContext snapshot = ctx.snapshot( NullLogService.getInstance(), timeouts, executor, acceptorInstances, objStream, objStream,
+        MultiPaxosContext snapshot = ctx.snapshot( NullLogProvider.getInstance(), timeouts, executor, acceptorInstances, objStream, objStream,
                 electionCredentials );
 
         // Then

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosNetworkTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosNetworkTest.java
@@ -55,10 +55,9 @@ import org.neo4j.cluster.timeout.MessageTimeoutStrategy;
 import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.lifecycle.LifeSupport;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
 
 /**
  * TODO
@@ -85,7 +84,7 @@ public class MultiPaxosNetworkTest
                                 "cluster://localhost:5001",
                                 "cluster://localhost:5002",
                                 "cluster://localhost:5003" ),
-                        NullLogService.getInstance(),
+                        NullLogProvider.getInstance(),
                         monitors.newMonitor( StateMachines.Monitor.class )
                 ),
                 timeoutStrategy, NullLogProvider.getInstance(), new ObjectStreamFactory(), new ObjectStreamFactory(),

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosServer.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/MultiPaxosServer.java
@@ -27,8 +27,6 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Collection;
 
-import org.neo4j.kernel.impl.logging.NullLogService;
-
 import org.neo4j.cluster.BindingListener;
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
@@ -92,7 +90,7 @@ public class MultiPaxosServer
             Monitors monitors = new Monitors();
             NetworkedServerFactory serverFactory = new NetworkedServerFactory( life,
                     new MultiPaxosServerFactory( new ClusterConfiguration( "default", NullLogProvider.getInstance() ),
-                            NullLogService.getInstance(), monitors.newMonitor( StateMachines.Monitor.class ) ),
+                            NullLogProvider.getInstance(), monitors.newMonitor( StateMachines.Monitor.class ) ),
                     timeoutStrategy, NullLogProvider.getInstance(), new ObjectStreamFactory(), new ObjectStreamFactory(),
                     monitors.newMonitor( NetworkReceiver.Monitor.class ),
                     monitors.newMonitor( NetworkSender.Monitor.class ),

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerStateTest.java
@@ -62,7 +62,7 @@ public class ProposerStateTest
     public void ifProposingWithClosedInstanceThenRetryWithNextInstance() throws Throwable
     {
         ProposerContext context = Mockito.mock(ProposerContext.class);
-        when(context.getInternalLog( any( Class.class ) )).thenReturn( NullLog.getInstance() );
+        when(context.getLog( any( Class.class ) )).thenReturn( NullLog.getInstance() );
 
         org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId instanceId = new org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId( 42 );
         PaxosInstanceStore paxosInstanceStore = new PaxosInstanceStore();
@@ -176,7 +176,7 @@ public class ProposerStateTest
         instance.ready( payload, true );
         instance.pending();
         ProposerContext context = mock( ProposerContext.class );
-        when( context.getInternalLog( any(Class.class) ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
         when( context.getPaxosInstance( any( org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId.class ) ) ).thenReturn( instance );
         when( context.getMyId() ).thenReturn( new org.neo4j.cluster.InstanceId( parseInt( instanceId ) ) );
         TrackingMessageHolder outgoing = new TrackingMessageHolder();

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImplTest.java
@@ -19,17 +19,12 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.RETURNS_MOCKS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.net.URI;
 import java.util.concurrent.Executor;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
@@ -39,7 +34,13 @@ import org.neo4j.cluster.protocol.cluster.ClusterContext;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ClusterContextImplTest
 {
@@ -60,7 +61,7 @@ public class ClusterContextImplTest
         CommonContextState commonContextState = mock( CommonContextState.class );
         when( commonContextState.configuration() ).thenReturn( clusterConfiguration );
 
-        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogService.getInstance(),
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
                 ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
 
@@ -94,7 +95,7 @@ public class ClusterContextImplTest
         CommonContextState commonContextState = mock( CommonContextState.class );
         when( commonContextState.configuration() ).thenReturn( clusterConfiguration );
 
-        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogService.getInstance(),
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
                 ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
 
@@ -124,7 +125,7 @@ public class ClusterContextImplTest
 
         CommonContextState commonContextState = mock( CommonContextState.class, RETURNS_MOCKS );
 
-        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogService.getInstance(),
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
                 ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
 
@@ -154,7 +155,7 @@ public class ClusterContextImplTest
 
         CommonContextState commonContextState = mock( CommonContextState.class, RETURNS_MOCKS );
 
-        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogService.getInstance(),
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 mock( Timeouts.class ), mock ( Executor.class ), mock( ObjectOutputStreamFactory.class ), mock(
                 ObjectInputStreamFactory.class ), mock( LearnerContext.class ), mock( HeartbeatContext.class ) );
 
@@ -189,7 +190,7 @@ public class ClusterContextImplTest
 
         ArgumentCaptor<HeartbeatListener> listenerCaptor = ArgumentCaptor.forClass( HeartbeatListener.class );
 
-        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogService.getInstance(),
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
                 ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
 
@@ -228,7 +229,7 @@ public class ClusterContextImplTest
 
         ArgumentCaptor<HeartbeatListener> listenerCaptor = ArgumentCaptor.forClass( HeartbeatListener.class );
 
-        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogService.getInstance(),
+        ClusterContext context = new ClusterContextImpl(me, commonContextState, NullLogProvider.getInstance(),
                 timeouts, executor, mock( ObjectOutputStreamFactory.class ), mock(
                 ObjectInputStreamFactory.class ), mock( LearnerContext.class ), heartbeatContext );
 

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImplTest.java
@@ -32,13 +32,11 @@ import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ClusterProtocolAtomicbroadcastTestUtil.ids;
 import static org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ClusterProtocolAtomicbroadcastTestUtil.members;
 
@@ -61,7 +59,7 @@ public class HeartbeatContextImplTest
         when( configuration.getMemberIds() ).thenReturn( ids( 3 ) );
 
         final List<Runnable> runnables = new ArrayList<Runnable>();
-        HeartbeatContext context = new HeartbeatContextImpl( me, commonState, NullLogService.getInstance(), timeouts, new DelayedDirectExecutor(
+        HeartbeatContext context = new HeartbeatContextImpl( me, commonState, NullLogProvider.getInstance(), timeouts, new DelayedDirectExecutor(
                 NullLogProvider.getInstance() )
         {
             @Override

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/LearnerContextImplTest.java
@@ -28,11 +28,7 @@ import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AcceptorInstanceSto
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.LearnerState;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.PaxosInstanceStore;
 import org.neo4j.cluster.timeout.Timeouts;
-import org.neo4j.kernel.impl.logging.AbstractLogService;
-import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.AssertableLogProvider;
-import org.neo4j.logging.LogProvider;
-import org.neo4j.logging.NullLogProvider;
 
 import static org.hamcrest.core.StringContains.containsString;
 import static org.mockito.Mockito.mock;
@@ -45,22 +41,8 @@ public class LearnerContextImplTest
     {
         // Given
         final AssertableLogProvider logProvider = new AssertableLogProvider();
-        LogService logService = new AbstractLogService()
-        {
-            @Override
-            public LogProvider getUserLogProvider()
-            {
-                return NullLogProvider.getInstance();
-            }
-
-            @Override
-            public LogProvider getInternalLogProvider()
-            {
-                return logProvider;
-            }
-        };
         LearnerContextImpl ctx = new LearnerContextImpl( new InstanceId( 1 ), mock( CommonContextState.class ),
-                logService, mock( Timeouts.class ), mock( PaxosInstanceStore.class ), mock( AcceptorInstanceStore.class ),
+                logProvider, mock( Timeouts.class ), mock( PaxosInstanceStore.class ), mock( AcceptorInstanceStore.class ),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( HeartbeatContextImpl.class ) );
 

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterContextTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.concurrent.Executor;
 
 import org.junit.Test;
+
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
@@ -34,10 +35,14 @@ import org.neo4j.cluster.protocol.election.ElectionRole;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.logging.NullLogProvider;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class ClusterContextTest
 {
@@ -60,7 +65,7 @@ public class ClusterContextTest
                     {
                         command.run();
                     }
-                }, NullLogService.getInstance(),
+                }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class )
@@ -107,7 +112,7 @@ public class ClusterContextTest
                     {
                         command.run();
                     }
-                }, NullLogService.getInstance(),
+                }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class )
@@ -147,7 +152,7 @@ public class ClusterContextTest
                     {
                         command.run();
                     }
-                }, NullLogService.getInstance(),
+                }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class )
@@ -194,7 +199,7 @@ public class ClusterContextTest
                     {
                         command.run();
                     }
-                }, NullLogService.getInstance(),
+                }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class )

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterNetworkTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterNetworkTest.java
@@ -44,8 +44,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.neo4j.kernel.impl.logging.NullLogService;
-import org.neo4j.logging.NullLogProvider;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
@@ -64,6 +62,7 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.LoggerRule;
 
 import static org.junit.Assert.assertEquals;
@@ -172,7 +171,7 @@ public class ClusterNetworkTest
             Monitors monitors = new Monitors();
             NetworkedServerFactory factory = new NetworkedServerFactory( life,
                     new MultiPaxosServerFactory( new ClusterConfiguration( "default", NullLogProvider.getInstance() ),
-                            NullLogService.getInstance(), monitors.newMonitor( StateMachines.Monitor.class )
+                            NullLogProvider.getInstance(), monitors.newMonitor( StateMachines.Monitor.class )
                     ),
                     new FixedTimeoutStrategy( 1000 ), NullLogProvider.getInstance(), new ObjectStreamFactory(), new ObjectStreamFactory(),
                     monitors.newMonitor( NetworkReceiver.Monitor.class ), monitors.newMonitor( NetworkSender.Monitor.class ), monitors.newMonitor( NamedThreadFactory.Monitor.class )

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
@@ -57,7 +57,7 @@ public class ClusterStateTest
         when( context.isCurrentlyAlive( any( InstanceId.class ) ) ).thenReturn( true );
         when( context.getMembers() ).thenReturn( existingMembers );
         when( context.getConfiguration() ).thenReturn( clusterConfiguration( existingMembers ) );
-        when( context.getInternalLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
         TrackingMessageHolder outgoing = new TrackingMessageHolder();
         Message<ClusterMessage> message = to( configurationRequest, uri( 1 ), configuration( 2 ) )
                 .setHeader( Message.FROM, uri( 2 ).toString() );
@@ -77,7 +77,7 @@ public class ClusterStateTest
     {
         // GIVEN
         ClusterContext context = mock( ClusterContext.class );
-        when( context.getInternalLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
         TrackingMessageHolder outgoing = new TrackingMessageHolder();
         Map<InstanceId, URI> members = members( 1, 2 );
         
@@ -96,7 +96,7 @@ public class ClusterStateTest
         // GIVEN
         ClusterContext context = mock( ClusterContext.class );
         Map<InstanceId, URI> existingMembers = members( 1, 2 );
-        when( context.getInternalLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
         when( context.getJoiningInstances() ).thenReturn( Collections.<URI>emptyList() );
         when( context.hasJoinBeenDenied() ).thenReturn( true );
         when( context.getJoinDeniedConfigurationResponseState() )
@@ -122,7 +122,7 @@ public class ClusterStateTest
         when( context.isCurrentlyAlive( id( 2 ) ) ).thenReturn( true );
         when( context.getMembers() ).thenReturn( existingMembers );
         when( context.getConfiguration() ).thenReturn( clusterConfiguration( existingMembers ) );
-        when( context.getInternalLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
         when( context.getUriForId( id( 2 ) ) ).thenReturn( uri( 2 ) );
         TrackingMessageHolder outgoing = new TrackingMessageHolder();
         Message<ClusterMessage> message = to( configurationRequest, uri( 1 ), configuration( 2 ) )

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionContextTest.java
@@ -41,7 +41,7 @@ import org.neo4j.cluster.protocol.cluster.ClusterContext;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.logging.NullLogProvider;
 
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
@@ -96,7 +96,7 @@ public class ElectionContextTest
 
         MultiPaxosContext context = new MultiPaxosContext( new InstanceId( 1 ),
                 Iterables.<ElectionRole, ElectionRole>iterable( new ElectionRole( "coordinator" ) ),
-                clusterConfiguration, mock( Executor.class ), NullLogService.getInstance(),
+                clusterConfiguration, mock( Executor.class ), NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class) );
@@ -129,7 +129,7 @@ public class ElectionContextTest
 
         MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), Iterables.<ElectionRole, ElectionRole>iterable(
                 new ElectionRole( "coordinator" ) ), clusterConfiguration,
-                mock( Executor.class ), NullLogService.getInstance(),
+                mock( Executor.class ), NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class) );
@@ -164,7 +164,7 @@ public class ElectionContextTest
 
         MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), Iterables.<ElectionRole, ElectionRole>iterable(
                 new ElectionRole( "coordinator" ) ), clusterConfiguration,
-                mock( Executor.class ), NullLogService.getInstance(),
+                mock( Executor.class ), NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class) );
@@ -197,7 +197,7 @@ public class ElectionContextTest
 
         MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), Iterables.<ElectionRole, ElectionRole>iterable(
                         new ElectionRole( coordinatorRole ) ), clusterConfiguration,
-                        mock( Executor.class ), NullLogService.getInstance(),
+                        mock( Executor.class ), NullLogProvider.getInstance(),
                         mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class) );
@@ -225,7 +225,7 @@ public class ElectionContextTest
 
         ElectionContext context = new MultiPaxosContext( new InstanceId(1), Iterables.<ElectionRole, ElectionRole>iterable(
                 new ElectionRole( coordinatorRole ) ),  mock( ClusterConfiguration.class ),
-                mock( Executor.class ),  NullLogService.getInstance(),
+                mock( Executor.class ),  NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) ).getElectionContext();
 
@@ -245,7 +245,7 @@ public class ElectionContextTest
 
         ElectionContext context = new MultiPaxosContext( new InstanceId(1), Iterables.<ElectionRole, ElectionRole>iterable(
                 new ElectionRole( coordinatorRole ) ),  mock( ClusterConfiguration.class ),
-                mock( Executor.class ), NullLogService.getInstance(),
+                mock( Executor.class ), NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) ).getElectionContext();
 
@@ -283,7 +283,7 @@ public class ElectionContextTest
                     {
                         command.run();
                     }
-                }, NullLogService.getInstance(),
+                }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) );
 
@@ -331,7 +331,7 @@ public class ElectionContextTest
                     {
                         command.run();
                     }
-                }, NullLogService.getInstance(),
+                }, NullLogProvider.getInstance(),
                 mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) );
 
@@ -387,7 +387,7 @@ public class ElectionContextTest
                         command.run();
                     }
                 },
-                NullLogService.getInstance(), mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
+                NullLogProvider.getInstance(), mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ), mock( ElectionCredentialsProvider.class ) );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
@@ -427,7 +427,7 @@ public class ElectionContextTest
 
         MultiPaxosContext context = new MultiPaxosContext( new InstanceId(1), Iterables.<ElectionRole, ElectionRole>iterable(
                         new ElectionRole( "coordinator" ) ), clusterConfiguration,
-                        mock( Executor.class ), NullLogService.getInstance(),
+                        mock( Executor.class ), NullLogProvider.getInstance(),
                         mock( ObjectInputStreamFactory.class ), mock( ObjectOutputStreamFactory.class ),
                 mock( AcceptorInstanceStore.class ), mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class) );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.cluster.protocol.election;
 
-import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,14 +26,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
 import org.neo4j.cluster.com.message.MessageType;
+import org.neo4j.cluster.protocol.MessageArgumentMatcher;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AtomicBroadcastMessage;
 import org.neo4j.cluster.protocol.cluster.ClusterContext;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
-import org.neo4j.cluster.protocol.MessageArgumentMatcher;
 import org.neo4j.logging.NullLog;
 
 import static org.junit.Assert.assertEquals;
@@ -65,7 +65,7 @@ public class ElectionStateTest
         ClusterContext clusterContextMock = mock( ClusterContext.class );
 
         when( context.electionOk() ).thenReturn( false );
-        when( clusterContextMock.getInternalLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( clusterContextMock.getLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
 //        when( context.getClusterContext() ).thenReturn( clusterContextMock );
 
         MessageHolder holder = mock( MessageHolder.class );
@@ -83,8 +83,8 @@ public class ElectionStateTest
         ClusterContext clusterContextMock = mock( ClusterContext.class );
 
         when( context.electionOk() ).thenReturn( false );
-        when( clusterContextMock.getInternalLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
-        when( context.getInternalLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( clusterContextMock.getLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
 
         MessageHolder holder = mock( MessageHolder.class );
 
@@ -106,7 +106,7 @@ public class ElectionStateTest
         ElectionContext context = mock( ElectionContext.class );
         ClusterContext clusterContextMock = mock( ClusterContext.class );
 
-        when( clusterContextMock.getInternalLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( clusterContextMock.getLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
 //        when( context.getClusterContext() ).thenReturn( clusterContextMock );
         MessageHolder holder = mock( MessageHolder.class );
 
@@ -130,7 +130,7 @@ public class ElectionStateTest
         when( context.voteRequestForRole( new ElectionRole( role ) ) ).thenReturn( voteRequest );
 
           // Required for logging
-        when( context.getInternalLog( Mockito.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( Mockito.<Class>any() ) ).thenReturn( NullLog.getInstance() );
 
         // When
         election.handle( context,
@@ -150,7 +150,7 @@ public class ElectionStateTest
         ElectionContext context = mock( ElectionContext.class );
         MessageHolder holder = mock( MessageHolder.class );
 
-        when( context.getInternalLog( Mockito.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( Mockito.<Class>any() ) ).thenReturn( NullLog.getInstance() );
 
         final String role = "master";
         final InstanceId voter = new InstanceId( 2 );
@@ -172,7 +172,7 @@ public class ElectionStateTest
         // When
         election.handle( context, vote, holder );
 
-        verify( context ).getInternalLog( Matchers.<Class>any() );
+        verify( context ).getLog( Matchers.<Class>any() );
         verify( context ).voted( role, voter, voteCredentialComparable, 4 );
 
         // Then
@@ -186,7 +186,7 @@ public class ElectionStateTest
         String coordinatorRole = "coordinator";
 
         ElectionContext context = mock( ElectionContext.class );
-        when( context.getInternalLog( Mockito.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( Mockito.<Class>any() ) ).thenReturn( NullLog.getInstance() );
 
         MessageHolder holder = mock( MessageHolder.class );
 
@@ -217,7 +217,7 @@ public class ElectionStateTest
         };
 
         ElectionContext context = mock( ElectionContext.class );
-        when( context.getInternalLog( Mockito.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( Mockito.<Class>any() ) ).thenReturn( NullLog.getInstance() );
         when( context.getNeededVoteCount() ).thenReturn( 3 );
         when( context.getVoteCount( coordinatorRole ) ).thenReturn( 3 );
         when( context.voted( coordinatorRole, votingInstance, voteCredentialComparable, 4 ) ).thenReturn( true );
@@ -295,7 +295,7 @@ public class ElectionStateTest
         when( electionContext.getNeededVoteCount() ).thenReturn( 3 );
         when( electionContext.getElectionWinner( COORDINATOR ) ).thenReturn( winner );
 
-        when( electionContext.getInternalLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
+        when( electionContext.getLog( any( Class.class ) ) ).thenReturn( NullLog.getInstance() );
         when( electionContext.newConfigurationStateChange() )
                 .thenReturn( mock( ClusterMessage.VersionedConfigurationStateChange.class ) );
 

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.cluster.protocol.election;
 
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,18 +30,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
-
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
 import org.neo4j.cluster.com.message.MessageType;
-import org.neo4j.cluster.protocol.MessageArgumentMatcher;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AtomicBroadcastMessage;
 import org.neo4j.cluster.protocol.cluster.ClusterContext;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
+import org.neo4j.cluster.protocol.MessageArgumentMatcher;
 import org.neo4j.logging.NullLog;
 
 import static org.junit.Assert.assertEquals;

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
@@ -43,7 +43,6 @@ import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.ElectionRole;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -92,7 +91,7 @@ public class HeartbeatContextTest
 
         MultiPaxosContext context = new MultiPaxosContext( instanceIds[0], Iterables.<ElectionRole, ElectionRole>iterable(
                         new ElectionRole( "coordinator" ) ), config,
-                        Mockito.mock( Executor.class ), NullLogService.getInstance(),
+                        Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
                         Mockito.mock( ObjectInputStreamFactory.class), Mockito.mock( ObjectOutputStreamFactory.class),
                         Mockito.mock( AcceptorInstanceStore.class), Mockito.mock( Timeouts.class),
                         mock( ElectionCredentialsProvider.class) );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
@@ -19,16 +19,21 @@
  */
 package org.neo4j.cluster.protocol.heartbeat;
 
+import java.net.URI;
+import java.util.concurrent.Executor;
+
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
-import java.net.URI;
-import java.util.concurrent.Executor;
-
+import org.neo4j.cluster.DelayedDirectExecutor;
 import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.StateMachines;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
+import org.neo4j.cluster.com.message.MessageSender;
+import org.neo4j.cluster.com.message.MessageSource;
+import org.neo4j.cluster.protocol.MessageArgumentMatcher;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectInputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.ObjectOutputStreamFactory;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AcceptorInstanceStore;
@@ -37,20 +42,26 @@ import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context.MultiPaxosC
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.election.ElectionCredentialsProvider;
 import org.neo4j.cluster.protocol.election.ElectionRole;
-import org.neo4j.cluster.protocol.MessageArgumentMatcher;
+import org.neo4j.cluster.statemachine.StateMachine;
+import org.neo4j.cluster.timeout.TimeoutStrategy;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.logging.SimpleLogService;
+import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class HeartbeatStateTest
 {
@@ -161,5 +172,83 @@ public class HeartbeatStateTest
         // Then
         verify( holder, times( 1 ) ).offer( Matchers.argThat( new MessageArgumentMatcher<LearnerMessage>()
                 .onMessageType( LearnerMessage.catchUp ).withHeader( Message.INSTANCE_ID, "2" ) ) );
+    }
+
+    @Test
+    public void shouldLogFirstHeartbeatAfterTimeout() throws Throwable
+    {
+        // given
+        InstanceId instanceId = new InstanceId( 1 ), otherInstance = new InstanceId( 2 );
+        ClusterConfiguration configuration = new ClusterConfiguration( "whatever", NullLogProvider.getInstance(),
+                "cluster://1", "cluster://2" );
+        configuration.getMembers().put( otherInstance, URI.create( "cluster://2" ) );
+        AssertableLogProvider userLog = new AssertableLogProvider( true );
+        AssertableLogProvider internalLog = new AssertableLogProvider( true );
+        LogService logging = new SimpleLogService( userLog, internalLog );
+        TimeoutStrategy timeoutStrategy = mock( TimeoutStrategy.class );
+        Timeouts timeouts = new Timeouts( timeoutStrategy );
+
+        MultiPaxosContext context = new MultiPaxosContext(
+                instanceId,
+                Iterables.<ElectionRole,ElectionRole>iterable( new ElectionRole( "coordinator" ) ),
+                configuration,
+                mock( Executor.class ),
+                logging,
+                mock( ObjectInputStreamFactory.class ),
+                mock( ObjectOutputStreamFactory.class ),
+                mock( AcceptorInstanceStore.class ),
+                timeouts,
+                mock( ElectionCredentialsProvider.class ) );
+
+        StateMachines stateMachines = new StateMachines(
+                logging.getInternalLogProvider(),
+                mock( StateMachines.Monitor.class ),
+                mock( MessageSource.class ),
+                mock( MessageSender.class ),
+                timeouts,
+                mock( DelayedDirectExecutor.class ),
+                new Executor()
+                {
+                    @Override
+                    public void execute( Runnable command )
+                    {
+                        command.run();
+                    }
+                },
+                instanceId );
+        stateMachines.addStateMachine(
+                new StateMachine( context.getHeartbeatContext(), HeartbeatMessage.class, HeartbeatState.start,
+                        logging.getInternalLogProvider() ) );
+
+        timeouts.tick( 0 );
+        when( timeoutStrategy.timeoutFor( any( Message.class ) ) ).thenReturn( 5l );
+
+        // when
+        stateMachines.process( Message.internal( HeartbeatMessage.join ) );
+        stateMachines.process(
+                Message.internal( HeartbeatMessage.i_am_alive, new HeartbeatMessage.IAmAliveState( otherInstance ) )
+                        .setHeader( Message.CREATED_BY, otherInstance.toString() ) );
+        for ( int i = 1; i <= 15; i++ )
+        {
+            timeouts.tick( i );
+        }
+
+        // then
+        verify( timeoutStrategy, times( 3 ) ).timeoutTriggered( argThat( new MessageArgumentMatcher<>()
+                .onMessageType( HeartbeatMessage.timed_out ) ) );
+        internalLog.assertExactly(
+                inLog( HeartbeatState.class ).debug( "Received timed out for server 2" ),
+                inLog( HeartbeatContext.class ).info( "1(me) is now suspecting 2" ),
+                inLog( HeartbeatState.class ).debug( "Received timed out for server 2" ),
+                inLog( HeartbeatState.class ).debug( "Received timed out for server 2" ) );
+        internalLog.clear();
+
+        // when
+        stateMachines.process(
+                Message.internal( HeartbeatMessage.i_am_alive, new HeartbeatMessage.IAmAliveState( otherInstance ) )
+                        .setHeader( Message.CREATED_BY, otherInstance.toString() ) );
+
+        // then
+        internalLog.assertExactly( inLog( HeartbeatState.class ).debug( "Received i_am_alive[2] after missing 3 (15ms)" ) );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterInstance.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ClusterInstance.java
@@ -55,14 +55,13 @@ import org.neo4j.kernel.ha.HighAvailabilityMemberInfoProvider;
 import org.neo4j.kernel.ha.cluster.DefaultElectionCredentialsProvider;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState;
 import org.neo4j.kernel.impl.core.LastTxIdGetter;
-import org.neo4j.kernel.impl.logging.LogService;
-import org.neo4j.logging.LogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.LogProvider;
 
 class ClusterInstance
 {
     private final Executor stateMachineExecutor;
-    private final LogService logService;
+    private final LogProvider logging;
     private final MultiPaxosServerFactory factory;
     private final ProtocolServer server;
     private final MultiPaxosContext ctx;
@@ -84,9 +83,10 @@ class ClusterInstance
     private boolean online = true;
 
     public static ClusterInstance newClusterInstance( InstanceId id, URI uri, Monitors monitors,
-                                                      ClusterConfiguration configuration, LogService logService )
+                                                      ClusterConfiguration configuration, LogProvider logging )
     {
-        MultiPaxosServerFactory factory = new MultiPaxosServerFactory( configuration, logService, monitors.newMonitor( StateMachines.Monitor.class ) );
+        MultiPaxosServerFactory factory = new MultiPaxosServerFactory( configuration,
+                logging, monitors.newMonitor( StateMachines.Monitor.class ) );
 
         ClusterInstanceInput input = new ClusterInstanceInput();
         ClusterInstanceOutput output = new ClusterInstanceOutput( uri );
@@ -97,12 +97,12 @@ class ClusterInstance
 
         InMemoryAcceptorInstanceStore acceptorInstances = new InMemoryAcceptorInstanceStore();
 
-        DelayedDirectExecutor executor = new DelayedDirectExecutor( logService.getInternalLogProvider() );
+        DelayedDirectExecutor executor = new DelayedDirectExecutor( logging );
         final MultiPaxosContext context = new MultiPaxosContext( id,
                 Iterables.<ElectionRole, ElectionRole>iterable( new ElectionRole( ClusterConfiguration.COORDINATOR ) ),
-                new ClusterConfiguration( configuration.getName(), logService.getInternalLogProvider(),
+                new ClusterConfiguration( configuration.getName(), logging,
                         configuration.getMemberURIs() ),
-                executor, logService, objStreamFactory, objStreamFactory, acceptorInstances, timeouts,
+                executor, logging, objStreamFactory, objStreamFactory, acceptorInstances, timeouts,
                 new DefaultElectionCredentialsProvider( id, new StateVerifierLastTxIdGetter(),
                         new MemberInfoProvider() )
         );
@@ -111,22 +111,22 @@ class ClusterInstance
         SnapshotContext snapshotContext = new SnapshotContext( context.getClusterContext(),
                 context.getLearnerContext() );
 
-        DelayedDirectExecutor taskExecutor = new DelayedDirectExecutor( logService.getInternalLogProvider() );
+        DelayedDirectExecutor taskExecutor = new DelayedDirectExecutor( logging );
         ProtocolServer ps = factory.newProtocolServer(
                 id, input, output, DIRECT_EXECUTOR, taskExecutor, timeouts, context, snapshotContext );
 
-        return new ClusterInstance( DIRECT_EXECUTOR, logService, factory, ps, context, acceptorInstances, timeouts,
+        return new ClusterInstance( DIRECT_EXECUTOR, logging, factory, ps, context, acceptorInstances, timeouts,
                 input, output, uri );
     }
 
-    public ClusterInstance( Executor stateMachineExecutor, LogService logService, MultiPaxosServerFactory factory,
+    public ClusterInstance( Executor stateMachineExecutor, LogProvider logging, MultiPaxosServerFactory factory,
                             ProtocolServer server,
                             MultiPaxosContext ctx, InMemoryAcceptorInstanceStore acceptorInstanceStore,
                             ProverTimeouts timeouts, ClusterInstanceInput input, ClusterInstanceOutput output,
                             URI uri )
     {
         this.stateMachineExecutor = stateMachineExecutor;
-        this.logService = logService;
+        this.logging = logging;
         this.factory = factory;
         this.server = server;
         this.ctx = ctx;
@@ -279,10 +279,10 @@ class ClusterInstance
         ClusterInstanceOutput output = new ClusterInstanceOutput( uri );
         ClusterInstanceInput input = new ClusterInstanceInput();
 
-        DelayedDirectExecutor executor = new DelayedDirectExecutor( logService.getInternalLogProvider() );
+        DelayedDirectExecutor executor = new DelayedDirectExecutor( logging );
 
         ObjectStreamFactory objectStreamFactory = new ObjectStreamFactory();
-        MultiPaxosContext snapshotCtx = ctx.snapshot( logService, timeoutsSnapshot, executor, snapshotAcceptorInstances,
+        MultiPaxosContext snapshotCtx = ctx.snapshot( logging, timeoutsSnapshot, executor, snapshotAcceptorInstances,
                 objectStreamFactory, objectStreamFactory,
                 new DefaultElectionCredentialsProvider( server.getServerId(), new StateVerifierLastTxIdGetter(),
                         new MemberInfoProvider() )
@@ -292,14 +292,14 @@ class ClusterInstance
         List<StateMachine> snapshotMachines = new ArrayList<>();
         for ( StateMachine stateMachine : server.getStateMachines().getStateMachines() )
         {
-            snapshotMachines.add( snapshotStateMachine( logService.getInternalLogProvider(), snapshotCtx, stateMachine ) );
+            snapshotMachines.add( snapshotStateMachine( logging, snapshotCtx, stateMachine ) );
         }
 
         ProtocolServer snapshotProtocolServer = factory.constructSupportingInfrastructureFor( server.getServerId(),
                 input, output, executor, timeoutsSnapshot, stateMachineExecutor,
                 snapshotCtx, snapshotMachines.toArray( new StateMachine[snapshotMachines.size()] ) );
 
-        return new ClusterInstance( stateMachineExecutor, logService, factory, snapshotProtocolServer, snapshotCtx,
+        return new ClusterInstance( stateMachineExecutor, logging, factory, snapshotProtocolServer, snapshotCtx,
                 snapshotAcceptorInstances, timeoutsSnapshot, input, output, uri );
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/Prover.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/Prover.java
@@ -30,12 +30,10 @@ import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
 import org.neo4j.helpers.Pair;
-import org.neo4j.kernel.impl.logging.NullLogService;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
 
 import static java.util.Arrays.asList;
-
 import static org.neo4j.ha.correctness.ClusterInstance.newClusterInstance;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
 
@@ -83,11 +81,11 @@ public class Prover
         ClusterState state = new ClusterState(
                 asList(
                         newClusterInstance( new InstanceId( 1 ), new URI( instance1 ), new Monitors(), config,
-                                NullLogService.getInstance() ),
+                                NullLogProvider.getInstance() ),
                         newClusterInstance( new InstanceId( 2 ), new URI( instance2 ), new Monitors(), config,
-                                NullLogService.getInstance() ),
+                                NullLogProvider.getInstance() ),
                         newClusterInstance( new InstanceId( 3 ), new URI( instance3 ), new Monitors(), config,
-                                NullLogService.getInstance() ) ),
+                                NullLogProvider.getInstance() ) ),
                 emptySetOf( ClusterAction.class )
         );
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ProverTimeouts.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/ProverTimeouts.java
@@ -69,9 +69,14 @@ class ProverTimeouts extends Timeouts
     }
 
     @Override
-    public void cancelTimeout( Object key )
+    public Message<? extends MessageType> cancelTimeout( Object key )
     {
-        timeouts.remove( key );
+        Pair<ProverTimeout,Long> timeout = timeouts.remove( key );
+        if ( timeout != null )
+        {
+            return timeout.first().getTimeoutMessage();
+        }
+        return null;
     }
 
     @Override

--- a/enterprise/ha/src/test/java/org/neo4j/ha/correctness/TestProver.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/correctness/TestProver.java
@@ -27,14 +27,11 @@ import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
-import org.neo4j.kernel.impl.logging.NullLogService;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
 
 import static java.util.Arrays.asList;
-
 import static junit.framework.TestCase.assertEquals;
-
 import static org.neo4j.ha.correctness.ClusterInstance.newClusterInstance;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
 
@@ -54,11 +51,11 @@ public class TestProver
         ClusterState state = new ClusterState(
                 asList(
                         newClusterInstance( new InstanceId( 1 ), new URI( "cluster://localhost:5001" ),
-                                new Monitors(), config, NullLogService.getInstance() ),
+                                new Monitors(), config, NullLogProvider.getInstance() ),
                         newClusterInstance( new InstanceId( 2 ), new URI( "cluster://localhost:5002" ),
-                                new Monitors(), config, NullLogService.getInstance() ),
+                                new Monitors(), config, NullLogProvider.getInstance() ),
                         newClusterInstance( new InstanceId( 3 ), new URI( "cluster://localhost:5003" ),
-                                new Monitors(), config, NullLogService.getInstance() ) ),
+                                new Monitors(), config, NullLogProvider.getInstance() ) ),
                 emptySetOf( ClusterAction.class )
         );
 
@@ -83,11 +80,11 @@ public class TestProver
         ClusterState state = new ClusterState(
                 asList(
                         newClusterInstance( new InstanceId( 1 ), new URI( "cluster://localhost:5001" ),
-                                new Monitors(), config, NullLogService.getInstance() ),
+                                new Monitors(), config, NullLogProvider.getInstance() ),
                         newClusterInstance( new InstanceId( 2 ), new URI( "cluster://localhost:5002" ),
-                                new Monitors(), config, NullLogService.getInstance() ),
+                                new Monitors(), config, NullLogProvider.getInstance() ),
                         newClusterInstance( new InstanceId( 3 ), new URI( "cluster://localhost:5003" ),
-                                new Monitors(), config, NullLogService.getInstance() ) ),
+                                new Monitors(), config, NullLogProvider.getInstance() ) ),
                 emptySetOf( ClusterAction.class )
         );
 


### PR DESCRIPTION
Previously we logged all heartbeat messages. This is too much logging for the system to handle, so we removed it. This change introduces logging of the interesting heartbeat messages, the ones for when the heartbeat comes back after having missed a few beats.

In order to ensure that logging from anywhere in the clustering code does not affect the cluster stability, all logging from the clustering code is made asynchronous.
