### PR TITLE
CSV path for metrics data defaults to store directory

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.configuration;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -328,5 +329,20 @@ public class Config implements DiagnosticsProvider
         Map<String, String> newParams = getParams(); // copy is returned
         newParams.putAll( additionalConfig );
         return new Config( newParams );
+    }
+
+    /**
+     * Looks at configured file {@code absoluteOrRelativeFile} and just returns it if absolute, otherwise
+     * returns a {@link File} with {@code baseDirectoryIfRelative} as parent.
+     *
+     * @param baseDirectoryIfRelative base directory to use as parent if {@code absoluteOrRelativeFile}
+     * is relative, otherwise unused.
+     * @param absoluteOrRelativeFile file to return as absolute or relative to {@code baseDirectoryIfRelative}.
+     */
+    public static File absoluteFileOrRelativeTo( File baseDirectoryIfRelative, File absoluteOrRelativeFile )
+    {
+        return absoluteOrRelativeFile.isAbsolute()
+                ? absoluteOrRelativeFile
+                : new File( baseDirectoryIfRelative, absoluteOrRelativeFile.getPath() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -170,7 +170,7 @@ public class PlatformModule
 
         transactionMonitor = dependencies.satisfyDependency( createTransactionCounters() );
 
-        KernelContext kernelContext = new KernelContext()
+        KernelContext kernelContext = dependencies.satisfyDependency( new KernelContext()
         {
             @Override
             public FileSystemAbstraction fileSystem()
@@ -183,7 +183,7 @@ public class PlatformModule
             {
                 return PlatformModule.this.storeDir;
             }
-        };
+        } );
 
         kernelExtensions = dependencies.satisfyDependency( new KernelExtensions(
                 kernelContext,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Dependencies.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Dependencies.java
@@ -75,8 +75,7 @@ public class Dependencies extends DependencyResolver.Adapter implements Dependen
         }
 
         // Out of options
-        throw new IllegalArgumentException(
-                "No dependency satisfies type " + type );
+        throw new UnsatisfiedDependencyException( type );
     }
 
     public <T> Supplier<T> provideDependency( final Class<T> type, final SelectionStrategy selector)

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/UnsatisfiedDependencyException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/UnsatisfiedDependencyException.java
@@ -25,4 +25,9 @@ public class UnsatisfiedDependencyException extends RuntimeException
     {
         super( cause );
     }
+
+    public UnsatisfiedDependencyException( Class<?> type )
+    {
+        super( "No dependency satisfies type " + type );
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestGuard.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestGuard.java
@@ -29,14 +29,15 @@ import org.neo4j.helpers.Settings;
 import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.guard.GuardOperationsCountException;
 import org.neo4j.kernel.guard.GuardTimeoutException;
+import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.test.TestGraphDatabaseFactory;
-
-import static java.lang.Integer.MAX_VALUE;
-import static java.lang.Thread.sleep;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Thread.sleep;
 
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
 import static org.neo4j.helpers.SillyUtils.ignore;
@@ -44,7 +45,7 @@ import static org.neo4j.helpers.SillyUtils.ignore;
 @SuppressWarnings("deprecation"/*getGuard() is deprecated (GraphDatabaseAPI), and used all throughout this test*/)
 public class TestGuard
 {
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UnsatisfiedDependencyException.class)
     public void testGuardNotInsertedByDefault()
     {
         GraphDatabaseAPI db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DependenciesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/DependenciesTest.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import org.junit.Test;
+
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.junit.Test;
 
 import static junit.framework.Assert.fail;
 import static org.hamcrest.Matchers.equalTo;
@@ -143,7 +143,7 @@ public class DependenciesTest
             dependencies.resolveDependency( Collection.class );
             fail();
         }
-        catch ( IllegalArgumentException e )
+        catch ( UnsatisfiedDependencyException e )
         {
             // Then
         }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -150,7 +151,7 @@ public class OnlineBackupKernelExtension implements Lifecycle
                     graphDatabaseAPI.getDependencyResolver().resolveDependency( BindingNotifier.class ).addBindingListener(
                             (BindingListener) bindingListener );
                 }
-                catch ( NoClassDefFoundError | IllegalArgumentException e )
+                catch ( NoClassDefFoundError | UnsatisfiedDependencyException e )
                 {
                     // Not running HA
                 }
@@ -181,7 +182,7 @@ public class OnlineBackupKernelExtension implements Lifecycle
                 ClusterMemberAvailability client = getClusterMemberAvailability();
                 client.memberIsUnavailable( BACKUP );
             }
