### PR TITLE
Fix LuceneIndexAccessorTest on IBM JDK

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/ThreadingRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ThreadingRule.java
@@ -21,7 +21,6 @@ package org.neo4j.test;
 
 import org.junit.rules.ExternalResource;
 
-import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,11 +33,7 @@ import org.neo4j.function.Consumers;
 import org.neo4j.function.Predicate;
 import org.neo4j.function.Predicates;
 import org.neo4j.function.ThrowingFunction;
-import org.neo4j.helpers.Cancelable;
-import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.helpers.ConcurrentTransfer;
-
-import static java.util.Objects.requireNonNull;
 
 public class ThreadingRule extends ExternalResource
 {
@@ -73,12 +68,6 @@ public class ThreadingRule extends ExternalResource
         return executor.submit( task( Barrier.NONE, function, parameter, Consumers.<Thread>noop() ) );
     }
 
-    public <FROM, TO, EX extends Exception> Future<TO> executeAfter(
-            Barrier barrier, ThrowingFunction<FROM,TO,EX> function, FROM parameter )
-    {
-        return executor.submit( task( barrier, function, parameter, Consumers.<Thread>noop() ) );
-    }
-
     public <FROM, TO, EX extends Exception> Future<TO> executeAndAwait(
             ThrowingFunction<FROM,TO,EX> function, FROM parameter, Predicate<Thread> threadCondition,
             long timeout, TimeUnit unit ) throws TimeoutException, InterruptedException
@@ -87,15 +76,6 @@ public class ThreadingRule extends ExternalResource
         Future<TO> future = executor.submit( task( Barrier.NONE, function, parameter, threadTransfer ) );
         Predicates.await( threadTransfer, threadCondition, timeout, unit );
         return future;
-    }
-
-    public Cancelable threadBlockMonitor( Thread thread, Runnable action )
-    {
-        CancellationHandle cancellation = new CancellationHandle();
-        executor.submit( new ThreadBlockMonitor( cancellation,
-                requireNonNull( thread, "thread" ),
-                requireNonNull( action, "action" ) ) );
-        return cancellation;
     }
 
     private static <FROM, TO, EX extends Exception> Callable<TO> task(
@@ -120,28 +100,6 @@ public class ThreadingRule extends ExternalResource
                 {
                     thread.setName( name );
                 }
-            }
-        };
-    }
-
-    public static Predicate<Thread> stackTracePredicate( final int depth, final Class<?> owner, final String method )
-    {
-        return new Predicate<Thread>()
-        {
-            @Override
-            public boolean test( Thread thread )
-            {
-                StackTraceElement[] stackTrace = thread.getStackTrace();
-                return stackTrace.length > depth &&
-                       stackTrace[depth].getClassName().equals( owner.getName() ) &&
-                       stackTrace[depth].getMethodName().equals( method );
-            }
-
-            @Override
-            public String toString()
-            {
-                return String.format( "Predicate[thread.getStackTrace()[%s] == %s.%s()]",
-                        depth, owner.getName(), method );
             }
         };
     }
@@ -176,78 +134,5 @@ public class ThreadingRule extends ExternalResource
                         owner.getName(), method );
             }
         };
-    }
-
-    private static class CancellationHandle implements Cancelable, CancellationRequest
-    {
-        private volatile boolean cancelled = false;
-
-        @Override
-        public boolean cancellationRequested()
-        {
-            return cancelled;
-        }
-
-        public void cancel()
-        {
-            cancelled = true;
-        }
-    }
-
-    private static class ThreadBlockMonitor implements Runnable
-    {
-        private final CancellationRequest cancellation;
-        private final Thread thread;
-        private final Runnable action;
-
-        public ThreadBlockMonitor( CancellationRequest cancellation, Thread thread, Runnable action )
-        {
-            this.cancellation = cancellation;
-            this.thread = thread;
-            this.action = action;
-        }
-
-        @Override
-        public void run()
-        {
-            StackTraceElement[] lastTrace = null;
-            Thread.State lastState = null;
-            do
-            {
-                Thread.State state = thread.getState();
-                switch ( state )
-                {
-                case BLOCKED:
-                case WAITING:
-                case TIMED_WAITING:
-                    StackTraceElement[] trace = thread.getStackTrace();
-                    if ( trace[0].isNativeMethod() &&
-                         Thread.class.getName().equals( trace[0].getClassName() ) &&
-                         "sleep".equals( trace[0].getMethodName() ) )
-                    {
-                        break; // don't regard Thread.sleep() as being blocked
-                    }
-                    if ( lastState == state && Arrays.equals( trace, lastTrace ) )
-                    {
-                        action.run();
-                        return;
-                    }
-                    lastTrace = trace;
-                    break;
-                default:
-                    lastTrace = null;
-                }
-                lastState = state;
-                try
-                {
-                    Thread.sleep( 500 );
-                }
-                catch ( InterruptedException e )
-                {
-                    return;
-                }
-            }
-            while ( !cancellation.cancellationRequested() );
-        }
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorTest.java
@@ -46,17 +46,15 @@ import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.register.Registers;
 import org.neo4j.test.ThreadingRule;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
 import static org.neo4j.helpers.collection.IteratorUtil.emptySetOf;
 import static org.neo4j.kernel.api.impl.index.IndexWriterFactories.reserving;
-import static org.neo4j.test.ThreadingRule.stackTracePredicate;
+import static org.neo4j.test.ThreadingRule.waitingWhileIn;
 
 @RunWith( Parameterized.class )
 public class LuceneIndexAccessorTest
@@ -177,7 +175,7 @@ public class LuceneIndexAccessorTest
                 accessor.drop();
                 return nothing;
             }
-        }, null, stackTracePredicate( 3, TaskCoordinator.class, "awaitCompletion" ), 3, SECONDS );
+        }, null, waitingWhileIn( TaskCoordinator.class, "awaitCompletion" ), 3, SECONDS );
 
         try ( IndexReader reader = indexReader /* do not inline! */ )
         {


### PR DESCRIPTION
Test `LuceneIndexAccessorTest#shouldStopSamplingWhenIndexIsDropped()` relied on stack depth of a stacktrace with `Thread#sleep()` in it. Implementation of `Thread#sleep()` is JDK dependent and different for Oracle and IMB. On Oracle JDK this method is a java method that calls into a native method, this results in two stack frames being added. On IBM JDK `Thread#sleep()` is a native method thus adds only one stack frame. This difference made test fail on IBM JDK.

Cleaned up unused methods and inner classes in `ThreadingRule`.
