### PR TITLE
in_use query param for node labels doc

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/rest/LabelsDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/LabelsDocIT.java
@@ -293,6 +293,9 @@ public class LabelsDocIT extends AbstractRestFunctionalTestBase
 
     /**
      * List all labels.
+     * 
+     * By default, the server will return labels in use only. If you want to also return not in use labels, 
+     * append the "in_use=0" query parameter. 
      */
     @Test
     @Documented

--- a/community/server/src/test/java/org/neo4j/server/rest/LabelsDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/LabelsDocIT.java
@@ -294,7 +294,7 @@ public class LabelsDocIT extends AbstractRestFunctionalTestBase
     /**
      * List all labels.
      * 
-     * By default, the server will return labels in use only. If you want to also return not in use labels, 
+     * By default, the server will return labels in use only. If you also want to return labels not in use, 
      * append the "in_use=0" query parameter. 
      */
     @Test


### PR DESCRIPTION
By default, the server will now return only labels in use. The `in_use` query parameter is now documented.
