### PR TITLE
Report correct HA role for pending instances

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMember.java
@@ -119,6 +119,11 @@ public class ClusterMember
         return new ClusterMember( this.instanceId, copy, storeId, this.alive );
     }
 
+    ClusterMember unavailable()
+    {
+        return new ClusterMember( this.instanceId, Collections.<String,URI>emptyMap(), storeId, this.alive );
+    }
+
     ClusterMember unavailableAs( String role )
     {
         return new ClusterMember( this.instanceId, MapUtil.copyAndRemove( roles, role ), this.storeId, this.alive );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/ClusterMembers.java
@@ -76,8 +76,8 @@ public class ClusterMembers
         {
             return null;
         }
-        String currentRole = roleOf( stateMachine.getCurrentState() );
-        return currentMember.availableAs( currentRole, currentMember.getHAUri(), currentMember.getStoreId() );
+        HighAvailabilityMemberState currentState = stateMachine.getCurrentState();
+        return updateRole( currentMember, currentState );
     }
 
     public String getCurrentMemberRole()
@@ -113,16 +113,16 @@ public class ClusterMembers
         }, members );
     }
 
-    private static String roleOf( HighAvailabilityMemberState state )
+    private static ClusterMember updateRole( ClusterMember member, HighAvailabilityMemberState state )
     {
         switch ( state )
         {
         case MASTER:
-            return HighAvailabilityModeSwitcher.MASTER;
+            return member.availableAs( HighAvailabilityModeSwitcher.MASTER, member.getHAUri(), member.getStoreId() );
         case SLAVE:
-            return HighAvailabilityModeSwitcher.SLAVE;
+            return member.availableAs( HighAvailabilityModeSwitcher.SLAVE, member.getHAUri(), member.getStoreId() );
         default:
-            return HighAvailabilityModeSwitcher.UNKNOWN;
+            return member.unavailable();
         }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ClusterMembersTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/ClusterMembersTest.java
@@ -106,6 +106,39 @@ public class ClusterMembersTest
         assertEquals( 2, countInstancesWithRole( currentMembers, HighAvailabilityModeSwitcher.MASTER ) );
     }
 
+    @Test
+    public void currentMemberHasCorrectRoleWhenInPendingState()
+    {
+        ClusterMember member = createClusterMember( 1, HighAvailabilityModeSwitcher.MASTER );
+
+        when( observedClusterMembers.getCurrentMember() ).thenReturn( member );
+        when( stateMachine.getCurrentState() ).thenReturn( HighAvailabilityMemberState.PENDING );
+
+        assertEquals( HighAvailabilityModeSwitcher.UNKNOWN, clusterMembers.getCurrentMemberRole() );
+    }
+
+    @Test
+    public void currentMemberHasCorrectRoleWhenInToSlaveState()
+    {
+        ClusterMember member = createClusterMember( 1, HighAvailabilityModeSwitcher.MASTER );
+
+        when( observedClusterMembers.getCurrentMember() ).thenReturn( member );
+        when( stateMachine.getCurrentState() ).thenReturn( HighAvailabilityMemberState.TO_SLAVE );
+
+        assertEquals( HighAvailabilityModeSwitcher.UNKNOWN, clusterMembers.getCurrentMemberRole() );
+    }
+
+    @Test
+    public void currentMemberHasCorrectRoleWhenInToMasterState()
+    {
+        ClusterMember member = createClusterMember( 1, HighAvailabilityModeSwitcher.MASTER );
+
+        when( observedClusterMembers.getCurrentMember() ).thenReturn( member );
+        when( stateMachine.getCurrentState() ).thenReturn( HighAvailabilityMemberState.TO_MASTER );
+
+        assertEquals( HighAvailabilityModeSwitcher.UNKNOWN, clusterMembers.getCurrentMemberRole() );
+    }
+
     private static int countInstancesWithRole( Iterable<ClusterMember> currentMembers, String role )
     {
         int counter = 0;


### PR DESCRIPTION
Commit fixes the issue where instance in `PENDING`, `TO_SALVE` or `TO_MASTER` state might still report it's old HA role. Issue occurred because map of roles in `ClusterMember` was not properly updated when `HighAvailabilityMemberStateMachine` reported state different from `MASTER`/`SLAVE`. With this fix map of roles would be just cleared.
