### PR TITLE
Added maven dependency for Bouncy Castle to server

### DIFF
--- a/advanced/server-advanced/LICENSES.txt
+++ b/advanced/server-advanced/LICENSES.txt
@@ -310,6 +310,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 ------------------------------------------------------------------------------
 

--- a/advanced/server-advanced/NOTICE.txt
+++ b/advanced/server-advanced/NOTICE.txt
@@ -60,6 +60,7 @@ BSD License
   scala-parser-combinators
 
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 
 Common Development and Distribution License Version 1.1

--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -311,6 +311,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 ------------------------------------------------------------------------------
 

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -62,6 +62,7 @@ BSD License
   scala-parser-combinators
 
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 
 Common Development and Distribution License Version 1.1

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -311,6 +311,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 ------------------------------------------------------------------------------
 

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -62,6 +62,7 @@ BSD License
   scala-parser-combinators
 
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 
 Common Development and Distribution License Version 1.1

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -230,6 +230,10 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+    </dependency>
 
     <!-- File uploads -->
     <dependency>

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -314,6 +314,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 ------------------------------------------------------------------------------
 

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -64,6 +64,7 @@ BSD License
   scala-parser-combinators
 
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 
 Common Development and Distribution License Version 1.1

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
@@ -352,6 +352,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 ------------------------------------------------------------------------------
 

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
@@ -70,6 +70,7 @@ BSD License
   scala-parser-combinators
 
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 
 Common Development and Distribution License Version 1.1

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/LICENSES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/LICENSES.txt
@@ -352,6 +352,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 ------------------------------------------------------------------------------
 

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/NOTICE.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/NOTICE.txt
@@ -69,6 +69,7 @@ BSD License
   scala-parser-combinators
 
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 
 Common Development and Distribution License Version 1.1

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -352,6 +352,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 ------------------------------------------------------------------------------
 

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -70,6 +70,7 @@ BSD License
   scala-parser-combinators
 
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 
 Common Development and Distribution License Version 1.1

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
@@ -356,6 +356,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 ------------------------------------------------------------------------------
 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -73,6 +73,7 @@ BSD License
   scala-parser-combinators
 
 Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
   Bouncy Castle Provider
 
 Common Development and Distribution License Version 1.1

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <lucene.version>3.6.2</lucene.version>
     <powermock.version>1.5.5</powermock.version>
     <logback-classic.version>1.1.2</logback-classic.version>
+    <bouncycastle.version>1.52</bouncycastle.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
     <hsqldb.version>2.3.2</hsqldb.version>
     <test.runner.jvm.settings>-Xmx1G -XX:MaxPermSize=128M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true</test.runner.jvm.settings>
@@ -701,7 +702,12 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
-        <version>1.52</version>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>${bouncycastle.version}</version>
       </dependency>
       <dependency>
         <groupId>org.neo4j.3rdparty.javax.ws.rs</groupId>


### PR DESCRIPTION
It is used by Netty for self-signed certificate generation. It is a fallback path if proprietary package `sun.security.x509` provided by OpenJDK is not in the classpath. In particular, IBM JDK does not include this package.
