### PR TITLE
Introduce PENDING_ELECTION state

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClient.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClient.java
@@ -62,8 +62,8 @@ public class ClusterClient
     private final Heartbeat heartbeat;
     private final Snapshot snapshot;
     private final Election election;
-    private LifeSupport life;
-    private ProtocolServer protocolServer;
+    private final LifeSupport life;
+    private final ProtocolServer protocolServer;
 
 
 
@@ -82,6 +82,7 @@ public class ClusterClient
     @Override
     public void broadcast( Payload payload )
     {
+        // Broadcasts this payload asynchronously and returns immediately
         broadcast.broadcast( payload );
     }
 
@@ -169,6 +170,7 @@ public class ClusterClient
         snapshot.refreshSnapshot();
     }
 
+    @Override
     public void addBindingListener( BindingListener bindingListener )
     {
         protocolServer.addBindingListener( bindingListener );


### PR DESCRIPTION
Introducing the PENDING_ELECTION state to solve a couple of clustering issues.

This is a pending state hinting that an election should be triggered when entering this state.
Otherwise this state is exactly like pending, even delegates to its methods.

It should only be used when an unexpected event is registered which we don't know how to handle. These can occur with various race conditions, such as two master elections happening almost simultaneously and a member goes to pending before receiving the call (from itself) that it is available as master. In this case there will be another member acting as master, this node is in pending, and the slaves can be confused as to which master is the real one. So, trigger an election to resolve the issue.
