### PR TITLE
Added documentation about LOAD CSV and redirects

### DIFF
--- a/manual/cypher/cypher-docs/src/docs/dev/ql/load-csv/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/load-csv/index.asciidoc
@@ -11,6 +11,7 @@
 * `LOAD CSV` supports resources compressed with _gzip_, _Deflate_, as well as _ZIP_ archives.
 * CSV files can be stored on the database server and are then accessible using a `file:///` URL.
   Alternatively, `LOAD CSV` also supports accessing CSV files via _HTTPS_, _HTTP_, and _FTP_.
+* `LOAD CSV` will follow _HTTP_ redirects but for security reasons it will not follow redirects that changes the protocol, for example if the redirect is going from _HTTPS_ to _HTTP_.
 
 [NOTE]
 .Configuration settings for file URLs

--- a/manual/cypher/cypher-docs/src/docs/graphgists/import/import-csv-with-cypher.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/graphgists/import/import-csv-with-cypher.asciidoc
@@ -11,6 +11,7 @@ In this example, we're given three CSV files: a list of persons, a list of movie
 
 CSV files can be stored on the database server and are then accessible using a +file://+ URL.
 Alternatively, +LOAD CSV+ also supports accessing CSV files via +HTTPS+, +HTTP+, and +FTP+.
++LOAD CSV+ will follow +HTTP+ redirects but for security reasons it will not follow redirects that changes the protocol, for example if the redirect is going from +HTTPS+ to +HTTP+.
 
 For more details, see <<query-load-csv>>.
 


### PR DESCRIPTION
We do follow redirects as long as it is not changing protocol.
I think there are good reasons to continue doing that but we
should probably mention it in the manual.
