### PR TITLE
Fixes relationship cursor issue for dense node w/o relationships

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
@@ -84,7 +84,7 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
         this.relTypes = relTypes;
         this.end = false;
 
-        if ( isDense )
+        if ( isDense && relationshipId != Record.NO_NEXT_RELATIONSHIP.intValue() )
         {
             groupStore.forceGetRecord( relationshipId, groupRecord );
             relationshipId = nextChainStart();

--- a/community/kernel/src/test/java/org/neo4j/graphdb/DenseNodeIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/DenseNodeIT.java
@@ -19,11 +19,18 @@
  */
 package org.neo4j.graphdb;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.Iterables.single;
 
 public class DenseNodeIT
 {
@@ -198,6 +205,48 @@ public class DenseNodeIT
             assertEquals( 25, sink.getDegree( DynamicRelationshipType.withName( "Type3" ) ) );
             tx.success();
         }
+    }
+
+    @Test
+    public void shouldBeAbleToCreateRelationshipsInEmptyDenseNode() throws Exception
+    {
+        // GIVEN
+        Node node;
+        try ( Transaction tx = databaseRule.beginTx() )
+        {
+            node = databaseRule.createNode();
+            createRelationshipsBetweenNodes( node, databaseRule.createNode(), denseNodeThreshold( databaseRule ) + 1 );
+            tx.success();
+        }
+        try ( Transaction tx = databaseRule.beginTx() )
+        {
+            for ( Relationship relationship : node.getRelationships() )
+            {
+                relationship.delete();
+            }
+            tx.success();
+        }
+
+        // WHEN
+        Relationship rel;
+        try ( Transaction tx = databaseRule.beginTx() )
+        {
+            rel = node.createRelationshipTo( databaseRule.createNode(), MyRelTypes.TEST );
+            tx.success();
+        }
+
+        try ( Transaction tx = databaseRule.beginTx() )
+        {
+            // THEN
+            assertEquals( rel, single( node.getRelationships() ) );
+            tx.success();
+        }
+    }
+
+    private int denseNodeThreshold( GraphDatabaseAPI db )
+    {
+        return db.getDependencyResolver()
+                .resolveDependency( Config.class ).get( GraphDatabaseSettings.dense_node_threshold );
     }
 
     private void deleteRelationshipsFromNode( Node root, int numberOfRelationships )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import org.junit.Test;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.RelationshipGroupStore;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.graphdb.Direction.BOTH;
+import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
+import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
+
+public class StoreNodeRelationshipCursorTest
+{
+    @Test
+    public void shouldHandleDenseNodeWithNoRelationships() throws Exception
+    {
+        // This can actually happen, since we upgrade sparse node --> dense node when creating relationships,
+        // but we don't downgrade dense --> sparse when we delete relationships. So if we have a dense node
+        // which no longer has relationships, there was this assumption that we could just call getRecord
+        // on the NodeRecord#getNextRel() value. Although that value could actually be -1
+
+        // GIVEN
+        NeoStores stores = mock( NeoStores.class );
+        NodeStore nodeStore = mock( NodeStore.class );
+        when( stores.getNodeStore() ).thenReturn( nodeStore );
+        RelationshipGroupStore relationshipGroupStore = mock( RelationshipGroupStore.class );
+        when( stores.getRelationshipGroupStore() ).thenReturn( relationshipGroupStore );
+
+        @SuppressWarnings( "unchecked" )
+        StoreNodeRelationshipCursor cursor = new StoreNodeRelationshipCursor(
+                new RelationshipRecord( -1 ),
+                stores,
+                new RelationshipGroupRecord( -1, -1 ),
+                mock( StoreStatement.class ),
+                mock( Consumer.class ),
+                NO_LOCK_SERVICE );
+
+        // WHEN
+        cursor.init( true, NO_NEXT_RELATIONSHIP.intValue(), 0, BOTH );
+
+        // THEN
+        verifyNoMoreInteractions( relationshipGroupStore );
+        assertFalse( cursor.next() );
+    }
+}


### PR DESCRIPTION
Nodes can be marked as dense when getting new relationships, although
never marked as sparse even after deleted below dense node threshold.
So there can be dense nodes w/o any relationships.

These was an assumption in StoreNodeRelationshipCursor that just because a
node was dense it had to have at least one relationship, and so it went
ahead and loaded a record regardless of the first relationship id, which
could be -1. This commit fixes that.

Closes #5691
