### PR TITLE
Got rid of compiler warning

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/wrappersFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/wrappersFor2_3.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.{CompilationPhaseTracer, CypherCo
 import org.neo4j.cypher.internal.frontend.v2_3.notification.{InternalNotification => InternalNotification2_3}
 import org.neo4j.cypher.internal.frontend.v2_3.{InputPosition => InputPosition2_3}
 import org.neo4j.cypher.internal.frontend.v3_0.InputPosition
-import org.neo4j.cypher.internal.frontend.v3_0.notification.{UnboundedShortestPathNotification, IndexLookupUnfulfillableNotification, CartesianProductNotification, EagerLoadCsvNotification, IndexHintUnfulfillableNotification, InternalNotification, JoinHintUnfulfillableNotification, JoinHintUnsupportedNotification, LargeLabelWithLoadCsvNotification, LegacyPlannerNotification, LengthOnNonPathNotification, MissingLabelNotification, MissingPropertyNameNotification, MissingRelTypeNotification, PlannerUnsupportedNotification, RuntimeUnsupportedNotification}
+import org.neo4j.cypher.internal.frontend.v3_0.notification.{CartesianProductNotification, EagerLoadCsvNotification, IndexHintUnfulfillableNotification, IndexLookupUnfulfillableNotification, InternalNotification, JoinHintUnfulfillableNotification, JoinHintUnsupportedNotification, LargeLabelWithLoadCsvNotification, LegacyPlannerNotification, LengthOnNonPathNotification, MissingLabelNotification, MissingPropertyNameNotification, MissingRelTypeNotification, PlannerUnsupportedNotification, RuntimeUnsupportedNotification, UnboundedShortestPathNotification}
 import org.neo4j.cypher.internal.frontend.{v2_3 => frontend2_3}
 
 /**
@@ -143,6 +143,9 @@ object wrappersFor2_3 {
       MissingPropertyNameNotification(as3_0(pos), name)
     case frontend2_3.notification.UnboundedShortestPathNotification(pos) =>
       UnboundedShortestPathNotification(as3_0(pos))
+    case frontend2_3.notification.BareNodeSyntaxDeprecatedNotification(pos) =>
+      throw new InternalException("Warnings for bare nodes are no longer supported, query should have already failed")
+
   }
 
   def as2_3(pos: InputPosition): InputPosition2_3 = InputPosition2_3(pos.offset, pos.line, pos.column)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -376,4 +376,12 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
 
     res.notifications should contain (UnboundedShortestPathNotification(InputPosition(26, 1, 27)))
   }
+
+  test("2.3 can warn about bare nodes") {
+    val res = eengine.execute("EXPLAIN CYPHER 2.3 MATCH n RETURN n")
+
+    res.notifications should not be empty
+  }
+
+
 }


### PR DESCRIPTION
Compiler was warning about non-exhaustive match for `BareNodeSyntaxDeprecatedNotification`,
which has beed removed in 3.0 but still there in 2.3
