### PR TITLE
Add metrics about replan events

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/PlanCacheMetricsMonitor.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/PlanCacheMetricsMonitor.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import java.util.concurrent.atomic.AtomicLong
+
+class PlanCacheMetricsMonitor extends StringCacheMonitor {
+  private val counter = new AtomicLong()
+  override def cacheDiscard(key: String): Unit = {
+    counter.incrementAndGet()
+  }
+
+  def numberOfReplans: Long = counter.get()
+}

--- a/enterprise/metrics/pom.xml
+++ b/enterprise/metrics/pom.xml
@@ -84,17 +84,16 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-lucene-index</artifactId>
+      <artifactId>neo4j-cypher</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher</artifactId>
+      <artifactId>neo4j-lucene-index</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -81,6 +81,9 @@ public class MetricsSettings
     @Description( "Enable reporting metrics about the current number of threads running on the HA cluster component." )
     public static Setting<Boolean> jvmThreadsEnabled = setting( "metrics.jvm.threads.enabled", Settings.BOOLEAN, neoEnabled );
 
+    @Description( "Enable reporting metrics about number of occurred replanning events." )
+    public static Setting<Boolean> cypherPlanningEnabled = setting( "metrics.cypher.replanning.enabled", Settings.BOOLEAN, neoEnabled );
+
     // CSV settings
     @Description( "Set to `true` to enable exporting metrics to CSV files" )
     public static Setting<Boolean> csvEnabled = setting( "metrics.csv.enabled", Settings.BOOLEAN, Settings.FALSE );

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/CypherMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/CypherMetrics.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.metrics.source;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+
+import java.io.IOException;
+
+import org.neo4j.cypher.PlanCacheMetricsMonitor;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.metrics.MetricsSettings;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class CypherMetrics extends LifecycleAdapter
+{
+    private static final String NAME_PREFIX = "neo4j.cypher";
+    public static final String REPLAN_EVENTS = name( NAME_PREFIX, "replan_events" );
+
+    private final Config config;
+    private final Monitors monitors;
+    private final MetricRegistry registry;
+    private final PlanCacheMetricsMonitor cacheMonitor = new PlanCacheMetricsMonitor();
+
+    public CypherMetrics( Config config, Monitors monitors, MetricRegistry registry )
+    {
+        this.config = config;
+        this.monitors = monitors;
+        this.registry = registry;
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        if ( config.get( MetricsSettings.cypherPlanningEnabled ) )
+        {
+            monitors.addMonitorListener( cacheMonitor );
+
+            registry.register( REPLAN_EVENTS, new Gauge<Long>()
+            {
+                @Override
+                public Long getValue()
+                {
+                    return cacheMonitor.numberOfReplans();
+                }
+            } );
+        }
+    }
+
+    @Override
+    public void stop() throws IOException
+    {
+        if ( config.get( MetricsSettings.cypherPlanningEnabled ) )
+        {
+            registry.remove( REPLAN_EVENTS );
+
+            monitors.removeMonitorListener( cacheMonitor );
+        }
+    }
+}
+

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/Neo4jMetricsFactory.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/Neo4jMetricsFactory.java
@@ -62,6 +62,7 @@ public class Neo4jMetricsFactory implements Factory<Lifecycle>
         final DBMetrics dbMetrics = new DBMetrics( registry, config, transactionCounters, pageCacheCounters, idGeneratorFactory );
         final NetworkMetrics networkMetrics = new NetworkMetrics( config, monitors, registry );
         final JvmMetrics jvmMetrics = new JvmMetrics( logService, config, registry );
+        final CypherMetrics cypherMetrics = new CypherMetrics( config, monitors, registry );
         return new LifecycleAdapter()
         {
             @Override
@@ -70,6 +71,7 @@ public class Neo4jMetricsFactory implements Factory<Lifecycle>
                 dbMetrics.start();
                 networkMetrics.start();
                 jvmMetrics.start();
+                cypherMetrics.start();
             }
 
             @Override
@@ -78,6 +80,7 @@ public class Neo4jMetricsFactory implements Factory<Lifecycle>
                 dbMetrics.stop();
                 networkMetrics.stop();
                 jvmMetrics.stop();
+                cypherMetrics.stop();
             }
         };
     }

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
@@ -29,15 +29,16 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.UUID;
 
+import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Settings;
-import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.metrics.source.CypherMetrics;
 import org.neo4j.test.TargetDirectory;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -64,6 +65,7 @@ public class MetricsKernelExtensionFactoryIT
         outputFile = folder.file( "metrics.csv" );
         db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( dbPath ).
                 setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE ).
+                setConfig( GraphDatabaseSettings.cypher_min_replan_interval, "0" ).
                 setConfig( csvEnabled, Settings.TRUE ).
                 setConfig( csvFile, single.name() ).
                 setConfig( csvPath, outputFile.getAbsolutePath() ).newGraphDatabase();
@@ -79,15 +81,7 @@ public class MetricsKernelExtensionFactoryIT
     public void mustLoadMetricsExtensionWhenConfigured() throws Exception
     {
         // Create some activity that will show up in the metrics data.
-        for ( int i = 0; i < 1000; i++ )
-        {
-            try ( Transaction tx = db.beginTx() )
-            {
-                Map<String,Object> params = MapUtil.map( "name", UUID.randomUUID().toString() );
-                db.execute( "create (n:Label {name: {name}})", params );
-                tx.success();
-            }
-        }
+        addNodes( 1000 );
 
         // Awesome. Let's get some metric numbers.
         // We should at least have a "timestamp" column, and a "neo4j.transaction.committed" column
@@ -110,4 +104,59 @@ public class MetricsKernelExtensionFactoryIT
             }
         }
     }
+
+    @Test
+    public void showReplanEvents() throws Exception
+    {
+        //do a simple query to populate cache
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.execute( "match (n:Label {name: 'Pontus'}) return n.name");
+            tx.success();
+        }
+        //add some data, should make plan stale
+        addNodes( 10 );
+        //now we should have to plan again
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.execute( "match (n:Label {name: 'Pontus'}) return n.name" );
+            tx.success();
+        }
+        //add more data just to make sure metrics are flushed
+        addNodes( 1000 );
+
+        //now we should have one replan event
+        try ( BufferedReader reader = new BufferedReader( new FileReader( outputFile ) ) )
+        {
+            String[] headers = reader.readLine().split( "," );
+            int replanColumn = Arrays.binarySearch( headers, CypherMetrics.REPLAN_EVENTS);
+            assertThat( replanColumn, is( not( -1 ) ) );
+
+            // Now we can verify that the number of committed transactions should never decrease.
+            int replanEvents = 0;
+            String line;
+            while ( (line = reader.readLine()) != null )
+            {
+                String[] fields = line.split( "," );
+                int newReplanEvents = Integer.parseInt( fields[replanColumn] );
+                assertThat( newReplanEvents, greaterThanOrEqualTo( replanEvents ) );
+                replanEvents = newReplanEvents;
+            }
+
+            assertThat( replanEvents, is( 1 ) );
+        }
+    }
+
+    private void addNodes( int numberOfNodes ) {
+        for ( int i = 0; i < numberOfNodes; i++ )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                Node node = db.createNode( DynamicLabel.label( "Label" ) );
+                node.setProperty( "name", UUID.randomUUID().toString() );
+                tx.success();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
In metrics we can now monitor the number of occurred plan cache
evictions.
