### PR TITLE
dbms.cypher.statistics_divergence_threshold=1.0 means never replan

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/InstrumentedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/InstrumentedGraphStatistics.scala
@@ -56,7 +56,7 @@ case class GraphStatisticsSnapshot(map: Map[StatisticsKey, Double] = Map.empty) 
     val v2 = snapshot.map.values
     //find the maximum relative difference (|e1 - e2| / max(e1, e2))
     val relativeDiff = v1.zip(v2).map(e => Math.abs(e._1 - e._2) / Math.max(e._1, e._2)).max
-    relativeDiff >= minThreshold
+    relativeDiff > minThreshold
   }
 }
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/PlanFingerprintReferenceTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/PlanFingerprintReferenceTest.scala
@@ -30,7 +30,7 @@ import org.neo4j.helpers.FakeClock
 class PlanFingerprintReferenceTest extends CypherFunSuite {
 
   test("should be stale if all properties are out of date") {
-    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 4.0))
     val ttl = 1000l
     val threshold = 0.0
     val clock = new FakeClock
@@ -42,7 +42,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
     val stale = PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(->(42), stats)
 
-    stale should be(true)
+    stale shouldBe true
   }
 
   test("should not be stale if stats are not diverged over the threshold") {
@@ -58,7 +58,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
     val stale = PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(->(42), stats)
 
-    stale should be(false)
+    stale shouldBe false
   }
 
   test("should not be stale if txId didn't change") {
@@ -74,7 +74,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
     val stale = PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(->(17), stats)
 
-    stale should be(false)
+    stale shouldBe false
   }
 
   test("should not be stale if life time has not expired") {
@@ -90,7 +90,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
     val stale = PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(->(42), stats)
 
-    stale should be(false)
+    stale shouldBe false
   }
 
   test("should update the timestamp if the life time is expired but transaction has not changed") {
@@ -105,10 +105,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
     val reference = PlanFingerprintReference(clock, ttl, threshold, fingerprint)
 
     clock.forward(2, SECONDS)
-    reference.isStale(->(17), stats) should be(false)
+    reference.isStale(->(17), stats) shouldBe false
 
     clock.forward(500, MILLISECONDS)
-    reference.isStale(->(23), stats) should be(false)
+    reference.isStale(->(23), stats) shouldBe false
   }
 
   test("should update the timestamp and the txId if the life time is expired the txId is old but stats has not changed over the threshold") {
@@ -123,10 +123,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
     val reference = PlanFingerprintReference(clock, ttl, threshold, fingerprint)
 
     clock.forward(2, SECONDS)
-    reference.isStale(->(23), stats) should be(false)
+    reference.isStale(->(23), stats) shouldBe false
 
     clock.forward(2, SECONDS)
-    reference.isStale(->(23), stats) should be(false)
+    reference.isStale(->(23), stats) shouldBe false
   }
 
   implicit def liftToOption[T](item: T): Option[T] = Option(item)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/GraphStatisticsSnapshotTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/spi/GraphStatisticsSnapshotTest.scala
