### PR TITLE
Align byte buffer sizes used for log reading.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/TransactionStream.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/TransactionStream.java
@@ -43,11 +43,8 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 
-import static javax.transaction.xa.Xid.MAXBQUALSIZE;
-import static javax.transaction.xa.Xid.MAXGTRIDSIZE;
-
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
-import static org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
 
 class TransactionStream
@@ -61,7 +58,7 @@ class TransactionStream
     {
         this.fs = fs;
         { // read metadata from all files in the directory
-            ByteBuffer buffer = ByteBuffer.allocateDirect( 9 + MAXGTRIDSIZE + MAXBQUALSIZE * 10 );
+            ByteBuffer buffer = ByteBuffer.allocateDirect( LOG_HEADER_SIZE );
             File[] files = fs.listFiles( path, new TxFileFilter( fs ) );
             ArrayList<LogFile> logFiles = new ArrayList<>( files.length );
             for ( File file : files )
@@ -126,7 +123,7 @@ class TransactionStream
 
     private class Cursor implements IOCursor<CommittedTransactionRepresentation>
     {
-        private final ByteBuffer buffer = ByteBuffer.allocateDirect( 9 + MAXGTRIDSIZE + MAXBQUALSIZE * 10 );
+        private final ByteBuffer buffer = ByteBuffer.allocateDirect( LOG_HEADER_SIZE );
         private int file;
         private CommittedTransactionRepresentation current;
         private IOCursor<LogEntry> entries;
@@ -310,7 +307,7 @@ class TransactionStream
     {
         return new LogEntryCursor( new ReadAheadLogChannel(
                 new PhysicalLogVersionedStoreChannel( channel, header.logVersion, header.logFormatVersion ),
-                NO_MORE_CHANNELS, DEFAULT_READ_AHEAD_SIZE ) );
+                NO_MORE_CHANNELS ) );
     }
 
     private static class TxFileFilter implements FilenameFilter

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogFileRecoverer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogFileRecoverer.java
@@ -28,7 +28,6 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.state.RecoverableTransaction;
 
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
-import static org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
 
 public class LogFileRecoverer implements Visitor<LogVersionedStoreChannel,IOException>
 {
@@ -45,8 +44,7 @@ public class LogFileRecoverer implements Visitor<LogVersionedStoreChannel,IOExce
     @Override
     public boolean visit( LogVersionedStoreChannel channel ) throws IOException
     {
-        final ReadableVersionableLogChannel recoveredDataChannel =
-                new ReadAheadLogChannel( channel, NO_MORE_CHANNELS, DEFAULT_READ_AHEAD_SIZE );
+        final ReadableVersionableLogChannel recoveredDataChannel = new ReadAheadLogChannel( channel, NO_MORE_CHANNELS );
 
         try ( final PhysicalTransactionCursor<ReadableLogChannel> physicalTransactionCursor =
                       new PhysicalTransactionCursor<>( recoveredDataChannel, logEntryReader ) )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
@@ -30,7 +30,6 @@ import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
-import static org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter.writeLogHeader;
@@ -192,7 +191,7 @@ public class PhysicalLogFile extends LifecycleAdapter implements LogFile
     {
         PhysicalLogVersionedStoreChannel logChannel = openForVersion( logFiles, fileSystem, position.getLogVersion() );
         logChannel.position( position.getByteOffset() );
-        return new ReadAheadLogChannel( logChannel, readerLogVersionBridge, DEFAULT_READ_AHEAD_SIZE );
+        return new ReadAheadLogChannel( logChannel, readerLogVersionBridge );
     }
 
     public static PhysicalLogVersionedStoreChannel openForVersion( PhysicalLogFiles logFiles,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadLogChannel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadAheadLogChannel.java
@@ -32,12 +32,17 @@ import static java.lang.System.arraycopy;
  */
 public class ReadAheadLogChannel implements ReadableVersionableLogChannel
 {
-    public static final int DEFAULT_READ_AHEAD_SIZE = 1024*4;
+    private static final int DEFAULT_READ_AHEAD_SIZE = 1024 * 4;
 
     private final ByteBuffer aheadBuffer;
     private LogVersionedStoreChannel channel;
     private final LogVersionBridge bridge;
     private final int readAheadSize;
+
+    public ReadAheadLogChannel( LogVersionedStoreChannel startingChannel, LogVersionBridge bridge )
+    {
+        this(startingChannel, bridge, DEFAULT_READ_AHEAD_SIZE);
+    }
 
     public ReadAheadLogChannel( LogVersionedStoreChannel startingChannel, LogVersionBridge bridge, int readAheadSize )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReader.java
@@ -46,7 +46,7 @@ public class LogHeaderReader
     {
         try ( StoreChannel channel = fileSystem.open( file, "r" ) )
         {
-            return readLogHeader( ByteBuffer.allocateDirect( 100 * 1000 ), channel, true );
+            return readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), channel, true );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/rawstorereader/RsdrMain.java
@@ -52,10 +52,9 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.logging.NullLogProvider;
 
-import static javax.transaction.xa.Xid.MAXBQUALSIZE;
-import static javax.transaction.xa.Xid.MAXGTRIDSIZE;
 import static org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory.createPageCache;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
 
 public class RsdrMain
@@ -264,14 +263,13 @@ public class RsdrMain
     {
         File file = new File( neoStores.getStoreDir(), fname );
         StoreChannel fileChannel = files.open( file, "r" );
-        ByteBuffer buffer = ByteBuffer.allocateDirect( 9 + MAXGTRIDSIZE + MAXBQUALSIZE * 10 );
-        LogHeader logHeader = readLogHeader( buffer, fileChannel, false );
+        LogHeader logHeader = readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), fileChannel, false );
         console.printf( "Logical log version: %s with prev committed tx[%s]%n",
                 logHeader.logVersion, logHeader.lastCommittedTxId );
 
         PhysicalLogVersionedStoreChannel channel =
                 new PhysicalLogVersionedStoreChannel( fileChannel, logHeader.logVersion, logHeader.logFormatVersion );
-        ReadableVersionableLogChannel logChannel = new ReadAheadLogChannel( channel, NO_MORE_CHANNELS, 4096 );
+        ReadableVersionableLogChannel logChannel = new ReadAheadLogChannel( channel, NO_MORE_CHANNELS );
         return new LogEntryCursor( logChannel );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LatestCheckPointFinder.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionRepository.INITIAL_LOG_VERSION;
-import static org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
 
 public class LatestCheckPointFinder
 {
@@ -68,8 +67,7 @@ public class LatestCheckPointFinder
             oldestVersionFound = version;
 
             CheckPoint latestCheckPoint = null;
-            ReadableLogChannel recoveredDataChannel =
-                    new ReadAheadLogChannel( channel, NO_MORE_CHANNELS, DEFAULT_READ_AHEAD_SIZE );
+            ReadableLogChannel recoveredDataChannel = new ReadAheadLogChannel( channel, NO_MORE_CHANNELS );
 
             try ( LogEntryCursor cursor = new LogEntryCursor( logEntryReader, recoveredDataChannel ) )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
@@ -25,11 +25,10 @@ import org.mockito.InOrder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.function.Consumer;
 import org.neo4j.helpers.Pair;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -69,16 +68,14 @@ import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verifyZeroInteractions;
-
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
-import static org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter.writeLogHeader;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
 
@@ -162,8 +159,8 @@ public class RecoveryTest
                         @Override
                         public boolean visit( LogVersionedStoreChannel element ) throws IOException
                         {
-                            try ( ReadableVersionableLogChannel channel =
-                                          new ReadAheadLogChannel( element, NO_MORE_CHANNELS, DEFAULT_READ_AHEAD_SIZE ) )
+                            try ( ReadableVersionableLogChannel channel = new ReadAheadLogChannel( element,
+                                    NO_MORE_CHANNELS ) )
                             {
                                 assertEquals( lastCommittedTxStartEntry, reader.readLogEntry( channel ) );
                                 assertEquals( lastCommittedTxCommitEntry, reader.readLogEntry( channel ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogMatchers.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogMatchers.java
@@ -29,14 +29,12 @@ import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.transaction.xa.Xid;
-
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.impl.transaction.command.Command;
-import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogEntryCursor;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadableVersionableLogChannel;
@@ -49,6 +47,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
 
 import static org.neo4j.helpers.collection.Iterables.iterable;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
 
 /**
@@ -60,16 +59,14 @@ public class LogMatchers
     public static List<LogEntry> logEntries( FileSystemAbstraction fileSystem, String logPath ) throws IOException
     {
         StoreChannel fileChannel = fileSystem.open( new File( logPath ), "r" );
-        ByteBuffer buffer = ByteBuffer.allocateDirect( 9 + Xid.MAXGTRIDSIZE + Xid.MAXBQUALSIZE * 10 );
 
         // Always a header
-        LogHeader header = readLogHeader( buffer, fileChannel, true );
+        LogHeader header = readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), fileChannel, true );
 
         // Read all log entries
         PhysicalLogVersionedStoreChannel versionedStoreChannel =
                 new PhysicalLogVersionedStoreChannel( fileChannel, header.logVersion, header.logFormatVersion );
-        ReadableVersionableLogChannel logChannel =
-                new ReadAheadLogChannel( versionedStoreChannel, NO_MORE_CHANNELS, 4096 );
+        ReadableVersionableLogChannel logChannel = new ReadAheadLogChannel( versionedStoreChannel, NO_MORE_CHANNELS );
         return Iterables.toList( iterable( new LogEntryCursor( logChannel ) ) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointerIntegrationTest.java
@@ -52,7 +52,6 @@ import static java.lang.System.getProperty;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionRepository.INITIAL_LOG_VERSION;
-import static org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
 
 public class CheckPointerIntegrationTest
 {
@@ -221,8 +220,7 @@ public class CheckPointerIntegrationTest
                     break;
                 }
 
-                ReadableLogChannel recoveredDataChannel =
-                        new ReadAheadLogChannel( channel, NO_MORE_CHANNELS, DEFAULT_READ_AHEAD_SIZE );
+                ReadableLogChannel recoveredDataChannel = new ReadAheadLogChannel( channel, NO_MORE_CHANNELS );
 
                 try ( LogEntryCursor cursor = new LogEntryCursor( logEntryReader, recoveredDataChannel ) )
                 {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/RebuildFromLogs.java
@@ -73,7 +73,6 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.api.TransactionApplicationMode.EXTERNAL;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
 import static org.neo4j.kernel.impl.transaction.log.PhysicalLogFile.openForVersion;
-import static org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel.DEFAULT_READ_AHEAD_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 
 class RebuildFromLogs
@@ -179,8 +178,7 @@ class RebuildFromLogs
     private long findLastTransactionId( PhysicalLogFiles logFiles, long highestVersion ) throws IOException
     {
         ReadableVersionableLogChannel logChannel = new ReadAheadLogChannel(
-                PhysicalLogFile.openForVersion( logFiles, fs, highestVersion ),
-                NO_MORE_CHANNELS, DEFAULT_READ_AHEAD_SIZE );
+                PhysicalLogFile.openForVersion( logFiles, fs, highestVersion ), NO_MORE_CHANNELS );
 
         long lastTransactionId = -1;
 
@@ -238,8 +236,7 @@ class RebuildFromLogs
             int startVersion = 0;
             ReaderLogVersionBridge versionBridge = new ReaderLogVersionBridge( fs, logFiles );
             PhysicalLogVersionedStoreChannel startingChannel = openForVersion( logFiles, fs, startVersion );
-            ReadableVersionableLogChannel channel =
-                    new ReadAheadLogChannel( startingChannel, versionBridge, DEFAULT_READ_AHEAD_SIZE );
+            ReadableVersionableLogChannel channel = new ReadAheadLogChannel( startingChannel, versionBridge );
             long txId = BASE_TX_ID;
             try ( IOCursor<CommittedTransactionRepresentation> cursor =
                           new PhysicalTransactionCursor<>( channel, new VersionAwareLogEntryReader<>() ) )


### PR DESCRIPTION
Use DEFAULT_READ_AHEAD_SIZE buffer size in ReadAheadLogChannel by default.
Use buffer with size LOG_HEADER_SIZE in readLogHeader.
