### PR TITLE
Compute correctly last tx log position fields in metadatastore

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrator.java
@@ -73,6 +73,7 @@ import org.neo4j.kernel.impl.storemigration.legacystore.v21.propertydeduplicatio
 import org.neo4j.kernel.impl.storemigration.legacystore.v22.Legacy22Store;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.util.Charsets;
 import org.neo4j.kernel.lifecycle.Lifespan;
@@ -104,6 +105,7 @@ import static org.neo4j.kernel.impl.storemigration.FileOperation.COPY;
 import static org.neo4j.kernel.impl.storemigration.FileOperation.DELETE;
 import static org.neo4j.kernel.impl.storemigration.FileOperation.MOVE;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_LOG_BYTE_OFFSET;
+import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_LOG_VERSION;
 import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.withDynamicProcessorAssignment;
 
 /**
@@ -154,7 +156,7 @@ public class StoreMigrator implements StoreMigrationParticipant
         File neoStore = new File( storeDir, MetaDataStore.DEFAULT_NAME );
         long lastTxId = MetaDataStore.getRecord( pageCache, neoStore, Position.LAST_TRANSACTION_ID );
         long lastTxChecksum = extractTransactionChecksum( neoStore, storeDir, lastTxId );
-        LogPosition lastTxLogPosition = extractTransactionLogPosition( neoStore, lastTxId );
+        LogPosition lastTxLogPosition = extractTransactionLogPosition( neoStore, storeDir, lastTxId );
         // Write the tx checksum to file in migrationDir, because we need it later when moving files into storeDir
         writeLastTxChecksum( migrationDir, lastTxChecksum );
         writeLastTxLogPosition( migrationDir, lastTxLogPosition );
@@ -206,7 +208,8 @@ public class StoreMigrator implements StoreMigrationParticipant
         }
     }
 
-    private long readLastTxChecksum( File migrationDir ) throws IOException
+    // accessible for tests
+    static long readLastTxChecksum( FileSystemAbstraction fileSystem, File migrationDir ) throws IOException
     {
         try ( Reader reader = fileSystem.openAsReader( lastTxChecksumFile( migrationDir ), UTF8 ) )
         {
@@ -216,7 +219,8 @@ public class StoreMigrator implements StoreMigrationParticipant
         }
     }
 
-    private LogPosition readLastTxLogPosition( File migrationDir ) throws IOException
+    // accessible for tests
+    static LogPosition readLastTxLogPosition( FileSystemAbstraction fileSystem, File migrationDir ) throws IOException
     {
         try ( Reader reader = fileSystem.openAsReader( lastTxLogPositionFile( migrationDir ), UTF8 ) )
         {
@@ -228,12 +232,12 @@ public class StoreMigrator implements StoreMigrationParticipant
         }
     }
 
-    private File lastTxChecksumFile( File migrationDir )
+    private static File lastTxChecksumFile( File migrationDir )
     {
         return new File( migrationDir, "lastxchecksum" );
     }
 
-    private File lastTxLogPositionFile( File migrationDir )
+    private static File lastTxLogPositionFile( File migrationDir )
     {
         return new File( migrationDir, "lastxlogposition" );
     }
@@ -264,24 +268,33 @@ public class StoreMigrator implements StoreMigrationParticipant
         }
     }
 
-    private LogPosition extractTransactionLogPosition( File neoStore, long lastTxId ) throws IOException
+    private LogPosition extractTransactionLogPosition( File neoStore, File storeDir, long lastTxId ) throws IOException
     {
-        try
+        long lastClosedTxLogVersion =
+                MetaDataStore.getRecord( pageCache, neoStore, Position.LAST_CLOSED_TRANSACTION_LOG_VERSION );
+        long lastClosedTxLogByteOffset =
+                MetaDataStore.getRecord( pageCache, neoStore, Position.LAST_CLOSED_TRANSACTION_LOG_BYTE_OFFSET );
+        if ( lastClosedTxLogVersion != MetaDataStore.FIELD_NOT_PRESENT &&
+             lastClosedTxLogByteOffset != MetaDataStore.FIELD_NOT_PRESENT )
         {
-            long lastClosedTxLogVersion =
-                    MetaDataStore.getRecord( pageCache, neoStore, Position.LAST_CLOSED_TRANSACTION_LOG_VERSION );
-            long lastClosedTxLogByteOffset =
-                    MetaDataStore.getRecord( pageCache, neoStore, Position.LAST_CLOSED_TRANSACTION_LOG_BYTE_OFFSET );
             return new LogPosition( lastClosedTxLogVersion, lastClosedTxLogByteOffset );
         }
-        catch ( IllegalStateException e )
+
+        // The legacy store we're migrating doesn't have this record in neostore so try to extract it from tx log
+        if ( lastTxId == TransactionIdStore.BASE_TX_ID )
         {
-            // The legacy store we're migrating doesn't have this record in neostore so try to extract it from tx log
-            return lastTxId == TransactionIdStore.BASE_TX_ID
-                   ? new LogPosition(TransactionIdStore.BASE_TX_LOG_VERSION, BASE_TX_LOG_BYTE_OFFSET )
-                   : new LogPosition( MetaDataStore.getRecord( pageCache, neoStore, Position.LOG_VERSION ),
-                           BASE_TX_LOG_BYTE_OFFSET );
+            return new LogPosition( BASE_TX_LOG_VERSION, BASE_TX_LOG_BYTE_OFFSET );
         }
+
+        PhysicalLogFiles logFiles = new PhysicalLogFiles( storeDir, fileSystem );
+        long logVersion = logFiles.getHighestLogVersion();
+        if ( logVersion == -1 )
+        {
+            return new LogPosition( BASE_TX_LOG_VERSION, BASE_TX_LOG_BYTE_OFFSET );
+        }
+        long offset = fileSystem.getFileSize( logFiles.getLogFileForVersion( logVersion ) );
+        return new LogPosition( logVersion, offset );
+
     }
 
     private void removeDuplicateEntityProperties( File storeDir, File migrationDir, PageCache pageCache,
@@ -837,13 +850,13 @@ public class StoreMigrator implements StoreMigrationParticipant
         //    to look up checksums for transactions succeeding T by looking at its transaction logs,
         //    but T needs to be stored in neostore to be accessible. Obvioously this scenario is only
         //    problematic as long as we don't migrate and translate old logs.
-        long lastTxChecksum = readLastTxChecksum( migrationDir );
+        long lastTxChecksum = readLastTxChecksum( fileSystem, migrationDir );
         MetaDataStore.setRecord( pageCache, storeDirNeoStore, Position.LAST_TRANSACTION_CHECKSUM, lastTxChecksum );
         MetaDataStore.setRecord( pageCache, storeDirNeoStore, Position.UPGRADE_TRANSACTION_CHECKSUM, lastTxChecksum );
 
         // add LAST_CLOSED_TRANSACTION_LOG_VERSION and LAST_CLOSED_TRANSACTION_LOG_BYTE_OFFSET to the migrated
         // NeoStore
-        LogPosition logPosition = readLastTxLogPosition( migrationDir );
+        LogPosition logPosition = readLastTxLogPosition( fileSystem, migrationDir );
         MetaDataStore.setRecord( pageCache, storeDirNeoStore, Position.LAST_CLOSED_TRANSACTION_LOG_VERSION, logPosition
                 .getLogVersion() );
         MetaDataStore.setRecord( pageCache, storeDirNeoStore, Position.LAST_CLOSED_TRANSACTION_LOG_BYTE_OFFSET,


### PR DESCRIPTION
The code in neostore/metadatastore return FIELD_NOT_PRESENT when a
field is missing. Unfortunately the migration code was expecting an
exception in such a case. Hence the constructed log position is always
incorrect, i.e., (-1,-1).  This causes problems if the migrated
database checkpoint on shutdown and no extra transactions are
committed.  This has been fixed by this commit.

This change also improves the code that computes those fields when
they are not present.
