### PR TITLE
Print when columns are ignored during CSV import

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -93,6 +93,7 @@ import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators.fro
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators.startingFromTheBeginning;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMappers.longs;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMappers.strings;
+import static org.neo4j.unsafe.impl.batchimport.input.Collectors.silentBadCollector;
 import static org.neo4j.unsafe.impl.batchimport.staging.ProcessorAssignmentStrategies.eagerRandomSaturation;
 import static org.neo4j.unsafe.impl.batchimport.store.BatchingPageCache.SYNCHRONOUS;
 
@@ -178,7 +179,8 @@ public class ParallelBatchImporterTest
                     nodes( nodeRandomSeed, NODE_COUNT, inputIdGenerator, groups ),
                     relationships( relationshipRandomSeed, RELATIONSHIP_COUNT, inputIdGenerator, groups ),
                     idMapper, idGenerator, false,
-                    RELATIONSHIP_COUNT/*insanely high bad tolerance, but it will actually never be that many*/ ) );
+                    /*insanely high bad tolerance, but it will actually never  be that many*/
+                    silentBadCollector( RELATIONSHIP_COUNT ) ) );
 
             // THEN
             GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( directory.absolutePath() );

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -278,12 +278,12 @@ public class Extractors
         protected abstract boolean extract0( char[] data, int offset, int length );
     }
 
-    private static class StringExtractor extends AbstractSingleValueExtractor<String>
+    public static class StringExtractor extends AbstractSingleValueExtractor<String>
     {
         private String value;
         private final boolean emptyStringsAsNull;
 
-        StringExtractor( boolean emptyStringsAsNull )
+        public StringExtractor( boolean emptyStringsAsNull )
         {
             super( String.class.getSimpleName() );
             this.emptyStringsAsNull = emptyStringsAsNull;

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -19,8 +19,10 @@
  */
 package org.neo4j.tooling;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.nio.charset.Charset;
@@ -53,6 +55,7 @@ import org.neo4j.kernel.logging.Logging;
 import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.DuplicateInputIdException;
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Input;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
@@ -176,7 +179,12 @@ public class ImportTool
                         + "nodes within the same group having the same id, the first encountered will be imported "
                         + "whereas consecutive such nodes will be skipped. "
                         + "Skipped nodes will be logged"
-                        + ", containing at most number of entities specified by " + BAD_TOLERANCE.key() + "." );
+                        + ", containing at most number of entities specified by " + BAD_TOLERANCE.key() + "." ),
+        IGNORE_EXTRA_COLUMNS( "ignore-extra-columns", Boolean.FALSE,
+                "<true/false>",
+                "Whether or not to ignore extra columns in the data not specified by the header. "
+                        + "Skipped columns will be logged, containing at most number of entities specified by "
+                        + BAD_TOLERANCE.key() + "." );
 
         private final String key;
         private final Object defaultValue;
@@ -293,12 +301,15 @@ public class ImportTool
         Input input = null;
         int badTolerance;
         Charset inputEncoding;
-        boolean skipBadRelationships, skipDuplicateNodes;
+        boolean skipBadRelationships, skipDuplicateNodes, ignoreExtraColumns;
 
         try
         {
             storeDir = args.interpretOption( Options.STORE_DIR.key(), Converters.<File>mandatory(),
                     Converters.toFile(), Validators.DIRECTORY_IS_WRITABLE, Validators.CONTAINS_NO_EXISTING_DATABASE );
+
+            File badFile = new File( storeDir, BAD_FILE_NAME );
+            OutputStream badOutput = new BufferedOutputStream( fs.openAsOutputStream( badFile, false ) );
             nodesFiles = INPUT_FILES_EXTRACTOR.apply( args, Options.NODE_DATA.key() );
             relationshipsFiles = INPUT_FILES_EXTRACTOR.apply( args, Options.RELATIONSHIP_DATA.key() );
             validateInputFiles( nodesFiles, relationshipsFiles );
@@ -313,15 +324,23 @@ public class ImportTool
                     (Boolean)Options.SKIP_BAD_RELATIONSHIPS.defaultValue(), true );
             skipDuplicateNodes = args.getBoolean( Options.SKIP_DUPLICATE_NODES.key(),
                     (Boolean)Options.SKIP_DUPLICATE_NODES.defaultValue(), true );
