### PR TITLE
Fixed lifecycle issue with TransactionCommitProces

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1042,10 +1042,9 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
             UpdateableSchemaState updateableSchemaState, LabelScanStore labelScanStore,
             SchemaIndexProviderMap schemaIndexProviderMap, ProcedureCache procedureCache )
     {
-        final TransactionCommitProcess transactionCommitProcess =
-                commitProcessFactory.create( appender, kernelHealth, neoStores, storeApplier,
-                        new NeoStoreInjectedTransactionValidator( integrityValidator ), indexUpdatesValidator,
-                        config );
+        NeoStoreInjectedTransactionValidator validator = new NeoStoreInjectedTransactionValidator( integrityValidator );
+        final TransactionCommitProcess transactionCommitProcess = commitProcessFactory.create( appender, storeApplier,
+                validator, indexUpdatesValidator, config );
 
         /*
          * This is used by legacy indexes and constraint indexes whenever a transaction is to be spawned

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityCommitProcessFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityCommitProcessFactory.java
@@ -17,16 +17,30 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.api;
+package org.neo4j.kernel.impl.factory;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.CommitProcessFactory;
+import org.neo4j.kernel.impl.api.ReadOnlyTransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
 import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreInjectedTransactionValidator;
 
-public interface CommitProcessFactory
+public class CommunityCommitProcessFactory implements CommitProcessFactory
 {
-    TransactionCommitProcess create( TransactionAppender appender, TransactionRepresentationStoreApplier storeApplier,
-            NeoStoreInjectedTransactionValidator txValidator, IndexUpdatesValidator indexUpdatesValidator,
-            Config config );
+    @Override
+    public TransactionCommitProcess create( TransactionAppender appender,
+            TransactionRepresentationStoreApplier storeApplier, NeoStoreInjectedTransactionValidator txValidator,
+            IndexUpdatesValidator indexUpdatesValidator, Config config )
+    {
+        if ( config.get( GraphDatabaseSettings.read_only ) )
+        {
+            return new ReadOnlyTransactionCommitProcess();
+        }
+        return new TransactionRepresentationCommitProcess( appender, storeApplier, indexUpdatesValidator );
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/CommunityCommitProcessFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/CommunityCommitProcessFactoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.factory;
+
+import org.junit.Test;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.ReadOnlyTransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
+import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreInjectedTransactionValidator;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class CommunityCommitProcessFactoryTest
+{
+    @Test
+    public void createReadOnlyCommitProcess()
+    {
+        CommunityCommitProcessFactory factory = new CommunityCommitProcessFactory();
+
+        Config config = new Config( stringMap( GraphDatabaseSettings.read_only.name(), "true" ) );
+
+        TransactionCommitProcess commitProcess = factory.create( mock( TransactionAppender.class ),
+                mock( TransactionRepresentationStoreApplier.class ), mock( NeoStoreInjectedTransactionValidator.class ),
+                mock( IndexUpdatesValidator.class ), config );
+
+        assertThat( commitProcess, instanceOf( ReadOnlyTransactionCommitProcess.class ) );
+    }
+
+    @Test
+    public void createRegularCommitProcess()
+    {
+        CommunityCommitProcessFactory factory = new CommunityCommitProcessFactory();
+
+        TransactionCommitProcess commitProcess = factory.create( mock( TransactionAppender.class ),
+                mock( TransactionRepresentationStoreApplier.class ), mock( NeoStoreInjectedTransactionValidator.class ),
+                mock( IndexUpdatesValidator.class ), new Config() );
+
+        assertThat( commitProcess, instanceOf( TransactionRepresentationCommitProcess.class ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -45,7 +45,7 @@ import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
-import org.neo4j.kernel.impl.factory.CommunityEditionModule;
+import org.neo4j.kernel.impl.factory.CommunityCommitProcessFactory;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
@@ -92,7 +92,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 fs, mock( StoreUpgrader.class ), mock( TransactionMonitor.class ), kernelHealth,
                 mock( PhysicalLogFile.Monitor.class ), TransactionHeaderInformationFactory.DEFAULT,
                 new StartupStatisticsProvider(), mock( NodeManager.class ), null, null,
-                CommunityEditionModule.createCommitProcessFactory(), mock( PageCache.class ),
+                new CommunityCommitProcessFactory(), mock( PageCache.class ),
                 mock( ConstraintSemantics.class), new Monitors(), new Tracers( "null", NullLog.getInstance() ) );
 
         return dataSource;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableCommitProcessFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableCommitProcessFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.factory;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.CommitProcessSwitcher;
+import org.neo4j.kernel.ha.DelegateInvocationHandler;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.ha.transaction.TransactionPropagator;
+import org.neo4j.kernel.impl.api.CommitProcessFactory;
+import org.neo4j.kernel.impl.api.ReadOnlyTransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
+import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreInjectedTransactionValidator;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+
+import static java.lang.reflect.Proxy.newProxyInstance;
+
+class HighlyAvailableCommitProcessFactory implements CommitProcessFactory
+{
+    private final LifeSupport modeSwitchersLife;
+    private final Master master;
+    private final TransactionPropagator transactionPropagator;
+    private final RequestContextFactory requestContextFactory;
+    private final HighAvailabilityModeSwitcher highAvailabilityModeSwitcher;
+
+    private final DelegateInvocationHandler<TransactionCommitProcess> commitProcessDelegate =
+            new DelegateInvocationHandler<>( TransactionCommitProcess.class );
+
+    HighlyAvailableCommitProcessFactory( LifeSupport modeSwitchersLife, Master master,
+            TransactionPropagator transactionPropagator, RequestContextFactory requestContextFactory,
+            HighAvailabilityModeSwitcher highAvailabilityModeSwitcher )
+    {
+        this.modeSwitchersLife = modeSwitchersLife;
+        this.master = master;
+        this.transactionPropagator = transactionPropagator;
+        this.requestContextFactory = requestContextFactory;
+        this.highAvailabilityModeSwitcher = highAvailabilityModeSwitcher;
+    }
+
+    @Override
+    public TransactionCommitProcess create( TransactionAppender appender,
+            TransactionRepresentationStoreApplier storeApplier, NeoStoreInjectedTransactionValidator txValidator,
+            IndexUpdatesValidator indexUpdatesValidator, Config config )
+    {
+        if ( config.get( GraphDatabaseSettings.read_only ) )
+        {
+            return new ReadOnlyTransactionCommitProcess();
+        }
+
+        removeOldCommitSwitcher();
+
+        TransactionCommitProcess commitProcess = new TransactionRepresentationCommitProcess( appender, storeApplier,
+                indexUpdatesValidator );
+
+        CommitProcessSwitcher commitProcessSwitcher = new CommitProcessSwitcher( transactionPropagator,
+                master, commitProcessDelegate, requestContextFactory, highAvailabilityModeSwitcher,
+                txValidator, commitProcess );
+
+        modeSwitchersLife.add( commitProcessSwitcher );
+
+        return (TransactionCommitProcess) newProxyInstance( TransactionCommitProcess.class.getClassLoader(),
+                new Class[]{TransactionCommitProcess.class}, commitProcessDelegate );
+    }
+
+    /**
+     * {@link CommitProcessSwitcher} register itself as listener of {@link HighAvailabilityModeSwitcher} during
+     * {@link CommitProcessSwitcher#start()} and de-registers in {@link CommitProcessSwitcher#stop()}.
+     * Problem is that life that contains {@link CommitProcessSwitcher} is only started on the database startup and
+     * stopped during it's shutdown. That is why we need to manually stop old switcher and remove it from the life
+     * when new commit process is create.
+     */
+    private void removeOldCommitSwitcher()
+    {
+        for ( Lifecycle instance : modeSwitchersLife.getLifecycleInstances() )
+        {
+            if ( instance instanceof CommitProcessSwitcher )
+            {
+                modeSwitchersLife.remove( instance );
+            }
+        }
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -625,6 +625,8 @@ public class HighlyAvailableEditionModule
                     return new ReadOnlyTransactionCommitProcess();
                 }
 
+                removeOldCommitSwitcher();
+
                 TransactionCommitProcess inner = new TransactionRepresentationCommitProcess( appender, storeApplier,
                         indexUpdatesValidator );
 
@@ -636,6 +638,17 @@ public class HighlyAvailableEditionModule
 
                 return (TransactionCommitProcess) newProxyInstance( TransactionCommitProcess.class.getClassLoader(),
                         new Class[]{TransactionCommitProcess.class}, commitProcessDelegate );
+            }
+
+            private void removeOldCommitSwitcher()
+            {
+                for ( Lifecycle instance : modeSwitchersLife.getLifecycleInstances() )
+                {
+                    if ( instance instanceof CommitProcessSwitcher )
+                    {
+                        modeSwitchersLife.remove( instance );
+                    }
+                }
             }
         };
     }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -41,7 +41,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -91,7 +90,6 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
