### PR TITLE
Deprecate metrics reporting into a single csv file

### DIFF
--- a/advanced/management/pom.xml
+++ b/advanced/management/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-management</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Graph DB Monitoring and Management tools</name>
   <description>Management support using JMX.</description>

--- a/advanced/neo4j-advanced/pom.xml
+++ b/advanced/neo4j-advanced/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-advanced</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Advanced</name>
   <packaging>jar</packaging>

--- a/advanced/pom.xml
+++ b/advanced/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.build</groupId>
   <artifactId>advanced-build</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Advanced Build</name>
   <packaging>pom</packaging>

--- a/advanced/server-advanced/pom.xml
+++ b/advanced/server-advanced/pom.xml
@@ -23,14 +23,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.app</groupId>
   <artifactId>neo4j-server-advanced</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Advanced Server</name>
   <description>Standalone Neo4j server application.</description>

--- a/community/browser/pom.xml
+++ b/community/browser/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j.app</groupId>
   <artifactId>neo4j-browser</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Browser</name>
   <description>Graph database client.</description>
 

--- a/community/codegen/pom.xml
+++ b/community/codegen/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -16,7 +16,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-codegen</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Code Generator</name>

--- a/community/consistency-check-legacy/pom.xml
+++ b/community/consistency-check-legacy/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-consistency-check-legacy</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Legacy Consistency Checker</name>
   <description>Legacy tool for checking consistency of a Neo4j data store.</description>

--- a/community/consistency-check/pom.xml
+++ b/community/consistency-check/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-consistency-check</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Consistency Checker</name>
   <description>Tool for checking consistency of a Neo4j data store.</description>

--- a/community/csv/pom.xml
+++ b/community/csv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -16,7 +16,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-csv</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - CSV reading and parsing</name>

--- a/community/cypher/acceptance/pom.xml
+++ b/community/cypher/acceptance/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>cypher-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-cypher-acceptance</artifactId>
   <packaging>jar</packaging>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Cypher Acceptance</name>
   <description>Neo4j query language acceptance tests</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/compatibility-suite/pom.xml
+++ b/community/cypher/compatibility-suite/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>cypher-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-cypher-compatibility-suite</artifactId>
   <packaging>jar</packaging>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Cypher Compatibility Suite</name>
   <description>Neo4j query language compatibility suite</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/cypher-compiler-2.3/pom.xml
+++ b/community/cypher/cypher-compiler-2.3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>cypher-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -11,7 +11,7 @@
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-cypher-compiler-2.3</artifactId>
   <packaging>jar</packaging>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Cypher Compiler 2.3</name>
   <description>Compiler for Cypher 2.3</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>cypher-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-cypher</artifactId>
   <packaging>jar</packaging>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Cypher</name>
   <description>Neo4j query language</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/frontend-2.3/pom.xml
+++ b/community/cypher/frontend-2.3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>cypher-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -11,7 +11,7 @@
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-cypher-frontend-2.3</artifactId>
   <packaging>jar</packaging>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Cypher Frontend 2.3</name>
   <description>Front end of the Cypher compiler</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>cypher-parent</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Neo4j - Community Cypher Build</name>
   <description>Project that builds the Neo4j Cypher modules as part of the Community distribution.</description>

--- a/community/embedded-examples/pom.xml
+++ b/community/embedded-examples/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j.examples</groupId>
   <artifactId>neo4j-examples</artifactId>
   <name>Neo4j - Examples</name>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <description>Neo4j Embedded Examples</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}/</url>

--- a/community/function/pom.xml
+++ b/community/function/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -16,7 +16,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-function</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Functions</name>

--- a/community/graph-algo/pom.xml
+++ b/community/graph-algo/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-graph-algo</artifactId>
   <groupId>org.neo4j</groupId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Graph Algorithms</name>

--- a/community/graph-matching/pom.xml
+++ b/community/graph-matching/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-graph-matching</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Graph Matching</name>
   <description>A graph pattern matcher for Neo4j.</description>

--- a/community/graphviz/pom.xml
+++ b/community/graphviz/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-graphviz</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Graphviz generation</name>
   <description>Utility component to generate Graphviz .dot notation from Neo4j graphs.</description>

--- a/community/import-tool/pom.xml
+++ b/community/import-tool/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -17,7 +17,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-import-tool</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Import Command Line Tool</name>

--- a/community/io/pom.xml
+++ b/community/io/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -16,7 +16,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-io</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - IO</name>