-            input = new CsvInput(
-                    nodeData( inputEncoding, nodesFiles ), defaultFormatNodeFileHeader(),
+            ignoreExtraColumns = args.getBoolean( Options.IGNORE_EXTRA_COLUMNS.key(),
+                    (Boolean)Options.IGNORE_EXTRA_COLUMNS.defaultValue(), true );
+
+            Collector badCollector = badCollector( badOutput, badTolerance, collect( skipBadRelationships,
+                    skipDuplicateNodes, ignoreExtraColumns ) );
+
+            input = new CsvInput( nodeData( inputEncoding, nodesFiles ), defaultFormatNodeFileHeader(),
                     relationshipData( inputEncoding, relationshipsFiles ), defaultFormatRelationshipFileHeader(),
-                    idType, csvConfiguration( args, defaultSettingsSuitableForTests ),
-                    badCollector( badTolerance, collect( skipBadRelationships, skipDuplicateNodes ) ) );
+                    idType, csvConfiguration( args, defaultSettingsSuitableForTests ), badCollector );
         }
         catch ( IllegalArgumentException e )
         {
             throw andPrintError( "Input error", e, false );
+        }
+        catch ( IOException e )
+        {
+            throw andPrintError( "File error", e, false );
         }
 
         LifeSupport life = new LifeSupport();
@@ -347,11 +366,16 @@ public class ImportTool
         }
         finally
         {
-            File badFile = new File( storeDir, BAD_FILE_NAME );
-            if ( badFile.exists() )
+            input.badCollector().close();
+
+            if ( input.badCollector().badEntries() > 0 )
             {
-                out.println( "There were bad entries which were skipped and logged into " +
-                        badFile.getAbsolutePath() );
+                File badFile = new File( storeDir, BAD_FILE_NAME );
+                if ( badFile.exists() )
+                {
+                    out.println(
+                            "There were bad entries which were skipped and logged into " + badFile.getAbsolutePath() );
+                }
             }
 
             life.shutdown();

--- a/community/import-tool/src/test/java/org/neo4j/tooling/CsvDataGeneratorInput.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/CsvDataGeneratorInput.java
@@ -47,10 +47,11 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.InputRelationshipDeserializat
 public class CsvDataGeneratorInput extends CsvDataGenerator<InputNode,InputRelationship> implements Input
 {
     private final IdType idType;
+    private final Collector badCollector;
 
     public CsvDataGeneratorInput( final Header nodeHeader, final Header relationshipHeader,
             Configuration config, long nodes, long relationships, final Groups groups, final IdType idType,
-            int numberOfLabels, int numberOfRelationshipTypes )
+            int numberOfLabels, int numberOfRelationshipTypes, Collector badCollector )
     {
         super( nodeHeader, relationshipHeader, config, nodes, relationships,
                 new Function<SourceTraceability,Deserialization<InputNode>>()
@@ -71,6 +72,7 @@ public class CsvDataGeneratorInput extends CsvDataGenerator<InputNode,InputRelat
                 },
                 numberOfLabels, numberOfRelationshipTypes );
         this.idType = idType;
+        this.badCollector = badCollector;
     }
 
     @Override
@@ -130,8 +132,8 @@ public class CsvDataGeneratorInput extends CsvDataGenerator<InputNode,InputRelat
     }
 
     @Override
-    public Collector badCollector( OutputStream out )
+    public Collector badCollector()
     {
-        return Collectors.badCollector( out, 0 );
+        return badCollector;
     }
 }

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -58,6 +58,9 @@ import org.neo4j.unsafe.impl.batchimport.input.InputException;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Type;
 
+import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -65,11 +68,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import static java.lang.String.format;
-import static java.lang.System.currentTimeMillis;
-import static java.util.Arrays.asList;
-
 import static org.neo4j.collection.primitive.PrimitiveIntCollections.alwaysTrue;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
@@ -192,6 +190,29 @@ public class ImportToolTest
             nodes = dbRule.findNodes( DynamicLabel.label( "SECOND 4096" ) );
             assertEquals( 1, IteratorUtil.asList( nodes ).size() );
         }
+    }
+
+    @Test
+    public void shouldPrintWarningsIfHeaderHasLessColumnsThanData() throws Exception
+    {
+        // GIVEN
+        List<String> nodeIds = nodeIds();
+        Configuration config = Configuration.TABS;
+
+        // WHEN data file contains more columns than header file
+        int extraColumns = 3;
+        String output = executeImportAndCatchOutput(
+                "--into", dbRule.getStoreDirAbsolutePath(),
+                "--delimiter", "TAB",
+                "--array-delimiter", String.valueOf( config.arrayDelimiter() ),
+                "--nodes", nodeHeader( config ).getAbsolutePath() + MULTI_FILE_DELIMITER +
+                        nodeData( false, config, nodeIds, alwaysTrue(), Charset.defaultCharset(), extraColumns )
+                                .getAbsolutePath(),
+                "--relationships", relationshipHeader( config ).getAbsolutePath() + MULTI_FILE_DELIMITER +
+                        relationshipData( false, config, nodeIds, alwaysTrue(), true ).getAbsolutePath() );
+
+        // THEN
+        assertTrue( "Should warn when columns are ignored:\n" + output, output.contains( "Warning: ignored columns" ) );
     }
 
     @Test
