### PR TITLE
Use toVector in EagerPipe

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/EagerPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/EagerPipe.scala
@@ -39,7 +39,7 @@ case class EagerPipe(src: Pipe)(val estimatedCardinality: Option[Double] = None)
   override def planDescription = src.planDescription.andThen(this.id, "Eager", identifiers)
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
-    input.toList.toIterator
+    input.toVector.toIterator
 
   override def planDescriptionWithoutCardinality: InternalPlanDescription = src.planDescription.andThen(this.id, "Eager", identifiers)
 


### PR DESCRIPTION
![compare](https://cloud.githubusercontent.com/assets/88000/10716246/a0c94a52-7b32-11e5-9866-88ffe857b2b4.png)
Using `toVector` instead of `toList` is approximately twice as fast.
