### PR TITLE
Make Cypher use IDP when planner=cost specified

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PreParsingAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PreParsingAcceptanceTest.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.internal.compatibility.{CompatibilityPlanDescription, CompatibilityPlanDescriptionFor2_3}
+import org.neo4j.cypher.internal.compiler.v2_3._
+import org.neo4j.cypher.internal.compiler.v2_2
+import org.neo4j.cypher.{ExecutionEngineFunSuite, ExtendedExecutionResult}
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+class PreParsingAcceptanceTest extends ExecutionEngineFunSuite {
+
+  test("specifying no planner should provide IDP") {
+    val query = "PROFILE RETURN 1"
+
+    eengine.execute(query) should havePlanner(IDPPlannerName)
+  }
+
+  test("specifying cost planner should provide IDP") {
+    val query = "PROFILE CYPHER planner=cost RETURN 1"
+
+    eengine.execute(query) should havePlanner(IDPPlannerName)
+  }
+
+  test("specifying idp planner should provide IDP") {
+    val query = "PROFILE CYPHER planner=idp RETURN 1"
+
+    eengine.execute(query) should havePlanner(IDPPlannerName)
+  }
+
+  test("specifying greedy planner should provide greedy") {
+    val query = "PROFILE CYPHER planner=greedy RETURN 1"
+
+    eengine.execute(query) should havePlanner(GreedyPlannerName)
+  }
+
+  test("specifying dp planner should provide DP") {
+    val query = "PROFILE CYPHER planner=dp RETURN 1"
+
+    eengine.execute(query) should havePlanner(DPPlannerName)
+  }
+
+  test("specifying rule planner should provide RULE") {
+    val query = "PROFILE CYPHER planner=rule RETURN 1"
+
+    eengine.execute(query) should havePlanner(RulePlannerName)
+  }
+
+  test("specifying no planner in a write query should provide RULE") {
+    val query = "PROFILE CREATE ()"
+
+    eengine.execute(query) should havePlanner(RulePlannerName)
+  }
+
+  test("specifying cost planner in a write query should fallback to RULE") {
+    val query = "PROFILE CYPHER planner=cost CREATE ()"
+
+    eengine.execute(query) should havePlanner(RulePlannerName)
+  }
+
+  test("specifying cost planner should provide IDP using old syntax") {
+    val query = "PROFILE CYPHER planner cost RETURN 1"
+
+    eengine.execute(query) should havePlanner(IDPPlannerName)
+  }
+
+  test("specifying idp planner should provide IDP using old syntax") {
+    val query = "PROFILE CYPHER planner idp RETURN 1"
+
+    eengine.execute(query) should havePlanner(IDPPlannerName)
+  }
+
+  test("specifying greedy planner should provide greedy using old syntax") {
+    val query = "PROFILE CYPHER planner greedy RETURN 1"
+
+    eengine.execute(query) should havePlanner(GreedyPlannerName)
+  }
+
+  test("specifying dp planner should provide DP using old syntax") {
+    val query = "PROFILE CYPHER planner dp RETURN 1"
+
+    eengine.execute(query) should havePlanner(DPPlannerName)
+  }
+
+  test("specifying rule planner should provide RULE using old syntax") {
+    val query = "PROFILE CYPHER planner rule RETURN 1"
+
+    eengine.execute(query) should havePlanner(RulePlannerName)
+  }
+
+  test("specifying cost planner in a write query should fallback to RULE using old syntax") {
+    val query = "PROFILE CYPHER planner cost CREATE ()"
+
+    eengine.execute(query) should havePlanner(RulePlannerName)
+  }
+
+  test("specifying idp planner in a write query should fallback to RULE using old syntax") {
+    val query = "PROFILE CYPHER planner idp CREATE ()"
+
+    eengine.execute(query) should havePlanner(RulePlannerName)
+  }
+
+  test("specifying greedy planner in a write query should fallback to RULE using old syntax") {
+    val query = "PROFILE CYPHER planner greedy CREATE ()"
+
+    eengine.execute(query) should havePlanner(RulePlannerName)
+  }
+
+  test("specifying dp planner in a write query should fallback to RULE using old syntax") {
+    val query = "PROFILE CYPHER planner dp CREATE ()"
+
+    eengine.execute(query) should havePlanner(RulePlannerName)
+  }
+
+  test("specifying no planner in 2.2 compatibility should provide COST") {
+    val query = "PROFILE CYPHER 2.2 RETURN 1"
+
+    eengine.execute(query) should havePlanner(v2_2.CostPlannerName)
+  }
+
+  test("specifying cost planner in 2.2 compatibility should provide COST") {
+    val query = "PROFILE CYPHER 2.2 planner=cost RETURN 1"
+
+    eengine.execute(query) should havePlanner(v2_2.CostPlannerName)
+  }
+
+  test("specifying idp planner in 2.2 compatibility should provide IDP") {
+    val query = "PROFILE CYPHER 2.2 planner=idp RETURN 1"
+
+    eengine.execute(query) should havePlanner(v2_2.IDPPlannerName)
+  }
+
+  test("specifying dp planner in 2.2 compatibility should provide DP") {
+    val query = "PROFILE CYPHER 2.2 planner=dp RETURN 1"
+
+    eengine.execute(query) should havePlanner(v2_2.DPPlannerName)
+  }
+
+  test("specifying rule planner in 2.2 compatibility should provide RULE") {
+    val query = "PROFILE CYPHER 2.2 planner=rule RETURN 1"
+
+    eengine.execute(query) should havePlanner(v2_2.RulePlannerName)
+  }
+
+  test("specifying no planner in 2.2 compatibility for a write query should provide RULE") {
+    val query = "PROFILE CYPHER 2.2 CREATE ()"
+
+    eengine.execute(query) should havePlanner(v2_2.RulePlannerName)
+  }
+
+  private def havePlanner(expected: PlannerName): Matcher[ExtendedExecutionResult] = new Matcher[ExtendedExecutionResult] {
+    override def apply(result: ExtendedExecutionResult): MatchResult = {
+      // exhaust the iterator so we can collect the plan description
+      result.length
+      result.executionPlanDescription() match {
+        case CompatibilityPlanDescriptionFor2_3(_, _, actual, _) =>
+          MatchResult(
+            matches = actual == expected,
+            rawFailureMessage = s"PlannerName should be $expected, but was $actual",
+            rawNegatedFailureMessage = s"PlannerName should not be $actual"
+          )
+        case planDesc =>
+          MatchResult(
+            matches = false,
+            rawFailureMessage = s"Plan description should be of type CompatibilityPlanDescriptionFor2_3, but was ${planDesc.getClass.getSimpleName}",
+            rawNegatedFailureMessage = s"Plan description should be of type CompatibilityPlanDescriptionFor2_3, but was ${planDesc.getClass.getSimpleName}"
+          )
+      }
+    }
+  }
+
+  private def havePlanner(expected: v2_2.PlannerName): Matcher[ExtendedExecutionResult] = new Matcher[ExtendedExecutionResult] {
+    override def apply(result: ExtendedExecutionResult): MatchResult = {
+      // exhaust the iterator so we can collect the plan description
+      result.length
+      result.executionPlanDescription() match {
+        case CompatibilityPlanDescription(_, _, actual) =>
+          MatchResult(
+            matches = actual == expected,
+            rawFailureMessage = s"PlannerName should be $expected, but was $actual",
+            rawNegatedFailureMessage = s"PlannerName should not be $actual"
+          )
+        case planDesc =>
+          MatchResult(
+            matches = false,
+            rawFailureMessage = s"Plan description should be of type CompatibilityPlanDescription, but was ${planDesc.getClass.getSimpleName}",
+            rawNegatedFailureMessage = s"Plan description should be of type CompatibilityPlanDescription, but was ${planDesc.getClass.getSimpleName}"
+          )
+      }
+    }
+  }
+
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherPreParser.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherPreParser.scala
@@ -45,7 +45,7 @@ case object CypherPreParser extends Parser with Base {
   }
 
   def PlannerOption: Rule1[PreParserOption] = rule("planner option") (
-      option("planner", "cost") ~ push(GreedyPlannerOption)
+      option("planner", "cost") ~ push(CostPlannerOption)
     | option("planner", "greedy") ~ push(GreedyPlannerOption)
     | option("planner", "rule") ~ push(RulePlannerOption)
     | option("planner", "idp") ~ push(IDPPlannerOption)
@@ -59,7 +59,7 @@ case object CypherPreParser extends Parser with Base {
 
   @deprecated
   def PlannerDeprecated = rule("PLANNER") (
-      keyword("PLANNER COST") ~ push(GreedyPlannerOption)
+      keyword("PLANNER COST") ~ push(CostPlannerOption)
     | keyword("PLANNER GREEDY") ~ push(GreedyPlannerOption)
     | keyword("PLANNER IDP") ~ push(IDPPlannerOption)
     | keyword("PLANNER DP") ~ push(DPPlannerOption)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreParserOption.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PreParserOption.scala
@@ -27,6 +27,7 @@ sealed abstract class RuntimePreParserOption(val name: String) extends PreParser
 case class VersionOption(version: String) extends PreParserOption
 case object ProfileOption extends ExecutionModePreParserOption("profile")
 case object ExplainOption extends ExecutionModePreParserOption("explain")
+case object CostPlannerOption extends PlannerPreParserOption("cost")
 case object GreedyPlannerOption extends PlannerPreParserOption("greedy")
 case object RulePlannerOption extends PlannerPreParserOption("rule")
 case object IDPPlannerOption extends PlannerPreParserOption("idp")

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherPreParserTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherPreParserTest.scala
@@ -31,21 +31,21 @@ class CypherPreParserTest extends CypherFunSuite with TableDrivenPropertyChecks 
     ("CYPHER 1.9 MATCH", PreParsedStatement("MATCH", Seq(ConfigurationOptions(Some(VersionOption("1.9")), Seq.empty)), (1, 12, 11))),
     ("CYPHER 2.0 THAT", PreParsedStatement("THAT", Seq(ConfigurationOptions(Some(VersionOption("2.0")), Seq.empty)), (1, 12, 11))),
     ("CYPHER 2.1 YO", PreParsedStatement("YO", Seq(ConfigurationOptions(Some(VersionOption("2.1")), Seq.empty)), (1, 12, 11))),
-    ("CYPHER 2.2 HO", PreParsedStatement("HO", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty)), (1, 12, 11))),
+    ("CYPHER 2.2 PRO", PreParsedStatement("PRO", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty)), (1, 12, 11))),
     ("PROFILE THINGS", PreParsedStatement("THINGS", Seq(ProfileOption), (1, 9, 8))),
     ("EXPLAIN THIS", PreParsedStatement("THIS", Seq(ExplainOption), (1, 9, 8))),
