### PR TITLE
Compute correct sampling of non-unique indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/NonUniqueIndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/NonUniqueIndexSampler.java
@@ -46,12 +46,18 @@ public class NonUniqueIndexSampler
 
     public void include( String value )
     {
+        include( value, 1 );
+    }
+
+    public void include( String value, long increment )
+    {
+        assert increment > 0;
         if ( bufferSize >= bufferSizeLimit )
         {
             nextStep();
         }
 
-        if ( values.add( value ) == 1 )
+        if ( values.increment( value, increment ) == increment )
         {
             bufferSize += value.length();
         }
@@ -59,7 +65,13 @@ public class NonUniqueIndexSampler
 
     public void exclude( String value )
     {
-        if ( values.remove( value ) == 0 )
+        exclude( value, 1 );
+    }
+
+    public void exclude( String value, long decrement )
+    {
+        assert decrement > 0;
+        if ( values.increment( value, -decrement ) == 0 )
         {
             bufferSize -= value.length();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexSamplingCancellationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexSamplingCancellationTest.java
@@ -48,7 +48,7 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.index_background_s
 import static org.neo4j.helpers.Settings.FALSE;
 import static org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode.TRIGGER_REBUILD_ALL;
 
-public class IndexSamplingIntegrationTest
+public class IndexSamplingCancellationTest
 {
     private final Barrier.Control samplingStarted = new Barrier.Control(), samplingDone = new Barrier.Control();
     private volatile Throwable samplingException;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/NonUniqueIndexSamplerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/sampling/NonUniqueIndexSamplerTest.java
@@ -51,11 +51,10 @@ public class NonUniqueIndexSamplerTest
         NonUniqueIndexSampler sampler = new NonUniqueIndexSampler( 10 );
 
         // when
-        sampler.include( value );
+        sampler.include( value, 2 );
 
         // then
-        assertSampledValues( sampler, 1, 1, 1 );
-
+        assertSampledValues( sampler, 2, 1, 2 );
     }
 
     @Test
@@ -65,12 +64,12 @@ public class NonUniqueIndexSamplerTest
         NonUniqueIndexSampler sampler = new NonUniqueIndexSampler( 10 );
 
         // when
-        sampler.include( value );
-        sampler.include( value );
-        sampler.include( "bbb" );
+        sampler.include( value, 5 );
+        sampler.include( value, 4 );
+        sampler.include( "bbb", 3 );
 
         // then
-        assertSampledValues( sampler, 3, 2, 3 );
+        assertSampledValues( sampler, 12, 2, 12 );
     }
 
     @Test
@@ -80,25 +79,42 @@ public class NonUniqueIndexSamplerTest
         NonUniqueIndexSampler sampler = new NonUniqueIndexSampler( 1 );
 
         // when
-        sampler.include( value );
-        sampler.include( value );
-        sampler.include( "bbb" );
+        sampler.include( value, 5 );
+        sampler.include( value, 4 );
+        sampler.include( "bbb", 3 );
 
         // then
-        assertSampledValues( sampler, 3, 1, 1 );
+        int expectedSampledSize = (/*  index size */ 12)  / (/* steps */ 3);
+        assertSampledValues( sampler, 12, 1, expectedSampledSize );
     }
 
     @Test
-    public void shouldExcludeValuesFromTheCurrentSampling()
+    public void shouldExcludeValuesFromTheCurrentSampling1()
     {
         // given
         NonUniqueIndexSampler sampler = new NonUniqueIndexSampler( 10 );
-        sampler.include( value );
-        sampler.include( value );
-        sampler.include( "bbb" );
+        sampler.include( value, 5  );
+        sampler.include( value, 4  );
+        sampler.include( "bbb", 3  );
 
         // when
-        sampler.exclude( value );
+        sampler.exclude( value, 3 );
+
+        // then
+        assertSampledValues( sampler, 9, 2, 9 );
+    }
+
+    @Test
+    public void shouldExcludeValuesFromTheCurrentSampling2()
+    {
+        // given
+        NonUniqueIndexSampler sampler = new NonUniqueIndexSampler( 10 );
+        sampler.include( value, 1  );
+        sampler.include( value, 4  );
+        sampler.include( "bbb", 1  );
+
+        // when
+        sampler.exclude( value, 4 );
 
         // then
         assertSampledValues( sampler, 2, 2, 2 );
@@ -111,8 +127,8 @@ public class NonUniqueIndexSamplerTest
         NonUniqueIndexSampler sampler = new NonUniqueIndexSampler( 10 );
 
         // when
-        sampler.exclude( value );
-        sampler.include( value );
+        sampler.exclude( value, 1 );
+        sampler.include( value, 1 );
 
         // then
         assertSampledValues( sampler, 1, 1, 1 );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReader.java
@@ -71,10 +71,12 @@ class LuceneIndexAccessorReader implements IndexReader
             while ( terms.next() )
             {
                 Term term = terms.term();
+
                 if ( !NODE_ID_KEY.equals( term.field() ))
                 {
                     String value = term.text();
-                    sampler.include( value );
+                    int frequency = terms.docFreq();
+                    sampler.include( value, frequency );
                 }
                 checkCancellation();
             }
@@ -86,7 +88,6 @@ class LuceneIndexAccessorReader implements IndexReader
 
         return sampler.result( result );
     }
-
 
     @Override
     public PrimitiveLongIterator lookup( Object value )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReaderTest.java
@@ -81,10 +81,10 @@ public class LuceneIndexAccessorReaderTest
     public void shouldProvideTheIndexUniqueValuesForAnIndexWithDuplicates() throws Exception
     {
         // Given
-        when( terms.next() ).thenReturn( true, true, true, false );
+        when( terms.next() ).thenReturn( true, true, false );
+        when( terms.docFreq() ).thenReturn( 1, 2 );
         when( terms.term() ).thenReturn(
                 new Term( "string", "aaa" ),
-                new Term( "string", "ccc" ),
                 new Term( "string", "ccc" )
         );
 
@@ -98,12 +98,12 @@ public class LuceneIndexAccessorReaderTest
         assertEquals( 3, output.readSecond() );
     }
 
-
     @Test
     public void shouldSkipTheNonNodeIdKeyEntriesWhenCalculatingIndexUniqueValues() throws Exception
     {
         // Given
         when( terms.next() ).thenReturn( true, true, false );
+        when( terms.docFreq() ).thenReturn( 1 );
         when( terms.term() ).thenReturn(
                 new Term( NODE_ID_KEY, "aaa" ), // <- this should be ignored
                 new Term( "string", "bbb" )
@@ -165,7 +165,7 @@ public class LuceneIndexAccessorReaderTest
 
         // Then
 
-        assertEquals( new HashSet<Class>( Arrays.asList( Array.class, String.class ) ), types );
+        assertEquals( new HashSet<>( Arrays.asList( Array.class, String.class ) ), types );
     }
 
     @Test
@@ -180,7 +180,7 @@ public class LuceneIndexAccessorReaderTest
         final Set<Class> types = accessor.valueTypesInIndex();
 
         // Then
-        assertEquals( new HashSet<Class>( Arrays.asList( Array.class, Number.class, String.class, Boolean.class ) ), types );
+        assertEquals( new HashSet<>( Arrays.asList( Array.class, Number.class, String.class, Boolean.class ) ), types );
     }
 
     @Test
@@ -194,7 +194,7 @@ public class LuceneIndexAccessorReaderTest
         try
         {
             accessor.valueTypesInIndex();
-            fail("Should have thrown");
+            fail( "Should have thrown" );
         }
         catch ( RuntimeException ex )
         {

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexSamplingIntegrationTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexSamplingIntegrationTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.counts.CountsTracker;
+import org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory;
+import org.neo4j.kernel.impl.store.counts.keys.IndexSampleKey;
+import org.neo4j.register.Register.DoubleLongRegister;
+import org.neo4j.register.Registers;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+
+public class IndexSamplingIntegrationTest
+{
+    @Rule
+    public final TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+
+    private final Label label = DynamicLabel.label( "Person" );
+    private final String property = "name";
+    private final int nodes = 1000;
+    private final String[] names = {"Neo4j", "Neo", "Graph", "Apa"};
+
+    @Test
+    public void shouldSampleNotUniqueIndex() throws Throwable
+    {
+        GraphDatabaseService db = null;
+        try
+        {
+            // Given
+            db = new TestGraphDatabaseFactory().newEmbeddedDatabase( testDirectory.graphDbDir().getAbsolutePath() );
+            IndexDefinition indexDefinition;
+            try ( Transaction tx = db.beginTx() )
+            {
+                indexDefinition = db.schema().indexFor( label ).on( property ).create();
+                tx.success();
+            }
+
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.schema().awaitIndexOnline( indexDefinition, 10, TimeUnit.SECONDS );
+                tx.success();
+            }
+
+            try ( Transaction tx = db.beginTx() )
+            {
+                for ( int i = 0; i < nodes; i++ )
+                {
+                    db.createNode( label ).setProperty( property, names[i % names.length] );
+                    tx.success();
+                }
+            }
+        }
+        finally
+        {
+            if ( db != null )
+            {
+                db.shutdown();
+            }
+        }
+
+        // When
+        triggerIndexResamplingOnNextStartup();
+
+        // Then
+        DoubleLongRegister register = fetchIndexSamplingValues( db );
+        assertEquals( names.length, register.readFirst() );
+        assertEquals( nodes, register.readSecond() );
+    }
+
+    @Test
+    public void shouldSampleUniqueIndex() throws Throwable
+    {
+        GraphDatabaseService db = null;
+        try
+        {
+            // Given
+            db = new TestGraphDatabaseFactory().newEmbeddedDatabase( testDirectory.graphDbDir().getAbsolutePath() );
+            try ( Transaction tx = db.beginTx() )
+            {
+                db.schema().constraintFor( label ).assertPropertyIsUnique( property ).create();
+                tx.success();
+            }
+
+            try ( Transaction tx = db.beginTx() )
+            {
+                for ( int i = 0; i < nodes; i++ )
+                {
+                    db.createNode( label ).setProperty( property, "" + i );
+                    tx.success();
+                }
+            }
+        }
+        finally
+        {
+            if ( db != null )
+            {
+                db.shutdown();
+            }
+        }
+
+        // When
+        triggerIndexResamplingOnNextStartup();
+
+        // Then
+        DoubleLongRegister register = fetchIndexSamplingValues( db );
+        assertEquals( nodes, register.readFirst() );
+        assertEquals( nodes, register.readSecond() );
+    }
+
+    private DoubleLongRegister fetchIndexSamplingValues( GraphDatabaseService db )
+    {
+        try
+        {
+            // Then
+            db = new TestGraphDatabaseFactory().newEmbeddedDatabase( testDirectory.graphDbDir().getAbsolutePath() );
+            @SuppressWarnings( "deprecation" )
+            GraphDatabaseAPI api = (GraphDatabaseAPI) db;
+            CountsTracker countsTracker = api.getDependencyResolver().resolveDependency( NeoStore.class ).getCounts();
+            IndexSampleKey key = CountsKeyFactory.indexSampleKey( 0, 0 ); // cheating a bit...
+            return countsTracker.get( key, Registers.newDoubleLongRegister() );
+        }
+        finally
+        {
+            if ( db != null )
+            {
+                db.shutdown();
+            }
+        }
+    }
+
+    private void triggerIndexResamplingOnNextStartup()
+    {
+        // Trigger index resampling on next at startup
+        String baseName = NeoStore.DEFAULT_NAME + StoreFactory.COUNTS_STORE;
+        FileUtils.deleteFile( new File( testDirectory.graphDbDir(), baseName + CountsTracker.LEFT ) );
+        FileUtils.deleteFile( new File( testDirectory.graphDbDir(), baseName + CountsTracker.RIGHT ) );
+    }
+}


### PR DESCRIPTION
Sampling of non-unique indexes was incorrect since the code was
expecting to see multiple terms with the same values in the lucene
store.  This is actually incorrect since we don't duplicate value
entries in lucene, but we simply use them to index the node ids.

This commit will fix the sampling by looking at the frequency of the
terms containing the values.  Such frequency will tell us how many ids
are indexed by the same value.
