### PR TITLE
Fix AsciiDoc output from new Cypher doc tests

### DIFF
--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/Document.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/Document.scala
@@ -181,7 +181,7 @@ case class QueryResultTable(columns: Seq[String], rows: Seq[ResultRow], footer: 
        |[role="queryresult",options="${header}footer",cols="$cols*<m"]
        ||===
        |$rowsOutput
-       |$cols+|$footerRows
+       |$cols+d|$footerRows
        ||===
        |
        |""".stripMargin

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/tests/DocumentTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/tests/DocumentTest.scala
@@ -233,7 +233,7 @@ class DocumentAsciiDocTest extends CypherFunSuite {
         |[role="queryresult",options="footer",cols="1*<m"]
         ||===
         |1+|(empty result)
-        |1+|0 rows +
+        |1+d|0 rows +
         |Nodes created: 2 +
         |Relationships created: 1
         ||===
@@ -250,7 +250,7 @@ class DocumentAsciiDocTest extends CypherFunSuite {
         ||===
         ||n1|n2
         ||1|2
-        |2+|1 row
+        |2+d|1 row
         ||===
         |
         |""".stripMargin)
@@ -265,7 +265,7 @@ class DocumentAsciiDocTest extends CypherFunSuite {
         ||===
         ||n1\|x1|n2
         ||1\|2|2
-        |2+|1 row
+        |2+d|1 row
         ||===
         |
         |""".stripMargin)


### PR DESCRIPTION
Avoid using monospace for the table footers.
