### PR TITLE
Fixes issue w/ BatchInserter in enterprise setting

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -148,6 +148,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 
 import static java.lang.Boolean.parseBoolean;
+
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.map;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.collection.IteratorUtil.first;

--- a/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/extension/KernelExtensionsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.extension;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.spi.KernelContext;
+import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.helpers.collection.Iterables.iterable;
+
+public class KernelExtensionsTest
+{
+    @Test
+    public void shouldConsultUnsatisfiedDependencyHandler() throws Exception
+    {
+        // GIVEN
+        KernelContext context = mock( KernelContext.class );
+        UnsatisfiedDependencyStrategy handler = mock( UnsatisfiedDependencyStrategy.class );
+        Dependencies dependencies = new Dependencies(); // that hasn't got anything.
+        TestingExtensionFactory extensionFactory = new TestingExtensionFactory();
+        KernelExtensions extensions = new KernelExtensions( context, extensions( extensionFactory ),
+                dependencies, handler );
+
+        // WHEN
+        LifeSupport life = new LifeSupport();
+        life.add( extensions );
+        try
+        {
+            life.start();
+
+            // THEN
+            verify( handler ).handle( eq( extensionFactory ), any( UnsatisfiedDependencyException.class ) );
+        }
+        finally
+        {
+            life.shutdown();
+        }
+    }
+
+    private Iterable<KernelExtensionFactory<?>> extensions( TestingExtensionFactory extension )
+    {
+        return iterable( extension );
+    }
+
+    private interface TestingDependencies
+    {
+        // Just some dependency
+        JobScheduler jobScheduler();
+    }
+
+    private static class TestingExtensionFactory extends KernelExtensionFactory<TestingDependencies>
+    {
+        public TestingExtensionFactory()
+        {
+            super( "testing" );
+        }
+
+        @Override
+        public Lifecycle newInstance( KernelContext context, TestingDependencies dependencies ) throws Throwable
+        {
+            return new TestingExtension( dependencies.jobScheduler() );
+        }
+    }
+
+    private static class TestingExtension extends LifecycleAdapter
+    {
+        public TestingExtension( JobScheduler jobScheduler )
+        {
+            // We don't need it right now
+        }
+    }
+}

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertEnterpriseTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertEnterpriseTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.batchinsert;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Map;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.unsafe.batchinsert.BatchInserter;
+import org.neo4j.unsafe.batchinsert.BatchInserters;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.Iterables.single;
+import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+/**
+ * Just testing the {@link BatchInserter} in an enterprise setting, i.e. with all packages and extensions
+ * that exist in enterprise edition.
+ */
+public class BatchInsertEnterpriseTest
+{
+    private enum Labels implements Label
+    {
+        One,
+        Two;
+    }
+
+    @Rule
+    public final TargetDirectory.TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void shouldInsertDifferentTypesOfThings() throws Exception
+    {
+        // GIVEN
+        BatchInserter inserter = BatchInserters.inserter( directory.directory(), stringMap(
+                GraphDatabaseSettings.log_queries.name(), "true",
+                GraphDatabaseSettings.log_queries_filename.name(), directory.file( "query.log" ).getAbsolutePath() ) );
+        long node1Id, node2Id, relationshipId;
+        try
+        {
+            // WHEN
+            node1Id = inserter.createNode( someProperties( 1 ), Labels.values() );
+            node2Id = node1Id + 10;
+            inserter.createNode( node2Id, someProperties( 2 ), Labels.values() );
+            relationshipId = inserter.createRelationship( node1Id, node2Id, MyRelTypes.TEST, someProperties( 3 ) );
+            inserter.createDeferredSchemaIndex( Labels.One ).on( "key" ).create();
+            inserter.createDeferredConstraint( Labels.Two ).assertPropertyIsUnique( "key" ).create();
+        }
+        finally
+        {
+            inserter.shutdown();
+        }
+
+        // THEN
+        GraphDatabaseService db = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( directory.directory() );
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node1 = db.getNodeById( node1Id );
+            Node node2 = db.getNodeById( node2Id );
+            assertEquals( someProperties( 1 ), node1.getAllProperties() );
+            assertEquals( someProperties( 2 ), node2.getAllProperties() );
+            assertEquals( relationshipId, single( node1.getRelationships() ).getId() );
+            assertEquals( relationshipId, single( node2.getRelationships() ).getId() );
+            assertEquals( someProperties( 3 ), single( node1.getRelationships() ).getAllProperties() );
+            tx.success();
+        }
+        finally
+        {
+            db.shutdown();
+        }
+    }
+
+    private Map<String,Object> someProperties( int id )
+    {
+        return map( "key", "value" + id, "number", 10 + id );
+    }
+}

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
@@ -70,6 +70,9 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
         final Config config = dependencies.config();
         boolean queryLogEnabled = config.get( GraphDatabaseSettings.log_queries );
         final File queryLogFile = config.get( GraphDatabaseSettings.log_queries_filename );
+        final FileSystemAbstraction fileSystem = dependencies.fileSystem();
+        final JobScheduler jobScheduler = dependencies.jobScheduler();
+        final Monitors monitoring = dependencies.monitoring();
 
         if (!queryLogEnabled)
         {
@@ -92,8 +95,6 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
             @Override
             public void init() throws Throwable
             {
-                final FileSystemAbstraction fileSystem = dependencies.fileSystem();
-
                 Long thresholdMillis = config.get( GraphDatabaseSettings.log_queries_threshold );
                 Long rotationThreshold = config.get( GraphDatabaseSettings.log_queries_rotation_threshold );
                 int maxArchives = config.get( GraphDatabaseSettings.log_queries_max_archives );
@@ -108,7 +109,6 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
                 }
                 else
                 {
-                    JobScheduler jobScheduler = dependencies.jobScheduler();
                     RotatingFileOutputStreamSupplier
                             rotatingSupplier = new RotatingFileOutputStreamSupplier( fileSystem, queryLogFile,
                             rotationThreshold, 0, maxArchives,
@@ -118,7 +118,7 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
                 }
 
                 QueryLogger logger = new QueryLogger( Clock.SYSTEM_CLOCK, log, thresholdMillis );
-                dependencies.monitoring().addMonitorListener( logger );
+                monitoring.addMonitorListener( logger );
             }
 
             @Override


### PR DESCRIPTION
namely that some kernel extensions that was loaded required additional
dependencies, which the BatchInserter didn't have available already.
KernelExtensions must pull out all dependencies in `newInstance` method,
not later when initializing the actual extension lifecycle instance,
otherwise exception flow trips up and unsatisfied exception handler won't
be called correctly.