@@ -458,7 +479,7 @@ public class ImportToolTest
     }
 
     @Test
-    public void shouldLogRelationshipsReferingToMissingNode() throws Exception
+    public void shouldLogRelationshipsReferringToMissingNode() throws Exception
     {
         // GIVEN
         List<String> nodeIds = asList( "a", "b", "c" );
@@ -907,6 +928,12 @@ public class ImportToolTest
     private File nodeData( boolean includeHeader, Configuration config, List<String> nodeIds,
             PrimitiveIntPredicate linePredicate, Charset encoding ) throws Exception
     {
+        return nodeData( includeHeader, config, nodeIds, linePredicate, encoding, 0 );
+    }
+
+    private File nodeData( boolean includeHeader, Configuration config, List<String> nodeIds,
+            PrimitiveIntPredicate linePredicate, Charset encoding, int extraColumns ) throws Exception
+    {
         File file = file( fileName( "nodes.csv" ) );
         try ( PrintStream writer = writer( file, encoding ) )
         {
@@ -914,7 +941,7 @@ public class ImportToolTest
             {
                 writeNodeHeader( writer, config, null );
             }
-            writeNodeData( writer, config, nodeIds, linePredicate );
+            writeNodeData( writer, config, nodeIds, linePredicate, extraColumns );
         }
         return file;
     }
@@ -956,7 +983,7 @@ public class ImportToolTest
     }
 
     private void writeNodeData( PrintStream writer, Configuration config, List<String> nodeIds,
-                                PrimitiveIntPredicate linePredicate )
+            PrimitiveIntPredicate linePredicate, int extraColumns )
     {
         char delimiter = config.delimiter();
         char arrayDelimiter = config.arrayDelimiter();
@@ -964,10 +991,22 @@ public class ImportToolTest
         {
             if ( linePredicate.accept( i ) )
             {
-                writer.println( nodeIds.get( i ) + delimiter + randomName() +
-                                delimiter + randomLabels( arrayDelimiter ) );
+                writer.println( getLine( nodeIds.get( i ), delimiter, arrayDelimiter, extraColumns ) );
             }
         }
+    }
+
+    private String getLine( String nodeId, char delimiter, char arrayDelimiter, int extraColumns )
+    {
+        StringBuilder stringBuilder = new StringBuilder().append( nodeId ).append( delimiter ).append( randomName() )
+                .append( delimiter ).append( randomLabels( arrayDelimiter ) );
+
+        for ( int i = 0; i < extraColumns; i++ )
+        {
+            stringBuilder.append( delimiter ).append( "ExtraColumn" ).append( i );
+        }
+
+        return stringBuilder.toString();
     }
 
     private String randomLabels( char arrayDelimiter )

--- a/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
@@ -40,6 +40,7 @@ import static org.neo4j.kernel.configuration.Config.parseLongWithUnit;
 import static org.neo4j.tooling.CsvDataGenerator.bareboneNodeHeader;
 import static org.neo4j.tooling.CsvDataGenerator.bareboneRelationshipHeader;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT;
