### PR TITLE
Fixes AVG and SUM overflow for Cypher

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/TypeSafeMathSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/TypeSafeMathSupport.scala
@@ -219,4 +219,120 @@ trait TypeSafeMathSupport {
 
     }
   }
+
+  /**
+   * Serves for a type-safe, overflow-aware summation.
+   * That is, tries to keep the sum type as narrow as possible, widening its value if necessary.
+   * Initial result type is Int. If a Double is added, the result becomes Double.
+   * If Long is added, the result becomes Long with the possibility to widen to Double later.
+   *
+   * @note  For the summation of floating-point numbers this class encapsulates Kahan's algorithm
+   *        for error minimization (https://en.wikipedia.org/wiki/Kahan_summation_algorithm)
+   */
+  sealed trait OverflowAwareSum[T] {
+    protected var sum: T = _
+    def value = sum
+
+    /**
+     * @param next  next number to add to the total sum
+     * @return      current value of the sum variable
+     * @note        sticks to integral type for as long as possible
+     */
+    def add(next: Any): OverflowAwareSum[_]
+  }
+
+  case class DoubleSum(private val doubleValue: Double) extends OverflowAwareSum[Double] {
+    sum = doubleValue
+    def add(next: Any) = {
+      next match {
+        case (x: Byte)    => sum += x
+        case (x: Short)   => sum += x
+        case (x: Char)    => sum += x
+        case (x: Int)     => sum += x
+        case (x: Long)    => sum += x
+        case (x: Float)   => sum += x
+        case (x: Double)  => sum += x
+        case _ =>
+      }
+      this
+    }
+  }
+
+  case class LongSum(private val longValue: Long) extends OverflowAwareSum[Long] {
+    sum = longValue
+    import OverflowAwareSum._
+
+    private def addLong(next: Long): OverflowAwareSum[_] = addExact(sum, next) match {
+      case doubleValue: Double => DoubleSum(doubleValue)
+      case other => sum =
+        other.asInstanceOf[Long]
+        this
+    }
+
+    override def add(next: Any): OverflowAwareSum[_] = next match {
+      case (x: Byte)    => addLong(x)
+      case (x: Short)   => addLong(x)
+      case (x: Char)    => addLong(x)
+      case (x: Int)     => addLong(x)
+      case (x: Long)    => addLong(x)
+      case (x: Float)   => DoubleSum(sum).add(next)
+      case (x: Double)  => DoubleSum(sum).add(next)
+      case _ => this
+    }
+  }
+
+  case class IntSum(private val intValue: Int) extends OverflowAwareSum[Int] {
+    sum = intValue
+    import OverflowAwareSum._
+
+    private def addInt(next: Int): OverflowAwareSum[_] = addExact(sum, next) match {
+      case doubleValue: Double => DoubleSum(doubleValue)
+      case longValue: Long => LongSum(longValue)
+      case other =>
+        sum = other.asInstanceOf[Int]
+        this
+    }
+
+    override def add(next: Any): OverflowAwareSum[_] = next match {
+      case (x: Byte)    => addInt(x)
+      case (x: Short)   => addInt(x)
+      case (x: Char)    => addInt(x)
+      case (x: Int)     => addInt(x)
+      case (x: Long)    => LongSum(sum).add(x)
+      case (x: Float)   => DoubleSum(sum).add(x)
+      case (x: Double)  => DoubleSum(sum).add(x)
+      case _ => this
+    }
+  }
+
+  /**
+   * Contains overloaded constructors for all available OverflowAwareSum subclasses.
+   * Also provides own analogs of JDK8's Math#addExact() methods that differ in that
+   * they don't throw exceptions on overflow, but rather widen the type
+   * of the value returned (int -> long -> double).
+   */
+  object OverflowAwareSum {
+
+    def apply(x: Int)     = IntSum(x)
+    def apply(x: Long)    = LongSum(x)
+    def apply(x: Double)  = DoubleSum(x)
+
+    def addExact(x: Int, y: Int): Any = {
+      val r: Int = x + y
+      if (((x ^ r) & (y ^ r)) >= 0) {
+        r
+      } else {    // integer overflow
+        addExact(x.toLong, y.toLong)
+      }
+    }
+
+    def addExact(x: Long, y: Long): Any= {
+      val r: Long = x + y
+      if (((x ^ r) & (y ^ r)) >= 0) {
+        r
+      } else {    // long overflow
+        x.toDouble + y.toDouble
+      }
+    }
+  }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/AvgFunction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/AvgFunction.scala
@@ -24,6 +24,10 @@ import commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.TypeSafeMathSupport
 import pipes.QueryState
 
