### PR TITLE
Steps towards a StorageEngine API

### DIFF
--- a/advanced/management/src/main/java/org/neo4j/management/impl/TransactionManagerBean.java
+++ b/advanced/management/src/main/java/org/neo4j/management/impl/TransactionManagerBean.java
@@ -94,7 +94,7 @@ public final class TransactionManagerBean extends ManagementBeanProvider
             {
                 return -1;
             }
-            return neoStoreDataSource.getNeoStores().getMetaDataStore().getLastCommittedTransactionId();
+            return neoStoreDataSource.getLastCommittedTransactionId();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -506,7 +506,7 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
                     storeLayerModule.indexUpdatesValidator(),
                     storeLayerModule.storeReadLayer(),
                     updateableSchemaState, storeLayerModule.labelScanStore(),
-                    storeLayerModule.schemaIndexProviderMap(), storeLayerModule.procedureCache() );
+                    storeLayerModule.schemaIndexProviderMap(), storeLayerModule.procedureCache(), storeLayerModule );
 
 
             // Do these assignments last so that we can ensure no cyclical dependencies exist
@@ -614,60 +614,6 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
                         relationshipTypeTokens, schemaStateChangeCallback, constraintSemantics, scheduler,
                         tokenNameLookup,
                         lockService, indexProvider, indexingServiceMonitor, kernelHealth, labelScanStoreProvider );
-            }
-
-            @Override
-            public NeoStores neoStores()
-            {
-                return neoStores;
-            }
-
-            @Override
-            public MetaDataStore metaDataStore()
-            {
-                return neoStores.getMetaDataStore();
-            }
-
-            @Override
-            public IndexingService indexingService()
-            {
-                return indexingService;
-            }
-
-            @Override
-            public IndexUpdatesValidator indexUpdatesValidator()
-            {
-                return indexUpdatesValidator;
-            }
-
-            @Override
-            public LabelScanStore labelScanStore()
-            {
-                return labelScanStore;
-            }
-
-            @Override
-            public IntegrityValidator integrityValidator()
-            {
-                return integrityValidator;
-            }
-
-            @Override
-            public SchemaIndexProviderMap schemaIndexProviderMap()
-            {
-                return providerMap;
-            }
-
-            @Override
-            public CacheAccessBackDoor cacheAccess()
-            {
-                return cacheAccess;
-            }
-
-            @Override
-            public ProcedureCache procedureCache()
-            {
-                return procedureCache;
             }
         }
 
@@ -885,10 +831,12 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
     }
 
     private KernelModule buildKernel( IntegrityValidator integrityValidator, TransactionAppender appender,
-            NeoStores neoStores, TransactionRepresentationStoreApplier storeApplier, IndexingService indexingService,
-            IndexUpdatesValidator indexUpdatesValidator, StoreReadLayer storeLayer,
-            UpdateableSchemaState updateableSchemaState, LabelScanStore labelScanStore,
-            SchemaIndexProviderMap schemaIndexProviderMap, ProcedureCache procedureCache )
+                                      NeoStores neoStores, TransactionRepresentationStoreApplier storeApplier,
+                                      IndexingService indexingService,
+                                      IndexUpdatesValidator indexUpdatesValidator, StoreReadLayer storeLayer,
+                                      UpdateableSchemaState updateableSchemaState, LabelScanStore labelScanStore,
+                                      SchemaIndexProviderMap schemaIndexProviderMap, ProcedureCache procedureCache,
+                                      StorageEngine storageEngine )
     {
         TransactionCommitProcess transactionCommitProcess = commitProcessFactory.create( appender, storeApplier,
                 indexUpdatesValidator, config );
@@ -924,11 +872,11 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
         final TransactionHooks hooks = new TransactionHooks();
         final KernelTransactions kernelTransactions =
                 life.add( new KernelTransactions( neoStoreTxContextFactory,
-                        neoStores, locks, integrityValidator, constraintIndexCreator, indexingService, labelScanStore,
-                        statementOperations, updateableSchemaState, schemaWriteGuard, schemaIndexProviderMap,
-                        transactionHeaderInformationFactory, storeLayer, transactionCommitProcess,
+                        locks, constraintIndexCreator,
+                        statementOperations, updateableSchemaState, schemaWriteGuard,
+                        transactionHeaderInformationFactory, transactionCommitProcess,
                         indexConfigStore, legacyIndexProviderLookup, hooks, constraintSemantics,
-                        transactionMonitor, life, procedureCache, tracers ) );
+                        transactionMonitor, life, tracers, storageEngine ) );
 
         final Kernel kernel = new Kernel( kernelTransactions, hooks, kernelHealth, transactionMonitor );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -414,7 +414,7 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
      * core API are now slowly accumulating in the Kernel implementation. Over time, these components should be
      * refactored into bigger components that wrap the very granular things we depend on here.
      */
-    public NeoStoreDataSource( File storeDir, Config config, StoreFactory sf, LogProvider logProvider,
+    public NeoStoreDataSource( File storeDir, Config config, IdGeneratorFactory idGeneratorFactory, LogProvider logProvider,
             JobScheduler scheduler, TokenNameLookup tokenNameLookup, DependencyResolver dependencyResolver,
             PropertyKeyTokenHolder propertyKeyTokens, LabelTokenHolder labelTokens,
             RelationshipTypeTokenHolder relationshipTypeTokens, Locks lockManager,
@@ -460,7 +460,7 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
 
         readOnly = config.get( Configuration.read_only );
         msgLog = logProvider.getLog( getClass() );
-        this.storeFactory = sf;
+        this.storeFactory = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs, logProvider );
         this.lockService = new ReentrantLockService();
         this.legacyIndexProviderLookup = new LegacyIndexProviderLookup()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -360,7 +360,7 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
     private final Locks locks;
     private final SchemaWriteGuard schemaWriteGuard;
     private final TransactionEventHandlers transactionEventHandlers;
-    private final StoreFactory storeFactory;
+    private final IdGeneratorFactory idGeneratorFactory;
     private final JobScheduler scheduler;
     private final Config config;
     private final LockService lockService;
@@ -460,7 +460,7 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
 
         readOnly = config.get( Configuration.read_only );
         msgLog = logProvider.getLog( getClass() );
-        this.storeFactory = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs, logProvider );
+        this.idGeneratorFactory = idGeneratorFactory;
         this.lockService = new ReentrantLockService();
         this.legacyIndexProviderLookup = new LegacyIndexProviderLookup()
         {
@@ -531,6 +531,7 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
             LegacyIndexApplierLookup legacyIndexApplierLookup =
                     dependencies.satisfyDependency( new LegacyIndexApplierLookup.Direct( legacyIndexProviderLookup ) );
 
+            StoreFactory storeFactory = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs, logProvider );
             final NeoStoreModule neoStoreModule =
                     buildNeoStore( storeFactory, labelTokens, relationshipTypeTokens, propertyKeyTokenHolder );
             // TODO The only reason this is here is because of the provider-stuff for DiskLayer. Remove when possible:
@@ -543,6 +544,7 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
                     tokenNameLookup, logProvider, indexingServiceMonitor,
                     neoStoreModule.neoStores(), cacheModule.updateableSchemaState() );
 
