### PR TITLE
Disable load_csv_file_url_root in Server by default

### DIFF
--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j.properties
@@ -22,7 +22,10 @@
 #cypher_parser_version=2.0
 
 # Set the root directory for use with file URLs (`file:///`) in LOAD CSV.
-dbms.security.load_csv_file_url_root=data/import
+# If enabled, file URLs will refer to locations inside the `data/import`
+# directory. I.e. `file:///movies/actors.csv` will load from the file
+# `data/import/movies/actors.csv`.
+#dbms.security.load_csv_file_url_root=data/import
 
 # Keep logical logs, helps debugging but uses more disk space, enabled for
 # legacy reasons To limit space needed to store historical logs use values such

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/data/import/README.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/data/import/README.txt
@@ -1,7 +1,6 @@
 #{product.fullname} Import Data
 =======================================
 
-Files placed into this directory are accessible using file URLs (`file:///`)
-with the `LOAD CSV` clause in Cypher. If the location of this directory needs
-to be changed, this can be achieved by altering the database configuration
-property `dbms.security.load_csv_file_url_root`.
+If `dbms.security.load_csv_file_url_root=data/import` is enabled, then files
+placed into this directory are accessible using file URLs (`file:///`)
+with the `LOAD CSV` clause in Cypher.

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.properties
@@ -22,7 +22,10 @@
 #cypher_parser_version=2.0
 
 # Set the root directory for use with file URLs (`file:///`) in LOAD CSV.
-dbms.security.load_csv_file_url_root=data/import
+# If enabled, file URLs will refer to locations inside the `data/import`
+# directory. I.e. `file:///movies/actors.csv` will load from the file
+# `data/import/movies/actors.csv`.
+#dbms.security.load_csv_file_url_root=data/import
 
 # Keep logical logs, helps debugging but uses more disk space, enabled for
 # legacy reasons To limit space needed to store historical logs use values such

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/data/import/README.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/data/import/README.txt
@@ -1,7 +1,6 @@
 #{product.fullname} Import Data
 =======================================
 
-Files placed into this directory are accessible using file URLs (`file:///`)
-with the `LOAD CSV` clause in Cypher. If the location of this directory needs
-to be changed, this can be achieved by altering the database configuration
-property `dbms.security.load_csv_file_url_root`.
+If `dbms.security.load_csv_file_url_root=data/import` is enabled, then files
+placed into this directory are accessible using file URLs (`file:///`)
+with the `LOAD CSV` clause in Cypher.

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -22,7 +22,10 @@
 #cypher_parser_version=2.0
 
 # Set the root directory for use with file URLs (`file:///`) in LOAD CSV.
-dbms.security.load_csv_file_url_root=data/import
+# If enabled, file URLs will refer to locations inside the `data/import`
+# directory. I.e. `file:///movies/actors.csv` will load from the file
+# `data/import/movies/actors.csv`.
+#dbms.security.load_csv_file_url_root=data/import
 
 # Keep logical logs, helps debugging but uses more disk space, enabled for
 # legacy reasons To limit space needed to store historical logs use values such

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/data/import/README.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/data/import/README.txt
@@ -1,7 +1,6 @@
 #{product.fullname} Import Data
 =======================================
 
-Files placed into this directory are accessible using file URLs (`file:///`)
-with the `LOAD CSV` clause in Cypher. If the location of this directory needs
-to be changed, this can be achieved by altering the database configuration
-property `dbms.security.load_csv_file_url_root`.
+If `dbms.security.load_csv_file_url_root=data/import` is enabled, then files
+placed into this directory are accessible using file URLs (`file:///`)
+with the `LOAD CSV` clause in Cypher.


### PR DESCRIPTION
Note that leaving this disabled does expose a security concern, which will be documented in 2.3 and closed in 3.0.
