### PR TITLE
Revert lsof fix because it broke stuff

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -143,7 +143,10 @@ detectrunning() {
     ## SmartOS has a different lsof command line arguments
     newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
   else
-    newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep "p")
+    # For some reason, this breaks stuff. Can there be multiple pids?
+    #newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep "p")
+    # This does NOT work on lsof > 4.87
+    newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
     newpid=${newpid:1}
   fi
 }


### PR DESCRIPTION
Some builds broke with this change. Possibly multiple pids
are returned?