+import static org.neo4j.unsafe.impl.batchimport.input.Collectors.silentBadCollector;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatNodeFileHeader;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatRelationshipFileHeader;
@@ -78,7 +79,8 @@ public class QuickImport
 
         Input input = new CsvDataGeneratorInput(
                 nodeHeader, relationshipHeader,
-                COMMAS, nodeCount, relationshipCount, new Groups(), idType, labelCount, relationshipTypeCount );
+                COMMAS, nodeCount, relationshipCount, new Groups(), idType, labelCount, relationshipTypeCount,
+                silentBadCollector( 0 ));
         BatchImporter importer = new ParallelBatchImporter( dir, DEFAULT, new SystemOutLogging(), defaultVisible() );
         importer.doImport( input );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -128,12 +128,11 @@ public class ParallelBatchImporter implements BatchImporter
         CountingStoreUpdateMonitor storeUpdateMonitor = new CountingStoreUpdateMonitor();
         try ( BatchingNeoStore neoStore = new BatchingNeoStore( fileSystem, storeDir, config,
                 writeMonitor, logging, monitors, writerFactory, additionalInitialIds );
-              OutputStream badOutput = new BufferedOutputStream( fileSystem.openAsOutputStream( badFile, false ) );
-              Collector badCollector = input.badCollector( badOutput );
                 CountsAccessor.Updater countsUpdater = neoStore.getCountsStore().reset(
                       neoStore.getLastCommittedTransactionId() );
               InputCache inputCache = new InputCache( fileSystem, storeDir ) )
         {
+            Collector badCollector = input.badCollector();
             // Some temporary caches and indexes in the import
             IdMapper idMapper = input.idMapper();
             IdGenerator idGenerator = input.idGenerator();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -19,10 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 
 import org.neo4j.function.Function;
 import org.neo4j.helpers.Exceptions;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
@@ -48,7 +48,8 @@ public class BadCollector implements Collector
 
     public static final int BAD_RELATIONSHIPS = 0x1;
     public static final int DUPLICATE_NODES = 0x2;
-    public static final int COLLECT_ALL = BAD_RELATIONSHIPS | DUPLICATE_NODES;
+    public static final int EXTRA_COLUMNS = 0x4;
+    public static final int COLLECT_ALL = BAD_RELATIONSHIPS | DUPLICATE_NODES | EXTRA_COLUMNS;
 
     private final PrintStream out;
     private final int tolerance;
@@ -112,6 +113,28 @@ public class BadCollector implements Collector
             leftOverDuplicateNodeIds = Arrays.copyOf( leftOverDuplicateNodeIds, leftOverDuplicateNodeIds.length*2 );
         }
         leftOverDuplicateNodeIds[leftOverDuplicateNodeIdsCursor++] = actualId;
+    }
+
+    @Override
+    public void collectExtraColumns( final String source, final long row, final String value )
+    {
+        checkTolerance( EXTRA_COLUMNS, new ProblemReporter()
+        {
+            private final String message = format( "Extra column not present in header on line %d in %s with value %s",
+                    row, source, value );
+
+            @Override
+            public String message()
+            {
+                return message;
+            }
+
+            @Override
+            public InputException exception()
+            {
+                return new InputException( message );
+            }
+        } );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collector.java
@@ -31,6 +31,8 @@ public interface Collector extends AutoCloseable
 
     void collectDuplicateNode( Object id, long actualId, String group, String firstSource, String otherSource );
 
+    void collectExtraColumns( final String source, final long row, final String value );
+
     int badEntries();
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input;
 
+import java.io.IOException;
 import java.io.OutputStream;
 
 import org.neo4j.function.Function;
@@ -28,6 +29,21 @@ import org.neo4j.function.Function;
  */
 public class Collectors
 {
+    public static Collector silentBadCollector( int tolerance ) {
+        return silentBadCollector( tolerance, BadCollector.COLLECT_ALL );
+    }
+
+    public static Collector silentBadCollector( int tolerance, int collect ) {
+        return badCollector( new OutputStream()
+        {
+            @Override
+            public void write( int i ) throws IOException
+            {
+                // ignored
+            }
+        }, tolerance, collect );
+    }
+
     public static Collector badCollector( OutputStream out, int tolerance )
     {
         return badCollector( out, tolerance, BadCollector.COLLECT_ALL );
@@ -55,9 +71,10 @@ public class Collectors
         };
     }
 
-    public static int collect( boolean skipBadRelationships, boolean skipDuplicateNodes )
+    public static int collect( boolean skipBadRelationships, boolean skipDuplicateNodes, boolean ignoreExtraColumns )
     {
         return (skipBadRelationships ? BadCollector.BAD_RELATIONSHIPS : 0 ) |
-               (skipDuplicateNodes ? BadCollector.DUPLICATE_NODES : 0 );
+               (skipDuplicateNodes ? BadCollector.DUPLICATE_NODES : 0 ) |
+               (ignoreExtraColumns ? BadCollector.EXTRA_COLUMNS : 0 );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Input.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Input.java
@@ -71,5 +71,5 @@ public interface Input
      * @return a {@link Collector} capable of writing {@link InputRelationship bad relationships}
      * and {@link InputNode duplicate nodes} to an output stream for later handling.
      */
-    Collector badCollector( OutputStream out );
+    Collector badCollector();
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
@@ -44,7 +44,7 @@ public class Inputs
     public static Input input(
             final InputIterable<InputNode> nodes, final InputIterable<InputRelationship> relationships,
             final IdMapper idMapper, final IdGenerator idGenerator, final boolean specificRelationshipIds,
-            final int badTolerance )
+            final Collector badCollector )
     {
         return new Input()
         {
@@ -79,20 +79,20 @@ public class Inputs
             }
 
             @Override
-            public Collector badCollector( OutputStream out )
+            public Collector badCollector()
             {
-                return Collectors.badCollector( out, badTolerance );
+                return badCollector;
             }
         };
     }
 
     public static Input csv( File nodes, File relationships, IdType idType,
-            Configuration configuration )
+            Configuration configuration, Collector badCollector )
     {
         return new CsvInput(
                 nodeData( data( NO_NODE_DECORATOR, defaultCharset(), nodes ) ), defaultFormatNodeFileHeader(),
                 relationshipData( data( NO_RELATIONSHIP_DECORATOR, defaultCharset(), relationships ) ),
                 defaultFormatRelationshipFileHeader(), idType, configuration,
-                Collectors.badCollector( 0 ) );
+                badCollector );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -52,7 +52,7 @@ public class CsvInput implements Input
     private final IdType idType;
     private final Configuration config;
     private final Groups groups = new Groups();
