### PR TITLE
Introduce ascending-order fixed tx push strategy.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
@@ -81,6 +81,14 @@ public class GraphDatabaseFactoryState
         }
     }
 
+    public void addSettingsClasses( Iterable<Class<?>> settings )
+    {
+        for ( Class<?> setting : settings )
+        {
+            settingsClasses.add( setting );
+        }
+    }
+
     public void addURLAccessRule( String protocol, URLAccessRule rule )
     {
         urlAccessRules.put( protocol, rule );

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/BaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/BaseConfigurationMigrator.java
@@ -42,6 +42,13 @@ public class BaseConfigurationMigrator implements ConfigurationMigrator
         String getDeprecationMessage();
     }
 
+    /**
+     * Base class for implementing a migration that applies to a specific config property key.
+     *
+     * By default, this class will print a  deprecation message and run {@link #setValueWithOldSetting(String, Map)}
+     * if the specified property key has been set by the user. Override {@link #appliesTo(Map)} if you want to
+     * trigger on more specific reasons than that.
+     */
     public static abstract class SpecificPropertyMigration implements Migration
     {
         private final String propertyKey;
@@ -94,6 +101,10 @@ public class BaseConfigurationMigrator implements ConfigurationMigrator
         }
     }
 
+    /**
+     * A simple migration where a config value (usually an enum) has been renamed.
+     * Eg. it used to be `dbms.thing=doit` and now it's `dbm.thing=gogogo`.
+     */
     public static class ConfigValueChanged implements Migration
     {
         private final String propertyKey;
@@ -128,6 +139,11 @@ public class BaseConfigurationMigrator implements ConfigurationMigrator
         {
             return message;
         }
+    }
+
+    public static Migration valueChanged( String key, String oldValue, String newValue, String deprecationMessage )
+    {
+        return new ConfigValueChanged( key, oldValue, newValue, deprecationMessage );
     }
 
     public static Migration propertyRenamed( String oldKey, String newKey, String deprecationMessage )

--- a/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
@@ -22,26 +22,40 @@ package org.neo4j.graphdb.factory;
 import java.io.File;
 import java.util.Map;
 