+/**
+ * AVG computation is calculated using cumulative moving average approach:
+ * https://en.wikipedia.org/wiki/Moving_average#Cumulative_moving_average
+ */
 class AvgFunction(val value: Expression)
   extends AggregationFunction
   with TypeSafeMathSupport
@@ -31,19 +35,21 @@ class AvgFunction(val value: Expression)
 
   def name = "AVG"
 
-  private var count: Int = 0
-  private var sofar: Any = 0
+  private var count: Long = 0L
+  private var sum: OverflowAwareSum[_] = OverflowAwareSum(0)
 
   def result =
-    if (count > 0)
-      divide(sofar, count.toDouble)
-    else
+    if (count > 0) {
+      sum.value
+    } else {
       null
+    }
 
   def apply(data: ExecutionContext)(implicit state: QueryState) {
     actOnNumber(value(data), (number) => {
       count += 1
-      sofar = plus(sofar, number)
+      val next = divide(minus(number, sum.value), count.toDouble)
+      sum = sum.add(next)
     })
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/SumFunction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/SumFunction.scala
@@ -31,11 +31,12 @@ class SumFunction(val value: Expression)
 
   def name = "SUM"
 
-  var result: Any = 0
+  private var sum: OverflowAwareSum[_] = OverflowAwareSum(0)
+  def result = sum.value
 
   def apply(data: ExecutionContext)(implicit state: QueryState) {
     actOnNumber(value(data), (number) => {
-      result = plus(result, number)
+      sum = sum.add(number)
     })
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/AvgFunctionTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/AvgFunctionTest.scala
@@ -28,42 +28,54 @@ class AvgFunctionTest extends CypherFunSuite with AggregateTest {
   test("singleOne") {
     val result = aggregateOn(1)
 
-     result should equal(1.0)
+    result should equal(1.0)
   }
 
   test("allOnesAvgIsOne") {
     val result = aggregateOn(1, 1)
 
-     result should equal(1.0)
+    result should equal(1.0)
   }
 
   test("twoAndEightAvgIs10") {
     val result = aggregateOn(2, 8)
 
-     result should equal(5.0)
+    result should equal(5.0)
   }
 
   test("negativeOneIsStillOk") {
     val result = aggregateOn(-1)
 
-     result should equal(-1.0)
+    result should equal(-1.0)
   }
 
   test("ZeroIsAnOKAvg") {
     val result = aggregateOn(-10, 10)
 
-     result should equal(0.0)
+    result should equal(0.0)
   }
 
   test("ADoubleInTheListTurnsTheAvgToDouble") {
     val result = aggregateOn(1, 1.0, 1)
 
-     result should equal(1.0)
+    result should equal(1.0)
   }
 
   test("nullDoesntChangeThings") {
     val result = aggregateOn(3, null, 6)
 
-     result should equal(4.5)
+    result should equal(4.5)
+  }
+
+  test("noOverflowOnLongListOfLargeNumbers") {
+    val result = aggregateOn(Long.MaxValue / 2, Long.MaxValue / 2, Long.MaxValue / 2)
+
+    result should equal(Long.MaxValue / 2)
+  }
+
+  test("onEmpty") {
+    val result = aggregateOn()
+
+    Option(result) should be (None)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/SumFunctionTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/SumFunctionTest.scala
@@ -71,4 +71,19 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
   test("noNumberValuesThrowAnException") {
     intercept[CypherTypeException](aggregateOn(1, "wut"))
   }
+
+  test("intOverflowTransformsSumToLong") {
+    val halfInt= Int.MaxValue
+    val result = aggregateOn(halfInt, halfInt, halfInt)
+    val expected = 3L * halfInt
+    result should equal(expected)
+  }
+
+  test("typesArentUnnecessaryWidened") {
+    val thirdOfMaxInt: Int = Int.MaxValue / 3
+    val result = aggregateOn(thirdOfMaxInt, thirdOfMaxInt)
+    val expected = thirdOfMaxInt + thirdOfMaxInt
+    result should equal(expected)
+    result shouldBe a [java.lang.Integer]
+  }
 }


### PR DESCRIPTION
This is an attempt to fix integer overflow in SUM and AVG functions.
All the tests are passing locally and since I'm have no access rights to see into the build logs, I'm not sure why do checks fail.
_This is an updated version of #5404. History and discussion may be found in that PR_