--- a/community/jmx/pom.xml
+++ b/community/jmx/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-jmx</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - JMX support</name>
   <description>Management support using JMX.</description>

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-kernel</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Graph Database Kernel</name>
   <description>

--- a/community/licensecheck-config/pom.xml
+++ b/community/licensecheck-config/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j.build</groupId>
   <artifactId>licensecheck-config</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Licensing configuration</name>
   <description>Licensing configuration for the Neo4j project.</description>

--- a/community/logging/pom.xml
+++ b/community/logging/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -16,7 +16,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-logging</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Logging</name>

--- a/community/lucene-index/pom.xml
+++ b/community/lucene-index/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-lucene-index</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Lucene Index</name>
   <description>

--- a/community/monitor-logging/pom.xml
+++ b/community/monitor-logging/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-monitor-logging</artifactId>
   <name>Neo4j - Monitor Logging</name>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <description>Logs information collected from a set of monitors.</description>
 

--- a/community/neo4j-community/pom.xml
+++ b/community/neo4j-community/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-community</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Community</name>
   <packaging>pom</packaging>

--- a/community/neo4j-harness/pom.xml
+++ b/community/neo4j-harness/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/community/neo4j-slf4j/pom.xml
+++ b/community/neo4j-slf4j/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -16,7 +16,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-slf4j</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>SLF4J Neo4j Binding</name>

--- a/community/neo4j/pom.xml
+++ b/community/neo4j/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Community</name>
   <packaging>jar</packaging>

--- a/community/pom.xml
+++ b/community/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.build</groupId>
   <artifactId>community-build</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Community Build</name>
   <packaging>pom</packaging>

--- a/community/primitive-collections/pom.xml
+++ b/community/primitive-collections/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -16,7 +16,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-primitive-collections</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Primitive Collections</name>

--- a/community/server-api/pom.xml
+++ b/community/server-api/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>server-api</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Server API</name>

--- a/community/server-examples/pom.xml
+++ b/community/server-examples/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j.examples</groupId>
   <artifactId>neo4j-server-examples</artifactId>
   <name>Neo4j - Server Examples</name>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <description>Neo4j Server Plugin Examples</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}/</url>

--- a/community/server-plugin-test/pom.xml
+++ b/community/server-plugin-test/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>server-plugin-test</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Server Plugin Tests</name>
   <description>Tests the server plugin registration functionality.</description>

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -23,14 +23,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.app</groupId>
   <artifactId>neo4j-server</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Server</name>
   <description>Standalone Neo4j server application.</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/shell/pom.xml
+++ b/community/shell/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-shell</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Generic shell</name>
   <description>

--- a/community/udc/pom.xml
+++ b/community/udc/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-udc</artifactId>
   <name>Neo4j - Usage Data Collection</name>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <description>Collects simple statistics about server deployment.</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/community/unsafe/pom.xml
+++ b/community/unsafe/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -16,7 +16,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>neo4j-unsafe</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
   <name>Neo4j - Unsafe Access</name>

--- a/enterprise/backup/pom.xml
+++ b/enterprise/backup/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-backup</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Backup Tool</name>
   <description>Command line tool for grabbing backups from a running Neo4j instance</description>

--- a/enterprise/cluster/pom.xml
+++ b/enterprise/cluster/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-cluster</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Clustering Infrastructure</name>
   <description>Library implementing Paxos and Heartbeat components required for High Availability Neo4j</description>

--- a/enterprise/com/pom.xml
+++ b/enterprise/com/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-com</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Communication Package</name>
   <packaging>jar</packaging>

--- a/enterprise/enterprise-performance-tests/pom.xml
+++ b/enterprise/enterprise-performance-tests/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-enterprise-performance-tests</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Enterprise Performance Tests</name>
   <description>Performance tests for modules in the Enterprise distribution of Neo4j.</description>

--- a/enterprise/ha/pom.xml
+++ b/enterprise/ha/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-ha</artifactId>
   <name>Neo4j - High Availability</name>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <description>This component provides the means to set up a cluster of Neo4j instances that act together
     as a cluster, providing Master-Slave replication and other features.

--- a/enterprise/kernel/pom.xml
+++ b/enterprise/kernel/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-enterprise-kernel</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Enterprise Graph Database Kernel Features</name>
   <description>Enterprise features for Neo4j</description>

--- a/enterprise/metrics/pom.xml
+++ b/enterprise/metrics/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-metrics</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Metrics Kernel Extension</name>
   <packaging>jar</packaging>

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -26,6 +26,7 @@ import org.neo4j.graphdb.factory.Description;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Obsoleted;
 
 import static org.neo4j.helpers.Settings.basePath;
 import static org.neo4j.helpers.Settings.setting;
