### PR TITLE
Merge on node with unique constraint must handle multiple labels

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/MergeStartPointBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/MergeStartPointBuilder.scala
@@ -93,10 +93,7 @@ class MergeStartPointBuilder extends PlanBuilder {
               Equals(Property(Identifier(identifier), key), props(key)),
               Equals(props(key), Property(Identifier(identifier), key))
             )
-            val hasLabelPredicates = labels.map {
-              HasLabel(Identifier(identifier), _)
-            }
-            val predicates = equalsPredicates ++ hasLabelPredicates
+            val predicates = equalsPredicates :+ HasLabel(Identifier(identifier), label)
             (label, key, RatedStartItem(SchemaIndex(identifier, label.name, key.name, UniqueIndex, Some(SingleQueryExpression(props(key)))), NodeFetchStrategy.IndexEquality, predicates))
         }
 

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -1,3 +1,8 @@
+2.2.7
+-----
+o Fixes #5631 - MERGE with multiple labels with uniqueness constraints
+o Fixed issue around aggregation and literal maps
+
 2.2.6
 -----
 o Fixes #5336 - Properly handle matching on multiple labels


### PR DESCRIPTION
Merge is not properly handling matching on multiple labels when there
is a unique constraint on one of the labels being matched on.

fixes #5631

Also added an update to `CHANGES.txt` which was missed in https://github.com/neo4j/neo4j/pull/5626
