### PR TITLE
Add warn log when waiting for the db to be available

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -281,6 +281,7 @@ public class AvailabilityGuard
             return availability;
         }
 
+        log.info( "Database is unavailable awaiting for it to be available again for " + millis + "ms" );
         long timeout = clock.currentTimeMillis() + millis;
         do
         {


### PR DESCRIPTION
This extra logging is useful to investigate issue when tx throughput
drops, indeed it helps determine if transactions are block by waiting
for the database to be available.
