### PR TITLE
Introduce simplified builders for GraphDatabase

### DIFF
--- a/advanced/management/src/test/java/org/neo4j/management/ManagementBeansTest.java
+++ b/advanced/management/src/test/java/org/neo4j/management/ManagementBeansTest.java
@@ -25,11 +25,11 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.jmx.Kernel;
 import org.neo4j.jmx.Primitives;
 import org.neo4j.jmx.impl.JmxKernelExtension;
-import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -37,13 +37,13 @@ import static org.junit.Assert.assertTrue;
 public class ManagementBeansTest
 {
     @ClassRule
-    public static EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( ManagementBeansTest.class );
-    private static GraphDatabaseAPI graphDb;
+    public static final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
+    private static TestGraphDatabase graphDb;
 
     @BeforeClass
     public static synchronized void startGraphDb()
     {
-        graphDb = dbRule.getGraphDatabaseAPI();
+        graphDb = dbRule.get();
     }
 
     @Test

--- a/advanced/management/src/test/java/org/neo4j/management/TestLockManagerBean.java
+++ b/advanced/management/src/test/java/org/neo4j/management/TestLockManagerBean.java
@@ -24,12 +24,13 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.jmx.impl.JmxKernelExtension;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.info.LockInfo;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.*;
 
@@ -38,14 +39,13 @@ public class TestLockManagerBean
     private LockManager lockManager;
 
     @Rule
-    public ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
-    @SuppressWarnings("deprecation")
-    private GraphDatabaseAPI graphDb;
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
+    private TestGraphDatabase graphDb;
 
     @Before
     public void setup()
     {
-        graphDb = dbRule.getGraphDatabaseAPI();
+        graphDb = dbRule.get();
         lockManager = graphDb.getDependencyResolver().resolveDependency( JmxKernelExtension.class )
                 .getSingleManagementBean( LockManager.class );
     }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import org.neo4j.consistency.ConsistencyCheckService.Result;
 import org.neo4j.consistency.checking.GraphStoreFixture;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -47,7 +48,6 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -120,7 +120,7 @@ public class ConsistencyCheckServiceIntegrationTest
         // given
         ConsistencyCheckService service = new ConsistencyCheckService();
         Config configuration = new Config( settings(), GraphDatabaseSettings.class, ConsistencyCheckSettings.class );
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( testDirectory.graphDbDir() );
+        GraphDatabaseService db = TestGraphDatabase.open( testDirectory.graphDbDir() );
 
         String propertyKey = "itemId";
         Label label = DynamicLabel.label( "Item" );

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/repair/RelationshipChainExplorerTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/repair/RelationshipChainExplorerTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import java.io.File;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
@@ -38,7 +39,6 @@ import org.neo4j.kernel.impl.store.StoreAccess;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -112,7 +112,7 @@ public class RelationshipChainExplorerTest
     private StoreAccess createStoreWithOneHighDegreeNodeAndSeveralDegreeTwoNodes( int nDegreeTwoNodes )
     {
         File storeDirectory = storeLocation.graphDbDir();
-        GraphDatabaseService database = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDirectory );
+        GraphDatabaseService database = TestGraphDatabase.open( storeDirectory );
 
         try ( Transaction transaction = database.beginTx() )
         {

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/GlueSteps.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/GlueSteps.scala
@@ -24,10 +24,9 @@ import _root_.cucumber.api.scala.{EN, ScalaDsl}
 import cypher.cucumber.db.DatabaseConfigProvider.cypherConfig
 import cypher.cucumber.db.DatabaseLoader
 import cypher.cucumber.prettifier.prettifier
-import org.neo4j.graphdb.factory.{GraphDatabaseBuilder, GraphDatabaseFactory, GraphDatabaseSettings}
+import org.neo4j.embedded.TestGraphDatabase
 import org.neo4j.graphdb.{GraphDatabaseService, Result}
 import org.neo4j.helpers.collection.IteratorUtil
-import org.neo4j.test.TestGraphDatabaseFactory
 import org.scalatest.{FunSuiteLike, Matchers}
 
 import scala.annotation.tailrec
@@ -48,13 +47,15 @@ class GlueSteps extends FunSuiteLike with Matchers with ScalaDsl with EN {
   }
 
   Given(USING_DB) { (dbName: String) =>
-    val builder = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder(DatabaseLoader(dbName))
-    graph = loadConfig(builder).newGraphDatabase()
+    val builder = TestGraphDatabase.build()
+    cypherConfig().map { case (s, v) => builder.withSetting(s, v) }
+    graph = builder.open(DatabaseLoader(dbName))
   }
 
   Given(INIT_DB) { (initQuery: String) =>
-    val builder = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-    graph = loadConfig(builder).newGraphDatabase()
+    val builder = TestGraphDatabase.buildEphemeral()
+    cypherConfig().map { case (s, v) => builder.withSetting(s, v) }
+    graph = builder.open()
     assert(!initQuery.contains("cypher"), "init query should do specify pre parser options")
     // init update queries should go with rule+interpreted regardless the database configuration
     graph.execute(s"cypher planner=rule runtime=interpreted $initQuery")
@@ -92,12 +93,6 @@ class GlueSteps extends FunSuiteLike with Matchers with ScalaDsl with EN {
     map.asScala.map { case (k, v) =>
       k -> Try(Integer.valueOf(v.toString)).getOrElse(v)
     }.asJava
-  }
-
-  private def loadConfig(builder: GraphDatabaseBuilder): GraphDatabaseBuilder = {
-    builder.setConfig(GraphDatabaseSettings.pagecache_memory, "8M")
-    cypherConfig().map { case (s, v) => builder.setConfig(s, v) }
-    builder
   }
 
   object sorter extends ((collection.Map[String, String], collection.Map[String, String]) => Boolean) {

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/GraphDatabaseServiceExecuteTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/GraphDatabaseServiceExecuteTest.java
@@ -21,9 +21,9 @@ package org.neo4j.cypher;
 
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
@@ -36,7 +36,7 @@ public class GraphDatabaseServiceExecuteTest
     public void shouldExecuteCypher() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        GraphDatabaseService graphDb = TestGraphDatabase.openEphemeral();
         final int before, after;
         try ( Transaction tx = graphDb.beginTx() )
         {

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/ManyMergesStressTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/ManyMergesStressTest.java
@@ -33,7 +33,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.Pair;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static java.lang.String.format;
 
@@ -47,12 +47,12 @@ public class ManyMergesStressTest
     private final static int TRIES = 8000;
 
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule();
+    public TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.forClass( getClass() );
 
     @Test
     public void shouldWorkFine() throws IOException
     {
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
 
         Label person = DynamicLabel.label( "Person" );
 

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/CypherLoggingTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/CypherLoggingTest.java
@@ -23,10 +23,9 @@ import java.io.IOException;
 
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.logging.AssertableLogProvider;
-import org.neo4j.logging.AssertableLogProvider.LogMatcherBuilder;
 import org.neo4j.logging.LogProvider;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 
@@ -50,6 +49,6 @@ public class CypherLoggingTest
 
     private ExecutionEngine engineWithLogger( LogProvider logProvider ) throws IOException
     {
-        return new ExecutionEngine( new TestGraphDatabaseFactory().newImpermanentDatabase(), logProvider );
+        return new ExecutionEngine( TestGraphDatabase.openEphemeral(), logProvider );
     }
 }

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/CypherUpdateMapTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/CypherUpdateMapTest.java
@@ -22,10 +22,11 @@ package org.neo4j.cypher.javacompat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
@@ -79,7 +80,7 @@ public class CypherUpdateMapTest
     @Before
     public void setup()
     {
-        gdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        gdb = TestGraphDatabase.openEphemeral();
         engine = new ExecutionEngine(gdb);
     }
 

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/ExecutionEngineTests.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/ExecutionEngineTests.java
@@ -24,8 +24,7 @@ import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -33,12 +32,12 @@ import static org.junit.Assert.assertThat;
 public class ExecutionEngineTests
 {
     @Rule
-    public DatabaseRule database = new ImpermanentDatabaseRule();
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     @Test
     public void shouldConvertListsAndMapsWhenPassingFromScalaToJava() throws Exception
     {
-        ExecutionEngine executionEngine = new ExecutionEngine( database.getGraphDatabaseService() );
+        ExecutionEngine executionEngine = new ExecutionEngine( dbRule.get() );
 
         ExecutionResult result = executionEngine.execute( "RETURN { key : 'Value' , " +
                 "collectionKey: [{ inner: 'Map1' }, { inner: 'Map2' }]}" );

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaCompatibilityTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/JavaCompatibilityTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.cypher.javacompat;
 
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
@@ -39,7 +39,7 @@ public class JavaCompatibilityTest
     @Before
     public void setUp() throws IOException
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().newGraphDatabase();
+        GraphDatabaseService db = TestGraphDatabase.openEphemeral();
         engine = new ExecutionEngine( db );
     }
 

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/internal/ServerExecutionEngineTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/internal/ServerExecutionEngineTest.java
@@ -23,7 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -31,13 +31,13 @@ import static org.junit.Assert.assertTrue;
 public class ServerExecutionEngineTest
 {
     @Rule
-    public EmbeddedDatabaseRule rule = new EmbeddedDatabaseRule();
+    public TestGraphDatabaseRule rule = TestGraphDatabaseRule.ephemeral();
 
     @Test
     public void shouldDetectPeriodicCommitQueries() throws Exception
     {
         // GIVEN
-        QueryExecutionEngine engine = rule.getGraphDatabaseAPI().getDependencyResolver()
+        QueryExecutionEngine engine = rule.get().getDependencyResolver()
                                           .resolveDependency( QueryExecutionEngine.class );
 
         // WHEN
@@ -51,7 +51,7 @@ public class ServerExecutionEngineTest
     public void shouldNotDetectNonPeriodicCommitQueriesAsPeriodicCommitQueries() throws Exception
     {
         // GIVEN
-        QueryExecutionEngine engine = rule.getGraphDatabaseAPI().getDependencyResolver()
+        QueryExecutionEngine engine = rule.get().getDependencyResolver()
                                           .resolveDependency( QueryExecutionEngine.class );
 
         // WHEN
@@ -65,7 +65,7 @@ public class ServerExecutionEngineTest
     public void shouldNotDetectInvalidQueriesAsPeriodicCommitQueries() throws Exception
     {
         // GIVEN
-        QueryExecutionEngine engine = rule.getGraphDatabaseAPI().getDependencyResolver()
+        QueryExecutionEngine engine = rule.get().getDependencyResolver()
                                           .resolveDependency( QueryExecutionEngine.class );
 
         // WHEN

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
@@ -19,12 +19,11 @@
  */
 package org.neo4j.cypher
 
+import org.neo4j.embedded.TestGraphDatabase
 import org.neo4j.kernel.api.exceptions.schema.{NoSuchIndexException, DropIndexFailureException}
 import java.util.concurrent.TimeUnit
 import java.io.{FileOutputStream, File}
-import org.neo4j.graphdb.factory.GraphDatabaseFactory
 import org.neo4j.graphdb.GraphDatabaseService
-import org.neo4j.test.TestGraphDatabaseFactory
 
 class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport {
 
@@ -95,7 +94,7 @@ class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistics
 
   private def createDbWithFailedIndex: GraphDatabaseService = {
     new File("target/test-data/impermanent-db").deleteAll()
-    var graph = new TestGraphDatabaseFactory().newEmbeddedDatabase("target/test-data/impermanent-db")
+    var graph = TestGraphDatabase.open( new File( "target/test-data/impermanent-db" ) )
     eengine = new ExecutionEngine(graph)
     execute("CREATE INDEX ON :Person(name)")
     execute("create (:Person {name:42})")
@@ -112,7 +111,7 @@ class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistics
     stream.write(65)
     stream.close()
 
-    graph = new TestGraphDatabaseFactory().newEmbeddedDatabase("target/test-data/impermanent-db")
+    graph = TestGraphDatabase.open( new File( "target/test-data/impermanent-db" ) )
     eengine = new ExecutionEngine(graph)
     graph
   }

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/ImpermanentGraphJavaDocTestBase.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/ImpermanentGraphJavaDocTestBase.java
@@ -20,13 +20,13 @@ package org.neo4j.examples;
 
 import org.junit.BeforeClass;
 
-import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.embedded.TestGraphDatabase;
 
 public class ImpermanentGraphJavaDocTestBase extends AbstractJavaDocTestBase
 {
     @BeforeClass
     public static void init()
     {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().newGraphDatabase();
+        db = TestGraphDatabase.openEphemeral();
     }
 }

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/JmxDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/JmxDocTest.java
@@ -23,9 +23,10 @@ import java.util.Date;
 import javax.management.ObjectName;
 
 import org.junit.Test;
+
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.jmx.JmxUtils;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -35,7 +36,7 @@ public class JmxDocTest
     @Test
     public void readJmxProperties()
     {
-        GraphDatabaseService graphDbService = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        GraphDatabaseService graphDbService = TestGraphDatabase.openEphemeral();
         try
         {
             Date startTime = getStartTimeFromManagementBean( graphDbService );

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/Neo4jBasicDocTest.java
@@ -22,11 +22,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -46,7 +46,7 @@ public class Neo4jBasicDocTest
     @Before
     public void prepareTestDatabase()
     {
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
     }
     // END SNIPPET: beforeTest
 
@@ -65,12 +65,11 @@ public class Neo4jBasicDocTest
     public void startWithConfiguration()
     {
         // START SNIPPET: startDbWithConfig
-        GraphDatabaseService db = new TestGraphDatabaseFactory()
-            .newImpermanentDatabaseBuilder()
-            .setConfig( GraphDatabaseSettings.pagecache_memory, "512M" )
-            .setConfig( GraphDatabaseSettings.string_block_size, "60" )
-            .setConfig( GraphDatabaseSettings.array_block_size, "300" )
-            .newGraphDatabase();
+        GraphDatabaseService db = TestGraphDatabase.buildEphemeral()
+                .withSetting( GraphDatabaseSettings.pagecache_memory, "512M" )
+                .withSetting( GraphDatabaseSettings.string_block_size, "60" )
+                .withSetting( GraphDatabaseSettings.array_block_size, "300" )
+                .open();
         // END SNIPPET: startDbWithConfig
         db.shutdown();
     }

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/PathFindingDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/PathFindingDocTest.java
@@ -41,14 +41,14 @@ import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 
 public class PathFindingDocTest
 {
     @ClassRule
-    public static EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( PathFindingDocTest.class );
+    public static TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
     private static GraphDatabaseService graphDb;
     private Transaction tx;
 
@@ -60,7 +60,7 @@ public class PathFindingDocTest
     @BeforeClass
     public static void startDb()
     {
-        graphDb = dbRule.getGraphDatabaseAPI();
+        graphDb = dbRule.get();
     }
 
     @Before

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/orderedpath/OrderedPathDocTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/orderedpath/OrderedPathDocTest.java
@@ -25,13 +25,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.JavaDocsGenerator;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.visualization.asciidoc.AsciidocHelper;
 
 import static org.junit.Assert.assertEquals;
@@ -55,7 +55,7 @@ public class OrderedPathDocTest
         {
             FileUtils.deleteRecursively( dir );
         }
-        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        db = TestGraphDatabase.openEphemeral();
         orderedPath = new OrderedPath( db );
         gen = new JavaDocsGenerator( "ordered-path-java", "dev" );
     }

--- a/community/embedded-examples/src/test/java/org/neo4j/examples/socnet/SocnetTest.java
+++ b/community/embedded-examples/src/test/java/org/neo4j/examples/socnet/SocnetTest.java
@@ -27,12 +27,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -50,7 +50,7 @@ public class SocnetTest
     @Before
     public void setup() throws Exception
     {
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
         try ( Transaction tx = graphDb.beginTx() )
         {
             Index<Node> index = graphDb.index().forNodes( "nodes" );

--- a/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
+++ b/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
@@ -32,12 +32,12 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +63,7 @@ public abstract class Neo4jAlgoTestCase
     @BeforeClass
     public static void setUpGraphDb() throws Exception
     {
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
         graph = new SimpleGraphBuilder( graphDb, MyRelTypes.R1 );
     }
 

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/ancestor/AncestorTestCase.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/ancestor/AncestorTestCase.java
@@ -28,6 +28,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -39,7 +40,6 @@ import org.neo4j.test.GraphDescription;
 import org.neo4j.test.GraphDescription.Graph;
 import org.neo4j.test.GraphHolder;
 import org.neo4j.test.TestData;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -138,7 +138,7 @@ public class AncestorTestCase implements GraphHolder
     @BeforeClass
     public static void before()
     {
-        gdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        gdb = TestGraphDatabase.openEphemeral();
     }
     @AfterClass
     public static void after()

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/PathExplosionIT.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/PathExplosionIT.java
@@ -25,6 +25,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphalgo.CostEvaluator;
 import org.neo4j.graphalgo.EstimateEvaluator;
 import org.neo4j.graphalgo.GraphAlgoFactory;
@@ -40,7 +41,6 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.lang.System.currentTimeMillis;
 
@@ -92,7 +92,7 @@ public class PathExplosionIT
             for ( int pathLength = MIN_PATH_LENGTH; pathLength <= MAX_PATH_LENGTH; pathLength++ )
             {
                 FileUtils.deleteRecursively( testDir.directory() );
-                GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+                GraphDatabaseService db = TestGraphDatabase.openEphemeral();
                 try
                 {
                     long[] startEndNodeIds = createPathGraphAndReturnStartAndEnd( pathLength, pathWidth, db );

--- a/community/graph-matching/src/test/java/examples/TestSiteIndexExamples.java
+++ b/community/graph-matching/src/test/java/examples/TestSiteIndexExamples.java
@@ -42,7 +42,7 @@ import org.neo4j.graphmatching.PatternNode;
 import org.neo4j.graphmatching.PatternRelationship;
 import org.neo4j.graphmatching.ValueMatcher;
 import org.neo4j.helpers.collection.IterableWrapper;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertTrue;
 public class TestSiteIndexExamples
 {
     @ClassRule
-    public static EmbeddedDatabaseRule graphDb = new EmbeddedDatabaseRule();
+    public static TestGraphDatabaseRule graphDb = TestGraphDatabaseRule.ephemeral();
 
     // START SNIPPET: findNodesWithRelationshipsTo
     public static Iterable<Node> findNodesWithRelationshipsTo(
@@ -182,7 +182,7 @@ public class TestSiteIndexExamples
                 return nodes;
             }
         } );
-        try ( Transaction tx = graphDb.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = graphDb.get().beginTx() )
         {
             assertEquals( 3, count( findNodesWithRelationshipsTo( type, nodes ) ) );
             tx.success();
@@ -239,7 +239,7 @@ public class TestSiteIndexExamples
         Set<String> expected = new HashSet<>( Arrays.asList( "Andy", "Bob" ) );
         Iterable<Node> friends = findFriendsSinceSpecifiedTimeInSpecifiedPlace( root, "Stockholm", 3 );
         
-        try ( Transaction transaction = graphDb.getGraphDatabaseService().beginTx() )
+        try ( Transaction transaction = graphDb.get().beginTx() )
         {
             for ( Node friend : friends )
             {
@@ -268,9 +268,9 @@ public class TestSiteIndexExamples
 
     private <T> T createGraph( GraphDefinition<T> definition )
     {
-        try ( Transaction tx = graphDb.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = graphDb.get().beginTx() )
         {
-            T result = definition.create( graphDb.getGraphDatabaseService() );
+            T result = definition.create( graphDb.get() );
             tx.success();
             return result;
         }

--- a/community/graphviz/src/test/java/org/neo4j/visualization/graphviz/TestGraphvizSubgraphOutput.java
+++ b/community/graphviz/src/test/java/org/neo4j/visualization/graphviz/TestGraphvizSubgraphOutput.java
@@ -30,8 +30,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 import org.neo4j.visualization.SubgraphMapper;
 
 import static java.util.Arrays.asList;
@@ -43,12 +42,13 @@ public class TestGraphvizSubgraphOutput
         KNOWS, WORKS_FOR
     }
 
-    public final @Rule DatabaseRule dbRule = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     @Test
     public void testSimpleGraph() throws Exception
     {
-        GraphDatabaseService neo = dbRule.getGraphDatabaseService();
+        GraphDatabaseService neo = dbRule.get();
         try ( Transaction tx = neo.beginTx() )
         {
             final Node emil = neo.createNode();

--- a/community/graphviz/src/test/java/org/neo4j/visualization/graphviz/TestNewGraphvizWriter.java
+++ b/community/graphviz/src/test/java/org/neo4j/visualization/graphviz/TestNewGraphvizWriter.java
@@ -34,8 +34,7 @@ import org.neo4j.graphdb.ReturnableEvaluator;
 import org.neo4j.graphdb.StopEvaluator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.Traverser.Order;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 import org.neo4j.walk.Walker;
 
 public class TestNewGraphvizWriter
@@ -45,12 +44,13 @@ public class TestNewGraphvizWriter
 		KNOWS, WORKS_FOR
 	}
 
-	public final @Rule DatabaseRule dbRule = new ImpermanentDatabaseRule();
+	@Rule
+	public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
 	@Test
 	public void testSimpleGraph() throws Exception
 	{
-	    GraphDatabaseService neo = dbRule.getGraphDatabaseService();
+	    GraphDatabaseService neo = dbRule.get();
 		try ( Transaction tx = neo.beginTx() )
 		{
 			final Node emil = neo.createNode();

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -44,7 +45,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.ImportTool.Options;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 
@@ -569,7 +569,7 @@ public class ImportToolDocIT
         printCommandToFile( arguments, realDir, "bad-duplicate-nodes-default.adoc" );
 
         // THEN
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( directory.absolutePath() );
+        GraphDatabaseService db = TestGraphDatabase.open( directory.directory() );
         try ( Transaction tx = db.beginTx();
               ResourceIterator<Node> nodes = db.findNodes( DynamicLabel.label( "Actor" ) ) )
         {
@@ -653,7 +653,7 @@ public class ImportToolDocIT
 
     private void verifyData()
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( directory.absolutePath() );
+        GraphDatabaseService db = TestGraphDatabase.open( directory.directory() );
         try ( Transaction tx = db.beginTx() )
         {
             int nodeCount = count( at( db ).getAllNodes() ), relationshipCount = 0, sequelCount = 0;

--- a/community/jmx/src/test/java/org/neo4j/jmx/DescriptionTest.java
+++ b/community/jmx/src/test/java/org/neo4j/jmx/DescriptionTest.java
@@ -28,10 +28,10 @@ import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.ObjectName;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.jmx.impl.JmxKernelExtension;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
 import static org.junit.Assert.assertEquals;
@@ -43,7 +43,7 @@ public class DescriptionTest
     @BeforeClass
     public static void startDb()
     {
-        graphdb = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().newGraphDatabase();
+        graphdb = TestGraphDatabase.openEphemeral();
     }
 
     @AfterClass

--- a/community/kernel/src/main/java/org/neo4j/embedded/GraphDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/embedded/GraphDatabase.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.event.KernelEventHandler;
+import org.neo4j.graphdb.event.TransactionEventHandler;
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+/**
+ * A running Neo4j graph database. Provides methods for controlling the database instance (e.g. shutdown,
+ * adding event handlers, etc), and also implements {@link GraphDatabaseService} to provides all the methods
+ * for working with the graph itself.
+ */
+public interface GraphDatabase extends GraphDatabaseService
+{
+    /**
+     * Start building a Graph Database.
+     *
+     * @return a builder for a {@link GraphDatabase}
+     */
+    static GraphDatabase.Builder build()
+    {
+        return new Builder();
+    }
+
+    /**
+     * Start a graph database by opening the specified filesystem directory containing the store.
+     *
+     * @param storeDir The filesystem location for the store, which will be created if necessary
+     * @return The running database
+     */
+    static GraphDatabase open( File storeDir )
+    {
+        return build().open( storeDir );
+    }
+
+    /**
+     * A builder for a {@link GraphDatabase}
+     */
+    class Builder extends GraphDatabaseBuilder<Builder,GraphDatabase>
+    {
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+
+        @Override
+        protected GraphDatabase newInstance( File storeDir, Map<String,String> params,
+                GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory )
+        {
+            return new GraphDatabaseImpl( facadeFactory, storeDir, params, dependencies );
+        }
+    }
+
+    /**
+     * Use this method to check if the database is currently in a usable state.
+     *
+     * @param timeout timeout (in milliseconds) to wait for the database to become available.
+     * If the database has been shut down {@code false} is returned immediately.
+     * @return the state of the database: {@code true} if it is available, otherwise {@code false}
+     */
+    @Override
+    boolean isAvailable( long timeout );
+
+    /**
+     * Shuts down Neo4j. After this method has been invoked, it's invalid to
+     * invoke any methods in the Neo4j API and all references to this instance
+     * of GraphDatabaseService should be discarded.
+     */
+    @Override
+    void shutdown();
+
+    /**
+     * Registers {@code handler} as a handler for transaction events which
+     * are generated from different places in the lifecycle of each
+     * transaction. To guarantee that the handler gets all events properly
+     * it shouldn't be registered when the application is running (i.e. in the
+     * middle of one or more transactions). If the specified handler instance
+     * has already been registered this method will do nothing.
+     *
+     * @param <T> the type of state object used in the handler, see more
+     * documentation about it at {@link TransactionEventHandler}.
+     * @param handler the handler to receive events about different states
+     * in transaction lifecycles.
+     * @return the handler passed in as the argument.
+     */
+    @Override
+    <T> TransactionEventHandler<T> registerTransactionEventHandler( TransactionEventHandler<T> handler );
+
+    /**
+     * Unregisters {@code handler} from the list of transaction event handlers.
+     * If {@code handler} hasn't been registered with
+     * {@link #registerTransactionEventHandler(TransactionEventHandler)} prior
+     * to calling this method an {@link IllegalStateException} will be thrown.
+     * After a successful call to this method the {@code handler} will no
+     * longer receive any transaction events.
+     *
+     * @param <T> the type of state object used in the handler, see more
+     * documentation about it at {@link TransactionEventHandler}.
+     * @param handler the handler to receive events about different states
+     * in transaction lifecycles.
+     * @return the handler passed in as the argument.
+     * @throws IllegalStateException if {@code handler} wasn't registered prior
+     * to calling this method.
+     */
+    @Override
+    <T> TransactionEventHandler<T> unregisterTransactionEventHandler( TransactionEventHandler<T> handler );
+
+    /**
+     * Registers {@code handler} as a handler for kernel events which
+     * are generated from different places in the lifecycle of the kernel.
+     * To guarantee proper behavior the handler should be registered right
+     * after the graph database has been started. If the specified handler
+     * instance has already been registered this method will do nothing.
+     *
+     * @param handler the handler to receive events about different states
+     * in the kernel lifecycle.
+     * @return the handler passed in as the argument.
+     */
+    @Override
+    KernelEventHandler registerKernelEventHandler( KernelEventHandler handler );
+
+    /**
+     * Unregisters {@code handler} from the list of kernel event handlers.
+     * If {@code handler} hasn't been registered with
+     * {@link #registerKernelEventHandler(KernelEventHandler)} prior to calling
+     * this method an {@link IllegalStateException} will be thrown.
+     * After a successful call to this method the {@code handler} will no
+     * longer receive any kernel events.
+     *
+     * @param handler the handler to receive events about different states
+     * in the kernel lifecycle.
+     * @return the handler passed in as the argument.
+     * @throws IllegalStateException if {@code handler} wasn't registered prior
+     * to calling this method.
+     */
+    @Override
+    KernelEventHandler unregisterKernelEventHandler( KernelEventHandler handler );
+}

--- a/community/kernel/src/main/java/org/neo4j/embedded/GraphDatabaseBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/embedded/GraphDatabaseBuilder.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Service;
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+
+/**
+ * A builder for a GraphDatabase.
+ *
+ * @param <BUILDER> The concrete type of the builder
+ * @param <GRAPHDB> The concrete type of the GraphDatabase being built
+ */
+abstract class GraphDatabaseBuilder<BUILDER extends GraphDatabaseBuilder<BUILDER,GRAPHDB>, GRAPHDB extends GraphDatabase>
+{
+    private LogProvider logProvider;
+    private final Map<String,String> params = new HashMap<>();
+    protected List<KernelExtensionFactory<?>> kernelExtensions = new ArrayList<>();
+
+    protected GraphDatabaseBuilder()
+    {
+        withLogProvider( NullLogProvider.getInstance() );
+        params.put( "ephemeral", "false" );
+        for ( KernelExtensionFactory factory : Service.load( KernelExtensionFactory.class ) )
+        {
+            kernelExtensions.add( factory );
+        }
+    }
+
+    protected abstract BUILDER self();
+
+    protected abstract GRAPHDB newInstance( File storeDir, Map<String,String> params,
+            GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory );
+
+    /**
+     * Set an internal parameter. Use of this method is not recommended.
+     *
+     * @param key the parameter key
+     * @param value the parameter value
+     * @return this builder
+     */
+    public BUILDER withParam( String key, String value )
+    {
+        this.params.put( key, value );
+        return self();
+    }
+
+    /**
+     * Set internal parameters. Use of this method is not recommended.
+     *
+     * @param params parameters to add
+     * @return this builder
+     */
+    public BUILDER withParams( Map<String,String> params )
+    {
+        this.params.putAll( params );
+        return self();
+    }
+
+    /**
+     * Configure a database setting.
+     *
+     * @param setting the setting instance to be set
+     * @param value the setting value
+     * @return this builder
+     */
+    public BUILDER withSetting( Setting setting, String value )
+    {
+        this.params.put( setting.name(), value );
+        return self();
+    }
+
+    /**
+     * Specify a {@link LogProvider} that will be used for logging within the graph database.
+     *
+     * @param logProvider a {@link LogProvider} to use for logging
+     * @return this builder
+     */
+    public BUILDER withLogProvider( LogProvider logProvider )
+    {
+        this.logProvider = logProvider;
+        return self();
+    }
+
+    /**
+     * Allow this graph database instance to upgrade the store if required.
+     *
+     * @return this builder
+     */
+    public BUILDER allowStoreUpgrade()
+    {
+        params.put( GraphDatabaseSettings.allow_store_upgrade.name(), "true" );
+        return self();
+    }
+
+    /**
+     * Open this graph database in read-only mode, allowing only read operations.
+     *
+     * @return this builder
+     */
+    public BUILDER readOnly()
+    {
+        params.put( GraphDatabaseSettings.read_only.name(), "true" );
+        return self();
+    }
+
+    /**
+     * Starts the graph database.
+     *
+     * @param storeDir The filesystem location for the store, which will be created if necessary
+     * @return The running database
+     */
+    public GRAPHDB open( File storeDir )
+    {
+        return newInstance( storeDir, params, createDependencies(), createFacadeFactory() );
+    }
+
+    protected GraphDatabaseDependencies createDependencies()
+    {
+        return GraphDatabaseDependencies.newDependencies()
+                .userLogProvider( logProvider )
+                .kernelExtensions( kernelExtensions )
+                .settingsClasses( GraphDatabaseSettings.class );
+    }
+
+    protected GraphDatabaseFacadeFactory createFacadeFactory()
+    {
+        return new CommunityFacadeFactory();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/embedded/GraphDatabaseImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/embedded/GraphDatabaseImpl.java
@@ -17,21 +17,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.test;
+package org.neo4j.embedded;
 
-import org.neo4j.embedded.TestGraphDatabase;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import java.io.File;
+import java.util.Map;
 
-/**
- * @deprecated use {@link TestGraphDatabase} instead
- */
-@Deprecated
-public class TestGraphDatabaseBuilder extends GraphDatabaseBuilder
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+class GraphDatabaseImpl extends GraphDatabaseFacade implements GraphDatabase
 {
-    public TestGraphDatabaseBuilder( DatabaseCreator creator )
+    GraphDatabaseImpl(
+            GraphDatabaseFacadeFactory facadeFactory,
+            File storeDir,
+            Map<String,String> params,
+            GraphDatabaseFacadeFactory.Dependencies dependencies )
     {
-        super( creator );
-        super.config.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
+        // TODO: collapse FacadeFactory into this implementation
+        facadeFactory.newFacade( storeDir, params, dependencies, this );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -21,29 +21,18 @@ package org.neo4j.graphdb;
 
 import java.util.Map;
 
+import org.neo4j.embedded.GraphDatabase;
 import org.neo4j.graphdb.event.KernelEventHandler;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
 import org.neo4j.graphdb.traversal.TraversalDescription;
-import org.neo4j.kernel.EmbeddedGraphDatabase;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 /**
- * The main access point to a running Neo4j instance. The most common
- * implementation is the {@link EmbeddedGraphDatabase} class, which is used to
- * embed Neo4j in an application. Typically, you would create an
- * <code>EmbeddedGraphDatabase</code> instance as follows:
- * <pre>
- * <code>GraphDatabaseService graphDb = new GraphDatabaseFactory().newEmbeddedDatabase( "var/graphDb" );
- * // ... use Neo4j
- * graphDb.{@link #shutdown() shutdown()};</code>
- * </pre>
- * <p>
- * GraphDatabaseService provides operations to {@link #createNode() create
- * nodes}, {@link #getNodeById(long) get nodes given an id} and ultimately {@link #shutdown()
- * shutdown Neo4j}.
+ * The main access point for working with a Graph Database. Most implementations will be
+ * based on {@link GraphDatabase}, which is used to embed Neo4j in an application.
  * <p>
  * Please note that all operations on the graph must be invoked in a
  * {@link Transaction transactional context}. Failure to do so will result in a
@@ -189,19 +178,15 @@ public interface GraphDatabaseService
     Iterable<RelationshipType> getRelationshipTypes();
 
     /**
-     * Use this method to check if the database is currently in a usable state.
-     * 
-     * @param timeout timeout (in milliseconds) to wait for the database to become available.
-     *   If the database has been shut down {@code false} is returned immediately.
-     * @return the state of the database: {@code true} if it is available, otherwise {@code false}
+     * @deprecated use {@link GraphDatabase#isAvailable(long)} instead
      */
+    @Deprecated
     boolean isAvailable( long timeout );
 
     /**
-     * Shuts down Neo4j. After this method has been invoked, it's invalid to
-     * invoke any methods in the Neo4j API and all references to this instance
-     * of GraphDatabaseService should be discarded.
+     * @deprecated use {@link GraphDatabase#shutdown()} instead
      */
+    @Deprecated
     void shutdown();
 
     /**
@@ -241,66 +226,27 @@ public interface GraphDatabaseService
     Result execute( String query, Map<String,Object> parameters ) throws QueryExecutionException;
 
     /**
-     * Registers {@code handler} as a handler for transaction events which
-     * are generated from different places in the lifecycle of each
-     * transaction. To guarantee that the handler gets all events properly
-     * it shouldn't be registered when the application is running (i.e. in the
-     * middle of one or more transactions). If the specified handler instance
-     * has already been registered this method will do nothing.
-     *
-     * @param <T>     the type of state object used in the handler, see more
-     *                documentation about it at {@link TransactionEventHandler}.
-     * @param handler the handler to receive events about different states
-     *                in transaction lifecycles.
-     * @return the handler passed in as the argument.
+     * @deprecated use {@link GraphDatabase#registerTransactionEventHandler(TransactionEventHandler)} instead
      */
+    @Deprecated
     <T> TransactionEventHandler<T> registerTransactionEventHandler( TransactionEventHandler<T> handler );
 
     /**
-     * Unregisters {@code handler} from the list of transaction event handlers.
-     * If {@code handler} hasn't been registered with
-     * {@link #registerTransactionEventHandler(TransactionEventHandler)} prior
-     * to calling this method an {@link IllegalStateException} will be thrown.
-     * After a successful call to this method the {@code handler} will no
-     * longer receive any transaction events.
-     *
-     * @param <T>     the type of state object used in the handler, see more
-     *                documentation about it at {@link TransactionEventHandler}.
-     * @param handler the handler to receive events about different states
-     *                in transaction lifecycles.
-     * @return the handler passed in as the argument.
-     * @throws IllegalStateException if {@code handler} wasn't registered prior
-     *                               to calling this method.
+     * @deprecated use {@link GraphDatabase#unregisterTransactionEventHandler(TransactionEventHandler)} instead
      */
+    @Deprecated
     <T> TransactionEventHandler<T> unregisterTransactionEventHandler( TransactionEventHandler<T> handler );
 
     /**
-     * Registers {@code handler} as a handler for kernel events which
-     * are generated from different places in the lifecycle of the kernel.
-     * To guarantee proper behavior the handler should be registered right
-     * after the graph database has been started. If the specified handler
-     * instance has already been registered this method will do nothing.
-     *
-     * @param handler the handler to receive events about different states
-     *                in the kernel lifecycle.
-     * @return the handler passed in as the argument.
+     * @deprecated use {@link GraphDatabase#registerKernelEventHandler(KernelEventHandler)} instead
      */
+    @Deprecated
     KernelEventHandler registerKernelEventHandler( KernelEventHandler handler );
 
     /**
-     * Unregisters {@code handler} from the list of kernel event handlers.
-     * If {@code handler} hasn't been registered with
-     * {@link #registerKernelEventHandler(KernelEventHandler)} prior to calling
-     * this method an {@link IllegalStateException} will be thrown.
-     * After a successful call to this method the {@code handler} will no
-     * longer receive any kernel events.
-     *
-     * @param handler the handler to receive events about different states
-     *                in the kernel lifecycle.
-     * @return the handler passed in as the argument.
-     * @throws IllegalStateException if {@code handler} wasn't registered prior
-     *                               to calling this method.
+     * @deprecated use {@link GraphDatabase#unregisterKernelEventHandler(KernelEventHandler)} instead
      */
+    @Deprecated
     KernelEventHandler unregisterKernelEventHandler( KernelEventHandler handler );
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.embedded.GraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
@@ -34,11 +35,9 @@ import org.neo4j.logging.LogProvider;
 import static java.util.Arrays.asList;
 
 /**
- * Creates a {@link org.neo4j.graphdb.GraphDatabaseService}.
- * <p>
- * Use {@link #newEmbeddedDatabase(File)} or
- * {@link #newEmbeddedDatabaseBuilder(File)} to create a database instance.
+ * @deprecated Use {@link GraphDatabase} instead
  */
+@Deprecated
 public class GraphDatabaseFactory
 {
     private final GraphDatabaseFactoryState state;
@@ -64,7 +63,7 @@ public class GraphDatabaseFactory
     }
 
     /**
-     * @deprecated use {@link #newEmbeddedDatabase(File)} instead.
+     * @deprecated use {@link GraphDatabase#open(File)} instead
      * @param storeDir the location of the database
      * @return the database
      */
@@ -74,13 +73,17 @@ public class GraphDatabaseFactory
         return newEmbeddedDatabase( new File( storeDir ) );
     }
 
+    /**
+     * @deprecated use {@link GraphDatabase#open(File)} instead
+     */
+    @Deprecated
     public GraphDatabaseService newEmbeddedDatabase( File storeDir )
     {
         return newEmbeddedDatabaseBuilder( storeDir ).newGraphDatabase();
     }
 
     /**
-     * @deprecated use {@link #newEmbeddedDatabaseBuilder(File)} instead
+     * @deprecated use {@link GraphDatabase#build()} instead
      * @param storeDir the location of the database
      * @return a builder which is used to configure and start a database
      */
@@ -90,6 +93,10 @@ public class GraphDatabaseFactory
         return newEmbeddedDatabaseBuilder( new File( storeDir ) );
     }
 
+    /**
+     * @deprecated use {@link GraphDatabase#build()} instead
+     */
+    @Deprecated
     public GraphDatabaseBuilder newEmbeddedDatabaseBuilder( File storeDir )
     {
         final GraphDatabaseFactoryState state = getStateCopy();

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactoryState.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.embedded.GraphDatabase;
 import org.neo4j.helpers.Service;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
@@ -33,6 +34,10 @@ import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.kernel.GraphDatabaseDependencies.newDependencies;
 
+/**
+ * Use {@link GraphDatabase#build()} to construct Graph Databases and set state
+ */
+@Deprecated
 public class GraphDatabaseFactoryState
 {
     private final List<Class<?>> settingsClasses;

--- a/community/kernel/src/main/java/org/neo4j/helpers/collection/MapUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/collection/MapUtil.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -467,4 +468,20 @@ public abstract class MapUtil
         }
     }
 
+    public static Map<String,String> loadPropertiesFromURL( URL url ) throws IOException
+    {
+        Properties props = new Properties();
+        try ( InputStream stream = url.openStream() )
+        {
+            props.load( stream );
+        }
+        Map<String,String> stringMap = new HashMap<>();
+        for ( Map.Entry<Object,Object> entry : props.entrySet() )
+        {
+            String key = (String) entry.getKey();
+            String value = (String) entry.getValue();
+            stringMap.put( key, value );
+        }
+        return stringMap;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseAPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseAPI.java
@@ -38,9 +38,11 @@ public interface GraphDatabaseAPI extends GraphDatabaseService
      * Look up database components for direct access.
      * Usage of this method is generally an indication of architectural error.
      */
+    @Deprecated
     DependencyResolver getDependencyResolver();
 
     /** Provides the unique id assigned to this database. */
+    @Deprecated
     StoreId storeId();
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -50,6 +50,7 @@ import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.helpers.collection.ResourceClosingIterator;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.IdType;
@@ -124,6 +125,7 @@ public class GraphDatabaseFacade
     private long transactionStartTimeout;
     private DependencyResolver dependencies;
     private Supplier<StoreId> storeId;
+    protected FileSystemAbstraction fileSystem;
     protected File storeDir;
 
     public PlatformModule platformModule;
@@ -161,6 +163,7 @@ public class GraphDatabaseFacade
         this.transactionStartTimeout = editionModule.transactionStartTimeout;
         this.dependencies = platformModule.dependencies;
         this.storeId = dataSourceModule.storeId;
+        this.fileSystem = platformModule.fileSystem;
         this.storeDir = platformModule.storeDir;
 
         initialized = true;

--- a/community/kernel/src/test/java/examples/DeadlockDocTest.java
+++ b/community/kernel/src/test/java/examples/DeadlockDocTest.java
@@ -30,12 +30,12 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.helpers.TransactionTemplate;
 import org.neo4j.kernel.DeadlockDetectedException;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 public class DeadlockDocTest
 {
     @Rule
-    public EmbeddedDatabaseRule rule = new EmbeddedDatabaseRule(  );
+    public TestGraphDatabaseRule rule = TestGraphDatabaseRule.ephemeral();
 
     @Test
     public void transactionWithRetries() throws InterruptedException
@@ -46,7 +46,7 @@ public class DeadlockDocTest
     @Test
     public void transactionWithTemplate() throws InterruptedException
     {
-        GraphDatabaseService graphDatabaseService = rule.getGraphDatabaseService();
+        GraphDatabaseService graphDatabaseService = rule.get();
 
         // START SNIPPET: template
         TransactionTemplate template = new TransactionTemplate(  ).retries( 5 ).backoff( 3, TimeUnit.SECONDS );
@@ -67,7 +67,7 @@ public class DeadlockDocTest
 
     private Object transactionWithRetry()
     {
-        GraphDatabaseService graphDatabaseService = rule.getGraphDatabaseService();
+        GraphDatabaseService graphDatabaseService = rule.get();
 
         // START SNIPPET: retry
         Throwable txEx = null;

--- a/community/kernel/src/test/java/org/neo4j/embedded/TestGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/embedded/TestGraphDatabase.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+/**
+ * A running Neo4j graph database, with additional methods exposed for test purposes.
+ */
+public interface TestGraphDatabase extends GraphDatabase
+{
+    /**
+     * Start building a test Graph Database.
+     *
+     * @return a builder for a test {@link TestGraphDatabase}
+     */
+    static TestGraphDatabase.Builder build()
+    {
+        return new Builder();
+    }
+
+    /**
+     * Start a graph database by opening the specified filesystem directory containing the store.
+     *
+     * @param storeDir The filesystem location for the store, which will be created if necessary
+     * @return The running database
+     */
+    static TestGraphDatabase open( File storeDir )
+    {
+        return build().open( storeDir );
+    }
+
+    /**
+     * Start building a test Graph Database, using an ephemeral filesystem.
+     *
+     * @return a builder for an ephemeral {@link TestGraphDatabase}
+     */
+    static TestGraphDatabase.EphemeralBuilder buildEphemeral()
+    {
+        return new EphemeralBuilder();
+    }
+
+    /**
+     * Start a graph database using an ephemeral filesystem.
+     *
+     * @return a builder for an ephemeral {@link TestGraphDatabase}
+     */
+    static TestGraphDatabase openEphemeral()
+    {
+        return buildEphemeral().open();
+    }
+
+    class Builder extends TestGraphDatabaseBuilder<Builder,TestGraphDatabase>
+    {
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+
+        @Override
+        protected TestGraphDatabase newInstance( File storeDir, Map<String,String> params,
+                GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory )
+        {
+            return new TestGraphDatabaseImpl( facadeFactory, storeDir, params, dependencies );
+        }
+    }
+
+    class EphemeralBuilder extends TestGraphDatabaseBuilder<EphemeralBuilder,TestGraphDatabase>
+    {
+        private static final File PATH = new File( "target/test-data/impermanent-db" );
+
+        EphemeralBuilder()
+        {
+            withParam( "ephemeral", "true" );
+            withFileSystem( new EphemeralFileSystemAbstraction() );
+        }
+
+        public TestGraphDatabase open()
+        {
+            return open( PATH );
+        }
+
+        @Override
+        protected EphemeralBuilder self()
+        {
+            return this;
+        }
+
+        @Override
+        protected TestGraphDatabase newInstance( File storeDir, Map<String,String> params,
+                GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory )
+        {
+            return new TestGraphDatabaseImpl( facadeFactory, storeDir, params, dependencies );
+        }
+    }
+
+    FileSystemAbstraction fileSystem();
+
+    File storeDir();
+
+    DependencyResolver getDependencyResolver();
+
+    /**
+     * @deprecated Method included for transitional purpose only - prefer not using this method
+     */
+    @Deprecated
+    GraphDatabaseAPI getGraphDatabaseAPI();
+}

--- a/community/kernel/src/test/java/org/neo4j/embedded/TestGraphDatabaseBuilder.java
+++ b/community/kernel/src/test/java/org/neo4j/embedded/TestGraphDatabaseBuilder.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.factory.CommunityEditionModule;
+import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.logging.AbstractLogService;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.LogProvider;
+
+/**
+ * A builder for a TestGraphDatabase.
+ *
+ * @param <BUILDER> The concrete type of the builder
+ * @param <GRAPHDB> The concrete type of the GraphDatabase being built
+ */
+abstract class TestGraphDatabaseBuilder<BUILDER extends TestGraphDatabaseBuilder<BUILDER,GRAPHDB>, GRAPHDB extends TestGraphDatabase>
+        extends GraphDatabaseBuilder<BUILDER,GRAPHDB>
+{
+    protected FileSystemAbstraction fs;
+    protected LogProvider internalLogProvider;
+    protected Monitors monitors;
+    protected IdGeneratorFactory idFactory;
+
+    TestGraphDatabaseBuilder()
+    {
+        withParam( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
+    }
+
+    protected abstract BUILDER self();
+
+    public BUILDER withFileSystem( FileSystemAbstraction fs )
+    {
+        this.fs = fs;
+        return self();
+    }
+
+    public BUILDER withInternalLogProvider( LogProvider logProvider )
+    {
+        this.internalLogProvider = logProvider;
+        return self();
+    }
+
+    public BUILDER withMonitors( Monitors monitors )
+    {
+        this.monitors = monitors;
+        return self();
+    }
+
+    public BUILDER addKernelExtension( KernelExtensionFactory<?> kernelExtension )
+    {
+        this.kernelExtensions.add( kernelExtension );
+        return self();
+    }
+
+    public BUILDER addKernelExtensions( Collection<KernelExtensionFactory<?>> kernelExtensions )
+    {
+        this.kernelExtensions.addAll( kernelExtensions );
+        return self();
+    }
+
+    public BUILDER withKernelExtensions( Collection<KernelExtensionFactory<?>> kernelExtensions )
+    {
+        this.kernelExtensions.clear();
+        return addKernelExtensions( kernelExtensions );
+    }
+
+    public BUILDER withIdGeneratorFactory( IdGeneratorFactory idFactory )
+    {
+        this.idFactory = idFactory;
+        return self();
+    }
+
+    @Override
+    protected GraphDatabaseDependencies createDependencies()
+    {
+        return super.createDependencies().monitors( monitors );
+    }
+
+    @Override
+    protected GraphDatabaseFacadeFactory createFacadeFactory()
+    {
+        // TODO: replace overriding with dependency injection
+        return new CommunityFacadeFactory()
+        {
+            @Override
+            protected PlatformModule createPlatform( File storeDir, Map<String,String> params,
+                    Dependencies dependencies, GraphDatabaseFacade graphDatabaseFacade )
+            {
+                return new PlatformModule( storeDir, params, dependencies, graphDatabaseFacade )
+                {
+                    @Override
+                    protected FileSystemAbstraction createFileSystemAbstraction()
+                    {
+                        return (fs != null) ? fs : super.createFileSystemAbstraction();
+                    }
+
+                    @Override
+                    protected LogService createLogService( final LogProvider userLogProvider )
+                    {
+                        if ( internalLogProvider == null )
+                        {
+                            return super.createLogService( userLogProvider );
+                        }
+
+                        return new AbstractLogService()
+                        {
+                            @Override
+                            public LogProvider getUserLogProvider()
+                            {
+                                return userLogProvider;
+                            }
+
+                            @Override
+                            public LogProvider getInternalLogProvider()
+                            {
+                                return internalLogProvider;
+                            }
+                        };
+                    }
+                };
+            }
+
+            @Override
+            protected EditionModule createEdition( PlatformModule platformModule )
+            {
+                return new CommunityEditionModule( platformModule )
+                {
+                    @Override
+                    protected IdGeneratorFactory createIdGeneratorFactory( FileSystemAbstraction fs )
+                    {
+                        return (idFactory != null) ? idFactory : super.createIdGeneratorFactory( fs );
+                    }
+                };
+            }
+        };
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/embedded/TestGraphDatabaseImpl.java
+++ b/community/kernel/src/test/java/org/neo4j/embedded/TestGraphDatabaseImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+class TestGraphDatabaseImpl extends GraphDatabaseImpl implements TestGraphDatabase
+{
+    TestGraphDatabaseImpl(
+            GraphDatabaseFacadeFactory facadeFactory,
+            File storeDir, Map<String,String> params,
+            GraphDatabaseFacadeFactory.Dependencies dependencies )
+    {
+        super( facadeFactory, storeDir, params, dependencies );
+    }
+
+    @Override
+    public FileSystemAbstraction fileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    public File storeDir()
+    {
+        return storeDir;
+    }
+
+    @Override
+    public GraphDatabaseAPI getGraphDatabaseAPI()
+    {
+        return this;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/graphdb/AbstractMandatoryTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/AbstractMandatoryTransactionsTest.java
@@ -22,18 +22,18 @@ package org.neo4j.graphdb;
 import org.junit.Rule;
 
 import org.neo4j.function.Consumer;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.fail;
 
 public abstract class AbstractMandatoryTransactionsTest<T>
 {
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule();
+    public TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     public T obtainEntity()
     {
-        GraphDatabaseService graphDatabaseService = dbRule.getGraphDatabaseService();
+        GraphDatabaseService graphDatabaseService = dbRule.get();
 
         try ( Transaction tx = graphDatabaseService.beginTx() )
         {
@@ -46,7 +46,7 @@ public abstract class AbstractMandatoryTransactionsTest<T>
 
     public void obtainEntityInTerminatedTransaction( Consumer<T> f )
     {
-        GraphDatabaseService graphDatabaseService = dbRule.getGraphDatabaseService();
+        GraphDatabaseService graphDatabaseService = dbRule.get();
 
         try ( Transaction tx = graphDatabaseService.beginTx() )
         {

--- a/community/kernel/src/test/java/org/neo4j/graphdb/CreateAndDeleteNodesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/CreateAndDeleteNodesIT.java
@@ -22,13 +22,12 @@ package org.neo4j.graphdb;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 public class CreateAndDeleteNodesIT
 {
-
-    public @Rule ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
+    public @Rule TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     enum RelTypes implements RelationshipType
     {
@@ -39,7 +38,7 @@ public class CreateAndDeleteNodesIT
     public void addingALabelUsingAValidIdentifierShouldSucceed() throws Exception
     {
         // Given
-        GraphDatabaseService dataBase = dbRule.getGraphDatabaseService();
+        GraphDatabaseService dataBase = dbRule.get();
         Node myNode;
 
         // When

--- a/community/kernel/src/test/java/org/neo4j/graphdb/DenseNodeIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/DenseNodeIT.java
@@ -22,26 +22,24 @@ package org.neo4j.graphdb;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.helpers.collection.Iterables.single;
 
 public class DenseNodeIT
 {
-    @Rule
-    public ImpermanentDatabaseRule databaseRule = new ImpermanentDatabaseRule();
+    @Rule public TestGraphDatabaseRule databaseRule = TestGraphDatabaseRule.ephemeral();
 
     @Test
     public void testBringingNodeOverDenseThresholdIsConsistent() throws Exception
     {
         // GIVEN
-        GraphDatabaseService db = databaseRule.getGraphDatabaseService();
-
+        GraphDatabaseService db = databaseRule.get();
 
         Node root;
         try( Transaction tx = db.beginTx() )
@@ -84,7 +82,7 @@ public class DenseNodeIT
     public void deletingRelationshipsFromDenseNodeIsConsistent() throws Exception
     {
         // GIVEN
-        GraphDatabaseService db = databaseRule.getGraphDatabaseService();
+        GraphDatabaseService db = databaseRule.get();
 
         Node root;
         try( Transaction tx = db.beginTx() )
@@ -118,7 +116,7 @@ public class DenseNodeIT
     public void movingBilaterallyOfTheDenseNodeThresholdIsConsistent() throws Exception
     {
         // GIVEN
-        GraphDatabaseService db = databaseRule.getGraphDatabaseService();
+        GraphDatabaseService db = databaseRule.get();
 
         Node root;
         // WHEN
@@ -149,7 +147,7 @@ public class DenseNodeIT
     public void testBringingTwoConnectedNodesOverDenseThresholdIsConsistent() throws Exception
     {
         // GIVEN
-        GraphDatabaseService db = databaseRule.getGraphDatabaseService();
+        GraphDatabaseService db = databaseRule.get();
 
         Node source;
         Node sink;
@@ -214,7 +212,7 @@ public class DenseNodeIT
         try ( Transaction tx = databaseRule.beginTx() )
         {
             node = databaseRule.createNode();
-            createRelationshipsBetweenNodes( node, databaseRule.createNode(), denseNodeThreshold( databaseRule ) + 1 );
+            createRelationshipsBetweenNodes( node, databaseRule.createNode(), denseNodeThreshold( databaseRule.get() ) + 1 );
             tx.success();
         }
         try ( Transaction tx = databaseRule.beginTx() )
@@ -239,7 +237,7 @@ public class DenseNodeIT
         }
     }
 
-    private int denseNodeThreshold( GraphDatabaseAPI db )
+    private int denseNodeThreshold( TestGraphDatabase db )
     {
         return db.getDependencyResolver()
                 .resolveDependency( Config.class ).get( GraphDatabaseSettings.dense_node_threshold );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/FirstStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/FirstStartupIT.java
@@ -22,8 +22,9 @@ package org.neo4j.graphdb;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
@@ -38,8 +39,7 @@ public class FirstStartupIT
     public void shouldBeEmptyWhenFirstStarted() throws Exception
     {
         // When
-        String storeDir = testDir.absolutePath();
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+        GraphDatabase db = TestGraphDatabase.open( testDir.graphDbDir() );
 
         // Then
         try(Transaction ignore = db.beginTx())

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
@@ -29,12 +29,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.test.CleanupRule;
 import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -45,7 +46,7 @@ public class GraphDatabaseServiceTest
     public void givenShutdownDatabaseWhenBeginTxThenExceptionIsThrown() throws Exception
     {
         // Given
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        final GraphDatabase db = TestGraphDatabase.openEphemeral();
 
         db.shutdown();
 
@@ -67,7 +68,7 @@ public class GraphDatabaseServiceTest
     public void givenDatabaseAndStartedTxWhenShutdownThenWaitForTxToFinish() throws Exception
     {
         // Given
-        final GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        final GraphDatabase db = TestGraphDatabase.openEphemeral();
 
         // When
         final CountDownLatch started = new CountDownLatch( 1 );
@@ -107,7 +108,7 @@ public class GraphDatabaseServiceTest
     public void terminateTransactionThrowsExceptionOnNextOperation() throws Exception
     {
         // Given
-        final GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        final GraphDatabase db = TestGraphDatabase.openEphemeral();
 
         try ( Transaction tx = db.beginTx() )
         {
@@ -129,7 +130,7 @@ public class GraphDatabaseServiceTest
     public void terminateNestedTransactionThrowsExceptionOnNextOperation() throws Exception
     {
         // Given
-        final GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        final GraphDatabase db = TestGraphDatabase.openEphemeral();
 
         try ( Transaction tx = db.beginTx() )
         {
@@ -154,7 +155,7 @@ public class GraphDatabaseServiceTest
     public void terminateNestedTransactionThrowsExceptionOnNextNestedOperation() throws Exception
     {
         // Given
-        final GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        final GraphDatabase db = TestGraphDatabase.openEphemeral();
 
         try ( Transaction tx = db.beginTx() )
         {
@@ -179,7 +180,7 @@ public class GraphDatabaseServiceTest
     public void givenDatabaseAndStartedTxWhenShutdownAndStartNewTxThenBeginTxTimesOut() throws Exception
     {
         // Given
-        final GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        final GraphDatabase db = TestGraphDatabase.openEphemeral();
 
         // When
         final CountDownLatch shutdown = new CountDownLatch( 1 );
@@ -254,7 +255,7 @@ public class GraphDatabaseServiceTest
         // GIVEN a database with a couple of entities:
         // (n1) --> (r1) --> (r2) --> (r3)
         // (n2)
-        GraphDatabaseService db = cleanup.add( new TestGraphDatabaseFactory().newImpermanentDatabase() );
+        GraphDatabaseService db = cleanup.add( TestGraphDatabase.openEphemeral() );
         Node n1 = createNode( db );
         Node n2 = createNode( db );
         Relationship r3 = createRelationship( n1 );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
@@ -21,22 +21,23 @@ package org.neo4j.graphdb;
 
 import org.junit.Rule;
 import org.junit.Test;
+
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -68,7 +69,7 @@ public class IndexingAcceptanceTest
     public void shouldInterpretPropertyAsChangedEvenIfPropertyMovesFromOneRecordToAnother() throws Exception
     {
         // GIVEN
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseAPI();
+        GraphDatabaseService beansAPI = dbRule.get();
         long smallValue = 10L, bigValue = 1L << 62;
         Node myNode;
         {
@@ -112,7 +113,7 @@ public class IndexingAcceptanceTest
     public void shouldUseDynamicPropertiesToIndexANodeWhenAddedAlongsideExistingPropertiesInASeparateTransaction() throws Exception
     {
         // Given
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseAPI();
+        GraphDatabaseService beansAPI = dbRule.get();
 
         // When
         long id;
@@ -160,7 +161,7 @@ public class IndexingAcceptanceTest
     public void searchingForNodeByPropertyShouldWorkWithoutIndex() throws Exception
     {
         // Given
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
+        GraphDatabaseService beansAPI = dbRule.get();
         Node myNode = createNode( beansAPI, map( "name", "Hawking" ), LABEL1 );
 
         // When
@@ -171,7 +172,7 @@ public class IndexingAcceptanceTest
     public void searchingUsesIndexWhenItExists() throws Exception
     {
         // Given
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
+        GraphDatabaseService beansAPI = dbRule.get();
         Node myNode = createNode( beansAPI, map( "name", "Hawking" ), LABEL1 );
         Neo4jMatchers.createIndex( beansAPI, LABEL1, "name" );
 
@@ -183,7 +184,7 @@ public class IndexingAcceptanceTest
     public void shouldCorrectlyUpdateIndexesWhenChangingLabelsAndPropertyAtTheSameTime() throws Exception
     {
         // Given
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
+        GraphDatabaseService beansAPI = dbRule.get();
         Node myNode = createNode( beansAPI, map( "name", "Hawking" ), LABEL1, LABEL2 );
         Neo4jMatchers.createIndex( beansAPI, LABEL1, "name" );
         Neo4jMatchers.createIndex( beansAPI, LABEL2, "name" );
@@ -216,7 +217,7 @@ public class IndexingAcceptanceTest
     public void shouldCorrectlyUpdateIndexesWhenChangingLabelsAndPropertyMultipleTimesAllAtOnce() throws Exception
     {
         // Given
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
+        GraphDatabaseService beansAPI = dbRule.get();
         Node myNode = createNode( beansAPI, map( "name", "Hawking" ), LABEL1, LABEL2 );
         Neo4jMatchers.createIndex( beansAPI, LABEL1, "name" );
         Neo4jMatchers.createIndex( beansAPI, LABEL2, "name" );
@@ -253,7 +254,7 @@ public class IndexingAcceptanceTest
     public void searchingByLabelAndPropertyReturnsEmptyWhenMissingLabelOrProperty() throws Exception
     {
         // Given
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
+        GraphDatabaseService beansAPI = dbRule.get();
 
         // When/Then
         assertThat( findNodesByLabelAndProperty( LABEL1, "name", "Hawking", beansAPI ), isEmpty() );
@@ -263,7 +264,7 @@ public class IndexingAcceptanceTest
     public void shouldSeeIndexUpdatesWhenQueryingOutsideTransaction() throws Exception
     {
         // GIVEN
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
+        GraphDatabaseService beansAPI = dbRule.get();
         Neo4jMatchers.createIndex( beansAPI, LABEL1, "name" );
         Node firstNode = createNode( beansAPI, map( "name", "Mattias" ), LABEL1 );
 
@@ -277,7 +278,7 @@ public class IndexingAcceptanceTest
     public void createdNodeShouldShowUpWithinTransaction() throws Exception
     {
         // GIVEN
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
+        GraphDatabaseService beansAPI = dbRule.get();
         Neo4jMatchers.createIndex( beansAPI, LABEL1, "name" );
 
         // WHEN
@@ -299,7 +300,7 @@ public class IndexingAcceptanceTest
     public void deletedNodeShouldShowUpWithinTransaction() throws Exception
     {
         // GIVEN
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
+        GraphDatabaseService beansAPI = dbRule.get();
         Neo4jMatchers.createIndex( beansAPI, LABEL1, "name" );
         Node firstNode = createNode( beansAPI, map( "name", "Mattias" ), LABEL1 );
 
@@ -321,7 +322,7 @@ public class IndexingAcceptanceTest
     public void createdNodeShouldShowUpInIndexQuery() throws Exception
     {
         // GIVEN
-        GraphDatabaseService beansAPI = dbRule.getGraphDatabaseService();
+        GraphDatabaseService beansAPI = dbRule.get();
         Neo4jMatchers.createIndex( beansAPI, LABEL1, "name" );
         createNode( beansAPI, map( "name", "Mattias" ), LABEL1 );
 
@@ -344,7 +345,7 @@ public class IndexingAcceptanceTest
     {
         // GIVEN
         String property = "name";
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         Neo4jMatchers.createIndex( db, LABEL1, property );
 
         // WHEN & THEN
@@ -384,7 +385,7 @@ public class IndexingAcceptanceTest
         // this test was included here for now as a precondition for the following test
 
         // given
-        GraphDatabaseService graph = dbRule.getGraphDatabaseService();
+        GraphDatabaseService graph = dbRule.get();
         Neo4jMatchers.createIndex( graph, LABEL1, "name" );
 
         Node node1, node2;
@@ -411,7 +412,7 @@ public class IndexingAcceptanceTest
     public void shouldThrowWhenMulitpleResultsForSingleNode() throws Exception
     {
         // given
-        GraphDatabaseService graph = dbRule.getGraphDatabaseService();
+        GraphDatabaseService graph = dbRule.get();
         Neo4jMatchers.createIndex( graph, LABEL1, "name" );
 
         Node node1, node2;
@@ -439,7 +440,7 @@ public class IndexingAcceptanceTest
         String labelPrefix = "foo";
         String propertyKeyPrefix = "bar";
         String propertyValuePrefix = "baz";
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
 
         for ( int i = 0; i < indexesCount; i++ )
         {
@@ -486,7 +487,7 @@ public class IndexingAcceptanceTest
             throws SchemaRuleNotFoundException, IndexNotFoundKernelException
     {
         // GIVEN
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        TestGraphDatabase db = dbRule.get();
         IndexDefinition index = createIndex( db, LABEL1, "name" );
         createNodes( db, LABEL1, "name", "Mattias", "Mats", "Carla" );
         PrimitiveLongSet expected = createNodes( db, LABEL1, "name", "Karl", "Karlsson" );
@@ -495,7 +496,7 @@ public class IndexingAcceptanceTest
         PrimitiveLongSet found = Primitive.longSet();
         try ( Transaction tx = db.beginTx() )
         {
-            Statement statement = getStatement( (GraphDatabaseAPI) db );
+            Statement statement = getStatement( db );
             ReadOperations ops = statement.readOperations();
             IndexDescriptor descriptor = indexDescriptor( ops, index );
             found.addAll( ops.nodesGetFromIndexRangeSeekByPrefix( descriptor, "Karl" ) );
@@ -510,7 +511,7 @@ public class IndexingAcceptanceTest
             throws SchemaRuleNotFoundException, IndexNotFoundKernelException
     {
         // GIVEN
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        TestGraphDatabase db = dbRule.get();
         IndexDefinition index = createIndex( db, LABEL1, "name" );
         createNodes( db, LABEL1, "name", "Mattias", "Mats" );
         PrimitiveLongSet expected = createNodes( db, LABEL1, "name", "Karl", "Karlsson" );
@@ -520,7 +521,7 @@ public class IndexingAcceptanceTest
         {
             expected.add( createNode( db, map( "name", "Karlchen" ), LABEL1 ).getId() );
             createNode( db, map( "name", "Carla" ), LABEL1 );
-            Statement statement = getStatement( (GraphDatabaseAPI) db );
+            Statement statement = getStatement( db );
             ReadOperations readOperations = statement.readOperations();
             IndexDescriptor descriptor = indexDescriptor( readOperations, index );
             found.addAll( readOperations.nodesGetFromIndexRangeSeekByPrefix( descriptor, "Karl" ) );
@@ -534,7 +535,7 @@ public class IndexingAcceptanceTest
             throws SchemaRuleNotFoundException, IndexNotFoundKernelException
     {
         // GIVEN
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        TestGraphDatabase db = dbRule.get();
         IndexDefinition index = createIndex( db, LABEL1, "name" );
         createNodes( db, LABEL1, "name", "Mattias" );
         PrimitiveLongSet toDelete = createNodes( db, LABEL1, "name", "Karlsson", "Mats" );
@@ -550,7 +551,7 @@ public class IndexingAcceptanceTest
                 db.getNodeById( id ).delete();
                 expected.remove( id );
             }
-            Statement statement = getStatement( (GraphDatabaseAPI) db );
+            Statement statement = getStatement( db );
             ReadOperations readOperations = statement.readOperations();
             IndexDescriptor descriptor = indexDescriptor( readOperations, index );
             found.addAll( readOperations.nodesGetFromIndexRangeSeekByPrefix( descriptor, "Karl" ) );
@@ -564,7 +565,7 @@ public class IndexingAcceptanceTest
             throws SchemaRuleNotFoundException, IndexNotFoundKernelException
     {
         // GIVEN
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        TestGraphDatabase db = dbRule.get();
         IndexDefinition index = createIndex( db, LABEL1, "name" );
         createNodes( db, LABEL1, "name", "Mattias" );
         PrimitiveLongSet toChangeToMatch = createNodes( db, LABEL1, "name", "Mats" );
@@ -589,7 +590,7 @@ public class IndexingAcceptanceTest
                 db.getNodeById( id ).setProperty( "name", "X" + id );
                 expected.remove( id );
             }
-            Statement statement = getStatement( (GraphDatabaseAPI) db );
+            Statement statement = getStatement( db );
             ReadOperations readOperations = statement.readOperations();
             IndexDescriptor descriptor = indexDescriptor( readOperations, index );
             found.addAll( readOperations.nodesGetFromIndexRangeSeekByPrefix( descriptor, prefix ) );
@@ -638,7 +639,7 @@ public class IndexingAcceptanceTest
         return readOperations.indexesGetForLabelAndPropertyKey( labelId, propertyId );
     }
 
-    private Statement getStatement( GraphDatabaseAPI db )
+    private Statement getStatement( TestGraphDatabase db )
     {
         return db.getDependencyResolver()
                 .resolveDependency( ThreadToStatementContextBridge.class ).get();
@@ -659,8 +660,8 @@ public class IndexingAcceptanceTest
 
     public static final String LONG_STRING = "a long string that has to be stored in dynamic records";
 
-    public @Rule
-    ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     private Label LABEL1 = DynamicLabel.label( "LABEL1" );
     private Label LABEL2 = DynamicLabel.label( "LABEL2" );
@@ -680,7 +681,7 @@ public class IndexingAcceptanceTest
 
     private Neo4jMatchers.Deferred<Label> labels( final Node myNode )
     {
-        return new Neo4jMatchers.Deferred<Label>( dbRule.getGraphDatabaseService() )
+        return new Neo4jMatchers.Deferred<Label>( dbRule.get() )
         {
             @Override
             protected Iterable<Label> manifest()

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelScanStoreIT.java
@@ -24,8 +24,7 @@ import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;
@@ -133,7 +132,7 @@ public class LabelScanStoreIT
     public void shouldHandleLargeAmountsOfNodesAddedAndRemovedInSameTx() throws Exception
     {
         // Given
-        GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
+        GraphDatabaseService db = dbRule.get();
         int labelsToAdd = 80;
         int labelsToRemove = 40;
 
@@ -173,7 +172,7 @@ public class LabelScanStoreIT
     
     private void removeLabels( Node node, Label... labels )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = dbRule.get().beginTx() )
         {
             for ( Label label : labels )
             {
@@ -185,7 +184,7 @@ public class LabelScanStoreIT
 
     private void deleteNode( Node node )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = dbRule.get().beginTx() )
         {
             node.delete();
             tx.success();
@@ -194,17 +193,17 @@ public class LabelScanStoreIT
 
     private Set<Node> getAllNodesWithLabel( Label label )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = dbRule.get().beginTx() )
         {
-            return asSet( dbRule.getGraphDatabaseService().findNodes( label ) );
+            return asSet( dbRule.get().findNodes( label ) );
         }
     }
 
     private Node createLabeledNode( Label... labels )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = dbRule.get().beginTx() )
         {
-            Node node = dbRule.getGraphDatabaseService().createNode( labels );
+            Node node = dbRule.get().createNode( labels );
             tx.success();
             return node;
         }
@@ -212,7 +211,7 @@ public class LabelScanStoreIT
     
     private void addLabels( Node node, Label... labels )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = dbRule.get().beginTx() )
         {
             for ( Label label : labels )
             {
@@ -222,7 +221,8 @@ public class LabelScanStoreIT
         }
     }
 
-    public final @Rule DatabaseRule dbRule = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
     
     private static enum Labels implements Label
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestKernelExtension.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestKernelExtension.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel;
 
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactoryContractTest;
 import org.neo4j.kernel.extension.KernelExtensions;
@@ -51,7 +52,7 @@ public final class TestKernelExtension extends KernelExtensionFactoryContractTes
     @Test
     public void shouldBeStarted() throws Exception
     {
-        GraphDatabaseAPI graphdb = graphdb( 0 );
+        TestGraphDatabase graphdb = graphdb( 0 );
         try
         {
             assertEquals( LifecycleStatus.STARTED, graphdb.getDependencyResolver().resolveDependency(
@@ -69,7 +70,7 @@ public final class TestKernelExtension extends KernelExtensionFactoryContractTes
     @Test
     public void dependenciesCanBeRetrieved() throws Exception
     {
-        GraphDatabaseAPI graphdb = graphdb( 0 );
+        TestGraphDatabase graphdb = graphdb( 0 );
         try
         {
             assertEquals( graphdb.getDependencyResolver().resolveDependency( Config.class ),
@@ -91,7 +92,7 @@ public final class TestKernelExtension extends KernelExtensionFactoryContractTes
     @Test
     public void shouldBeShutdown() throws Exception
     {
-        GraphDatabaseAPI graphdb = graphdb( 0 );
+        TestGraphDatabase graphdb = graphdb( 0 );
         graphdb.shutdown();
 
         assertEquals( LifecycleStatus.SHUTDOWN, graphdb.getDependencyResolver().resolveDependency( KernelExtensions

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestTransactionEventDeadlocks.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestTransactionEventDeadlocks.java
@@ -27,8 +27,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertThat;
 import static org.neo4j.graphdb.Neo4jMatchers.hasProperty;
@@ -38,12 +37,12 @@ import static org.neo4j.helpers.collection.IteratorUtil.count;
 public class TestTransactionEventDeadlocks
 {
     @Rule
-    public DatabaseRule database = new ImpermanentDatabaseRule();
+    public final TestGraphDatabaseRule database = TestGraphDatabaseRule.ephemeral();
     
     @Test
     public void canAvoidDeadlockThatWouldHappenIfTheRelationshipTypeCreationTransactionModifiedData() throws Exception
     {
-        GraphDatabaseService graphdb = database.getGraphDatabaseService();
+        GraphDatabaseService graphdb = database.get();
         Node node = null;
         try ( Transaction tx = graphdb.beginTx() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SchemaConstraintProviderApprovalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SchemaConstraintProviderApprovalTest.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -37,7 +39,6 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.ArrayUtil;
 import org.neo4j.helpers.ObjectUtil;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.graphdb.DynamicLabel.label;
@@ -128,7 +129,7 @@ public abstract class SchemaConstraintProviderApprovalTest
     @BeforeClass
     public static void init()
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        GraphDatabase db = TestGraphDatabase.openEphemeral();
         for ( TestValue value : TestValue.values() )
         {
             createNode( db, PROPERTY_KEY, value.value );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SchemaIndexProviderApprovalTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SchemaIndexProviderApprovalTest.java
@@ -30,6 +30,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -37,7 +39,6 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.ArrayUtil;
 import org.neo4j.helpers.ObjectUtil;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -133,7 +134,7 @@ public abstract class SchemaIndexProviderApprovalTest
     @BeforeClass
     public static void init()
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        GraphDatabase db = TestGraphDatabase.openEphemeral();
         for ( TestValue value : TestValue.values() )
         {
             createNode( db, PROPERTY_KEY, value.value );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.api.index;
 
-import java.io.File;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -33,9 +32,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.function.Consumer;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.DependencyResolver;
@@ -51,8 +50,6 @@ import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.lifecycle.Lifecycle;
-import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -998,15 +995,12 @@ public class UniqueConstraintCompatibility extends IndexProviderCompatibilityTes
 
     // -- Set Up: Environment parts
 
-    @Rule
-    public TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
-
     @Before
-    public void setUp() {
-        File storeDir = testDirectory.graphDbDir();
-        TestGraphDatabaseFactory dbfactory = new TestGraphDatabaseFactory();
-        dbfactory.addKernelExtension( new PredefinedSchemaIndexProviderFactory( indexProvider ) );
-        db = dbfactory.newImpermanentDatabase( storeDir );
+    public void setUp()
+    {
+        db = TestGraphDatabase.buildEphemeral()
+                .addKernelExtension( new PredefinedSchemaIndexProviderFactory( indexProvider ) )
+                .open();
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/CompositeCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/CompositeCountsTest.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.function.Supplier;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -32,8 +33,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 
@@ -42,7 +42,15 @@ import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
 public class CompositeCountsTest
 {
-    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
+    private GraphDatabaseService db;
+
+    @Before
+    public void setUp()
+    {
+        db = dbRule.get();
+    }
 
     @Test
     public void shouldReportNumberOfRelationshipsFromNodesWithGivenLabel() throws Exception
@@ -348,7 +356,7 @@ public class CompositeCountsTest
      */
     private MatchingRelationships numberOfRelationshipsMatching( Label lhs, RelationshipType type, Label rhs )
     {
-        try ( Transaction tx = db.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = db.beginTx() )
         {
             long nodeCount = countsForRelationship( lhs, type, rhs );
             tx.success();
@@ -429,7 +437,7 @@ public class CompositeCountsTest
     @Before
     public void exposeGuts()
     {
-        statementSupplier = db.getGraphDatabaseAPI().getDependencyResolver()
+        statementSupplier = dbRule.get().getDependencyResolver()
                               .resolveDependency( ThreadToStatementContextBridge.class );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/LabelCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/LabelCountsTest.java
@@ -31,8 +31,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,13 +39,14 @@ import static org.neo4j.graphdb.DynamicLabel.label;
 
 public class LabelCountsTest
 {
-    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     @Test
     public void shouldGetNumberOfNodesWithLabel() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = db.getGraphDatabaseService();
+        GraphDatabaseService graphDb = dbRule.get();
         try ( Transaction tx = graphDb.beginTx() )
         {
             graphDb.createNode( label( "Foo" ) );
@@ -69,7 +69,7 @@ public class LabelCountsTest
     public void shouldAccountForDeletedNodes() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = db.getGraphDatabaseService();
+        GraphDatabaseService graphDb = dbRule.get();
         Node node;
         try ( Transaction tx = graphDb.beginTx() )
         {
@@ -96,7 +96,7 @@ public class LabelCountsTest
     public void shouldAccountForAddedLabels() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = db.getGraphDatabaseService();
+        GraphDatabaseService graphDb = dbRule.get();
         Node n1, n2, n3;
         try ( Transaction tx = graphDb.beginTx() )
         {
@@ -128,7 +128,7 @@ public class LabelCountsTest
     public void shouldAccountForRemovedLabels() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = db.getGraphDatabaseService();
+        GraphDatabaseService graphDb = dbRule.get();
         Node n1, n2, n3;
         try ( Transaction tx = graphDb.beginTx() )
         {
@@ -159,7 +159,7 @@ public class LabelCountsTest
     /** Transactional version of {@link #countsForNode(Label)} */
     private long numberOfNodesWith( Label label )
     {
-        try ( Transaction tx = db.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = dbRule.get().beginTx() )
         {
             long nodeCount = countsForNode( label );
             tx.success();
@@ -191,7 +191,7 @@ public class LabelCountsTest
     @Before
     public void exposeGuts()
     {
-        statementSupplier = db.getGraphDatabaseAPI().getDependencyResolver()
+        statementSupplier = dbRule.get().getDependencyResolver()
                               .resolveDependency( ThreadToStatementContextBridge.class );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/NodeCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/NodeCountsTest.java
@@ -34,16 +34,16 @@ import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.test.Barrier;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
 import org.neo4j.test.NamedFunction;
+import org.neo4j.test.TestGraphDatabaseRule;
 import org.neo4j.test.ThreadingRule;
 
 import static org.junit.Assert.assertEquals;
 
 public class NodeCountsTest
 {
-    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
     public final @Rule ThreadingRule threading = new ThreadingRule();
 
     @Test
@@ -60,7 +60,7 @@ public class NodeCountsTest
     public void shouldReportNumberOfNodes() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = db.getGraphDatabaseService();
+        GraphDatabaseService graphDb = dbRule.get();
         try ( Transaction tx = graphDb.beginTx() )
         {
             graphDb.createNode();
@@ -79,7 +79,7 @@ public class NodeCountsTest
     public void shouldReportAccurateNumberOfNodesAfterDeletion() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = db.getGraphDatabaseService();
+        GraphDatabaseService graphDb = dbRule.get();
         Node one;
         try ( Transaction tx = graphDb.beginTx() )
         {
@@ -104,7 +104,7 @@ public class NodeCountsTest
     public void shouldIncludeNumberOfNodesAddedInTransaction() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = db.getGraphDatabaseService();
+        GraphDatabaseService graphDb = dbRule.get();
         try ( Transaction tx = graphDb.beginTx() )
         {
             graphDb.createNode();
@@ -129,7 +129,7 @@ public class NodeCountsTest
     public void shouldIncludeNumberOfNodesDeletedInTransaction() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = db.getGraphDatabaseService();
+        GraphDatabaseService graphDb = dbRule.get();
         Node one;
         try ( Transaction tx = graphDb.beginTx() )
         {
@@ -155,7 +155,7 @@ public class NodeCountsTest
     public void shouldNotSeeNodeCountsOfOtherTransaction() throws Exception
     {
         // given
-        GraphDatabaseService graphDb = db.getGraphDatabaseService();
+        GraphDatabaseService graphDb = dbRule.get();
         final Barrier.Control barrier = new Barrier.Control();
         long before = numberOfNodes();
         Future<Long> done = threading.execute( new NamedFunction<GraphDatabaseService, Long>( "create-nodes" )
@@ -192,7 +192,7 @@ public class NodeCountsTest
     /** Transactional version of {@link #countsForNode()} */
     private long numberOfNodes()
     {
-        try ( Transaction tx = db.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = dbRule.get().beginTx() )
         {
             long nodeCount = countsForNode();
             tx.success();
@@ -210,7 +210,7 @@ public class NodeCountsTest
     @Before
     public void exposeGuts()
     {
-        statementSupplier = db.getGraphDatabaseAPI().getDependencyResolver()
+        statementSupplier = dbRule.get().getDependencyResolver()
                               .resolveDependency( ThreadToStatementContextBridge.class );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionFactoryContractTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionFactoryContractTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.helpers.Service;
 import org.neo4j.helpers.collection.MapUtil;
@@ -54,27 +56,27 @@ public abstract class KernelExtensionFactoryContractTest
         this.key = key;
     }
 
-    public GraphDatabaseAPI graphdb( int instance )
+    public TestGraphDatabase graphdb( int instance )
     {
-        Map<String, String> config = configuration( true, instance );
-        return (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().setConfig( config ).newGraphDatabase();
+        TestGraphDatabase.EphemeralBuilder builder = TestGraphDatabase.buildEphemeral();
+        configure( builder, true, instance );
+        return builder.open();
     }
 
     /**
      * Override to create default configuration for the {@link org.neo4j.kernel.extension.KernelExtensionFactory}
      * under test.
      *
+     * @param builder    the builder to configure
      * @param shouldLoad <code>true</code> if configuration that makes the
      *                   extension load should be created, <code>false</code> if
      *                   configuration that makes the extension not load should be
      *                   created.
      * @param instance   used for differentiating multiple instances that will run
      *                   simultaneously.
-     * @return configuration for an {@link org.neo4j.kernel.EmbeddedGraphDatabase} that
      */
-    protected Map<String, String> configuration( boolean shouldLoad, int instance )
+    protected void configure( TestGraphDatabase.EphemeralBuilder builder, boolean shouldLoad, int instance )
     {
-        return MapUtil.stringMap();
     }
 
     static KernelExtensions getExtensions( GraphDatabaseService graphdb )
@@ -139,7 +141,7 @@ public abstract class KernelExtensionFactoryContractTest
     @Test
     public void canLoadKernelExtension() throws Exception
     {
-        GraphDatabaseService graphdb = graphdb( 0 );
+        GraphDatabase graphdb = graphdb( 0 );
         try
         {
             assertTrue( "Failed to load extension", getExtensions( graphdb ).isRegistered( extClass ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataAndSchemaTransactionSeparationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataAndSchemaTransactionSeparationIT.java
@@ -28,8 +28,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.helpers.Pair;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -39,7 +38,8 @@ import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 
 public class DataAndSchemaTransactionSeparationIT
 {
-    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule db = TestGraphDatabaseRule.ephemeral();
 
     private static Function<GraphDatabaseService, Void> expectFailureAfterSchemaOperation(
             final Function<GraphDatabaseService, ?> function )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LabelRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LabelRecoveryTest.java
@@ -22,11 +22,11 @@ package org.neo4j.kernel.impl.api;
 import org.junit.After;
 import org.junit.Test;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 
 import static org.junit.Assert.assertTrue;
@@ -49,7 +49,7 @@ public class LabelRecoveryTest
     public void shouldRecoverNodeWithDynamicLabelRecords() throws Exception
     {
         // GIVEN
-        database = new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase();
+        database = TestGraphDatabase.buildEphemeral().withFileSystem( fs ).open();
         Node node;
         Label[] labels = new Label[] { label( "a" ),
                 label( "b" ),
@@ -76,7 +76,7 @@ public class LabelRecoveryTest
         }
         EphemeralFileSystemAbstraction snapshot = fs.snapshot();
         database.shutdown();
-        database = new TestGraphDatabaseFactory().setFileSystem( snapshot ).newImpermanentDatabase();
+        database = TestGraphDatabase.buildEphemeral().withFileSystem( snapshot ).open();
 
         // THEN
         try ( Transaction ignored = database.beginTx() )
@@ -100,5 +100,5 @@ public class LabelRecoveryTest
     }
 
     public final EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
-    private GraphDatabaseService database;
+    private GraphDatabase database;
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PropertyTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/PropertyTransactionStateTest.java
@@ -22,21 +22,22 @@ package org.neo4j.kernel.impl.api;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.graphdb.GraphDatabaseService;
+
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.*;
 
 public class PropertyTransactionStateTest
 {
-    private GraphDatabaseService db;
+    private GraphDatabase db;
 
     @Before
     public void setUp() throws Exception
     {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        db = TestGraphDatabase.openEphemeral();
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.Label;
@@ -41,7 +42,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.Pair;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.collection.Visitor;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.index.IndexConfiguration;
@@ -74,7 +74,6 @@ import org.neo4j.test.CleanupRule;
 import org.neo4j.test.DoubleLatch;
 import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -586,7 +585,7 @@ public class IndexPopulationJobTest
         return new InMemoryIndexProvider().getPopulator( 21, descriptor, indexConfig, samplingConfig );
     }
 
-    private GraphDatabaseAPI db;
+    private TestGraphDatabase db;
 
     private final Label FIRST = DynamicLabel.label( "FIRST" );
     private final Label SECOND = DynamicLabel.label( "SECOND" );
@@ -604,7 +603,7 @@ public class IndexPopulationJobTest
     @Before
     public void before() throws Exception
     {
-        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
+        db = TestGraphDatabase.openEphemeral();
         ctxSupplier = db.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
         counts = db.getDependencyResolver().resolveDependency( NeoStoresSupplier.class ).get().getCounts();
         stateHolder = new KernelSchemaStateStore( NullLogProvider.getInstance() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
@@ -27,7 +27,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -35,6 +34,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 import org.neo4j.graphdb.Label;
@@ -44,7 +44,6 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexConfiguration;
@@ -63,7 +62,6 @@ import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.register.Register.DoubleLong;
 import org.neo4j.test.EphemeralFileSystemRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -256,7 +254,7 @@ public class IndexRecoveryIT
                         any( IndexSamplingConfig.class ) );
     }
 
-    @SuppressWarnings("deprecation") private GraphDatabaseAPI db;
+    private TestGraphDatabase db;
     @Rule public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
     private final SchemaIndexProvider mockedIndexProvider = mock( SchemaIndexProvider.class );
     private final KernelExtensionFactory<?> mockedIndexProviderFactory =
@@ -276,18 +274,16 @@ public class IndexRecoveryIT
                 any( FileSystemAbstraction.class), any( PageCache.class ) ) ).thenReturn( NOT_PARTICIPATING );
     }
 
-    @SuppressWarnings("deprecation")
     private void startDb()
     {
         if ( db != null )
         {
             db.shutdown();
         }
-
-        TestGraphDatabaseFactory factory = new TestGraphDatabaseFactory();
-        factory.setFileSystem( fs.get() );
-        factory.addKernelExtensions( Arrays.<KernelExtensionFactory<?>>asList( mockedIndexProviderFactory ) );
-        db = (GraphDatabaseAPI) factory.newImpermanentDatabase();
+        db = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( fs.get() )
+                .addKernelExtension( mockedIndexProviderFactory )
+                .open();
     }
 
     private void killDb()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -20,8 +20,8 @@
 package org.neo4j.kernel.impl.api.index;
 
 import com.google.common.jimfs.Jimfs;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -38,11 +38,9 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DependencyResolver;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DelegateFileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;
@@ -59,9 +57,6 @@ import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.register.Register.DoubleLongRegister;
 import org.neo4j.register.Registers;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -634,40 +629,26 @@ public class IndexStatisticsTest
     private static final int MISSED_UPDATES_TOLERANCE = NAMES.length;
     private static final double DOUBLE_ERROR_TOLERANCE = 0.00001d;
 
-    @Rule
-    public DatabaseRule dbRule = new ImpermanentDatabaseRule()
-    {
-        @Override
-        protected GraphDatabaseFactory newFactory()
-        {
-            TestGraphDatabaseFactory factory = (TestGraphDatabaseFactory) super.newFactory();
-            factory.setFileSystem( new DelegateFileSystemAbstraction( Jimfs.newFileSystem() ) );
-            return factory;
-        }
-
-        @Override
-        protected void configure( GraphDatabaseBuilder builder )
-        {
-            super.configure( builder );
-            // make sure we don't sample in these tests
-            builder.setConfig( GraphDatabaseSettings.index_background_sampling_enabled, "false" );
-        }
-    };
-
-    private GraphDatabaseService db;
+    private TestGraphDatabase db;
     private ThreadToStatementContextBridge bridge;
     private final IndexOnlineMonitor indexOnlineMonitor = new IndexOnlineMonitor();
 
     @Before
     public void before()
     {
-        GraphDatabaseAPI graphDatabaseAPI = dbRule.getGraphDatabaseAPI();
-        this.db = graphDatabaseAPI;
-        DependencyResolver dependencyResolver = graphDatabaseAPI.getDependencyResolver();
+        this.db = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( new DelegateFileSystemAbstraction( Jimfs.newFileSystem() ) )
+                .withSetting( GraphDatabaseSettings.index_background_sampling_enabled, "false" )
+                .open();
+        DependencyResolver dependencyResolver = db.getDependencyResolver();
         this.bridge = dependencyResolver.resolveDependency( ThreadToStatementContextBridge.class );
-        graphDatabaseAPI.getDependencyResolver()
-                        .resolveDependency( Monitors.class )
-                        .addMonitorListener( indexOnlineMonitor );
+        dependencyResolver.resolveDependency( Monitors.class ).addMonitorListener( indexOnlineMonitor );
+    }
+
+    @After
+    public void after()
+    {
+        this.db.shutdown();
     }
 
     private static class IndexOnlineMonitor extends IndexingService.MonitorAdapter

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -174,7 +174,7 @@ public class PropertyIT extends KernelIntegrationTest
     public void shouldRemoveSetExistingProperty() throws Exception
     {
         // GIVEN
-        dbWithNoCache();
+        restartDb();
 
         int propertyKeyId;
         long nodeId;
@@ -354,7 +354,7 @@ public class PropertyIT extends KernelIntegrationTest
     public void shouldListAllPropertyKeys() throws Exception
     {
         // given
-        dbWithNoCache();
+        restartDb();
 
         long prop1;
         long prop2;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/SchemaRecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/SchemaRecoveryIT.java
@@ -22,14 +22,16 @@ package org.neo4j.kernel.impl.api.integrationtest;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.List;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.subprocess.SubProcess;
 
 import static org.junit.Assert.assertEquals;
@@ -42,13 +44,13 @@ public class SchemaRecoveryIT
     public void schemaTransactionsShouldSurviveRecovery() throws Exception
     {
         // given
-        String storeDir = testDirectory.absolutePath();
+        File storeDir = testDirectory.graphDbDir();
         Process process = new CreateConstraintButDoNotShutDown().start( storeDir );
         process.waitForSchemaTransactionCommitted();
         SubProcess.kill( process );
 
         // when
-        GraphDatabaseService recoveredDatabase = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+        GraphDatabase recoveredDatabase = TestGraphDatabase.open( storeDir );
 
         // then
         assertEquals(1, constraints( recoveredDatabase ).size());
@@ -81,15 +83,15 @@ public class SchemaRecoveryIT
         void waitForSchemaTransactionCommitted() throws InterruptedException;
     }
 
-    static class CreateConstraintButDoNotShutDown extends SubProcess<Process, String> implements Process
+    static class CreateConstraintButDoNotShutDown extends SubProcess<Process, File> implements Process
     {
         // Would use a CountDownLatch but fields of this class need to be serializable.
         private volatile boolean started = false;
 
         @Override
-        protected void startup( String storeDir ) throws Throwable
+        protected void startup( File storeDir ) throws Throwable
         {
-            GraphDatabaseService database = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+            GraphDatabase database = TestGraphDatabase.open( storeDir );
             try ( Transaction transaction = database.beginTx() )
             {
                 database.schema().constraintFor( label("User") ).assertPropertyIsUnique( "uuid" ).create();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationConcurrencyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationConcurrencyIT.java
@@ -28,10 +28,9 @@ import org.neo4j.function.Function;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
 import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -42,7 +41,8 @@ import static org.neo4j.test.OtherThreadRule.isWaiting;
 
 public class UniquenessConstraintValidationConcurrencyIT
 {
-    public final @Rule DatabaseRule database = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule database = TestGraphDatabaseRule.ephemeral();
     public final @Rule OtherThreadRule<Void> otherThread = new OtherThreadRule<>();
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestReferenceDangling.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/TestReferenceDangling.java
@@ -22,11 +22,12 @@ package org.neo4j.kernel.impl.api.store;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 /**
  * This test ensures that lazy properties
@@ -34,13 +35,13 @@ import org.neo4j.test.ImpermanentDatabaseRule;
 public class TestReferenceDangling
 {
     @Rule
-    public ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule( );
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     @Test
     public void testPropertyStoreReferencesOnRead() throws Throwable
     {
         // Given
-        GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
+        TestGraphDatabase db = dbRule.get();
 
         // and Given the cache contains a LazyProperty
         long nId = ensurePropertyIsCachedLazyProperty( db, "some" );
@@ -60,7 +61,7 @@ public class TestReferenceDangling
     public void testPropertyStoreReferencesOnWrite() throws Throwable
     {
         // Given
-        GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
+        TestGraphDatabase db = dbRule.get();
 
         // and Given the cache contains a LazyProperty
         long nId = ensurePropertyIsCachedLazyProperty( db, "some" );
@@ -76,7 +77,7 @@ public class TestReferenceDangling
         }
     }
 
-    private long ensurePropertyIsCachedLazyProperty( GraphDatabaseAPI slave, String key )
+    private long ensurePropertyIsCachedLazyProperty( GraphDatabaseService slave, String key )
     {
         long nId;
         try( Transaction tx = slave.beginTx() )
@@ -95,7 +96,7 @@ public class TestReferenceDangling
         return nId;
     }
 
-    private void restartNeoDataSource( GraphDatabaseAPI slave ) throws Throwable
+    private void restartNeoDataSource( TestGraphDatabase slave ) throws Throwable
     {
         slave.getDependencyResolver().resolveDependency( DataSourceManager.class ).getDataSource().stop();
         slave.getDependencyResolver().resolveDependency( DataSourceManager.class ).getDataSource().start();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ConcurrentCreateAndGetRelationshipsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ConcurrentCreateAndGetRelationshipsIT.java
@@ -34,7 +34,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static java.lang.Thread.sleep;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -59,7 +59,7 @@ public class ConcurrentCreateAndGetRelationshipsIT
     public void tryToReproduceTheIssue() throws Exception
     {
         // GIVEN
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         CountDownLatch startSignal = new CountDownLatch( 1 );
         AtomicBoolean stopSignal = new AtomicBoolean();
         AtomicReference<Exception> failure = new AtomicReference<Exception>();
@@ -116,7 +116,8 @@ public class ConcurrentCreateAndGetRelationshipsIT
         }
     }
 
-    public final @Rule ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
     private static final RelationshipType RELTYPE = MyRelTypes.TEST;
 
     private static class Worker extends Thread

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/LargePropertiesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/LargePropertiesIT.java
@@ -26,14 +26,13 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.graphdb.Node;
-import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.GraphTransactionRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 public class LargePropertiesIT
 {
     @ClassRule
-    public static DatabaseRule db = new ImpermanentDatabaseRule();
+    public static final TestGraphDatabaseRule db = TestGraphDatabaseRule.ephemeral();
 
     @Rule
     public GraphTransactionRule tx = new GraphTransactionRule( db );
@@ -43,7 +42,7 @@ public class LargePropertiesIT
     @Before
     public void createInitialNode()
     {
-        node = db.getGraphDatabaseService().createNode();
+        node = db.get().createNode();
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NestedTransactionLocksIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NestedTransactionLocksIT.java
@@ -27,13 +27,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Lock;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -48,12 +48,12 @@ import static org.junit.Assert.fail;
  */
 public class NestedTransactionLocksIT
 {
-    private GraphDatabaseService db;
+    private GraphDatabase db;
 
     @Before
     public void before() throws Exception
     {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        db = TestGraphDatabase.openEphemeral();
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
@@ -26,14 +26,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.PlaceboTransaction;
 import org.neo4j.kernel.PropertyTracker;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -45,12 +44,12 @@ import static org.neo4j.helpers.collection.IteratorUtil.addToCollection;
 
 public class NodeManagerTest
 {
-    private GraphDatabaseAPI db;
+    private TestGraphDatabase db;
 
     @Before
     public void init()
     {
-        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
+        db = TestGraphDatabase.openEphemeral();
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeTest.java
@@ -36,9 +36,8 @@ import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
-import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.GraphTransactionRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -50,7 +49,7 @@ import static org.neo4j.helpers.Exceptions.launderedException;
 public class NodeTest
 {
     @ClassRule
-    public static DatabaseRule db = new ImpermanentDatabaseRule();
+    public static final TestGraphDatabaseRule db = TestGraphDatabaseRule.ephemeral();
 
     @Rule
     public GraphTransactionRule tx = new GraphTransactionRule( db );
@@ -483,6 +482,6 @@ public class NodeTest
 
     private GraphDatabaseService getGraphDb()
     {
-        return db.getGraphDatabaseService();
+        return db.get();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentIteratorModification.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentIteratorModification.java
@@ -30,20 +30,20 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 
 public class TestConcurrentIteratorModification {
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule();
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     @Test
     public void shouldNotThrowConcurrentModificationExceptionWhenUpdatingWhileIterating()
     {
         // given
-        GraphDatabaseService graph = dbRule.getGraphDatabaseService();
+        GraphDatabaseService graph = dbRule.get();
         Label label = DynamicLabel.label( "Bird" );
 
         Node node1, node2, node3;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentRelationshipChainLoadingIssue.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestConcurrentRelationshipChainLoadingIssue.java
@@ -28,11 +28,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -69,10 +70,10 @@ public class TestConcurrentRelationshipChainLoadingIssue
 
     private void tryToTriggerRelationshipLoadingStoppingMidWay( int denseNodeThreshold ) throws Throwable
     {
-        GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-                .setConfig( relationship_grab_size, "" + relCount/2 )
-                .setConfig( dense_node_threshold, "" + denseNodeThreshold )
-                .newGraphDatabase();
+        GraphDatabase db = TestGraphDatabase.buildEphemeral()
+                .withSetting( relationship_grab_size, "" + relCount / 2 )
+                .withSetting( dense_node_threshold, "" + denseNodeThreshold )
+                .open();
         Node node = createNodeWithRelationships( db );
 
         checkStateToHelpDiagnoseFlakeyTest( db, node );
@@ -87,14 +88,14 @@ public class TestConcurrentRelationshipChainLoadingIssue
         db.shutdown();
     }
 
-    private void checkStateToHelpDiagnoseFlakeyTest( GraphDatabaseAPI db, Node node )
+    private void checkStateToHelpDiagnoseFlakeyTest( GraphDatabaseService db, Node node )
     {
         loadNode( db, node );
         // TODO clear cache here
         loadNode( db, node );
     }
 
-    private void loadNode( GraphDatabaseAPI db, Node node )
+    private void loadNode( GraphDatabaseService db, Node node )
     {
         try (Transaction ignored = db.beginTx()) {
             count( node.getRelationships() );
@@ -114,7 +115,7 @@ public class TestConcurrentRelationshipChainLoadingIssue
         }
     }
 
-    private void tryOnce( final GraphDatabaseAPI db, final Node node, int iterations ) throws Throwable
+    private void tryOnce( final GraphDatabaseService db, final Node node, int iterations ) throws Throwable
     {
         ExecutorService executor = newCachedThreadPool();
         final CountDownLatch startSignal = new CountDownLatch( 1 );
@@ -166,7 +167,7 @@ public class TestConcurrentRelationshipChainLoadingIssue
         return i.get();
     }
 
-    private Node createNodeWithRelationships( GraphDatabaseAPI db )
+    private Node createNodeWithRelationships( GraphDatabaseService db )
     {
         Node node;
         try ( Transaction tx = db.beginTx() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -41,7 +42,6 @@ import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.Settings;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.kernel.impl.store.CommonAbstractStore;
@@ -50,7 +50,6 @@ import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -131,8 +130,8 @@ public class TestCrashWithRebuildSlow
     public void crashAndRebuildSlowWithDynamicStringDeletions() throws Exception
     {
         File storeDir = new File( "dir" ).getAbsoluteFile();
-        final GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
-                .setFileSystem( fs.get() ).newImpermanentDatabase( storeDir );
+        final TestGraphDatabase db = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( fs.get() ).open( storeDir );
         List<Long> deletedNodeIds = produceNonCleanDefraggedStringStore( db );
         Map<IdType,Long> highIdsBeforeCrash = getHighIds( db );
 
@@ -159,11 +158,10 @@ public class TestCrashWithRebuildSlow
 
         // Recover with rebuild_idgenerators_fast=false
         assertNumberOfFreeIdsEquals( storeDir, snapshot, 0 );
-        GraphDatabaseAPI newDb = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
-                .setFileSystem( snapshot )
-                .newImpermanentDatabaseBuilder( storeDir )
-                .setConfig( GraphDatabaseSettings.rebuild_idgenerators_fast, Settings.FALSE )
-                .newGraphDatabase();
+        TestGraphDatabase newDb = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( snapshot )
+                .withSetting( GraphDatabaseSettings.rebuild_idgenerators_fast, Settings.FALSE )
+                .open( storeDir );
         Map<IdType,Long> highIdsAfterCrash = getHighIds( newDb );
         assertEquals( highIdsBeforeCrash, highIdsAfterCrash );
 
@@ -197,7 +195,7 @@ public class TestCrashWithRebuildSlow
         }
     }
 
-    private Map<IdType,Long> getHighIds( GraphDatabaseAPI db )
+    private Map<IdType,Long> getHighIds( TestGraphDatabase db )
     {
         final Map<IdType,Long> highIds = new HashMap<>();
         NeoStores neoStores = db.getDependencyResolver().resolveDependency(

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestExceptionTypeOnInvalidIds.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestExceptionTypeOnInvalidIds.java
@@ -25,18 +25,17 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.UUID;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.fail;
-import static org.neo4j.helpers.Settings.TRUE;
 
 public class TestExceptionTypeOnInvalidIds
 {
@@ -48,24 +47,24 @@ public class TestExceptionTypeOnInvalidIds
     private static final long SMALL_NEGATIVE_LONG = -((long) Integer.MIN_VALUE) - 1;
     private static final long BIG_POSSITIVE_LONG = Long.MAX_VALUE;
     private static final long BIG_NEGATIVE_LONG = Long.MIN_VALUE;
-    private static GraphDatabaseService graphdb;
-    private static GraphDatabaseService graphDbReadOnly;
+    private static GraphDatabase graphdb;
+    private static GraphDatabase graphDbReadOnly;
     private Transaction tx;
 
     @BeforeClass
     public static void createDatabase()
     {
-        graphdb = new TestGraphDatabaseFactory().newEmbeddedDatabase( getRandomStoreDir() );
-        String storeDir = getRandomStoreDir();
-        new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir ).shutdown();
-        graphDbReadOnly = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir ).
-            setConfig( GraphDatabaseSettings.read_only, TRUE ).
-            newGraphDatabase();
+        graphdb = TestGraphDatabase.open( getRandomStoreDir() );
+        File storeDir = getRandomStoreDir();
+        TestGraphDatabase.open( storeDir ).shutdown();
+        graphDbReadOnly = TestGraphDatabase.build()
+                .readOnly()
+                .open( storeDir );
     }
 
-    private static String getRandomStoreDir()
+    private static File getRandomStoreDir()
     {
-        return "target/var/id_test/" + UUID.randomUUID();
+        return new File( "target/var/id_test/" + UUID.randomUUID() );
     }
 
     @AfterClass

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIdReuse.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIdReuse.java
@@ -24,11 +24,12 @@ import java.io.File;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.EphemeralFileSystemRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -68,16 +69,18 @@ public class TestIdReuse
     {
         File storeDir = new File( "target/var/idreuse" );
         File file = new File( storeDir, fileName );
-        GraphDatabaseService db = new TestGraphDatabaseFactory().setFileSystem( fs.get() ).
-            newImpermanentDatabaseBuilder( storeDir ).
-            newGraphDatabase();
+        GraphDatabase db = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( fs.get() )
+                .open();
         for ( int i = 0; i < 5; i++ )
         {
             setAndRemoveSomeProperties( db, value );
         }
         db.shutdown();
         long sizeBefore = file.length();
-        db = new TestGraphDatabaseFactory().setFileSystem( fs.get() ).newImpermanentDatabase( storeDir );
+        db = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( fs.get() )
+                .open( storeDir );
         for ( int i = 0; i < iterations; i++ )
         {
             setAndRemoveSomeProperties( db, value );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIsolationMultipleThreads.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestIsolationMultipleThreads.java
@@ -28,12 +28,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Lock;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.DeadlockDetectedException;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 /**
  * Test atomicity of Neo4j. How to get consistent results with or without locks?
@@ -41,14 +43,14 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 @Ignore( "unstable" )
 public class TestIsolationMultipleThreads
 {
-    GraphDatabaseService database;
+    GraphDatabase database;
 
     private static final int COUNT = 1000;
 
     @Before
     public void setup()
     {
-        database = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        database = TestGraphDatabase.openEphemeral();
         try ( Transaction tx = database.beginTx() )
         {
             for ( int i = 0; i < COUNT; i++ )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jApiExceptions.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jApiExceptions.java
@@ -22,6 +22,9 @@ package org.neo4j.kernel.impl.core;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -31,7 +34,6 @@ import org.neo4j.graphdb.NotInTransactionException;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
@@ -193,7 +195,7 @@ public class TestNeo4jApiExceptions
     }
 
     private Transaction tx;
-    private GraphDatabaseService graph;
+    private GraphDatabase graph;
 
 
     private void newTransaction()
@@ -228,7 +230,7 @@ public class TestNeo4jApiExceptions
     @Before
     public void init()
     {
-        graph = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graph = TestGraphDatabase.openEphemeral();
         newTransaction();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jCacheAndPersistence.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jCacheAndPersistence.java
@@ -24,17 +24,15 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Direction;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
@@ -42,7 +40,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -50,6 +47,7 @@ import static org.junit.Assert.fail;
 
 import static org.neo4j.graphdb.Direction.INCOMING;
 import static org.neo4j.graphdb.Direction.OUTGOING;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.relationship_grab_size;
 import static org.neo4j.helpers.collection.Iterables.toList;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 
@@ -388,12 +386,9 @@ public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
     @Test
     public void testLowGrabSize()
     {
-        Map<String,String> config = new HashMap<>();
-        config.put( "relationship_grab_size", "1" );
-        File storeDir = getStorePath( "neo2" );
-        deleteFileOrDirectory( storeDir );
-        GraphDatabaseService graphDb = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().setConfig( config ).newGraphDatabase();
-
+        GraphDatabase graphDb = TestGraphDatabase.buildEphemeral()
+                .withSetting( relationship_grab_size, "1" )
+                .open();
         Node node1, node2;
         try ( Transaction tx = graphDb.beginTx() )
         {
@@ -445,11 +440,9 @@ public class TestNeo4jCacheAndPersistence extends AbstractNeo4jTestCase
 
     private void testLowGrabSize( boolean includeLoops )
     {
-        Map<String, String> config = new HashMap<>();
-        config.put( "relationship_grab_size", "2" );
-        File storeDir = getStorePath( "neo2" );
-        deleteFileOrDirectory( storeDir );
-        GraphDatabaseService graphDb = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().setConfig( config ).newGraphDatabase();
+        GraphDatabase graphDb = TestGraphDatabase.buildEphemeral()
+                .withSetting( relationship_grab_size, "2" )
+                .open();
         Transaction tx = graphDb.beginTx();
         Node node1 = graphDb.createNode();
         Node node2 = graphDb.createNode();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationship.java
@@ -946,7 +946,7 @@ public class TestRelationship extends AbstractNeo4jTestCase
     public void shouldLoadAllRelationships() throws Exception
     {
         // GIVEN
-        GraphDatabaseService db = getGraphDbAPI();
+        GraphDatabaseService db = getGraphDb();
         Node node;
         try ( Transaction tx = db.beginTx() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipCount.java
@@ -33,18 +33,18 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.embedded.TestGraphDatabase;
+import org.neo4j.function.Consumer;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -69,19 +69,20 @@ public class TestRelationshipCount
         return data;
     }
 
-    public final @Rule DatabaseRule dbRule;
+    @Rule
+    public final TestGraphDatabaseRule dbRule;
     private Transaction tx;
 
     public TestRelationshipCount( final int denseNodeThreshold )
     {
-        this.dbRule = new ImpermanentDatabaseRule()
+        this.dbRule = TestGraphDatabaseRule.ephemeral( new Consumer<TestGraphDatabase.EphemeralBuilder>()
         {
             @Override
-            protected void configure( GraphDatabaseBuilder builder )
+            public void accept( TestGraphDatabase.EphemeralBuilder builder )
             {
-                builder.setConfig( GraphDatabaseSettings.dense_node_threshold, String.valueOf( denseNodeThreshold ) );
+                builder.withSetting( GraphDatabaseSettings.dense_node_threshold, String.valueOf( denseNodeThreshold ) );
             }
-        };
+        } );
     }
 
     @Test
@@ -590,6 +591,6 @@ public class TestRelationshipCount
 
     private GraphDatabaseService getGraphDb()
     {
-        return dbRule.getGraphDatabaseService();
+        return dbRule.get();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipGrabSize.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestRelationshipGrabSize.java
@@ -26,14 +26,15 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.lang.String.valueOf;
 
@@ -47,16 +48,15 @@ import static org.neo4j.kernel.impl.MyRelTypes.TEST;
 public class TestRelationshipGrabSize
 {
     private static final int GRAB_SIZE = 10;
-    private static GraphDatabaseAPI db;
+    private static GraphDatabase db;
     private Transaction tx;
 
     @BeforeClass
     public static void doBefore() throws Exception
     {
-        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
-                .newImpermanentDatabaseBuilder()
-                .setConfig( GraphDatabaseSettings.relationship_grab_size, valueOf( GRAB_SIZE ) )
-                .newGraphDatabase();
+        db = TestGraphDatabase.buildEphemeral()
+                .withSetting( GraphDatabaseSettings.relationship_grab_size, valueOf( GRAB_SIZE ) )
+                .open();
     }
 
     @AfterClass
@@ -221,7 +221,7 @@ public class TestRelationshipGrabSize
         clearCacheAndCreateDeleteCount( db, node1, node2, type2, type2, count );
     }
 
-    private void clearCacheAndCreateDeleteCount( GraphDatabaseAPI db, Node node1, Node node2,
+    private void clearCacheAndCreateDeleteCount( GraphDatabaseService db, Node node1, Node node2,
             RelationshipType createType, RelationshipType deleteType, int expectedCount )
     {
         try ( Transaction tx = db.beginTx() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShortStringProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShortStringProperties.java
@@ -32,9 +32,8 @@ import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.impl.store.AbstractDynamicStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.TestShortString;
-import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.GraphTransactionRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
@@ -48,7 +47,7 @@ import static org.neo4j.graphdb.Neo4jMatchers.inTx;
 public class TestShortStringProperties extends TestShortString
 {
     @ClassRule
-    public static DatabaseRule graphdb = new ImpermanentDatabaseRule();
+    public static final TestGraphDatabaseRule graphdb = TestGraphDatabaseRule.ephemeral();
 
     @Rule
     public GraphTransactionRule tx = new GraphTransactionRule( graphdb );
@@ -70,20 +69,20 @@ public class TestShortStringProperties extends TestShortString
     public void canAddMultipleShortStringsToTheSameNode() throws Exception
     {
         long recordCount = dynamicRecordsInUse();
-        Node node = graphdb.getGraphDatabaseService().createNode();
+        Node node = graphdb.get().createNode();
         node.setProperty( "key", "value" );
         node.setProperty( "reverse", "esrever" );
         commit();
         assertEquals( recordCount, dynamicRecordsInUse() );
-        assertThat( node, inTx( graphdb.getGraphDatabaseService(), hasProperty( "key" ).withValue( "value" )  ) );
-        assertThat( node, inTx( graphdb.getGraphDatabaseService(), hasProperty( "reverse" ).withValue( "esrever" )  ) );
+        assertThat( node, inTx( graphdb.get(), hasProperty( "key" ).withValue( "value" )  ) );
+        assertThat( node, inTx( graphdb.get(), hasProperty( "reverse" ).withValue( "esrever" )  ) );
     }
 
     @Test
     public void canAddShortStringToRelationship() throws Exception
     {
         long recordCount = dynamicRecordsInUse();
-        GraphDatabaseService db = graphdb.getGraphDatabaseService();
+        GraphDatabaseService db = graphdb.get();
         Relationship rel = db.createNode().createRelationshipTo( db.createNode(), withName( "REL_TYPE" ) );
         rel.setProperty( "type", "dimsedut" );
         commit();
@@ -98,7 +97,7 @@ public class TestShortStringProperties extends TestShortString
         {
             long recordCount = dynamicRecordsInUse();
             long propCount = propertyRecordsInUse();
-            Node node = graphdb.getGraphDatabaseService().createNode();
+            Node node = graphdb.get().createNode();
             node.setProperty( "key", "value" );
 
             newTx();
@@ -112,7 +111,7 @@ public class TestShortStringProperties extends TestShortString
 
             assertEquals( recordCount, dynamicRecordsInUse() );
             assertEquals( propCount + 1, propertyRecordsInUse() );
-            assertThat( node, inTx( graphdb.getGraphDatabaseService(), hasProperty( "key" ).withValue( "other" )  ) );
+            assertThat( node, inTx( graphdb.get(), hasProperty( "key" ).withValue( "other" )  ) );
         }
         catch ( Exception e )
         {
@@ -126,7 +125,7 @@ public class TestShortStringProperties extends TestShortString
     {
         long recordCount = dynamicRecordsInUse();
         long propCount = propertyRecordsInUse();
-        Node node = graphdb.getGraphDatabaseService().createNode();
+        Node node = graphdb.get().createNode();
         node.setProperty( "key", LONG_STRING );
         newTx();
 
@@ -139,7 +138,7 @@ public class TestShortStringProperties extends TestShortString
 
         assertEquals( recordCount, dynamicRecordsInUse() );
         assertEquals( propCount + 1, propertyRecordsInUse() );
-        assertThat( node, inTx( graphdb.getGraphDatabaseService(), hasProperty( "key" ).withValue( "value" )  ) );
+        assertThat( node, inTx( graphdb.get(), hasProperty( "key" ).withValue( "value" )  ) );
     }
 
     @Test
@@ -147,7 +146,7 @@ public class TestShortStringProperties extends TestShortString
     {
         long recordCount = dynamicRecordsInUse();
         long propCount = propertyRecordsInUse();
-        Node node = graphdb.getGraphDatabaseService().createNode();
+        Node node = graphdb.get().createNode();
         node.setProperty( "key", "value" );
         newTx();
 
@@ -160,7 +159,7 @@ public class TestShortStringProperties extends TestShortString
 
         assertEquals( recordCount + 1, dynamicRecordsInUse() );
         assertEquals( propCount + 1, propertyRecordsInUse() );
-        assertThat( node, inTx( graphdb.getGraphDatabaseService(), hasProperty( "key" ).withValue( LONG_STRING )  ) );
+        assertThat( node, inTx( graphdb.get(), hasProperty( "key" ).withValue( LONG_STRING )  ) );
     }
 
     @Test
@@ -168,7 +167,7 @@ public class TestShortStringProperties extends TestShortString
     {
         long recordCount = dynamicRecordsInUse();
         long propCount = propertyRecordsInUse();
-        GraphDatabaseService db = graphdb.getGraphDatabaseService();
+        GraphDatabaseService db = graphdb.get();
         Node node = db.createNode();
         node.setProperty( "key", "value" );
         newTx();
@@ -196,7 +195,7 @@ public class TestShortStringProperties extends TestShortString
     private void encode( String string, boolean isShort )
     {
         long recordCount = dynamicRecordsInUse();
-        Node node = graphdb.getGraphDatabaseService().createNode();
+        Node node = graphdb.get().createNode();
         node.setProperty( "key", string );
         newTx();
         if ( isShort )
@@ -245,6 +244,6 @@ public class TestShortStringProperties extends TestShortString
 
     private PropertyStore propertyStore()
     {
-        return graphdb.getGraphDatabaseAPI().getDependencyResolver().resolveDependency( NeoStoreDataSource.class).getNeoStores().getPropertyStore();
+        return graphdb.get().getDependencyResolver().resolveDependency( NeoStoreDataSource.class).getNeoStores().getPropertyStore();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShutdownSequence.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShutdownSequence.java
@@ -24,23 +24,23 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.event.ErrorState;
 import org.neo4j.graphdb.event.KernelEventHandler;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.impl.AbstractNeo4jTestCase.getStorePath;
 
 public class TestShutdownSequence
 {
-    private GraphDatabaseService graphDb;
+    private GraphDatabase graphDb;
     
     @Before
     public void createGraphDb()
     {
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestKernelEvents.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestKernelEvents.java
@@ -26,14 +26,17 @@ import static org.neo4j.kernel.impl.AbstractNeo4jTestCase.deleteFileOrDirectory;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.neo4j.graphdb.GraphDatabaseService;
+
+import java.io.File;
+
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.event.ErrorState;
 import org.neo4j.graphdb.event.KernelEventHandler;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 public class TestKernelEvents
 {
-    private static final String PATH = "target/var/neodb";
+    private static final File PATH = new File( "target/var/neodb" );
     
     private static final Object RESOURCE1 = new Object();
     private static final Object RESOURCE2 = new Object();
@@ -47,7 +50,7 @@ public class TestKernelEvents
     @Test
     public void testRegisterUnregisterHandlers()
     {
-        GraphDatabaseService graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        GraphDatabase graphDb = TestGraphDatabase.openEphemeral();
         KernelEventHandler handler1 = new DummyKernelEventHandler( RESOURCE1 )
         {
             @Override
@@ -107,7 +110,7 @@ public class TestKernelEvents
     @Test
     public void testShutdownEvents()
     {
-        GraphDatabaseService graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        GraphDatabase graphDb = TestGraphDatabase.openEphemeral();
         DummyKernelEventHandler handler1 = new DummyKernelEventHandler( RESOURCE1 )
         {
             @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
@@ -51,6 +51,7 @@ import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 import org.neo4j.test.TestLabels;
 
 import static org.hamcrest.Matchers.is;
@@ -81,7 +82,7 @@ public class TestTransactionEvents
         DummyTransactionEventHandler<Integer> handler1 = new DummyTransactionEventHandler<>( (Integer) value1 );
         DummyTransactionEventHandler<Double> handler2 = new DummyTransactionEventHandler<>( (Double) value2 );
 
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         try
         {
             db.unregisterTransactionEventHandler( handler1 );
@@ -132,7 +133,7 @@ public class TestTransactionEvents
     public void makeSureHandlersCantBeRegisteredTwice()
     {
         DummyTransactionEventHandler<Object> handler = new DummyTransactionEventHandler<>( null );
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         db.registerTransactionEventHandler( handler );
         db.registerTransactionEventHandler( handler );
         try ( Transaction tx = db.beginTx() )
@@ -153,7 +154,7 @@ public class TestTransactionEvents
         // Create new data, nothing modified, just added/created
         ExpectedTransactionData expectedData = new ExpectedTransactionData();
         VerifyingTransactionEventHandler handler = new VerifyingTransactionEventHandler( expectedData );
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         db.registerTransactionEventHandler( handler );
         Node node1 = null, node2, node3 = null;
         Relationship rel1 = null, rel2 = null;
@@ -282,7 +283,7 @@ public class TestTransactionEvents
         handlers.add( new FailingEventHandler<>( new DummyTransactionEventHandler<>( null ), false ) );
         handlers.add( new FailingEventHandler<>( new DummyTransactionEventHandler<>( null ), true ) );
         handlers.add( new FailingEventHandler<>( new DummyTransactionEventHandler<>( null ), false ) );
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         for ( TransactionEventHandler<Object> handler : handlers )
         {
             db.registerTransactionEventHandler( handler );
@@ -333,7 +334,7 @@ public class TestTransactionEvents
         }
 
         ExceptionThrowingEventHandler handler = new ExceptionThrowingEventHandler( new MyFancyException(), null, null );
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         db.registerTransactionEventHandler( handler );
 
         try
@@ -370,7 +371,7 @@ public class TestTransactionEvents
     @Test
     public void deleteNodeRelTriggerPropertyRemoveEvents()
     {
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         Node node1;
         Node node2;
         Relationship rel;
@@ -390,7 +391,6 @@ public class TestTransactionEvents
         db.registerTransactionEventHandler( handler );
         try ( Transaction tx = db.beginTx() )
         {
-            GraphDatabaseAPI dbApi = dbRule.getGraphDatabaseAPI();
             rel.delete();
             node1.delete();
             node2.delete();
@@ -611,7 +611,7 @@ public class TestTransactionEvents
     {
         DummyTransactionEventHandler<Integer> handler =
             new DummyTransactionEventHandler<>( 10 );
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         db.registerTransactionEventHandler( handler );
         try
         {
@@ -634,7 +634,7 @@ public class TestTransactionEvents
     {
         // Given
         // -- create node and set property on it in one transaction
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         final String key = "key";
         final Object value1 = "the old value";
         final Object value2 = "the new value";
@@ -674,7 +674,7 @@ public class TestTransactionEvents
     public void nodeCanBecomeSchemaIndexableInBeforeCommitByAddingProperty() throws Exception
     {
         // Given we have a schema index...
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         Label label = DynamicLabel.label( "Label" );
         IndexDefinition index;
         try ( Transaction tx = db.beginTx() )
@@ -720,7 +720,7 @@ public class TestTransactionEvents
     public void nodeCanBecomeSchemaIndexableInBeforeCommitByAddingLabel() throws Exception
     {
         // Given we have a schema index...
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         final Label label = DynamicLabel.label( "Label" );
         IndexDefinition index;
         try ( Transaction tx = db.beginTx() )
@@ -767,7 +767,7 @@ public class TestTransactionEvents
     public void shouldAccessAssignedLabels() throws Exception
     {
         // given
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
 
         ChangedLabels labels = (ChangedLabels) db.registerTransactionEventHandler( new ChangedLabels() );
         try
@@ -798,7 +798,7 @@ public class TestTransactionEvents
     public void shouldAccessRemovedLabels() throws Exception
     {
         // given
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
 
         ChangedLabels labels = (ChangedLabels) db.registerTransactionEventHandler( new ChangedLabels() );
         try
@@ -843,7 +843,7 @@ public class TestTransactionEvents
     public void shouldAccessRelationshipDataInAfterCommit() throws Exception
     {
         // GIVEN
-        final GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        final GraphDatabaseService db = dbRule.get();
         final AtomicInteger accessCount = new AtomicInteger();
         final Map<Long,Triplet<Node,String,Node>> expectedRelationshipData = new HashMap<>();
         TransactionEventHandler<Void> handler = new TransactionEventHandler.Adapter<Void>()
@@ -928,7 +928,7 @@ public class TestTransactionEvents
     @Test
     public void shouldProvideTheCorrectRelationshipData()
     {
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
 
         // create a rel type so the next type id is non zero
         try( Transaction tx = db.beginTx() )
@@ -984,13 +984,13 @@ public class TestTransactionEvents
     {
         // GIVEN
         Node root = createTree( 3, 3 );
-        dbRule.getGraphDatabaseService().registerTransactionEventHandler(
+        dbRule.get().registerTransactionEventHandler(
                 new ExceptionThrowingEventHandler( new RuntimeException( "Just failing" ) ) );
 
         // WHEN
         try ( Transaction tx = dbRule.beginTx() )
         {
-            count( dbRule.getGraphDatabaseService().traversalDescription().traverse( root ) );
+            count( dbRule.get().traversalDescription().traverse( root ) );
             tx.success();
         }
     }
@@ -1000,7 +1000,7 @@ public class TestTransactionEvents
     {
         // GIVEN
         final AtomicInteger counter = new AtomicInteger();
-        dbRule.getGraphDatabaseService().registerTransactionEventHandler( new TransactionEventHandler.Adapter<Void>()
+        dbRule.get().registerTransactionEventHandler( new TransactionEventHandler.Adapter<Void>()
         {
             @Override
             public Void beforeCommit( TransactionData data ) throws Exception
@@ -1065,7 +1065,7 @@ public class TestTransactionEvents
     {
         // GIVEN
         final Node node = createNode( "one", "Two", "three", "Four" );
-        dbRule.getGraphDatabaseService().registerTransactionEventHandler( new TransactionEventHandler.Adapter<Object>()
+        dbRule.get().registerTransactionEventHandler( new TransactionEventHandler.Adapter<Object>()
         {
             @Override
             public void afterCommit( TransactionData data, Object nothing )
@@ -1205,5 +1205,5 @@ public class TestTransactionEvents
     }
 
     @Rule
-    public final DatabaseRule dbRule = new ImpermanentDatabaseRule();
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/TestIndexImplOnNeo.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/TestIndexImplOnNeo.java
@@ -27,12 +27,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.test.EphemeralFileSystemRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -45,12 +45,12 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 public class TestIndexImplOnNeo
 {
     @Rule public EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
-    private GraphDatabaseService db;
+    private GraphDatabase db;
 
     @Before
     public void createDb() throws Exception
     {
-        db = new TestGraphDatabaseFactory().setFileSystem( fs.get() ).newImpermanentDatabase( new File( "mydb" ) );
+        db = TestGraphDatabase.buildEphemeral().withFileSystem( fs.get() ).open( new File( "mydb" ) );
     }
 
     private void restartDb() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
@@ -34,7 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
@@ -47,7 +48,6 @@ import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.is;
@@ -621,7 +621,7 @@ public class IdGeneratorTest
     {
         File storeDir = new File( "target/var/free-id-once" );
         deleteRecursively( storeDir );
-        GraphDatabaseService db = new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase( storeDir );
+        GraphDatabase db = TestGraphDatabase.buildEphemeral().withFileSystem( fs ).open( storeDir );
         RelationshipType type = withName( "SOME_TYPE" );
 
         // This transaction will, if some commands may be executed more than
@@ -655,7 +655,7 @@ public class IdGeneratorTest
         // After a clean shutdown, create new nodes and relationships and see so
         // that
         // all ids are unique.
-        db = new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase( storeDir );
+        db = TestGraphDatabase.buildEphemeral().withFileSystem( fs ).open( storeDir );
         tx = db.beginTx();
         commonNode = db.getNodeById( commonNode.getId() );
         for ( int i = 0; i < 100; i++ )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresIT.java
@@ -26,28 +26,28 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.embedded.TestGraphDatabase;
+import org.neo4j.function.Consumer;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Exceptions;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 public class NeoStoresIT
 {
-    public final @Rule DatabaseRule db = new EmbeddedDatabaseRule()
+    @Rule
+    public final TestGraphDatabaseRule db = TestGraphDatabaseRule.forClass( getClass(), new Consumer<TestGraphDatabase.Builder>()
     {
         @Override
-        protected void configure( GraphDatabaseBuilder builder )
+        public void accept( TestGraphDatabase.Builder builder )
         {
-            super.configure( builder );
-            builder.setConfig(  GraphDatabaseSettings.dense_node_threshold, "1");
+            builder.withSetting( GraphDatabaseSettings.dense_node_threshold, "1" );
         }
-    };
+    } );
 
     private static final DynamicRelationshipType FRIEND = DynamicRelationshipType.withName( "FRIEND" );
 
@@ -111,9 +111,9 @@ public class NeoStoresIT
 
         for ( int i = 0; i < 100_000; i++ )
         {
-            try ( Transaction tx = db.getGraphDatabaseAPI().beginTx() )
+            try ( Transaction tx = db.get().beginTx() )
             {
-                Node node = db.getGraphDatabaseService().getNodeById( latestNodeId[0] );
+                Node node = db.get().getNodeById( latestNodeId[0] );
 
                 for ( String propertyKey : node.getPropertyKeys() )
                 {
@@ -160,9 +160,9 @@ public class NeoStoresIT
 
         for ( int i = 0; i < 100_000; i++ )
         {
-            try ( Transaction tx = db.getGraphDatabaseAPI().beginTx() )
+            try ( Transaction tx = db.beginTx() )
             {
-                Node node = db.getGraphDatabaseService().getNodeById( latestNodeId[0] );
+                Node node = db.get().getNodeById( latestNodeId[0] );
 
                 for ( String propertyKey : node.getPropertyKeys() )
                 {
@@ -213,8 +213,8 @@ public class NeoStoresIT
                 {
                     try ( Transaction tx = db.beginTx() )
                     {
-                        Node node1 = db.getGraphDatabaseService().getNodeById( node1Id );
-                        Node node2 = db.getGraphDatabaseService().getNodeById( node2Id );
+                        Node node1 = db.get().getNodeById( node1Id );
+                        Node node2 = db.get().getNodeById( node2Id );
 
                         Relationship rel = node1.createRelationshipTo( node2, FRIEND );
                         latestRelationshipId[0] = rel.getId();
@@ -228,9 +228,9 @@ public class NeoStoresIT
 
         for ( int i = 0; i < 100_000; i++ )
         {
-            try ( Transaction tx = db.getGraphDatabaseAPI().beginTx() )
+            try ( Transaction tx = db.beginTx() )
             {
-                Relationship rel = db.getGraphDatabaseService().getRelationshipById( latestRelationshipId[0] );
+                Relationship rel = db.get().getRelationshipById( latestRelationshipId[0] );
 
                 for ( String propertyKey : rel.getPropertyKeys() )
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyKeyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyKeyTest.java
@@ -26,13 +26,13 @@ import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.test.EphemeralFileSystemRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchInserters;
 
@@ -53,7 +53,7 @@ public class PropertyKeyTest
         long nodeId = inserter.createNode( mapWithManyProperties( count /* larger than initial property index load threshold */ ) );
         inserter.shutdown();
         
-        GraphDatabaseService db = new TestGraphDatabaseFactory().setFileSystem( fileSystem ).newImpermanentDatabase( dir );
+        GraphDatabase db = TestGraphDatabase.buildEphemeral().withFileSystem( fileSystem ).open( dir );
 
         // When
         try (Transaction tx = db.beginTx())

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestBrokenStoreRecovery.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestBrokenStoreRecovery.java
@@ -27,10 +27,10 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.test.ProcessStreamHandler;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -60,7 +60,7 @@ public class TestBrokenStoreRecovery
         trimFileToSize( new File( storeDir, "neostore.propertystore.db" ), 42 );
         File log = new File( storeDir, PhysicalLogFile.DEFAULT_NAME + PhysicalLogFile.DEFAULT_VERSION_SUFFIX + "0" );
         trimFileToSize( log, 78 );
-        new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir.getAbsolutePath() ).shutdown();
+        TestGraphDatabase.open( storeDir ).shutdown();
     }
 
     @Rule

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
@@ -25,7 +25,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -33,7 +34,6 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.recovery.RecoveryRequiredChecker;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertTrue;
 
@@ -61,8 +61,7 @@ public class TestStoreAccess
 
     private EphemeralFileSystemAbstraction produceUncleanStore()
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().setFileSystem( fs.get() )
-                .newImpermanentDatabase( storeDir );
+        GraphDatabase db = TestGraphDatabase.buildEphemeral().withFileSystem( fs.get() ).open( storeDir );
         try ( Transaction tx = db.beginTx() )
         {
             db.createNode();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ManualAcquireLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ManualAcquireLockTest.java
@@ -32,10 +32,9 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Lock;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.GraphTransactionRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
 import org.neo4j.test.OtherThreadExecutor;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -43,7 +42,7 @@ import static org.junit.Assert.fail;
 
 public class ManualAcquireLockTest
 {
-    public DatabaseRule db = new ImpermanentDatabaseRule(  );
+    public final TestGraphDatabaseRule db = TestGraphDatabaseRule.ephemeral();
     public GraphTransactionRule tx = new GraphTransactionRule( db );
 
     @Rule public TestRule chain = RuleChain.outerRule( db ).around( tx );
@@ -149,7 +148,7 @@ public class ManualAcquireLockTest
 
     private GraphDatabaseService getGraphDb()
     {
-        return db.getGraphDatabaseService();
+        return db.get();
     }
 
     private class State

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionMonitorTest.java
@@ -21,9 +21,8 @@ package org.neo4j.kernel.impl.transaction;
 
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -32,7 +31,7 @@ public class TransactionMonitorTest
     @Test
     public void shouldCountCommittedTransactions() throws Exception
     {
-        GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestGraphDatabase db = TestGraphDatabase.openEphemeral();
         try
         {
             TransactionCounters monitor = db.getDependencyResolver().resolveDependency( TransactionCounters.class );
@@ -57,7 +56,7 @@ public class TransactionMonitorTest
     @Test
     public void shouldNotCountRolledBackTransactions() throws Exception
     {
-        GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestGraphDatabase db = TestGraphDatabase.openEphemeral();
         try
         {
             TransactionCounters monitor = db.getDependencyResolver().resolveDependency( TransactionCounters.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/TestTxEntries.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/TestTxEntries.java
@@ -24,13 +24,14 @@ import java.io.File;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.test.EphemeralFileSystemRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.neo4j.test.EphemeralFileSystemRule.shutdownDbAction;
 
@@ -47,11 +48,11 @@ public class TestTxEntries
     @Test
     public void testStartEntryWrittenOnceOnRollback() throws Exception
     {
-        final GraphDatabaseService db = new TestGraphDatabaseFactory().setFileSystem( fs.get() ).newImpermanentDatabase( storeDir );
+        final GraphDatabase db = TestGraphDatabase.buildEphemeral().withFileSystem( fs.get() ).open( storeDir );
         createSomeTransactions( db );
         EphemeralFileSystemAbstraction snapshot = fs.snapshot( shutdownDbAction( db ) );
 
-        new TestGraphDatabaseFactory().setFileSystem( snapshot ).newImpermanentDatabase( storeDir ).shutdown();
+        TestGraphDatabase.buildEphemeral().withFileSystem( snapshot ).open( storeDir ).shutdown();
     }
 
     private void createSomeTransactions( GraphDatabaseService db )

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestImpermanentGraphDatabase.java
@@ -23,12 +23,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.Matchers.is;
@@ -39,12 +39,12 @@ import static org.neo4j.test.GraphDatabaseServiceCleaner.cleanDatabaseContent;
 
 public class TestImpermanentGraphDatabase
 {
-    private GraphDatabaseService db;
+    private GraphDatabase db;
 
     @Before
     public void createDb()
     {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        db = TestGraphDatabase.openEphemeral();
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/metatest/TestJavaTestDocsGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/metatest/TestJavaTestDocsGenerator.java
@@ -30,6 +30,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.util.Map;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.kernel.impl.annotations.Documented;
@@ -39,14 +41,13 @@ import org.neo4j.test.GraphHolder;
 import org.neo4j.test.JavaTestDocsGenerator;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestData;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class TestJavaTestDocsGenerator implements GraphHolder
 {
-    private static GraphDatabaseService graphdb;
+    private static GraphDatabase graphdb;
     public @Rule
     TestData<Map<String,Node>> data = TestData.producedThrough( GraphDescription.createGraphFor( this, true ) );
     public @Rule
@@ -158,7 +159,7 @@ public class TestJavaTestDocsGenerator implements GraphHolder
     @BeforeClass
     public static void setUp()
     {
-        graphdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphdb = TestGraphDatabase.openEphemeral();
     }
 
     @AfterClass

--- a/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
@@ -29,13 +29,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
@@ -75,9 +76,7 @@ public class DbRepresentation implements Serializable
     
     public static DbRepresentation of( File storeDir, boolean includeIndexes )
     {
-        GraphDatabaseBuilder builder =
-                new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir.getPath() );
-        GraphDatabaseService db = builder.newGraphDatabase();
+        GraphDatabase db = TestGraphDatabase.open( storeDir );
         try
         {
             return of( db, includeIndexes );

--- a/community/kernel/src/test/java/org/neo4j/test/GraphTransactionRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/GraphTransactionRule.java
@@ -30,11 +30,11 @@ import org.neo4j.graphdb.Transaction;
 public class GraphTransactionRule
     extends ExternalResource
 {
-    private final DatabaseRule database;
+    private final TestGraphDatabaseRule database;
 
     private Transaction tx;
 
-    public GraphTransactionRule( DatabaseRule database )
+    public GraphTransactionRule( TestGraphDatabaseRule database )
     {
         this.database = database;
     }
@@ -59,7 +59,7 @@ public class GraphTransactionRule
 
     public Transaction begin()
     {
-        tx = database.getGraphDatabaseService().beginTx();
+        tx = database.get().beginTx();
         return tx;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.Service;
 import org.neo4j.helpers.collection.Iterables;
@@ -60,7 +61,7 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
     protected static final File PATH = new File( "target/test-data/impermanent-db" );
 
     /**
-     * This is deprecated. Use {@link TestGraphDatabaseFactory} instead
+     * This is deprecated. Use {@link TestGraphDatabase} instead
      */
     @Deprecated
     public ImpermanentGraphDatabase()
@@ -83,7 +84,7 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
     }
 
     /**
-     * This is deprecated. Use {@link TestGraphDatabaseFactory} instead
+     * This is deprecated. Use {@link TestGraphDatabase} instead
      */
     @Deprecated
     public ImpermanentGraphDatabase( Map<String, String> params )
@@ -92,7 +93,7 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
     }
 
     /**
-     * This is deprecated. Use {@link TestGraphDatabaseFactory} instead
+     * This is deprecated. Use {@link TestGraphDatabase} instead
      */
     @Deprecated
     public ImpermanentGraphDatabase( File storeDir, Map<String, String> params )
@@ -103,7 +104,7 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
     }
 
     /**
-     * This is deprecated. Use {@link TestGraphDatabaseFactory} instead
+     * This is deprecated. Use {@link TestGraphDatabase} instead
      */
     @Deprecated
     public ImpermanentGraphDatabase( Map<String, String> params,
@@ -113,7 +114,7 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
     }
 
     /**
-     * This is deprecated. Use {@link TestGraphDatabaseFactory} instead
+     * This is deprecated. Use {@link TestGraphDatabase} instead
      */
     @Deprecated
     public ImpermanentGraphDatabase( File storeDir, Map<String, String> params,

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -22,6 +22,7 @@ package org.neo4j.test;
 import java.io.File;
 import java.util.Map;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
@@ -42,7 +43,9 @@ import org.neo4j.logging.NullLogProvider;
 
 /**
  * Test factory for graph databases
+ * @deprecated use {@link TestGraphDatabase} instead
  */
+@Deprecated
 public class TestGraphDatabaseFactory extends GraphDatabaseFactory
 {
     public TestGraphDatabaseFactory()

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseRule.java
@@ -35,6 +35,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.helpers.Pair;
@@ -258,6 +259,11 @@ public class TestGraphDatabaseRule extends ExternalResource implements Supplier<
     public Schema schema()
     {
         return get().schema();
+    }
+
+    public IndexManager index()
+    {
+        return get().index();
     }
 
     public <T> T resolveDependency( Class<T> type )

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseRule.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.neo4j.embedded.TestGraphDatabase;
+import org.neo4j.function.Consumer;
+import org.neo4j.function.Consumers;
+import org.neo4j.function.Function;
+import org.neo4j.function.Functions;
+import org.neo4j.function.Supplier;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.graphdb.schema.Schema;
+import org.neo4j.helpers.Pair;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileUtils;
+import org.neo4j.logging.LogProvider;
+
+public class TestGraphDatabaseRule extends ExternalResource implements Supplier<TestGraphDatabase>
+{
+    public static TestGraphDatabaseRule forClass( final Class<?> testClass )
+    {
+        return forClass( testClass, Consumers.<TestGraphDatabase.Builder>noop() );
+    }
+
+    public static TestGraphDatabaseRule forClass( final Class<?> testClass, final Consumer<TestGraphDatabase.Builder> configuration )
+    {
+        final TargetDirectory testDirectory = new TargetDirectory( new DefaultFileSystemAbstraction(), testClass );
+        return new TestGraphDatabaseRule( new Supplier<Pair<TestGraphDatabase,Consumer<Boolean>>>()
+        {
+            @Override
+            public Pair<TestGraphDatabase,Consumer<Boolean>> get()
+            {
+                final File storeDir = testDirectory.makeGraphDbDir();
+                cleanup();
+                TestGraphDatabase.Builder builder = TestGraphDatabase.build();
+                configuration.accept( builder );
+                final TestGraphDatabase graphDB = builder.open( storeDir );
+                Consumer<Boolean> finalCleanup = success -> {
+                    graphDB.shutdown();
+                    if ( success )
+                    {
+                        cleanup();
+                    }
+                };
+                return Pair.of( graphDB, finalCleanup );
+            }
+
+            private void cleanup()
+            {
+                try
+                {
+                    testDirectory.cleanup();
+                }
+                catch ( IOException e )
+                {
+                    throw new RuntimeException( e );
+                }
+            }
+        } );
+    }
+
+    public static TestGraphDatabaseRule forStoreDir( final File storeDir )
+    {
+        return forStoreDir( storeDir, Consumers.<TestGraphDatabase.Builder>noop() );
+    }
+
+    public static TestGraphDatabaseRule forStoreDir( final File storeDir, final Consumer<TestGraphDatabase.Builder> configuration )
+    {
+        return new TestGraphDatabaseRule( new Supplier<Pair<TestGraphDatabase,Consumer<Boolean>>>()
+        {
+            @Override
+            public Pair<TestGraphDatabase,Consumer<Boolean>> get()
+            {
+                TestGraphDatabase.Builder builder = TestGraphDatabase.build();
+                configuration.accept( builder );
+                final TestGraphDatabase graphDB = builder.open( storeDir );
+                Consumer<Boolean> finalCleanup = success -> {
+                    graphDB.shutdown();
+                    if ( success )
+                    {
+                        cleanup();
+                    }
+                };
+                return Pair.of( graphDB, finalCleanup );
+            }
+
+            private void cleanup()
+            {
+                try
+                {
+                    FileUtils.deleteRecursively( storeDir );
+                }
+                catch ( IOException e )
+                {
+                    throw new RuntimeException( e );
+                }
+            }
+        } );
+    }
+
+    public static TestGraphDatabaseRule ephemeral()
+    {
+        return ephemeral( Consumers.<TestGraphDatabase.EphemeralBuilder>noop() );
+    }
+
+    public static TestGraphDatabaseRule ephemeral( final LogProvider logProvider )
+    {
+        return ephemeral( builder -> {
+            builder.withLogProvider( logProvider ).withInternalLogProvider( logProvider );
+        } );
+    }
+
+    public static TestGraphDatabaseRule ephemeral( final Consumer<TestGraphDatabase.EphemeralBuilder> configuration )
+    {
+        return new TestGraphDatabaseRule( () -> {
+            final EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+            TestGraphDatabase.EphemeralBuilder builder = TestGraphDatabase.buildEphemeral().withFileSystem( fs );
+            configuration.accept( builder );
+            final TestGraphDatabase graphDatabase = builder.open();
+            Consumer<Boolean> cleanup1 = success -> {
+                graphDatabase.shutdown();
+                fs.shutdown();
+            };
+            return Pair.of( graphDatabase, cleanup1 );
+        } );
+    }
+
+
+    private final Supplier<Pair<TestGraphDatabase,Consumer<Boolean>>> resourceSupplier;
+
+    private TestGraphDatabase graphDb;
+    private Consumer<Boolean> cleanup;
+
+    protected TestGraphDatabaseRule( Supplier<Pair<TestGraphDatabase,Consumer<Boolean>>> resourceSupplier )
+    {
+        this.resourceSupplier = resourceSupplier;
+    }
+
+    @Override
+    public TestGraphDatabase get()
+    {
+        if ( graphDb == null )
+        {
+            synchronized ( this )
+            {
+                if ( graphDb == null )
+                {
+                    Pair<TestGraphDatabase,Consumer<Boolean>> pair = resourceSupplier.get();
+                    graphDb = pair.first();
+                    cleanup = pair.other();
+                }
+            }
+        }
+        return graphDb;
+    }
+
+    @Override
+    protected void after( boolean successful ) throws Throwable
+    {
+        if ( cleanup != null )
+        {
+            cleanup.accept( successful );
+        }
+    }
+
+    public <T> T when( Function<GraphDatabaseService,T> function )
+    {
+        return function.apply( get() );
+    }
+
+    public Transaction beginTx()
+    {
+        return get().beginTx();
+    }
+
+    public Result execute( String query ) throws QueryExecutionException
+    {
+        return get().execute( query );
+    }
+
+    public Result execute( String query, Map<String,Object> parameters ) throws QueryExecutionException
+    {
+        return get().execute( query, parameters );
+    }
+
+    public void executeAndCommit( Consumer<? super GraphDatabaseService> consumer )
+    {
+        executeAndCommit( Functions.fromConsumer( consumer ) );
+    }
+
+    public <T> T executeAndCommit( Function<? super GraphDatabaseService,T> function )
+    {
+        GraphDatabaseService gds = get();
+        try ( Transaction tx = gds.beginTx() )
+        {
+            T result = function.apply( gds );
+
+            tx.success();
+            return result;
+        }
+    }
+
+    public <T> T executeAndRollback( Function<? super GraphDatabaseService,T> function )
+    {
+        GraphDatabaseService gds = get();
+        try ( Transaction tx = gds.beginTx() )
+        {
+            return function.apply( gds );
+        }
+    }
+
+    public <FROM, TO> AlgebraicFunction<FROM,TO> tx( final Function<FROM,TO> function )
+    {
+        return new AlgebraicFunction<FROM,TO>()
+        {
+            @Override
+            public TO apply( final FROM from )
+            {
+                return executeAndCommit( graphDb -> {
+                    return function.apply( from );
+                } );
+            }
+        };
+    }
+
+    public Node createNode( Label... labels )
+    {
+        return get().createNode( labels );
+    }
+
+    public Schema schema()
+    {
+        return get().schema();
+    }
+
+    public <T> T resolveDependency( Class<T> type )
+    {
+        return get().getDependencyResolver().resolveDependency( type );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BigBatchStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BigBatchStoreIT.java
@@ -38,14 +38,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Direction;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.kernel.IdType;
 import org.neo4j.test.EphemeralFileSystemRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.unsafe.batchinsert.BatchInserters;
-import org.neo4j.unsafe.batchinsert.BatchRelationship;
 
 public class BigBatchStoreIT implements RelationshipType
 {
@@ -125,7 +124,7 @@ public class BigBatchStoreIT implements RelationshipType
         assertEquals( asSet( asList( relBelowTheLine, relAboveTheLine ) ), asIds( db.getRelationships( idBelow ) ) );
         db.shutdown();
         
-        GraphDatabaseService edb = new TestGraphDatabaseFactory().setFileSystem( fs.get() ).newImpermanentDatabase( PATH );
+        GraphDatabase edb = TestGraphDatabase.buildEphemeral().withFileSystem( fs.get() ).open( PATH );
         assertEquals( nodeAboveTheLine, edb.getNodeById( highMark ).getId() );
         assertEquals( relBelowTheLine, edb.getNodeById( idBelow ).getSingleRelationship( this, Direction.OUTGOING ).getId() );
         assertEquals( relAboveTheLine, edb.getNodeById( idBelow ).getSingleRelationship( this, Direction.INCOMING ).getId() );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputBatchImportIT.java
@@ -38,8 +38,9 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.function.Function;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -57,7 +58,6 @@ import org.neo4j.kernel.impl.transaction.state.NeoStoresSupplier;
 import org.neo4j.kernel.impl.util.AutoCreatingHashMap;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
@@ -256,7 +256,7 @@ public class CsvInputBatchImportIT
                 expectedNodeCounts, expectedRelationshipCounts );
 
         // Do the verification
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( directory.graphDbDir() );
+        GraphDatabase db = TestGraphDatabase.open( directory.graphDbDir() );
         try ( Transaction tx = db.beginTx() )
         {
             // Verify nodes

--- a/community/lucene-index/src/test/java/examples/LuceneIndexSiteExamples.java
+++ b/community/lucene-index/src/test/java/examples/LuceneIndexSiteExamples.java
@@ -24,23 +24,23 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertNotNull;
 
 public class LuceneIndexSiteExamples
 {
-    private static GraphDatabaseService graphDb;
+    private static GraphDatabase graphDb;
     private Transaction tx;
     
     @BeforeClass
     public static void setUpDb()
     {
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
     }
     
     @Before

--- a/community/lucene-index/src/test/java/examples/RelatedNodesQuestionTest.java
+++ b/community/lucene-index/src/test/java/examples/RelatedNodesQuestionTest.java
@@ -21,14 +21,14 @@ package examples;
 
 import org.junit.Test;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.graphdb.index.RelationshipIndex;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -42,7 +42,7 @@ public class RelatedNodesQuestionTest
     @Test
     public void question5346011()
     {
-        GraphDatabaseService service = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        GraphDatabase service = TestGraphDatabase.openEphemeral();
         try ( Transaction tx = service.beginTx() )
         {
             RelationshipIndex index = service.index().forRelationships( "exact" );

--- a/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
@@ -22,18 +22,17 @@ package org.neo4j.concurrencytest;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.function.Function;
 import org.neo4j.function.Supplier;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyConstraintViolationKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 import org.neo4j.test.ThreadingRule;
 
 import static org.junit.Assert.assertEquals;
@@ -44,7 +43,7 @@ import static org.neo4j.kernel.api.properties.Property.property;
 public class ConstraintIndexConcurrencyTest
 {
     @Rule
-    public final DatabaseRule db = new ImpermanentDatabaseRule();
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
     @Rule
     public final ThreadingRule threads = new ThreadingRule();
 
@@ -52,7 +51,7 @@ public class ConstraintIndexConcurrencyTest
     public void shouldNotAllowConcurrentViolationOfConstraint() throws Exception
     {
         // Given
-        GraphDatabaseAPI graphDb = db.getGraphDatabaseAPI();
+        TestGraphDatabase graphDb = dbRule.get();
 
         Supplier<Statement> statementSupplier = graphDb.getDependencyResolver()
                 .resolveDependency( ThreadToStatementContextBridge.class );

--- a/community/lucene-index/src/test/java/org/neo4j/concurrencytest/LegacyIndexAddDropConcurrently.java
+++ b/community/lucene-index/src/test/java/org/neo4j/concurrencytest/LegacyIndexAddDropConcurrently.java
@@ -34,19 +34,19 @@ import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 public class LegacyIndexAddDropConcurrently
 {
     @Rule
-    public ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     @Test
     public void shouldHandleConcurrentIndexDropping() throws Exception
     {
         // Given
         ExecutorService exec = Executors.newFixedThreadPool( 4 );
-        final GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        final GraphDatabaseService db = dbRule.get();
 
         List<Callable<Object>> jobs = new ArrayList<>();
         for ( int i = 0; i < 4; i++ )

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreChaosIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/LuceneLabelScanStoreChaosIT.java
@@ -27,14 +27,15 @@ import java.nio.channels.FileChannel;
 import java.util.Random;
 import java.util.Set;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
+import org.neo4j.function.Consumer;
 import org.neo4j.function.Predicates;
-import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.DatabaseRule.RestartAction;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TargetDirectory;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -52,6 +53,26 @@ import static org.neo4j.io.fs.FileUtils.deleteRecursively;
  */
 public class LuceneLabelScanStoreChaosIT
 {
+    @Rule
+    public final TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+
+    private final Random random = new Random();
+    private File storeDir;
+    private TestGraphDatabase db;
+
+    @Before
+    public void setUp()
+    {
+        storeDir = testDirectory.graphDbDir();
+        db = TestGraphDatabase.build().open( storeDir );
+    }
+
+    @After
+    public void tearDown()
+    {
+        db.shutdown();
+    }
+
     @Test
     public void shouldRebuildDeletedLabelScanStoreOnStartup() throws Exception
     {
@@ -64,7 +85,7 @@ public class LuceneLabelScanStoreChaosIT
         // WHEN
         // TODO how do we make sure it was deleted and then fully rebuilt? I mean if we somehow deleted
         // the wrong directory here then it would also work, right?
-        dbRule.restartDatabase( deleteTheLabelScanStoreIndex() );
+        restartDatabase( deleteTheLabelScanStoreIndex() );
 
         // THEN
         assertEquals(
@@ -83,7 +104,7 @@ public class LuceneLabelScanStoreChaosIT
         // the wrong directory here then it would also work, right?
         try
         {
-            dbRule.restartDatabase( corruptTheLabelScanStoreIndex() );
+            restartDatabase( corruptTheLabelScanStoreIndex() );
             fail( "Shouldn't be able to start up" );
         }
         catch ( RuntimeException e )
@@ -95,12 +116,19 @@ public class LuceneLabelScanStoreChaosIT
         }
     }
 
-    private RestartAction corruptTheLabelScanStoreIndex()
+    public void restartDatabase( Consumer<File> action ) throws IOException
     {
-        return new RestartAction()
+        db.shutdown();
+        action.accept( storeDir );
+        db = TestGraphDatabase.build().open( storeDir );
+    }
+
+    private Consumer<File> corruptTheLabelScanStoreIndex()
+    {
+        return new Consumer<File>()
         {
             @Override
-            public void run( FileSystemAbstraction fs, File storeDirectory )
+            public void accept( File storeDirectory )
             {
                 try
                 {
@@ -120,12 +148,12 @@ public class LuceneLabelScanStoreChaosIT
         };
     }
 
-    private RestartAction deleteTheLabelScanStoreIndex()
+    private static Consumer<File> deleteTheLabelScanStoreIndex()
     {
-        return new RestartAction()
+        return new Consumer<File>()
         {
             @Override
-            public void run( FileSystemAbstraction fs, File storeDirectory )
+            public void accept( File storeDirectory )
             {
                 try
                 {
@@ -142,17 +170,16 @@ public class LuceneLabelScanStoreChaosIT
         };
     }
 
-    private File labelScanStoreIndexDirectory( File storeDirectory )
+    private static File labelScanStoreIndexDirectory( File storeDirectory )
     {
-        File directory = new File( new File( new File( storeDirectory, "schema" ), "label" ), "lucene" );
-        return directory;
+        return new File( new File( new File( storeDirectory, "schema" ), "label" ), "lucene" );
     }
 
     private Node createLabeledNode( Label... labels )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = db.beginTx() )
         {
-            Node node = dbRule.getGraphDatabaseService().createNode( labels );
+            Node node = db.createNode( labels );
             tx.success();
             return node;
         }
@@ -160,15 +187,15 @@ public class LuceneLabelScanStoreChaosIT
 
     private Set<Node> getAllNodesWithLabel( Label label )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = db.beginTx() )
         {
-            return asSet( dbRule.getGraphDatabaseService().findNodes( label ) );
+            return asSet( db.findNodes( label ) );
         }
     }
 
     private void deleteNode( Node node )
     {
-        try ( Transaction tx = dbRule.getGraphDatabaseService().beginTx() )
+        try ( Transaction tx = db.beginTx() )
         {
             node.delete();
             tx.success();
@@ -203,7 +230,4 @@ public class LuceneLabelScanStoreChaosIT
         Second,
         Third;
     }
-
-    public final @Rule DatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() );
-    private final Random random = new Random();
 }

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexHitsFacadeTests.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexHitsFacadeTests.java
@@ -25,14 +25,14 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.fail;
 
 public class MandatoryTransactionsForIndexHitsFacadeTests
 {
     @Rule
-    public ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     private IndexHits<Node> indexHits;
 
@@ -86,7 +86,7 @@ public class MandatoryTransactionsForIndexHitsFacadeTests
 
     private Index<Node> createIndex()
     {
-        GraphDatabaseService graphDatabaseService = dbRule.getGraphDatabaseService();
+        GraphDatabaseService graphDatabaseService = dbRule.get();
         try ( Transaction transaction = graphDatabaseService.beginTx() )
         {
             Index<Node> index = graphDatabaseService.index().forNodes( "foo" );
@@ -97,7 +97,7 @@ public class MandatoryTransactionsForIndexHitsFacadeTests
 
     private IndexHits<Node> queryIndex( Index<Node> index )
     {
-        GraphDatabaseService graphDatabaseService = dbRule.getGraphDatabaseService();
+        GraphDatabaseService graphDatabaseService = dbRule.get();
         try ( Transaction transaction = graphDatabaseService.beginTx() )
         {
             return index.get( "foo", 42 );

--- a/community/lucene-index/src/test/java/org/neo4j/index/Neo4jTestCase.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/Neo4jTestCase.java
@@ -30,9 +30,10 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -40,13 +41,13 @@ import static org.neo4j.helpers.SillyUtils.nonNull;
 
 public abstract class Neo4jTestCase
 {
-    private static GraphDatabaseService graphDb;
+    private static GraphDatabase graphDb;
     private Transaction tx;
 
     @BeforeClass
     public static void setUpDb() throws Exception
     {
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
     }
     
     @Before

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AbstractLuceneIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AbstractLuceneIndexTest.java
@@ -28,8 +28,9 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
@@ -38,18 +39,17 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.RelationshipIndex;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 public abstract class AbstractLuceneIndexTest
 {
-    protected static GraphDatabaseService graphDb;
+    protected static GraphDatabase graphDb;
     protected Transaction tx;
     public final @Rule TestName testname = new TestName();
 
     @BeforeClass
     public static void setUpStuff()
     {
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
     }
 
     @AfterClass

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AutoIndexerTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/AutoIndexerTest.java
@@ -24,17 +24,17 @@ import org.junit.Test;
 
 import java.util.Iterator;
 
+import org.neo4j.embedded.TestGraphDatabase;
+import org.neo4j.function.Consumer;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.graphdb.index.ReadableRelationshipIndex;
 import org.neo4j.kernel.impl.MyRelTypes;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 
@@ -42,16 +42,15 @@ import static org.neo4j.helpers.collection.IteratorUtil.count;
 
 public class AutoIndexerTest
 {
-    public final @Rule DatabaseRule db = new EmbeddedDatabaseRule()
+    public final @Rule TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral( new Consumer<TestGraphDatabase.EphemeralBuilder>()
     {
         @Override
-        protected void configure( GraphDatabaseBuilder builder )
+        public void accept( TestGraphDatabase.EphemeralBuilder builder )
         {
-            super.configure( builder );
-            builder.setConfig( GraphDatabaseSettings.relationship_keys_indexable, "Type" );
-            builder.setConfig( GraphDatabaseSettings.relationship_auto_indexing, "true" );
+            builder.withSetting( GraphDatabaseSettings.relationship_keys_indexable, "Type" );
+            builder.withSetting( GraphDatabaseSettings.relationship_auto_indexing, "true" );
         }
-    };
+    } );
 
     @Test
     public void shouldNotSeeDeletedRelationshipWhenQueryingWithStartAndEndNode()
@@ -60,6 +59,7 @@ public class AutoIndexerTest
         long startId;
         long endId;
         Relationship rel;
+        final TestGraphDatabase db = dbRule.get();
         try ( Transaction tx = db.beginTx() )
         {
             Node start = db.createNode();

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
@@ -24,12 +24,12 @@ import org.junit.Test;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertTrue;
@@ -40,11 +40,11 @@ public class LuceneRecoveryIT
     @Test
     public void testHardCoreRecovery() throws Exception
     {
-        String path = "target/hcdb";
-        FileUtils.deleteRecursively( new File( path ) );
+        File path = new File( "target/hcdb" );
+        FileUtils.deleteRecursively( path );
         Process process = Runtime.getRuntime().exec( new String[]{
                 "java", "-cp", System.getProperty( "java.class.path" ),
-                Inserter.class.getName(), path
+                Inserter.class.getName(), path.getAbsolutePath()
         } );
 
         // Let it run for a while and then kill it, and wait for it to die
@@ -53,7 +53,7 @@ public class LuceneRecoveryIT
         process.destroy();
         process.waitFor();
 
-        final GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( path );
+        final GraphDatabase db = TestGraphDatabase.open( path );
         try ( Transaction transaction = db.beginTx() )
         {
             assertTrue( db.index().existsForNodes( "myIndex" ) );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/PerformanceAndSanityIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/PerformanceAndSanityIT.java
@@ -36,16 +36,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.index.lucene.QueryContext;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.lang.System.currentTimeMillis;
 import static java.lang.System.out;
@@ -135,7 +134,7 @@ public class PerformanceAndSanityIT extends AbstractLuceneIndexTest
     {
         commitTx();
 
-        graphDb = new GraphDatabaseFactory().newEmbeddedDatabase(testDirectory.directory( "filesClosedProperty" ) );
+        graphDb = TestGraphDatabase.open( testDirectory.directory( "filesClosedProperty" ) );
         final Index<Node> index = nodeIndex( "open-files", LuceneIndexImplementation.EXACT_CONFIG );
         final long time = System.currentTimeMillis();
         final CountDownLatch latch = new CountDownLatch( 30 );
@@ -209,7 +208,7 @@ public class PerformanceAndSanityIT extends AbstractLuceneIndexTest
         pool.shutdown();
         pool.awaitTermination( 10, TimeUnit.DAYS );
         graphDb.shutdown();
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
     }
 
     @Ignore

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexDelectionFs.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexDelectionFs.java
@@ -26,26 +26,26 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.index.IndexEntityType;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TestIndexDelectionFs
 {
-    private static GraphDatabaseAPI db;
+    private static TestGraphDatabase db;
 
     @BeforeClass
     public static void doBefore() throws IOException
     {
-        FileUtils.deleteRecursively( new File( "target/test-data/deletion" ) );
-        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newEmbeddedDatabase( "target/test-data/deletion" );
+        final File storeDir = new File( "target/test-data/deletion" );
+        FileUtils.deleteRecursively( storeDir );
+        db = TestGraphDatabase.open( storeDir );
     }
 
     @AfterClass
@@ -60,7 +60,7 @@ public class TestIndexDelectionFs
         String indexName = "index";
         String otherIndexName = "other-index";
 
-        File indexBaseDir = new File( db.getStoreDir(), "index" );
+        File indexBaseDir = new File( db.storeDir(), "index" );
         File pathToLuceneIndex = LuceneDataSource.getFileDirectory( indexBaseDir,
                 new IndexIdentifier( IndexEntityType.Node, indexName ) );
         File pathToOtherLuceneIndex = LuceneDataSource.getFileDirectory( indexBaseDir,

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexDeletion.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexDeletion.java
@@ -29,13 +29,13 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -49,7 +49,7 @@ import static org.neo4j.index.impl.lucene.Contains.contains;
 public class TestIndexDeletion
 {
     private static final String INDEX_NAME = "index";
-    private static GraphDatabaseService graphDb;
+    private static GraphDatabase graphDb;
     private Index<Node> index;
     private Transaction tx;
     private String key;
@@ -60,7 +60,7 @@ public class TestIndexDeletion
     @BeforeClass
     public static void setUpStuff()
     {
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
     }
 
     @AfterClass

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexNames.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestIndexNames.java
@@ -26,24 +26,24 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.index.Neo4jTestCase.assertContains;
 
 public class TestIndexNames
 {
-    private static GraphDatabaseService graphDb;
+    private static GraphDatabase graphDb;
     private Transaction tx;
     
     @BeforeClass
     public static void setUpStuff()
     {
-        graphDb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
     }
 
     @AfterClass

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestMigration.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestMigration.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
@@ -45,7 +47,6 @@ import org.neo4j.index.Neo4jTestCase;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -189,9 +190,9 @@ public class TestMigration
         graphDb.shutdown();
     }
 
-    private GraphDatabaseService startDatabase( File storeDir )
+    private GraphDatabase startDatabase( File storeDir )
     {
-        return new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir.getPath() );
+        return TestGraphDatabase.open( storeDir );
     }
 
     private void removeProvidersFromIndexDbFile( File storeDir )

--- a/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
@@ -36,7 +38,6 @@ import org.neo4j.kernel.api.exceptions.schema.UnableToValidateConstraintKernelEx
 import org.neo4j.kernel.api.index.util.FailureStorage;
 import org.neo4j.kernel.api.index.util.FolderLayout;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -80,9 +81,9 @@ public class ConstraintIndexFailureIT
         }
     }
 
-    private GraphDatabaseService startDatabase()
+    private GraphDatabase startDatabase()
     {
-        return new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir.directory().getAbsolutePath() );
+        return TestGraphDatabase.open( storeDir.directory() );
     }
 
     private void dbWithConstraint()

--- a/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTests.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/recovery/UniqueIndexRecoveryTests.java
@@ -34,12 +34,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.impl.index.LuceneLabelScanStoreExtension;
 import org.neo4j.kernel.api.impl.index.LuceneSchemaIndexProviderFactory;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
@@ -49,7 +49,6 @@ import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.impl.transaction.log.rotation.StoreFlusher;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -111,7 +110,7 @@ public class UniqueIndexRecoveryTests
     private void restart( File newStore )
     {
         db.shutdown();
-        db = (GraphDatabaseAPI) factory.newEmbeddedDatabase( newStore.getAbsolutePath() );
+        db = TestGraphDatabase.open( newStore );
     }
 
     private File snapshot( final String path ) throws IOException
@@ -225,8 +224,7 @@ public class UniqueIndexRecoveryTests
     private static final String PROPERTY_VALUE = "value";
     private static final Label LABEL = label( "label" );
 
-    private final TestGraphDatabaseFactory factory = new TestGraphDatabaseFactory();
-    private GraphDatabaseAPI db;
+    private TestGraphDatabase db;
 
     @Before
     public void before()
@@ -234,8 +232,9 @@ public class UniqueIndexRecoveryTests
         List<KernelExtensionFactory<?>> extensionFactories = new ArrayList<>();
         extensionFactories.add( kernelExtensionFactory );
         extensionFactories.add(new LuceneLabelScanStoreExtension());
-        factory.setKernelExtensions( extensionFactories );
-        db = (GraphDatabaseAPI) factory.newEmbeddedDatabase( storeDir.absolutePath() );
+        db = TestGraphDatabase.build()
+                .addKernelExtensions( extensionFactories )
+                .open( storeDir.directory() );
     }
 
     @After

--- a/community/lucene-index/src/test/java/org/neo4j/index/timeline/TestTimeline.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/timeline/TestTimeline.java
@@ -27,8 +27,10 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
@@ -39,7 +41,6 @@ import org.neo4j.graphdb.index.RelationshipIndex;
 import org.neo4j.helpers.Pair;
 import org.neo4j.index.lucene.LuceneTimeline;
 import org.neo4j.index.lucene.TimelineIndex;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Collections.sort;
 import static org.junit.Assert.*;
@@ -47,12 +48,12 @@ import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 
 public class TestTimeline
 {
-    private GraphDatabaseService db;
+    private GraphDatabase db;
 
     @Before
     public void before() throws Exception
     {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().newGraphDatabase();
+        db = TestGraphDatabase.openEphemeral();
     }
 
     @After

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/SchemaIndexAcceptanceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/SchemaIndexAcceptanceTest.java
@@ -26,6 +26,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -33,7 +35,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema.IndexState;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertThat;
 
@@ -154,7 +155,7 @@ public class SchemaIndexAcceptanceTest
     }
 
     private EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
-    private GraphDatabaseService db;
+    private GraphDatabase db;
     private final Label label = label( "PERSON" );
     private final String propertyKey = "key";
 
@@ -164,9 +165,9 @@ public class SchemaIndexAcceptanceTest
         db = newDb();
     }
 
-    private GraphDatabaseService newDb()
+    private GraphDatabase newDb()
     {
-        return new TestGraphDatabaseFactory().setFileSystem( fs ).newImpermanentDatabase();
+        return TestGraphDatabase.buildEphemeral().withFileSystem( fs ).open();
     }
 
     private void crashAndRestart()

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueIndexApplicationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/UniqueIndexApplicationIT.java
@@ -36,8 +36,7 @@ import org.neo4j.function.Function;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -56,7 +55,8 @@ import static org.neo4j.test.DatabaseFunctions.uniquenessConstraint;
 @RunWith(Parameterized.class)
 public class UniqueIndexApplicationIT
 {
-    public final @Rule DatabaseRule db = new ImpermanentDatabaseRule();
+    @Rule
+    public final TestGraphDatabaseRule db = TestGraphDatabaseRule.ephemeral();
 
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> indexTypes()

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
@@ -24,16 +24,16 @@ import org.junit.Test;
 
 import java.io.File;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.impl.index.LuceneSchemaIndexProviderFactory;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
-import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -43,13 +43,13 @@ public class ConstraintCreationIT
 {
     private static final Label LABEL = DynamicLabel.label( "label1" );
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( ConstraintCreationIT.class );
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.forClass( ConstraintCreationIT.class );
 
     @Test
     public void shouldNotLeaveLuceneIndexFilesHangingAroundIfConstraintCreationFails()
     {
         // given
-        GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
+        TestGraphDatabase db = dbRule.get();
 
         try ( Transaction tx = db.beginTx() )
         {
@@ -78,7 +78,7 @@ public class ConstraintCreationIT
         }
 
         File schemaStorePath = SchemaIndexProvider
-                .getRootDirectory( new File( db.getStoreDir() ), LuceneSchemaIndexProviderFactory.KEY );
+                .getRootDirectory( db.storeDir(), LuceneSchemaIndexProviderFactory.KEY );
 
         String indexId = "1";
         File[] files = new File(schemaStorePath, indexId ).listFiles();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintRecoveryIT.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.Label;
@@ -34,12 +35,10 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.transaction.state.NeoStoresSupplier;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.EphemeralFileSystemRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
@@ -51,7 +50,7 @@ public class ConstraintRecoveryIT
     private static final Label LABEL = DynamicLabel.label( "label1" );
     @Rule
     public EphemeralFileSystemRule fileSystemRule = new EphemeralFileSystemRule();
-    private GraphDatabaseAPI db;
+    private TestGraphDatabase db;
 
     @Test
     public void shouldNotHaveAnIndexIfUniqueConstraintCreationOnRecoveryFails() throws IOException
@@ -60,9 +59,6 @@ public class ConstraintRecoveryIT
         final EphemeralFileSystemAbstraction fs = fileSystemRule.get();
         fs.mkdir( new File("/tmp") );
         File pathToDb = new File( "/tmp/bar2" );
-
-        TestGraphDatabaseFactory dbFactory = new TestGraphDatabaseFactory();
-        dbFactory.setFileSystem( fs );
 
         final EphemeralFileSystemAbstraction[] storeInNeedOfRecovery = new EphemeralFileSystemAbstraction[1];
         final AtomicBoolean monitorCalled = new AtomicBoolean( false );
@@ -78,10 +74,11 @@ public class ConstraintRecoveryIT
                 storeInNeedOfRecovery[0] = fs.snapshot();
             }
         } );
-        dbFactory.setMonitors( monitors );
 
-
-        db = (GraphDatabaseAPI) dbFactory.newImpermanentDatabase( pathToDb );
+        db = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( fs )
+                .withMonitors( monitors )
+                .open( pathToDb );
 
         try ( Transaction tx = db.beginTx() )
         {
@@ -107,9 +104,9 @@ public class ConstraintRecoveryIT
         assertTrue( monitorCalled.get() );
 
         // when
-        dbFactory = new TestGraphDatabaseFactory();
-        dbFactory.setFileSystem( storeInNeedOfRecovery[0] );
-        db = (GraphDatabaseAPI) dbFactory.newImpermanentDatabase( pathToDb );
+        db = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( storeInNeedOfRecovery[0] )
+                .open( pathToDb );
 
         // then
         try(Transaction tx = db.beginTx())

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEventsWithIndexes.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEventsWithIndexes.java
@@ -41,7 +41,7 @@ public class TestTransactionEventsWithIndexes extends TestTransactionEvents
     public void nodeCanBeLegacyIndexedInBeforeCommit() throws Exception
     {
         // Given we have a legacy index...
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         final Index<Node> index;
         try ( Transaction tx = db.beginTx() )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/TestLuceneBatchInsert.java
+++ b/community/lucene-index/src/test/java/org/neo4j/unsafe/batchinsert/TestLuceneBatchInsert.java
@@ -31,13 +31,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.function.Predicate;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.config.Setting;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
@@ -53,7 +53,6 @@ import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStoreExtension;
 import org.neo4j.kernel.impl.cache.LruCache;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.apache.lucene.search.NumericRangeQuery.newIntRange;
 import static org.hamcrest.core.Is.is;
@@ -549,12 +548,12 @@ public class TestLuceneBatchInsert
     private void switchToGraphDatabaseService( ConfigurationParameter... config )
     {
         shutdownInserter();
-        GraphDatabaseBuilder builder = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir );
+        final TestGraphDatabase.Builder builder = TestGraphDatabase.build();
         for ( ConfigurationParameter configurationParameter : config )
         {
-            builder = builder.setConfig( configurationParameter.key, configurationParameter.value );
+            builder.withSetting( configurationParameter.key, configurationParameter.value );
         }
-        db = builder.newGraphDatabase();
+        db = builder.open( storeDir );
     }
 
     private static ConfigurationParameter configure( Setting<?> key, String value )

--- a/community/monitor-logging/src/test/java/org/neo4j/ext/monitorlogging/MonitorLoggingAcceptanceTest.java
+++ b/community/monitor-logging/src/test/java/org/neo4j/ext/monitorlogging/MonitorLoggingAcceptanceTest.java
@@ -21,10 +21,9 @@ package org.neo4j.ext.monitorlogging;
 
 import org.junit.Test;
 
-import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.kernel.monitoring.Monitors;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 
@@ -34,9 +33,11 @@ public class MonitorLoggingAcceptanceTest
     public void shouldBeAbleToLoadPropertiesFromAFile() throws InterruptedException
     {
         AssertableLogProvider logProvider = new AssertableLogProvider();
-        GraphDatabaseAPI dbAPI = (GraphDatabaseAPI) new TestGraphDatabaseFactory().setInternalLogProvider( logProvider ).newImpermanentDatabase();
+        TestGraphDatabase db = TestGraphDatabase.buildEphemeral()
+                .withInternalLogProvider( logProvider )
+                .open();
 
-        Monitors monitors = dbAPI.getDependencyResolver().resolveDependency( Monitors.class );
+        Monitors monitors = db.getDependencyResolver().resolveDependency( Monitors.class );
         AMonitor aMonitor = monitors.newMonitor( AMonitor.class );
         aMonitor.doStuff();
 

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
@@ -40,7 +40,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.Transaction;
@@ -52,7 +53,6 @@ import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.server.HTTP;
 import org.neo4j.tooling.GlobalGraphOperations;
 
@@ -165,7 +165,7 @@ public class InProcessBuilderTest
         try
         {
 
-            GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( dir.toString() );
+            GraphDatabase db = TestGraphDatabase.open( dir.toFile() );
             try
             {
                 db.execute( "create ()" );
@@ -193,7 +193,7 @@ public class InProcessBuilderTest
             }
 
             // Then: we still only have one node since the server is supposed to work on a copy
-            db = new TestGraphDatabaseFactory().newEmbeddedDatabase( dir.toString() );
+            db = TestGraphDatabase.open( dir.toFile() );
             try
             {
                 try ( Transaction tx = db.beginTx() )

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexTxStateLookupTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexTxStateLookupTest.java
@@ -32,8 +32,7 @@ import java.util.Random;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 
@@ -185,7 +184,7 @@ public class IndexTxStateLookupTest
     }
 
     @Rule
-    public final DatabaseRule db = new ImpermanentDatabaseRule();
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     private final Object store;
     private final Object lookup;
@@ -205,7 +204,7 @@ public class IndexTxStateLookupTest
     @Before
     public void given()
     {
-        graphDb = db.getGraphDatabaseService();
+        graphDb = dbRule.get();
         // database with an index on `(:Node).prop`
         try ( Transaction tx = graphDb.beginTx() )
         {

--- a/community/neo4j/src/test/java/org/neo4j/metatest/TestGraphDescription.java
+++ b/community/neo4j/src/test/java/org/neo4j/metatest/TestGraphDescription.java
@@ -29,6 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -42,7 +43,6 @@ import org.neo4j.test.GraphDescription.PROP;
 import org.neo4j.test.GraphDescription.REL;
 import org.neo4j.test.GraphHolder;
 import org.neo4j.test.TestData;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -216,7 +216,7 @@ public class TestGraphDescription implements GraphHolder
     @BeforeClass
     public static void startDatabase()
     {
-        graphdb = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().newGraphDatabase();
+        graphdb = TestGraphDatabase.openEphemeral();
     }
 
     @AfterClass

--- a/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryScenarios.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -39,7 +40,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProvider;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
@@ -49,7 +49,6 @@ import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.StoreFlusher;
 import org.neo4j.test.EphemeralFileSystemRule;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
@@ -57,7 +56,6 @@ import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.register.Registers.newDoubleLongRegister;
 import static org.neo4j.test.EphemeralFileSystemRule.shutdownDbAction;
-
 
 /**
  * Arbitrary recovery scenarios boiled down to as small tests as possible
@@ -258,7 +256,7 @@ public class TestRecoveryScenarios
         FORCE_EVERYTHING
                 {
                     @Override
-                    void flush( GraphDatabaseAPI db )
+                    void flush( TestGraphDatabase db )
                     {
                         db.getDependencyResolver().resolveDependency( StoreFlusher.class ).forceEverything();
                     }
@@ -266,19 +264,19 @@ public class TestRecoveryScenarios
         FLUSH_PAGE_CACHE
                 {
                     @Override
-                    void flush( GraphDatabaseAPI db ) throws IOException
+                    void flush( TestGraphDatabase db ) throws IOException
                     {
                         db.getDependencyResolver().resolveDependency( PageCache.class ).flushAndForce();
                     }
                 };
         final Object[] parameters = new Object[]{this};
 
-        abstract void flush( GraphDatabaseAPI db ) throws IOException;
+        abstract void flush( TestGraphDatabase db ) throws IOException;
     }
 
     public final @Rule EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
     private final Label label = label( "label" );
-    @SuppressWarnings("deprecation") private GraphDatabaseAPI db;
+    private TestGraphDatabase db;
     private final InMemoryIndexProvider indexProvider = new InMemoryIndexProvider( 100 );
 
     private final FlushStrategy flush;
@@ -288,17 +286,13 @@ public class TestRecoveryScenarios
         this.flush = flush;
     }
 
-    @SuppressWarnings("deprecation")
     @Before
     public void before()
     {
-        db = (GraphDatabaseAPI) databaseFactory( fsRule.get(), indexProvider ).newImpermanentDatabase();
-    }
-
-    private TestGraphDatabaseFactory databaseFactory( FileSystemAbstraction fs, InMemoryIndexProvider indexProvider )
-    {
-        return new TestGraphDatabaseFactory()
-            .setFileSystem( fs ).addKernelExtension( new InMemoryIndexProviderFactory( indexProvider ) );
+        db = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( fsRule.get() )
+                .addKernelExtension( new InMemoryIndexProviderFactory( indexProvider ) )
+                .open();
     }
 
     @After
@@ -336,6 +330,9 @@ public class TestRecoveryScenarios
     private void crashAndRestart( InMemoryIndexProvider indexProvider )
     {
         FileSystemAbstraction uncleanFs = fsRule.snapshot( shutdownDbAction( db ) );
-        db = (GraphDatabaseAPI) databaseFactory( uncleanFs, indexProvider ).newImpermanentDatabase();
+        db = TestGraphDatabase.buildEphemeral()
+                .withFileSystem( uncleanFs )
+                .addKernelExtension( new InMemoryIndexProviderFactory( indexProvider ) )
+                .open();
     }
 }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgradeOnStartupTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgradeOnStartupTest.java
@@ -32,8 +32,8 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -46,7 +46,6 @@ import org.neo4j.kernel.impl.storemigration.legacystore.v21.Legacy21Store;
 import org.neo4j.kernel.impl.storemigration.legacystore.v22.Legacy22Store;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -131,9 +130,8 @@ public class StoreUpgradeOnStartupTest
 
     private GraphDatabaseService createGraphDatabaseService()
     {
-        return new TestGraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( workingDirectory )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" )
-                .newGraphDatabase();
+        return TestGraphDatabase.build()
+                .allowStoreUpgrade()
+                .open( workingDirectory );
     }
 }

--- a/community/neo4j/src/test/java/visibility/TestDatasourceCommitOrderDataVisibility.java
+++ b/community/neo4j/src/test/java/visibility/TestDatasourceCommitOrderDataVisibility.java
@@ -23,12 +23,13 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -41,12 +42,14 @@ public class TestDatasourceCommitOrderDataVisibility
     private static final String PROPERTY_NAME = "quux";
     private static final int PROPERTY_VALUE = 42;
 
+    @Rule
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
     private GraphDatabaseService graphDatabaseService;
 
     @Before
     public void setUp() throws Exception
     {
-        graphDatabaseService = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDatabaseService = dbRule.get();
     }
 
     @Test

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginManagerTest.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginManagerTest.java
@@ -27,11 +27,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.rest.repr.formats.NullFormat;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertNotNull;
@@ -40,12 +39,12 @@ import static org.junit.Assert.assertThat;
 public class PluginManagerTest
 {
     private static PluginManager manager;
-    private static GraphDatabaseAPI graphDb;
+    private static TestGraphDatabase graphDb;
 
     @BeforeClass
     public static void loadExtensionManager() throws Exception
     {
-        graphDb = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
+        graphDb = TestGraphDatabase.openEphemeral();
         manager = new PluginManager( null, NullLogProvider.getInstance() );
     }
 
@@ -72,7 +71,7 @@ public class PluginManagerTest
     @Test
     public void canInvokeExtension() throws Exception
     {
-        manager.invoke( graphDb, FunctionalTestPlugin.class.getSimpleName(), GraphDatabaseService.class,
+        manager.invoke( graphDb.getGraphDatabaseAPI(), FunctionalTestPlugin.class.getSimpleName(), GraphDatabaseService.class,
                 FunctionalTestPlugin.CREATE_NODE, graphDb,
                 new NullFormat( null, (MediaType[]) null ).readParameterList( "" ) );
     }

--- a/community/server/src/main/java/org/neo4j/server/modules/ExtensionInitializer.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/ExtensionInitializer.java
@@ -22,8 +22,8 @@ package org.neo4j.server.modules;
 import java.util.Collection;
 import java.util.HashSet;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.helpers.Service;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.configuration.ConfigWrappingConfiguration;
@@ -47,7 +47,7 @@ public class ExtensionInitializer
 
     public Collection<Injectable<?>> initializePackages( Iterable<String> packageNames )
     {
-        GraphDatabaseAPI graphDatabaseService = neoServer.getDatabase().getGraph();
+        GraphDatabaseService graphDatabaseService = neoServer.getDatabase().getGraph();
         Config configuration = neoServer.getConfig();
 
         Collection<Injectable<?>> injectables = new HashSet<>();

--- a/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/domain/PropertySettingStrategy.java
@@ -26,9 +26,9 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.server.rest.web.PropertyValueException;
 
 /**
@@ -36,9 +36,9 @@ import org.neo4j.server.rest.web.PropertyValueException;
  */
 public class PropertySettingStrategy
 {
-    private final GraphDatabaseAPI db;
+    private final GraphDatabaseService db;
 
-    public PropertySettingStrategy( GraphDatabaseAPI db )
+    public PropertySettingStrategy( GraphDatabaseService db )
     {
         this.db = db;
     }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
@@ -37,11 +37,10 @@ public class TransitionalPeriodTransactionMessContainer
     public TransitionalTxManagementKernelTransaction newTransaction()
     {
         Transaction tx = db.beginTx();
-        TransactionTerminator txInterruptor = new TransactionTerminator( tx );
 
         // Get and use the TransactionContext created in db.beginTx(). The role of creating
         // TransactionContexts will be reversed soonish.
-        return new TransitionalTxManagementKernelTransaction( txInterruptor, txBridge );
+        return new TransitionalTxManagementKernelTransaction( tx, txBridge );
     }
 
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.server.rest.transactional;
 
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.TopLevelTransaction;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -26,14 +27,14 @@ import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 
 class TransitionalTxManagementKernelTransaction
 {
-    private final TransactionTerminator txTerminator;
+    private final Transaction tx;
     private final ThreadToStatementContextBridge bridge;
 
     private TopLevelTransaction suspendedTransaction;
 
-    TransitionalTxManagementKernelTransaction( TransactionTerminator txTerminator, ThreadToStatementContextBridge bridge )
+    TransitionalTxManagementKernelTransaction( Transaction tx, ThreadToStatementContextBridge bridge )
     {
-        this.txTerminator = txTerminator;
+        this.tx = tx;
         this.bridge = bridge;
     }
 
@@ -53,7 +54,7 @@ class TransitionalTxManagementKernelTransaction
 
     public void terminate()
     {
-        txTerminator.terminate();
+        tx.terminate();
     }
 
     public void rollback()

--- a/community/server/src/test/java/org/neo4j/server/database/TestLifecycleManagedDatabase.java
+++ b/community/server/src/test/java/org/neo4j/server/database/TestLifecycleManagedDatabase.java
@@ -34,8 +34,8 @@ import org.neo4j.kernel.StoreLockException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.server.web.ServerInternalSettings;
-import org.neo4j.test.ImpermanentDatabaseRule;
 import org.neo4j.test.SuppressOutput;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -57,7 +57,7 @@ public class TestLifecycleManagedDatabase
     private final AssertableLogProvider logProvider = new AssertableLogProvider();
 
     @Rule
-    public ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule( logProvider );
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral( logProvider );
 
     private File databaseDirectory;
     private Database theDatabase;
@@ -71,7 +71,7 @@ public class TestLifecycleManagedDatabase
 
         dbFactory = mock( LifecycleManagingDatabase.GraphFactory.class );
         when(dbFactory.newGraphDatabase( any( Config.class ), any( GraphDatabaseFacadeFactory.Dependencies.class ) ))
-                .thenReturn( dbRule.getGraphDatabaseAPI() );
+                .thenReturn( dbRule.get().getGraphDatabaseAPI() );
         theDatabase = newDatabase();
     }
 

--- a/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
@@ -27,12 +27,12 @@ import java.net.ServerSocket;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.NeoServer;
 import org.neo4j.tooling.GlobalGraphOperations;
@@ -53,7 +53,7 @@ public class ServerHelper
         removeLogs( server );
     }
 
-    public static void cleanTheDatabase( GraphDatabaseAPI db )
+    public static void cleanTheDatabase( GraphDatabaseService db )
     {
         new Transactor( db, new DeleteAllData( db ), 10 ).execute();
         new Transactor( db, new DeleteAllSchema( db ), 10 ).execute();
@@ -151,9 +151,9 @@ public class ServerHelper
 
     private static class DeleteAllData implements UnitOfWork
     {
-        private final GraphDatabaseAPI db;
+        private final GraphDatabaseService db;
 
-        public DeleteAllData( GraphDatabaseAPI db )
+        public DeleteAllData( GraphDatabaseService db )
         {
             this.db = db;
         }
@@ -227,9 +227,9 @@ public class ServerHelper
 
     private static class DeleteAllSchema implements UnitOfWork
     {
-        private final GraphDatabaseAPI db;
+        private final GraphDatabaseService db;
 
-        public DeleteAllSchema( GraphDatabaseAPI db )
+        public DeleteAllSchema( GraphDatabaseService db )
         {
             this.db = db;
         }

--- a/community/server/src/test/java/org/neo4j/server/rest/domain/PropertySettingStrategyTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/domain/PropertySettingStrategyTest.java
@@ -30,11 +30,11 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.server.rest.web.PropertyValueException;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -42,14 +42,14 @@ import static org.neo4j.helpers.collection.MapUtil.map;
 
 public class PropertySettingStrategyTest
 {
-    private static GraphDatabaseAPI db;
+    private static GraphDatabase db;
     private Transaction tx;
     private static PropertySettingStrategy propSetter;
 
     @BeforeClass
     public static void createDb()
     {
-        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
+        db = TestGraphDatabase.openEphemeral();
         propSetter = new PropertySettingStrategy( db );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserTest.java
@@ -34,7 +34,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.traversal.Traverser;
 import org.neo4j.kernel.Traversal;
 import org.neo4j.kernel.Uniqueness;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertNull;
 public class PagedTraverserTest
 {
     @Rule
-    public ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule( );
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
 
     private static final int LIST_LENGTH = 100;
     private Node startNode;
@@ -50,7 +50,7 @@ public class PagedTraverserTest
     @Before
     public void clearDb() throws Throwable
     {
-        createLinkedList( LIST_LENGTH, dbRule.getGraphDatabaseService() );
+        createLinkedList( LIST_LENGTH, dbRule.get() );
     }
 
     private void createLinkedList( int listLength, GraphDatabaseService db )
@@ -93,7 +93,7 @@ public class PagedTraverserTest
     @SuppressWarnings( "unused" )
     private int iterateThroughPagedTraverser( PagedTraverser traversalPager )
     {
-        try ( Transaction transaction = dbRule.getGraphDatabaseService().beginTx() )
+        try ( Transaction transaction = dbRule.get().beginTx() )
         {
             int count = 0;
             for ( List<Path> paths : traversalPager )

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormatPerformanceTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormatPerformanceTest.java
@@ -32,13 +32,11 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.server.WrappingNeoServer;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 /**
  * Ignored performance test.
@@ -48,16 +46,16 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 public class StreamingJsonFormatPerformanceTest {
 
     public static final String QUERY = "start n=node(*) match p=n-[r:TYPE]->m return n,r,m,p";
-    private GraphDatabaseService gdb;
+    private TestGraphDatabase gdb;
     private WrappingNeoServer server;
 
     @Before
     public void setUp() {
-        gdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        gdb = TestGraphDatabase.openEphemeral();
         for ( int i = 0; i < 10; i++ ) {
             createData();
         }
-        server = new WrappingNeoServer( (GraphDatabaseAPI) gdb );
+        server = new WrappingNeoServer( gdb.getGraphDatabaseAPI() );
         server.start();
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormatTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/formats/StreamingJsonFormatTest.java
@@ -27,7 +27,8 @@ import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.server.rest.domain.JsonHelper;
@@ -37,7 +38,6 @@ import org.neo4j.server.rest.repr.MappingSerializer;
 import org.neo4j.server.rest.repr.NodeRepresentation;
 import org.neo4j.server.rest.repr.OutputFormat;
 import org.neo4j.server.rest.repr.ValueRepresentation;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -57,7 +57,7 @@ public class StreamingJsonFormatTest
     @Test
     public void canFormatNode() throws Exception
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        GraphDatabase db = TestGraphDatabase.openEphemeral();
         try ( Transaction transaction = db.beginTx() )
         {
             final Node n = db.createNode();

--- a/community/server/src/test/java/org/neo4j/server/rest/web/PagingTraversalTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/PagingTraversalTest.java
@@ -28,18 +28,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.FakeClock;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.database.WrappedDatabase;
 import org.neo4j.server.rest.domain.GraphDbHelper;
 import org.neo4j.server.rest.domain.TraverserReturnType;
 import org.neo4j.server.rest.paging.LeaseManager;
 import org.neo4j.server.rest.repr.formats.JsonFormat;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.server.EntityOutputFormat;
 
 import static org.hamcrest.Matchers.containsString;
@@ -58,13 +57,13 @@ public class PagingTraversalTest
     private GraphDbHelper helper;
     private LeaseManager leaseManager;
     private static final int SIXTY_SECONDS = 60;
-    private GraphDatabaseAPI graph;
+    private TestGraphDatabase graph;
 
     @Before
     public void startDatabase() throws IOException
     {
-        graph = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
-        database = new WrappedDatabase(graph);
+        graph = TestGraphDatabase.openEphemeral();
+        database = new WrappedDatabase(graph.getGraphDatabaseAPI());
         helper = new GraphDbHelper( database );
         output = new EntityOutputFormat( new JsonFormat(), URI.create( BASE_URI ), null );
         leaseManager = new LeaseManager( new FakeClock() );

--- a/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabasePagedTraversalTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/RestfulGraphDatabasePagedTraversalTest.java
@@ -28,18 +28,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.FakeClock;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.database.WrappedDatabase;
 import org.neo4j.server.rest.domain.GraphDbHelper;
 import org.neo4j.server.rest.domain.TraverserReturnType;
 import org.neo4j.server.rest.paging.LeaseManager;
 import org.neo4j.server.rest.repr.formats.JsonFormat;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.server.EntityOutputFormat;
 
 import static org.hamcrest.Matchers.containsString;
@@ -57,13 +56,13 @@ public class RestfulGraphDatabasePagedTraversalTest
     private EntityOutputFormat output;
     private GraphDbHelper helper;
     private LeaseManager leaseManager;
-    private GraphDatabaseAPI graph;
+    private TestGraphDatabase graph;
 
     @Before
     public void startDatabase() throws IOException
     {
-        graph = (GraphDatabaseAPI)new TestGraphDatabaseFactory().newImpermanentDatabase();
-        database = new WrappedDatabase(graph);
+        graph = TestGraphDatabase.openEphemeral();
+        database = new WrappedDatabase(graph.getGraphDatabaseAPI());
         helper = new GraphDbHelper( database );
         output = new EntityOutputFormat( new JsonFormat(), URI.create( BASE_URI ), null );
         leaseManager = new LeaseManager( new FakeClock() );

--- a/community/server/src/test/java/org/neo4j/server/webadmin/console/CypherSessionDocTest.java
+++ b/community/server/src/test/java/org/neo4j/server/webadmin/console/CypherSessionDocTest.java
@@ -23,14 +23,13 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.helpers.Pair;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.database.CypherExecutor;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.database.WrappedDatabase;
 import org.neo4j.server.rest.management.console.CypherSession;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -41,8 +40,8 @@ public class CypherSessionDocTest
     @Test
     public void shouldReturnASingleNode() throws Throwable
     {
-        GraphDatabaseAPI graphdb = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
-        Database database = new WrappedDatabase( graphdb );
+        TestGraphDatabase graphdb = TestGraphDatabase.openEphemeral();
+        Database database = new WrappedDatabase( graphdb.getGraphDatabaseAPI() );
         CypherExecutor executor = new CypherExecutor( database );
         executor.start();
         try

--- a/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsTest.java
@@ -28,11 +28,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.embedded.TestGraphDatabase;
+import org.neo4j.function.Consumer;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Settings;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -41,35 +41,21 @@ import static org.junit.Assert.assertThat;
 public class ErrorsAndWarningsTest
 {
     @Rule
-    public ImpermanentDatabaseRule db = null;
+    public TestGraphDatabaseRule db = null;
 
     public void startDatabase( final Boolean presentError )
     {
-        db = new ImpermanentDatabaseRule()
+        db = TestGraphDatabaseRule.ephemeral( new Consumer<TestGraphDatabase.EphemeralBuilder>()
         {
             @Override
-            protected void configure( GraphDatabaseBuilder builder )
+            public void accept( TestGraphDatabase.EphemeralBuilder builder )
             {
-                builder.setConfig( ShellSettings.remote_shell_enabled, Settings.TRUE );
-                builder.setConfig( GraphDatabaseSettings.cypher_hints_error, presentError.toString() );
+                builder.withSetting( ShellSettings.remote_shell_enabled, Settings.TRUE );
+                builder.withSetting( GraphDatabaseSettings.cypher_hints_error, presentError.toString() );
             }
+        } );
 
-            @Override
-            public GraphDatabaseService getGraphDatabaseService()
-            {
-                try
-                {
-                    before();
-                }
-                catch ( Throwable throwable )
-                {
-                    throwable.printStackTrace();
-                }
-                return super.getGraphDatabaseService();
-            }
-        };
-
-        db.getGraphDatabaseService();
+        db.get();
     }
 
     @Test

--- a/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
@@ -23,16 +23,14 @@ import org.junit.Test;
 
 import java.io.PrintWriter;
 
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.embedded.GraphDatabase;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.helpers.Settings;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.RemoteClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static java.lang.System.lineSeparator;
@@ -42,6 +40,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.MapUtil.loadPropertiesFromURL;
 import static org.neo4j.shell.ShellLobby.NO_INITIAL_SESSION;
 import static org.neo4j.shell.ShellLobby.remoteLocation;
 import static org.neo4j.visualization.asciidoc.AsciidocHelper.createGraphViz;
@@ -96,11 +95,10 @@ public class ShellDocTest
     public void testEnableRemoteShellOnCustomPort() throws Exception
     {
         int port = 8085;
-        GraphDatabaseService graphDb = new TestGraphDatabaseFactory().
-                newImpermanentDatabaseBuilder().
-                setConfig( ShellSettings.remote_shell_enabled, "true" ).
-                setConfig( ShellSettings.remote_shell_port, "" + port ).
-                newGraphDatabase();
+        GraphDatabase graphDb = TestGraphDatabase.buildEphemeral()
+                .withSetting( ShellSettings.remote_shell_enabled, "true" )
+                .withSetting( ShellSettings.remote_shell_port, String.valueOf( port ) )
+                .open();
         RemoteClient client = new RemoteClient( NO_INITIAL_SESSION, remoteLocation( port ), new CollectingOutput() );
         client.evaluate( "help" );
         client.shutdown();
@@ -110,9 +108,9 @@ public class ShellDocTest
     @Test
     public void testEnableServerOnDefaultPort() throws Exception
     {
-        GraphDatabaseService graphDb = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().
-                setConfig( ShellSettings.remote_shell_enabled, Settings.TRUE ).
-                newGraphDatabase();
+        GraphDatabase graphDb = TestGraphDatabase.buildEphemeral()
+                .withSetting( ShellSettings.remote_shell_enabled, "true" )
+                .open();
         try
         {
             RemoteClient client = new RemoteClient( NO_INITIAL_SESSION, remoteLocation(), new CollectingOutput() );
@@ -128,8 +126,8 @@ public class ShellDocTest
     @Test
     public void testRemoveReferenceNode() throws Exception
     {
-        GraphDatabaseAPI db = (GraphDatabaseAPI)new TestGraphDatabaseFactory().newImpermanentDatabase();
-        final GraphDatabaseShellServer server = new GraphDatabaseShellServer( db, false );
+        TestGraphDatabase db = TestGraphDatabase.openEphemeral();
+        final GraphDatabaseShellServer server = new GraphDatabaseShellServer( db.getGraphDatabaseAPI(), false );
 
         Documenter doc = new Documenter( "sample session", server );
         doc.add( "mknode --cd", "", "Create a node");
@@ -159,8 +157,8 @@ public class ShellDocTest
     @Test
     public void testDumpCypherResultSimple() throws Exception
     {
-        GraphDatabaseAPI db = (GraphDatabaseAPI)new TestGraphDatabaseFactory().newImpermanentDatabase();
-        final GraphDatabaseShellServer server = new GraphDatabaseShellServer( db, false );
+        TestGraphDatabase db = TestGraphDatabase.openEphemeral();
+        final GraphDatabaseShellServer server = new GraphDatabaseShellServer( db.getGraphDatabaseAPI(), false );
 
         try ( Transaction tx = db.beginTx() )
         {
@@ -178,8 +176,8 @@ public class ShellDocTest
     @Test
     public void testDumpDatabase() throws Exception
     {
-        GraphDatabaseAPI db = (GraphDatabaseAPI)new TestGraphDatabaseFactory().newImpermanentDatabase();
-        final GraphDatabaseShellServer server = new GraphDatabaseShellServer( db, false );
+        TestGraphDatabase db = TestGraphDatabase.openEphemeral();
+        final GraphDatabaseShellServer server = new GraphDatabaseShellServer( db.getGraphDatabaseAPI(), false );
 
         Documenter doc = new Documenter( "database dump", server );
         doc.add( "create index on :Person(name);", "", "create an index" );
@@ -198,9 +196,10 @@ public class ShellDocTest
     @Test
     public void testMatrix() throws Exception
     {
-        GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-                .loadPropertiesFromURL( getClass().getResource( "/autoindex.properties" ) ).newGraphDatabase();
-        final GraphDatabaseShellServer server = new GraphDatabaseShellServer( db, false );
+        TestGraphDatabase db = TestGraphDatabase.buildEphemeral()
+                .withParams( loadPropertiesFromURL( getClass().getResource( "/autoindex.properties" ) ) )
+                .open();
+        final GraphDatabaseShellServer server = new GraphDatabaseShellServer( db.getGraphDatabaseAPI(), false );
 
         Documenter doc = new Documenter( "a matrix example", server );
         doc.add("mknode --cd", "", "Create a reference node");

--- a/community/shell/src/test/java/org/neo4j/shell/TestApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestApps.java
@@ -318,7 +318,7 @@ public class TestApps extends AbstractShellTest
             tx.success();
         }
 
-        GraphDatabaseShellServer server = new GraphDatabaseShellServer( db );
+        GraphDatabaseShellServer server = new GraphDatabaseShellServer( db.getGraphDatabaseAPI() );
         ShellClient client = newShellClient( server );
         executeCommand( client, "pwd", Pattern.quote( "(?)" ) );
         executeCommand( client, "ls " + node.getId(), "Test" );

--- a/community/shell/src/test/java/org/neo4j/shell/TestConfiguration.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestConfiguration.java
@@ -23,26 +23,23 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertTrue;
 
 public class TestConfiguration
 {
-    private GraphDatabaseAPI db;
+    private TestGraphDatabase db;
     private ShellServer server;
     private ShellClient client;
 
     @Before
     public void before() throws Exception
     {
-        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
-                .newImpermanentDatabaseBuilder()
-                .newGraphDatabase();
-        server = new GraphDatabaseShellServer( db );
+        db = TestGraphDatabase.openEphemeral();
+        server = new GraphDatabaseShellServer( db.getGraphDatabaseAPI() );
         client = ShellLobby.newClient( server, InterruptSignalHandler.getHandler() );
     }
 

--- a/community/shell/src/test/java/org/neo4j/shell/TestReadOnlyServer.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestReadOnlyServer.java
@@ -23,18 +23,18 @@ import java.rmi.RemoteException;
 
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.shell.kernel.ReadOnlyGraphDatabaseProxy;
 
 public class TestReadOnlyServer extends AbstractShellTest
 {
     @Override
-    protected ShellServer newServer( GraphDatabaseAPI db ) throws ShellException, RemoteException
+    protected ShellServer newServer( TestGraphDatabase db ) throws ShellException, RemoteException
     {
-        return new GraphDatabaseShellServer( new ReadOnlyGraphDatabaseProxy( db ) );
+        return new GraphDatabaseShellServer( new ReadOnlyGraphDatabaseProxy( db.getGraphDatabaseAPI() ) );
     }
 
     @Test

--- a/community/shell/src/test/java/org/neo4j/shell/TestTransactionApps.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TestTransactionApps.java
@@ -29,11 +29,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.omg.CORBA.SystemException;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.SameJvmClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.regex.Pattern.compile;
 
@@ -44,15 +44,15 @@ import static org.neo4j.helpers.collection.IteratorUtil.asCollection;
 
 public class TestTransactionApps
 {
-    protected GraphDatabaseAPI db;
+    protected TestGraphDatabase db;
     private FakeShellServer shellServer;
     private ShellClient shellClient;
 
     @Before
     public void doBefore() throws Exception
     {
-        db = (GraphDatabaseAPI)new TestGraphDatabaseFactory().newImpermanentDatabase();
-        shellServer = new FakeShellServer( db );
+        db = TestGraphDatabase.openEphemeral();
+        shellServer = new FakeShellServer( db.getGraphDatabaseAPI() );
         shellClient = new SameJvmClient( new HashMap<String, Serializable>(), shellServer, new CollectingOutput() );
    }
 

--- a/community/shell/src/test/java/org/neo4j/shell/TransactionSoakIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/TransactionSoakIT.java
@@ -29,12 +29,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.shell.impl.CollectingOutput;
 import org.neo4j.shell.impl.SameJvmClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
-import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.junit.Assert.assertEquals;
@@ -65,15 +65,15 @@ import static org.neo4j.helpers.collection.Iterables.count;
 @Ignore("Jake 2013-09-13: Exposes bug that will be fixed by kernel API")
 public class TransactionSoakIT
 {
-    protected GraphDatabaseAPI db;
+    protected TestGraphDatabase db;
     private ShellServer server;
     private final Random r = new Random( System.currentTimeMillis() );
 
     @Before
     public void doBefore() throws Exception
     {
-        db = (GraphDatabaseAPI)new TestGraphDatabaseFactory().newImpermanentDatabase();
-        server = new GraphDatabaseShellServer( db );
+        db = TestGraphDatabase.openEphemeral();
+        server = new GraphDatabaseShellServer( db.getGraphDatabaseAPI() );
     }
 
     @After

--- a/community/shell/src/test/java/org/neo4j/shell/impl/TestShellServerExtension.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/TestShellServerExtension.java
@@ -19,8 +19,7 @@
  */
 package org.neo4j.shell.impl;
 
-import java.util.Map;
-
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.helpers.Settings;
 import org.neo4j.kernel.extension.KernelExtensionFactoryContractTest;
 import org.neo4j.shell.ShellSettings;
@@ -34,14 +33,13 @@ public class TestShellServerExtension extends
     }
 
     @Override
-    protected Map<String, String> configuration( boolean shouldLoad, int instance )
+    protected void configure( TestGraphDatabase.EphemeralBuilder builder, boolean shouldLoad, int instance )
     {
-        Map<String, String> configuration = super.configuration( shouldLoad, instance );
+        super.configure( builder, shouldLoad, instance );
         if ( shouldLoad )
         {
-            configuration.put( ShellSettings.remote_shell_enabled.name(), Settings.TRUE );
-            configuration.put( ShellSettings.remote_shell_name.name(), "neo4j-shell-" + instance );
+            builder.withSetting( ShellSettings.remote_shell_enabled, Settings.TRUE );
+            builder.withSetting( ShellSettings.remote_shell_name, "neo4j-shell-" + instance );
         }
-        return configuration;
     }
 }

--- a/community/shell/src/test/java/org/neo4j/shell/kernel/apps/CdTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/kernel/apps/CdTest.java
@@ -26,10 +26,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.shell.AppCommandParser;
 import org.neo4j.shell.Output;
@@ -37,8 +37,7 @@ import org.neo4j.shell.Session;
 import org.neo4j.shell.SilentLocalOutput;
 import org.neo4j.shell.Variables;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.test.TestGraphDatabaseRule;
 
 import static org.junit.Assert.assertTrue;
 
@@ -77,7 +76,7 @@ public class CdTest
 
     private Node createNodeWithSomeSubNodes( String... names )
     {
-        GraphDatabaseService db = dbRule.getGraphDatabaseService();
+        GraphDatabaseService db = dbRule.get();
         try ( Transaction tx = db.beginTx() )
         {
             Node root = db.createNode();
@@ -94,15 +93,16 @@ public class CdTest
 
     private final Output silence = new SilentLocalOutput();
     private final Session session = new Session( "test" );
-    public final @Rule DatabaseRule dbRule = new ImpermanentDatabaseRule();
-    private GraphDatabaseAPI db;
+    @Rule
+    public final TestGraphDatabaseRule dbRule = TestGraphDatabaseRule.ephemeral();
+    private TestGraphDatabase db;
     private GraphDatabaseShellServer server;
 
     @Before
     public void setup() throws Exception
     {
-        db = dbRule.getGraphDatabaseAPI();
-        server = new GraphDatabaseShellServer( db );
+        db = dbRule.get();
+        server = new GraphDatabaseShellServer( db.getGraphDatabaseAPI() );
         session.set( Variables.TITLE_KEYS_KEY, "name" );
     }
 

--- a/community/udc/src/test/java/org/neo4j/ext/udc/UdcSettingsIT.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/UdcSettingsIT.java
@@ -21,9 +21,8 @@ package org.neo4j.ext.udc;
 
 import org.junit.Test;
 
-import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -34,11 +33,9 @@ public class UdcSettingsIT
     @Test
     public void testUdcHostSettingIsUnchanged() throws Exception
     {
-        //noinspection deprecation
-        GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
-                .newImpermanentDatabaseBuilder()
-                .setConfig( UdcSettings.udc_host, TEST_HOST_AND_PORT )
-                .newGraphDatabase();
+        TestGraphDatabase db = TestGraphDatabase.buildEphemeral()
+                .withSetting( UdcSettings.udc_host, TEST_HOST_AND_PORT )
+                .open();
 
         Config config = db.getDependencyResolver().resolveDependency( Config.class );
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupTests.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupTests.java
@@ -27,16 +27,15 @@ import org.junit.rules.TestName;
 
 import java.io.File;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Settings;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -140,11 +139,9 @@ public class IncrementalBackupTests
 
     private GraphDatabaseService startGraphDatabase( File path )
     {
-        return new TestGraphDatabaseFactory().
-                newEmbeddedDatabaseBuilder( path.getPath() ).
-                setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE ).
-                setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE ).
-                newGraphDatabase();
+        return TestGraphDatabase.build()
+                .withSetting( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
+                .open( path );
     }
 
     private ServerInterface startServer( File path, String serverAddress ) throws Exception

--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestConfiguration.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestConfiguration.java
@@ -26,41 +26,41 @@ import org.junit.Test;
 import java.io.File;
 import java.net.InetAddress;
 
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.helpers.Settings;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.fail;
 
 public class TestConfiguration
 {
-    private static final String SOURCE_DIR = "target/db";
-    private static final String BACKUP_DIR = "target/full-backup";
+    private static final File SOURCE_DIR = new File( "target/db" );
+    private static final File BACKUP_DIR = new File( "target/full-backup" );
     
     @Before
     public void before() throws Exception
     {
-        FileUtils.deleteDirectory( new File( SOURCE_DIR ) );
-        FileUtils.deleteDirectory( new File( BACKUP_DIR ) );
+        FileUtils.deleteDirectory( SOURCE_DIR );
+        FileUtils.deleteDirectory( BACKUP_DIR );
     }
     
     @Test
     public void testOnByDefault() throws Exception
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( SOURCE_DIR );
-        OnlineBackup.from( InetAddress.getLocalHost().getHostAddress() ).full( BACKUP_DIR );
+        GraphDatabaseService db = TestGraphDatabase.open( SOURCE_DIR );
+        OnlineBackup.from( InetAddress.getLocalHost().getHostAddress() ).backup( BACKUP_DIR );
         db.shutdown();
     }
     
     @Test
     public void testOffByConfig() throws Exception
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( SOURCE_DIR ).
-            setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE ).
-            newGraphDatabase();
+        GraphDatabaseService db = TestGraphDatabase.build()
+                .withSetting( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
+                .open( SOURCE_DIR );
         try
         {
-            OnlineBackup.from( InetAddress.getLocalHost().getHostAddress() ).full( BACKUP_DIR );
+            OnlineBackup.from( InetAddress.getLocalHost().getHostAddress() ).backup( BACKUP_DIR );
             fail( "Shouldn't be possible" );
         }
         catch ( Exception e )
@@ -72,11 +72,11 @@ public class TestConfiguration
     @Test
     public void testEnableDefaultsInConfig() throws Exception
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( SOURCE_DIR ).
-            setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE ).
-            newGraphDatabase();
+        GraphDatabaseService db = TestGraphDatabase.build()
+            .withSetting( OnlineBackupSettings.online_backup_enabled, Settings.TRUE )
+            .open( SOURCE_DIR );
 
-        OnlineBackup.from( InetAddress.getLocalHost().getHostAddress() ).full( BACKUP_DIR );
+        OnlineBackup.from( InetAddress.getLocalHost().getHostAddress() ).backup( BACKUP_DIR );
         db.shutdown();
     }
 
@@ -84,19 +84,20 @@ public class TestConfiguration
     public void testEnableCustomPortInConfig() throws Exception
     {
         String customPort = "12345";
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( SOURCE_DIR ).
-            setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE ).
-            setConfig( OnlineBackupSettings.online_backup_server, ":"+customPort ).newGraphDatabase();
+        GraphDatabaseService db = TestGraphDatabase.build()
+                .withSetting( OnlineBackupSettings.online_backup_enabled, Settings.TRUE )
+                .withSetting( OnlineBackupSettings.online_backup_server, ":" + customPort )
+                .open( SOURCE_DIR );
         try
         {
-            OnlineBackup.from( InetAddress.getLocalHost().getHostAddress() ).full( BACKUP_DIR );
+            OnlineBackup.from( InetAddress.getLocalHost().getHostAddress() ).backup( BACKUP_DIR );
             fail( "Shouldn't be possible" );
         }
         catch ( Exception e )
         { // Good
         }
         
-        OnlineBackup.from( InetAddress.getLocalHost().getHostAddress(), Integer.parseInt(customPort) ).full( BACKUP_DIR );
+        OnlineBackup.from( InetAddress.getLocalHost().getHostAddress(), Integer.parseInt(customPort) ).backup( BACKUP_DIR );
         db.shutdown();
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestOnlineBackupExtension.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestOnlineBackupExtension.java
@@ -19,8 +19,7 @@
  */
 package org.neo4j.backup;
 
-import java.util.Map;
-
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.helpers.Settings;
 import org.neo4j.kernel.extension.KernelExtensionFactoryContractTest;
 
@@ -32,14 +31,13 @@ public class TestOnlineBackupExtension extends KernelExtensionFactoryContractTes
     }
 
     @Override
-    protected Map<String, String> configuration( boolean shouldLoad, int instance )
+    protected void configure( TestGraphDatabase.EphemeralBuilder builder, boolean shouldLoad, int instance )
     {
-        Map<String, String> configuration = super.configuration( shouldLoad, instance );
+        super.configure( builder, shouldLoad, instance );
         if ( shouldLoad )
         {
-            configuration.put( OnlineBackupSettings.online_backup_enabled.name(), Settings.TRUE );
-            configuration.put( OnlineBackupSettings.online_backup_server.name(), ":"+(BackupServer.DEFAULT_PORT + instance) );
+            builder.withSetting( OnlineBackupSettings.online_backup_enabled, Settings.TRUE );
+            builder.withSetting( OnlineBackupSettings.online_backup_server, ":" + (BackupServer.DEFAULT_PORT + instance) );
         }
-        return configuration;
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/embedded/HighAvailabilityGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/embedded/HighAvailabilityGraphDatabase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+/**
+ * A running Neo4j Enterprise high availability graph database.
+ */
+public interface HighAvailabilityGraphDatabase extends EnterpriseGraphDatabase
+{
+    /**
+     * Roles the high availability graph database may currently be in
+     */
+    enum Role
+    {
+        /**
+         * The master of the HA cluster
+         */
+        MASTER,
+        /**
+         * A slave within the HA cluster
+         */
+        SLAVE,
+        /**
+         * Currently unknown - the database is either trying to join the cluster or is in the middle of changing roles
+         */
+        UNKNOWN
+    }
+
+    /**
+     * Start building a HA graph database instance with the specified cluster member identifier.
+     *
+     * @param memberId the id to use for this cluster member
+     * @return a builder for a {@link HighAvailabilityGraphDatabase}
+     */
+    static HighAvailabilityGraphDatabase.Builder withMemberId( int memberId )
+    {
+        return new Builder( memberId );
+    }
+
+    /**
+     * A builder for a {@link HighAvailabilityGraphDatabase}
+     */
+    class Builder extends HighAvailabilityGraphDatabaseBuilder<Builder,HighAvailabilityGraphDatabase>
+    {
+        Builder( int memberId )
+        {
+            super( memberId );
+        }
+
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+
+        @Override
+        protected HighAvailabilityGraphDatabase newInstance( File storeDir, Map<String,String> params,
+                GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory )
+        {
+            return new HighAvailabilityGraphDatabaseImpl( facadeFactory, storeDir, params, dependencies );
+        }
+    }
+
+    /**
+     * @return true if this database is the master of the cluster, and false otherwise
+     */
+    boolean isMaster();
+
+    /**
+     * Obtain the current role of the this database in the HA cluster.
+     *
+     * @return the current role of this database in the HA cluster
+     */
+    Role haClusterRole();
+}

--- a/enterprise/ha/src/main/java/org/neo4j/embedded/HighAvailabilityGraphDatabaseBuilder.java
+++ b/enterprise/ha/src/main/java/org/neo4j/embedded/HighAvailabilityGraphDatabaseBuilder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.util.List;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.helpers.ArrayUtil;
+import org.neo4j.kernel.ha.HaSettings;
+
+abstract class HighAvailabilityGraphDatabaseBuilder<
+        BUILDER extends HighAvailabilityGraphDatabaseBuilder<BUILDER,GRAPHDB>, GRAPHDB extends HighAvailabilityGraphDatabase>
+        extends EnterpriseGraphDatabaseBuilder<BUILDER,GRAPHDB>
+{
+    HighAvailabilityGraphDatabaseBuilder( int memberId )
+    {
+        withSetting( ClusterSettings.server_id, String.valueOf( memberId ) );
+    }
+
+    /**
+     * Set the address for binding the cluster listener to
+     *
+     * @param address the address to bind the cluster listener to, which must be the address of a local interface
+     * @return this builder
+     */
+    public BUILDER bindClusterListenerTo( String address )
+    {
+        withSetting( ClusterSettings.cluster_server, address );
+        return self();
+    }
+
+    /**
+     * Set the address for binding the transaction listener to
+     *
+     * @param address the address to bind the transaction listener to, which must be the address of a local interface
+     * @return this builder
+     */
+    public BUILDER bindTransactionListenerTo( String address )
+    {
+        withSetting( HaSettings.ha_server, address );
+        return self();
+    }
+
+    /**
+     * Set the addresses of other servers to contact when trying to connect to a cluster.
+     *
+     * @param addresses the list of server addresses to contact when trying to connect to a cluster
+     * @return this builder
+     */
+    public BUILDER withInitialHostAddresses( String... addresses )
+    {
+        withSetting( ClusterSettings.initial_hosts, ArrayUtil.join( addresses, "," ) );
+        return self();
+    }
+
+    /**
+     * Set the addresses of other servers to contact when trying to connect to a cluster.
+     *
+     * @param addresses the list of server addresses to contact when trying to connect to a cluster
+     * @return this builder
+     */
+    public BUILDER withInitialHostAddresses( List<String> addresses )
+    {
+        return withInitialHostAddresses( addresses.toArray( new String[addresses.size()] ) );
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/embedded/HighAvailabilityGraphDatabaseImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/embedded/HighAvailabilityGraphDatabaseImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
+import org.neo4j.kernel.ha.cluster.member.ClusterMember;
+import org.neo4j.kernel.ha.factory.HighlyAvailableEditionModule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+class HighAvailabilityGraphDatabaseImpl extends EnterpriseGraphDatabaseImpl implements HighAvailabilityGraphDatabase
+{
+    HighAvailabilityGraphDatabaseImpl(
+            GraphDatabaseFacadeFactory facadeFactory,
+            File storeDir,
+            Map<String,String> params,
+            GraphDatabaseFacadeFactory.Dependencies dependencies )
+    {
+        super( facadeFactory, storeDir, params, dependencies );
+    }
+
+    @Override
+    public boolean isMaster()
+    {
+        return ((HighlyAvailableEditionModule) editionModule).memberStateMachine.isMaster();
+    }
+
+    @Override
+    public Role haClusterRole()
+    {
+        ClusterMember self = ((HighlyAvailableEditionModule) editionModule).members.getSelf();
+        if ( self.hasRole( HighAvailabilityModeSwitcher.MASTER ) )
+        {
+            return Role.MASTER;
+        }
+        else if ( self.hasRole( HighAvailabilityModeSwitcher.SLAVE ) )
+        {
+            return Role.SLAVE;
+        }
+        else
+        {
+            return Role.UNKNOWN;
+        }
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
@@ -22,12 +22,15 @@ package org.neo4j.graphdb.factory;
 import java.io.File;
 import java.util.Map;
 
+import org.neo4j.embedded.HighAvailabilityGraphDatabase;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 
 /**
  * Factory for HA Neo4j instances.
+ * @deprecated use {@link HighAvailabilityGraphDatabase} instead
  */
+@Deprecated
 public class HighlyAvailableGraphDatabaseFactory extends GraphDatabaseFactory
 {
     @Override

--- a/enterprise/ha/src/test/java/org/neo4j/embedded/HighAvailabilityTestGraphDatabase.java
+++ b/enterprise/ha/src/test/java/org/neo4j/embedded/HighAvailabilityTestGraphDatabase.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+public interface HighAvailabilityTestGraphDatabase extends HighAvailabilityGraphDatabase, TestGraphDatabase
+{
+    /**
+     * Start building a test HA graph database instance with the specified cluster member identifier.
+     *
+     * @param memberId the id to use for this cluster member
+     * @return a builder for a test {@link HighAvailabilityGraphDatabase}
+     */
+    static HighAvailabilityTestGraphDatabase.Builder withMemberId( int memberId )
+    {
+        return new Builder( memberId );
+    }
+
+    /**
+     * Start building an impermanent HA graph database instance with the specified cluster member identifier.
+     *
+     * @param memberId the id to use for this cluster member
+     * @return a builder for a test {@link HighAvailabilityGraphDatabase}
+     */
+    static HighAvailabilityTestGraphDatabase.EphemeralBuilder ephemeralWithMemberId( int memberId )
+    {
+        return new EphemeralBuilder( memberId );
+    }
+
+    class Builder extends HighAvailabilityTestGraphDatabaseBuilder<Builder,HighAvailabilityTestGraphDatabase>
+    {
+        Builder( int memberId )
+        {
+            super( memberId );
+        }
+
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+
+        @Override
+        protected HighAvailabilityTestGraphDatabase newInstance( File storeDir, Map<String,String> params,
+                GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory )
+        {
+            return new HighAvailabilityTestGraphDatabaseImpl( facadeFactory, storeDir, params, dependencies );
+        }
+    }
+
+    class EphemeralBuilder extends HighAvailabilityTestGraphDatabaseBuilder<EphemeralBuilder,HighAvailabilityTestGraphDatabase>
+    {
+        public static final File PATH = new File( "target/test-data/impermanent-db" );
+
+        EphemeralBuilder( int memberId )
+        {
+            super( memberId );
+            withFileSystem( new EphemeralFileSystemAbstraction() );
+        }
+
+        public TestGraphDatabase open()
+        {
+            return open( PATH );
+        }
+
+        @Override
+        protected EphemeralBuilder self()
+        {
+            return this;
+        }
+
+        @Override
+        protected HighAvailabilityTestGraphDatabase newInstance( File storeDir, Map<String,String> params,
+                GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory )
+        {
+            return new HighAvailabilityTestGraphDatabaseImpl( facadeFactory, storeDir, params, dependencies );
+        }
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/embedded/HighAvailabilityTestGraphDatabaseBuilder.java
+++ b/enterprise/ha/src/test/java/org/neo4j/embedded/HighAvailabilityTestGraphDatabaseBuilder.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.impl.enterprise.EnterpriseEditionModule;
+import org.neo4j.kernel.impl.enterprise.EnterpriseFacadeFactory;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.logging.AbstractLogService;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.LogProvider;
+
+abstract class HighAvailabilityTestGraphDatabaseBuilder<
+        BUILDER extends HighAvailabilityTestGraphDatabaseBuilder<BUILDER,GRAPHDB>, GRAPHDB extends HighAvailabilityTestGraphDatabase>
+        extends TestGraphDatabaseBuilder<BUILDER,HighAvailabilityTestGraphDatabase>
+{
+    HighAvailabilityTestGraphDatabaseBuilder( int memberId )
+    {
+        withSetting( ClusterSettings.server_id, String.valueOf( memberId ) );
+        withSetting( GraphDatabaseSettings.pagecache_memory, "8m" );
+    }
+
+    @Override
+    protected GraphDatabaseFacadeFactory createFacadeFactory()
+    {
+        // TODO: replace overriding with dependency injection
+        return new EnterpriseFacadeFactory()
+        {
+            @Override
+            protected PlatformModule createPlatform( File storeDir, Map<String,String> params,
+                    Dependencies dependencies, GraphDatabaseFacade graphDatabaseFacade )
+            {
+                return new PlatformModule( storeDir, params, dependencies, graphDatabaseFacade )
+                {
+                    @Override
+                    protected FileSystemAbstraction createFileSystemAbstraction()
+                    {
+                        return (fs != null) ? fs : super.createFileSystemAbstraction();
+                    }
+
+                    @Override
+                    protected LogService createLogService( final LogProvider userLogProvider )
+                    {
+                        if ( internalLogProvider == null )
+                        {
+                            return super.createLogService( userLogProvider );
+                        }
+
+                        return new AbstractLogService()
+                        {
+                            @Override
+                            public LogProvider getUserLogProvider()
+                            {
+                                return userLogProvider;
+                            }
+
+                            @Override
+                            public LogProvider getInternalLogProvider()
+                            {
+                                return internalLogProvider;
+                            }
+                        };
+                    }
+                };
+            }
+
+            @Override
+            protected EditionModule createEdition( PlatformModule platformModule )
+            {
+                return new EnterpriseEditionModule( platformModule )
+                {
+                    @Override
+                    protected IdGeneratorFactory createIdGeneratorFactory( FileSystemAbstraction fs )
+                    {
+                        return (idFactory != null) ? idFactory : super.createIdGeneratorFactory( fs );
+                    }
+                };
+            }
+        };
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/embedded/HighAvailabilityTestGraphDatabaseImpl.java
+++ b/enterprise/ha/src/test/java/org/neo4j/embedded/HighAvailabilityTestGraphDatabaseImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.enterprise.EnterpriseFacadeFactory;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+public class HighAvailabilityTestGraphDatabaseImpl extends HighAvailabilityGraphDatabaseImpl implements HighAvailabilityTestGraphDatabase
+{
+    HighAvailabilityTestGraphDatabaseImpl(
+            GraphDatabaseFacadeFactory facadeFactory,
+            File storeDir,
+            Map<String,String> params,
+            GraphDatabaseFacadeFactory.Dependencies dependencies )
+    {
+        super( facadeFactory, storeDir, params, dependencies );
+    }
+
+    @Override
+    public FileSystemAbstraction fileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    public File storeDir()
+    {
+        return storeDir;
+    }
+
+    @Override
+    public GraphDatabaseAPI getGraphDatabaseAPI()
+    {
+        return this;
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/RollingUpgradeIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/RollingUpgradeIT.java
@@ -38,9 +38,11 @@ import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.embedded.GraphDatabase;
 import org.neo4j.backup.OnlineBackup;
 import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.embedded.TestGraphDatabase;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -55,7 +57,6 @@ import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.ha.UpdatePuller;
 import org.neo4j.test.TargetDirectory;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertTrue;
@@ -315,7 +316,7 @@ public class RollingUpgradeIT
             break;
         }
 
-        startStandaloneDbToRunUpgrade( storeDir, i );
+        startStandaloneDbToRunUpgrade( storeDirFile, i );
 
         // start that db up in this JVM
         newDbs[i] = (GraphDatabaseAPI) new TestHighlyAvailableGraphDatabaseFactory()
@@ -356,16 +357,15 @@ public class RollingUpgradeIT
         }
     }
 
-    private void startStandaloneDbToRunUpgrade( String storeDir, int dbIndex )
+    private void startStandaloneDbToRunUpgrade( File storeDir, int dbIndex )
     {
-        GraphDatabaseService tempDbForUpgrade = null;
+        GraphDatabase tempDbForUpgrade = null;
         try
         {
             debug( "Starting standalone db " + dbIndex + " to run upgrade" );
-            tempDbForUpgrade = new TestGraphDatabaseFactory()
-                    .newEmbeddedDatabaseBuilder( storeDir )
-                    .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" )
-                    .newGraphDatabase();
+            tempDbForUpgrade = TestGraphDatabase.build()
+                    .allowStoreUpgrade()
+                    .open( storeDir );
         }
         finally
         {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.neo4j.embedded.HighAvailabilityGraphDatabase;
 import org.neo4j.function.Predicate;
 import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.ConstraintViolationException;
@@ -317,7 +318,7 @@ public class SchemaIndexHaIT
         @Override
         public boolean test( GraphDatabaseService item )
         {
-            return item instanceof HighlyAvailableGraphDatabase && ((HighlyAvailableGraphDatabase) item).isMaster();
+            return item instanceof HighAvailabilityGraphDatabase && ((HighAvailabilityGraphDatabase) item).isMaster();
         }
     };
 

--- a/enterprise/kernel/src/main/java/org/neo4j/embedded/EnterpriseGraphDatabase.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/embedded/EnterpriseGraphDatabase.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+/**
+ * A running Neo4j Enterprise graph database. Provides methods for controlling the database instance (e.g. shutdown,
+ * adding event handlers, etc), and also implements {@link GraphDatabaseService} to provides all the methods
+ * for working with the graph itself.
+ */
+public interface EnterpriseGraphDatabase extends GraphDatabase
+{
+    /**
+     * Start building a Graph Database.
+     *
+     * @return a builder for a {@link GraphDatabase}
+     */
+    static EnterpriseGraphDatabase.Builder build()
+    {
+        return new Builder();
+    }
+
+    /**
+     * Start a graph database by opening the specified filesystem directory containing the store.
+     *
+     * @param storeDir The filesystem location for the store, which will be created if necessary
+     * @return The running database
+     */
+    static EnterpriseGraphDatabase open( File storeDir )
+    {
+        return build().open( storeDir );
+    }
+
+    /**
+     * A builder for a {@link GraphDatabase}
+     */
+    class Builder extends EnterpriseGraphDatabaseBuilder<Builder,EnterpriseGraphDatabase>
+    {
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+
+        @Override
+        protected EnterpriseGraphDatabase newInstance( File storeDir, Map<String,String> params,
+                GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory )
+        {
+            return new EnterpriseGraphDatabaseImpl( facadeFactory, storeDir, params, dependencies );
+        }
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/embedded/EnterpriseGraphDatabaseBuilder.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/embedded/EnterpriseGraphDatabaseBuilder.java
@@ -17,23 +17,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.graphdb.factory;
+package org.neo4j.embedded;
 
-import org.neo4j.kernel.impl.ha.ClusterManager;
-import org.neo4j.embedded.HighAvailabilityTestGraphDatabase;
+import org.neo4j.kernel.impl.enterprise.EnterpriseFacadeFactory;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 
-/**
- * @deprecated use {@link HighAvailabilityTestGraphDatabase} instead
- */
-@Deprecated
-public class TestHighlyAvailableGraphDatabaseFactory extends HighlyAvailableGraphDatabaseFactory
+abstract class EnterpriseGraphDatabaseBuilder<BUILDER extends EnterpriseGraphDatabaseBuilder<BUILDER,GRAPHDB>, GRAPHDB extends EnterpriseGraphDatabase>
+        extends GraphDatabaseBuilder<BUILDER,GRAPHDB>
 {
     @Override
-    protected void configure( GraphDatabaseBuilder builder )
+    protected GraphDatabaseFacadeFactory createFacadeFactory()
     {
-        super.configure( builder );
-        builder.setConfig( ClusterManager.CONFIG_FOR_SINGLE_JVM_CLUSTER );
-        builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
-        builder.setConfig( GraphDatabaseSettings.store_internal_log_level, "DEBUG" );
+        return new EnterpriseFacadeFactory();
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/embedded/EnterpriseGraphDatabaseImpl.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/embedded/EnterpriseGraphDatabaseImpl.java
@@ -17,23 +17,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.graphdb.factory;
+package org.neo4j.embedded;
 
-import org.neo4j.kernel.impl.ha.ClusterManager;
-import org.neo4j.embedded.HighAvailabilityTestGraphDatabase;
+import java.io.File;
+import java.util.Map;
 
-/**
- * @deprecated use {@link HighAvailabilityTestGraphDatabase} instead
- */
-@Deprecated
-public class TestHighlyAvailableGraphDatabaseFactory extends HighlyAvailableGraphDatabaseFactory
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+class EnterpriseGraphDatabaseImpl extends GraphDatabaseImpl implements EnterpriseGraphDatabase
 {
-    @Override
-    protected void configure( GraphDatabaseBuilder builder )
+    EnterpriseGraphDatabaseImpl(
+            GraphDatabaseFacadeFactory facadeFactory,
+            File storeDir,
+            Map<String,String> params,
+            GraphDatabaseFacadeFactory.Dependencies dependencies )
     {
-        super.configure( builder );
-        builder.setConfig( ClusterManager.CONFIG_FOR_SINGLE_JVM_CLUSTER );
-        builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
-        builder.setConfig( GraphDatabaseSettings.store_internal_log_level, "DEBUG" );
+        super( facadeFactory, storeDir, params, dependencies );
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/graphdb/EnterpriseGraphDatabase.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/graphdb/EnterpriseGraphDatabase.java
@@ -31,6 +31,10 @@ import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.kernel.GraphDatabaseDependencies.newDependencies;
 
+/**
+ * @deprecated Use {@link org.neo4j.embedded.EnterpriseGraphDatabase}
+ */
+@Deprecated
 public class EnterpriseGraphDatabase extends GraphDatabaseFacade
 {
 

--- a/enterprise/kernel/src/test/java/org/neo4j/embedded/EnterpriseTestGraphDatabase.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/embedded/EnterpriseTestGraphDatabase.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+public interface EnterpriseTestGraphDatabase extends EnterpriseGraphDatabase, TestGraphDatabase
+{
+    /**
+     * Start building a test Graph Database.
+     *
+     * @return a builder for a test {@link TestGraphDatabase}
+     */
+    static EnterpriseTestGraphDatabase.Builder build()
+    {
+        return new Builder();
+    }
+
+    /**
+     * Start a graph database by opening the specified filesystem directory containing the store.
+     *
+     * @param storeDir The filesystem location for the store, which will be created if necessary
+     * @return The running database
+     */
+    static EnterpriseTestGraphDatabase open( File storeDir )
+    {
+        return build().open( storeDir );
+    }
+
+    /**
+     * Start building a test Graph Database, using an ephemeral filesystem.
+     *
+     * @return a builder for an ephemeral {@link TestGraphDatabase}
+     */
+    static EnterpriseTestGraphDatabase.EphemeralBuilder buildEphemeral()
+    {
+        return new EphemeralBuilder();
+    }
+
+    /**
+     * Start a graph database using an ephemeral filesystem.
+     *
+     * @return a builder for an ephemeral {@link TestGraphDatabase}
+     */
+    static EnterpriseTestGraphDatabase openEphemeral()
+    {
+        return buildEphemeral().open();
+    }
+
+    class Builder extends EnterpriseTestGraphDatabaseBuilder<Builder,EnterpriseTestGraphDatabase>
+    {
+        @Override
+        protected Builder self()
+        {
+            return this;
+        }
+
+        @Override
+        protected EnterpriseTestGraphDatabase newInstance( File storeDir, Map<String,String> params,
+                GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory )
+        {
+            return new EnterpriseTestGraphDatabaseImpl( facadeFactory, storeDir, params, dependencies );
+        }
+    }
+
+    class EphemeralBuilder extends EnterpriseTestGraphDatabaseBuilder<EphemeralBuilder,EnterpriseTestGraphDatabase>
+    {
+        private static final File PATH = new File( "target/test-data/impermanent-db" );
+
+        EphemeralBuilder()
+        {
+            withParam( "ephemeral", "true" );
+            withFileSystem( new EphemeralFileSystemAbstraction() );
+        }
+
+        public EnterpriseTestGraphDatabase open()
+        {
+            return open( PATH );
+        }
+
+        @Override
+        protected EphemeralBuilder self()
+        {
+            return this;
+        }
+
+        @Override
+        protected EnterpriseTestGraphDatabase newInstance( File storeDir, Map<String,String> params,
+                GraphDatabaseDependencies dependencies, GraphDatabaseFacadeFactory facadeFactory )
+        {
+            return new EnterpriseTestGraphDatabaseImpl( facadeFactory, storeDir, params, dependencies );
+        }
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/embedded/EnterpriseTestGraphDatabaseBuilder.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/embedded/EnterpriseTestGraphDatabaseBuilder.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.embedded;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.impl.enterprise.EnterpriseEditionModule;
+import org.neo4j.kernel.impl.enterprise.EnterpriseFacadeFactory;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.logging.AbstractLogService;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.LogProvider;
+
+abstract class EnterpriseTestGraphDatabaseBuilder<
+        BUILDER extends EnterpriseTestGraphDatabaseBuilder<BUILDER,GRAPHDB>, GRAPHDB extends EnterpriseTestGraphDatabase>
+        extends TestGraphDatabaseBuilder<BUILDER,EnterpriseTestGraphDatabase>
+{
+    @Override
+    protected GraphDatabaseFacadeFactory createFacadeFactory()
+    {
+        // TODO: replace overriding with dependency injection
+        return new EnterpriseFacadeFactory()
+        {
+            @Override
+            protected PlatformModule createPlatform( File storeDir, Map<String,String> params,
+                    Dependencies dependencies, GraphDatabaseFacade graphDatabaseFacade )
+            {
+                return new PlatformModule( storeDir, params, dependencies, graphDatabaseFacade )
+                {
+                    @Override
+                    protected FileSystemAbstraction createFileSystemAbstraction()
+                    {
+                        return (fs != null) ? fs : super.createFileSystemAbstraction();
+                    }
+
+                    @Override
+                    protected LogService createLogService( final LogProvider userLogProvider )
+                    {
+                        if ( internalLogProvider == null )
+                        {
+                            return super.createLogService( userLogProvider );
+                        }
+
+                        return new AbstractLogService()
+                        {
+                            @Override
+                            public LogProvider getUserLogProvider()
+                            {
+                                return userLogProvider;
+                            }
+
+                            @Override
+                            public LogProvider getInternalLogProvider()
+                            {
+                                return internalLogProvider;
+                            }
+                        };
+                    }
+                };
+            }
+
+            @Override
+            protected EditionModule createEdition( PlatformModule platformModule )
+            {
+                return new EnterpriseEditionModule( platformModule )
+                {
+                    @Override
+                    protected IdGeneratorFactory createIdGeneratorFactory( FileSystemAbstraction fs )
+                    {
+                        return (idFactory != null) ? idFactory : super.createIdGeneratorFactory( fs );
+                    }
+                };
+            }
+        };
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/embedded/EnterpriseTestGraphDatabaseImpl.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/embedded/EnterpriseTestGraphDatabaseImpl.java
@@ -17,23 +17,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.graphdb.factory;
+package org.neo4j.embedded;
 
-import org.neo4j.kernel.impl.ha.ClusterManager;
-import org.neo4j.embedded.HighAvailabilityTestGraphDatabase;
+import java.io.File;
+import java.util.Map;
 
-/**
- * @deprecated use {@link HighAvailabilityTestGraphDatabase} instead
- */
-@Deprecated
-public class TestHighlyAvailableGraphDatabaseFactory extends HighlyAvailableGraphDatabaseFactory
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+
+class EnterpriseTestGraphDatabaseImpl extends TestGraphDatabaseImpl implements EnterpriseTestGraphDatabase
 {
-    @Override
-    protected void configure( GraphDatabaseBuilder builder )
+    EnterpriseTestGraphDatabaseImpl(
+            GraphDatabaseFacadeFactory facadeFactory,
+            File storeDir, Map<String,String> params,
+            GraphDatabaseFacadeFactory.Dependencies dependencies )
     {
-        super.configure( builder );
-        builder.setConfig( ClusterManager.CONFIG_FOR_SINGLE_JVM_CLUSTER );
-        builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
-        builder.setConfig( GraphDatabaseSettings.store_internal_log_level, "DEBUG" );
+        super( facadeFactory, storeDir, params, dependencies );
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/TestPECListing.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/TestPECListing.java
@@ -22,23 +22,20 @@ package org.neo4j.shell;
 import org.junit.Test;
 
 import org.neo4j.SchemaHelper;
+import org.neo4j.embedded.EnterpriseTestGraphDatabase;
 import org.neo4j.graphdb.DynamicLabel;
 import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 
 import static org.neo4j.graphdb.DynamicLabel.label;
 
 public class TestPECListing extends AbstractShellTest
 {
     @Override
-    protected GraphDatabaseAPI newDb()
+    protected EnterpriseTestGraphDatabase newDb()
     {
-        return (GraphDatabaseAPI) new TestEnterpriseGraphDatabaseFactory()
-                .setFileSystem( fs.get() )
-                .newImpermanentDatabase();
+        return EnterpriseTestGraphDatabase.openEphemeral();
     }
 
     @Test

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/EnterpriseServerIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/functional/EnterpriseServerIT.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.configuration.Configurator;
 import org.neo4j.server.configuration.ServerSettings;
+import org.neo4j.server.database.Database;
 import org.neo4j.server.enterprise.helpers.EnterpriseServerBuilder;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -71,9 +72,9 @@ public class EnterpriseServerIT
         try
         {
             server.start();
-            server.getDatabase();
+            Database db = server.getDatabase();
 
-            assertThat( server.getDatabase().getGraph(), is( instanceOf(HighlyAvailableGraphDatabase.class) ) );
+            assertThat( db.getGraph(), is( instanceOf(HighlyAvailableGraphDatabase.class) ) );
 
             Client client = Client.create();
             ClientResponse r = client.resource( "http://localhost:" + DEFAULT_WEBSERVER_PORT +


### PR DESCRIPTION
- **This is a 3.0 based version of #4674, which was deferred until the 3.0 work could be started**

Includes:

| class | description |
| --- | --- |
| `org.neo4j.embedded.GraphDatabase` | An interface for a Neo4j Graph Database that holds additional methods necessary for managing the database instance itself, in addition to the graph API methods inherited from `GraphDatabaseService`. Construction of such a class is done via static constructor methods `#open(File)` and `#build()`. |
| `org.neo4j.embedded.TestGraphDatabase` | An extension to the `GraphDatabase` interface, providing methods useful for internal testing. Static constructor methods for test databases include regular and ephemeral versions `#open(File)`, `#openEphemeral()`, `#build()` and `#buildEphemeral()`. |
| `org.neo4j.embedded.EnterpriseGraphDatabase` | An interface for a Neo4j Enterprise graph database, extending `GraphDatabase`. Static constructor methods for HighAvailabilityGraphDatabases include configuration directives relevant to enterprise HA instances. |
| `org.neo4j.embedded.EnterpriseTestGraphDatabase` | An extension to the `EnterpriseGraphDatabase` interface, providing methods useful for internal testing. |
| `org.neo4j.embedded.HighAvailabilityGraphDatabase` | An interface for a Neo4j High Availability graph database, extending `GraphDatabase`, and including methods relevant to managing and monitoring an enterprise HA instance. Static constructor methods for HighAvailabilityGraphDatabases include configuration directives relevant to enterprise HA instances. |
| `org.neo4j.embedded.HighAvailabilityTestGraphDatabase` | An extension to the `HighAvailabilityGraphDatabase` interface, providing methods useful for internal testing. |

For common use, the static `#open(...)` method provides a convenient way to start an embedded graph database. I.e.:

```
    GraphDatabase db = GraphDatabase.open( new File("/var/graph.db") );
```

The static `#build()` constructor methods return a builder that uses a fluent, programatic construction for injecting dependencies. I.e.:

```
    GraphDatabase db = GraphDatabase.build()
            .withLogProvider( customLogProvider )
            .open( new File("/var/graph.db") );
```

Notes:
- Also opens the way to leverage Rickard's improvements breaking up `InternalAbstractGraphDatabase` by providing full dependency injection of all configuration and components (like shared page caches) into the graph database at construction, and skipping the use of `Config` or requiring overriding of internal methods in order to do injection.

Written with input from @lutovich and @thobe.
