### PR TITLE
Abort rewriting of predicates with too large DNF

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/WhereAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/WhereAcceptanceTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.{SyntaxException, ExecutionEngineFunSuite, IncomparableValuesException, NewPlannerTestSupport}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, IncomparableValuesException, NewPlannerTestSupport}
 
 class WhereAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
@@ -37,5 +37,39 @@ class WhereAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
     val query = "MATCH (n:Label) WHERE n.prop < 10 RETURN n.prop AS prop"
 
     a[IncomparableValuesException] should be thrownBy executeWithAllPlanners(query)
+  }
+
+  test("should be able to handle a large DNF predicate without running out of memory") {
+    // given
+    val query = """MATCH (a)-[r]->(b) WHERE
+                  |(ID(a)= 12466 AND ID(b)= 12449 AND type(r)= 'class1') OR
+                  |(ID(a)= 12466 AND ID(b)= 12462 AND type(r)= 'class1') OR
+                  |(ID(a)= 12466 AND ID(b)= 12458 AND type(r)= 'class1') OR
+                  |(ID(a)= 12466 AND ID(b)= 12447 AND type(r)= 'class2') OR
+                  |(ID(a)= 12466 AND ID(b)= 12459 AND type(r)= 'class1') OR
+                  |(ID(a)= 12466 AND ID(b)= 12464 AND type(r)= 'class1') OR
+                  |(ID(a)= 12466 AND ID(b)= 12460 AND type(r)= 'class1') OR
+                  |(ID(a)= 12466 AND ID(b)= 12446 AND type(r)= 'class3') OR
+                  |(ID(a)= 12466 AND ID(b)= 12472 AND type(r)= 'class4') OR
+                  |(ID(a)= 12466 AND ID(b)= 12457 AND type(r)= 'class1') OR
+                  |(ID(a)= 12467 AND ID(b)= 12449 AND type(r)= 'class1') OR
+                  |(ID(a)= 12467 AND ID(b)= 12459 AND type(r)= 'class1') OR
+                  |(ID(a)= 12467 AND ID(b)= 12451 AND type(r)= 'class2') OR
+                  |(ID(a)= 12467 AND ID(b)= 12470 AND type(r)= 'class4') OR
+                  |(ID(a)= 12467 AND ID(b)= 12445 AND type(r)= 'class3') OR
+                  |(ID(a)= 12471 AND ID(b)= 12449 AND type(r)= 'class1') OR
+                  |(ID(a)= 12471 AND ID(b)= 12467 AND type(r)= 'class4') OR
+                  |(ID(a)= 12471 AND ID(b)= 12455 AND type(r)= 'class1') OR
+                  |(ID(a)= 12471 AND ID(b)= 12459 AND type(r)= 'class1') OR
+                  |(ID(a)= 12471 AND ID(b)= 12452 AND type(r)= 'class2') OR
+                  |(ID(a)= 12471 AND ID(b)= 12451 AND type(r)= 'class3') OR
+                  |(ID(a)= 12469 AND ID(b)= 12449 AND type(r)= 'class1') OR
+                  |(ID(a)= 12469 AND ID(b)= 12450 AND type(r)= 'class2') OR
+                  |(ID(a)= 12469 AND ID(b)= 12447 AND type(r)= 'class3')
+                  |RETURN ID(a), ID(b), type(r)""".stripMargin
+
+    // when
+    executeWithAllPlanners(query)
+    // then it should not fail or run out of memory
   }
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/CypherCompiler.scala
@@ -38,6 +38,7 @@ import org.neo4j.helpers.Clock
 
 trait AstRewritingMonitor {
   def abortedRewriting(obj: AnyRef)
+  def abortedRewritingDueToLargeDNF(obj: AnyRef)
 }
 
 trait CypherCacheFlushingMonitor[T] {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/CNFNormalizer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/CNFNormalizer.scala
@@ -20,8 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters
 
 import org.neo4j.cypher.internal.compiler.v2_3._
-import org.neo4j.cypher.internal.frontend.v2_3.ast._
+import org.neo4j.cypher.internal.frontend.v2_3.Foldable._
 import org.neo4j.cypher.internal.frontend.v2_3.Rewritable._
+import org.neo4j.cypher.internal.frontend.v2_3.ast._
 import org.neo4j.cypher.internal.frontend.v2_3.{Rewriter, bottomUp, inSequence, repeat}
 
 case class CNFNormalizer()(implicit monitor: AstRewritingMonitor) extends Rewriter {
@@ -54,8 +55,26 @@ case class deMorganRewriter()(implicit monitor: AstRewritingMonitor) extends Rew
   private val instance: Rewriter = repeatWithSizeLimit(bottomUp(step))(monitor)
 }
 
+object distributeLawsRewriter {
+  // converting from DNF to CNF is exponentially expensive, so we only do it for a small amount of clauses
+  // see https://en.wikipedia.org/wiki/Conjunctive_normal_form#Conversion_into_CNF
+  val DNF_CONVERSION_LIMIT = 16
+}
+
 case class distributeLawsRewriter()(implicit monitor: AstRewritingMonitor) extends Rewriter {
-  def apply(that: AnyRef): AnyRef = instance(that)
+  def apply(that: AnyRef): AnyRef = {
+    if (dnfCounts(that) < distributeLawsRewriter.DNF_CONVERSION_LIMIT)
+      instance(that)
+    else {
+      monitor.abortedRewritingDueToLargeDNF(that)
+      that
+    }
+  }
+
+  private def dnfCounts(value: Any) = value.treeFold(1) {
+    case Or(lhs, a: And) => (acc, children) => children(acc + 1)
+    case Or(a: And, rhs) => (acc, children) => children(acc + 1)
+  }
 
   private val step = Rewriter.lift {
     case p@Or(exp1, And(exp2, exp3)) => And(Or(exp1, exp2)(p.position), Or(exp1.endoRewrite(copyIdentifiers), exp3)(p.position))(p.position)

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/repeatWithSizeLimit.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/repeatWithSizeLimit.scala
@@ -47,7 +47,7 @@ case class repeatWithSizeLimit(rewriter: Rewriter)(implicit val monitor: AstRewr
     val newSize = astNodeSize(t)
 
     if (newSize > limit) {
-      monitor.abortedRewriting(that )
+      monitor.abortedRewriting(that)
       that
     }
     else if (t == that) {

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/DistributeLawRewriterTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/DistributeLawRewriterTest.scala
@@ -19,13 +19,16 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_3.ast.rewriters
 
+import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v2_3.AstRewritingMonitor
 import org.neo4j.cypher.internal.frontend.v2_3.Rewriter
+import org.neo4j.cypher.internal.frontend.v2_3.ast.Or
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
 
 class DistributeLawRewriterTest extends CypherFunSuite with PredicateTestSupport {
 
-  val rewriter: Rewriter = distributeLawsRewriter()(mock[AstRewritingMonitor])
+  val monitor = mock[AstRewritingMonitor]
+  val rewriter: Rewriter = distributeLawsRewriter()(monitor)
 
   test("(P or (Q and R))  iff  (P or Q) and (P or R)") {
     or(P, and(Q, R)) <=> and(or(P, Q), or(P, R))
@@ -38,4 +41,35 @@ class DistributeLawRewriterTest extends CypherFunSuite with PredicateTestSupport
   test("((Q and R and S) or P)  iff  (Q or P) and (R or P) and (S or P)") {
     or(and(Q, and(R, S)), P) <=> and(or(Q, P), and(or(R, P), or(S, P)))
   }
+
+  test("should not rewrite DNF predicates larger than the limit") {
+    // given
+    val start = or(and(P, Q), and(Q, R))
+    val fullOr = combineUntilLimit(start, distributeLawsRewriter.DNF_CONVERSION_LIMIT - 2)
+
+    // when
+    val result = rewriter.apply(fullOr)
+
+    // then result should be the same and aborted due to DNF-limit
+    if (result == fullOr) verify(monitor).abortedRewritingDueToLargeDNF(fullOr)
+    else fail(s"result was different: $result")
+  }
+
+  test("should rewrite DNF predicates smaller than the limit") {
+    // given
+    val start = or(and(P, Q), and(Q, R))
+    val fullOr = combineUntilLimit(start, distributeLawsRewriter.DNF_CONVERSION_LIMIT - 3)
+
+    // when
+    val result = rewriter.apply(fullOr)
+
+    // then result should be different, or equal but aborted due to repeatWithSizeLimit
+    if (result == fullOr) verify(monitor).abortedRewriting(fullOr)
+  }
+
+  private def combineUntilLimit(start: Or, limit: Int): Or =
+    if (limit > 0)
+      combineUntilLimit(or(start, and(P, Q)), limit - 1)
+    else
+      start
 }

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/helpers/NonEmptyList.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/helpers/NonEmptyList.scala
@@ -298,13 +298,15 @@ sealed trait NonEmptyList[+T] {
 }
 
 final case class Fby[+T](head: T, tail: NonEmptyList[T]) extends NonEmptyList[T] {
-  def tailOption: Option[NonEmptyList[T]] = Some(tail)
-  def hasTail: Boolean = true
-  def isLast: Boolean = false
+  override def tailOption: Option[NonEmptyList[T]] = Some(tail)
+  override def hasTail: Boolean = true
+  override def isLast: Boolean = false
+  override def toString = s"${head.toString}, ${tail.toString}"
 }
 
 final case class Last[+T](head: T) extends NonEmptyList[T] {
-  def tailOption: Option[NonEmptyList[T]] = None
-  def hasTail: Boolean = false
-  def isLast: Boolean = true
+  override def tailOption: Option[NonEmptyList[T]] = None
+  override def hasTail: Boolean = false
+  override def isLast: Boolean = true
+  override def toString = s"${head.toString}"
 }


### PR DESCRIPTION
Rewriting predicates on disjunctive normal form (DNF) into conjunctive normal form (CNF) is exponentially expensive. To accommodate for this, we won't try rewriting predicates that are larger than a set limit.
Fixes #5714 
