### PR TITLE
Allow toInt and toFloat to accept type Number

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
@@ -46,6 +46,14 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
     result should equal(42)
   }
 
+  test("toInt should handle mixed number types") {
+    // When
+    val result = executeWithAllPlanners("WITH [2, 2.9] AS numbers RETURN [n in numbers | toInt(n)] AS int_numbers")
+
+    // Then
+    result.toList should equal(List(Map("int_numbers" -> List(2, 2))))
+  }
+
   test("toFloat should work as expected") {
     // Given
     createLabeledNode(Map("rating" -> 4), "Movie")
@@ -57,6 +65,14 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
 
     // Then
     result should equal(4.0)
+  }
+
+  test("toFloat should handle mixed number types") {
+    // When
+    val result = executeWithAllPlanners("WITH [3.4, 3] AS numbers RETURN [n in numbers | toFloat(n)] AS float_numbers")
+
+    // Then
+    result.toList should equal(List(Map("float_numbers" -> List(3.4, 3.0))))
   }
 
   test("toString should work as expected") {

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToFloat.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToFloat.scala
@@ -28,6 +28,7 @@ case object ToFloat extends Function with SimpleTypedFunction {
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat),
     Signature(argumentTypes = Vector(CTInteger), outputType = CTFloat),
-    Signature(argumentTypes = Vector(CTString), outputType = CTFloat)
+    Signature(argumentTypes = Vector(CTString), outputType = CTFloat),
+    Signature(argumentTypes = Vector(CTNumber), outputType = CTFloat)
   )
 }

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToFloat.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToFloat.scala
@@ -26,8 +26,6 @@ case object ToFloat extends Function with SimpleTypedFunction {
   def name = "toFloat"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat),
-    Signature(argumentTypes = Vector(CTInteger), outputType = CTFloat),
     Signature(argumentTypes = Vector(CTString), outputType = CTFloat),
     Signature(argumentTypes = Vector(CTNumber), outputType = CTFloat)
   )

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToInt.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToInt.scala
@@ -26,8 +26,6 @@ case object ToInt extends Function with SimpleTypedFunction {
   def name = "toInt"
 
   val signatures = Vector(
-    Signature(argumentTypes = Vector(CTFloat), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
     Signature(argumentTypes = Vector(CTString), outputType = CTInteger),
     Signature(argumentTypes = Vector(CTNumber), outputType = CTInteger)
   )

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToInt.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToInt.scala
@@ -28,6 +28,7 @@ case object ToInt extends Function with SimpleTypedFunction {
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTFloat), outputType = CTInteger),
     Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTString), outputType = CTInteger)
+    Signature(argumentTypes = Vector(CTString), outputType = CTInteger),
+    Signature(argumentTypes = Vector(CTNumber), outputType = CTInteger)
   )
 }

--- a/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToFloatTest.scala
+++ b/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToFloatTest.scala
@@ -27,15 +27,16 @@ class ToFloatTest extends FunctionTestBase("toFloat")  {
     testValidTypes(CTString)(CTFloat)
     testValidTypes(CTFloat)(CTFloat)
     testValidTypes(CTInteger)(CTFloat)
+    testValidTypes(CTNumber)(CTFloat)
   }
 
   test("shouldFailTypeCheckForIncompatibleArguments") {
     testInvalidApplication(CTCollection(CTAny))(
-      "Type mismatch: expected Float, Integer or String but was Collection<Any>"
+      "Type mismatch: expected Float, Integer, Number or String but was Collection<Any>"
     )
 
     testInvalidApplication(CTNode)(
-      "Type mismatch: expected Float, Integer or String but was Node"
+      "Type mismatch: expected Float, Integer, Number or String but was Node"
     )
   }
 

--- a/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToIntTest.scala
+++ b/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/ToIntTest.scala
@@ -27,15 +27,16 @@ class ToIntTest extends FunctionTestBase("toInt")  {
     testValidTypes(CTString)(CTInteger)
     testValidTypes(CTFloat)(CTInteger)
     testValidTypes(CTInteger)(CTInteger)
+    testValidTypes(CTNumber)(CTInteger)
   }
 
   test("shouldFailTypeCheckForIncompatibleArguments") {
     testInvalidApplication(CTCollection(CTAny))(
-      "Type mismatch: expected Float, Integer or String but was Collection<Any>"
+      "Type mismatch: expected Float, Integer, Number or String but was Collection<Any>"
     )
 
     testInvalidApplication(CTNode)(
-      "Type mismatch: expected Float, Integer or String but was Node"
+      "Type mismatch: expected Float, Integer, Number or String but was Node"
     )
   }
 


### PR DESCRIPTION
To better be able to use functions on mixed number type collections
