### PR TITLE
Add -XX:+AlwaysPreTouch to default JVM arguments

### DIFF
--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
@@ -9,8 +9,23 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 # JVM Parameters
 #********************************************************************
 
+# Java Heap Size: by default the Java heap size is dynamically
+# calculated based on available system resources.
+# Uncomment these lines to set specific initial and maximum
+# heap size in MB.
+#wrapper.java.initmemory=512
+#wrapper.java.maxmemory=512
+
+# G1GC generally strikes a good balance between throughput and tail
+# latency, without too much tuning.
 wrapper.java.additional=-XX:+UseG1GC
+
+# Have common exceptions keep producing stack traces, so they can be
+# debugged regardless of how often logs are rotated.
 wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
+
+# Reduce probability of objects getting the same identity hash code
+# via a race, by computing them with thread-local PRNGs.
 wrapper.java.additional=-XX:hashCode=5
 
 # Remote JMX monitoring, uncomment and adjust the following lines as needed.
@@ -37,13 +52,6 @@ wrapper.java.additional=-XX:hashCode=5
 #wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
 #wrapper.java.additional=-XX:+PrintPromotionFailure
 #wrapper.java.additional=-XX:+PrintTenuringDistribution
-
-# Java Heap Size: by default the Java heap size is dynamically
-# calculated based on available system resources.
-# Uncomment these lines to set specific initial and maximum
-# heap size in MB.
-#wrapper.java.initmemory=512
-#wrapper.java.maxmemory=512
 
 #********************************************************************
 # Wrapper settings

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/conf/neo4j-wrapper.conf
@@ -28,6 +28,23 @@ wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
 # via a race, by computing them with thread-local PRNGs.
 wrapper.java.additional=-XX:hashCode=5
 
+# Make sure that `initmemory` is not only allocated, but committed to
+# the process, before starting the database. This reduces memory
+# fragmentation, increasing the effectiveness of transparent huge
+# pages. It also reduces the possibility of seeing performance drop
+# due to heap-growing GC events, where a decrease in available page
+# cache leads to an increase in mean IO response time.
+# Try reducing the heap memory, if this flag degrades performance.
+wrapper.java.additional=-XX:+AlwaysPreTouch
+
+# Uncomment the following lines to enable garbage collection logging
+#wrapper.java.additional=-Xloggc:data/log/neo4j-gc.log
+#wrapper.java.additional=-XX:+PrintGCDetails
+#wrapper.java.additional=-XX:+PrintGCDateStamps
+#wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
+#wrapper.java.additional=-XX:+PrintPromotionFailure
+#wrapper.java.additional=-XX:+PrintTenuringDistribution
+
 # Remote JMX monitoring, uncomment and adjust the following lines as needed.
 # Also make sure to update the jmx.access and jmx.password files with appropriate permission roles and passwords,
 # the shipped configuration contains only a read only role called 'monitor' with password 'Neo4j'.
@@ -44,14 +61,6 @@ wrapper.java.additional=-XX:hashCode=5
 
 # Some systems cannot discover host name automatically, and need this line configured:
 #wrapper.java.additional=-Djava.rmi.server.hostname=$THE_NEO4J_SERVER_HOSTNAME
-
-# Uncomment the following lines to enable garbage collection logging
-#wrapper.java.additional=-Xloggc:data/log/neo4j-gc.log
-#wrapper.java.additional=-XX:+PrintGCDetails
-#wrapper.java.additional=-XX:+PrintGCDateStamps
-#wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
-#wrapper.java.additional=-XX:+PrintPromotionFailure
-#wrapper.java.additional=-XX:+PrintTenuringDistribution
 
 #********************************************************************
 # Wrapper settings

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
@@ -9,8 +9,23 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 # JVM Parameters
 #********************************************************************
 
+# Java Heap Size: by default the Java heap size is dynamically
+# calculated based on available system resources.
+# Uncomment these lines to set specific initial and maximum
+# heap size in MB.
+#wrapper.java.initmemory=512
+#wrapper.java.maxmemory=512
+
+# G1GC generally strikes a good balance between throughput and tail
+# latency, without too much tuning.
 wrapper.java.additional=-XX:+UseG1GC
+
+# Have common exceptions keep producing stack traces, so they can be
+# debugged regardless of how often logs are rotated.
 wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
+
+# Reduce probability of objects getting the same identity hash code
+# via a race, by computing them with thread-local PRNGs.
 wrapper.java.additional=-XX:hashCode=5
 
 # Uncomment the following lines to enable garbage collection logging
@@ -20,13 +35,6 @@ wrapper.java.additional=-XX:hashCode=5
 #wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
 #wrapper.java.additional=-XX:+PrintPromotionFailure
 #wrapper.java.additional=-XX:+PrintTenuringDistribution
