### PR TITLE
Fix rule planner index seek node fetch strategy

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/NodeFetchStrategy.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/builders/NodeFetchStrategy.scala
@@ -160,20 +160,18 @@ object IndexSeekStrategy extends NodeStrategy {
     result.flatten
   }
 
-  private def findEqualityPredicatesOnProperty(identifier: IdentifierName, where: Seq[Predicate], initialSymbols: SymbolTable): Seq[SolvedPredicate[PropertyKey]] = {
-    val symbols = initialSymbols.add(identifier, CTNode)
-
+  private def findEqualityPredicatesOnProperty(identifier: IdentifierName, where: Seq[Predicate],
+                                               symbols: SymbolTable): Seq[SolvedPredicate[PropertyKey]] =
     where.collect {
       case predicate @ Equals(Property(Identifier(id), propertyKey), expression)
-        if id == identifier && predicate.symbolDependenciesMet(symbols) => SolvedPredicate(propertyKey.name, predicate)
+        if id == identifier && expression.symbolDependenciesMet(symbols) => SolvedPredicate(propertyKey.name, predicate)
 
       case predicate @ Equals(expression, Property(Identifier(id), propertyKey))
-        if id == identifier && predicate.symbolDependenciesMet(symbols) => SolvedPredicate(propertyKey.name, predicate)
+        if id == identifier && expression.symbolDependenciesMet(symbols) => SolvedPredicate(propertyKey.name, predicate)
 
       case predicate @ AnyInCollection(expression, _, Equals(Property(Identifier(id), propertyKey),Identifier(_)))
-        if id == identifier && predicate.symbolDependenciesMet(symbols) => SolvedPredicate(propertyKey.name, predicate)
+        if id == identifier && expression.symbolDependenciesMet(symbols) => SolvedPredicate(propertyKey.name, predicate)
     }
-  }
 
   private def findIndexSeekByPrefixPredicatesOnProperty(identifier: IdentifierName, where: Seq[Predicate], initialSymbols: SymbolTable): Seq[SolvedPredicate[PropertyKey]] = {
     where.collect {
@@ -182,12 +180,10 @@ object IndexSeekStrategy extends NodeStrategy {
     }
   }
 
-  private def findIndexSeekByRangePredicatesOnProperty(identifier: IdentifierName, where: Seq[Predicate], initialSymbols: SymbolTable): Seq[SolvedPredicate[PropertyKey]] = {
-    val symbols = initialSymbols.add(identifier, CTNode)
-
+  private def findIndexSeekByRangePredicatesOnProperty(identifier: IdentifierName, where: Seq[Predicate], symbols: SymbolTable): Seq[SolvedPredicate[PropertyKey]] = {
     where.collect {
       case predicate@AndedPropertyComparablePredicates(Identifier(id), Property(_, key), comparables)
-        if id == identifier && predicate.symbolDependenciesMet(symbols) =>
+        if id == identifier && comparables.forall(_.symbolDependenciesMet(symbols)) =>
         SolvedPredicate(key.name, predicate)
     }
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekAcceptanceTest.scala
@@ -19,8 +19,6 @@
  */
 package org.neo4j.cypher
 
-import org.neo4j.cypher.internal.compiler.v2_3.pipes.{UniqueIndexSeekByRange, IndexSeekByRange}
-
 /**
  * These tests are testing the actual index implementation, thus they should all check the actual result.
  * If you only want to verify that plans using indexes are actually planned, please use
@@ -102,6 +100,56 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with NewPlanne
 
     // Then
     result should (use("NodeIndexSeek") and evaluateTo(List(Map("p" -> null, "placeName" -> null))))
+  }
+
+  test("should not use indexes when RHS of property comparison depends on the node searched for (equality)") {
+    // Given
+    val n1 = createLabeledNode(Map("a" -> 1), "MyNodes")
+    val n2 = createLabeledNode(Map("a" -> 0), "MyNodes")
+    val n3 = createLabeledNode(Map("a" -> 1, "b" -> 1), "MyNodes")
+    val n4 = createLabeledNode(Map("a" -> 1, "b" -> 5), "MyNodes")
+
+    graph.createIndex("MyNodes", "a")
+
+    val query =
+      """|MATCH (m:MyNodes)
+         |WHERE m.a = coalesce(m.b, 0)
+         |RETURN m""".stripMargin
+
+    // When
+    val result = executeWithAllPlanners(query)
+
+    // Then
+    result.toList should equal(List(
+      Map("m" -> n2),
+      Map("m" -> n3)
+    ))
+    result.executionPlanDescription().toString shouldNot include("Index")
+  }
+
+  test("should not use indexes when RHS of property comparison depends on the node searched for (range query)") {
+    // Given
+    val n1 = createLabeledNode(Map("a" -> 1), "MyNodes")
+    val n2 = createLabeledNode(Map("a" -> 0), "MyNodes")
+    val n3 = createLabeledNode(Map("a" -> 1, "b" -> 1), "MyNodes")
+    val n4 = createLabeledNode(Map("a" -> 5, "b" -> 1), "MyNodes")
+
+    graph.createIndex("MyNodes", "a")
+
+    val query =
+      """|MATCH (m:MyNodes)
+         |WHERE m.a > coalesce(m.b, 0)
+         |RETURN m""".stripMargin
+
+    // When
+    val result = executeWithAllPlanners(query)
+
+    // Then
+    result.toList should equal(List(
+      Map("m" -> n1),
+      Map("m" -> n4)
+    ))
+    result.executionPlanDescription().toString shouldNot include("Index")
   }
 
   private def setUpDatabaseForTests() {


### PR DESCRIPTION
Fixes #5768
A node symbol dependency on the right-hand side of a predicate
could erroneously be declared as met
