### PR TITLE
Make sub-process tests use correct java executable

### DIFF
--- a/community/function/src/main/java/org/neo4j/function/Predicate.java
+++ b/community/function/src/main/java/org/neo4j/function/Predicate.java
@@ -24,7 +24,7 @@ package org.neo4j.function;
  *
  * @param <T> the type of the input to the predicate
  */
-public interface Predicate<T> extends ThrowingPredicate<T,RuntimeException>
+public interface Predicate<T> extends ThrowingPredicate<T,RuntimeException>, java.util.function.Predicate<T>
 {
     /**
      * Evaluates this predicate on the given argument.

--- a/community/io/src/main/java/org/neo4j/io/proc/ProcessUtil.java
+++ b/community/io/src/main/java/org/neo4j/io/proc/ProcessUtil.java
@@ -27,25 +27,54 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Utility methods for accessing information about the current Java process.
+ */
 public class ProcessUtil
 {
+    /**
+     * Get the path to the {@code java} executable that is running this Java program.
+     * <p>
+     * This is useful for starting other Java programs using the same exact version of Java.
+     * <p>
+     * This value is computed from the {@code java.home} system property.
+     *
+     * @return The path to the {@code java} executable that launched this Java process.
+     */
     public static Path getJavaExecutable()
     {
         String javaHome = System.getProperty( "java.home" );
         return Paths.get( javaHome, "bin", "java" );
     }
 
+    /**
+     * Get the list of command line arguments that were passed to the Java runtime, as opposed to the Java program.
+     *
+     * @see RuntimeMXBean#getInputArguments()
+     * @return The list of arguments, as Strings, that were given to the Java runtime.
+     */
     public static List<String> getJavaExecutableArguments()
     {
         RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
         return runtimeMxBean.getInputArguments();
     }
 
+    /**
+     * Get the current classpath as a list of file names.
+     * @return The list of file names that makes the classpath.
+     */
     public static List<String> getClassPathList()
     {
         return Arrays.asList( getClassPath().split( File.pathSeparator ) );
     }
 
+    /**
+     * Get the classpath as a single string of all the classpath file entries, separated by the path separator.
+     *
+     * This is based on the {@code java.class.path} system property.
+     * @see File#pathSeparator
+     * @return The current classpath.
+     */
     public static String getClassPath()
     {
         return System.getProperty( "java.class.path" );

--- a/community/io/src/main/java/org/neo4j/io/proc/ProcessUtil.java
+++ b/community/io/src/main/java/org/neo4j/io/proc/ProcessUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.proc;
+
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+public class ProcessUtil
+{
+    public static Path getJavaExecutable()
+    {
+        String javaHome = System.getProperty( "java.home" );
+        return Paths.get( javaHome, "bin", "java" );
+    }
+
+    public static List<String> getJavaExecutableArguments()
+    {
+        RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+        return runtimeMxBean.getInputArguments();
+    }
+
+    public static List<String> getClassPathList()
+    {
+        return Arrays.asList( getClassPath().split( File.pathSeparator ) );
+    }
+
+    public static String getClassPath()
+    {
+        return System.getProperty( "java.class.path" );
+    }
+}

--- a/community/io/src/test/java/org/neo4j/io/proc/ProcessUtilTest.java
+++ b/community/io/src/test/java/org/neo4j/io/proc/ProcessUtilTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.proc;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ProcessUtilTest
+{
+    private static final String HELLO_WORLD = "Hello World";
+
+    public static void main( String[] args )
+    {
+        System.out.println( HELLO_WORLD );
+    }
+
+    @Test
+    public void mustFindWorkingJavaExecutableAndClassPath() throws Exception
+    {
+        List<String> command = new ArrayList<>();
+        command.add( ProcessUtil.getJavaExecutable().toString() );
+        command.add( "-cp" );
+        command.add( ProcessUtil.getClassPath() );
+        command.add( getClass().getName() );
+
+        ProcessBuilder builder = new ProcessBuilder( command );
+        Process process = builder.start();
+
+        BufferedReader in = new BufferedReader( new InputStreamReader( process.getInputStream() ) );
+        String line = in.readLine();
+
+        assertThat( process.waitFor(), is( 0 ) );
+        assertThat( line, equalTo( HELLO_WORLD ) );
+    }
+}

--- a/community/io/src/test/java/org/neo4j/test/bootclasspathrunner/BootClassPathRunner.java
+++ b/community/io/src/test/java/org/neo4j/test/bootclasspathrunner/BootClassPathRunner.java
@@ -30,16 +30,15 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
 import java.net.URL;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.neo4j.io.proc.ProcessUtil;
 
 public class BootClassPathRunner extends Runner
 {
@@ -88,12 +87,10 @@ public class BootClassPathRunner extends Runner
         {
             int port = server.getPort();
             server.export( RMI_RUN_NOTIFIER_NAME, new DelegatingRemoteRunNotifier( notifier ) );
-            RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
-            List<String> arguments = runtimeMxBean.getInputArguments();
 
             List<String> command = new ArrayList<>();
-            command.add( "java" );
-            for ( String argument : arguments )
+            command.add( ProcessUtil.getJavaExecutable().toString() );
+            for ( String argument : ProcessUtil.getJavaExecutableArguments() )
             {
                 if ( !argument.startsWith( "-agentlib" ) )
                 {
@@ -123,7 +120,7 @@ public class BootClassPathRunner extends Runner
     private StringBuilder buildClassPath()
     {
         Set<String> classpathEntries = new HashSet<>();
-        classpathEntries.addAll( Arrays.asList( System.getProperty( "java.class.path" ).split( File.pathSeparator ) ) );
+        classpathEntries.addAll( ProcessUtil.getClassPathList() );
         classpathEntries.remove( classpathEntryToBootWith );
         StringBuilder classpath = new StringBuilder();
         for ( String classpathEntry : classpathEntries )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.fail;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
-import static org.neo4j.test.ProcessUtil.executeSubProcess;
+import static org.neo4j.test.ProcessTestUtil.executeSubProcess;
 
 public class IdGeneratorImplTest
 {

--- a/community/kernel/src/test/java/org/neo4j/test/ProcessTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ProcessTestUtil.java
@@ -31,8 +31,10 @@ import java.util.concurrent.TimeoutException;
 import org.neo4j.helpers.FutureAdapter;
 
 import static java.util.Arrays.asList;
+import static org.neo4j.io.proc.ProcessUtil.getClassPath;
+import static org.neo4j.io.proc.ProcessUtil.getJavaExecutable;
 
-public class ProcessUtil
+public class ProcessTestUtil
 {
     public static void executeSubProcess( Class<?> mainClass, long timeout, TimeUnit unit,
             String... arguments ) throws Exception
@@ -50,7 +52,7 @@ public class ProcessUtil
     public static Future<Integer> startSubProcess( Class<?> mainClass, String... arguments ) throws IOException
     {
         List<String> args = new ArrayList<>();
-        args.addAll( asList( "java", "-cp", System.getProperty( "java.class.path" ), mainClass.getName() ) );
+        args.addAll( asList( getJavaExecutable().toString(), "-cp", getClassPath(), mainClass.getName() ) );
         args.addAll( asList( arguments ) );
         Process process = Runtime.getRuntime().exec( args.toArray( new String[args.size()] ) );
         final ProcessStreamHandler processOutput = new ProcessStreamHandler( process, false );


### PR DESCRIPTION
When you are running the tests with one version of Java, but your default JDK is an older version, those tests would start their sub-processes with the wrong version of Java, and fail.
The logic of choosing the correct version of Java to run sub-processes is now fixed, and collected in the new org.neo4j.io.proc.ProcessUtil.
