### PR TITLE
Ensures all lock clients closed during role switch

### DIFF
--- a/community/io/src/test/java/org/neo4j/test/TargetDirectory.java
+++ b/community/io/src/test/java/org/neo4j/test/TargetDirectory.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.test;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-
+import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -57,8 +58,20 @@ public class TargetDirectory
     public class TestDirectory implements TestRule
     {
         private File subdir = null;
+        private boolean keepDirectoryAfterSuccefulTest;
 
         private TestDirectory() { }
+
+        /**
+         * Tell this {@link Rule} to keep the store directory, even after a successful test.
+         * It's just a useful debug mechanism to have for analyzing store after a test.
+         * by default directories aren't kept.
+         */
+        public TestDirectory keepDirectoryAfterSuccefulTest()
+        {
+            keepDirectoryAfterSuccefulTest = true;
+            return this;
+        }
 
         public String absolutePath()
         {
@@ -88,7 +101,8 @@ public class TargetDirectory
             return dir;
         }
 
-        public File graphDbDir() {
+        public File graphDbDir()
+        {
             return directory( "graph-db" );
         }
 
@@ -124,7 +138,7 @@ public class TargetDirectory
 
         private void complete( boolean success )
         {
-            if ( success && subdir != null )
+            if ( success && subdir != null && !keepDirectoryAfterSuccefulTest )
             {
                 try
                 {
@@ -155,6 +169,7 @@ public class TargetDirectory
      * {@link org.neo4j.test.TargetDirectory} directly. The easiest way to do this is with
      * {@link #testDirForTest(Class)}.
      */
+    @Deprecated
     public static TargetDirectory forTest( Class<?> owningTest )
     {
         return new TargetDirectory( new DefaultFileSystemAbstraction(), owningTest );

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1365,14 +1365,25 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
     }
 
     /**
-     * Hook that must be called whenever there is an HA mode switch (eg master/slave switch).
+     * Hook that must be called before there is an HA mode switch (eg master/slave switch),
+     * i.e. after state has changed to pending and before state is about to change to the new target state.
+     * This must only be called when the database is otherwise inaccessible.
+     */
+    public void beforeModeSwitch()
+    {
+        // Get rid of all pooled transactions, as they will otherwise reference
+        // components that have been swapped out during the mode switch.
+        kernelModule.kernelTransactions().disposeAll();
+    }
+
+    /**
+     * Hook that must be called after an HA mode switch (eg master/slave switch) have completed.
      * This must only be called when the database is otherwise inaccessible.
      */
     public void afterModeSwitch()
     {
         loadSchemaCache();
-
-        // Stop all running transactions and get rid of all pooled transactions, as they will otherwise reference
+        // Get rid of all pooled transactions, as they will otherwise reference
         // components that have been swapped out during the mode switch.
         kernelModule.kernelTransactions().disposeAll();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -224,10 +224,10 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
     {
         for ( KernelTransactionImplementation tx : allTransactions )
         {
-            if ( tx.isOpen() )
-            {
-                tx.markForTermination();
-            }
+            // we mark all transactions for termination since we want to make sure these transactions
+            // won't be reused, ever. Each transaction has, among other things, a Locks.Client and we
+            // certainly want to keep that from being reused from this point.
+            tx.markForTermination();
         }
         localTxPool.disposeAll();
         globalTxPool.disposeAll();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -118,6 +118,8 @@ public interface Locks extends Lifecycle
     /**
      * A client is able to grab and release locks, and compete with other clients for them. This can be re-used until
      * you call {@link Locks.Client#close()}.
+     *
+     * @throws IllegalStateException if this instance has been closed, i.e has had {@link #shutdown()} called.
      */
     Client newClient();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockManger.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/community/CommunityLockManger.java
@@ -25,10 +25,18 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 public class CommunityLockManger extends LifecycleAdapter implements Locks
 {
     private final LockManagerImpl manager = new LockManagerImpl( new RagManager() );
+    private volatile boolean closed;
 
     @Override
     public Client newClient()
     {
+        // We check this volatile closed flag here, which may seem like a contention overhead, but as the time
+        // of writing we apply pooling of transactions and in extension pooling of lock clients,
+        // so this method is called very rarely.
+        if ( closed )
+        {
+            throw new IllegalStateException( this + " already closed" );
+        }
         return new CommunityLockClient( manager );
     }
 
@@ -50,5 +58,11 @@ public class CommunityLockManger extends LifecycleAdapter implements Locks
                 return false;
             }
         } );
+    }
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+        closed = true;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.locking.Locks.Client;
+
+import static org.junit.Assert.fail;
+
+@Ignore("Not a test. This is a compatibility suite, run from LockingCompatibilityTestSuite.")
+public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibility
+{
+    public CloseCompatibility( LockingCompatibilityTestSuite suite )
+    {
+        super( suite );
+    }
+
+    @Test
+    public void shouldNotBeAbleToHandOutClientsIfShutDown() throws Throwable
+    {
+        // GIVEN a lock manager and working clients
+        try ( Client client = locks.newClient() )
+        {
+            client.acquireExclusive( ResourceTypes.NODE, 0 );
+        }
+
+        // WHEN
+        locks.stop();
+        locks.shutdown();
+
+        // THEN
+        try
+        {
+            locks.newClient();
+            fail( "Should fail" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // Good
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockingCompatibilityTestSuite.java
@@ -19,11 +19,9 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.fail;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.neo4j.test.OtherThreadExecutor.WorkerCommand;
-import static org.neo4j.test.OtherThreadRule.isWaiting;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,11 +30,15 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Rule;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 import org.neo4j.kernel.api.index.ParameterizedSuiteRunner;
+import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.OtherThreadRule;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.neo4j.test.OtherThreadRule.isWaiting;
 
 /** Base for locking tests. */
 @RunWith(ParameterizedSuiteRunner.class)
@@ -44,7 +46,8 @@ import org.neo4j.test.OtherThreadRule;
         AcquireAndReleaseLocksCompatibility.class,
         DeadlockCompatibility.class,
         LockReentrancyCompatibility.class,
-        RWLockCompatibility.class
+        RWLockCompatibility.class,
+        CloseCompatibility.class
 })
 public abstract class LockingCompatibilityTestSuite
 {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -528,7 +528,8 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
                 monitors.newMonitor( MasterImpl.Monitor.class, MasterImpl.class ) );
 
         highAvailabilityModeSwitcher = new HighAvailabilityModeSwitcher( switchToSlaveInstance, switchToMasterInstance,
-                clusterClient, clusterMemberAvailability, getDependencyResolver(), config.get( ClusterSettings.server_id ), logging );
+                clusterClient, clusterMemberAvailability, getDependencyResolver(), config.get( ClusterSettings.server_id ),
+                logging, dataSourceManager );
 
         paxosLife.add( new UpdatePullerModeSwitcher( highAvailabilityModeSwitcher, updatePullerDelegate,
                 pullerFactory ) );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -78,18 +78,20 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.RETURNS_MOCKS;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.MASTER;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.SLAVE;
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcherTest.neoStoreDataSourceSupplierMock;
 
 public class HighAvailabilityMemberStateMachineTest
 {
@@ -446,7 +448,8 @@ public class HighAvailabilityMemberStateMachineTest
                 mock( RequestMonitor.class ), monitor, mock( StoreCopyClient.Monitor.class ) );
 
         HighAvailabilityModeSwitcher haModeSwitcher = new HighAvailabilityModeSwitcher( switchToSlave,
-                mock( SwitchToMaster.class ), election, clusterMemberAvailability, dependencyResolver, me, logging );
+                mock( SwitchToMaster.class ), election, clusterMemberAvailability, dependencyResolver, me, logging,
+                neoStoreDataSourceSupplierMock() );
         haModeSwitcher.init();
         haModeSwitcher.start();
         haModeSwitcher.listeningAt( URI.create( "http://localhost:12345" ) );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.transaction;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
+import org.neo4j.kernel.impl.ha.ClusterManager;
+import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
+import org.neo4j.kernel.impl.ha.ClusterManager.NetworkFlag;
+import org.neo4j.kernel.impl.ha.ClusterManager.RepairKit;
+import org.neo4j.test.ha.ClusterRule;
+import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.Workers;
+
+import static org.junit.Assert.assertEquals;
+
+import static java.lang.System.currentTimeMillis;
+
+import static org.neo4j.helpers.TimeUtil.parseTimeMillis;
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.MASTER;
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.UNKNOWN;
+import static org.neo4j.kernel.impl.MyRelTypes.TEST;
+import static org.neo4j.kernel.impl.ha.ClusterManager.memberSeesOtherMemberAsFailed;
+import static org.neo4j.kernel.impl.ha.ClusterManager.memberThinksItIsRole;
+
+/**
+ * Non-deterministically tries to reproduce a problem where transactions may, at the time of master switches,
+ * sometimes overwrite each others data. More specifically not respect each others locks, among other things.
+ * There is no chance this test will yield a false failure, although sometimes it will be successful
+ * meaning it didn't manage to reproduce the problem. At the time of writing 2.2.6 and 2.3.0 is out.
+ *
+ * The master switching in this test focuses on keeping the same master, but fiddle with the cluster so that
+ * the master loses quorum and goes to pending, to quickly thereafter go to master role again.
+ * Transactions happen before, during and after that (re)election. Each transaction does the following:
+ *
+ * <ol>
+ * <li>Locks the node (all transactions use the same node)
+ * <li>Reads an int property from that node
+ * <li>Increments and sets that int property value back
+ * <li>Commits
+ * </ol>
+ *
+ * Some transactions may not commit, that's fine. For all those that commit the int property (counter)
+ * on that node must be incremented by one. In the end, after all threads have.completed, the number of successes
+ * is compared with the counter node property. They should be the same. If not, then it means that one or more
+ * transactions made changes off of stale values and still managed to commit.
+ *
+ * This test is a stress test and duration of execution can be controlled via system property
+ * -D{@link org.neo4j.kernel.ha.transaction.TransactionThroughMasterSwitchStressIT}.duration
+ */
+public class TransactionThroughMasterSwitchStressIT
+{
+    @Rule
+    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+
+    @Test
+    public void shouldNotHaveTransactionsRunningThroughRoleSwitchProduceInconsistencies() throws Throwable
+    {
+        // Duration of this test. If the timeout is hit in the middle of a round, the round will be completed
+        // and exit after that.
+        long duration = parseTimeMillis.apply( System.getProperty( getClass().getName() + ".duration", "30s" ) );
+        long endTime = currentTimeMillis() + duration;
+        while ( currentTimeMillis() < endTime )
+        {
+            oneRound();
+        }
+    }
+
+    private void oneRound() throws Throwable
+    {
+        // GIVEN a cluster and a node
+        final String key = "key";
+        ManagedCluster cluster = clusterRule.startCluster();
+        final GraphDatabaseService master = cluster.getMaster();
+        final long nodeId = createNode( master );
+        cluster.sync();
+
+        // and a bunch of workers contending on that node, each changing it
+        Workers<Runnable> transactors = new Workers<>( "Transactors" );
+        final AtomicInteger successes = new AtomicInteger();
+        final AtomicBoolean end = new AtomicBoolean();
+        for ( int i = 0; i < 10; i++ )
+        {
+            transactors.start( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    Random random = ThreadLocalRandom.current();
+                    while ( !end.get() )
+                    {
+                        boolean committed = true;
+                        try ( Transaction tx = master.beginTx() )
+                        {
+                            Node node = master.getNodeById( nodeId );
+
+                            // Acquiring lock, read int property value, increment, set incremented int property
+                            // should not break under any circumstances.
+                            tx.acquireWriteLock( node );
+                            node.setProperty( key, (Integer) node.getProperty( key, 0 )+1 );
+                            // Throw in relationship for good measure
+                            node.createRelationshipTo( master.createNode(), TEST );
+
+                            Thread.sleep( random.nextInt( 1_000 ) );
+                            tx.success();
+                        }
+                        catch ( Throwable e )
+                        {
+                            // It's OK
+                            committed = false;
+                        }
+                        if ( committed )
+                        {
+                            successes.incrementAndGet();
+                        }
+                    }
+                }
+            } );
+        }
+
+        // WHEN entering a period of induced cluster instabilities
+        reelectTheSameMasterMakingItGoToPendingAndBack( cluster );
+
+        // ... letting transactions run a bit after the role switch as well.
+        long targetSuccesses = successes.get() + 20;
+        while ( successes.get() < targetSuccesses )
+        {
+            Thread.sleep( 100 );
+        }
+        end.set( true );
+        transactors.awaitAndThrowOnError( RuntimeException.class );
+
+        // THEN verify that the count is equal to the number of successful transactions
+        assertEquals( successes.get(), getNodePropertyValue( master, nodeId, key ) );
+    }
+
+    private Object getNodePropertyValue( GraphDatabaseService db, long nodeId, String key )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Object value = db.getNodeById( nodeId ).getProperty( key );
+            tx.success();
+            return value;
+        }
+    }
+
+    private void reelectTheSameMasterMakingItGoToPendingAndBack( ManagedCluster cluster ) throws Throwable
+    {
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+        HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
+
+        // Fail one slave, so that there's only two alive left
+        RepairKit slaveRepair = cluster.fail( slave );
+        cluster.await( memberSeesOtherMemberAsFailed( master, slave ) );
+
+        // Fail master and wait for master to go to pending, since cluster lost quorum
+        RepairKit masterRepair = cluster.fail( master, NetworkFlag.IN );
+        cluster.await( memberThinksItIsRole( master, UNKNOWN ) );
+
+        // Then Immediately repair
+        masterRepair.repair();
+        slaveRepair.repair();
+
+        // Wait for this instance to go to master again
+        cluster.await( memberThinksItIsRole( master, MASTER ) );
+        cluster.await( ClusterManager.masterAvailable() );
+        assertEquals( master, cluster.getMaster() );
+    }
+
+    private long createNode( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            tx.success();
+            return node.getId();
+        }
+    }
+}