-    private final Function<OutputStream,Collector> collectorFactory;
+    private final Collector badCollector;
 
     /**
      * @param nodeDataFactory multiple {@link DataFactory} instances providing data, each {@link DataFactory}
@@ -69,7 +69,7 @@ public class CsvInput implements Input
     public CsvInput(
             Iterable<DataFactory<InputNode>> nodeDataFactory, Header.Factory nodeHeaderFactory,
             Iterable<DataFactory<InputRelationship>> relationshipDataFactory, Header.Factory relationshipHeaderFactory,
-            IdType idType, Configuration config, Function<OutputStream,Collector> collectorFactory )
+            IdType idType, Configuration config, Collector badCollector )
     {
         assertSaneConfiguration( config );
 
@@ -79,7 +79,7 @@ public class CsvInput implements Input
         this.relationshipHeaderFactory = relationshipHeaderFactory;
         this.idType = idType;
         this.config = config;
-        this.collectorFactory = collectorFactory;
+        this.badCollector = badCollector;
     }
 
     private void assertSaneConfiguration( Configuration config )
@@ -117,7 +117,7 @@ public class CsvInput implements Input
                     {
                         return new InputEntityDeserializer<>( dataHeader, dataStream, config.delimiter(),
                                 new InputNodeDeserialization( dataStream, dataHeader, groups, idType.idsAreExternal() ),
-                                decorator, Validators.<InputNode>emptyValidator() );
+                                decorator, Validators.<InputNode>emptyValidator(), badCollector );
                     }
                 };
             }
@@ -165,7 +165,7 @@ public class CsvInput implements Input
                                             throw new DataException( entity + " is missing " + Type.TYPE + " field" );
                                         }
                                     }
-                                } );
+                                }, badCollector );
                     }
                 };
             }
@@ -197,8 +197,8 @@ public class CsvInput implements Input
     }
 
     @Override
-    public Collector badCollector( OutputStream out )
+    public Collector badCollector()
     {
-        return collectorFactory.apply( out );
+        return badCollector;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
@@ -23,6 +23,7 @@ import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.function.Function;
 import org.neo4j.function.Functions;
 import org.neo4j.kernel.impl.util.Validators;
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.UpdateBehaviour;
@@ -58,14 +59,14 @@ public class ExternalPropertiesDecorator implements Function<InputNode,InputNode
      * and which properties to extract. All other should be {@link Type#IGNORE ignored}. I think.
      */
     public ExternalPropertiesDecorator( DataFactory<InputNode> data, Header.Factory headerFactory,
-            Configuration config, IdType idType, UpdateBehaviour updateBehaviour )
+            Configuration config, IdType idType, UpdateBehaviour updateBehaviour, Collector badCollector )
     {
         this.updateBehaviour = updateBehaviour;
         CharSeeker dataStream = data.create( config ).stream();
         Header header = headerFactory.create( dataStream, config, idType );
         this.deserializer = new InputEntityDeserializer<>( header, dataStream, config.delimiter(),
                 new InputNodeDeserialization( dataStream, header, new Groups(), idType.idsAreExternal() ),
-                Functions.<InputNode>identity(), Validators.<InputNode>emptyValidator() );
+                Functions.<InputNode>identity(), Validators.<InputNode>emptyValidator(), badCollector );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -62,6 +62,7 @@ import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 import org.neo4j.unsafe.impl.batchimport.Configuration.Default;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
+import org.neo4j.unsafe.impl.batchimport.input.Collectors;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 
@@ -74,6 +75,7 @@ import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.kernel.impl.util.AutoCreatingHashMap.nested;
 import static org.neo4j.kernel.impl.util.AutoCreatingHashMap.values;
 import static org.neo4j.register.Registers.newDoubleLongRegister;
