### PR TITLE
Prints nicer message about multiline fields

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -34,6 +34,7 @@ import org.neo4j.function.Function2;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.Args.Option;
 import org.neo4j.helpers.ArrayUtil;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.helpers.collection.Iterables;
@@ -469,7 +470,10 @@ public class ImportTool
                     " read more about how to use id spaces in the manual:" +
                     manualReference( "import-tool-header-format.html#_id_spaces" ), e, stackTrace );
         }
-        else if ( e.getClass().equals( IllegalMultilineFieldException.class ) )
+        // This type of exception is wrapped since our input code throws InputException consistently,
+        // and so IllegalMultilineFieldException comes from the csv component, which has no access to InputException
+        // therefore it's wrapped.
+        else if ( Exceptions.contains( e, IllegalMultilineFieldException.class ) )
         {
             printErrorMessage( "Detected field which spanned multiple lines for an import where " +
                     Options.MULTILINE_FIELDS.argument() + "=false. If you know that your input data include " +
@@ -499,6 +503,7 @@ public class ImportTool
     private static void printErrorMessage( String string, Exception e, boolean stackTrace )
     {
         System.err.println( string );
+        System.err.println( "Caused by:" + e.getMessage() );
         if ( stackTrace )
         {
             e.printStackTrace( System.err );

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -761,6 +761,39 @@ public class ImportToolTest
         }
     }
 
+    @Test
+    public void shouldPrintUserFriendlyMessageAboutUnsupportedMultilineFields() throws Exception
+    {
+        // GIVEN
+        File data = data(
+                ":ID,name",
+                "1,\"one\ntwo\nthree\"",
+                "2,four" );
+
+        // WHEN
+        ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();
+        PrintStream prevErr = System.err;
+        System.setErr( new PrintStream( errBuffer ) );
+        try
+        {
+            importTool(
+                    "--into", dbRule.getStoreDirAbsolutePath(),
+                    "--nodes", data.getAbsolutePath(),
+                    "--multiline-fields", "false" );
+            fail( "Should have failed" );
+        }
+        catch ( InputException e )
+        {
+            // THEN
+            assertThat( errBuffer.toString(), containsString( "Detected field which spanned multiple lines" ) );
+            assertThat( errBuffer.toString(), containsString( "multiline-fields" ) );
+        }
+        finally
+        {
+            System.setErr( prevErr );
+        }
+    }
+
     private File data( String... lines ) throws Exception
     {
         File file = file( fileName( "data.csv" ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/lifecycle/LifeSupport.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.lifecycle;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.collection.Iterables;


### PR DESCRIPTION
when those are encountered, but the option is set to false. The code was
there but looked at the wrong exception. Now there's a test for it as
well.
