### PR TITLE
Revert the extraction of GlobalGraphOperations

### DIFF
--- a/community/consistency-check-legacy/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check-legacy/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -60,7 +60,6 @@ import org.neo4j.test.RandomRule;
 import org.neo4j.test.Randoms;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collectors;
@@ -326,8 +325,6 @@ public class ParallelBatchImporterTest
     protected void verifyData( int nodeCount, int relationshipCount, GraphDatabaseService db, IdGroupDistribution groups,
             long nodeRandomSeed, long relationshipRandomSeed )
     {
-        GlobalGraphOperations globalOps = GlobalGraphOperations.at( db );
-
         // Read all nodes, relationships and properties ad verify against the input data.
         try ( InputIterator<InputNode> nodes = nodes( nodeRandomSeed, nodeCount, inputIdGenerator, groups ).iterator();
               InputIterator<InputRelationship> relationships = relationships( relationshipRandomSeed, relationshipCount,
@@ -335,7 +332,7 @@ public class ParallelBatchImporterTest
         {
             // Nodes
             Map<String,Node> nodeByInputId = new HashMap<>( nodeCount );
-            Iterator<Node> dbNodes = globalOps.getAllNodes().iterator();
+            Iterator<Node> dbNodes = db.getAllNodes().iterator();
             int verifiedNodes = 0;
             while ( nodes.hasNext() )
             {
@@ -350,7 +347,7 @@ public class ParallelBatchImporterTest
 
             // Relationships
             Map<String,Relationship> relationshipByName = new HashMap<>();
-            for ( Relationship relationship : globalOps.getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 relationshipByName.put( (String) relationship.getProperty( "id" ), relationship );
             }

--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -60,7 +60,6 @@ import org.neo4j.test.RandomRule;
 import org.neo4j.test.Randoms;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Group;
@@ -327,8 +326,6 @@ public class ParallelBatchImporterTest
     protected void verifyData( int nodeCount, int relationshipCount, GraphDatabaseService db, IdGroupDistribution groups,
             long nodeRandomSeed, long relationshipRandomSeed )
     {
-        GlobalGraphOperations globalOps = GlobalGraphOperations.at( db );
-
         // Read all nodes, relationships and properties ad verify against the input data.
         try ( InputIterator<InputNode> nodes = nodes( nodeRandomSeed, nodeCount, inputIdGenerator, groups ).iterator();
               InputIterator<InputRelationship> relationships = relationships( relationshipRandomSeed, relationshipCount,
@@ -336,7 +333,7 @@ public class ParallelBatchImporterTest
         {
             // Nodes
             Map<String,Node> nodeByInputId = new HashMap<>( nodeCount );
-            Iterator<Node> dbNodes = globalOps.getAllNodes().iterator();
+            Iterator<Node> dbNodes = db.getAllNodes().iterator();
             int verifiedNodes = 0;
             while ( nodes.hasNext() )
             {
@@ -351,7 +348,7 @@ public class ParallelBatchImporterTest
 
             // Relationships
             Map<String,Relationship> relationshipByName = new HashMap<>();
-            for ( Relationship relationship : globalOps.getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 relationshipByName.put( (String) relationship.getProperty( "id" ), relationship );
             }

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -24,7 +24,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 /**
  * @author mh
@@ -47,15 +46,13 @@ public class DatabaseSubGraph implements SubGraph
     @Override
     public Iterable<Node> getNodes()
     {
-        final GlobalGraphOperations operations = GlobalGraphOperations.at( gdb );
-        return operations.getAllNodes();
+        return gdb.getAllNodes();
     }
 
     @Override
     public Iterable<Relationship> getRelationships()
     {
-        final GlobalGraphOperations operations = GlobalGraphOperations.at( gdb );
-        return operations.getAllRelationships();
+        return gdb.getAllRelationships();
     }
 
     @Override

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -332,7 +332,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       case e: NotFoundException => throw new EntityNotFoundException(s"Node with id $id", e)
     }
 
-    def all: Iterator[Node] = GlobalGraphOperations.at(graph).getAllNodes.iterator().asScala
+    def all: Iterator[Node] = graph.getAllNodes.iterator().asScala
 
     def indexGet(name: String, key: String, value: Any): Iterator[Node] =
       graph.index.forNodes(name).get(key, value).iterator().asScala
@@ -373,7 +373,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     }
 
     def all: Iterator[Relationship] =
-      GlobalGraphOperations.at(graph).getAllRelationships.iterator().asScala
+      graph.getAllRelationships.iterator().asScala
 
     def indexGet(name: String, key: String, value: Any): Iterator[Relationship] =
       graph.index.forRelationships(name).get(key, value).iterator().asScala

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -45,7 +45,6 @@ import org.neo4j.kernel.impl.core.{RelationshipProxy, ThreadToStatementContextBr
 import org.neo4j.kernel.impl.locking.ResourceTypes
 import org.neo4j.kernel.security.URLAccessValidationError
 import org.neo4j.kernel.{GraphDatabaseAPI, Traversal, Uniqueness}
-import org.neo4j.tooling.GlobalGraphOperations
 
 import scala.collection.JavaConverters._
 import scala.collection.{Iterator, mutable}
@@ -330,7 +329,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       case e: NotFoundException => throw new EntityNotFoundException(s"Node with id $id", e)
     }
 
-    def all: Iterator[Node] = GlobalGraphOperations.at(graph).getAllNodes.iterator().asScala
+    def all: Iterator[Node] = graph.getAllNodes.iterator().asScala
 
     def indexGet(name: String, key: String, value: Any): Iterator[Node] =
       graph.index.forNodes(name).get(key, value).iterator().asScala
@@ -376,8 +375,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       case e: NotFoundException => throw new EntityNotFoundException(s"Relationship with id $id", e)
     }
 
-    def all: Iterator[Relationship] =
-      GlobalGraphOperations.at(graph).getAllRelationships.iterator().asScala
+    def all: Iterator[Relationship] = graph.getAllRelationships.iterator().asScala
 
     def indexGet(name: String, key: String, value: Any): Iterator[Relationship] =
       graph.index.forRelationships(name).get(key, value).iterator().asScala

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/GraphDatabaseServiceExecuteTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/GraphDatabaseServiceExecuteTest.java
@@ -24,10 +24,8 @@ import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 
 public class GraphDatabaseServiceExecuteTest
@@ -40,7 +38,7 @@ public class GraphDatabaseServiceExecuteTest
         final int before, after;
         try ( Transaction tx = graphDb.beginTx() )
         {
-            before = count( GlobalGraphOperations.at( graphDb ).getAllNodes() );
+            before = count( graphDb.getAllNodes() );
             tx.success();
         }
 
@@ -50,7 +48,7 @@ public class GraphDatabaseServiceExecuteTest
         // then
         try ( Transaction tx = graphDb.beginTx() )
         {
-            after = count( GlobalGraphOperations.at( graphDb ).getAllNodes() );
+            after = count( graphDb.getAllNodes() );
             tx.success();
         }
         assertEquals( before + 1, after );

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -29,7 +29,6 @@ import org.neo4j.kernel.api.{DataWriteOperations, KernelAPI}
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 import org.neo4j.kernel.{GraphDatabaseAPI, monitoring}
 import org.neo4j.test.TestGraphDatabaseFactory
-import org.neo4j.tooling.GlobalGraphOperations
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
@@ -89,11 +88,11 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
   }
 
   def countNodes() = graph.inTx {
-    GlobalGraphOperations.at(graph).getAllNodes.asScala.size
+    graph.getAllNodes.asScala.size
   }
 
   def countRelationships() = graph.inTx {
-    GlobalGraphOperations.at(graph).getAllRelationships.asScala.size
+    graph.getAllRelationships.asScala.size
   }
 
   def createNode(): Node = createNode(Map[String, Any]())
@@ -130,13 +129,13 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
   def createNode(values: (String, Any)*): Node = createNode(values.toMap)
 
   def deleteAllEntities() = graph.inTx {
-    val relIterator = GlobalGraphOperations.at(graph).getAllRelationships.iterator()
+    val relIterator = graph.getAllRelationships.iterator()
 
     while (relIterator.hasNext) {
       relIterator.next().delete()
     }
 
-    val nodeIterator = GlobalGraphOperations.at(graph).getAllNodes.iterator()
+    val nodeIterator = graph.getAllNodes.iterator()
     while (nodeIterator.hasNext) {
       nodeIterator.next().delete()
     }
@@ -188,7 +187,7 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
     nodes.find(_.getProperty("name") == name).get
   }
 
-  def relType(name: String): RelationshipType = GlobalGraphOperations.at(graph).getAllRelationshipTypes.asScala.find(_.name() == name).get
+  def relType(name: String): RelationshipType = graph.getAllRelationshipTypes.asScala.find(_.name() == name).get
 
   def createNodes(names: String*): List[Node] = {
     nodes = names.map(x => createNode(Map("name" -> x))).toList

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
@@ -23,7 +23,6 @@ import java.util
 
 import org.neo4j.graphdb._
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
-import org.neo4j.tooling.GlobalGraphOperations
 import org.scalatest.Assertions
 
 import scala.collection.JavaConverters._
@@ -31,24 +30,24 @@ import scala.collection.JavaConverters._
 class MutatingIntegrationTest extends ExecutionEngineFunSuite with Assertions with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
   test("create a single node") {
-    val before = graph.inTx(GlobalGraphOperations.at(graph).getAllNodes.asScala.size)
+    val before = graph.inTx(graph.getAllNodes.asScala.size)
 
     val result = updateWithBothPlanners("create (a)")
 
     assertStats(result, nodesCreated = 1)
     graph.inTx {
-      GlobalGraphOperations.at(graph).getAllNodes.asScala should have size before + 1
+      graph.getAllNodes.asScala should have size before + 1
     }
   }
 
   test("create a single node with props and return it") {
-    val before = graph.inTx(GlobalGraphOperations.at(graph).getAllNodes.asScala.size)
+    val before = graph.inTx(graph.getAllNodes.asScala.size)
 
     val result = updateWithBothPlanners("create (a {name : 'Andres'}) return a.name")
 
     assertStats(result, nodesCreated = 1, propertiesSet = 1)
     graph.inTx {
-      GlobalGraphOperations.at(graph).getAllNodes.asScala should have size before + 1
+      graph.getAllNodes.asScala should have size before + 1
     }
 
     result.toList should equal(List(Map("a.name" -> "Andres")))
@@ -271,7 +270,7 @@ return distinct center""")
     executeWithRulePlanner("""start n=node(*) optional match (n)-[r]-() delete n,r""")
 
     graph.inTx {
-      GlobalGraphOperations.at(graph).getAllNodes.asScala shouldBe empty
+      graph.getAllNodes.asScala shouldBe empty
     }
   }
 
@@ -283,7 +282,7 @@ return distinct center""")
     updateWithBothPlanners("""match (n) where id(n) = 0 match p=(n)-->() delete p""")
 
     graph.inTx {
-      GlobalGraphOperations.at(graph).getAllNodes.asScala shouldBe empty
+      graph.getAllNodes.asScala shouldBe empty
     }
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/DoubleCheckCreateUniqueTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/DoubleCheckCreateUniqueTest.scala
@@ -120,7 +120,7 @@ class Wrapper(delegate: GraphDatabaseAPI) extends GraphDatabaseAPI
   override def unregisterTransactionEventHandler[T](handler: TransactionEventHandler[T]): TransactionEventHandler[T] =
     delegate.unregisterTransactionEventHandler(handler)
 
-  override def getAllNodes: Iterable[Node] = delegate.getAllNodes
+  override def getAllNodes: ResourceIterable[Node] = delegate.getAllNodes
 
   override def getRelationshipById(id: Long): Relationship = delegate.getRelationshipById(id)
 
@@ -137,7 +137,13 @@ class Wrapper(delegate: GraphDatabaseAPI) extends GraphDatabaseAPI
   override def registerTransactionEventHandler[T](handler: TransactionEventHandler[T]): TransactionEventHandler[T] =
     delegate.registerTransactionEventHandler(handler)
 
-  override def getRelationshipTypes: Iterable[RelationshipType] = delegate.getRelationshipTypes
+  override def getAllRelationshipTypes: ResourceIterable[RelationshipType] = delegate.getAllRelationshipTypes
+
+  override def getAllRelationships: ResourceIterable[Relationship] = delegate.getAllRelationships
+
+  override def getAllPropertyKeys: ResourceIterable[String] = delegate.getAllPropertyKeys
+
+  override def getAllLabels: ResourceIterable[Label] = delegate.getAllLabels
 
   override def traversalDescription(): TraversalDescription = delegate.traversalDescription()
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LazyTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LazyTest.scala
@@ -28,7 +28,6 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.neo4j.collection.primitive.PrimitiveLongCollections
 import org.neo4j.cypher._
 import org.neo4j.cypher.internal.ExecutionPlan
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Variable, Literal}
@@ -41,12 +40,12 @@ import org.neo4j.cypher.internal.frontend.v3_0.symbols.CTInteger
 import org.neo4j.cypher.internal.spi.v3_0.MonoDirectionalTraversalMatcher
 import org.neo4j.graphdb.Traverser.Order
 import org.neo4j.graphdb._
+import org.neo4j.helpers.collection.Iterables.asResourceIterable
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.{ReadOperations, Statement}
 import org.neo4j.kernel.impl.api.OperationsFacade
 import org.neo4j.kernel.impl.core.{NodeManager, NodeProxy, ThreadToStatementContextBridge}
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore
-import org.neo4j.tooling.GlobalGraphOperations
 
 import scala.collection.JavaConverters._
 
@@ -186,8 +185,6 @@ class LazyTest extends ExecutionEngineFunSuite {
 
   test("graph global queries are lazy") {
     //Given:
-    val counter = new CountingJIterator()
-
     val fakeGraph = mock[GraphDatabaseAPI]
     val tx = mock[Transaction]
     val nodeManager = mock[NodeManager]
@@ -213,8 +210,17 @@ class LazyTest extends ExecutionEngineFunSuite {
     when(dependencies.resolveDependency(classOf[TransactionIdStore])).thenReturn(idStore)
     when(dependencies.resolveDependency(classOf[org.neo4j.kernel.monitoring.Monitors])).thenReturn(monitors)
     when(fakeGraph.beginTx()).thenReturn(tx)
-    val nodesIterator = PrimitiveLongCollections.iterator( 0L, 1L, 2L, 3L, 4L, 5L, 6L )
-    when(fakeReadStatement.nodesGetAll()).thenReturn(nodesIterator)
+    val n0 = mock[Node]
+    val n1 = mock[Node]
+    val n2 = mock[Node]
+    val n3 = mock[Node]
+    val n4 = mock[Node]
+    val n5 = mock[Node]
+    val n6 = mock[Node]
+    val nodesIterator = java.util.Arrays.asList( n0, n1, n2, n3, n4, n5, n6 ).iterator()
+    when(fakeGraph.getAllNodes).thenReturn(asResourceIterable(new java.lang.Iterable[Node](){
+      override def iterator() = nodesIterator
+    }))
 
     val cache = new LRUCache[String, (ExecutionPlan, Map[String, Any])](1)
     when(fakeReadStatement.schemaStateGetOrCreate(any(), any())).then(
@@ -226,13 +232,12 @@ class LazyTest extends ExecutionEngineFunSuite {
 
     //When:
     graph.inTx {
-      counter.source = GlobalGraphOperations.at(graph).getAllNodes.iterator()
       engine.execute("match (n) return n limit 5", Map.empty[String,Any]).toList
     }
 
     //Then:
     assert( nodesIterator.hasNext )
-    assert( nodesIterator.next() === 5L )
+    assert( nodesIterator.next() === n5 )
   }
 
   test("traversalmatcherpipe is lazy") {

--- a/community/graphviz/src/main/java/org/neo4j/walk/Walker.java
+++ b/community/graphviz/src/main/java/org/neo4j/walk/Walker.java
@@ -27,7 +27,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public abstract class Walker
 {
@@ -40,7 +39,7 @@ public abstract class Walker
             @Override
             public <R, E extends Throwable> R accept( Visitor<R, E> visitor ) throws E
             {
-                for ( Node node : GlobalGraphOperations.at( graphDb ).getAllNodes() )
+                for ( Node node : graphDb.getAllNodes() )
                 {
                     visitor.visitNode( node );
                     for ( Relationship edge : node.getRelationships( Direction.OUTGOING ) )

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
@@ -55,7 +55,6 @@ import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 import static org.neo4j.io.fs.FileUtils.readTextFile;
 import static org.neo4j.io.fs.FileUtils.writeToFile;
-import static org.neo4j.tooling.GlobalGraphOperations.at;
 import static org.neo4j.tooling.ImportTool.MULTI_FILE_DELIMITER;
 
 public class ImportToolDocIT
@@ -619,10 +618,10 @@ public class ImportToolDocIT
         GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabase( directory.absolutePath() );
         try ( Transaction tx = db.beginTx() )
         {
-            int nodeCount = count( at( db ).getAllNodes() ), relationshipCount = 0;
+            int nodeCount = count( db.getAllNodes() ), relationshipCount = 0;
             assertEquals( 2, nodeCount );
 
-            for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 assertTrue( relationship.hasProperty( "roles" ) );
 
@@ -656,9 +655,9 @@ public class ImportToolDocIT
         GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( directory.absolutePath() );
         try ( Transaction tx = db.beginTx() )
         {
-            int nodeCount = count( at( db ).getAllNodes() ), relationshipCount = 0, sequelCount = 0;
+            int nodeCount = count( db.getAllNodes() ), relationshipCount = 0, sequelCount = 0;
             assertEquals( NODE_COUNT, nodeCount );
-            for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 assertTrue( relationship.hasProperty( "role" ) );
                 relationshipCount++;

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -357,7 +357,7 @@ public class ImportToolTest
         try ( Transaction tx = db.beginTx() )
         {
             int nodeCount = 0;
-            for ( Node node : at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 assertTrue( node.hasProperty( "name" ) );
                 nodeCount++;
@@ -397,7 +397,7 @@ public class ImportToolTest
         try ( Transaction tx = db.beginTx() )
         {
             int nodeCount = 0;
-            for ( Node node : at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 assertTrue( node.hasProperty( "name" ) );
                 nodeCount++;
@@ -503,7 +503,7 @@ public class ImportToolTest
         GraphDatabaseService db = dbRule.getGraphDatabaseService();
         try ( Transaction tx = db.beginTx() )
         {
-            Iterator<Node> nodes = at( db ).getAllNodes().iterator();
+            Iterator<Node> nodes = db.getAllNodes().iterator();
             Iterator<String> expectedIds = FilteringIterator.noDuplicates( nodeIds.iterator() );
             while ( expectedIds.hasNext() )
             {
@@ -716,7 +716,7 @@ public class ImportToolTest
         GraphDatabaseService db = dbRule.getGraphDatabaseService();
         try ( Transaction tx = db.beginTx() )
         {
-            Iterable<Node> allNodes = at( db ).getAllNodes();
+            Iterable<Node> allNodes = db.getAllNodes();
             int anonymousCount = 0;
             for ( final String id : nodeIds )
             {
@@ -818,7 +818,7 @@ public class ImportToolTest
         GraphDatabaseService db = dbRule.getGraphDatabaseAPI();
         try ( Transaction tx = db.beginTx() )
         {
-            ResourceIterator<Node> allNodes = at( db ).getAllNodes().iterator();
+            ResourceIterator<Node> allNodes = db.getAllNodes().iterator();
             Node node = IteratorUtil.single( allNodes );
             allNodes.close();
 
@@ -842,7 +842,7 @@ public class ImportToolTest
         GraphDatabaseService graphDatabaseService = dbRule.getGraphDatabaseService();
         try ( Transaction tx = graphDatabaseService.beginTx() )
         {
-            ResourceIterator<Node> allNodes = at( graphDatabaseService ).getAllNodes().iterator();
+            ResourceIterator<Node> allNodes = graphDatabaseService.getAllNodes().iterator();
             assertFalse( "Expected database to be empty", allNodes.hasNext() );
             tx.success();
         }
@@ -866,7 +866,7 @@ public class ImportToolTest
         GraphDatabaseService db = dbRule.getGraphDatabaseAPI();
         try ( Transaction tx = db.beginTx() )
         {
-            Node node = single( at( db ).getAllNodes() );
+            Node node = single( db.getAllNodes() );
             assertEquals( "three", single( node.getPropertyKeys() ) );
             tx.success();
         }
@@ -944,14 +944,14 @@ public class ImportToolTest
         try ( Transaction tx = db.beginTx() )
         {
             int nodeCount = 0, relationshipCount = 0;
-            for ( Node node : at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 assertTrue( node.hasProperty( "name" ) );
                 nodeAdditionalValidation.validate( node );
                 nodeCount++;
             }
             assertEquals( NODE_COUNT, nodeCount );
-            for ( Relationship relationship : at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 assertTrue( relationship.hasProperty( "created" ) );
                 relationshipAdditionalValidation.validate( relationship );
@@ -1000,7 +1000,7 @@ public class ImportToolTest
         try ( Transaction tx = db.beginTx() )
         {
             Map<String,Node> nodes = new HashMap<>();
-            for ( Node node : at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 nodes.put( idOf( node ), node );
             }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -28,7 +28,6 @@ import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.kernel.EmbeddedGraphDatabase;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 /**
  * The main access point to a running Neo4j instance. The most common
@@ -92,10 +91,15 @@ public interface GraphDatabaseService
      * Returns all nodes in the graph.
      *
      * @return all nodes in the graph.
-     * @deprecated this operation can be found in {@link GlobalGraphOperations} instead.
      */
-    @Deprecated
-    Iterable<Node> getAllNodes();
+    ResourceIterable<Node> getAllNodes();
+
+    /**
+     * Returns all relationships in the graph.
+     *
+     * @return all relationships in the graph.
+     */
+    ResourceIterable<Relationship> getAllRelationships();
 
     /**
      * Returns all nodes having the label, and the wanted property value.
@@ -183,10 +187,32 @@ public interface GraphDatabaseService
      * space).
      *
      * @return all relationship types in the underlying store
-     * @deprecated this operation can be found in {@link GlobalGraphOperations} instead.
      */
-    @Deprecated
-    Iterable<RelationshipType> getRelationshipTypes();
+    ResourceIterable<RelationshipType> getAllRelationshipTypes();
+
+    /**
+     * Returns all labels currently in the underlying store. Labels are added to the store the first time
+     * they are used. This method guarantees that it will return all labels currently in use. However,
+     * it may also return <i>more</i> than that (e.g. it can return "historic" labels that are no longer used).
+     *
+     * Please take care that the returned {@link ResourceIterable} is closed correctly and as soon as possible
+     * inside your transaction to avoid potential blocking of write operations.
+     *
+     * @return all labels in the underlying store.
+     */
+    ResourceIterable<Label> getAllLabels();
+
+    /**
+     * Returns all property keys currently in the underlying store. This method guarantees that it will return all
+     * property keys currently in use. However, it may also return <i>more</i> than that (e.g. it can return "historic"
+     * labels that are no longer used).
+     *
+     * Please take care that the returned {@link ResourceIterable} is closed correctly and as soon as possible
+     * inside your transaction to avoid potential blocking of write operations.
+     *
+     * @return all property keys in the underlying store.
+     */
+    ResourceIterable<String> getAllPropertyKeys();
 
     /**
      * Use this method to check if the database is currently in a usable state.

--- a/community/kernel/src/main/java/org/neo4j/graphdb/ResourceIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/ResourceIterator.java
@@ -20,6 +20,7 @@
 package org.neo4j.graphdb;
 
 import java.util.Iterator;
+import java.util.function.Function;
 
 /**
  * Closeable Iterator with associated resources.
@@ -42,4 +43,28 @@ public interface ResourceIterator<T> extends Iterator<T>, Resource
      */
     @Override
     void close();
+
+    default <R> ResourceIterator<R> map( Function<T,R> map )
+    {
+        return new ResourceIterator<R>()
+        {
+            @Override
+            public void close()
+            {
+                ResourceIterator.this.close();
+            }
+
+            @Override
+            public boolean hasNext()
+            {
+                return ResourceIterator.this.hasNext();
+            }
+
+            @Override
+            public R next()
+            {
+                return map.apply( ResourceIterator.this.next() );
+            }
+        };
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/Iterables.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.function.Function;
 import org.neo4j.function.Predicate;
+import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.impl.transaction.log.IOCursor;
@@ -617,14 +618,18 @@ public final class Iterables
         return list.toArray( (T[]) Array.newInstance( componentType, list.size() ) );
     }
 
-    public static <T> ResourceIterable<T> asResourceIterable( final Iterable<T> labels )
+    public static <T> ResourceIterable<T> asResourceIterable( final Iterable<T> iterable )
     {
+        if ( iterable instanceof ResourceIterable<?> )
+        {
+            return (ResourceIterable<T>) iterable;
+        }
         return new ResourceIterable<T>()
         {
             @Override
             public ResourceIterator<T> iterator()
             {
-                return asResourceIterator( labels.iterator() );
+                return asResourceIterator( iterable.iterator() );
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/IteratorUtil.java
@@ -1050,6 +1050,10 @@ public abstract class IteratorUtil
 
     public static <T> ResourceIterator<T> asResourceIterator( final Iterator<T> iterator )
     {
+        if ( iterator instanceof ResourceIterator<?> )
+        {
+            return (ResourceIterator<T>) iterator;
+        }
         return new WrappingResourceIterator<>( iterator );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/TokenRead.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/TokenRead.java
@@ -52,6 +52,9 @@ interface TokenRead
     /** Returns the labels currently stored in the database * */
     Iterator<Token> labelsGetAllTokens(); // TODO: Token is a store level concern, should not make it this far up the stack
 
+    /** Returns the relationship types currently stored in the database */
+    Iterator<Token> relationshipTypesGetAllTokens();
+
     int relationshipTypeGetForName( String relationshipTypeName );
 
     String relationshipTypeGetName( int relationshipTypeId ) throws RelationshipTypeIdNotFoundKernelException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -770,6 +770,13 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     }
 
     @Override
+    public Iterator<Token> relationshipTypesGetAllTokens()
+    {
+        statement.assertOpen();
+        return tokenRead().relationshipTypesGetAllTokens( statement );
+    }
+
+    @Override
     public int relationshipTypeGetForName( String relationshipTypeName )
     {
         statement.assertOpen();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -1308,6 +1308,12 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
+    public Iterator<Token> relationshipTypesGetAllTokens( Statement state )
+    {
+        return storeLayer.relationshipTypeGetAllTokens();
+    }
+
+    @Override
     public int relationshipTypeGetForName( Statement state, String relationshipTypeName )
     {
         return storeLayer.relationshipTypeGetForName( relationshipTypeName );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import java.util.Iterator;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Resource;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.PrefetchingResourceIterator;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.impl.core.Token;
+
+import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.kernel.api.CountsRead.ANY_LABEL;
+
+public abstract class TokenAccess<R>
+{
+    public static final TokenAccess<RelationshipType> RELATIONSHIP_TYPES = new TokenAccess<RelationshipType>()
+    {
+        @Override
+        Iterator<Token> tokens( ReadOperations read )
+        {
+            return read.relationshipTypesGetAllTokens();
+        }
+
+        @Override
+        RelationshipType token( Token token )
+        {
+            if ( token instanceof RelationshipType )
+            {
+                return (RelationshipType) token;
+            }
+            else
+            {
+                return RelationshipType.withName( token.name() );
+            }
+        }
+
+        @Override
+        boolean inUse( ReadOperations read, int tokenId )
+        {
+            return hasAny( read.constraintsGetForRelationshipType( tokenId ) ) ||   // used by constraint
+                   read.countsForRelationship( ANY_LABEL, tokenId, ANY_LABEL ) > 0; // used by data
+        }
+    };
+    public static final TokenAccess<Label> LABELS = new TokenAccess<Label>()
+    {
+        @Override
+        Iterator<Token> tokens( ReadOperations read )
+        {
+            return read.labelsGetAllTokens();
+        }
+
+        @Override
+        Label token( Token token )
+        {
+            return label( token.name() );
+        }
+
+        @Override
+        boolean inUse( ReadOperations read, int tokenId )
+        {
+            return hasAny( read.indexesGetForLabel( tokenId ) ) ||     // used by index
+                   hasAny( read.constraintsGetForLabel( tokenId ) ) || // used by constraint
+                   read.countsForNode( tokenId ) > 0;                  // used by data
+        }
+    };
+
+    public static final TokenAccess<String> PROPERTY_KEYS = new TokenAccess<String>()
+    {
+        @Override
+        Iterator<Token> tokens( ReadOperations read )
+        {
+            return read.propertyKeyGetAllTokens();
+        }
+
+        @Override
+        String token( Token token )
+        {
+            return token.name();
+        }
+
+        @Override
+        boolean inUse( ReadOperations read, int tokenId )
+        {
+            return true; // TODO: add support for telling if a property key is in use or not
+        }
+    };
+
+    public final ResourceIterator<R> inUse( Statement statement )
+    {
+        return TokenIterator.inUse( statement, this );
+    }
+
+    public final ResourceIterator<R> all( Statement statement )
+    {
+        return TokenIterator.all( statement, this );
+    }
+
+    private static boolean hasAny( Iterator<?> iter )
+    {
+        if ( iter.hasNext() )
+        {
+            return true;
+        }
+        if ( iter instanceof Resource )
+        {
+            ((Resource) iter).close();
+        }
+        return false;
+    }
+
+    private static abstract class TokenIterator<T> extends PrefetchingResourceIterator<T>
+    {
+        final Statement statement;
+        final TokenAccess<T> access;
+        final Iterator<Token> tokens;
+
+        TokenIterator( Statement statement, TokenAccess<T> access )
+        {
+            this.statement = statement;
+            this.access = access;
+            this.tokens = access.tokens( statement.readOperations() );
+        }
+
+        @Override
+        public void close()
+        {
+            statement.close();
+        }
+
+        static <T> ResourceIterator<T> inUse( Statement statement, TokenAccess<T> access )
+        {
+            return new TokenIterator<T>( statement, access )
+            {
+                @Override
+                protected T fetchNextOrNull()
+                {
+                    while ( tokens.hasNext() )
+                    {
+                        Token token = tokens.next();
+                        if ( access.inUse( statement.readOperations(), token.id() ) )
+                        {
+                            return access.token( token );
+                        }
+                    }
+                    return null;
+                }
+            };
+        }
+
+        static <T> ResourceIterator<T> all( Statement statement, TokenAccess<T> access )
+        {
+            return new TokenIterator<T>( statement, access )
+            {
+                @Override
+                protected T fetchNextOrNull()
+                {
+                    return tokens.hasNext() ? access.token( tokens.next() ) : null;
+                }
+            };
+        }
+    }
+
+    abstract Iterator<Token> tokens( ReadOperations read );
+
+    abstract R token( Token token );
+
+    abstract boolean inUse( ReadOperations read, int tokenId );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/KeyReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/KeyReadOperations.java
@@ -55,6 +55,9 @@ public interface KeyReadOperations
     /** Returns the labels currently stored in the database **/
     Iterator<Token> labelsGetAllTokens( Statement state ); // TODO: Token is a store level concern, should not make it this far up the stack
 
+    /** Returns the relationship types currently stored in the database */
+    Iterator<Token> relationshipTypesGetAllTokens( Statement state );
+
     int relationshipTypeGetForName( Statement state, String relationshipTypeName );
 
     String relationshipTypeGetName( Statement state, int relationshipTypeId )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -399,6 +399,12 @@ public class CacheLayer implements StoreReadLayer
     }
 
     @Override
+    public Iterator<Token> relationshipTypeGetAllTokens()
+    {
+        return diskLayer.relationshipTypeGetAllTokens();
+    }
+
+    @Override
     public int relationshipTypeGetForName( String relationshipTypeName )
     {
         return diskLayer.relationshipTypeGetForName( relationshipTypeName );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/DiskLayer.java
@@ -534,6 +534,13 @@ public class DiskLayer implements StoreReadLayer
         return labelTokenHolder.getAllTokens().iterator();
     }
 
+    @SuppressWarnings( "unchecked" )
+    @Override
+    public Iterator<Token> relationshipTypeGetAllTokens()
+    {
+        return (Iterator)relationshipTokenHolder.getAllTokens().iterator();
+    }
+
     @Override
     public int relationshipTypeGetForName( String relationshipTypeName )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreReadLayer.java
@@ -131,6 +131,8 @@ public interface StoreReadLayer
 
     Iterator<Token> labelsGetAllTokens();
 
+    Iterator relationshipTypeGetAllTokens();
+
     int relationshipTypeGetForName( String relationshipTypeName );
 
     String relationshipTypeGetName( int relationshipTypeId ) throws RelationshipTypeIdNotFoundKernelException;

--- a/community/kernel/src/main/java/org/neo4j/tooling/GlobalGraphOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/tooling/GlobalGraphOperations.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.tooling;
 
-import java.util.Iterator;
-
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
-import org.neo4j.function.Function;
-import org.neo4j.function.Predicate;
-import org.neo4j.function.primitive.FunctionFromPrimitiveLong;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -32,42 +26,26 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterable;
-import org.neo4j.graphdb.ResourceIterator;
-import org.neo4j.helpers.collection.PrefetchingResourceIterator;
-import org.neo4j.helpers.collection.ResourceClosingIterator;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
-import org.neo4j.kernel.impl.core.NodeManager;
-import org.neo4j.kernel.impl.core.RelationshipTypeToken;
-import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
+import org.neo4j.kernel.impl.api.TokenAccess;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.kernel.impl.core.Token;
-
-import static org.neo4j.collection.primitive.PrimitiveLongCollections.map;
-import static org.neo4j.graphdb.Label.label;
-import static org.neo4j.helpers.collection.Iterables.cast;
-import static org.neo4j.helpers.collection.Iterables.filter;
-import static org.neo4j.helpers.collection.Iterables.map;
-import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
-import static org.neo4j.kernel.api.CountsRead.ANY_LABEL;
 
 /**
  * A tool for doing global operations, for example {@link #getAllNodes()}.
+ * @deprecated use methods on {@link GraphDatabaseService} instead
  */
+@Deprecated
 public class GlobalGraphOperations
 {
-    private final NodeManager nodeManager;
     private final ThreadToStatementContextBridge statementCtxSupplier;
-    private final RelationshipTypeTokenHolder relationshipTypes;
+    private final GraphDatabaseService db;
 
     private GlobalGraphOperations( GraphDatabaseService db )
     {
+        this.db = db;
         GraphDatabaseAPI dbApi = (GraphDatabaseAPI) db;
         DependencyResolver resolver = dbApi.getDependencyResolver();
-        this.nodeManager = resolver.resolveDependency( NodeManager.class );
         this.statementCtxSupplier = resolver.resolveDependency( ThreadToStatementContextBridge.class );
-        this.relationshipTypes = resolver.resolveDependency( RelationshipTypeTokenHolder.class );
     }
 
     /**
@@ -85,68 +63,24 @@ public class GlobalGraphOperations
      * Returns all nodes in the graph.
      *
      * @return all nodes in the graph.
+     * @deprecated use {@link GraphDatabaseService#getAllNodes()} instead
      */
+    @Deprecated
     public ResourceIterable<Node> getAllNodes()
     {
-        assertInUnterminatedTransaction();
-        return new ResourceIterable<Node>()
-        {
-            @Override
-            public ResourceIterator<Node> iterator()
-            {
-                final Statement statement = statementCtxSupplier.get();
-                final PrimitiveLongIterator ids = statement.readOperations().nodesGetAll();
-                return new PrefetchingResourceIterator<Node>()
-                {
-                    @Override
-                    public void close()
-                    {
-                        statement.close();
-                    }
-
-                    @Override
-                    protected Node fetchNextOrNull()
-                    {
-                        assert ids != null : "ids null";
-                        assert nodeManager != null : "nodeManager null";
-                        return ids.hasNext() ? nodeManager.newNodeProxyById( ids.next() ) : null;
-                    }
-                };
-            }
-        };
+        return db.getAllNodes();
     }
 
     /**
      * Returns all relationships in the graph.
      *
      * @return all relationships in the graph.
+     * @deprecated use {@link GraphDatabaseService#getAllRelationships()} instead
      */
+    @Deprecated
     public Iterable<Relationship> getAllRelationships()
     {
-        assertInUnterminatedTransaction();
-        return new ResourceIterable<Relationship>()
-        {
-            @Override
-            public ResourceIterator<Relationship> iterator()
-            {
-                final Statement statement = statementCtxSupplier.get();
-                final PrimitiveLongIterator ids = statement.readOperations().relationshipsGetAll();
-                return new PrefetchingResourceIterator<Relationship>()
-                {
-                    @Override
-                    public void close()
-                    {
-                        statement.close();
-                    }
-
-                    @Override
-                    protected Relationship fetchNextOrNull()
-                    {
-                        return ids.hasNext() ? nodeManager.newRelationshipProxy( ids.next() ) : null;
-                    }
-                };
-            }
-        };
+        return db.getAllRelationships();
     }
 
     /**
@@ -158,10 +92,12 @@ public class GlobalGraphOperations
      * have any relationships in the graph).
      *
      * @return all relationship types in the underlying store
+     * @deprecated use {@link GraphDatabaseService#getAllRelationshipTypes()} instead
      */
+    @Deprecated
     public Iterable<RelationshipType> getAllRelationshipTypes()
     {
-        return getAllRelationshipTypes( false );
+        return all( TokenAccess.RELATIONSHIP_TYPES );
     }
 
     /**
@@ -172,32 +108,13 @@ public class GlobalGraphOperations
      * "historic" relationship types that no longer have any relationships in the graph.
      *
      * @return all relationship types in use in the underlying store
+     * @deprecated use {@link GraphDatabaseService#getAllRelationshipTypes()} instead
      */
+    @Deprecated
     public Iterable<RelationshipType> getAllRelationshipTypesInUse()
     {
-        return getAllRelationshipTypes( true );
+        return db.getAllRelationshipTypes();
     }
-
-    private Iterable<RelationshipType> getAllRelationshipTypes( boolean inUse )
-    {
-        assertInUnterminatedTransaction();
-        Iterable<RelationshipTypeToken> relationshipTypes = this.relationshipTypes.getAllTokens();
-        if ( inUse )
-        {
-            relationshipTypes = filter( new Predicate<Token>()
-            {
-                @Override
-                public boolean test( Token token )
-                {
-                    Statement statement = statementCtxSupplier.get();
-                    long count = statement.readOperations().countsForRelationship( ANY_LABEL, token.id(), ANY_LABEL );
-                    return count > 0;
-                }
-            }, relationshipTypes );
-        }
-        return cast( relationshipTypes );
-    }
-
 
     /**
      * Returns all labels currently in the underlying store. Labels are added to the store the first time
@@ -208,10 +125,12 @@ public class GlobalGraphOperations
      * inside your transaction to avoid potential blocking of write operations.
      *
      * @return all labels in the underlying store.
+     * @deprecated use {@link GraphDatabaseService#getAllLabels()} instead
      */
+    @Deprecated
     public ResourceIterable<Label> getAllLabels()
     {
-        return getAllLabels( false );
+        return all( TokenAccess.LABELS );
     }
 
     /**
@@ -223,45 +142,12 @@ public class GlobalGraphOperations
      * inside your transaction to avoid potential blocking of write operations.
      *
      * @return all labels in use in the underlying store.
+     * @deprecated use {@link GraphDatabaseService#getAllLabels()} instead
      */
+    @Deprecated
     public ResourceIterable<Label> getAllLabelsInUse()
     {
-        return getAllLabels( true );
-    }
-
-    private ResourceIterable<Label> getAllLabels( final boolean inUse )
-    {
-        assertInUnterminatedTransaction();
-        return new ResourceIterable<Label>()
-        {
-            @Override
-            public ResourceIterator<Label> iterator()
-            {
-                final Statement statement = statementCtxSupplier.get();
-                Iterator<Token> labels = statement.readOperations().labelsGetAllTokens();
-                if ( inUse )
-                {
-                    labels = filter(  new Predicate<Token>()
-                    {
-                        @Override
-                        public boolean test( Token token )
-                        {
-                            long count = statement.readOperations().countsForNode( token.id() );
-                            return count > 0;
-                        }
-                    }, labels );
-                }
-                return ResourceClosingIterator.newResourceIterator( statement, map( new Function<Token,Label>()
-                {
-
-                    @Override
-                    public Label apply( Token labelToken )
-                    {
-                        return label( labelToken.name() );
-                    }
-                }, labels ) );
-            }
-        };
+        return db.getAllLabels();
     }
 
     /**
@@ -273,27 +159,12 @@ public class GlobalGraphOperations
      * inside your transaction to avoid potential blocking of write operations.
      *
      * @return all property keys in the underlying store.
+     * @deprecated use {@link GraphDatabaseService#getAllPropertyKeys()} instead
      */
+    @Deprecated
     public ResourceIterable<String> getAllPropertyKeys()
     {
-        assertInUnterminatedTransaction();
-        return new ResourceIterable<String>()
-        {
-            @Override
-            public ResourceIterator<String> iterator()
-            {
-                Statement statement = statementCtxSupplier.get();
-                return ResourceClosingIterator.newResourceIterator( statement, map( new Function<Token,String>()
-                {
-
-                    @Override
-                    public String apply( Token propertyToken )
-                    {
-                        return propertyToken.name();
-                    }
-                }, statement.readOperations().propertyKeyGetAllTokens() ) );
-            }
-        };
+        return all( TokenAccess.PROPERTY_KEYS );
     }
 
     /**
@@ -309,41 +180,13 @@ public class GlobalGraphOperations
     @Deprecated
     public ResourceIterable<Node> getAllNodesWithLabel( final Label label )
     {
-        assertInUnterminatedTransaction();
-        return new ResourceIterable<Node>()
-        {
-            @Override
-            public ResourceIterator<Node> iterator()
-            {
-                return allNodesWithLabel( label.name() );
-            }
-        };
+        statementCtxSupplier.assertInUnterminatedTransaction();
+        return () -> db.findNodes( label );
     }
 
-    private ResourceIterator<Node> allNodesWithLabel( String label )
-    {
-        Statement statement = statementCtxSupplier.get();
-
-        int labelId = statement.readOperations().labelGetForName( label );
-        if ( labelId == KeyReadOperations.NO_SUCH_LABEL )
-        {
-            statement.close();
-            return emptyIterator();
-        }
-
-        final PrimitiveLongIterator nodeIds = statement.readOperations().nodesGetForLabel( labelId );
-        return ResourceClosingIterator.newResourceIterator( statement, map( new FunctionFromPrimitiveLong<Node>()
-        {
-            @Override
-            public Node apply( long nodeId )
-            {
-                return nodeManager.newNodeProxyById( nodeId );
-            }
-        }, nodeIds ) );
-    }
-
-    private void assertInUnterminatedTransaction()
+    private <T> ResourceIterable<T> all( final TokenAccess<T> tokens )
     {
         statementCtxSupplier.assertInUnterminatedTransaction();
+        return () -> tokens.all( statementCtxSupplier.get() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/CreateAndDeleteNodesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/CreateAndDeleteNodesIT.java
@@ -23,7 +23,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.test.ImpermanentDatabaseRule;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public class CreateAndDeleteNodesIT
 {
@@ -56,12 +55,12 @@ public class CreateAndDeleteNodesIT
         // When
         try ( Transaction tx2 = dataBase.beginTx() )
         {
-            for ( Relationship r : GlobalGraphOperations.at( dataBase ).getAllRelationships() )
+            for ( Relationship r : dataBase.getAllRelationships() )
             {
                 r.delete();
             }
 
-            for ( Node n : GlobalGraphOperations.at( dataBase ).getAllNodes() )
+            for ( Node n : dataBase.getAllNodes() )
             {
                 n.delete();
             }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/FirstStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/FirstStartupIT.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.helpers.collection.Iterables.count;
@@ -44,13 +43,11 @@ public class FirstStartupIT
         // Then
         try(Transaction ignore = db.beginTx())
         {
-            GlobalGraphOperations global = GlobalGraphOperations.at( db );
-
-            assertEquals(0, count( global.getAllNodes() ));
-            assertEquals(0, count( global.getAllRelationships() ));
-            assertEquals(0, count( global.getAllRelationshipTypes() ));
-            assertEquals(0, count( global.getAllLabels() ));
-            assertEquals(0, count( global.getAllPropertyKeys() ));
+            assertEquals(0, count( db.getAllNodes() ));
+            assertEquals(0, count( db.getAllRelationships() ));
+            assertEquals(0, count( db.getAllRelationshipTypes() ));
+            assertEquals(0, count( db.getAllLabels() ));
+            assertEquals(0, count( db.getAllPropertyKeys() ));
         }
 
         db.shutdown();

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceFacadeMethods.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceFacadeMethods.java
@@ -125,13 +125,33 @@ public class GraphDatabaseServiceFacadeMethods
                 }
             };
 
-    static final FacadeMethod<GraphDatabaseService> GET_RELATIONSHIP_TYPES =
-            new FacadeMethod<GraphDatabaseService>( "Iterable<RelationshipType> getRelationshipTypes()" )
+    static final FacadeMethod<GraphDatabaseService> GET_ALL_RELATIONSHIP_TYPES =
+            new FacadeMethod<GraphDatabaseService>( "Iterable<RelationshipType> getAllRelationshipTypes()" )
     {
         @Override
         public void call( GraphDatabaseService graphDatabaseService )
         {
-            graphDatabaseService.getRelationshipTypes();
+            graphDatabaseService.getAllRelationshipTypes();
+        }
+    };
+
+    static final FacadeMethod<GraphDatabaseService> GET_ALL_LABELS =
+            new FacadeMethod<GraphDatabaseService>( "Iterable<Label> getAllLabels()" )
+    {
+        @Override
+        public void call( GraphDatabaseService graphDatabaseService )
+        {
+            graphDatabaseService.getAllLabels();
+        }
+    };
+
+    static final FacadeMethod<GraphDatabaseService> GET_ALL_PROPERTY_KEYS =
+            new FacadeMethod<GraphDatabaseService>( "Iterable<String> getAllPropertyKeys()" )
+    {
+        @Override
+        public void call( GraphDatabaseService graphDatabaseService )
+        {
+            graphDatabaseService.getAllPropertyKeys();
         }
     };
 
@@ -155,7 +175,9 @@ public class GraphDatabaseServiceFacadeMethods
             FIND_NODES_BY_LABEL_AND_PROPERTY,
             FIND_NODES_BY_LABEL_AND_PROPERTY_DEPRECATED,
             FIND_NODES_BY_LABEL,
-            GET_RELATIONSHIP_TYPES,
+            GET_ALL_RELATIONSHIP_TYPES,
+            GET_ALL_LABELS,
+            GET_ALL_PROPERTY_KEYS,
             SCHEMA
             // TODO: INDEX
         ) );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -56,7 +56,6 @@ import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactoryState;
 import org.neo4j.test.impl.EphemeralIdGenerator;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
@@ -418,14 +417,13 @@ public class LabelsAcceptanceTest
     {
         // Given
         GraphDatabaseService db = dbRule.getGraphDatabaseService();
-        GlobalGraphOperations globalOps = GlobalGraphOperations.at( db );
         createNode( db, Labels.MY_LABEL, Labels.MY_OTHER_LABEL );
         List<Label> labels = null;
 
         // When
         try (Transaction tx = db.beginTx())
         {
-            labels = toList( globalOps.getAllLabels() );
+            labels = toList( db.getAllLabels() );
         }
 
         // Then
@@ -457,7 +455,7 @@ public class LabelsAcceptanceTest
         // WHEN
         try ( Transaction tx = db.beginTx() )
         {
-            for ( final Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( final Node node : db.getAllNodes() )
             {
                 node.removeLabel( label ); // remove Label ...
                 node.delete(); // ... and afterwards the node
@@ -468,7 +466,7 @@ public class LabelsAcceptanceTest
         // THEN
         try (Transaction transaction = db.beginTx())
         {
-            assertEquals( 0, count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+            assertEquals( 0, count( db.getAllNodes() ) );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/Neo4jConstraintsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/Neo4jConstraintsTest.java
@@ -27,7 +27,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,7 +47,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
         // long numNodesPre = getNodeManager().getNumberOfIdsInUse( Node.class
         // );
         // empty the DB instance
-        for ( Node node : GlobalGraphOperations.at( getGraphDb() ).getAllNodes() )
+        for ( Node node : getGraphDb().getAllNodes() )
         {
             for ( Relationship rel : node.getRelationships() )
             {
@@ -59,7 +58,7 @@ public class Neo4jConstraintsTest extends AbstractNeo4jTestCase
         tx.success();
         tx.close();
         tx = getGraphDb().beginTx();
-        assertFalse( GlobalGraphOperations.at( getGraphDb() ).getAllNodes().iterator().hasNext() );
+        assertFalse( getGraphDb().getAllNodes().iterator().hasNext() );
         // TODO: this should be valid, fails right now!
         // assertEquals( 0, numNodesPost );
         tx.success();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
@@ -34,7 +34,6 @@ import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.PlaceboTransaction;
 import org.neo4j.kernel.PropertyTracker;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -128,7 +127,7 @@ public class NodeManagerTest
 
         // WHEN iterator is started
         Transaction transaction = db.beginTx();
-        Iterator<Node> allNodes = GlobalGraphOperations.at( db ).getAllNodes().iterator();
+        Iterator<Node> allNodes = db.getAllNodes().iterator();
         allNodes.next();
 
         // and WHEN another node is then added
@@ -165,7 +164,7 @@ public class NodeManagerTest
 
         // WHEN
         tx = db.beginTx();
-        Iterator<Relationship> allRelationships = GlobalGraphOperations.at( db ).getAllRelationships().iterator();
+        Iterator<Relationship> allRelationships = db.getAllRelationships().iterator();
 
         Thread thread = new Thread( new Runnable()
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
@@ -51,7 +51,6 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -172,7 +171,7 @@ public class TestCrashWithRebuildSlow
             // Verify that the data we didn't delete is still around
             int nameCount = 0;
             int relCount = 0;
-            for ( Node node : GlobalGraphOperations.at( newDb ).getAllNodes() )
+            for ( Node node : newDb.getAllNodes() )
             {
                 nameCount++;
                 assertThat( node, inTx( newDb, hasProperty( "name" ), true ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4j.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4j.java
@@ -36,7 +36,6 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -190,13 +189,13 @@ public class TestNeo4j extends AbstractNeo4jTestCase
         long highId = getIdGenerator( IdType.NODE ).getHighestPossibleIdInUse();
         if ( highId >= 0 && highId < 10000 )
         {
-            int count = IteratorUtil.count( GlobalGraphOperations.at( getGraphDb() ).getAllNodes() );
+            int count = IteratorUtil.count( getGraphDb().getAllNodes() );
             boolean found = false;
             Node newNode = getGraphDb().createNode();
             newTransaction();
             int oldCount = count;
             count = 0;
-            for ( Node node : GlobalGraphOperations.at( getGraphDb() ).getAllNodes() )
+            for ( Node node : getGraphDb().getAllNodes() )
             {
                 count++;
                 if ( node.equals( newNode ) )
@@ -208,14 +207,14 @@ public class TestNeo4j extends AbstractNeo4jTestCase
             assertEquals( count, oldCount + 1 );
 
             // Tests a bug in the "all nodes" iterator
-            Iterator<Node> allNodesIterator = GlobalGraphOperations.at( getGraphDb() ).getAllNodes().iterator();
+            Iterator<Node> allNodesIterator = getGraphDb().getAllNodes().iterator();
             assertNotNull( allNodesIterator.next() );
 
             newNode.delete();
             newTransaction();
             found = false;
             count = 0;
-            for ( Node node : GlobalGraphOperations.at( getGraphDb() ).getAllNodes() )
+            for ( Node node : getGraphDb().getAllNodes() )
             {
                 count++;
                 if ( node.equals( newNode ) )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
@@ -47,7 +47,6 @@ import static org.neo4j.graphdb.RelationshipType.withName;
 import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 import static org.neo4j.kernel.impl.MyRelTypes.TEST;
-import static org.neo4j.tooling.GlobalGraphOperations.at;
 
 public class TestRelationship extends AbstractNeo4jTestCase
 {
@@ -889,7 +888,7 @@ public class TestRelationship extends AbstractNeo4jTestCase
     @Test
     public void getAllRelationships() throws Exception
     {
-        Set<Relationship> existingRelationships = addToCollection( at( getGraphDb() ).getAllRelationships(), new HashSet<Relationship>() );
+        Set<Relationship> existingRelationships = addToCollection( getGraphDb().getAllRelationships(), new HashSet<>() );
 
         Set<Relationship> createdRelationships = new HashSet<>();
         Node node = getGraphDb().createNode();
@@ -904,7 +903,7 @@ public class TestRelationship extends AbstractNeo4jTestCase
         allRelationships.addAll( createdRelationships );
 
         int count = 0;
-        for ( Relationship rel : at( getGraphDb() ).getAllRelationships() )
+        for ( Relationship rel : getGraphDb().getAllRelationships() )
         {
             assertTrue( "Unexpected rel " + rel + ", expected one of " + allRelationships, allRelationships.contains( rel ) );
             count++;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -51,7 +51,6 @@ import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.ImpermanentGraphDatabase;
 import org.neo4j.test.PageCacheRule;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
@@ -154,7 +153,7 @@ public class IdGeneratorRebuildFailureEmulationTest
         try ( Transaction tx = graphdb.beginTx() )
         {
             int nodecount = 0;
-            for ( Node node : GlobalGraphOperations.at( graphdb ).getAllNodes() )
+            for ( Node node : graphdb.getAllNodes() )
             {
                 int propcount = readProperties( node );
                 int relcount = 0;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
@@ -48,7 +48,6 @@ import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -676,7 +675,7 @@ public class IdGeneratorTest
 
         // Verify by loading everything from scratch
         tx = db.beginTx();
-        for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+        for ( Node node : db.getAllNodes() )
         {
             lastOrNull( node.getRelationships() );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
@@ -38,9 +38,10 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.test.GraphDefinition;
 import org.neo4j.test.GraphDescription;
-import org.neo4j.tooling.GlobalGraphOperations;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public abstract class TraversalTestBase extends AbstractNeo4jTestCase
 {
@@ -84,7 +85,7 @@ public abstract class TraversalTestBase extends AbstractNeo4jTestCase
 
     protected Node getNodeWithName( String name )
     {
-        for ( Node node : GlobalGraphOperations.at( getGraphDb() ).getAllNodes() )
+        for ( Node node : getGraphDb().getAllNodes() )
         {
             String nodeName = (String) node.getProperty( "name", null );
             if ( nodeName != null && nodeName.equals( name ) )

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
@@ -29,7 +29,6 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -98,7 +97,7 @@ public class TestImpermanentGraphDatabase
     private int nodeCount()
     {
         Transaction transaction = db.beginTx();
-        int count = IteratorUtil.count( GlobalGraphOperations.at( db ).getAllNodes() );
+        int count = IteratorUtil.count( db.getAllNodes() );
         transaction.close();
         return count;
     }

--- a/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DatabaseRule.java
@@ -401,9 +401,27 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
     }
 
     @Override
-    public Iterable<Node> getAllNodes()
+    public ResourceIterable<Node> getAllNodes()
     {
         return database.getAllNodes();
+    }
+
+    @Override
+    public ResourceIterable<Relationship> getAllRelationships()
+    {
+        return database.getAllRelationships();
+    }
+
+    @Override
+    public ResourceIterable<Label> getAllLabels()
+    {
+        return database.getAllLabels();
+    }
+
+    @Override
+    public ResourceIterable<String> getAllPropertyKeys()
+    {
+        return database.getAllPropertyKeys();
     }
 
     @Override
@@ -431,9 +449,9 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
     }
 
     @Override
-    public Iterable<RelationshipType> getRelationshipTypes()
+    public ResourceIterable<RelationshipType> getAllRelationshipTypes()
     {
-        return database.getRelationshipTypes();
+        return database.getAllRelationshipTypes();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
@@ -39,7 +39,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public class DbRepresentation implements Serializable
 {
@@ -57,7 +56,7 @@ public class DbRepresentation implements Serializable
         try ( Transaction ignore = db.beginTx() )
         {
             DbRepresentation result = new DbRepresentation();
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 NodeRep nodeRep = new NodeRep( db, node, includeIndexes );
                 result.nodes.put( node.getId(), nodeRep );

--- a/community/kernel/src/test/java/org/neo4j/test/EmbeddedDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/EmbeddedDatabaseRule.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.test;
 
-import org.junit.rules.TemporaryFolder;
-
 import java.io.File;
 import java.io.IOException;
+
+import org.junit.rules.TemporaryFolder;
 
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;

--- a/community/kernel/src/test/java/org/neo4j/test/GraphDatabaseServiceCleaner.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphDatabaseServiceCleaner.java
@@ -25,7 +25,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public class GraphDatabaseServiceCleaner
 {
@@ -52,12 +51,12 @@ public class GraphDatabaseServiceCleaner
 
         try ( Transaction tx = db.beginTx() )
         {
-            for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 relationship.delete();
             }
 
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 node.delete();
             }

--- a/community/kernel/src/test/java/org/neo4j/test/GraphDescription.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphDescription.java
@@ -39,7 +39,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.AutoIndexer;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.copyOfRange;
@@ -307,7 +306,7 @@ public class GraphDescription implements GraphDefinition
         GraphDatabaseService db = nodes.values().iterator().next().getGraphDatabase();
         try ( Transaction tx = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 for ( Relationship rel : node.getRelationships() )
                     rel.delete();

--- a/community/kernel/src/test/java/org/neo4j/tooling/GlobalGraphOperationsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/tooling/GlobalGraphOperationsIT.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.tooling;
 
+import java.util.Collections;
+
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Collections;
 
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -56,12 +56,10 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When
         try( Transaction tx = db.beginTx() )
         {
-            assertThat( toList( gg.getAllPropertyKeys() ), equalTo( asList( "myProperty" ) ) );
+            assertThat( toList( db.getAllPropertyKeys() ), equalTo( asList( "myProperty" ) ) );
         }
     }
 
@@ -86,12 +84,12 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When - Then
         try( Transaction ignored = db.beginTx() )
         {
-            assertThat( toSet( gg.getAllLabels() ), equalTo( toSet( asList( alive, dead ) ) ) );
+            assertThat(
+                    toSet( GlobalGraphOperations.at( db ).getAllLabels() ),
+                    equalTo( toSet( asList( alive, dead ) ) ) );
         }
     }
 
@@ -116,12 +114,10 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When - Then
         try( Transaction ignored = db.beginTx() )
         {
-            assertThat( toSet( gg.getAllLabelsInUse() ), equalTo( Collections.singleton( alive ) ) );
+            assertThat( toSet( db.getAllLabels() ), equalTo( Collections.singleton( alive ) ) );
         }
     }
 
@@ -146,8 +142,6 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When - Then
         try( Transaction ignored = db.beginTx() )
         {
@@ -158,7 +152,7 @@ public class GlobalGraphOperationsIT
                 {
                     return relationshipType.name();
                 }
-            }, gg.getAllRelationshipTypes() );
+            }, GlobalGraphOperations.at( db ).getAllRelationshipTypes() );
             assertThat( toSet( result ), equalTo( toSet( asList( alive.name(), dead.name() ) ) ) );
         }
     }
@@ -184,8 +178,6 @@ public class GlobalGraphOperationsIT
             tx.success();
         }
 
-        GlobalGraphOperations gg = GlobalGraphOperations.at( db );
-
         // When - Then
         try( Transaction ignored = db.beginTx() )
         {
@@ -196,7 +188,7 @@ public class GlobalGraphOperationsIT
                 {
                     return relationshipType.name();
                 }
-            }, gg.getAllRelationshipTypesInUse() );
+            }, db.getAllRelationshipTypes() );
             assertThat( toSet( result ) , equalTo( Collections.singleton( alive.name() ) ) );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -58,7 +58,6 @@ import org.neo4j.kernel.impl.util.AutoCreatingHashMap;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 import org.neo4j.unsafe.impl.batchimport.Configuration.Default;
@@ -261,7 +260,7 @@ public class CsvInputBatchImportIT
         try ( Transaction tx = db.beginTx() )
         {
             // Verify nodes
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 String name = (String) node.getProperty( "name" );
                 String[] labels = expectedNodeNames.remove( name );
@@ -270,7 +269,7 @@ public class CsvInputBatchImportIT
             assertEquals( 0, expectedNodeNames.size() );
 
             // Verify relationships
-            for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 String startNodeName = (String) relationship.getStartNode().getProperty( "name" );
                 Map<String, Map<String, AtomicInteger>> inner = expectedRelationships.get( startNodeName );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
@@ -31,7 +31,6 @@ import org.neo4j.graphdb.index.Index;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.proc.ProcessUtil;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -59,7 +58,7 @@ public class LuceneRecoveryIT
         {
             assertTrue( db.index().existsForNodes( "myIndex" ) );
             Index<Node> index = db.index().forNodes( "myIndex" );
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 for ( String key : node.getPropertyKeys() )
                 {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
@@ -39,7 +39,6 @@ import org.neo4j.kernel.impl.transaction.state.NeoStoresSupplier;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -118,7 +117,7 @@ public class ConstraintRecoveryIT
 
         try(Transaction tx = db.beginTx())
         {
-            assertEquals(2, Iterables.count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+            assertEquals(2, Iterables.count( db.getAllNodes() ) );
         }
 
         try(Transaction tx = db.beginTx())

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
@@ -46,6 +46,7 @@ import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.harness.extensionpackage.MyUnmanagedExtension;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.configuration.ServerSettings;
@@ -54,7 +55,6 @@ import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.server.HTTP;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -181,8 +181,7 @@ public class InProcessBuilderTest
                 // Then
                 try ( Transaction tx = server.graph().beginTx() )
                 {
-                    ResourceIterable<Node> allNodes = GlobalGraphOperations.at(
-                            server.graph() ).getAllNodes();
+                    ResourceIterable<Node> allNodes = Iterables.asResourceIterable( server.graph().getAllNodes() );
 
                     assertTrue( IteratorUtil.count( allNodes ) > 0 );
 
@@ -198,7 +197,7 @@ public class InProcessBuilderTest
             {
                 try ( Transaction tx = db.beginTx() )
                 {
-                    assertEquals( 1, IteratorUtil.count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+                    assertEquals( 1, IteratorUtil.count( db.getAllNodes() ) );
                     tx.success();
                 }
             }

--- a/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
@@ -33,7 +33,6 @@ import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.Runtime.getRuntime;
 import static java.lang.System.exit;
@@ -68,8 +67,7 @@ public class TestRecoveryMultipleDataSources
         // Then
         try ( Transaction ignored = db.beginTx() )
         {
-            assertEquals( MyRelTypes.TEST.name(),
-                    GlobalGraphOperations.at( db ).getAllRelationshipTypes().iterator().next().name() );
+            assertEquals( MyRelTypes.TEST.name(), db.getAllRelationshipTypes().iterator().next().name() );
         }
         finally
         {

--- a/community/neo4j/src/test/java/upgrade/DatabaseContentVerifier.java
+++ b/community/neo4j/src/test/java/upgrade/DatabaseContentVerifier.java
@@ -33,7 +33,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.store.PropertyType;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertArrayEquals;
@@ -64,7 +63,7 @@ public class DatabaseContentVerifier
         try ( Transaction tx = database.beginTx() )
         {
             int traversalCount = 0;
-            for ( Relationship rel : GlobalGraphOperations.at( database ).getAllRelationships() )
+            for ( Relationship rel : database.getAllRelationships() )
             {
                 traversalCount++;
                 verifyProperties( rel );
@@ -79,7 +78,7 @@ public class DatabaseContentVerifier
         int nodeCount = 0;
         try ( Transaction tx = database.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( database ).getAllNodes() )
+            for ( Node node : database.getAllNodes() )
             {
                 nodeCount++;
                 if ( node.getId() >= numberOfUnrelatedNodes )

--- a/community/server-examples/src/main/java/org/neo4j/examples/server/plugins/GetAll.java
+++ b/community/server-examples/src/main/java/org/neo4j/examples/server/plugins/GetAll.java
@@ -44,7 +44,7 @@ public class GetAll extends ServerPlugin
         ArrayList<Node> nodes = new ArrayList<>();
         try (Transaction tx = graphDb.beginTx())
         {
-            for ( Node node : GlobalGraphOperations.at( graphDb ).getAllNodes() )
+            for ( Node node : graphDb.getAllNodes() )
             {
                 nodes.add( node );
             }
@@ -60,7 +60,7 @@ public class GetAll extends ServerPlugin
         List<Relationship> rels = new ArrayList<>();
         try (Transaction tx = graphDb.beginTx())
         {
-            for ( Relationship rel : GlobalGraphOperations.at( graphDb ).getAllRelationships() )
+            for ( Relationship rel : graphDb.getAllRelationships() )
             {
                 rels.add( rel );
             }

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/CloneSubgraphPluginTest.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/CloneSubgraphPluginTest.java
@@ -44,7 +44,6 @@ import org.neo4j.server.rest.RestRequest;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.server.ExclusiveServerTestBase;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -191,8 +190,7 @@ public class CloneSubgraphPluginTest extends ExclusiveServerTestBase
         try ( Transaction tx = server.getDatabase().getGraph().beginTx() )
         {
             int count = 0;
-            for ( @SuppressWarnings("unused") Node node : GlobalGraphOperations.at( server.getDatabase().getGraph() )
-                                                                               .getAllNodes() )
+            for ( @SuppressWarnings("unused") Node node : server.getDatabase().getGraph().getAllNodes() )
             {
                 count++;
             }

--- a/community/server/src/main/java/org/neo4j/server/rest/repr/NodeRepresentation.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/repr/NodeRepresentation.java
@@ -23,7 +23,6 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import java.util.Collection;
 
@@ -163,7 +162,7 @@ public final class NodeRepresentation extends ObjectRepresentation implements Ex
         if ( writer.isInteractive() )
         {
             serializer.putList( "relationship_types", ListRepresentation.relationshipTypes(
-                    GlobalGraphOperations.at( node.getGraphDatabase() ).getAllRelationshipTypes() ) );
+                    node.getGraphDatabase().getAllRelationshipTypes() ) );
         }
         properties.done();
     }

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
@@ -246,7 +246,7 @@ public class DatabaseActions
             {
                 return ValueRepresentation.string( key );
             }
-        }, GlobalGraphOperations.at( graphDb ).getAllPropertyKeys() ) );
+        }, graphDb.getAllPropertyKeys() ) );
 
         return new ListRepresentation( RepresentationType.STRING, propKeys );
     }
@@ -1459,8 +1459,7 @@ public class DatabaseActions
 
     public ListRepresentation getAllLabels( boolean inUse )
     {
-        GlobalGraphOperations operations = GlobalGraphOperations.at( graphDb );
-        ResourceIterable<Label> labels = inUse ? operations.getAllLabelsInUse() : operations.getAllLabels();
+        ResourceIterable<Label> labels = inUse ? graphDb.getAllLabels() : GlobalGraphOperations.at( graphDb ).getAllLabels();
         Collection<ValueRepresentation> labelNames = asSet( map( new Function<Label,ValueRepresentation>()
         {
             @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseMetadataService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseMetadataService.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.rest.repr.RepresentationWriteHandler;
@@ -50,10 +51,10 @@ public class DatabaseMetadataService
     {
         try
         {
-            GlobalGraphOperations operations = GlobalGraphOperations.at( database.getGraph() );
+            GraphDatabaseService db = database.getGraph();
             Iterable<RelationshipType> relationshipTypes = inUse
-                                                           ? operations.getAllRelationshipTypesInUse()
-                                                           : operations.getAllRelationshipTypes();
+                                                           ? db.getAllRelationshipTypes()
+                                                           : GlobalGraphOperations.at( db ).getAllRelationshipTypes();
             return Response.ok()
                     .type( MediaType.APPLICATION_JSON )
                     .entity( generateJsonRepresentation( relationshipTypes ) )

--- a/community/server/src/test/java/org/dummy/web/service/DummyThirdPartyWebService.java
+++ b/community/server/src/test/java/org/dummy/web/service/DummyThirdPartyWebService.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.Response;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 @Path( "/" )
 public class DummyThirdPartyWebService
@@ -100,7 +99,7 @@ public class DummyThirdPartyWebService
     private int countNodesIn( GraphDatabaseService db )
     {
         int count = 0;
-        for ( @SuppressWarnings("unused") Node node : GlobalGraphOperations.at(db).getAllNodes() )
+        for ( @SuppressWarnings("unused") Node node : db.getAllNodes() )
         {
             count++;
         }

--- a/community/server/src/test/java/org/neo4j/server/NeoServerJAXRSDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerJAXRSDocIT.java
@@ -37,7 +37,6 @@ import org.neo4j.server.helpers.UnitOfWork;
 import org.neo4j.server.rest.JaxRsResponse;
 import org.neo4j.server.rest.RestRequest;
 import org.neo4j.test.server.ExclusiveServerTestBase;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.server.helpers.FunctionalTestHelper.CLIENT;
@@ -112,9 +111,9 @@ public class NeoServerJAXRSDocIT extends ExclusiveServerTestBase
                     graph.createNode();
                 }
 
-                for ( Node n1 : GlobalGraphOperations.at(graph).getAllNodes() )
+                for ( Node n1 : graph.getAllNodes() )
                 {
-                    for ( Node n2 : GlobalGraphOperations.at(graph).getAllNodes() )
+                    for ( Node n2 : graph.getAllNodes() )
                     {
                         if ( n1.equals( n2 ) )
                         {

--- a/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
@@ -175,7 +175,7 @@ public class ServerHelper
 
         private void deleteAllNodesAndRelationships()
         {
-            Iterable<Node> allNodes = GlobalGraphOperations.at( db ).getAllNodes();
+            Iterable<Node> allNodes = db.getAllNodes();
             for ( Node n : allNodes )
             {
                 Iterable<Relationship> relationships = n.getRelationships();

--- a/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/BatchOperationDocIT.java
@@ -764,7 +764,7 @@ public class BatchOperationDocIT extends AbstractRestFunctionalDocTestBase
         try ( Transaction tx = graphdb().beginTx() )
         {
             int count = 0;
-            for(Node node : GlobalGraphOperations.at(graphdb()).getAllNodes())
+            for(Node node : graphdb().getAllNodes())
             {
                 count++;
             }

--- a/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/streaming/StreamingBatchOperationDocIT.java
@@ -653,7 +653,7 @@ public class StreamingBatchOperationDocIT extends AbstractRestFunctionalTestBase
     {
         try ( Transaction transaction = graphdb().beginTx() )
         {
-            return IteratorUtil.count( (Iterable) GlobalGraphOperations.at(graphdb()).getAllNodes() );
+            return IteratorUtil.count( (Iterable) graphdb().getAllNodes() );
         }
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
@@ -875,7 +875,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         try ( Transaction transaction = graphdb().beginTx() )
         {
             long count = 0;
-            for ( Node node : GlobalGraphOperations.at( graphdb() ).getAllNodes() )
+            for ( Node node : graphdb().getAllNodes() )
             {
                 Set<Label> nodeLabels = IteratorUtil.asSet( node.getLabels() );
                 if ( nodeLabels.containsAll( givenLabels ) )

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionMatchers.java
@@ -29,6 +29,7 @@ import org.codehaus.jackson.JsonNode;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -36,11 +37,11 @@ import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.server.rest.repr.util.RFC1123;
 import org.neo4j.test.server.HTTP;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.IteratorUtil.iterator;
 
 /**
@@ -142,7 +143,7 @@ public class TransactionMatchers
         try ( Transaction ignore = graphdb.beginTx() )
         {
             long count = 0;
-            Iterator<Node> allNodes = GlobalGraphOperations.at( graphdb ).getAllNodes().iterator();
+            Iterator<Node> allNodes = graphdb.getAllNodes().iterator();
             while ( allNodes.hasNext() )
             {
                 allNodes.next();

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
@@ -60,7 +60,6 @@ import org.neo4j.shell.impl.AbstractApp;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.shell.util.json.JSONArray;
 import org.neo4j.shell.util.json.JSONException;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.neo4j.shell.ShellException.stackTraceAsString;
 
@@ -742,7 +741,7 @@ public abstract class TransactionProvidingApp extends AbstractApp
             boolean looseFilters ) throws ShellException
     {
         Map<String, Direction> matches = new TreeMap<String, Direction>();
-        for ( RelationshipType type : GlobalGraphOperations.at( db ).getAllRelationshipTypes() )
+        for ( RelationshipType type : db.getAllRelationshipTypes() )
         {
             Direction direction = null;
             if ( filterMap == null || filterMap.isEmpty() )

--- a/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
@@ -33,7 +33,6 @@ import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.RemoteClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.System.lineSeparator;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -263,11 +262,10 @@ public class ShellDocTest
 
         try (Transaction tx = db.beginTx())
         {
-            assertEquals( 7, Iterables.count( GlobalGraphOperations.at( db ).getAllRelationships() ) );
-            assertEquals( 7, Iterables.count( GlobalGraphOperations.at( db ).getAllNodes() ) );
+            assertEquals( 7, Iterables.count( db.getAllRelationships() ) );
+            assertEquals( 7, Iterables.count( db.getAllNodes() ) );
             boolean foundRootAndNeoRelationship = false;
-            for ( Relationship relationship : GlobalGraphOperations.at( db )
-                    .getAllRelationships() )
+            for ( Relationship relationship : db.getAllRelationships() )
             {
                 if ( relationship.getType().name().equals( "ROOT" ) )
                 {

--- a/community/shell/src/test/java/org/neo4j/shell/TransactionSoakIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TransactionSoakIT.java
@@ -29,13 +29,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.SameJvmClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.helpers.collection.Iterables.count;
@@ -96,7 +96,7 @@ public class TransactionSoakIT
 
         try ( Transaction tx = db.beginTx() )
         {
-            long relationshipCount = count( GlobalGraphOperations.at( db ).getAllRelationships() );
+            long relationshipCount = count( db.getAllRelationships() );
             int expected = committerCount( testers );
     
             assertEquals( expected, relationshipCount );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/RebuildFromLogsTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/RebuildFromLogsTest.java
@@ -44,7 +44,6 @@ import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
@@ -164,7 +163,7 @@ public class RebuildFromLogsTest
                     @Override
                     void applyTx( GraphDatabaseService graphDb )
                     {
-                        for ( Node node : GlobalGraphOperations.at( graphDb ).getAllNodes() )
+                        for ( Node node : graphDb.getAllNodes() )
                         {
                             if ( "value".equals( node.getProperty( CREATE_NODE_WITH_PROPERTY.name(), null ) ) )
                             {
@@ -186,7 +185,7 @@ public class RebuildFromLogsTest
 
         private static Node firstNode( GraphDatabaseService graphDb )
         {
-            return Iterables.first( GlobalGraphOperations.at( graphDb ).getAllNodes() );
+            return Iterables.first( graphDb.getAllNodes() );
         }
 
         private final Transaction[] dependencies;

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -36,7 +36,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.helpers.Service;
-import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
@@ -55,7 +55,6 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNotNull;
@@ -127,12 +126,10 @@ public class StoreCopyClientTest
 
         try ( Transaction tx = copy.beginTx() )
         {
-            GlobalGraphOperations globalOps = GlobalGraphOperations.at( copy );
-
-            long nodesCount = Iterables.count( globalOps.getAllNodesWithLabel( label( "BeforeCopyBegins" ) ) );
+            long nodesCount = IteratorUtil.count( copy.findNodes( label( "BeforeCopyBegins" ) ) );
             assertThat( nodesCount, equalTo( 1l ) );
 
-            assertThat( Iterables.single( globalOps.getAllNodesWithLabel( label( "BeforeCopyBegins" ) ) ).getId(),
+            assertThat( IteratorUtil.single( copy.findNodes( label( "BeforeCopyBegins" ) ) ).getId(),
                     equalTo( 0l ) );
 
             tx.success();
@@ -198,9 +195,7 @@ public class StoreCopyClientTest
 
         try ( Transaction tx = copy.beginTx() )
         {
-            GlobalGraphOperations globalOps = GlobalGraphOperations.at( copy );
-
-            long nodesCount = Iterables.count( globalOps.getAllNodesWithLabel( label( "BeforeCopyBegins" ) ) );
+            long nodesCount = IteratorUtil.count( copy.findNodes( label( "BeforeCopyBegins" ) ) );
             assertThat( nodesCount, equalTo( 0l ) );
 
             tx.success();

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ForeignStoreIdIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ForeignStoreIdIT.java
@@ -31,7 +31,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -132,7 +131,7 @@ public class ForeignStoreIdIT
     {
         try ( Transaction transaction = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
                 if ( name.equals( node.getProperty( "name", null ) ) )
                     return node.getId();
             fail( "Didn't find node '" + name + "' in " + db );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
@@ -49,7 +49,6 @@ import org.neo4j.kernel.lifecycle.LifeRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -231,7 +230,7 @@ public class TestBranchedData
     {
         try ( Transaction tx = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 if ( nodeName.equals( node.getProperty( "name", null ) ) )
                 {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
@@ -50,7 +50,6 @@ import org.neo4j.kernel.impl.coreapi.schema.RelationshipPropertyExistenceConstra
 import org.neo4j.kernel.impl.coreapi.schema.UniquenessConstraintDefinition;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterRule;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -157,7 +156,7 @@ public class ConstraintHaIT
         {
             try ( Transaction tx = db.beginTx() )
             {
-                for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+                for ( Relationship relationship : db.getAllRelationships() )
                 {
                     if ( relationship.isType( withName( type ) ) )
                     {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
@@ -33,7 +33,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.TransactionTemplate;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterRule;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 
@@ -115,7 +114,7 @@ public class BiggerThanLogTxIT
     {
         try ( Transaction tx = db.beginTx() )
         {
-            int count = count( GlobalGraphOperations.at( db ).getAllNodes() );
+            int count = count( db.getAllNodes() );
             tx.success();
             return count;
         }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HardKillIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HardKillIT.java
@@ -43,7 +43,6 @@ import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
 import org.neo4j.kernel.ha.cluster.modeswitch.HighAvailabilityModeSwitcher;
 import org.neo4j.test.ProcessStreamHandler;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
@@ -138,7 +137,7 @@ public class HardKillIT
     {
         try ( Transaction transaction = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 if ( name.equals( node.getProperty( "name", null ) ) )
                 {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
@@ -50,7 +50,6 @@ import org.neo4j.test.OtherThreadRule;
 import org.neo4j.test.RepeatRule;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.ha.ClusterRule;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -542,7 +541,7 @@ public class PropertyConstraintsStressIT
         {
             try ( Transaction tx = db.beginTx() )
             {
-                for ( Relationship relationship : GlobalGraphOperations.at( db ).getAllRelationships() )
+                for ( Relationship relationship : db.getAllRelationships() )
                 {
                     if ( relationship.getType().name().equals( type ) )
                     {

--- a/enterprise/ha/src/test/java/slavetest/TestInstanceJoin.java
+++ b/enterprise/ha/src/test/java/slavetest/TestInstanceJoin.java
@@ -36,7 +36,6 @@ import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
@@ -143,7 +142,7 @@ public class TestInstanceJoin
         try ( Transaction tx = slave.beginTx() )
         {
             int count = 0;
-            for ( Node node : GlobalGraphOperations.at( slave ).getAllNodes() )
+            for ( Node node : slave.getAllNodes() )
             {
                 if ( value.equals( node.getProperty( key, null ) ) )
                 {

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipPropertyExistenceConstraintCreationIT.java
@@ -26,7 +26,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.neo4j.graphdb.RelationshipType.withName;
 
@@ -76,7 +75,7 @@ public class RelationshipPropertyExistenceConstraintCreationIT
     @Override
     void removeOffendingDataInRunningTx( GraphDatabaseService db )
     {
-        Iterable<Relationship> relationships = GlobalGraphOperations.at( db ).getAllRelationships();
+        Iterable<Relationship> relationships = db.getAllRelationships();
         for ( Relationship relationship : relationships )
         {
             relationship.delete();

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom19IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom19IT.java
@@ -60,7 +60,6 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -227,7 +226,7 @@ public class StoreMigratorFrom19IT
     {
         try ( Transaction tx = db.beginTx() )
         {
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 if ( name.equals( node.getProperty( "name", null ) ) )
                 {

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/test/server/ha/EnterpriseServerHelper.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/test/server/ha/EnterpriseServerHelper.java
@@ -32,7 +32,6 @@ import org.neo4j.server.enterprise.EnterpriseNeoServer;
 import org.neo4j.server.enterprise.helpers.EnterpriseServerBuilder;
 import org.neo4j.server.helpers.Transactor;
 import org.neo4j.server.helpers.UnitOfWork;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 public class EnterpriseServerHelper
 {
@@ -56,7 +55,7 @@ public class EnterpriseServerHelper
 
             private void deleteAllNodesAndRelationships( final EnterpriseNeoServer server )
             {
-                Iterable<Node> allNodes = GlobalGraphOperations.at( server.getDatabase().getGraph() ).getAllNodes();
+                Iterable<Node> allNodes = server.getDatabase().getGraph().getAllNodes();
                 for ( Node n : allNodes )
                 {
                     Iterable<Relationship> relationships = n.getRelationships();

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -72,7 +72,6 @@ import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.database.Database;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -443,7 +442,7 @@ public class StoreUpgradeIntegrationTest
         try ( Transaction ignored = db.beginTx() )
         {
             HashMap<Label,Long> counts = new HashMap<>();
-            for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+            for ( Node node : db.getAllNodes() )
             {
                 for ( Label label : node.getLabels() )
                 {
@@ -491,7 +490,7 @@ public class StoreUpgradeIntegrationTest
         try ( Transaction ignored = db.beginTx() )
         {
             // count nodes
-            long nodeCount = count( GlobalGraphOperations.at( db ).getAllNodes() );
+            long nodeCount = count( db.getAllNodes() );
             assertThat( nodeCount, is( store.expectedNodeCount ) );
 
             // count indexes

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ArticleTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ArticleTest.scala
@@ -236,7 +236,7 @@ abstract class ArticleTest extends Assertions with DocumentationHelper {
         case (name, node) => name -> node.getId
       }.toMap
 
-      GlobalGraphOperations.at(db).getAllNodes.asScala.foreach((n) => {
+      db.getAllNodes.asScala.foreach((n) => {
         indexProperties(n, nodeIndex)
         n.getRelationships(Direction.OUTGOING).asScala.foreach(indexProperties(_, relIndex))
       })

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentingTestBase.scala
@@ -469,7 +469,7 @@ abstract class DocumentingTestBase extends JUnitSuite with DocumentationHelper w
 
       setupQueries.foreach(engine.execute)
 
-      GlobalGraphOperations.at(db).getAllNodes.asScala.foreach((n) => {
+      db.getAllNodes.asScala.foreach((n) => {
         indexProperties(n, nodeIndex)
         n.getRelationships(Direction.OUTGOING).asScala.foreach(indexProperties(_, relIndex))
       })

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MatchTest.scala
@@ -21,7 +21,6 @@ package org.neo4j.cypher.docgen
 
 import org.neo4j.cypher.docgen.tooling._
 import org.neo4j.graphdb.{Relationship, Path, Node}
-import org.neo4j.tooling.GlobalGraphOperations
 
 import scala.collection.JavaConverters._
 
@@ -297,7 +296,7 @@ class MatchTest extends DocumentingTest {
   private def assertAllNodesReturned = ResultAndDbAssertions((p, db) => {
     val tx = db.beginTx()
     try {
-      val allNodes: List[Node] = GlobalGraphOperations.at(db).getAllNodes.asScala.toList
+      val allNodes: List[Node] = db.getAllNodes.asScala.toList
       allNodes should equal(p.columnAs[Node]("n").toList)
     } finally tx.close()
   })


### PR DESCRIPTION
The GlobalGraphOperations class was a bad idea. This Change moves those operations back to GraphDatabaseService.