@@ -26,21 +26,26 @@ import org.neo4j.cypher.internal.compiler.v2_2.{LabelId, PropertyKeyId, RelTypeI
 import scala.language.reflectiveCalls
 
 class GraphStatisticsSnapshotTest extends CypherFunSuite {
-  val graphStatistics = new GraphStatistics {
-    var FACTOR = 1
+  def graphStatistics() = new GraphStatistics {
+    private var _factor = 1L
+
     def nodesWithLabelCardinality(labelId: Option[LabelId]): Cardinality =
-      Cardinality(labelId.fold(500)(_.id * 10) * FACTOR)
+      Cardinality(labelId.fold(500)(_.id * 10) * _factor)
 
     def cardinalityByLabelsAndRelationshipType(fromLabel: Option[LabelId], relTypeId: Option[RelTypeId], toLabel: Option[LabelId]): Cardinality =
-      Cardinality(relTypeId.fold(5000)(_.id * 10) * FACTOR)
+      Cardinality(relTypeId.fold(5000)(_.id * 10) * _factor)
 
     def indexSelectivity(label: LabelId, property: PropertyKeyId): Option[Selectivity] =
-      Selectivity.of(1.0 / ((property.id + 1) * FACTOR))
+      Selectivity.of(1.0 / ((property.id + 1) * _factor))
+
+    def factor(factor: Long): Unit = {
+     _factor = factor
+    }
   }
 
   test("records queries and its observed values") {
     val snapshot = MutableGraphStatisticsSnapshot()
-    val instrumentedStatistics = InstrumentedGraphStatistics(graphStatistics, snapshot)
+    val instrumentedStatistics = InstrumentedGraphStatistics(graphStatistics(), snapshot)
     instrumentedStatistics.nodesWithLabelCardinality(None)
     instrumentedStatistics.indexSelectivity(LabelId(0), PropertyKeyId(3))
     instrumentedStatistics.nodesWithLabelCardinality(Some(LabelId(4)))
@@ -57,7 +62,7 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
 
   test("a snapshot shouldn't diverge from itself") {
     val snapshot = MutableGraphStatisticsSnapshot()
-    val instrumentedStatistics = InstrumentedGraphStatistics(graphStatistics, snapshot)
+    val instrumentedStatistics = InstrumentedGraphStatistics(graphStatistics(), snapshot)
     instrumentedStatistics.nodesWithLabelCardinality(None)
     instrumentedStatistics.indexSelectivity(LabelId(0), PropertyKeyId(3))
     instrumentedStatistics.nodesWithLabelCardinality(Some(LabelId(4)))
@@ -72,17 +77,18 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
 
   test("a snapshot should pick up divergences") {
     val snapshot1 = MutableGraphStatisticsSnapshot()
-    val instrumentedStatistics1 = InstrumentedGraphStatistics(graphStatistics, snapshot1)
+    val statistics = graphStatistics()
+    val instrumentedStatistics1 = InstrumentedGraphStatistics(statistics, snapshot1)
     instrumentedStatistics1.nodesWithLabelCardinality(None)
     instrumentedStatistics1.indexSelectivity(LabelId(0), PropertyKeyId(3))
     instrumentedStatistics1.nodesWithLabelCardinality(Some(LabelId(4)))
 
     val snapshot2 = MutableGraphStatisticsSnapshot()
-    val instrumentedStatistics2 = InstrumentedGraphStatistics(graphStatistics, snapshot2)
+    val instrumentedStatistics2 = InstrumentedGraphStatistics(statistics, snapshot2)
     instrumentedStatistics2.nodesWithLabelCardinality(None)
     instrumentedStatistics2.nodesWithLabelCardinality(Some(LabelId(4)))
 
-    graphStatistics.FACTOR = 2
+    statistics.factor(2)
     instrumentedStatistics2.indexSelectivity(LabelId(0), PropertyKeyId(3))
 
     val frozen1 = snapshot1.freeze
@@ -92,5 +98,27 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
 
     frozen1.diverges(frozen2, smallNumber) should equal(true)
     frozen1.diverges(frozen2, bigNumber) should equal(false)
+  }
+
+  test("if threshold is 1.0 nothing diverges") {
+    val snapshot1 = MutableGraphStatisticsSnapshot()
+    val statistics = graphStatistics()
+    val instrumentedStatistics1 = InstrumentedGraphStatistics(statistics, snapshot1)
+    instrumentedStatistics1.nodesWithLabelCardinality(None)
+    instrumentedStatistics1.indexSelectivity(LabelId(0), PropertyKeyId(3))
+    instrumentedStatistics1.nodesWithLabelCardinality(Some(LabelId(4)))
+
+    val snapshot2 = MutableGraphStatisticsSnapshot()
+    val instrumentedStatistics2 = InstrumentedGraphStatistics(statistics, snapshot2)
+    instrumentedStatistics2.nodesWithLabelCardinality(None)
+    instrumentedStatistics2.nodesWithLabelCardinality(Some(LabelId(4)))
+
+    statistics.factor(Long.MaxValue)
+    instrumentedStatistics2.indexSelectivity(LabelId(0), PropertyKeyId(3))
+
+    val frozen1 = snapshot1.freeze
+    val frozen2 = snapshot2.freeze
+
+    frozen1.diverges(frozen2, 1.0) should equal(false)
   }
 }

--- a/community/cypher/cypher/CHANGES.txt
+++ b/community/cypher/cypher/CHANGES.txt
@@ -1,5 +1,7 @@
 2.2.7
 -----
+o Setting dbms.cypher.statistics_divergence_threshold=1.0 disables replanning
+  due to non-schema changing updates.
 o Fixes #5631 - MERGE with multiple labels with uniqueness constraints
 o Fixed issue around aggregation and literal maps
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -1046,7 +1046,7 @@ order by a.COL1""")
     planningListener.planRequests.toSeq should equal(Seq(
       s"match (n:Person) return n"
     ))
-    (0 until 100).foreach { _ => createLabeledNode("Person") }
+    (0 until 150).foreach { _ => createLabeledNode("Person") }
     eengine.execute(s"match (n:Person) return n").toList
 
     //THEN


### PR DESCRIPTION
The comparison to `dbms.cypher.statistics_divergence_threshold=1.0` was
inclusive which meant that setting the threshold to 1.0 did not
completely disable planning.