+import static org.neo4j.unsafe.impl.batchimport.input.Collectors.silentBadCollector;
 import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
 import static org.neo4j.unsafe.impl.batchimport.input.Inputs.csv;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.Configuration.COMMAS;
@@ -95,7 +97,7 @@ public class CsvInputBatchImportIT
         try
         {
             importer.doImport( csv( nodeDataAsFile( nodeData ), relationshipDataAsFile( relationshipData ),
-                    IdType.STRING, lowBufferSize( COMMAS ) ) );
+                    IdType.STRING, lowBufferSize( COMMAS ), silentBadCollector( 0 ) ) );
             // THEN
             verifyImportedData( nodeData, relationshipData );
             success = true;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.verify;
 import static org.neo4j.csv.reader.Readables.wrap;
 import static org.neo4j.helpers.ArrayUtil.union;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
-import static org.neo4j.unsafe.impl.batchimport.input.Collectors.badCollector;
+import static org.neo4j.unsafe.impl.batchimport.input.Collectors.silentBadCollector;
 import static org.neo4j.unsafe.impl.batchimport.input.Group.GLOBAL;
 import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
 import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.additiveLabels;
@@ -83,7 +83,7 @@ public class CsvInputTest
                 header( entry( null, Type.ID, idType.extractor( extractors ) ),
                         entry( "name", Type.PROPERTY, extractors.string() ),
                         entry( "labels", Type.LABEL, extractors.string() ) ),
-                        null, null, idType, COMMAS, badCollector( 0 ) );
+                        null, null, idType, COMMAS, silentBadCollector( 0 ) );
 
         // WHEN/THEN
         Iterator<InputNode> nodes = input.nodes().iterator();
@@ -105,7 +105,7 @@ public class CsvInputTest
                         entry( "to", Type.END_ID, idType.extractor( extractors ) ),
                         entry( "type", Type.TYPE, extractors.string() ),
                         entry( "since", Type.PROPERTY, extractors.long_() ) ), idType, COMMAS,
-                        badCollector( 0 ) );
+                        silentBadCollector( 0 ) );
 
         // WHEN/THEN
         Iterator<InputRelationship> relationships = input.relationships().iterator();
@@ -129,7 +129,7 @@ public class CsvInputTest
                 relationshipDataIterable, header(
                         entry( null, Type.START_ID, idType.extractor( extractors ) ),
                         entry( null, Type.END_ID, idType.extractor( extractors ) ) ),
-                idType, COMMAS, badCollector( 0 ) );
+                idType, COMMAS, silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> iterator = input.nodes().iterator() )
@@ -160,7 +160,7 @@ public class CsvInputTest
                       entry( "unit", Type.PROPERTY, extractors.string() ),
                       entry( "type", Type.LABEL, extractors.string() ),
                       entry( "kills", Type.PROPERTY, extractors.int_() ) ),
-                null, null, IdType.ACTUAL, Configuration.COMMAS, badCollector( 0 ) );
+                null, null, IdType.ACTUAL, Configuration.COMMAS, silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -184,7 +184,7 @@ public class CsvInputTest
                 header(
                       entry( null, Type.ID, extractors.long_() ),
                       entry( "name", Type.PROPERTY, extractors.string() ) ),
-                null, null, IdType.ACTUAL, Configuration.COMMAS, badCollector( 0 ) );
+                null, null, IdType.ACTUAL, Configuration.COMMAS, silentBadCollector( 4 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -209,7 +209,7 @@ public class CsvInputTest
         Iterable<DataFactory<InputNode>> data = dataIterable( group1, group2 );
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(),
                                     null, null,
-                                    IdType.STRING, Configuration.COMMAS, badCollector( 0 ) );
+                                    IdType.STRING, Configuration.COMMAS, silentBadCollector( 0 ) );
 
         // WHEN iterating over them, THEN the expected data should come out
         ResourceIterator<InputNode> nodes = input.nodes().iterator();
