### PR TITLE
Better error handling for percentileCont and percentileDisc

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
@@ -219,6 +219,23 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
     result.toList should equal(List(Map("n" -> node)))
   }
 
+  test("percentileDisc should work in the valid range") {
+    createNode("prop" -> 10.0)
+    createNode("prop" -> 20.0)
+    createNode("prop" -> 30.0)
 
+    executeScalarWithAllPlanners[Double]("MATCH (n) RETURN percentileDisc(n.prop, 0.0)") should equal (10.0 +- 0.1)
+    executeScalarWithAllPlanners[Double]("MATCH (n) RETURN percentileDisc(n.prop, 0.5)") should equal (20.0 +- 0.1)
+    executeScalarWithAllPlanners[Double]("MATCH (n) RETURN percentileDisc(n.prop, 1.0)") should equal (30.0 +- 0.1)
+  }
 
+  test("percentileCont should work in the valid range") {
+    createNode("prop" -> 10.0)
+    createNode("prop" -> 20.0)
+    createNode("prop" -> 30.0)
+
+    executeScalarWithAllPlanners[Double]("MATCH (n) RETURN percentileCont(n.prop, 0)") should equal (10.0 +- 0.1)
+    executeScalarWithAllPlanners[Double]("MATCH (n) RETURN percentileCont(n.prop, 0.5)") should equal (20.0 +- 0.1)
+    executeScalarWithAllPlanners[Double]("MATCH (n) RETURN percentileCont(n.prop, 1)") should equal (30.0 +- 0.1)
+  }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternGen.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/PatternGen.scala
@@ -249,7 +249,7 @@ trait PatternGen extends  PropertyChecks {
     for {
       relType <- relTypeName
       direction <- relDirection
-      properties <- Gen.listOf(property)
+      properties <- Gen.nonEmptyListOf(property)
     } yield TypedWithPropertiesRelationship(relType, direction, properties)
 
   def typedRelWithLengthGen =

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticDeleteAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticDeleteAcceptanceTest.scala
@@ -40,15 +40,16 @@ class SemanticDeleteAcceptanceTest extends ExecutionEngineFunSuite with PatternG
 
       whenever(pattern.nonEmpty) {
         val patternString = pattern.map(_.string).mkString
+        withClue(s"failing on pattern $patternString") {
+          //update
+          updateWithBothPlanners(s"CREATE $patternString")
+          //delete
+          val identifiers = findAllRelationshipNames(pattern) ++ findAllNodeNames(pattern)
+          updateWithBothPlanners(s"MATCH $patternString DELETE ${identifiers.mkString(",")} RETURN count(*)")
 
-        //update
-        updateWithBothPlanners(s"CREATE $patternString")
-        //delete
-        val identifiers = findAllRelationshipNames(pattern) ++ findAllNodeNames(pattern)
-        updateWithBothPlanners(s"MATCH $patternString DELETE ${identifiers.mkString(",")} RETURN count(*)")
-
-        //now db should be empty
-        executeWithAllPlanners("MATCH () RETURN count(*) AS c").toList should equal(List(Map("c" -> 0)))
+          //now db should be empty
+          executeWithAllPlanners("MATCH () RETURN count(*) AS c").toList should equal(List(Map("c" -> 0)))
+        }
       }
     }
   }
@@ -61,15 +62,16 @@ class SemanticDeleteAcceptanceTest extends ExecutionEngineFunSuite with PatternG
 
       whenever(pattern.nonEmpty) {
         val patternString = pattern.map(_.string).mkString
+        withClue(s"failing on pattern $patternString") {
+          //update
+          updateWithBothPlanners(s"CREATE $patternString")
+          //delete
+          val identifiers = findAllNodeNames(pattern)
+          updateWithBothPlanners(s"MATCH $patternString DETACH DELETE ${identifiers.mkString(",")} RETURN count(*)")
 
-        //update
-        updateWithBothPlanners(s"CREATE $patternString")
-        //delete
-        val identifiers = findAllNodeNames(pattern)
-        updateWithBothPlanners(s"MATCH $patternString DETACH DELETE ${identifiers.mkString(",")} RETURN count(*)")
-
-        //now db should be empty
-        executeWithAllPlanners("MATCH () RETURN count(*) AS c").toList should equal(List(Map("c" -> 0)))
+          //now db should be empty
+          executeWithAllPlanners("MATCH () RETURN count(*) AS c").toList should equal(List(Map("c" -> 0)))
+        }
       }
     }
   }
@@ -82,16 +84,17 @@ class SemanticDeleteAcceptanceTest extends ExecutionEngineFunSuite with PatternG
 
       whenever(pattern.nonEmpty) {
         val patternString = pattern.map(_.string).mkString
+        withClue(s"failing on pattern $patternString") {
+          //update
+          updateWithBothPlanners(s"CREATE $patternString")
+          //delete
+          val identifiers = findAllRelationshipNames(pattern) ++ findAllNodeNames(pattern)
+          val undirected = makeUndirected(pattern).map(_.string).mkString
+          updateWithBothPlanners(s"MATCH $undirected DELETE ${identifiers.mkString(",")}")
 
-        //update
-        updateWithBothPlanners(s"CREATE $patternString")
-        //delete
-        val identifiers = findAllRelationshipNames(pattern) ++ findAllNodeNames(pattern)
-        val undirected = makeUndirected(pattern).map(_.string).mkString
-        updateWithBothPlanners(s"MATCH $undirected DELETE ${identifiers.mkString(",")}")
-
-        //now db should be empty
-        executeWithAllPlanners("MATCH () RETURN count(*) AS c").toList should equal(List(Map("c" -> 0)))
+          //now db should be empty
+          executeWithAllPlanners("MATCH () RETURN count(*) AS c").toList should equal(List(Map("c" -> 0)))
+        }
       }
     }
   }
