### PR TITLE
Show parameters in query logging

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
@@ -22,10 +22,10 @@ package org.neo4j.cypher
 import java.lang.Boolean.FALSE
 import java.util.{Map => JavaMap}
 
-import org.neo4j.cypher.internal.compiler.v3_0.helpers.using
 import org.neo4j.cypher.internal.compiler.v3_0.prettifier.Prettifier
 import org.neo4j.cypher.internal.compiler.v3_0.{LRUCache => LRUCachev3_0, _}
-import org.neo4j.cypher.internal.tracing.CompilationTracer.QueryCompilationEvent
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.JavaCompatibility
+import JavaCompatibility._
 import org.neo4j.cypher.internal.tracing.{TimingCompilationTracer, CompilationTracer}
 import org.neo4j.cypher.internal.{CypherCompiler, _}
 import org.neo4j.graphdb.GraphDatabaseService
@@ -87,7 +87,7 @@ class ExecutionEngine(graph: GraphDatabaseService, logProvider: LogProvider = Nu
 
   @throws(classOf[SyntaxException])
   def profile(query: String, params: Map[String, Any],session: QuerySession): ExtendedExecutionResult = {
-    executionMonitor.startQueryExecution(session, query)
+    executionMonitor.startQueryExecution(session, query, asJavaMap(params))
 
     val (preparedPlanExecution, txInfo) = planQuery(query)
     preparedPlanExecution.profile(graphAPI, txInfo, params, session)
@@ -113,7 +113,8 @@ class ExecutionEngine(graph: GraphDatabaseService, logProvider: LogProvider = Nu
 
   @throws(classOf[SyntaxException])
   def execute(query: String, params: Map[String, Any], session: QuerySession): ExtendedExecutionResult = {
-    executionMonitor.startQueryExecution(session, query)
+    executionMonitor.startQueryExecution(session, query,
+     asJavaMap(params))
     val (preparedPlanExecution, txInfo) = planQuery(query)
     preparedPlanExecution.execute(graphAPI, txInfo, params, session)
   }
@@ -252,6 +253,7 @@ class ExecutionEngine(graph: GraphDatabaseService, logProvider: LogProvider = Nu
       .andThen(_.getOrElse(defaultValue))
       .applyOrElse(graph, (_: GraphDatabaseService) => defaultValue)
   }
+
 }
 
 object ExecutionEngine {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -276,11 +276,20 @@ case class ExecutionResultWrapperFor3_0(inner: InternalExecutionResult, planner:
     )
   }
 
-  def close() = exceptionHandlerFor3_0.runSafely{ inner.close() }
+  def close() = exceptionHandlerFor3_0.runSafely{
+    endQueryExecution()
+    inner.close()
+  }
 
   def next() = exceptionHandlerFor3_0.runSafely{ inner.next() }
 
-  def hasNext = exceptionHandlerFor3_0.runSafely{ inner.hasNext }
+  def hasNext = exceptionHandlerFor3_0.runSafely {
+    val next = inner.hasNext
+    if (!next) {
+      endQueryExecution()
+    }
+    next
+  }
 
   def convert(i: InternalPlanDescription): ExtendedPlanDescription = exceptionHandlerFor3_0.runSafely {
     CompatibilityPlanDescriptionFor3_0(i, CypherVersion.v3_0, planner, runtime)

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher
 
+import java.util.Collections
+
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.GraphDatabaseService
@@ -37,7 +39,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     engine.execute("RETURN 42", Map.empty[String, Any], session)
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42", Collections.emptyMap())
     verify(monitor, never()).endSuccess(session)
   }
 
@@ -53,7 +55,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     }
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -65,7 +67,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CREATE()", Map.empty[String, Any], session).javaIterator
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CREATE()")
+    verify(monitor, times(1)).startQueryExecution(session, "CREATE()", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -77,7 +79,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
 
     //then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]", Collections.emptyMap())
     while (result.hasNext) {
       verify(monitor, never).endSuccess(session)
       result.next()
@@ -102,7 +104,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("RETURN 42", Map.empty[String, Any], session).javaIterator.close()
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -123,7 +125,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     }
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endFailure(session, throwable)
   }
 
@@ -135,7 +137,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.profile("RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
 
     //then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]", Collections.emptyMap())
     while (result.hasNext) {
       verify(monitor, never).endSuccess(session)
       result.next()
@@ -151,7 +153,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.profile("CYPHER 2.3 RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
 
     //then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.3 RETURN [1, 2, 3, 4, 5]")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.3 RETURN [1, 2, 3, 4, 5]", Collections.emptyMap())
     while (result.hasNext) {
       verify(monitor, never).endSuccess(session)
       result.next()
@@ -167,7 +169,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CYPHER 2.3 RETURN 42", Map.empty[String, Any], session).javaIterator.close()
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.3 RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.3 RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -188,7 +190,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     }
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.3 RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.3 RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endFailure(session, throwable)
   }
 
@@ -200,7 +202,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CYPHER 2.3 CREATE()", Map.empty[String, Any], session).javaIterator
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.3 CREATE()")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.3 CREATE()", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher
 
+import java.util
+
 import org.neo4j.cypher.internal.compatibility.ExecutionResultWrapperFor3_0
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InternalExecutionResult
 import org.neo4j.cypher.internal.compiler.v3_0.{CompiledRuntimeName, CostBasedPlannerName}
@@ -35,7 +37,8 @@ trait QueryStatisticsTestSupport {
 
     def apply(actual: InternalExecutionResult) {
       implicit val monitor = new QueryExecutionMonitor {
-        override def startQueryExecution(session: QuerySession, query: String){}
+        override def startQueryExecution(session: QuerySession, query: String,
+                                         parameters: util.Map[String, AnyRef]){}
 
         override def endSuccess(session: QuerySession){}
 

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/helpers/JavaCompatibility.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/helpers/JavaCompatibility.scala
@@ -17,20 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.query;
+package org.neo4j.cypher.internal.frontend.v3_0.helpers
 
-import java.util.Map;
+import java.util
 
-/**
- * The current (December 2014) usage of this interface expects the {@code end*} methods to be idempotent.
- * That is, once either of them have been invoked with a particular session as parameter, invoking either
- * of them with the same session parameter should do nothing.
- */
-public interface QueryExecutionMonitor
-{
-    void startQueryExecution( QuerySession session, String query, Map<String,Object> parameters);
+import scala.collection.JavaConverters._
 
-    void endFailure( QuerySession session, Throwable failure );
+object JavaCompatibility {
 
-    void endSuccess( QuerySession session );
+  def asJavaCompatible(value: Any): Any = value match {
+    case seq: Seq[_]    => seq.map(asJavaCompatible).asJava
+    case map: Map[_, _] => Eagerly.immutableMapValues(map, asJavaCompatible).asJava
+    case x              => x
+  }
+
+  def asJavaMap[S,T](map: Map[S,T]): util.Map[S, AnyRef] = Eagerly.immutableMapValues(map, asJavaCompatible).asJava.asInstanceOf[util.Map[S, AnyRef]]
 }

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.kernel.impl.query;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -39,6 +43,7 @@ public class QueryLoggerTest
     public static final String QUERY_1 = "MATCH (n) RETURN n";
     public static final String QUERY_2 = "MATCH (a)--(b) RETURN b.name";
     public static final String QUERY_3 = "MATCH (c)-[:FOO]->(d) RETURN d.size";
+    public static final String QUERY_4 = "MATCH (n) WHERE n.age IN {ages} RETURN n";
 
     @Test
     public void shouldLogQuerySlowerThanThreshold() throws Exception
@@ -50,13 +55,13 @@ public class QueryLoggerTest
         QueryLogger queryLogger = new QueryLogger( clock, logProvider.getLog( getClass() ), 10/*ms*/ );
 
         // when
-        queryLogger.startQueryExecution( session, QUERY_1 );
+        queryLogger.startQueryExecution( session, QUERY_1, Collections.emptyMap() );
         clock.forward( 11, TimeUnit.MILLISECONDS );
         queryLogger.endSuccess( session );
 
         // then
         logProvider.assertExactly(
-                inLog( getClass() ).info( "%d ms: %s - %s", 11L, SESSION_1_NAME, QUERY_1 )
+                inLog( getClass() ).info( "%d ms: %s - %s - %s", 11L, SESSION_1_NAME, QUERY_1, "{}" )
         );
     }
 
@@ -70,7 +75,7 @@ public class QueryLoggerTest
         QueryLogger queryLogger = new QueryLogger( clock, logProvider.getLog( getClass() ), 10/*ms*/ );
 
         // when
-        queryLogger.startQueryExecution( session, QUERY_1 );
+        queryLogger.startQueryExecution( session, QUERY_1, Collections.emptyMap() );
         clock.forward( 9, TimeUnit.MILLISECONDS );
         queryLogger.endSuccess( session );
 
@@ -90,11 +95,11 @@ public class QueryLoggerTest
         QueryLogger queryLogger = new QueryLogger( clock, logProvider.getLog( getClass() ), 10/*ms*/ );
 
         // when
-        queryLogger.startQueryExecution( session1, QUERY_1 );
+        queryLogger.startQueryExecution( session1, QUERY_1, Collections.emptyMap() );
         clock.forward( 1, TimeUnit.MILLISECONDS );
-        queryLogger.startQueryExecution( session2, QUERY_2 );
+        queryLogger.startQueryExecution( session2, QUERY_2, Collections.emptyMap() );
         clock.forward( 1, TimeUnit.MILLISECONDS );
-        queryLogger.startQueryExecution( session3, QUERY_3 );
+        queryLogger.startQueryExecution( session3, QUERY_3, Collections.emptyMap() );
         clock.forward( 7, TimeUnit.MILLISECONDS );
         queryLogger.endSuccess( session3 );
         clock.forward( 7, TimeUnit.MILLISECONDS );
@@ -104,8 +109,8 @@ public class QueryLoggerTest
 
         // then
         logProvider.assertExactly(
-                inLog( getClass() ).info( "%d ms: %s - %s", 15L, SESSION_2_NAME, QUERY_2 ),
-                inLog( getClass() ).info( "%d ms: %s - %s", 23L, SESSION_1_NAME, QUERY_1 )
+                inLog( getClass() ).info( "%d ms: %s - %s - %s", 15L, SESSION_2_NAME, QUERY_2, "{}" ),
+                inLog( getClass() ).info( "%d ms: %s - %s - %s", 23L, SESSION_1_NAME, QUERY_1, "{}" )
         );
     }
 
@@ -120,13 +125,58 @@ public class QueryLoggerTest
         RuntimeException failure = new RuntimeException();
 
         // when
-        queryLogger.startQueryExecution( session, QUERY_1 );
+        queryLogger.startQueryExecution( session, QUERY_1, Collections.emptyMap() );
         clock.forward( 1, TimeUnit.MILLISECONDS );
         queryLogger.endFailure( session, failure );
 
         // then
         logProvider.assertExactly(
-                inLog( getClass() ).error( is( "1 ms: {session one} - MATCH (n) RETURN n" ), sameInstance( failure ) )
+                inLog( getClass() ).error( is( "1 ms: {session one} - MATCH (n) RETURN n - {}" ), sameInstance( failure ) )
+        );
+    }
+
+    @Test
+    public void shouldLogQueryParameters() throws Exception
+    {
+        // given
+        final AssertableLogProvider logProvider = new AssertableLogProvider();
+        QuerySession session = session( SESSION_1_NAME );
+        FakeClock clock = new FakeClock();
+        QueryLogger queryLogger = new QueryLogger( clock, logProvider.getLog( getClass() ), 10/*ms*/ );
+
+        // when
+        Map<String, Object> params = new HashMap<>(  );
+        params.put("ages", Arrays.asList(41, 42, 43));
+        queryLogger.startQueryExecution( session, QUERY_4, params );
+        clock.forward( 11, TimeUnit.MILLISECONDS );
+        queryLogger.endSuccess( session );
+
+        // then
+        logProvider.assertExactly(
+                inLog( getClass() ).info( "%d ms: %s - %s - %s", 11L, SESSION_1_NAME, QUERY_4, "{ages: [41, 42, 43]}" )
+        );
+    }
+
+    @Test
+    public void shouldLogQueryParametersOnFailure() throws Exception
+    {
+        // given
+        final AssertableLogProvider logProvider = new AssertableLogProvider();
+        QuerySession session = session( SESSION_1_NAME );
+        FakeClock clock = new FakeClock();
+        QueryLogger queryLogger = new QueryLogger( clock, logProvider.getLog( getClass() ), 10/*ms*/ );
+        RuntimeException failure = new RuntimeException();
+
+        // when
+        Map<String, Object> params = new HashMap<>(  );
+        params.put("ages", Arrays.asList(41, 42, 43));
+        queryLogger.startQueryExecution( session, QUERY_4, params );
+        clock.forward( 1, TimeUnit.MILLISECONDS );
+        queryLogger.endFailure( session, failure );
+
+        // then
+        logProvider.assertExactly(
+                inLog( getClass() ).error( is( "1 ms: {session one} - MATCH (n) WHERE n.age IN {ages} RETURN n - {ages: [41, 42, 43]}" ), sameInstance( failure ) )
         );
     }
 


### PR DESCRIPTION
When logging slow queries we now also display the parameters
that was used for the specific case