@@ -232,7 +232,7 @@ public class CsvInputTest
                                             additiveLabels( addedLabels ) );
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(),
-                null, null, IdType.ACTUAL, Configuration.COMMAS, badCollector( 0 ) );
+                null, null, IdType.ACTUAL, Configuration.COMMAS, silentBadCollector( 0 ) );
 
         // WHEN/THEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -261,7 +261,7 @@ public class CsvInputTest
         Iterable<DataFactory<InputRelationship>> dataIterable = dataIterable( data );
         Input input = new CsvInput( null, null,
                 dataIterable, defaultFormatRelationshipFileHeader(), IdType.ACTUAL, Configuration.COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN/THEN
         try ( ResourceIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -284,7 +284,7 @@ public class CsvInputTest
         Iterable<DataFactory<InputRelationship>> dataIterable = dataIterable( data );
         Input input = new CsvInput( null, null,
                 dataIterable, defaultFormatRelationshipFileHeader(), IdType.ACTUAL, Configuration.COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN/THEN
         try ( ResourceIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -312,7 +312,7 @@ public class CsvInputTest
                 "Johan,2\n" );
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.STRING, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -334,7 +334,7 @@ public class CsvInputTest
                 ",Johan,2\n" ); // this node is anonymous
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.STRING, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -356,7 +356,7 @@ public class CsvInputTest
                 ",Johan,2\n" ); // this node is anonymous
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.STRING, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -378,7 +378,7 @@ public class CsvInputTest
                 "def,Johan,2\n" ); // this node is anonymous
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.STRING, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -400,7 +400,7 @@ public class CsvInputTest
                 "1,Johan,2\n" ); // this node is anonymous
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.ACTUAL, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -422,7 +422,7 @@ public class CsvInputTest
                 "1,Johan,Additional\n" );
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.ACTUAL, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -444,7 +444,7 @@ public class CsvInputTest
                 "1,Johan,10\n" );
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.ACTUAL, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -463,7 +463,7 @@ public class CsvInputTest
         try
         {
             new CsvInput( null, null, null, null, IdType.ACTUAL, customConfig( ',', ',', '"' ),
-                    badCollector( 0 ) );
+                    silentBadCollector( 0 ) );
             fail( "Should not be possible" );
         }
         catch ( IllegalArgumentException e )
@@ -480,7 +480,7 @@ public class CsvInputTest
         try
         {
             new CsvInput( null, null, null, null, IdType.ACTUAL, customConfig( ',', ';', ',' ),
-                    badCollector( 0 ) );
+                    silentBadCollector( 0 ) );
             fail( "Should not be possible" );
         }
         catch ( IllegalArgumentException e )
@@ -498,7 +498,7 @@ public class CsvInputTest
         try
         {
             new CsvInput( null, null, null, null, IdType.ACTUAL, customConfig( ',', ';', ';' ),
-                    badCollector( 0 ) );
+                    silentBadCollector( 0 ) );
             fail( "Should not be possible" );
         }
         catch ( IllegalArgumentException e )
@@ -524,7 +524,7 @@ public class CsvInputTest
                 header( entry( null, Type.ID, group.name(), idType.extractor( extractors ) ),
                         entry( "name", Type.PROPERTY, extractors.string() ) ),
                         null, null, idType, COMMAS,
-                        badCollector( 0 ) );
+                        silentBadCollector( 0 ) );
 
         // WHEN/THEN
         Iterator<InputNode> nodes = input.nodes().iterator();
@@ -550,7 +550,7 @@ public class CsvInputTest
                         entry( null, Type.TYPE, extractors.string() ),
                         entry( null, Type.END_ID, endNodeGroup.name(), idType.extractor( extractors ) ) ),
                         idType, COMMAS,
-                        badCollector( 0 ) );
+                        silentBadCollector( 0 ) );
 
         // WHEN/THEN
         Iterator<InputRelationship> relationships = input.relationships().iterator();