+            // TODO Introduce a StorageEngine abstraction at the StoreLayerModule boundary
             StoreLayerModule storeLayerModule = buildStoreLayer( neoStoreModule.neoStores(),
                     propertyKeyTokenHolder, labelTokens, relationshipTypeTokens,
                     indexingModule.indexingService(), cacheModule.schemaCache(), cacheModule.procedureCache() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/RecoveryLabelScanWriterProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/RecoveryLabelScanWriterProvider.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
-import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
@@ -37,7 +37,7 @@ import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.SORT_BY_NODE_ID;
  * Provides {@link LabelScanWriter} that takes advantage of the single-threaded context of recovery
  * to cache writes and apply in bigger batches, where each batch holds data from many transactions.
  */
-public class RecoveryLabelScanWriterProvider implements Provider<LabelScanWriter>, Closeable
+public class RecoveryLabelScanWriterProvider implements Supplier<LabelScanWriter>, Closeable
 {
     private int callCount;
     private final LabelScanStore labelScanStore;
@@ -54,7 +54,7 @@ public class RecoveryLabelScanWriterProvider implements Provider<LabelScanWriter
      * Called once for every transactions that have any label updates.
      */
     @Override
-    public LabelScanWriter instance()
+    public LabelScanWriter get()
     {
         return recoveryWriter;
     }
@@ -80,7 +80,7 @@ public class RecoveryLabelScanWriterProvider implements Provider<LabelScanWriter
 
         /**
          * Called from the transaction applier code. We won't close the actual writer every time
-         * we get this call, only every {@link RecoveryLabelScanWriterProvider#BATCH_SIZE} time,
+         * we get this call, only every {@link RecoveryLabelScanWriterProvider#batchSize} time,
          * at which point {@link #writePendingUpdates()} is called.
          */
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
@@ -23,14 +23,12 @@ import java.io.IOException;
 import java.util.function.Supplier;
 
 import org.neo4j.concurrent.WorkSync;
-import org.neo4j.kernel.KernelHealth;
-import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
-import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.storageengine.StorageEngine;
+import org.neo4j.kernel.impl.transaction.CommandStream;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.CacheInvalidationTransactionApplier;
 import org.neo4j.kernel.impl.transaction.command.CommandHandler;
@@ -48,53 +46,48 @@ import org.neo4j.unsafe.batchinsert.LabelScanWriter;
  */
 public class TransactionRepresentationStoreApplier
 {
-    private final NeoStores neoStores;
-    protected final IndexingService indexingService;
-    private final CacheAccessBackDoor cacheAccess;
     private final LockService lockService;
     private final Supplier<LabelScanWriter> labelScanWriters;
     private final IndexConfigStore indexConfigStore;
     private final LegacyIndexApplierLookup legacyIndexProviderLookup;
-    private final KernelHealth health;
     private final IdOrderingQueue legacyIndexTransactionOrdering;
 
     private final WorkSync<Supplier<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork> labelScanStoreSync;
+    private final StorageEngine storageEngine;
 
     public TransactionRepresentationStoreApplier(
-            IndexingService indexingService, Supplier<LabelScanWriter> labelScanWriters, NeoStores neoStores,
-            CacheAccessBackDoor cacheAccess, LockService lockService, LegacyIndexApplierLookup
-            legacyIndexProviderLookup,
-            IndexConfigStore indexConfigStore, KernelHealth health, IdOrderingQueue legacyIndexTransactionOrdering )
+            Supplier<LabelScanWriter> labelScanWriters,
+            LockService lockService,
+            IndexConfigStore indexConfigStore,
+            IdOrderingQueue legacyIndexTransactionOrdering,
+            StorageEngine storageEngine )
     {
-        this.indexingService = indexingService;
+        this.storageEngine = storageEngine;
         this.labelScanWriters = labelScanWriters;
-        this.neoStores = neoStores;
-        this.cacheAccess = cacheAccess;
         this.lockService = lockService;
-        this.legacyIndexProviderLookup = legacyIndexProviderLookup;
+        this.legacyIndexProviderLookup = storageEngine.legacyIndexApplierLookup();
         this.indexConfigStore = indexConfigStore;
-        this.health = health;
         this.legacyIndexTransactionOrdering = legacyIndexTransactionOrdering;
         labelScanStoreSync = new WorkSync<>( labelScanWriters );
     }
 
-    public void apply( TransactionRepresentation representation, ValidatedIndexUpdates indexUpdates, LockGroup locks,
+    public void apply( CommandStream representation, ValidatedIndexUpdates indexUpdates, LockGroup locks,
             long transactionId, TransactionApplicationMode mode ) throws IOException
     {
         // Graph store application. The order of the decorated store appliers is irrelevant
         CommandHandler storeApplier = new NeoStoreTransactionApplier(
-                neoStores, cacheAccess, lockService, locks, transactionId );
+                storageEngine.neoStores(), storageEngine.cacheAccess(), lockService, locks, transactionId );
         if ( mode.needsIdTracking() )
         {
-            storeApplier = new HighIdTransactionApplier( storeApplier, neoStores );
+            storeApplier = new HighIdTransactionApplier( storeApplier, storageEngine.neoStores() );
         }
         if ( mode.needsCacheInvalidationOnUpdates() )
         {
-            storeApplier = new CacheInvalidationTransactionApplier( storeApplier, neoStores, cacheAccess );
+            storeApplier = new CacheInvalidationTransactionApplier( storeApplier, storageEngine.neoStores(), storageEngine.cacheAccess() );
         }
 
         // Schema index application
-        IndexTransactionApplier indexApplier = new IndexTransactionApplier( indexingService, indexUpdates,
+        IndexTransactionApplier indexApplier = new IndexTransactionApplier( storageEngine.indexingService(), indexUpdates,
                 labelScanStoreSync );
 
         // Legacy index application
@@ -112,7 +105,7 @@ public class TransactionRepresentationStoreApplier
         }
         catch ( Throwable cause )
         {
-            health.panic( cause );
+            storageEngine.kernelHealth().panic( cause );
             throw cause;
         }
     }
@@ -120,7 +113,7 @@ public class TransactionRepresentationStoreApplier
     private CommandHandler getCountsStoreApplier( long transactionId, TransactionApplicationMode mode )
     {
         Optional<CommandHandler> handlerOption =
-                neoStores.getCounts().apply( transactionId ).map( CountsStoreApplier.FACTORY );
+                storageEngine.neoStores().getCounts().apply( transactionId ).map( CountsStoreApplier.FACTORY );
         if ( mode == TransactionApplicationMode.RECOVERY )
         {
             handlerOption = handlerOption.or( CommandHandler.EMPTY );
@@ -131,7 +124,8 @@ public class TransactionRepresentationStoreApplier
     public TransactionRepresentationStoreApplier withLegacyIndexTransactionOrdering(
             IdOrderingQueue legacyIndexTransactionOrdering )
     {
-        return new TransactionRepresentationStoreApplier( indexingService, labelScanWriters, neoStores, cacheAccess,
-                lockService, legacyIndexProviderLookup, indexConfigStore, health, legacyIndexTransactionOrdering );
+        return new TransactionRepresentationStoreApplier( labelScanWriters,
+                lockService, indexConfigStore, legacyIndexTransactionOrdering,
+                storageEngine );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplier.java
@@ -20,9 +20,9 @@
 package org.neo4j.kernel.impl.api;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import org.neo4j.concurrent.WorkSync;
-import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
@@ -52,16 +52,16 @@ public class TransactionRepresentationStoreApplier
     protected final IndexingService indexingService;
     private final CacheAccessBackDoor cacheAccess;
     private final LockService lockService;
-    private final Provider<LabelScanWriter> labelScanWriters;
+    private final Supplier<LabelScanWriter> labelScanWriters;
     private final IndexConfigStore indexConfigStore;
     private final LegacyIndexApplierLookup legacyIndexProviderLookup;
     private final KernelHealth health;
     private final IdOrderingQueue legacyIndexTransactionOrdering;
 
-    private final WorkSync<Provider<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork> labelScanStoreSync;
+    private final WorkSync<Supplier<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork> labelScanStoreSync;
 
     public TransactionRepresentationStoreApplier(
-            IndexingService indexingService, Provider<LabelScanWriter> labelScanWriters, NeoStores neoStores,
+            IndexingService indexingService, Supplier<LabelScanWriter> labelScanWriters, NeoStores neoStores,
             CacheAccessBackDoor cacheAccess, LockService lockService, LegacyIndexApplierLookup
             legacyIndexProviderLookup,
             IndexConfigStore indexConfigStore, KernelHealth health, IdOrderingQueue legacyIndexTransactionOrdering )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxySetup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxySetup.java
@@ -28,7 +28,6 @@ import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
-import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
@@ -42,26 +41,26 @@ public class IndexProxySetup
     private final IndexSamplingConfig samplingConfig;
     private final IndexStoreView storeView;
     private final SchemaIndexProviderMap providerMap;
-    private final UpdateableSchemaState updateableSchemaState;
     private final TokenNameLookup tokenNameLookup;
     private final JobScheduler scheduler;
     private final LogProvider logProvider;
+    private final Runnable schemaStateChangeCallback;
 
     public IndexProxySetup( IndexSamplingConfig samplingConfig,
                             IndexStoreView storeView,
                             SchemaIndexProviderMap providerMap,
-                            UpdateableSchemaState updateableSchemaState,
                             TokenNameLookup tokenNameLookup,
                             JobScheduler scheduler,
-                            LogProvider logProvider )
+                            LogProvider logProvider,
+                            Runnable schemaStateChangeCallback )
     {
         this.samplingConfig = samplingConfig;
         this.storeView = storeView;
         this.providerMap = providerMap;
-        this.updateableSchemaState = updateableSchemaState;
         this.tokenNameLookup = tokenNameLookup;
         this.scheduler = scheduler;
         this.logProvider = logProvider;
+        this.schemaStateChangeCallback = schemaStateChangeCallback;
     }
 
     public IndexProxy createPopulatingIndexProxy( final long ruleId,
@@ -90,7 +89,8 @@ public class IndexProxySetup
 
         PopulatingIndexProxy populatingIndex =
                 new PopulatingIndexProxy( scheduler, descriptor, config, failureDelegateFactory, populator, flipper,
-                        storeView, updateableSchemaState, logProvider, indexUserDescription, providerDescriptor, monitor );
+                        storeView, logProvider, indexUserDescription, providerDescriptor, monitor,
+                        schemaStateChangeCallback );
         flipper.flipTo( populatingIndex );
 
         // Prepare for flipping to online mode

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -51,7 +51,6 @@ import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.index.SchemaIndexProvider.Descriptor;
-import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingController;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingControllerFactory;
@@ -182,9 +181,10 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
                                           SchemaIndexProviderMap providerMap,
                                           IndexStoreView storeView,
                                           TokenNameLookup tokenNameLookup,
-                                          UpdateableSchemaState updateableSchemaState,
                                           Iterable<IndexRule> indexRules,
-                                          LogProvider logProvider, Monitor monitor )
+                                          LogProvider logProvider,
+                                          Monitor monitor,
+                                          Runnable schemaStateChangeCallback )
     {
         if ( providerMap == null || providerMap.getDefaultProvider() == null )
         {
@@ -199,8 +199,8 @@ public class IndexingService extends LifecycleAdapter implements PrimitiveLongVi
                 new IndexSamplingControllerFactory( samplingConfig, storeView, scheduler, tokenNameLookup, logProvider );
         IndexSamplingController indexSamplingController = factory.create( indexMapRef );
         IndexProxySetup proxySetup = new IndexProxySetup(
-                samplingConfig, storeView, providerMap, updateableSchemaState, tokenNameLookup, scheduler, logProvider
-        );
+                samplingConfig, storeView, providerMap, tokenNameLookup, scheduler, logProvider,
+                schemaStateChangeCallback );
 
         return new IndexingService( proxySetup, providerMap, indexMapRef, storeView, indexRules,
                 indexSamplingController, tokenNameLookup, logProvider, monitor );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -40,7 +40,6 @@ import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.index.Reservation;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
-import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.LogProvider;
 
@@ -63,11 +62,11 @@ public class PopulatingIndexProxy implements IndexProxy
                                  IndexPopulator writer,
                                  FlippableIndexProxy flipper,
                                  IndexStoreView storeView,
-                                 UpdateableSchemaState updateableSchemaState,
                                  LogProvider logProvider,
                                  String indexUserDescription,
                                  SchemaIndexProvider.Descriptor providerDescriptor,
-                                 IndexingService.Monitor monitor )
+                                 IndexingService.Monitor monitor,
+                                 Runnable schemaStateChangeCallback )
     {
         this.scheduler = scheduler;
         this.descriptor = descriptor;
@@ -75,7 +74,7 @@ public class PopulatingIndexProxy implements IndexProxy
         this.providerDescriptor = providerDescriptor;
         this.job = new IndexPopulationJob( descriptor, configuration, providerDescriptor,
                 indexUserDescription, failureDelegateFactory, writer, flipper, storeView,
-                updateableSchemaState, logProvider, monitor );
+                logProvider, monitor, schemaStateChangeCallback );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
@@ -19,7 +19,8 @@
  */
 package org.neo4j.kernel.impl.api.state;
 
-import org.neo4j.function.Supplier;
+import java.util.function.Supplier;
+
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.cache;
 
-import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.store.SchemaCache;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
@@ -32,18 +31,18 @@ import org.neo4j.kernel.impl.store.record.SchemaRule;
 public class BridgingCacheAccess implements CacheAccessBackDoor
 {
     private final SchemaCache schemaCache;
-    private final SchemaState schemaState;
+    private final Runnable schemaStateChangeCallback;
     private final PropertyKeyTokenHolder propertyKeyTokenHolder;
     private final RelationshipTypeTokenHolder relationshipTypeTokenHolder;
     private final LabelTokenHolder labelTokenHolder;
 
-    public BridgingCacheAccess( SchemaCache schemaCache, SchemaState schemaState,
+    public BridgingCacheAccess( SchemaCache schemaCache, Runnable schemaStateChangeCallback,
             PropertyKeyTokenHolder propertyKeyTokenHolder,
             RelationshipTypeTokenHolder relationshipTypeTokenHolder,
             LabelTokenHolder labelTokenHolder )
     {
         this.schemaCache = schemaCache;
-        this.schemaState = schemaState;
+        this.schemaStateChangeCallback = schemaStateChangeCallback;
         this.propertyKeyTokenHolder = propertyKeyTokenHolder;
         this.relationshipTypeTokenHolder = relationshipTypeTokenHolder;
         this.labelTokenHolder = labelTokenHolder;
@@ -59,7 +58,7 @@ public class BridgingCacheAccess implements CacheAccessBackDoor
     public void removeSchemaRuleFromCache( long id )
     {
         schemaCache.removeSchemaRule( id );
-        schemaState.clear();
+        schemaStateChangeCallback.run();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -66,7 +66,6 @@ import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
-import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.storemigration.StoreMigrator;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
@@ -163,8 +162,6 @@ public class DataSourceModule
 
         // Factories for things that needs to be created later
         PageCache pageCache = platformModule.pageCache;
-        StoreFactory storeFactory = new StoreFactory( storeDir, config, editionModule.idGeneratorFactory,
-                pageCache, fileSystem, logging.getInternalLogProvider() );
 
         StartupStatisticsProvider startupStatistics = deps.satisfyDependency( new StartupStatisticsProvider() );
 
@@ -191,7 +188,7 @@ public class DataSourceModule
                 logging.getInternalLog( KernelHealth.class ) ) );
 
         neoStoreDataSource = deps.satisfyDependency( new NeoStoreDataSource( storeDir, config,
-                storeFactory, logging.getInternalLogProvider(), platformModule.jobScheduler,
+                editionModule.idGeneratorFactory, logging.getInternalLogProvider(), platformModule.jobScheduler,
                 new NonTransactionalTokenNameLookup( editionModule.labelTokenHolder,
                         editionModule.relationshipTypeTokenHolder, editionModule.propertyKeyTokenHolder ),
                 deps, editionModule.propertyKeyTokenHolder, editionModule.labelTokenHolder, relationshipTypeTokenHolder,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -62,7 +62,6 @@ import org.neo4j.kernel.impl.coreapi.LegacyIndexProxy;
 import org.neo4j.kernel.impl.coreapi.NodeAutoIndexerImpl;
 import org.neo4j.kernel.impl.coreapi.RelationshipAutoIndexerImpl;
 import org.neo4j.kernel.impl.coreapi.schema.SchemaImpl;
-import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
@@ -135,9 +134,6 @@ public class DataSourceModule
         transactionEventHandlers = new TransactionEventHandlers( nodeActions, relationshipActions,
                 threadToTransactionBridge );
 
-        IndexConfigStore indexStore =
-                life.add( deps.satisfyDependency( new IndexConfigStore( storeDir, fileSystem ) ) );
-
         diagnosticsManager.prependProvider( config );
 
         life.add( platformModule.kernelExtensions );
@@ -196,7 +192,7 @@ public class DataSourceModule
                 platformModule.monitors.newMonitor( IndexingService.Monitor.class ), fileSystem,
                 storeMigrationProcess, platformModule.transactionMonitor, kernelHealth,
                 platformModule.monitors.newMonitor( PhysicalLogFile.Monitor.class ),
-                editionModule.headerInformationFactory, startupStatistics, nodeManager, guard, indexStore,
+                editionModule.headerInformationFactory, startupStatistics, nodeManager, guard,
                 editionModule.commitProcessFactory, pageCache, editionModule.constraintSemantics,
                 platformModule.monitors, platformModule.tracers ) );
         dataSourceManager.register( neoStoreDataSource );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/LegacyIndexStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/LegacyIndexStore.java
@@ -22,9 +22,9 @@ package org.neo4j.kernel.impl.index;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.neo4j.function.Function;
-import org.neo4j.function.Supplier;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/StorageEngine.java
@@ -28,8 +28,11 @@ import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
 import org.neo4j.kernel.impl.api.store.ProcedureCache;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.state.IntegrityValidator;
 
 /**
@@ -38,6 +41,8 @@ import org.neo4j.kernel.impl.transaction.state.IntegrityValidator;
 public interface StorageEngine
 {
     StoreReadLayer storeReadLayer();
+    TransactionIdStore transactionIdStore();
+    LogVersionRepository logVersionRepository();
 
     @Deprecated
     ProcedureCache procedureCache();
@@ -68,6 +73,9 @@ public interface StorageEngine
 
     @Deprecated
     LegacyIndexApplierLookup legacyIndexApplierLookup();
+
+    @Deprecated
+    IndexConfigStore indexConfigStore();
 
     @Deprecated
     KernelHealth kernelHealth();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/StorageEngine.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.kernel.impl.storageengine;
 
+import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.impl.api.LegacyIndexApplierLookup;
 import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
@@ -63,4 +65,12 @@ public interface StorageEngine
 
     @Deprecated
     CacheAccessBackDoor cacheAccess();
+
+    @Deprecated
+    LegacyIndexApplierLookup legacyIndexApplierLookup();
+
+    @Deprecated
+    KernelHealth kernelHealth();
+
+    void loadSchemaCache();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/StorageEngine.java
@@ -19,7 +19,16 @@
  */
 package org.neo4j.kernel.impl.storageengine;
 
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
+import org.neo4j.kernel.impl.api.store.ProcedureCache;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
+import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.transaction.state.IntegrityValidator;
 
 /**
  * A StorageEngine provides the functionality to durably store data, and read it back.
@@ -27,4 +36,31 @@ import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 public interface StorageEngine
 {
     StoreReadLayer storeReadLayer();
+
+    @Deprecated
+    ProcedureCache procedureCache();
+
+    @Deprecated
+    NeoStores neoStores();
+
+    @Deprecated
+    MetaDataStore metaDataStore();
+
+    @Deprecated
+    IndexingService indexingService();
+
+    @Deprecated
+    IndexUpdatesValidator indexUpdatesValidator();
+
+    @Deprecated
+    LabelScanStore labelScanStore();
+
+    @Deprecated
+    IntegrityValidator integrityValidator();
+
+    @Deprecated
+    SchemaIndexProviderMap schemaIndexProviderMap();
+
+    @Deprecated
+    CacheAccessBackDoor cacheAccess();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/StorageEngine.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storageengine;
+
+import org.neo4j.kernel.impl.api.store.StoreReadLayer;
+
+/**
+ * A StorageEngine provides the functionality to durably store data, and read it back.
+ */
+public interface StorageEngine
+{
+    StoreReadLayer storeReadLayer();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storageengine.impl.recordstorage;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.neo4j.function.Factory;
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.KernelHealth;
+import org.neo4j.kernel.api.TokenNameLookup;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
+import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.api.index.OnlineIndexUpdatesValidator;
+import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
+import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
+import org.neo4j.kernel.impl.api.store.CacheLayer;
+import org.neo4j.kernel.impl.api.store.DiskLayer;
+import org.neo4j.kernel.impl.api.store.ProcedureCache;
+import org.neo4j.kernel.impl.api.store.SchemaCache;
+import org.neo4j.kernel.impl.api.store.StoreReadLayer;
+import org.neo4j.kernel.impl.api.store.StoreStatement;
+import org.neo4j.kernel.impl.cache.BridgingCacheAccess;
+import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
+import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
+import org.neo4j.kernel.impl.core.LabelTokenHolder;
+import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
+import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
+import org.neo4j.kernel.impl.locking.LockService;
+import org.neo4j.kernel.impl.storageengine.StorageEngine;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.SchemaStorage;
+import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.record.SchemaRule;
+import org.neo4j.kernel.impl.transaction.state.DefaultSchemaIndexProviderMap;
+import org.neo4j.kernel.impl.transaction.state.IntegrityValidator;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreIndexStoreView;
+import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.logging.LogProvider;
+
+import static org.neo4j.helpers.Settings.BOOLEAN;
+import static org.neo4j.helpers.Settings.TRUE;
+import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.helpers.collection.Iterables.toList;
+import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
+
+public class RecordStorageEngine implements StorageEngine, Lifecycle
+{
+    /**
+     * This setting is hidden to the user and is here merely for making it easier to back out of
+     * a change where reading property chains incurs read locks on {@link LockService}.
+     */
+    private static final Setting<Boolean> use_read_locks_on_property_reads =
+            setting( "experimental.use_read_locks_on_property_reads", BOOLEAN, TRUE );
+
+    private final StoreReadLayer storeLayer;
+    protected final IndexingService indexingService;
+    protected final NeoStores neoStores;
+    private final PropertyKeyTokenHolder propertyKeyTokenHolder;
+    private final RelationshipTypeTokenHolder relationshipTypeTokenHolder;
+    private final LabelTokenHolder labelTokenHolder;
+    private final SchemaCache schemaCache;
+    protected final IntegrityValidator integrityValidator;
+    protected final IndexUpdatesValidator indexUpdatesValidator;
+    protected final CacheAccessBackDoor cacheAccess;
+    protected final LabelScanStore labelScanStore;
+    protected final DefaultSchemaIndexProviderMap providerMap;
+    protected final ProcedureCache procedureCache;
+
+    public RecordStorageEngine(
+            File storeDir, Config config, IdGeneratorFactory idGeneratorFactory, PageCache pageCache,
+            FileSystemAbstraction fs, LogProvider logProvider,
+            PropertyKeyTokenHolder propertyKeyTokenHolder,
+            LabelTokenHolder labelTokens,
+            RelationshipTypeTokenHolder relationshipTypeTokens,
+            Runnable schemaStateChangeCallback,
+            ConstraintSemantics constraintSemantics,
+            JobScheduler scheduler,
+            TokenNameLookup tokenNameLookup,
+            LockService lockService,
+            SchemaIndexProvider indexProvider,
+            IndexingService.Monitor indexingServiceMonitor,
+            KernelHealth kernelHealth,
+            LabelScanStoreProvider labelScanStoreProvider )
+    {
+        this.propertyKeyTokenHolder = propertyKeyTokenHolder;
+        this.relationshipTypeTokenHolder = relationshipTypeTokens;
+        this.labelTokenHolder = labelTokens;
+        final StoreFactory storeFactory = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs, logProvider );
+        neoStores = storeFactory.openAllNeoStores( true );
+
+        try
+        {
+            schemaCache = new SchemaCache( constraintSemantics, Collections.<SchemaRule>emptyList() );
+            SchemaStorage schemaStorage = new SchemaStorage( neoStores.getSchemaStore() );
+
+            providerMap = new DefaultSchemaIndexProviderMap( indexProvider );
+            indexingService = IndexingService.create(
+                    new IndexSamplingConfig( config ), scheduler, providerMap,
+                    new NeoStoreIndexStoreView( lockService, neoStores ), tokenNameLookup,
+                    toList( new SchemaStorage( neoStores.getSchemaStore() ).allIndexRules() ), logProvider,
+                    indexingServiceMonitor, schemaStateChangeCallback );
+
+            integrityValidator = new IntegrityValidator( neoStores, indexingService );
+            indexUpdatesValidator = new OnlineIndexUpdatesValidator(
+                    neoStores, kernelHealth, new PropertyLoader( neoStores ),
+                    indexingService, IndexUpdateMode.ONLINE );
+            cacheAccess = new BridgingCacheAccess( schemaCache, schemaStateChangeCallback,
+                    propertyKeyTokenHolder, relationshipTypeTokens, labelTokens );
+
+            DiskLayer diskLayer = new DiskLayer( propertyKeyTokenHolder, labelTokens, relationshipTypeTokens,
+                    schemaStorage,
+                    neoStores, indexingService, storeStatementFactory( neoStores, config, lockService ) );
+            procedureCache = new ProcedureCache();
+            storeLayer = new CacheLayer( diskLayer, schemaCache, procedureCache );
+            this.labelScanStore = labelScanStoreProvider.getLabelScanStore();
+        }
+        catch ( Throwable failure )
+        {
+            neoStores.close();
+            throw failure;
+        }
+    }
+
+    private static Factory<StoreStatement> storeStatementFactory(
+            NeoStores neoStores, Config config, LockService lockService )
+    {
+        final LockService currentLockService =
+                config.get( use_read_locks_on_property_reads ) ? lockService : NO_LOCK_SERVICE;
+        return () -> new StoreStatement( neoStores, currentLockService );
+    }
+
+    @Override
+    public StoreReadLayer storeReadLayer()
+    {
+        return storeLayer;
+    }
+
+    @Override
+    public void init() throws Throwable
+    {
+        indexingService.init();
+        labelScanStore.init();
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        neoStores.makeStoreOk();
+
+        propertyKeyTokenHolder.setInitialTokens(
+                neoStores.getPropertyKeyTokenStore().getTokens( Integer.MAX_VALUE ) );
+        relationshipTypeTokenHolder.setInitialTokens(
+                neoStores.getRelationshipTypeTokenStore().getTokens( Integer.MAX_VALUE ) );
+        labelTokenHolder.setInitialTokens(
+                neoStores.getLabelTokenStore().getTokens( Integer.MAX_VALUE ) );
+
+        neoStores.rebuildCountStoreIfNeeded(); // TODO: move this to counts store lifecycle
+        loadSchemaCache();
+        indexingService.start();
+        labelScanStore.start();
+    }
+
+    public void loadSchemaCache()
+    {
+        List<SchemaRule> schemaRules = toList( neoStores.getSchemaStore().loadAllSchemaRules() );
+        schemaCache.load( schemaRules );
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        labelScanStore.stop();
+        indexingService.stop();
+    }
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+        labelScanStore.shutdown();
+        indexingService.shutdown();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.OnlineIndexUpdatesValidator;
+import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.api.store.CacheLayer;
@@ -53,6 +54,7 @@ import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.storageengine.StorageEngine;
+import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.store.StoreFactory;
@@ -161,6 +163,60 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
     public StoreReadLayer storeReadLayer()
     {
         return storeLayer;
+    }
+
+    @Override
+    public ProcedureCache procedureCache()
+    {
+        return procedureCache;
+    }
+
+    @Override
+    public NeoStores neoStores()
+    {
+        return neoStores;
+    }
+
+    @Override
+    public MetaDataStore metaDataStore()
+    {
+        return neoStores.getMetaDataStore();
+    }
+
+    @Override
+    public IndexingService indexingService()
+    {
+        return indexingService;
+    }
+
+    @Override
+    public IndexUpdatesValidator indexUpdatesValidator()
+    {
+        return indexUpdatesValidator;
+    }
+
+    @Override
+    public LabelScanStore labelScanStore()
+    {
+        return labelScanStore;
+    }
+
+    @Override
+    public IntegrityValidator integrityValidator()
+    {
+        return integrityValidator;
+    }
+
+    @Override
+    public SchemaIndexProviderMap schemaIndexProviderMap()
+    {
+        return providerMap;
+    }
+
+    @Override
+    public CacheAccessBackDoor cacheAccess()
+    {
+        return cacheAccess;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/CommandStream.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/CommandStream.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import java.io.IOException;
+
+import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.kernel.impl.transaction.command.Command;
+
+/**
+ * A stream of commands from one or more transactions, that can be serialised to a transaction log or applied to a
+ * store.
+ */
+public interface CommandStream
+{
+    /**
+     * Accepts a visitor into the commands making up this transaction.
+     * @param visitor {@link Visitor} which will see the commands.
+     * @throws IOException if there were any problem reading the commands.
+     */
+    void accept( Visitor<Command,IOException> visitor ) throws IOException;
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionRepresentation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/TransactionRepresentation.java
@@ -28,15 +28,8 @@ import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
 /**
  * Representation of a transaction that can be written to a {@link TransactionAppender} and read back later.
  */
-public interface TransactionRepresentation
+public interface TransactionRepresentation extends CommandStream
 {
-    /**
-     * Accepts a visitor into the commands making up this transaction.
-     * @param visitor {@link Visitor} which will see the commands.
-     * @throws IOException if there were any problem reading the commands.
-     */
-    void accept( Visitor<Command, IOException> visitor ) throws IOException;
-
     /**
      * @return an additional header of this transaction. Just arbitrary bytes that means nothing
      * to this transaction representation.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/StoreFlusher.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/StoreFlusher.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.transaction.log.rotation;
 import org.neo4j.graphdb.index.IndexImplementation;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.index.IndexingService;
+import org.neo4j.kernel.impl.storageengine.StorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
 
 public class StoreFlusher
@@ -31,13 +32,13 @@ public class StoreFlusher
     private final LabelScanStore labelScanStore;
     private final Iterable<IndexImplementation> indexProviders;
 
-    public StoreFlusher( NeoStores neoStores, IndexingService indexingService,
-            LabelScanStore labelScanStore,
+    public StoreFlusher(
+            StorageEngine storageEngine,
             Iterable<IndexImplementation> indexProviders )
     {
-        this.neoStores = neoStores;
-        this.indexingService = indexingService;
-        this.labelScanStore = labelScanStore;
+        this.neoStores = storageEngine.neoStores();
+        this.indexingService = storageEngine.indexingService();
+        this.labelScanStore = storageEngine.labelScanStore();
         this.indexProviders = indexProviders;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DataSourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DataSourceManager.java
@@ -69,28 +69,14 @@ public class DataSourceManager implements Lifecycle, Supplier<KernelAPI>
         this.dataSource = dataSource;
         if ( life.getStatus().equals( LifecycleStatus.STARTED ) )
         {
-            Listeners.notifyListeners( dsRegistrationListeners, new Listeners.Notification<Listener>()
-            {
-                @Override
-                public void notify( Listener listener )
-                {
-                    listener.registered( dataSource );
-                }
-            } );
+            Listeners.notifyListeners( dsRegistrationListeners, listener -> listener.registered( dataSource ) );
         }
     }
 
     public void unregister( final NeoStoreDataSource dataSource )
     {
         this.dataSource = null;
-        Listeners.notifyListeners( dsRegistrationListeners, new Listeners.Notification<Listener>()
-        {
-            @Override
-            public void notify( Listener listener )
-            {
-                listener.unregistered( dataSource );
-            }
-        } );
+        Listeners.notifyListeners( dsRegistrationListeners, listener -> listener.unregistered( dataSource ) );
         life.remove( dataSource );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/Optionals.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/function/Optionals.java
@@ -28,7 +28,7 @@ public class Optionals
         @Override
         public Object get()
         {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException( "Cannot get Optionals.none()" );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryLabelScanWriterProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryLabelScanWriterProviderTest.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
-import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
@@ -73,10 +73,10 @@ public class RecoveryLabelScanWriterProviderTest
         }
     }
 
-    private void simulateTransaction( Provider<LabelScanWriter> provider, int i, List<NodeLabelUpdate> expectedUpdates )
+    private void simulateTransaction( Supplier<LabelScanWriter> provider, int i, List<NodeLabelUpdate> expectedUpdates )
             throws Exception
     {
-        try ( LabelScanWriter writer = provider.instance() )
+        try ( LabelScanWriter writer = provider.get() )
         {
             NodeLabelUpdate update = NodeLabelUpdate.labelChanges( i, longs(), longs( 1 ) );
             expectedUpdates.add( update );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.api;
 
 import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.Clock;
-import org.neo4j.kernel.impl.api.store.ProcedureCache;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
@@ -31,8 +30,8 @@ import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionHooks;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
-import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.locking.NoOpClient;
+import org.neo4j.kernel.impl.storageengine.StorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
@@ -50,17 +49,19 @@ public class KernelTransactionFactory
         TransactionHeaderInformationFactory headerInformationFactory = mock( TransactionHeaderInformationFactory.class );
         when( headerInformationFactory.create() ).thenReturn( headerInformation );
 
+        StorageEngine storageEngine = mock( StorageEngine.class );
+        when( storageEngine.neoStores() ).thenReturn( mock( NeoStores.class ) );
         return new KernelTransactionImplementation( mock( StatementOperationParts.class ),
-                mock( SchemaWriteGuard.class ), null, null,
+                mock( SchemaWriteGuard.class ),
                 null, mock( TransactionRecordState.class ),
-                null, mock( NeoStores.class ), new NoOpClient(), new TransactionHooks(),
+                new NoOpClient(), new TransactionHooks(),
                 mock( ConstraintIndexCreator.class ), headerInformationFactory,
                 mock( TransactionRepresentationCommitProcess.class ), mock( TransactionMonitor.class ),
-                mock( StoreReadLayer.class ),
                 mock( LegacyIndexTransactionState.class ),
                 mock(Pool.class),
                 mock( ConstraintSemantics.class ),
                 Clock.SYSTEM_CLOCK,
-                TransactionTracer.NULL, new ProcedureCache() );
+                TransactionTracer.NULL,
+                storageEngine );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
@@ -19,6 +19,13 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,19 +39,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import java.util.function.Supplier;
 
 import org.neo4j.function.Functions;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.index.IndexImplementation;
 import org.neo4j.graphdb.index.IndexManager;
-import org.neo4j.helpers.Provider;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -253,7 +253,7 @@ public class TransactionRepresentationCommitProcessIT
             KernelHealth kernelHealth )
     {
         return new TransactionRepresentationStoreApplier( mock( IndexingService.class ),
-                mock( Provider.class ), neoStores, mock( CacheAccessBackDoor.class ), mock( LockService.class ),
+                mock( Supplier.class ), neoStores, mock( CacheAccessBackDoor.class ), mock( LockService.class ),
                 legacyIndexApplierLookup, indexStore, kernelHealth, legacyIndexTransactionOrdering );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplierTest.java
@@ -25,8 +25,8 @@ import org.mockito.Matchers;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Supplier;
 
-import org.neo4j.helpers.Provider;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.KernelHealth;
@@ -58,7 +58,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.impl.api.TransactionApplicationMode.INTERNAL;
 import static org.neo4j.kernel.impl.util.function.Optionals.some;
 
@@ -66,7 +65,7 @@ public class TransactionRepresentationStoreApplierTest
 {
     private final IndexingService indexService = mock( IndexingService.class );
     @SuppressWarnings( "unchecked" )
-    private final Provider<LabelScanWriter> labelScanStore = mock( Provider.class );
+    private final Supplier<LabelScanWriter> labelScanStore = mock( Supplier.class );
     private final NeoStores neoStores = mock( NeoStores.class );
     private final CacheAccessBackDoor cacheAccess = mock( CacheAccessBackDoor.class );
     private final LockService lockService = new ReentrantLockService();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationStoreApplierTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -38,6 +39,7 @@ import org.neo4j.kernel.impl.index.IndexDefineCommand;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.locking.ReentrantLockService;
+import org.neo4j.kernel.impl.storageengine.StorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
@@ -74,20 +76,28 @@ public class TransactionRepresentationStoreApplierTest
     private final IndexConfigStore indexConfigStore = mock( IndexConfigStore.class );
     private final IdOrderingQueue queue = mock( IdOrderingQueue.class );
     private final KernelHealth kernelHealth = mock( KernelHealth.class );
+    private final StorageEngine storageEngine = mock( StorageEngine.class );
     private final int transactionId = 12;
 
+    @Before
+    public void setUp()
     {
         final CountsTracker tracker = mock( CountsTracker.class );
         when( neoStores.getCounts() ).thenReturn( tracker );
         when( tracker.apply( anyLong() ) ).thenReturn( some( mock( CountsAccessor.Updater.class ) ) );
+        when( storageEngine.indexingService() ).thenReturn( indexService );
+        when( storageEngine.cacheAccess() ).thenReturn( cacheAccess );
+        when( storageEngine.legacyIndexApplierLookup() ).thenReturn( legacyIndexProviderLookup );
+        when( storageEngine.neoStores() ).thenReturn( neoStores );
+        when( storageEngine.kernelHealth() ).thenReturn( kernelHealth );
     }
 
     @Test
     public void transactionRepresentationShouldAcceptApplierVisitor() throws IOException
     {
         TransactionRepresentationStoreApplier applier =
-                new TransactionRepresentationStoreApplier( indexService, labelScanStore, neoStores, cacheAccess,
-                        lockService, legacyIndexProviderLookup, indexConfigStore, kernelHealth, queue );
+                new TransactionRepresentationStoreApplier( labelScanStore,
+                        lockService, indexConfigStore, queue, storageEngine );
 
         TransactionRepresentation transaction = mock( TransactionRepresentation.class );
 
@@ -106,8 +116,8 @@ public class TransactionRepresentationStoreApplierTest
         NodeStore nodeStore = mock( NodeStore.class );
         when( neoStores.getNodeStore() ).thenReturn( nodeStore );
         TransactionRepresentationStoreApplier applier =
-                new TransactionRepresentationStoreApplier( indexService, labelScanStore, neoStores, cacheAccess,
-                        lockService, legacyIndexProviderLookup, indexConfigStore, kernelHealth, queue );
+                new TransactionRepresentationStoreApplier( labelScanStore,
+                        lockService, indexConfigStore, queue, storageEngine );
         long nodeId = 5L;
         TransactionRepresentation transaction = createNodeTransaction( nodeId );
 
@@ -126,8 +136,8 @@ public class TransactionRepresentationStoreApplierTest
         // GIVEN
         IdOrderingQueue queue = mock( IdOrderingQueue.class );
         TransactionRepresentationStoreApplier applier =
-                new TransactionRepresentationStoreApplier( indexService, labelScanStore, neoStores, cacheAccess,
-                        lockService, legacyIndexProviderLookup, indexConfigStore, kernelHealth, queue );
+                new TransactionRepresentationStoreApplier( labelScanStore,
+                        lockService, indexConfigStore, queue, storageEngine );
         TransactionRepresentation transaction = new PhysicalTransactionRepresentation( indexTransaction() );
 
         // WHEN
@@ -146,8 +156,8 @@ public class TransactionRepresentationStoreApplierTest
         // GIVEN
         IdOrderingQueue queue = mock( IdOrderingQueue.class );
         TransactionRepresentationStoreApplier applier =
-                new TransactionRepresentationStoreApplier( indexService, labelScanStore, neoStores, cacheAccess,
-                        lockService, legacyIndexProviderLookup, indexConfigStore, kernelHealth, queue );
+                new TransactionRepresentationStoreApplier( labelScanStore,
+                        lockService, indexConfigStore, queue, storageEngine );
         TransactionRepresentation transaction = mock( TransactionRepresentation.class );
         IOException ioex = new IOException();
         //noinspection unchecked

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.neo4j.function.Suppliers;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -49,7 +48,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.impl.api.StatementOperationsTestHelper.mockedParts;
 import static org.neo4j.kernel.impl.api.StatementOperationsTestHelper.mockedState;
 import static org.neo4j.kernel.impl.store.SchemaStorage.IndexRuleKind.CONSTRAINT;
@@ -74,7 +72,7 @@ public class ConstraintIndexCreatorTest
         IndexProxy indexProxy = mock( IndexProxy.class );
         when( indexingService.getIndexProxy( 2468l ) ).thenReturn( indexProxy );
 
-        ConstraintIndexCreator creator = new ConstraintIndexCreator( Suppliers.<KernelAPI>singleton( kernel ), indexingService );
+        ConstraintIndexCreator creator = new ConstraintIndexCreator( () -> kernel, indexingService );
 
         // when
         long indexId = creator.createUniquenessConstraintIndex( state, constraintCreationContext.schemaReadOperations(), 123, 456 );
@@ -109,7 +107,7 @@ public class ConstraintIndexCreatorTest
         doThrow( new IndexPopulationFailedKernelException( descriptor, "some index", cause) )
                 .when(indexProxy).awaitStoreScanCompleted();
 
-        ConstraintIndexCreator creator = new ConstraintIndexCreator( Suppliers.<KernelAPI>singleton( kernel ), indexingService );
+        ConstraintIndexCreator creator = new ConstraintIndexCreator( () -> kernel, indexingService );
 
         // when
         try
@@ -144,7 +142,7 @@ public class ConstraintIndexCreatorTest
 
         IndexDescriptor descriptor = new IndexDescriptor( 123, 456 );
 
-        ConstraintIndexCreator creator = new ConstraintIndexCreator( Suppliers.<KernelAPI>singleton( kernel ), indexingService );
+        ConstraintIndexCreator creator = new ConstraintIndexCreator( () -> kernel, indexingService );
 
         // when
         creator.dropUniquenessConstraintIndex( descriptor );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import java.util.Set;
 
-import org.neo4j.function.Suppliers;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.kernel.api.SchemaWriteOperations;
@@ -132,7 +131,7 @@ public class IndexIT extends KernelIntegrationTest
     public void shouldRemoveAConstraintIndexWithoutOwnerInRecovery() throws Exception
     {
         // given
-        ConstraintIndexCreator creator = new ConstraintIndexCreator( Suppliers.singleton( kernel ), indexingService );
+        ConstraintIndexCreator creator = new ConstraintIndexCreator( () -> kernel, indexingService );
         creator.createConstraintIndex( labelId, propertyKeyId );
 
         // when

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -657,7 +657,7 @@ public class IndexPopulationJobTest
                 format( ":%s(%s)", label.name(), propertyKey ),
                 failureDelegateFactory,
                 populator, flipper, storeView,
-                stateHolder, logProvider, IndexingService.NO_MONITOR );
+                logProvider, IndexingService.NO_MONITOR, stateHolder::clear );
     }
 
     private IndexDescriptor indexDescriptor( Label label, String propertyKey )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/StorageEngineTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/StorageEngineTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storageengine;
+
+import org.junit.Before;
+
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.test.impl.EphemeralIdGenerator;
+
+public abstract class StorageEngineTest
+{
+    private IdGeneratorFactory idGeneratorFactory;
+
+    @Before
+    public void setUp()
+    {
+        idGeneratorFactory = new EphemeralIdGenerator.Factory();
+    }
+
+    protected abstract StorageEngine buildEngine( IdGeneratorFactory idGeneratorFactory );
+
+
+    // bigger things
+    // TODO provide access to StoreReadLayer
+    // TODO create a stream of commands from a transaction state
+    // TODO apply a stream of commands to the store
+    // TODO deserialise a stream of byte buffers into commands
+    // TODO flush to durable storage
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngineTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngineTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storageengine.impl.recordstorage;
+
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.impl.storageengine.StorageEngine;
+import org.neo4j.kernel.impl.storageengine.StorageEngineTest;
+
+public class RecordStorageEngineTest extends StorageEngineTest
+{
+    @Override
+    protected StorageEngine buildEngine( IdGeneratorFactory idGeneratorFactory )
+    {
+        throw new UnsupportedOperationException( "TODO" );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexTransactionApplierTest.java
@@ -22,9 +22,9 @@ package org.neo4j.kernel.impl.transaction.command;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import org.neo4j.concurrent.WorkSync;
-import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.api.exceptions.index.IndexCapacityExceededException;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -35,7 +35,6 @@ import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-
 import static org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates.NONE;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_PROPERTY;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
@@ -48,7 +47,7 @@ public class IndexTransactionApplierTest
         // GIVEN
         IndexingService indexing = mock( IndexingService.class );
         LabelScanWriter writer = new OrderVerifyingLabelScanWriter( 10, 15, 20 );
-        WorkSync<Provider<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork> labelScanSync =
+        WorkSync<Supplier<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork> labelScanSync =
                 new WorkSync<>( singletonProvider( writer ) );
         try ( IndexTransactionApplier applier = new IndexTransactionApplier( indexing, NONE, labelScanSync ) )
         {
@@ -61,16 +60,9 @@ public class IndexTransactionApplierTest
         // THEN all assertions happen inside the LabelScanWriter#write and #close
     }
 
-    private Provider<LabelScanWriter> singletonProvider( final LabelScanWriter writer )
+    private Supplier<LabelScanWriter> singletonProvider( final LabelScanWriter writer )
     {
-        return new Provider<LabelScanWriter>()
-        {
-            @Override
-            public LabelScanWriter instance()
-            {
-                return writer;
-            }
-        };
+        return () -> writer;
     }
 
     private NodeCommand node( long nodeId )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionStoreApplierTest.java
@@ -27,9 +27,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Supplier;
 
 import org.neo4j.concurrent.WorkSync;
-import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.api.exceptions.index.IndexActivationFailedKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
@@ -85,7 +85,7 @@ public class NeoTransactionStoreApplierTest
     private final NeoStores neoStores = mock( NeoStores.class );
     private final IndexingService indexingService = mock( IndexingService.class );
     @SuppressWarnings( "unchecked" )
-    private final Provider<LabelScanWriter> labelScanStore = mock( Provider.class );
+    private final Supplier<LabelScanWriter> labelScanStore = mock( Supplier.class );
     private final CacheAccessBackDoor cacheAccess = mock( CacheAccessBackDoor.class );
     private final LockService lockService = mock( LockService.class );
 
@@ -104,7 +104,7 @@ public class NeoTransactionStoreApplierTest
     private final DynamicRecord one = DynamicRecord.dynamicRecord( 1, true );
     private final DynamicRecord two = DynamicRecord.dynamicRecord( 2, true );
     private final DynamicRecord three = DynamicRecord.dynamicRecord( 3, true );
-    private final WorkSync<Provider<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork>
+    private final WorkSync<Supplier<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork>
             labelScanStoreSynchronizer = new WorkSync<>( labelScanStore );
 
     @Before

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
@@ -39,12 +39,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.Pair;
-import org.neo4j.helpers.Provider;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
@@ -109,6 +109,7 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
+import static java.lang.Integer.parseInt;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -127,9 +128,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-
-import static java.lang.Integer.parseInt;
-
 import static org.neo4j.graphdb.Direction.INCOMING;
 import static org.neo4j.graphdb.Direction.OUTGOING;
 import static org.neo4j.helpers.collection.Iterables.count;
@@ -1491,8 +1489,8 @@ public class NeoStoreTransactionTest
                 Matchers.<TransactionRepresentation>any(),
                 any( LogAppendEvent.class ) ) ).thenReturn( new FakeCommitment( nextTxId++, neoStores.getMetaDataStore() ) );
         @SuppressWarnings( "unchecked" )
-        Provider<LabelScanWriter> labelScanStore = mock( Provider.class );
-        when( labelScanStore.instance() ).thenReturn( mock( LabelScanWriter.class ) );
+        Supplier<LabelScanWriter> labelScanStore = mock( Supplier.class );
+        when( labelScanStore.get() ).thenReturn( mock( LabelScanWriter.class ) );
         TransactionRepresentationStoreApplier applier = new TransactionRepresentationStoreApplier(
                 indexing, labelScanStore, neoStores, cacheAccessBackDoor, locks, null, null, null, null );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreTransactionTest.java
@@ -56,11 +56,9 @@ import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
 import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
-import org.neo4j.kernel.impl.api.UpdateableSchemaState;
 import org.neo4j.kernel.impl.api.index.IndexMapReference;
 import org.neo4j.kernel.impl.api.index.IndexProxySetup;
 import org.neo4j.kernel.impl.api.index.IndexStoreView;
@@ -1593,7 +1591,6 @@ public class NeoStoreTransactionTest
         NeoStoreIndexStoreView storeView = new NeoStoreIndexStoreView( locks, neoStores );
         SchemaIndexProviderMap providerMap = new DefaultSchemaIndexProviderMap( NO_INDEX_PROVIDER );
         IndexingService.Monitor monitor = IndexingService.NO_MONITOR;
-        UpdateableSchemaState schemaState = new KernelSchemaStateStore( NULL_LOG_PROVIDER );
         IndexSamplingConfig samplingConfig = new IndexSamplingConfig( new Config() );
         TokenNameLookup tokenNameLookup = mock( TokenNameLookup.class );
         IndexMapReference indexMapRef = new IndexMapReference();
@@ -1602,7 +1599,8 @@ public class NeoStoreTransactionTest
                 samplingConfig, storeView, null, tokenNameLookup, NULL_LOG_PROVIDER
         );
         IndexProxySetup proxySetup =
-                new IndexProxySetup( samplingConfig, storeView, providerMap, schemaState, null, null, NULL_LOG_PROVIDER );
+                new IndexProxySetup( samplingConfig, storeView, providerMap, null, null, NULL_LOG_PROVIDER,
+                        () -> {} );
         IndexSamplingController samplingController = samplingFactory.create( indexMapRef );
         return new CapturingIndexingService(
                 proxySetup,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/SchemaRuleCommandTest.java
@@ -21,18 +21,18 @@ package org.neo4j.kernel.impl.transaction.state;
 
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Supplier;
 
 import org.neo4j.concurrent.WorkSync;
-import org.neo4j.helpers.Provider;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.SchemaStore;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.IndexRule;
@@ -53,7 +53,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
 import static org.neo4j.kernel.impl.store.record.UniquePropertyConstraintRule.uniquenessConstraintRule;
@@ -211,10 +210,10 @@ public class SchemaRuleCommandTest
     private final SchemaStore schemaStore = mock( SchemaStore.class );
     private final IndexingService indexes = mock( IndexingService.class );
     @SuppressWarnings( "unchecked" )
-    private final Provider<LabelScanWriter> labelScanStore = mock( Provider.class );
+    private final Supplier<LabelScanWriter> labelScanStore = mock( Supplier.class );
     private final NeoStoreTransactionApplier storeApplier = new NeoStoreTransactionApplier( neoStores,
             mock( CacheAccessBackDoor.class ), LockService.NO_LOCK_SERVICE, new LockGroup(), txId );
-    private final WorkSync<Provider<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork> labelScanStoreSynchronizer =
+    private final WorkSync<Supplier<LabelScanWriter>,IndexTransactionApplier.LabelUpdateWork> labelScanStoreSynchronizer =
             new WorkSync<>( labelScanStore );
     private final IndexTransactionApplier indexApplier = new IndexTransactionApplier( indexes,
             ValidatedIndexUpdates.NONE, labelScanStoreSynchronizer );
@@ -235,7 +234,7 @@ public class SchemaRuleCommandTest
         {
             record.setInUse( true );
         }
-        return Arrays.asList( record );
+        return Collections.singletonList( record );
     }
 
     private void assertSchemaRule( SchemaRuleCommand readSchemaCommand )

--- a/community/kernel/src/test/java/org/neo4j/qa/tooling/DumpProcessInformationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/qa/tooling/DumpProcessInformationTest.java
@@ -32,11 +32,11 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.neo4j.helpers.Pair;
+import org.neo4j.io.proc.ProcessUtil;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.TargetDirectory;
 
 import static java.lang.Runtime.getRuntime;
-import static java.lang.System.getProperty;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertTrue;
@@ -54,7 +54,8 @@ public class DumpProcessInformationTest
         // GIVEN
         File directory = testDirectory.directory( "dump" );
         // a process spawned from this test which pauses at a specific point of execution
-        Process process = getRuntime().exec( new String[] { "java", "-cp", getProperty( "java.class.path" ),
+        String java = ProcessUtil.getJavaExecutable().toString();
+        Process process = getRuntime().exec( new String[] {java, "-cp", ProcessUtil.getClassPath(),
                 DumpableProcess.class.getName(), SIGNAL } );
         awaitSignal( process );
 

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -88,7 +88,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 mock( SchemaWriteGuard.class ), mock( TransactionEventHandlers.class ), IndexingService.NO_MONITOR,
                 fs, mock( StoreUpgrader.class ), mock( TransactionMonitor.class ), kernelHealth,
                 mock( PhysicalLogFile.Monitor.class ), TransactionHeaderInformationFactory.DEFAULT,
-                new StartupStatisticsProvider(), mock( NodeManager.class ), null, null,
+                new StartupStatisticsProvider(), mock( NodeManager.class ), null,
                 new CommunityCommitProcessFactory(), pageCache,
                 mock( ConstraintSemantics.class), new Monitors(), new Tracers( "null", NullLog.getInstance() ) );
 

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -47,7 +47,6 @@ import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.factory.CommunityCommitProcessFactory;
 import org.neo4j.kernel.impl.locking.Locks;
-import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
@@ -78,13 +77,11 @@ public class NeoStoreDataSourceRule extends ExternalResource
         final Config config = new Config( stringMap( additionalConfig ),
                 GraphDatabaseSettings.class );
 
-        StoreFactory sf = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs ), pageCache, fs,
-                NullLogProvider.getInstance() );
-
         Locks locks = mock( Locks.class );
         when( locks.newClient() ).thenReturn( mock( Locks.Client.class ) );
 
-        dataSource = new NeoStoreDataSource( storeDir, config, sf, NullLogProvider.getInstance(),
+        dataSource = new NeoStoreDataSource( storeDir, config, new DefaultIdGeneratorFactory( fs ),
+                NullLogProvider.getInstance(),
                 mock( JobScheduler.class, RETURNS_MOCKS ), mock( TokenNameLookup.class ),
                 dependencyResolverForNoIndexProvider(), mock( PropertyKeyTokenHolder.class ),
                 mock( LabelTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ), locks,
@@ -92,7 +89,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 fs, mock( StoreUpgrader.class ), mock( TransactionMonitor.class ), kernelHealth,
                 mock( PhysicalLogFile.Monitor.class ), TransactionHeaderInformationFactory.DEFAULT,
                 new StartupStatisticsProvider(), mock( NodeManager.class ), null, null,
-                new CommunityCommitProcessFactory(), mock( PageCache.class ),
+                new CommunityCommitProcessFactory(), pageCache,
                 mock( ConstraintSemantics.class), new Monitors(), new Tracers( "null", NullLog.getInstance() ) );
 
         return dataSource;

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndexImplementation.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndexImplementation.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.index.IndexCommandFactory;
@@ -57,10 +58,10 @@ public class LuceneIndexImplementation extends LifecycleAdapter implements Index
     private LuceneDataSource dataSource;
     private final File storeDir;
     private final Config config;
-    private final IndexConfigStore indexStore;
+    private final Supplier<IndexConfigStore> indexStore;
     private final FileSystemAbstraction fileSystemAbstraction;
 
-    public LuceneIndexImplementation( File storeDir, Config config, IndexConfigStore indexStore,
+    public LuceneIndexImplementation( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
             FileSystemAbstraction fileSystemAbstraction )
     {
         this.storeDir = storeDir;
@@ -72,7 +73,7 @@ public class LuceneIndexImplementation extends LifecycleAdapter implements Index
     @Override
     public void init() throws Throwable
     {
-        this.dataSource = new LuceneDataSource( storeDir, config, indexStore, fileSystemAbstraction );
+        this.dataSource = new LuceneDataSource( storeDir, config, indexStore.get(), fileSystemAbstraction );
         this.dataSource.init();
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.index.lucene;
 
+import java.io.File;
+import java.util.function.Supplier;
+
 import org.neo4j.graphdb.index.IndexProviders;
 import org.neo4j.index.impl.lucene.LuceneIndexImplementation;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -26,17 +29,15 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
-import java.io.File;
-
 public class LuceneKernelExtension extends LifecycleAdapter
 {
     private final File storeDir;
     private final Config config;
-    private final IndexConfigStore indexStore;
+    private final Supplier<IndexConfigStore> indexStore;
     private final FileSystemAbstraction fileSystemAbstraction;
     private final IndexProviders indexProviders;
 
-    public LuceneKernelExtension( File storeDir, Config config, IndexConfigStore indexStore,
+    public LuceneKernelExtension( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
             FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders )
     {
         this.storeDir = storeDir;

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtensionFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtensionFactory.java
@@ -46,7 +46,11 @@ public class LuceneKernelExtensionFactory extends KernelExtensionFactory<LuceneK
     @Override
     public Lifecycle newInstance( KernelContext context, Dependencies dependencies ) throws Throwable
     {
-        return new LuceneKernelExtension( context.storeDir(), dependencies.getConfig(), dependencies.getIndexStore(),
-                context.fileSystem(), dependencies.getIndexProviders() );
+        return new LuceneKernelExtension(
+                context.storeDir(),
+                dependencies.getConfig(),
+                dependencies::getIndexStore,
+                context.fileSystem(),
+                dependencies.getIndexProviders() );
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneRecoveryIT.java
@@ -29,6 +29,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.io.fs.FileUtils;
+import org.neo4j.io.proc.ProcessUtil;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.tooling.GlobalGraphOperations;
 
@@ -43,7 +44,7 @@ public class LuceneRecoveryIT
         String path = "target/hcdb";
         FileUtils.deleteRecursively( new File( path ) );
         Process process = Runtime.getRuntime().exec( new String[]{
-                "java", "-cp", System.getProperty( "java.class.path" ),
+                ProcessUtil.getJavaExecutable().toString(), "-cp", ProcessUtil.getClassPath(),
                 Inserter.class.getName(), path
         } );
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
@@ -37,6 +37,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.Settings;
+import org.neo4j.io.proc.ProcessUtil;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.EmbeddedDatabaseRule;
 import org.neo4j.test.ProcessStreamHandler;
@@ -138,7 +139,8 @@ public class BackupEmbeddedIT
     public static int runBackupToolFromOtherJvmToGetExitCode( String... args )
             throws Exception
     {
-        List<String> allArgs = new ArrayList<>( Arrays.asList( "java", "-cp", System.getProperty( "java.class.path" ), BackupTool.class.getName() ) );
+        List<String> allArgs = new ArrayList<>( Arrays.asList(
+                ProcessUtil.getJavaExecutable().toString(), "-cp", ProcessUtil.getClassPath(), BackupTool.class.getName() ) );
         allArgs.addAll( Arrays.asList( args ) );
 
         Process process = Runtime.getRuntime().exec( allArgs.toArray( new String[allArgs.size()] ));

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -618,7 +618,7 @@ public class BackupServiceIT
 
         final DependencyResolver resolver = db.getDependencyResolver();
         NeoStoreDataSource ds = resolver.resolveDependency( DataSourceManager.class ).getDataSource();
-        long expectedLastTxId = ds.getNeoStores().getMetaDataStore().getLastCommittedTransactionId();
+        long expectedLastTxId = ds.getLastCommittedTransactionId();
 
         // This monitor is added server-side...
         monitors.addMonitorListener( new StoreSnoopingMonitor( barrier ) );

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/DefaultUnpackerDependencies.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/DefaultUnpackerDependencies.java
@@ -22,17 +22,15 @@ package org.neo4j.com.storecopy;
 import org.neo4j.function.Supplier;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.KernelHealth;
-import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.BatchingTransactionRepresentationStoreApplier;
-import org.neo4j.kernel.impl.api.LegacyIndexApplierLookup;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.OnlineIndexUpdatesValidator;
-import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.storageengine.StorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.log.LogFile;
 import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
@@ -54,20 +52,15 @@ public class DefaultUnpackerDependencies implements TransactionCommittingRespons
     public BatchingTransactionRepresentationStoreApplier transactionRepresentationStoreApplier()
     {
         return new BatchingTransactionRepresentationStoreApplier(
-                resolver.resolveDependency( IndexingService.class ),
-                resolver.resolveDependency( LabelScanStore.class ),
-                resolver.resolveDependency( NeoStoresSupplier.class ).get(),
-                resolver.resolveDependency( CacheAccessBackDoor.class ),
                 resolver.resolveDependency( LockService.class ),
-                resolver.resolveDependency( LegacyIndexApplierLookup.class ),
                 resolver.resolveDependency( IndexConfigStore.class ),
-                resolver.resolveDependency( KernelHealth.class ),
 
                 // Ideally we don't want/need a real IdOrderingQueue here because we know that
                 // we only have a single thread applying updates as a slave anyway. But the thing
                 // is that it's hard to change a TransactionAppender depending on role, so we
                 // use a real one, or rather, whatever is available through the dependency resolver.
-                resolver.resolveDependency( IdOrderingQueue.class ) );
+                resolver.resolveDependency( IdOrderingQueue.class ),
+                resolver.resolveDependency( StorageEngine.class ) );
     }
 
     @Override


### PR DESCRIPTION
We want to introduce a StorageEngine API, that decouples the mechanics of turning graph IO into byte IO, from the mechanics of a full-blown database. In essence, we would like an API for non-transactionally reading a graph store, and for turning transaction state into a stream of store change commands, and for applying said stream of change commands to the store.

This way, storage gets decoupled from the rest of the database, allowing us to have more than one storage implementation. The refactorings in this PR moves us in this direction.