-    ("CYPHER 2.2 PLANNER COST PROFILE PATTERN", PreParsedStatement("PATTERN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty), GreedyPlannerOption, ProfileOption), (1, 33, 32))),
+    ("CYPHER 2.2 PLANNER COST PROFILE PATTERN", PreParsedStatement("PATTERN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty), CostPlannerOption, ProfileOption), (1, 33, 32))),
     ("EXPLAIN CYPHER 2.1 YALL", PreParsedStatement("YALL", Seq(ExplainOption, ConfigurationOptions(Some(VersionOption("2.1")), Seq.empty)), (1, 20, 19))),
-    ("CYPHER 2.2 PLANNER COST RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty), GreedyPlannerOption), (1, 25, 24))),
-    ("PLANNER COST RETURN", PreParsedStatement("RETURN", Seq(GreedyPlannerOption), (1, 14, 13))),
+    ("CYPHER 2.2 PLANNER COST RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty), CostPlannerOption), (1, 25, 24))),
+    ("PLANNER COST RETURN", PreParsedStatement("RETURN", Seq(CostPlannerOption), (1, 14, 13))),
     ("CYPHER 2.2 PLANNER RULE RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty), RulePlannerOption), (1, 25, 24))),
     ("PLANNER RULE RETURN", PreParsedStatement("RETURN", Seq(RulePlannerOption), (1, 14, 13))),
     ("CYPHER 2.2 PLANNER IDP RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty), IDPPlannerOption), (1, 24, 23))),
     ("CYPHER 2.2 PLANNER DP RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq.empty), DPPlannerOption), (1, 23, 22))),
     ("PLANNER IDP RETURN", PreParsedStatement("RETURN", Seq(IDPPlannerOption), (1, 13, 12))),
     ("PLANNER DP RETURN", PreParsedStatement("RETURN", Seq(DPPlannerOption), (1, 12, 11))),
-    ("CYPHER planner=cost RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(None, Seq(GreedyPlannerOption))), (1, 21, 20))),
-    ("CYPHER 2.2 planner=cost RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq(GreedyPlannerOption))), (1, 25, 24))),
+    ("CYPHER planner=cost RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(None, Seq(CostPlannerOption))), (1, 21, 20))),
+    ("CYPHER 2.2 planner=cost RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq(CostPlannerOption))), (1, 25, 24))),
     ("CYPHER 2.2 planner = idp RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(Some(VersionOption("2.2")), Seq(IDPPlannerOption))), (1, 26, 25))),
     ("CYPHER planner =dp RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(None, Seq(
       DPPlannerOption))), (1, 20, 19))),
@@ -54,9 +54,9 @@ class CypherPreParserTest extends CypherFunSuite with TableDrivenPropertyChecks 
     ("CYPHER runtime=compiled RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(None, Seq(CompiledRuntimeOption))), (1, 25, 24))),
 
     ("CYPHER 2.3 planner=cost runtime=interpreted RETURN", PreParsedStatement("RETURN", Seq(
-      ConfigurationOptions(Some(VersionOption("2.3")), Seq(GreedyPlannerOption, InterpretedRuntimeOption))), (1, 45, 44))),
+      ConfigurationOptions(Some(VersionOption("2.3")), Seq(CostPlannerOption, InterpretedRuntimeOption))), (1, 45, 44))),
     ("CYPHER 2.3 planner=cost runtime=compiled RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(
-      Some(VersionOption("2.3")), Seq(GreedyPlannerOption, CompiledRuntimeOption))), (1, 42, 41))),
+      Some(VersionOption("2.3")), Seq(CostPlannerOption, CompiledRuntimeOption))), (1, 42, 41))),
     ("CYPHER 2.3 planner=dp runtime=interpreted RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(
       Some(VersionOption("2.3")), Seq(DPPlannerOption, InterpretedRuntimeOption))), (1, 43, 42))),
     ("CYPHER 2.3 planner=dp runtime=compiled RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(


### PR DESCRIPTION
The default planner is cost. In 2.2 that means the now-called greedy
planner. In 2.3 that means the IDP planner. Specifying no planner gives
the correct default, but specifying planner=cost gave the greedy planner
in 2.3 by mistake.