@@ -571,7 +571,7 @@ public class CsvInputTest
         Iterable<DataFactory<InputRelationship>> dataIterable = dataIterable( data );
         Input input = new CsvInput( null, null, dataIterable, defaultFormatRelationshipFileHeader(),
                 IdType.ACTUAL, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( ResourceIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -594,7 +594,7 @@ public class CsvInputTest
                 "3,Emil,12" ) );
         Input input = new CsvInput( data, DataFactories.defaultFormatNodeFileHeader(), null, null,
                 IdType.INTEGER, Configuration.COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -624,7 +624,7 @@ public class CsvInputTest
                 "2,Johan,111,Person\n" +
                 "3,Emil,12,Person" ) );
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(), null, null, IdType.INTEGER, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -646,7 +646,7 @@ public class CsvInputTest
                 "2,KNOWS,3,Johan,111\n" +
                 "3,KNOWS,4,Emil,12" ) );
         Input input = new CsvInput( null, null, data, defaultFormatRelationshipFileHeader(), IdType.INTEGER, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( InputIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -667,7 +667,7 @@ public class CsvInputTest
                 DataFactories.nodeData( CsvInputTest.<InputNode>data( ":ID,name\n1,Mattias",
                         new FailingNodeDecorator( failure ) ) );
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(), null, null, IdType.INTEGER, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -691,7 +691,7 @@ public class CsvInputTest
                 "2,a;b,10;20"
                 ) );
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(), null, null, IdType.INTEGER, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN/THEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -711,7 +711,7 @@ public class CsvInputTest
                 ":START_ID,:END_ID,:TYPE\n" +
                 ",1," ) );
         Input input = new CsvInput( null, null, data, defaultFormatRelationshipFileHeader(), IdType.INTEGER, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( InputIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -734,7 +734,7 @@ public class CsvInputTest
                 ":START_ID,:END_ID,:TYPE\n" +
                 "1,," ) );
         Input input = new CsvInput( null, null, data, defaultFormatRelationshipFileHeader(), IdType.INTEGER, COMMAS,
-                badCollector( 0 ) );
+                silentBadCollector( 0 ) );
 
         // WHEN
         try ( InputIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -765,7 +765,7 @@ public class CsvInputTest
             }
         };
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(),
-                null, null, IdType.INTEGER, config, badCollector( 0 ) );
+                null, null, IdType.INTEGER, config, silentBadCollector( 0 ) );
 
         // WHEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.unsafe.impl.batchimport.input.Collectors.silentBadCollector;
 import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.NO_NODE_DECORATOR;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatNodeFileHeader;
 
@@ -57,7 +58,8 @@ public class ExternalPropertiesDecoratorTest
         IdType idType = IdType.STRING;
         Function<InputNode,InputNode> externalPropertiesDecorator = new ExternalPropertiesDecorator(
                 DataFactories.<InputNode>data( NO_NODE_DECORATOR, readable( propertyData ) ),
-                defaultFormatNodeFileHeader(), config, idType, UpdateBehaviour.ADD );
+                defaultFormatNodeFileHeader(), config, idType, UpdateBehaviour.ADD,
+                silentBadCollector( 0 ));
 
         // WHEN
         assertProperties( externalPropertiesDecorator.apply( node( "1", "key", "value1" ) ),
@@ -84,7 +86,8 @@ public class ExternalPropertiesDecoratorTest
         IdType idType = IdType.STRING;
         Function<InputNode,InputNode> externalPropertiesDecorator = new ExternalPropertiesDecorator(
                 DataFactories.<InputNode>data( NO_NODE_DECORATOR, readable( propertyData ) ),
-                defaultFormatNodeFileHeader(), config, idType, UpdateBehaviour.ADD );
+                defaultFormatNodeFileHeader(), config, idType, UpdateBehaviour.ADD,
+                silentBadCollector( 0 ));
 
         // WHEN
         assertProperties( externalPropertiesDecorator.apply( node( "1", "key", "value1", "email", "existing" ) ),


### PR DESCRIPTION
This change warns the user about a typical symptom of an incorrect header being used (for example using different delimiters in header versus data). After some thinking (and implementing a version with StringLogger) I came to the decision that a simple System.out.println is exactly what we want here. Doing almost anything else will introduce more changes elsewhere and be harder to test for.

Example of the output:

```
Importing the contents of these files into /home/jonas/workspace/2.2/community/import-tool/target/test-data/org.neo4j.tooling.ImportToolTest/graph-db:
Nodes:
  /home/jonas/workspace/2.2/community/import-tool/target/test-data/org.neo4j.tooling.ImportToolTest/graph-db/0-nodes-header.csv
  /home/jonas/workspace/2.2/community/import-tool/target/test-data/org.neo4j.tooling.ImportToolTest/graph-db/1-nodes.csv
Relationships:
  /home/jonas/workspace/2.2/community/import-tool/target/test-data/org.neo4j.tooling.ImportToolTest/graph-db/2-relationships-header.csv
  /home/jonas/workspace/2.2/community/import-tool/target/test-data/org.neo4j.tooling.ImportToolTest/graph-db/3-relationships.csv

Available memory:
  Free machine memory: 288.05 MB
  Max heap memory : 910.50 MB

Nodes

[>:??----------|PROPERTIES-|NODE:7.63 MB--|*LABEL SCAN---------------------------------------|v] 10k
Done in 340ms
Warning: Ignored 3 extra columns in /home/jonas/workspace/2.2/community/import-tool/target/test-data/org.neo4j.tooling.ImportToolTest/graph-db/1-nodes.csv
Prepare node index

[*DETECT:7.63 MB-------------------------------------------------------------------------------]   0
Done in 24ms
Calculate dense nodes
[...]
```