### PR DESCRIPTION
Observed issue:
After an instance switching role in HA, for some reason some transactions
just wouldn't respect the locks that other transactions held. This would
lead to some transactions making changes on top of stale data, effectively
overwriting changes of other transactions.

Cause(s):
Among other things a new lock manager instance is created during role
switching. Transaction instances pooled and created with a locks client
instance which is kept throughout its life. While there may be transactions
still executing at the time of switching role, all open transactions are
marked for termination and transactions pool cleared. Transactions marked
for termination cannot commit, but when closed they were happily returned
to the transaction pool and would be reused again and again.
These transactions would have its termination flag reset at the point of
being reused and would still contain a locks client for the previous
lock manager. These transaction instances would forever disrespect the
locks that all other transactions respected and would continue to do so until
the next role switch, where they at least would have a chance of being
properly disposed of. Although the next role switch would have a chance of
introducing new rogue transactions as well...

Solution(s)
Many small issues here and there caused this to happen. There are a number
of changes that will prevent this from happening. Some of them are
belt-and-suspenders additions, although at virtually no cost:
- Disposing kernel transactions as part of switching to pending.
  Previously they were disposed of as late as after creating the new ones,
  which would increase the chance of transactions using locks clients from
  the old lock manager to be used and cause harm.
- Mark _all_ transactions, not just open transactions, for termination
  when switching role. No transactions referring to the previous lock manager
  can be around after the role switch.
- Do not return transaction (KernelTransactionImplementation) instances
  that are marked for termination to the pool.
- Have Locks instances know when they are closed and refuse to hand out new
  clients if closed.

On top of those changes, with accompanied unit tests, there's an added
stress test `TransactionThroughMasterSwitchStressIT` which quite
deterministically could reproduce the problem. It can be set to run for a
longer period of time (default 30s in the main build) using
system property, like:

  `-Dorg.neo4j.kernel.ha.transaction.TransactionThroughMasterSwitchStressIT.duration=10m`

Currently that stress test provokes only one role switch scenario:
master --> pending --> master, although more scenarios could be added
later on for an even broader net to catch these sorts of problems.
