### PR TITLE
MergeIntoPipe comparing array properties by referential equality

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipe.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.frontend.v2_3.symbols._
 import org.neo4j.cypher.internal.frontend.v2_3.{InvalidSemanticsException, InternalException, SemanticDirection}
 import org.neo4j.graphdb.{Node, Relationship}
 import org.neo4j.helpers.collection.PrefetchingIterator
+import org.neo4j.kernel.api.properties.Property
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
@@ -125,14 +126,13 @@ case class MergeIntoPipe(source: Pipe,
     val relationships = query.getRelationshipsForIds(start, localDirection, Some(Seq(typeId)))
 
     new PrefetchingIterator[Relationship] {
-      //we do not expect two nodes to have many connecting relationships
-      val connectedRelationships = new ArrayBuffer[Relationship](2)
 
       private def hasCorrectProperties(rel: Relationship): Boolean = props.forall { case (key, expression) =>
         val expressionValue = expression(execution)(queryState)
         val propertyKeyId = key.getOptId(query)
-
-        propertyKeyId.exists { id => query.relationshipOps.getProperty(rel.getId, id) == expressionValue }
+        propertyKeyId.exists { id =>
+          toComparableProperty(query.relationshipOps.getProperty(rel.getId, id)) == expressionValue
+        }
       }
 
       override def fetchNextOrNull(): Relationship = {
@@ -140,15 +140,20 @@ case class MergeIntoPipe(source: Pipe,
           val rel = relationships.next()
           val other = rel.getOtherNode(start)
           if (end == other) {
-            if (hasCorrectProperties(rel)) {
-              connectedRelationships.append(rel)
-              return rel
-            }
+            if (hasCorrectProperties(rel)) return rel
           }
         }
         null
       }
     }.asScala
+  }
+
+  /*
+   * Properties can contain arrays which are not comparable with ==
+   */
+  private def toComparableProperty(property: Any) = property match {
+    case a: Array[_] => a.toVector
+    case o => o
   }
 
   private def getDegree(node: Node, typeId: Int, direction: SemanticDirection, query: QueryContext) = {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/MergeIntoPipeTest.scala
@@ -25,7 +25,7 @@ import org.mockito.Mockito.{mock => jmock, _}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compiler.v2_3.ExecutionContext
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Identifier, Property, Expression, Literal}
+import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{Identifier, Property, Expression, Literal, Collection}
 import org.neo4j.cypher.internal.compiler.v2_3.commands.values.{KeyToken, TokenType}
 import org.neo4j.cypher.internal.compiler.v2_3.mutation.{PropertySetAction, SetAction}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{Operations, QueryContext}
@@ -282,6 +282,29 @@ class MergeIntoPipeTest extends CypherFunSuite {
     val left = newMockedPipe("a", row("a" -> node_a, "b" -> node_b))
     val result = createPipeAndRun(query, left, INCOMING, "A", Map("key" -> Literal(42),
       "foo" -> Literal("bar")))
+
+    // then
+    val (single :: Nil) = result
+    single.m should equal(Map("a" -> node_a, "r" -> rel_a_A_b, "b" -> node_b))
+    verify(query.relationshipOps).getProperty(1, "key".hashCode())
+    verify(query.relationshipOps).getProperty(1, "foo".hashCode())
+    verifyNoMoreInteractions(query.relationshipOps)
+  }
+
+  test("should find a matching relationship between two nodes with matching array properties") {
+    // given
+    implicit val query = setupMockingInQueryContext()
+    markAsNotDense(node_a)
+    markAsNotDense(node_b)
+
+    // when
+    setupRelationshipFromNode(node_a, INCOMING, rel_a_A_b)
+    when(query.relationshipOps.getProperty(1, "key".hashCode())).thenReturn(Array(42, 43), Seq.empty: _*)
+    when(query.relationshipOps.getProperty(1, "foo".hashCode())).thenReturn(Array("foo", "bar"), Seq.empty: _*)
+
+    val left = newMockedPipe("a", row("a" -> node_a, "b" -> node_b))
+    val result = createPipeAndRun(query, left, INCOMING, "A", Map("key" -> Collection(Literal(42), Literal(43)),
+      "foo" -> Collection(Literal("foo"), Literal("bar"))))
 
     // then
     val (single :: Nil) = result


### PR DESCRIPTION
Whenever a relationship property is an array, `MergeIntoPipe` was doing
the wrong thing when checking if a given relationship had a given property.
This lead to unwanted creation of relationships in `MERGE`
