### PR TITLE
Suspicions from failed instances should be ignored

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
@@ -141,6 +141,14 @@ class HeartbeatContextImpl
     @Override
     public void suspicions( InstanceId from, Set<InstanceId> suspicions )
     {
+        // A failed instance might suspect instances which are alive so ignore it
+        if ( isFailed( from ) )
+        {
+            getInternalLog( HeartbeatContext.class ).info(
+                    "Ignoring suspicions from failed instance " + from + ": " + Iterables.toString( suspicions, "," ) );
+            return;
+        }
+
         Set<InstanceId> serverSuspicions = suspicionsFor( from );
 
         // Check removals
@@ -244,6 +252,12 @@ class HeartbeatContextImpl
                 (commonState.configuration().getMembers().size() - failed.size() - adjust) / 2;
     }
 
+    /**
+     * Get the suspicions as reported by a specific server.
+     *
+     * @param server which might suspect someone.
+     * @return a list of those members which server suspects.
+     */
     @Override
     public List<InstanceId> getSuspicionsOf( InstanceId server )
     {
@@ -261,6 +275,12 @@ class HeartbeatContextImpl
         return suspicions;
     }
 
+    /**
+     * Get all of the servers which suspect a specific member.
+     *
+     * @param uri for the member of interest.
+     * @return a set of servers which suspect the specified member.
+     */
     @Override
     public Set<InstanceId> getSuspicionsFor( InstanceId uri )
     {

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
@@ -154,6 +154,22 @@ public class HeartbeatContextTest
     }
 
     @Test
+    public void testFailedInstanceReportingSuspicions()
+    {
+        InstanceId suspect = instanceIds[1];
+        InstanceId newSuspiciousBastard = instanceIds[2];
+        toTest.suspicions( newSuspiciousBastard, Collections.singleton( suspect ) );
+        toTest.suspect( suspect );
+
+        // Just make sure
+        assertTrue( toTest.isFailed( suspect ) );
+
+        // Suspicions of a failed instance should be ignored
+        toTest.suspicions( suspect, Collections.singleton( newSuspiciousBastard ) );
+        assertTrue( "Suspicions should have been ignored", toTest.getSuspicionsOf( newSuspiciousBastard ).isEmpty() );
+    }
+
+    @Test
     public void testFailedInstanceBecomingAlive()
     {
         InstanceId suspect = instanceIds[1];

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessorTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessorTest.java
@@ -100,6 +100,68 @@ public class HeartbeatIAmAliveProcessorTest
     }
 
     @Test
+    public void shouldNotGenerateHeartbeatsForSuspicions() throws Exception
+    {
+        URI to = URI.create( "ha://1" );
+
+        // GIVEN
+        MessageHolder outgoing = mock( MessageHolder.class );
+        ClusterContext mockContext = mock( ClusterContext.class );
+        ClusterConfiguration mockConfiguration = mock( ClusterConfiguration.class );
+        when( mockConfiguration.getMembers() ).thenReturn(
+                new HashMap<InstanceId, URI>()
+                {{
+                        put( new InstanceId( 1 ), URI.create( "ha://1" ) );
+                        put( new InstanceId( 2 ), URI.create( "ha://2" ) );
+                    }}
+        );
+        when( mockContext.getConfiguration() ).thenReturn( mockConfiguration );
+
+        HeartbeatIAmAliveProcessor processor = new HeartbeatIAmAliveProcessor( outgoing, mockContext );
+        Message incoming = Message.to( HeartbeatMessage.suspicions , to ).setHeader( Message.FROM, to
+            .toASCIIString() )
+                .setHeader( Message.INSTANCE_ID, "1" );
+        assertEquals( HeartbeatMessage.suspicions, incoming.getMessageType() );
+
+        // WHEN
+        processor.process( incoming );
+
+        // THEN
+        verifyZeroInteractions( outgoing );
+    }
+
+    @Test
+    public void shouldNotGenerateHeartbeatsForHeartbeats() throws Exception
+    {
+        URI to = URI.create( "ha://1" );
+
+        // GIVEN
+        MessageHolder outgoing = mock( MessageHolder.class );
+        ClusterContext mockContext = mock( ClusterContext.class );
+        ClusterConfiguration mockConfiguration = mock( ClusterConfiguration.class );
+        when( mockConfiguration.getMembers() ).thenReturn(
+                new HashMap<InstanceId, URI>()
+                {{
+                        put( new InstanceId( 1 ), URI.create( "ha://1" ) );
+                        put( new InstanceId( 2 ), URI.create( "ha://2" ) );
+                    }}
+        );
+        when( mockContext.getConfiguration() ).thenReturn( mockConfiguration );
+
+        HeartbeatIAmAliveProcessor processor = new HeartbeatIAmAliveProcessor( outgoing, mockContext );
+        Message incoming = Message.to( HeartbeatMessage.i_am_alive , to ).setHeader( Message.FROM, to
+                .toASCIIString() )
+                .setHeader( Message.INSTANCE_ID, "1" );
+        assertEquals( HeartbeatMessage.i_am_alive, incoming.getMessageType() );
+
+        // WHEN
+        processor.process( incoming );
+
+        // THEN
+        verifyZeroInteractions( outgoing );
+    }
+
+    @Test
     public void shouldCorrectlySetTheInstanceIdHeaderInTheGeneratedHeartbeat() throws Exception
     {
         final List<Message> sentOut = new LinkedList<Message>();


### PR DESCRIPTION
A failed instance (in case of GC pauses for example) might suspect instances
which are alive in the cluster. By ignoring suspicions from a failed instance
we avoid possibly marking alive instances as failed.

Once the instance has sent and received some heartbeats it will be marked as
alive and should no longer incorrectly suspect alive instances. So it is only
when the instance if failed we need to do anything special.

To avoid a race between generated heartbeats and suspicions, we also don't
generate a heartbeat for suspicions.