-
-# Java Heap Size: by default the Java heap size is dynamically
-# calculated based on available system resources.
-# Uncomment these lines to set specific initial and maximum
-# heap size in MB.
-#wrapper.java.initmemory=512
-#wrapper.java.maxmemory=512
 
 #********************************************************************
 # Wrapper settings

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
@@ -28,6 +28,15 @@ wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
 # via a race, by computing them with thread-local PRNGs.
 wrapper.java.additional=-XX:hashCode=5
 
+# Make sure that `initmemory` is not only allocated, but committed to
+# the process, before starting the database. This reduces memory
+# fragmentation, increasing the effectiveness of transparent huge
+# pages. It also reduces the possibility of seeing performance drop
+# due to heap-growing GC events, where a decrease in available page
+# cache leads to an increase in mean IO response time.
+# Try reducing the heap memory, if this flag degrades performance.
+wrapper.java.additional=-XX:+AlwaysPreTouch
+
 # Uncomment the following lines to enable garbage collection logging
 #wrapper.java.additional=-Xloggc:data/log/neo4j-gc.log
 #wrapper.java.additional=-XX:+PrintGCDetails

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
@@ -9,8 +9,23 @@ wrapper.java.additional=-Dlog4j.configuration=file:conf/log4j.properties
 # JVM Parameters
 #********************************************************************
 
+# Java Heap Size: by default the Java heap size is dynamically
+# calculated based on available system resources.
+# Uncomment these lines to set specific initial and maximum
+# heap size in MB.
+#wrapper.java.initmemory=512
+#wrapper.java.maxmemory=512
+
+# G1GC generally strikes a good balance between throughput and tail
+# latency, without too much tuning.
 wrapper.java.additional=-XX:+UseG1GC
+
+# Have common exceptions keep producing stack traces, so they can be
+# debugged regardless of how often logs are rotated.
 wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
+
+# Reduce probability of objects getting the same identity hash code
+# via a race, by computing them with thread-local PRNGs.
 wrapper.java.additional=-XX:hashCode=5
 
 # Remote JMX monitoring, uncomment and adjust the following lines as needed.
@@ -37,13 +52,6 @@ wrapper.java.additional=-XX:hashCode=5
 #wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
 #wrapper.java.additional=-XX:+PrintPromotionFailure
 #wrapper.java.additional=-XX:+PrintTenuringDistribution
-
-# Java Heap Size: by default the Java heap size is dynamically
-# calculated based on available system resources.
-# Uncomment these lines to set specific initial and maximum
-# heap size in MB.
-#wrapper.java.initmemory=512
-#wrapper.java.maxmemory=512
 
 #********************************************************************
 # Wrapper settings

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j-wrapper.conf
@@ -28,6 +28,23 @@ wrapper.java.additional=-XX:-OmitStackTraceInFastThrow
 # via a race, by computing them with thread-local PRNGs.
 wrapper.java.additional=-XX:hashCode=5
 
+# Make sure that `initmemory` is not only allocated, but committed to
+# the process, before starting the database. This reduces memory
+# fragmentation, increasing the effectiveness of transparent huge
+# pages. It also reduces the possibility of seeing performance drop
+# due to heap-growing GC events, where a decrease in available page
+# cache leads to an increase in mean IO response time.
+# Try reducing the heap memory, if this flag degrades performance.
+wrapper.java.additional=-XX:+AlwaysPreTouch
+
+# Uncomment the following lines to enable garbage collection logging
+#wrapper.java.additional=-Xloggc:data/log/neo4j-gc.log
+#wrapper.java.additional=-XX:+PrintGCDetails
+#wrapper.java.additional=-XX:+PrintGCDateStamps
+#wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
+#wrapper.java.additional=-XX:+PrintPromotionFailure
+#wrapper.java.additional=-XX:+PrintTenuringDistribution
+
 # Remote JMX monitoring, uncomment and adjust the following lines as needed.
 # Also make sure to update the jmx.access and jmx.password files with appropriate permission roles and passwords,
 # the shipped configuration contains only a read only role called 'monitor' with password 'Neo4j'.
@@ -44,14 +61,6 @@ wrapper.java.additional=-XX:hashCode=5
 
 # Some systems cannot discover host name automatically, and need this line configured:
 #wrapper.java.additional=-Djava.rmi.server.hostname=$THE_NEO4J_SERVER_HOSTNAME
-
-# Uncomment the following lines to enable garbage collection logging
-#wrapper.java.additional=-Xloggc:data/log/neo4j-gc.log
-#wrapper.java.additional=-XX:+PrintGCDetails
-#wrapper.java.additional=-XX:+PrintGCDateStamps
-#wrapper.java.additional=-XX:+PrintGCApplicationStoppedTime
-#wrapper.java.additional=-XX:+PrintPromotionFailure
-#wrapper.java.additional=-XX:+PrintTenuringDistribution
 
 #********************************************************************
 # Wrapper settings


### PR DESCRIPTION
Issued for 3.0, because it can degrade performance for people who currently have bad heap configurations but are saved by fortunate GC ergonomics.