+import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
+
+import static java.util.Arrays.asList;
 
 /**
  * Factory for HA Neo4j instances.
  */
 public class HighlyAvailableGraphDatabaseFactory extends GraphDatabaseFactory
 {
+    public HighlyAvailableGraphDatabaseFactory()
+    {
+        super( highlyAvailableFactoryState() );
+    }
+
+    private static GraphDatabaseFactoryState highlyAvailableFactoryState()
+    {
+        GraphDatabaseFactoryState state = new GraphDatabaseFactoryState();
+        state.addSettingsClasses( asList( ClusterSettings.class, HaSettings.class ) );
+        return state;
+    }
+
     @Override
     protected GraphDatabaseBuilder.DatabaseCreator createDatabaseCreator(
             final File storeDir, final GraphDatabaseFactoryState state )
     {
         return new GraphDatabaseBuilder.DatabaseCreator()
         {
-
             @Override
             public GraphDatabaseService newDatabase( final Map<String, String> config )
             {
                 config.put( "ephemeral", "false" );
-
                 return new HighlyAvailableGraphDatabase( storeDir, config, state.databaseDependencies() );
             }
         };

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/EnterpriseConfigurationMigrator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/EnterpriseConfigurationMigrator.java
@@ -21,15 +21,25 @@ package org.neo4j.kernel.ha;
 
 import org.neo4j.kernel.configuration.GraphDatabaseConfigurationMigrator;
 
+import static org.neo4j.kernel.ha.HaSettings.TxPushStrategy.fixed_ascending;
+import static org.neo4j.kernel.ha.HaSettings.TxPushStrategy.fixed_descending;
+
 // TODO: This shouldn't extend GraphDatabaseConfigurationMigrator,
 // the migrations there will be applied when we load config from GraphDatabaseSettings.
 // We need to move the migration of online backup settings out before this can be done.
 public class EnterpriseConfigurationMigrator extends GraphDatabaseConfigurationMigrator
 {
     {
-        add(propertyRenamed(
-        		"ha.machine_id", 
-        		"ha.server_id", 
-        		"ha.machine_id has been replaced with ha.server_id"));
+        add( propertyRenamed(
+                "ha.machine_id",
+                "ha.server_id",
+                "ha.machine_id has been replaced with ha.server_id" ) );
+        add( valueChanged(
+                "ha.tx_push_strategy",
+                "fixed",
+                fixed_descending.name(),
+                "The `fixed` push strategy has been renamed to `" + fixed_descending.name() + "`. Please update your configuration, and consider its sibling " +
+                "configuration option, `" + fixed_ascending.name() + "`, which is likely a better option to choose."
+        ) );
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
@@ -34,6 +34,7 @@ import static org.neo4j.helpers.Settings.INTEGER;
 import static org.neo4j.helpers.Settings.min;
 import static org.neo4j.helpers.Settings.options;
 import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.ha.HaSettings.TxPushStrategy.fixed_descending;
 
 /**
  * Settings for High Availability mode
@@ -90,8 +91,7 @@ public class HaSettings
     public static final Setting<Integer> tx_push_factor = setting( "ha.tx_push_factor", INTEGER, "1", min( 0 ) );
 
     @Description( "Push strategy of a transaction to a slave during commit." )
-    public static final Setting<TxPushStrategy> tx_push_strategy = setting( "ha.tx_push_strategy", options(
-            TxPushStrategy.class ), "fixed" );
+    public static final Setting<TxPushStrategy> tx_push_strategy = setting( "ha.tx_push_strategy", options( TxPushStrategy.class ), fixed_descending.name() );
 
     @Description( "Size of batches of transactions applied on slaves when pulling from master" )
     public static final Setting<Integer> pull_apply_batch_size = setting( "ha.pull_apply_batch_size", INTEGER, "100" );
@@ -101,7 +101,19 @@ public class HaSettings
         @Description("Round robin")
         round_robin,
 
-        @Description("Fixed")
-        fixed
+        @Deprecated
+        @Description("Deprecated, please use `fixed_ascending` or `fixed_descending` instead.")
+        fixed,
+
+        @Description("Fixed, prioritized by server id in descending order. This strategy will push to the same set of instances, as long as they remain " +
+                     "available, and will prioritize available instances with the highest instance ids.")
+        fixed_descending,
+
+        @Description("Fixed, prioritized by server id in ascending order. This strategy will push to the same set of instances, as long as they remain " +
+                     "available, and will prioritize those available instances with the lowest instance ids. This strategy makes it more likely that the most " +
+                     "up-to-date instance in a cluster will be an instance with a low id. This is consistent with the master reelection tie-breaking strategy of letting the " +
+                     "instance with the lowest id win an election if several instances are equally up-to-date. Thus, using this strategy makes it very likely " +
+                     "that failover will happen in a low-id part of the cluster, which can be very helpful in planning a multi-data center deployment.")
+        fixed_ascending
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlavePriorities.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlavePriorities.java
@@ -104,9 +104,9 @@ public abstract class SlavePriorities
     
     /**
      * @return {@link SlavePriority} which returns the slaves in the same fixed order
-     * sorted by server id in descending order. 
+     * sorted by server id in descending order.
      */
-    public static SlavePriority fixed()
+    public static SlavePriority fixedDescending()
     {
         return new SlavePriority()
         {
@@ -114,6 +114,32 @@ public abstract class SlavePriorities
             public Iterable<Slave> prioritize( final Iterable<Slave> slaves )
             {
                 return sortSlaves( slaves, false );
+            }
+        };
+    }
+
+    /**
+     * @return {@link SlavePriority} which returns the slaves in the same fixed order
+     * sorted by server id in ascending order. This is generally preferrable to {@link #fixedDescending()},
+     * because this aligns with the tie-breaker aspect of the lowest server id becoming master.
+     * <p>
+     * Eg. if you want to ensure that failover most likely will happen in a specific datacenter,
+     * you would place low-id instances in that datacenter and choose this strategy. That way,
+     * most of the time the most up-to-date instance will be in this data center, and if there is
+     * a tie, the tie-break will also end up electing a master in the same data center.
+     * <p>
+     * This is in contrast to {@link #fixedDescending()}, where a high-id server is likely to be most
+     * up-to-date if the master fails, but a low-id server is likely to be elected if there is a tie.
+     * This makes the two scenarios consistently choose a low-id server as the new master.
+     */
+    public static SlavePriority fixedAscending()
+    {
+        return new SlavePriority()
+        {
+            @Override
+            public Iterable<Slave> prioritize( final Iterable<Slave> slaves )
+            {
+                return sortSlaves( slaves, true );
             }
         };
     }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TransactionPropagator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/TransactionPropagator.java
@@ -103,8 +103,11 @@ public class TransactionPropagator implements Lifecycle
             {
                 switch ( config.get( HaSettings.tx_push_strategy ) )
                 {
-                    case fixed:
-                        return SlavePriorities.fixed();
+                    case fixed_descending:
+                        return SlavePriorities.fixedDescending();
+
+                    case fixed_ascending:
+                        return SlavePriorities.fixedAscending();
 
                     case round_robin:
                         return SlavePriorities.roundRobin();

--- a/enterprise/ha/src/test/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactoryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.factory;
+
+import org.junit.Test;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.kernel.ha.HaSettings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+public class HighlyAvailableGraphDatabaseFactoryTest
+{
+    @Test
+    public void shouldIncludeCorrectSettingsClasses() throws Throwable
+    {
+        // When
+        GraphDatabaseFactoryState state = new HighlyAvailableGraphDatabaseFactory().getCurrentState();
+
+        // Then
+        assertThat( state.databaseDependencies().settingsClasses(),
+            containsInAnyOrder( GraphDatabaseSettings.class, HaSettings.class, ClusterSettings.class ) );
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/EnterpriseConfigurationMigratorTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/EnterpriseConfigurationMigratorTest.java
@@ -19,15 +19,18 @@
  */
 package org.neo4j.kernel.ha;
 
-import static org.hamcrest.CoreMatchers.is;
+import org.junit.Test;
 
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.logging.NullLog;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.kernel.ha.HaSettings.tx_push_strategy;
 
 /**
  * EnterpriseConfigurationMigrator tests
@@ -42,9 +45,9 @@ public class EnterpriseConfigurationMigratorTest
     {
         Map<String, String> original = MapUtil.stringMap( "enable_online_backup", "true" );
         Map<String, String> migrated = migrator.apply( original, NullLog.getInstance() );
-        Assert.assertThat( migrated.containsKey( "enable_online_backup" ), is( false ) );
-        Assert.assertThat( migrated.get( "online_backup_enabled" ), is( "true" ) );
-        Assert.assertThat( migrated.get( "online_backup_server" ), is( OnlineBackupSettings.online_backup_server.getDefaultValue() ) );
+        assertThat( migrated.containsKey( "enable_online_backup" ), is( false ) );
+        assertThat( migrated.get( "online_backup_enabled" ), is( "true" ) );
+        assertThat( migrated.get( "online_backup_server" ), is( OnlineBackupSettings.online_backup_server.getDefaultValue() ) );
     }
 
     @Test
@@ -53,9 +56,9 @@ public class EnterpriseConfigurationMigratorTest
     {
         Map<String, String> original = MapUtil.stringMap( "enable_online_backup", "port=123" );
         Map<String, String> migrated = migrator.apply( original, NullLog.getInstance() );
-        Assert.assertThat( migrated.containsKey( "enable_online_backup" ), is( false ) );
-        Assert.assertThat( migrated.get( "online_backup_enabled" ), is( "true" ) );
-        Assert.assertThat( migrated.get( "online_backup_server" ), is( "0.0.0.0:123" ) );
+        assertThat( migrated.containsKey( "enable_online_backup" ), is( false ) );
+        assertThat( migrated.get( "online_backup_enabled" ), is( "true" ) );
+        assertThat( migrated.get( "online_backup_server" ), is( "0.0.0.0:123" ) );
     }
 
     @Test
@@ -64,7 +67,21 @@ public class EnterpriseConfigurationMigratorTest
     {
         Map<String, String> original = MapUtil.stringMap( "ha.machine_id", "123" );
         Map<String, String> migrated = migrator.apply( original, NullLog.getInstance() );
-        Assert.assertThat( migrated.containsKey( "ha.machine_id" ), is( false ) );
-        Assert.assertThat( migrated.get( "ha.server_id" ), is( "123" ) );
+        assertThat( migrated.containsKey( "ha.machine_id" ), is( false ) );
+        assertThat( migrated.get( "ha.server_id" ), is( "123" ) );
+    }
+
+    @Test
+    public void testFixedPushStrategyMigration()
+            throws Exception
+    {
+        // Given
+        Map<String, String> original = MapUtil.stringMap( tx_push_strategy.name(), "fixed" );
+
+        // When
+        Map<String, String> migrated = migrator.apply( original, NullLog.getInstance() );
+
+        // Then
+        assertThat( migrated.get( tx_push_strategy.name() ), equalTo( HaSettings.TxPushStrategy.fixed_descending.name() ) );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveUpgradeTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveUpgradeTest.java
@@ -47,7 +47,9 @@ public class SlaveUpgradeTest
 
             new TestHighlyAvailableGraphDatabaseFactory()
                     .newHighlyAvailableDatabaseBuilder( dir.getAbsolutePath() )
-                    .setConfig( ClusterSettings.server_id, "1" ).newGraphDatabase();
+                    .setConfig( ClusterSettings.server_id, "1" )
+                    .setConfig( ClusterSettings.initial_hosts, "localhost:9999" ) // Mandatory setting, irrelevant for this test though, just needs to be here
+                    .newGraphDatabase();
 
             fail( "Should exit abnormally" );
         }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestMasterCommittingAtSlave.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestMasterCommittingAtSlave.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.kernel.ha;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-
-import org.junit.Rule;
-import org.junit.Test;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.com.ComException;
@@ -45,10 +45,10 @@ import org.neo4j.kernel.ha.com.master.SlavePriority;
 import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.ha.transaction.CommitPusher;
 import org.neo4j.kernel.ha.transaction.TransactionPropagator;
-import org.neo4j.logging.AssertableLogProvider.LogMatcher;
 import org.neo4j.kernel.impl.store.StoreId;
-import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.AssertableLogProvider.LogMatcher;
 import org.neo4j.logging.NullLog;
 import org.neo4j.test.CleanupRule;
 
@@ -59,7 +59,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.kernel.ha.com.master.SlavePriorities.givenOrder;
 import static org.neo4j.kernel.ha.com.master.SlavePriorities.roundRobin;
 import static org.neo4j.logging.AssertableLogProvider.Level.ERROR;
@@ -190,8 +189,8 @@ public class TestMasterCommittingAtSlave
     public void testFixedPriorityStrategy()
     {
         int[] serverIds = new int[]{55, 101, 66};
-        SlavePriority fixed = SlavePriorities.fixed();
-        ArrayList<Slave> slaves = new ArrayList<Slave>( 3 );
+        SlavePriority fixed = SlavePriorities.fixedDescending();
+        ArrayList<Slave> slaves = new ArrayList<>( 3 );
         slaves.add( new FakeSlave( false, serverIds[0] ) );
         slaves.add( new FakeSlave( false, serverIds[1] ) );
         slaves.add( new FakeSlave( false, serverIds[2] ) );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
@@ -73,7 +73,7 @@ public class TxPushStrategyConfigIT
     @Test
     public void shouldPushToSlavesInDescendingOrder() throws Exception
     {
-        ManagedCluster cluster = startCluster( 4, 2, HaSettings.TxPushStrategy.fixed );
+        ManagedCluster cluster = startCluster( 4, 2, HaSettings.TxPushStrategy.fixed_descending );
 
         for ( int i = 0; i < 5; i++ )
         {
@@ -81,6 +81,21 @@ public class TxPushStrategyConfigIT
             assertLastTransactions( cluster, lastTx( THIRD_SLAVE, BASE_TX_ID + 1 + i ) );
             assertLastTransactions( cluster, lastTx( SECOND_SLAVE, BASE_TX_ID + 1 + i ) );
             assertLastTransactions( cluster, lastTx( FIRST_SLAVE, BASE_TX_ID ) );
+        }
+    }
+
+
+    @Test
+    public void shouldPushToSlavesInAscendingOrder() throws Exception
+    {
+        ManagedCluster cluster = startCluster( 4, 2, HaSettings.TxPushStrategy.fixed_ascending );
+
+        for ( int i = 0; i < 5; i++ )
+        {
+            createTransactionOnMaster( cluster );
+            assertLastTransactions( cluster, lastTx( FIRST_SLAVE, BASE_TX_ID + 1 + i ) );
+            assertLastTransactions( cluster, lastTx( SECOND_SLAVE, BASE_TX_ID + 1 + i ) );
+            assertLastTransactions( cluster, lastTx( THIRD_SLAVE, BASE_TX_ID ) );
         }
     }
 
@@ -115,7 +130,7 @@ public class TxPushStrategyConfigIT
     @Test
     public void shouldPushToOneLessSlaveOnSlaveCommit() throws Exception
     {
-        ManagedCluster cluster = startCluster( 4, 2, HaSettings.TxPushStrategy.fixed );
+        ManagedCluster cluster = startCluster( 4, 2, HaSettings.TxPushStrategy.fixed_descending );
 
         createTransactionOn( cluster, new InstanceId( FIRST_SLAVE ) );
         assertLastTransactions( cluster,
@@ -142,7 +157,7 @@ public class TxPushStrategyConfigIT
     @Test
     public void slavesListGetsUpdatedWhenSlaveLeavesNicely() throws Exception
     {
-        ManagedCluster cluster = startCluster( 3, 1, HaSettings.TxPushStrategy.fixed );
+        ManagedCluster cluster = startCluster( 3, 1, HaSettings.TxPushStrategy.fixed_ascending );
 
         cluster.shutdown( cluster.getAnySlave() );
         cluster.await( masterSeesSlavesAsAvailable( 1 ) );
@@ -151,7 +166,7 @@ public class TxPushStrategyConfigIT
     @Test
     public void slaveListIsCorrectAfterMasterSwitch() throws Exception
     {
-        ManagedCluster cluster = startCluster( 3, 1, HaSettings.TxPushStrategy.fixed );
+        ManagedCluster cluster = startCluster( 3, 1, HaSettings.TxPushStrategy.fixed_ascending );
         cluster.shutdown( cluster.getMaster() );
         cluster.await( masterAvailable() );
         HighlyAvailableGraphDatabase newMaster = cluster.getMaster();
@@ -165,7 +180,7 @@ public class TxPushStrategyConfigIT
     @Test
     public void slavesListGetsUpdatedWhenSlaveRageQuits() throws Throwable
     {
-        ManagedCluster cluster = startCluster( 3, 1, HaSettings.TxPushStrategy.fixed );
+        ManagedCluster cluster = startCluster( 3, 1, HaSettings.TxPushStrategy.fixed_ascending );
         cluster.fail( cluster.getAnySlave() );
 
         cluster.await( masterSeesSlavesAsAvailable( 1 ) );


### PR DESCRIPTION
When failover happens, the most up-to-date slave will be selected as the
one to fail over to. With the default push strategy, fixed, that is very
likely to be an instance with a high instance id.

However, if there is a tie, the instance with the lowest instance id will
be used as a tie breaker. For someone wanting to with high probability keep
master in a specific data center, this makes it very hard since the two
strategies contradict each other.

Likewise, it is likely in the real world that low-instance ids are assigned
together in the data center where a master is desired - meaning a master
will run in the data center with low instance ids, but pushes will happen
cross-data center.