-            catch ( NoClassDefFoundError | IllegalArgumentException e )
+            catch ( NoClassDefFoundError | UnsatisfiedDependencyException e )
             {
                 // Not running HA
             }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
 import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
 import org.neo4j.kernel.impl.util.Access;
+import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.Log;
 
@@ -161,7 +162,7 @@ public class TransactionCommittingResponseUnpacker implements ResponseUnpacker, 
         {
             return supplier.get();
         }
-        catch ( IllegalArgumentException e )
+        catch ( UnsatisfiedDependencyException e )
         {
             return new TransactionObligationFulfiller()
             {

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsExtension.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsExtension.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.LogRotationMonitor;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.impl.transaction.TransactionCounters;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointerMonitor;
 import org.neo4j.kernel.lifecycle.LifeSupport;
@@ -49,7 +50,7 @@ public class MetricsExtension implements Lifecycle
     private final CheckPointerMonitor checkPointerMonitor;
     private final IdGeneratorFactory idGeneratorFactory;
     private final LogRotationMonitor logRotationMonitor;
-
+    private final KernelContext kernelContext;
 
     public MetricsExtension( MetricsKernelExtensionFactory.Dependencies dependencies )
     {
@@ -62,6 +63,7 @@ public class MetricsExtension implements Lifecycle
         checkPointerMonitor = dependencies.checkPointerCounters();
         logRotationMonitor = dependencies.logRotationCounters();
         idGeneratorFactory = dependencies.idGeneratorFactory();
+        kernelContext = dependencies.kernelContext();
     }
 
     @Override
@@ -77,7 +79,7 @@ public class MetricsExtension implements Lifecycle
         // Setup output
         String prefix = computePrefix( configuration );
 
-        life.add( new CsvOutput( configuration, registry, logger ) );
+        life.add( new CsvOutput( configuration, registry, logger, kernelContext ) );
         life.add( new GraphiteOutput( configuration, registry, logger, prefix ) );
         life.add( new GangliaOutput( configuration, registry, logger, prefix ) );
 

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsKernelExtensionFactory.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsKernelExtensionFactory.java
@@ -25,6 +25,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.api.LogRotationMonitor;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.impl.transaction.TransactionCounters;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointerMonitor;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -51,6 +52,8 @@ public class MetricsKernelExtensionFactory
         IdGeneratorFactory idGeneratorFactory();
 
         Monitors monitors();
+
+        KernelContext kernelContext();
     }
 
     public MetricsKernelExtensionFactory()

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -23,12 +23,10 @@ import java.io.File;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.Settings;
 import org.neo4j.kernel.configuration.Obsoleted;
 
-import static org.neo4j.helpers.Settings.basePath;
 import static org.neo4j.helpers.Settings.setting;
 
 /**
@@ -100,8 +98,8 @@ public class MetricsSettings
                   "the path to an individual CSV file, that have each of the reported metrics fields as columns, or " +
                   "it is a path to a directory wherein a CSV file per reported field will be written. Relative paths " +
                   "will be intepreted relative to the configured Neo4j store directory." )
-    public static Setting<File> csvPath = setting(
-            "metrics.csv.path", Settings.PATH, "metrics.csv" , basePath( GraphDatabaseSettings.store_dir ) );
+    public static Setting<File> csvPath = setting( "metrics.csv.path", Settings.PATH, Settings.NO_DEFAULT );
+
     @Deprecated
     @Obsoleted( "This setting will be removed in the next major release." )
     @Description( "Write to a single CSV file or to multiple files. " +

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/CsvOutputTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/CsvOutputTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.metrics.output;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.spi.KernelContext;
+import org.neo4j.kernel.lifecycle.LifeRule;
+import org.neo4j.logging.NullLog;
+import org.neo4j.metrics.MetricsSettings;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.fail;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class CsvOutputTest
+{
+    @Rule
+    public final LifeRule life = new LifeRule();
+    @Rule
+    public final TargetDirectory.TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void shouldHaveMetricsCsvPathEndUpRelativeToGraphDbDirectoryIfRelativePathSpecified() throws Exception
+    {
+        // GIVEN
+        File storeDir = directory.directory();
+        String name = "metrics.csv";
+        CsvOutput output = life.add( new CsvOutput( config(
+                MetricsSettings.csvEnabled.name(), "true",
+                MetricsSettings.csvInterval.name(), "10ms",
+                MetricsSettings.csvPath.name(), name ),
+                new MetricRegistry(), NullLog.getInstance(), kerneContext( storeDir ) ) );
+
+        // WHEN
+        life.start();
+
+        // THEN
+        waitForFileToAppear( new File( storeDir, name ) );
+    }
+
+    @Test
+    public void shouldHaveRelativeMetricsCsvPathBeRelativeToGraphDbDirectory() throws Exception
+    {
+        // GIVEN
+        File storeDir = directory.directory();
+        CsvOutput output = life.add( new CsvOutput( config(
+                MetricsSettings.csvEnabled.name(), "true",
+                MetricsSettings.csvInterval.name(), "10ms",
+                MetricsSettings.csvPath.name(), "test.csv" ),
+                new MetricRegistry(), NullLog.getInstance(), kerneContext( storeDir ) ) );
+
+        // WHEN
+        life.start();
+
+        // THEN
+        waitForFileToAppear( new File( storeDir, "test.csv" ) );
+    }
+
+    @Test
+    public void shouldHaveAbsoluteMetricsCsvPathBeAbsolute() throws Exception
+    {
+        // GIVEN
+        File storeDir = directory.directory();
+        File file = File.createTempFile( "neo4j", "csvoutput" );
+        CsvOutput output = life.add( new CsvOutput( config(
+                MetricsSettings.csvEnabled.name(), "true",
+                MetricsSettings.csvInterval.name(), "10ms",
+                MetricsSettings.csvPath.name(), file.getAbsolutePath() ),
+                new MetricRegistry(), NullLog.getInstance(), kerneContext( storeDir ) ) );
+
+        // WHEN
+        life.start();
+
+        // THEN
+        waitForFileToAppear( file );
+    }
+
+    private KernelContext kerneContext( final File storeDir )
+    {
+        return new KernelContext()
+        {
+            @Override
+            public File storeDir()
+            {
+                return storeDir;
+            }
+
+            @Override
+            public FileSystemAbstraction fileSystem()
+            {
+                return new DefaultFileSystemAbstraction();
+            }
+        };
+    }
+
+    private Config config( String... keysValues )
+    {
+        return new Config( stringMap( keysValues ) );
+    }
+
+    private void waitForFileToAppear( File file ) throws InterruptedException
+    {
+        long end = currentTimeMillis() + SECONDS.toMillis( 10 );
+        while ( !file.exists() )
+        {
+            Thread.sleep( 10 );
+            if ( currentTimeMillis() > end )
+            {
+                fail( file + " didn't appear" );
+            }
+        }
+    }
+}


### PR DESCRIPTION
That setting was using a deprecated and unused "store_dir" setting
function. Now uses KernelContext instead. Added common utility for
getting absolute/relative paths from config values.
