### PR TITLE
Add metrics for slave pull updates

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PullerFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/PullerFactory.java
@@ -29,8 +29,9 @@ import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.slave.InvalidEpochExceptionHandler;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.util.JobScheduler;
-import org.neo4j.logging.LogProvider;
 import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.LogProvider;
 
 /**
  * Helper factory that provide more convenient way of construction and dependency management for update pulling
@@ -49,12 +50,13 @@ public class PullerFactory
     private final DependencyResolver dependencyResolver;
     private final AvailabilityGuard availabilityGuard;
     private final HighAvailabilityMemberStateMachine memberStateMachine;
+    private final Monitors monitors;
 
     public PullerFactory( RequestContextFactory requestContextFactory, Master master,
             LastUpdateTime lastUpdateTime, LogProvider logging, InstanceId serverId,
             InvalidEpochExceptionHandler invalidEpochHandler, long pullInterval,
             JobScheduler jobScheduler, DependencyResolver dependencyResolver, AvailabilityGuard availabilityGuard,
-            HighAvailabilityMemberStateMachine memberStateMachine )
+            HighAvailabilityMemberStateMachine memberStateMachine, Monitors monitors )
     {
 
         this.requestContextFactory = requestContextFactory;
@@ -68,12 +70,13 @@ public class PullerFactory
         this.dependencyResolver = dependencyResolver;
         this.availabilityGuard = availabilityGuard;
         this.memberStateMachine = memberStateMachine;
+        this.monitors = monitors;
     }
 
     public UpdatePuller createUpdatePuller( LifeSupport life )
     {
         return life.add( new SlaveUpdatePuller( requestContextFactory, master, lastUpdateTime, logging, serverId,
-                availabilityGuard, invalidEpochHandler ) );
+                availabilityGuard, invalidEpochHandler, monitors.newMonitor( SlaveUpdatePuller.Monitor.class ) ) );
     }
 
     public TransactionObligationFulfiller createObligationFulfiller( LifeSupport life, UpdatePuller updatePuller )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -370,7 +370,7 @@ public class HighlyAvailableEditionModule
         PullerFactory pullerFactory = new PullerFactory( requestContextFactory, master, lastUpdateTime,
                 logging.getInternalLogProvider(), serverId, invalidEpochHandler,
                 config.get( HaSettings.pull_interval ), platformModule.jobScheduler,
-                dependencies, platformModule.availabilityGuard, memberStateMachine );
+                dependencies, platformModule.availabilityGuard, memberStateMachine, monitors );
 
         dependencies.satisfyDependency( pullerFactory.createObligationFulfiller( paxosLife, updatePullerProxy ) );
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullerModeSwitcherTest.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.ha.com.slave.InvalidEpochExceptionHandler;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -56,7 +57,7 @@ public class UpdatePullerModeSwitcherTest
         PullerFactory pullersFactory = new PullerFactory( mock( RequestContextFactory.class ), mock( Master.class ),
                 mock( LastUpdateTime.class ), mock( LogProvider.class ), mock( InstanceId.class ), mock(
                 InvalidEpochExceptionHandler.class ), 42, mock( JobScheduler.class ), mock( DependencyResolver.class ),
-                mock( AvailabilityGuard.class ), mock( HighAvailabilityMemberStateMachine.class ) );
+                mock( AvailabilityGuard.class ), mock( HighAvailabilityMemberStateMachine.class ), new Monitors() );
         modeSwitcher = new UpdatePullerModeSwitcher( switcherNotifier, invocationHandler, pullersFactory );
     }
 

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -79,6 +79,9 @@ public class MetricsSettings
                   + "complete." )
     public static Setting<Boolean> neoLogRotationEnabled = setting(
             "metrics.neo4j.logrotation.enabled", Settings.BOOLEAN, neoEnabled );
+    @Description( "Enable reporting metrics about HA cluster info." )
+    public static Setting<Boolean> neoClusterEnabled = setting(
+            "metrics.neo4j.cluster.enabled", Settings.BOOLEAN, neoEnabled );
 
     @Description( "Enable reporting metrics about the duration of garbage collections" )
     public static Setting<Boolean> jvmGcEnabled = setting( "metrics.jvm.gc.enabled", Settings.BOOLEAN, neoEnabled );

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/ClusterMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/ClusterMetrics.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.metrics.source;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.SlaveUpdatePuller;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.metrics.MetricsSettings;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class ClusterMetrics extends LifecycleAdapter
+{
+    private static final String NAME_PREFIX = "neo4j.cluster";
+    private static final String SLAVE_PULL_UPDATES = name( NAME_PREFIX, "slave_pull_updates" );
+    private static final String SLAVE_PULL_UPDATE_UP_TO_TX = name( NAME_PREFIX, "slave_pull_update_up_to_tx" );
+
+    private final Config config;
+    private final Monitors monitors;
+    private final MetricRegistry registry;
+    private final SlaveUpdatePullerMonitor monitor = new SlaveUpdatePullerMonitor();
+
+    public ClusterMetrics( Config config, Monitors monitors, MetricRegistry registry )
+    {
+        this.config = config;
+        this.monitors = monitors;
+        this.registry = registry;
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        if ( config.get( MetricsSettings.neoClusterEnabled ) )
+        {
+            monitors.addMonitorListener( monitor );
+
+            registry.register( SLAVE_PULL_UPDATES, new Gauge<Long>()
+            {
+                @Override
+                public Long getValue()
+                {
+                    return monitor.events.get();
+                }
+            } );
+
+            registry.register( SLAVE_PULL_UPDATE_UP_TO_TX, new Gauge<Long>()
+            {
+                @Override
+                public Long getValue()
+                {
+                    return monitor.lastAppliedTxId;
+                }
+            } );
+        }
+    }
+
+    @Override
+    public void stop() throws IOException
+    {
+        if ( config.get( MetricsSettings.neoClusterEnabled ) )
+        {
+            registry.remove( SLAVE_PULL_UPDATES );
+            registry.remove( SLAVE_PULL_UPDATE_UP_TO_TX );
+
+            monitors.removeMonitorListener( monitor );
+        }
+    }
+
+    private static class SlaveUpdatePullerMonitor implements SlaveUpdatePuller.Monitor
+    {
+        private AtomicLong events = new AtomicLong();
+        private volatile long lastAppliedTxId;
+
+        @Override
+        public void pulledUpdates( long lastAppliedTxId )
+        {
+            events.incrementAndGet();
+            this.lastAppliedTxId = lastAppliedTxId;
+        }
+    }
+}

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/Neo4jMetricsFactory.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/Neo4jMetricsFactory.java
@@ -67,6 +67,7 @@ public class Neo4jMetricsFactory implements Factory<Lifecycle>
                 transactionCounters, pageCacheCounters, checkPointerMonitor, logRotationMonitor, idGeneratorFactory );
         final NetworkMetrics networkMetrics = new NetworkMetrics( config, monitors, registry );
         final JvmMetrics jvmMetrics = new JvmMetrics( config, registry );
+        final ClusterMetrics clusterMetrics = new ClusterMetrics( config, monitors, registry );
         return new LifecycleAdapter()
         {
             @Override
@@ -74,6 +75,7 @@ public class Neo4jMetricsFactory implements Factory<Lifecycle>
             {
                 dbMetrics.start();
                 networkMetrics.start();
+                clusterMetrics.start();
                 jvmMetrics.start();
             }
 
@@ -82,6 +84,7 @@ public class Neo4jMetricsFactory implements Factory<Lifecycle>
             {
                 dbMetrics.stop();
                 networkMetrics.stop();
+                clusterMetrics.stop();
                 jvmMetrics.stop();
             }
         };


### PR DESCRIPTION
The metrics expose the number of pulled update events happened so far and the tx id used to pull updates in the last event.