@@ -101,6 +102,8 @@ public class MetricsSettings
                   "will be intepreted relative to the configured Neo4j store directory." )
     public static Setting<File> csvPath = setting(
             "metrics.csv.path", Settings.PATH, "metrics.csv" , basePath( GraphDatabaseSettings.store_dir ) );
+    @Deprecated
+    @Obsoleted( "This setting will be removed in the next major release." )
     @Description( "Write to a single CSV file or to multiple files. " +
                   "Set to `single` (the default) for reporting the metrics in a single CSV file (given by " +
                   "metrics.csv.path), with a column per metrics field. Or set to `split` to produce a CSV file for " +

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/CsvReporterSingle.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/CsvReporterSingle.java
@@ -48,7 +48,11 @@ import static java.lang.String.format;
  * Version of CSV reporter that logs all metrics into a single file.
  * Restriction is that all metrics must be set up before starting it,
  * as it cannot handle changing sets of metrics at runtime.
+ *
+ * @deprecated please use {@code com.codahale.metrics.CsvReporter} instead. This reporter is incompatible with the
+ * event based reporting that will be introduced in the next major release, hence it will be removed.
  */
+@Deprecated
 public class CsvReporterSingle extends ScheduledReporter
 {
     // CSV separator

--- a/enterprise/neo4j-enterprise/pom.xml
+++ b/enterprise/neo4j-enterprise/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>neo4j-enterprise</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Enterprise</name>
   <packaging>jar</packaging>

--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.build</groupId>
   <artifactId>enterprise-build</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Enterprise Build</name>
   <packaging>pom</packaging>

--- a/enterprise/query-logging/pom.xml
+++ b/enterprise/query-logging/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-query-logging</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Query Logging</name>
   <description>Extension for logging queries to a separate query log file</description>

--- a/enterprise/server-enterprise/pom.xml
+++ b/enterprise/server-enterprise/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.app</groupId>
   <artifactId>neo4j-server-enterprise</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Enterprise Server</name>
   <description>Standalone Neo4j server application.</description>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>neo4j-integrationtests</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Integration Tests</name>
   <packaging>jar</packaging>

--- a/manual/contents/pom.xml
+++ b/manual/contents/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-manual-contents</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Reference Manual Contents</name>
   <description>Neo4j Reference Manual Contents.</description>

--- a/manual/cypher/cypher-docs/pom.xml
+++ b/manual/cypher/cypher-docs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-cypher-docs-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -11,7 +11,7 @@
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-cypher-docs</artifactId>
   <packaging>jar</packaging>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Cypher Documentation</name>
   <description>Neo4j query language documentation</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/manual/cypher/graphgist/pom.xml
+++ b/manual/cypher/graphgist/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-cypher-docs-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-graphgist</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - GraphGist</name>
   <description>Cypher tutorial documentation tool.</description>
 

--- a/manual/cypher/pom.xml
+++ b/manual/cypher/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>cypher-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../../community/cypher/</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-cypher-docs-parent</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Cypher Documentation Build</name>
   <description>Neo4j - Cypher Documentation Build</description>
   <packaging>pom</packaging>

--- a/manual/cypher/refcard-tests/pom.xml
+++ b/manual/cypher/refcard-tests/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-cypher-docs-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-cypher-refcard-tests</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Cypher Reference Card Tests</name>
   <description>Test for Reference Card for the Neo4j Cypher Query Language.</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/manual/javadocs/pom.xml
+++ b/manual/javadocs/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-javadocs</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Javadocs</name>
   <packaging>pom</packaging>

--- a/manual/manual/pom.xml
+++ b/manual/manual/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-manual</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Reference Manual</name>
   <description>Neo4j Reference Manual.</description>

--- a/manual/neo4j-harness-test/pom.xml
+++ b/manual/neo4j-harness-test/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.neo4j.test</groupId>
   <artifactId>neo4j-harness-test</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
 

--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-manual-parent</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Reference Manual Build</name>
   <description>Neo4j Reference Manual Build.</description>

--- a/manual/refcard/pom.xml
+++ b/manual/refcard/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.neo4j.doc</groupId>
   <artifactId>neo4j-cypher-refcard</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <name>Neo4j - Cypher Reference Card</name>
   <description>Reference Card for the Neo4j Cypher Query Language.</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>

--- a/packaging/installer-linux/installer-debian/pom.xml
+++ b/packaging/installer-linux/installer-debian/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../../..</relativePath>
   </parent>
 
   <groupId>org.neo4j</groupId>
   <artifactId>neo4j-installer-debian</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 

--- a/packaging/installer-linux/installer-rpm/installer-rpm-advanced/pom.xml
+++ b/packaging/installer-linux/installer-rpm/installer-rpm-advanced/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-installer-rpm</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>neo4j-advanced-rpm</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
 

--- a/packaging/installer-linux/installer-rpm/installer-rpm-community/pom.xml
+++ b/packaging/installer-linux/installer-rpm/installer-rpm-community/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-installer-rpm</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>neo4j-community-rpm</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
 

--- a/packaging/installer-linux/installer-rpm/installer-rpm-enterprise/pom.xml
+++ b/packaging/installer-linux/installer-rpm/installer-rpm-enterprise/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.neo4j</groupId>
         <artifactId>neo4j-installer-rpm</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
     <artifactId>neo4j-enterprise-rpm</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
 

--- a/packaging/installer-linux/installer-rpm/pom.xml
+++ b/packaging/installer-linux/installer-rpm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j</groupId>
         <artifactId>parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
     <properties>
@@ -14,7 +14,7 @@
     </properties>
 
     <artifactId>neo4j-installer-rpm</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Neo4j RPM Installers</name>

--- a/packaging/installer-linux/pom.xml
+++ b/packaging/installer-linux/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.neo4j</groupId>
         <artifactId>parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <groupId>org.neo4j</groupId>
     <artifactId>neo4j-installer-linux</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Neo4j Linux Installers</name>

--- a/packaging/neo4j-desktop/pom.xml
+++ b/packaging/neo4j-desktop/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.neo4j.assembly</groupId>
     <artifactId>neo4j-standalone</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../standalone</relativePath>
   </parent>
 
@@ -13,7 +13,7 @@
 
   <groupId>org.neo4j.build</groupId>
   <artifactId>neo4j-desktop</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j Desktop</name>
   <description>Easy-to-use Neo4j database in an .exe</description>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.build</groupId>
   <artifactId>packaging-build</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j Packaging Build</name>
   <packaging>pom</packaging>

--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
@@ -14,7 +14,7 @@
 
   <name>Neo4j - Server Assembler</name>
 
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <description>This project assembles the Neo4j stand-alone distribution,
     pulling together all the deliverable artifacts and packaging them

--- a/packaging/standalone/standalone-advanced/pom.xml
+++ b/packaging/standalone/standalone-advanced/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.neo4j.assembly</groupId>
     <artifactId>neo4j-standalone</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -14,7 +14,7 @@
 
   <name>Neo4j Advanced - Server Assembler</name>
 
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <description>This project assembles the Neo4j Advanced stand-alone distribution,
     pulling together all the deliverable artifacts and packaging them

--- a/packaging/standalone/standalone-community/pom.xml
+++ b/packaging/standalone/standalone-community/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.neo4j.assembly</groupId>
     <artifactId>neo4j-standalone</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -13,7 +13,7 @@
 
   <name>Neo4j Community - Server Assembler</name>
 
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <description>This project assembles the Neo4j Community stand-alone distribution,
     pulling together all the deliverable artifacts and packaging them

--- a/packaging/standalone/standalone-enterprise/pom.xml
+++ b/packaging/standalone/standalone-enterprise/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.neo4j.assembly</groupId>
     <artifactId>neo4j-standalone</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -14,7 +14,7 @@
 
   <name>Neo4j Enterprise - Server Assembler</name>
 
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <description>This project assembles the Neo4j Enterprise stand-alone distribution,
     pulling together all the deliverable artifacts and packaging them

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.neo4j</groupId>
   <artifactId>parent</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Neo4j</name>
   <description>Neo4j Graph Database</description>

--- a/stresstests/pom.xml
+++ b/stresstests/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>neo4j-stresstests</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Stress Tests</name>
   <packaging>jar</packaging>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -7,12 +7,12 @@
   <parent>
     <groupId>org.neo4j</groupId>
     <artifactId>parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>neo4j-tools</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
 
   <name>Neo4j - Low Level Tools</name>
   <packaging>jar</packaging>


### PR DESCRIPTION
Since the next major release will support event based reporting of
metrics, writing all the metrics into a single file is not feasible
anymore.  Indeed the metrics reported at different times cannot be
correlated to each others anylonger, hence having all of the
aggregated in the same file could be confusing.

In the future the only supported csv reporter will report each metric
in its own csv file.
