### PR TITLE
Greedy planner should handle selections in tail

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.PathImpl
 import org.neo4j.cypher._
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.PathImpl
 import org.neo4j.graphdb._
 
 import scala.collection.JavaConverters._
@@ -73,7 +73,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     val query = "MATCH (:Root {name:'x'})-->(i:Child) WHERE i.id > 'te' RETURN i"
 
-    a [IncomparableValuesException] should be thrownBy executeWithAllPlanners(query)
+    an [IncomparableValuesException] should be thrownBy executeWithAllPlanners(query)
   }
 
   test("exceptions should be thrown if rows are kept through OR'd predicates") {
@@ -83,7 +83,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     val query = "MATCH (:Root {name:'x'})-->(i) WHERE NOT has(i.id) OR i.id > 'te' RETURN i"
 
-    a [IncomparableValuesException] should be thrownBy executeWithAllPlanners(query)
+    an [IncomparableValuesException] should be thrownBy executeWithAllPlanners(query)
   }
 
   test("combines aggregation and named path") {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanEventHorizon.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanEventHorizon.scala
@@ -38,7 +38,7 @@ case class PlanEventHorizon(config: QueryPlannerConfiguration = QueryPlannerConf
         val aggregationPlan = plan match {
           case n: NodeCountFromCountStore => projection(selectedPlan, aggregatingProjection.projections)
           case r: RelationshipCountFromCountStore => projection(selectedPlan, aggregatingProjection.projections)
-          case _ => aggregation(plan, aggregatingProjection)
+          case _ => aggregation(selectedPlan, aggregatingProjection)
         }
         sortSkipAndLimit(aggregationPlan, query)
 


### PR DESCRIPTION
In `PlanEventHorizon` the resulting plan from `applySelections`
was ignored which caused the greedy planner to fail when having
predicates after `WITH`.
