### PR TITLE
Deprecate all org.neo4j.function interfaces that have replacements in Java8

### DIFF
--- a/community/function/src/main/java/org/neo4j/function/BiConsumer.java
+++ b/community/function/src/main/java/org/neo4j/function/BiConsumer.java
@@ -24,6 +24,7 @@ package org.neo4j.function;
  * Unlike most other functional interfaces, BiConsumer is expected to operate via side-effects.
  *
  * @param <T> the type of the input to the operation
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface BiConsumer<T, U> extends ThrowingBiConsumer<T,U,RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/BiConsumers.java
+++ b/community/function/src/main/java/org/neo4j/function/BiConsumers.java
@@ -21,6 +21,7 @@ package org.neo4j.function;
 
 /**
  * Constructors for basic {@link BiConsumer} types
+ * @deprecated This class relies on deprecated interfaces, and will be retrofitted to work with the {@code java.util.function} interfaces in 3.0.
  */
 public final class BiConsumers
 {

--- a/community/function/src/main/java/org/neo4j/function/BiFunction.java
+++ b/community/function/src/main/java/org/neo4j/function/BiFunction.java
@@ -25,6 +25,7 @@ package org.neo4j.function;
  * @param <T> the type of the first argument to the function
  * @param <U> the type of the second argument to the function
  * @param <R> the type of the result of the function
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface BiFunction<T, U, R> extends ThrowingBiFunction<T,U,R,RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/BinaryOperator.java
+++ b/community/function/src/main/java/org/neo4j/function/BinaryOperator.java
@@ -24,6 +24,7 @@ package org.neo4j.function;
  * case where the operand and result are of the same type.
  *
  * @param <T> the type of the operand and result of the operator
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface BinaryOperator<T> extends BiFunction<T,T,T>, ThrowingBinaryOperator<T,RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/BooleanSupplier.java
+++ b/community/function/src/main/java/org/neo4j/function/BooleanSupplier.java
@@ -22,6 +22,7 @@ package org.neo4j.function;
 /**
  * Represents a supplier of boolean-valued results. This is the boolean-producing primitive specialization of {@link Supplier}.
  * There is no requirement that a new or distinct result be returned each time the supplier is invoked.
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface BooleanSupplier
 {

--- a/community/function/src/main/java/org/neo4j/function/Consumer.java
+++ b/community/function/src/main/java/org/neo4j/function/Consumer.java
@@ -24,6 +24,7 @@ package org.neo4j.function;
  * via side-effects.
  *
  * @param <T> the type of the input to the operation
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface Consumer<T> extends ThrowingConsumer<T,RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/Consumers.java
+++ b/community/function/src/main/java/org/neo4j/function/Consumers.java
@@ -21,6 +21,7 @@ package org.neo4j.function;
 
 /**
  * Constructors for basic {@link Consumer} types
+ * @deprecated This class relies on deprecated interfaces, and will be retrofitted to work with the {@code java.util.function} interfaces in 3.0.
  */
 public final class Consumers
 {

--- a/community/function/src/main/java/org/neo4j/function/Function.java
+++ b/community/function/src/main/java/org/neo4j/function/Function.java
@@ -24,6 +24,7 @@ package org.neo4j.function;
  *
  * @param <T> the type of the input to the function
  * @param <R> the type of the result of the function
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface Function<T, R> extends ThrowingFunction<T,R,RuntimeException>, RawFunction<T,R,RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/Functions.java
+++ b/community/function/src/main/java/org/neo4j/function/Functions.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 /**
  * Constructors for basic {@link Function} and {@link BiFunction} types
+ * @deprecated This class relies on deprecated interfaces, and will be retrofitted to work with the {@code java.util.function} interfaces in 3.0.
  */
 public final class Functions
 {

--- a/community/function/src/main/java/org/neo4j/function/IntFunction.java
+++ b/community/function/src/main/java/org/neo4j/function/IntFunction.java
@@ -23,6 +23,7 @@ package org.neo4j.function;
  * Represents a function that accepts an int-valued argument and produces a result. This is the int-consuming primitive specialization for {@link Function}.
  *
  * @param <R> the type of the result of the function
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface IntFunction<R> extends ThrowingIntFunction<R,RuntimeException>, org.neo4j.function.primitive.FunctionFromPrimitiveInt<R>
 {

--- a/community/function/src/main/java/org/neo4j/function/IntPredicate.java
+++ b/community/function/src/main/java/org/neo4j/function/IntPredicate.java
@@ -21,6 +21,7 @@ package org.neo4j.function;
 
 /**
  * Represents a predicate (boolean-valued function) of one int-valued argument. This is the int-consuming primitive type specialization of {@link Predicate}.
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface IntPredicate extends ThrowingIntPredicate<RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/IntPredicates.java
+++ b/community/function/src/main/java/org/neo4j/function/IntPredicates.java
@@ -21,6 +21,7 @@ package org.neo4j.function;
 
 /**
  * Constructors for basic {@link IntPredicate} types
+ * @deprecated This class relies on deprecated interfaces, and will be retrofitted to work with the {@code java.util.function} interfaces in 3.0.
  */
 public final class IntPredicates
 {

--- a/community/function/src/main/java/org/neo4j/function/IntSupplier.java
+++ b/community/function/src/main/java/org/neo4j/function/IntSupplier.java
@@ -21,6 +21,7 @@ package org.neo4j.function;
 
 /**
  * Represents a supplier of int-valued results. This is the int-producing primitive specialization of {@link Supplier}.
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface IntSupplier extends ThrowingIntSupplier<RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/LongBinaryOperator.java
+++ b/community/function/src/main/java/org/neo4j/function/LongBinaryOperator.java
@@ -22,6 +22,7 @@ package org.neo4j.function;
 /**
  * Represents an operation upon two long-valued operands and producing a long-valued result. This is the primitive type specialization of {@link BinaryOperator}
  * for long.
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface LongBinaryOperator extends ThrowingLongBinaryOperator<RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/LongFunction.java
+++ b/community/function/src/main/java/org/neo4j/function/LongFunction.java
@@ -23,6 +23,7 @@ package org.neo4j.function;
  * Represents a function that accepts a long-valued argument and produces a result. This is the long-consuming primitive specialization for {@link Function}.
  *
  * @param <R> the type of the result of the function
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface LongFunction<R> extends ThrowingLongFunction<R,RuntimeException>, org.neo4j.function.primitive.FunctionFromPrimitiveLong<R>
 {

--- a/community/function/src/main/java/org/neo4j/function/LongPredicate.java
+++ b/community/function/src/main/java/org/neo4j/function/LongPredicate.java
@@ -21,6 +21,7 @@ package org.neo4j.function;
 
 /**
  * Represents a predicate (boolean-valued function) of one long-valued argument. This is the long-consuming primitive type specialization of {@link Predicate}.
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface LongPredicate extends ThrowingLongPredicate<RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/LongSupplier.java
+++ b/community/function/src/main/java/org/neo4j/function/LongSupplier.java
@@ -21,6 +21,7 @@ package org.neo4j.function;
 
 /**
  * Represents a supplier of long-valued results. This is the long-producing primitive specialization of {@link Supplier}.
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface LongSupplier extends ThrowingLongSupplier<RuntimeException>, org.neo4j.function.primitive.LongSupplier
 {

--- a/community/function/src/main/java/org/neo4j/function/LongUnaryOperator.java
+++ b/community/function/src/main/java/org/neo4j/function/LongUnaryOperator.java
@@ -22,6 +22,7 @@ package org.neo4j.function;
 /**
  * Represents an operation on a single long-valued operand that produces a long-valued result. This is the primitive type specialization of {@link
  * UnaryOperator} for long.
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface LongUnaryOperator extends ThrowingLongUnaryOperator<RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/Predicate.java
+++ b/community/function/src/main/java/org/neo4j/function/Predicate.java
@@ -23,6 +23,7 @@ package org.neo4j.function;
  * Represents a predicate (boolean-valued function) of one argument.
  *
  * @param <T> the type of the input to the predicate
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface Predicate<T> extends ThrowingPredicate<T,RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/Predicates.java
+++ b/community/function/src/main/java/org/neo4j/function/Predicates.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * Constructors for basic {@link Predicate} types
+ * @deprecated This class relies on deprecated interfaces, and will be retrofitted to work with the {@code java.util.function} interfaces in 3.0.
  */
 public class Predicates
 {

--- a/community/function/src/main/java/org/neo4j/function/Supplier.java
+++ b/community/function/src/main/java/org/neo4j/function/Supplier.java
@@ -23,6 +23,7 @@ package org.neo4j.function;
  * Represents a supplier of results.
  *
  * @param <T> the type of results supplied by this supplier
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface Supplier<T> extends ThrowingSupplier<T,RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/ToIntFunction.java
+++ b/community/function/src/main/java/org/neo4j/function/ToIntFunction.java
@@ -23,6 +23,7 @@ package org.neo4j.function;
  * Represents a function that accepts one argument and produces an int.
  *
  * @param <T> the type of the argument of the function
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface ToIntFunction<T>
 {

--- a/community/function/src/main/java/org/neo4j/function/ToLongFunction.java
+++ b/community/function/src/main/java/org/neo4j/function/ToLongFunction.java
@@ -23,6 +23,7 @@ package org.neo4j.function;
  * Represents a function that produces a long-valued result. This is the long-producing primitive specialization for {@link Function}.
  *
  * @param <T> the type of the input to the function
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface ToLongFunction<T> extends ThrowingToLongFunction<T,RuntimeException>
 {

--- a/community/function/src/main/java/org/neo4j/function/UnaryOperator.java
+++ b/community/function/src/main/java/org/neo4j/function/UnaryOperator.java
@@ -24,6 +24,7 @@ package org.neo4j.function;
  * where the operand and result are of the same type.
  *
  * @param <T> the type of the operand and result of the operator
+ * @deprecated Usages will be replaced by corresponding {@code java.util.function} interface and classes in 3.0.
  */
 public interface UnaryOperator<T> extends Function<T,T>, ThrowingUnaryOperator<T,RuntimeException>
 {


### PR DESCRIPTION
In Neo4j 3.0, we'll move to use the Java8 interfaces instead.
