### PR TITLE
Update lsof parsing for newer and older versions.

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -143,11 +143,16 @@ detectrunning() {
     ## SmartOS has a different lsof command line arguments
     newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
   else
-    # For some reason, this breaks stuff. Can there be multiple pids?
-    #newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep "p")
-    # This does NOT work on lsof > 4.87
-    newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
-    newpid=${newpid:1}
+    LSOFVER=`lsof -v 2>&1 | grep revision | grep -v latest | cut -d: -f2 | tr -d ' ' | tr -d .`
+    #Newer versions of lsof has the -sTCP:LISTEN flag, which is exactly what we need.
+    #This flag does not exist before 4.78, therefore grepping for TST=LISTEN worked there.
+    #Only in 4.89 did grepping begin to not work, as the output from lsof changed.
+    if [ $LSOFVER -ge 478 ]; then
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -sTCP:LISTEN -t)
+    else
+      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
+      newpid=${newpid:1}
+    fi
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -143,14 +143,14 @@ detectrunning() {
     ## SmartOS has a different lsof command line arguments
     newpid=$(lsof -o $NEO4J_SERVER_PORT | grep '::' | head -n1 | cut -d ' ' -f 1)
   else
-    LSOFVER=`lsof -v 2>&1 | grep revision | grep -v latest | cut -d: -f2 | tr -d ' ' | tr -d .`
+    LSOFVER=$(lsof -v 2>&1 | grep revision | grep -v latest | cut -d: -f2 | tr -d ' ' | tr -d .)
     #Newer versions of lsof has the -sTCP:LISTEN flag, which is exactly what we need.
     #This flag does not exist before 4.78, therefore grepping for TST=LISTEN worked there.
     #Only in 4.89 did grepping begin to not work, as the output from lsof changed.
-    if [ $LSOFVER -ge 478 ]; then
-      newpid=$(lsof -i :$NEO4J_SERVER_PORT -sTCP:LISTEN -t)
+    if [ "$LSOFVER" -ge 478 ]; then
+      newpid=$(lsof -i :"$NEO4J_SERVER_PORT" -sTCP:LISTEN -t)
     else
-      newpid=$(lsof -i :$NEO4J_SERVER_PORT -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
+      newpid=$(lsof -i :"$NEO4J_SERVER_PORT" -F T -Ts | grep -i "TST=LISTEN" -B1 | head -n1)
       newpid=${newpid:1}
     fi
   fi


### PR DESCRIPTION
This change handles multiple pid numbers which can be attached to the same port, which was not accounted for in the previous version of this script. This change now handles the older versions of lsof and the newer versions. The reason things broke was because the newer version did not produce the expected output.

Improves on the fix in #5646, by taking into account the possibility of multiple pids.
