### PR TITLE
Fix int overflow bug in reported page cache memory when dump_configuration=true

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
@@ -85,7 +85,9 @@ public class ConfiguringPageCacheFactory
         long totalPhysicalMemory = totalPhysicalMemory();
         String totalPhysicalMemMb = totalPhysicalMemory == -1? "?" : "" + totalPhysicalMemory / 1024 / 1024;
         long maxVmUsageMb = Runtime.getRuntime().maxMemory() / 1024 / 1024;
-        long pageCacheMb = (calculateMaxPages( config ) * calculatePageSize( config )) / 1024 / 1024;
+        long maxPages = calculateMaxPages( config );
+        long pageSize = calculatePageSize( config );
+        long pageCacheMb = (maxPages * pageSize) / 1024 / 1024;
         String msg = "Physical mem: " + totalPhysicalMemMb + " MiB," +
                      " Heap size: " + maxVmUsageMb + " MiB," +
                      " Page cache size: " + pageCacheMb + " MiB.";


### PR DESCRIPTION
This has no impact on how much memory will actually be used by the page cache at runtime.
It's only about how much memory we _say_ we use for the page cache when `dump_configuration` is `true`.

_NOTE:_ This is already fixed in 2.3, so it has to be forward merged with `-s ours`, aka. _null-merged_.
