### PR TITLE
Add more docs around file URLs

### DIFF
--- a/community/server/src/docs/ops/security.asciidoc
+++ b/community/server/src/docs/ops/security.asciidoc
@@ -1,5 +1,5 @@
 [[security-server]]
-= Securing access to the Neo4j Server
+= Securing the Neo4j Server
 
 == Secure the port and remote client connection accepts ==
 
@@ -108,7 +108,8 @@ include::using-wildcards-to-target-security-rules.asciidoc[]
 
 include::using-complex-wildcards-to-target-security-rules.asciidoc[]
 
-== Security in depth ==
+
+== Using a proxy ==
 
 Although the Neo4j server has a number of security features built-in (see the above chapters), for sensitive deployments it is often sensible to front against the outside world it with a proxy like Apache `mod_proxy` footnote:[http://httpd.apache.org/docs/2.2/mod/mod_proxy.html].
 
@@ -146,6 +147,12 @@ BalancerMember http://192.168.1.51:80
 </Proxy>
 ProxyPass /test balancer://mycluster
 --------------
+
+== LOAD CSV
+
+The Cypher `LOAD CSV` clause can load files from the filesystem, thus presenting a security vulnerability.
+To secure production deployments, use the <<config_allow_file_urls>> and <<config_dbms.security.load_csv_file_url_root>> settings.
+Further information can be found in <<query-load-csv>> as well.
 
 == Neo4j Web Interface Security
 

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/load-csv/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/load-csv/index.asciidoc
@@ -2,11 +2,37 @@
 = Load CSV
 
 [abstract]
+--
 `LOAD CSV` is used to import data from CSV files.
-Supports resources compressed with `gzip`, `Deflate`, as well as `ZIP` archives.
+--
 
-The URL of the CSV file is specified by using `FROM` followed by an arbitrary expression evaluating to the URL in question.
-It is required to specify an identifier for the CSV data using `AS`.
+* The URL of the CSV file is specified by using `FROM` followed by an arbitrary expression evaluating to the URL in question.
+* It is required to specify an identifier for the CSV data using `AS`.
+* `LOAD CSV` supports resources compressed with _gzip_, _Deflate_, as well as _ZIP_ archives.
+* CSV files can be stored on the database server and are then accessible using a `file:///` URL.
+  Alternatively, `LOAD CSV` also supports accessing CSV files via _HTTPS_, _HTTP_, and _FTP_.
+
+[NOTE]
+.Configuration settings for file URLs
+====
+<<config_allow_file_urls>>::
+This setting determines if Cypher will allow using file URLs when loading data using `LOAD CSV`.
+Default is _true_.
+
+<<config_dbms.security.load_csv_file_url_root>>::
+Sets the root directory for file URLs used with the Cypher `LOAD CSV` clause.
+This must be set to a single directory, restricting access to only those files within that directory and its subdirectories.
+By default, this setting is not set.
++
+* When not set, file URLs will be resolved as relative to the filesystem root.
+  If this is the case, a file URL will typically look like `file:///home/username/myfile.csv` or `file:///C:/Users/username/myfile.csv`.
+  These URLs will map to the filesystem locations `/home/username/myfile.csv` and `C:\Users\username\myfile.csv`.
+  _For security reasons you may not want users to be able to load files located anywhere in the filesystem and should then set `dbms.security.load_csv_file_url_root` to a safe location to load files from._
+* When set, file URLs will be resolved as relative to the directory it's set to.
+  In this case a file URL will typically look like `file:///myfile.csv` or `file:///myproject/myfile.csv`.
+**  If set to `data/import` the above URLs would map to `data/import/myfile.csv` and `data/import/myproject/myfile.csv` relative to the database install directory.
+**  If set to `/home/neo4j` the above URLs would map to `/home/neo4j/myfile.csv` and `/home/neo4j/myproject/myfile.csv`.
+====
 
 See the examples below for further details.
 

--- a/manual/cypher/cypher-docs/src/docs/graphgists/import/import-csv-with-cypher.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/graphgists/import/import-csv-with-cypher.asciidoc
@@ -12,6 +12,8 @@ In this example, we're given three CSV files: a list of persons, a list of movie
 CSV files can be stored on the database server and are then accessible using a +file://+ URL.
 Alternatively, +LOAD CSV+ also supports accessing CSV files via +HTTPS+, +HTTP+, and +FTP+.
 
+For more details, see <<query-load-csv>>.
+
 Using the following Cypher queries, we'll create a node for each person, a node for each movie and a relationship between the two with a property denoting the role.
 We're also keeping track of the country in which each movie was made.
 

--- a/manual/cypher/cypher-docs/src/docs/graphgists/intro/loading-data.adoc
+++ b/manual/cypher/cypher-docs/src/docs/graphgists/intro/loading-data.adoc
@@ -53,6 +53,8 @@ Then you can use whatever Cypher operations you want to apply to either create n
 
 As CSV files usually represent either node- or relationship-lists, you run multiple passes to create nodes and relationships separately.
 
+For more details, see <<query-load-csv>>.
+
 .movies.csv
 [source]
 ----


### PR DESCRIPTION
This change depends on `dbms.security.load_csv_file_url_root` not being set by default.