-
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.fs.FileUtils.copyRecursively;
@@ -1035,7 +1033,7 @@ public class ClusterManager
                     }
                 }, clusterClientModule.clusterClient.getServerId() ) );
 
-                life.add( new FutureLifecycleAdapter<>( clusterClientModule.life ) );
+                life.add( new FutureLifecycleAdapter<>( clusterClientLife ) );
             }
         }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableCommitProcessFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableCommitProcessFactoryTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.factory;
+
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.CommitProcessSwitcher;
+import org.neo4j.kernel.ha.DelegateInvocationHandler;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
+import org.neo4j.kernel.ha.cluster.ModeSwitcherNotifier;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+import org.neo4j.kernel.ha.com.master.Master;
+import org.neo4j.kernel.ha.transaction.TransactionPropagator;
+import org.neo4j.kernel.impl.api.ReadOnlyTransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
+import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreInjectedTransactionValidator;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class HighlyAvailableCommitProcessFactoryTest
+{
+    @Test
+    public void createReadOnlyCommitProcess()
+    {
+        HighlyAvailableCommitProcessFactory factory = new HighlyAvailableCommitProcessFactory(
+                mock( LifeSupport.class ), mock( Master.class ), mock( TransactionPropagator.class ),
+                mock( RequestContextFactory.class ), mock( HighAvailabilityModeSwitcher.class ) );
+
+        Config config = new Config( stringMap( GraphDatabaseSettings.read_only.name(), "true" ) );
+
+        TransactionCommitProcess commitProcess = factory.create( mock( TransactionAppender.class ),
+                mock( TransactionRepresentationStoreApplier.class ), mock( NeoStoreInjectedTransactionValidator.class ),
+                mock( IndexUpdatesValidator.class ), config );
+
+        assertThat( commitProcess, instanceOf( ReadOnlyTransactionCommitProcess.class ) );
+    }
+
+    @Test
+    public void createRegularCommitProcess()
+    {
+        LifeSupport modeSwitchersLife = mock( LifeSupport.class );
+        when( modeSwitchersLife.getLifecycleInstances() ).thenReturn( Iterables.<Lifecycle>empty() );
+
+        HighlyAvailableCommitProcessFactory factory = new HighlyAvailableCommitProcessFactory(
+                modeSwitchersLife, mock( Master.class ), mock( TransactionPropagator.class ),
+                mock( RequestContextFactory.class ), mock( HighAvailabilityModeSwitcher.class ) );
+
+        TransactionCommitProcess commitProcess = factory.create( mock( TransactionAppender.class ),
+                mock( TransactionRepresentationStoreApplier.class ), mock( NeoStoreInjectedTransactionValidator.class ),
+                mock( IndexUpdatesValidator.class ), new Config() );
+
+        assertThat( commitProcess, not( instanceOf( ReadOnlyTransactionCommitProcess.class ) ) );
+        assertThat( Proxy.getInvocationHandler( commitProcess ), instanceOf( DelegateInvocationHandler.class ) );
+    }
+
+    @Test
+    public void removesOldCommitProcessSwitcherFromLifeWhenNewOneIsCreated() throws Throwable
+    {
+        CommitProcessSwitcher oldCommitSwitcher1 = newCommitProcessSwitcher();
+        CommitProcessSwitcher oldCommitSwitcher2 = newCommitProcessSwitcher();
+
+        LifeSupport life = new LifeSupport();
+        life.add( oldCommitSwitcher1 );
+        life.add( oldCommitSwitcher2 );
+
+        HighlyAvailableCommitProcessFactory factory = new HighlyAvailableCommitProcessFactory( life,
+                mock( Master.class ), mock( TransactionPropagator.class ), mock( RequestContextFactory.class ),
+                mock( HighAvailabilityModeSwitcher.class ) );
+
+        TransactionCommitProcess commitProcess = factory.create( mock( TransactionAppender.class ),
+                mock( TransactionRepresentationStoreApplier.class ), mock( NeoStoreInjectedTransactionValidator.class ),
+                mock( IndexUpdatesValidator.class ), new Config() );
+
+        assertNotNull( commitProcess );
+
+        List<Lifecycle> lifecycle = Iterables.toList( life.getLifecycleInstances() );
+        assertEquals( 1, lifecycle.size() );
+
+        assertFalse( lifecycle.contains( oldCommitSwitcher1 ) );
+        assertFalse( lifecycle.contains( oldCommitSwitcher2 ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private CommitProcessSwitcher newCommitProcessSwitcher()
+    {
+        return new CommitProcessSwitcher( mock( TransactionPropagator.class ), mock( Master.class ),
+                mock( DelegateInvocationHandler.class ), mock( RequestContextFactory.class ),
+                mock( ModeSwitcherNotifier.class ), mock( NeoStoreInjectedTransactionValidator.class ),
+                mock( TransactionCommitProcess.class ) );
+    }
+}

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneClusterClientIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneClusterClientIT.java
@@ -188,8 +188,10 @@ public class StandaloneClusterClientIT
             config.put( server_id.name(), "" + i );
             config.put( initial_hosts.name(), ":5001" );
 
-            ClusterClientModule clusterClientModule = new ClusterClientModule(null, new Dependencies(), new Monitors(),
-                    new Config(config),  NullLogService.getInstance(), new ServerIdElectionCredentialsProvider());
+            LifeSupport moduleLife = new LifeSupport();
+            ClusterClientModule clusterClientModule = new ClusterClientModule( moduleLife, new Dependencies(),
+                    new Monitors(), new Config(config),  NullLogService.getInstance(),
+                    new ServerIdElectionCredentialsProvider() );
 
             final ClusterClient client = clusterClientModule.clusterClient;
             final CountDownLatch latch = new CountDownLatch( 1 );
@@ -202,7 +204,7 @@ public class StandaloneClusterClientIT
                     client.removeClusterListener( this );
                 }
             } );
-            life.add(clusterClientModule.life);
+            life.add( moduleLife );
             clients[i - 1] = client;
             assertTrue( "Didn't join the cluster", latch.await( 20, SECONDS ) );
         }


### PR DESCRIPTION
This PR consists of three parts:
- fix for lifecycle issue around mode switching and `TransactionCommitProces` initialization
- fix to ensure that only single `CommitProcessSwitcher` is present in the lifecycle
- simplification of `CommitProcessFactory` interface and it's implementors

First problem was the main motivation for these changes. It might cause master HA instance to look healthy but not able to commit any transactions because commit process is not correctly initialized.

Co-authored-by: @MishaDemianenko
