### PR TITLE
Fallback to TransactionIdStore.BASE_TX_ID in OnDiskLastTxIdGetter whe…

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/OnDiskLastTxIdGetter.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/transaction/OnDiskLastTxIdGetter.java
@@ -33,11 +33,15 @@ public class OnDiskLastTxIdGetter implements LastTxIdGetter
         this.neoStoresSupplier = neoStoresSupplier;
     }
 
+    // This method is used to construct credentials for election process.
+    // And can be invoked at any moment of instance lifecycle.
+    // It mean that its possible that we will be invoked when neo stores are stopped
+    // (for example while we copy store)
     @Override
     public long getLastTxId()
     {
         TransactionIdStore neoStore = getNeoStores().getMetaDataStore();
-        return neoStore.getLastCommittedTransactionId();
+        return neoStore != null ? neoStore.getLastCommittedTransactionId() : TransactionIdStore.BASE_TX_ID;
     }
 
     private NeoStores getNeoStores()


### PR DESCRIPTION
…n neo stores are closed

OnDiskLastTxIdGetter is used for credentials creation in cluster election process.
It means that we should be ready to handle cases when neo stores are stopped: for example while we are copying store from master.
For those cases we will fallback to BASE_TX_ID as current latest commited transaction value.
