### PR TITLE
Translates InvalidEpochException into TransientFailureException to user

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/Client.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Client.java
@@ -49,6 +49,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
 import static java.util.concurrent.Executors.newCachedThreadPool;
+
 import static org.neo4j.com.Protocol.addLengthFieldPipes;
 import static org.neo4j.com.Protocol.assertChunkSizeIsWithinFrameSize;
 import static org.neo4j.com.ResourcePool.DEFAULT_CHECK_INTERVAL;
@@ -256,8 +257,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         catch ( ComException e )
         {
             failure = e;
-            comExceptionHandler.handle( e );
-            throw e;
+            throw comExceptionHandler.handle( e );
         }
         catch ( Throwable e )
         {

--- a/enterprise/com/src/main/java/org/neo4j/com/ComExceptionHandler.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ComExceptionHandler.java
@@ -24,10 +24,19 @@ public interface ComExceptionHandler
     static ComExceptionHandler NO_OP = new ComExceptionHandler()
     {
         @Override
-        public void handle( ComException exception )
+        public RuntimeException handle( ComException exception )
         {
+            return exception;
         }
     };
 
-    void handle( ComException exception );
+    /**
+     * Adds additional handling of a {@link ComException} when it occurs on the client side in a client->server
+     * communication scenario.
+     *
+     * @param exception {@link ComException} describing the failure.
+     * @return {@link RuntimeException} describing the failure to the user. This transaction will
+     * fail the user transaction and this exception will be the exception thrown out to the user.
+     */
+    RuntimeException handle( ComException exception );
 }


### PR DESCRIPTION
because it's an exception that signals to user that transaction should be
retried. The invalid epoch exception can be thrown if the slave the
transaction was issued for wasn't fully up to date with recent master
election, which is a temporary condition.

Also changes
ClusterTopologyChangesIT#slaveShouldServeTxsAfterMasterLostQuorumWentToPendingAndThenQuorumWasRestored
to handle cases where a condition that was expected to happen after
cluster reformed, actually happened while it was reforming and so the test
would wait for that condition to happen indefinitely after it reformed.
The condition was that the test expected to see slave members unavailable
in response to an invalid epoch.
