### PR TITLE
Upgrade clirr plugin to version 1.0.1 (support for java 8 added)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <plugin>
           <groupId>org.neo4j.build.plugins</groupId>
           <artifactId>clirr-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>1.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Previous version of clirr plugin was not able to coupe with java 8 code.
This version of plugin provide this possibility