@@ -104,16 +107,17 @@ class SemanticDeleteAcceptanceTest extends ExecutionEngineFunSuite with PatternG
 
       whenever(pattern.nonEmpty) {
         val patternString = pattern.map(_.string).mkString
+        withClue(s"failing on pattern $patternString") {
+          //update
+          updateWithBothPlanners(s"CREATE $patternString")
+          //delete
+          val identifiers = findAllNodeNames(pattern)
+          val undirected = makeUndirected(pattern).map(_.string).mkString
+          updateWithBothPlanners(s"MATCH $undirected DETACH DELETE ${identifiers.mkString(",")}")
 
-        //update
-        updateWithBothPlanners(s"CREATE $patternString")
-        //delete
-        val identifiers = findAllNodeNames(pattern)
-        val undirected = makeUndirected(pattern).map(_.string).mkString
-        updateWithBothPlanners(s"MATCH $undirected DETACH DELETE ${identifiers.mkString(",")}")
-
-        //now db should be empty
-        executeWithAllPlanners("MATCH () RETURN count(*) AS c").toList should equal(List(Map("c" -> 0)))
+          //now db should be empty
+          executeWithAllPlanners("MATCH () RETURN count(*) AS c").toList should equal(List(Map("c" -> 0)))
+        }
       }
     }
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -545,6 +545,26 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
                           "Invalid input '1.7' is not a valid value, must be a positive integer (line 1, column 26 (offset: 25))")
   )
 
+  test("should fail when invalid percentile in percentileDisc") (
+    executeAndEnsureError("MATCH (n) RETURN percentileDisc(n.prop, 95)",
+      "Invalid input '95' is not a valid argument, must be a number in the range 0.0 to 1.0 (line 1, column 41 (offset: 40))")
+  )
+
+  test("should fail when floating number is not in range in percentileDisc") (
+    executeAndEnsureError("MATCH (n) RETURN percentileDisc(n.prop, 1.1)",
+      "Invalid input '1.1' is not a valid argument, must be a number in the range 0.0 to 1.0 (line 1, column 41 (offset: 40))")
+  )
+
+  test("should fail when invalid percentile in percentileCont") (
+    executeAndEnsureError("MATCH (n) RETURN percentileCont(n.prop, 95)",
+      "Invalid input '95' is not a valid argument, must be a number in the range 0.0 to 1.0 (line 1, column 41 (offset: 40))")
+  )
+
+  test("should fail when floating number is not in range in percentileCont") (
+    executeAndEnsureError("MATCH (n) RETURN percentileCont(n.prop, -0.1)",
+      "Invalid input '-0.1' is not a valid argument, must be a number in the range 0.0 to 1.0 (line 1, column 41 (offset: 40))")
+  )
+
   def executeAndEnsureError(query: String, expected: String) {
     import org.neo4j.cypher.internal.frontend.v3_0.helpers.StringHelper._
 

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/PercentileCont.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/PercentileCont.scala
@@ -19,7 +19,8 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_0.ast.functions
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{AggregatingFunction, SimpleTypedFunction}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression.SemanticContext
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{AggregatingFunction, FunctionInvocation, SimpleTypedFunction}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 
 case object PercentileCont extends AggregatingFunction with SimpleTypedFunction {
@@ -28,4 +29,6 @@ case object PercentileCont extends AggregatingFunction with SimpleTypedFunction 
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
+  override def semanticCheck(ctx: SemanticContext, invocation: FunctionInvocation) =
+    super.semanticCheck(ctx, invocation) ifOkChain checkPercentileRange(invocation.args(1))
 }

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/PercentileDisc.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/PercentileDisc.scala
@@ -19,8 +19,10 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_0.ast.functions
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{AggregatingFunction, SimpleTypedFunction}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression.SemanticContext
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{Parameter, AggregatingFunction, DoubleLiteral, FunctionInvocation, Literal, SimpleTypedFunction}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
+import org.neo4j.cypher.internal.frontend.v3_0.{SemanticCheck, SemanticCheckResult, SemanticError}
 
 case object PercentileDisc extends AggregatingFunction with SimpleTypedFunction {
   def name = "percentileDisc"
@@ -29,4 +31,7 @@ case object PercentileDisc extends AggregatingFunction with SimpleTypedFunction 
     Signature(argumentTypes = Vector(CTInteger, CTFloat), outputType = CTInteger),
     Signature(argumentTypes = Vector(CTFloat, CTFloat), outputType = CTFloat)
   )
+
+  override def semanticCheck(ctx: SemanticContext, invocation: FunctionInvocation) =
+    super.semanticCheck(ctx, invocation) ifOkChain  checkPercentileRange(invocation.args(1))
 }


### PR DESCRIPTION
Instead of failing at runtime `percentileCont` and `percentileDisc`
now fails in semantic checking when the provided percentile is not
in the valid range.

fixes #5432
