### PR TITLE
Added Master/Available cluster metrics

### DIFF
--- a/enterprise/metrics/pom.xml
+++ b/enterprise/metrics/pom.xml
@@ -100,7 +100,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-kernel</artifactId>
+      <artifactId>neo4j-ha</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
@@ -135,6 +135,11 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsExtension.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsExtension.java
@@ -22,9 +22,11 @@ package org.neo4j.metrics;
 import com.codahale.metrics.MetricRegistry;
 
 import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.io.pagecache.monitoring.PageCacheMonitor;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.cluster.member.ClusterMembers;
 import org.neo4j.kernel.impl.api.LogRotationMonitor;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.transaction.TransactionCounters;
@@ -49,7 +51,7 @@ public class MetricsExtension implements Lifecycle
     private final CheckPointerMonitor checkPointerMonitor;
     private final IdGeneratorFactory idGeneratorFactory;
     private final LogRotationMonitor logRotationMonitor;
-
+    private final DependencyResolver dependencyResolver;
 
     public MetricsExtension( MetricsKernelExtensionFactory.Dependencies dependencies )
     {
@@ -62,6 +64,7 @@ public class MetricsExtension implements Lifecycle
         checkPointerMonitor = dependencies.checkPointerCounters();
         logRotationMonitor = dependencies.logRotationCounters();
         idGeneratorFactory = dependencies.idGeneratorFactory();
+        dependencyResolver = dependencies.getDependencyResolver();
     }
 
     @Override
@@ -83,7 +86,8 @@ public class MetricsExtension implements Lifecycle
 
         // Setup metric gathering
         Neo4jMetricsFactory factory = new Neo4jMetricsFactory( registry, configuration, monitors,
-                transactionCounters, pageCacheCounters, checkPointerMonitor, logRotationMonitor, idGeneratorFactory );
+                transactionCounters, pageCacheCounters, checkPointerMonitor, logRotationMonitor, idGeneratorFactory,
+                dependencyResolver, logService );
         life.add( factory.newInstance() );
 
         life.init();

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsKernelExtensionFactory.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsKernelExtensionFactory.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.metrics;
 
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.io.pagecache.monitoring.PageCacheMonitor;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
@@ -51,6 +52,8 @@ public class MetricsKernelExtensionFactory
         IdGeneratorFactory idGeneratorFactory();
 
         Monitors monitors();
+
+        DependencyResolver getDependencyResolver();
     }
 
     public MetricsKernelExtensionFactory()

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/ClusterMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/ClusterMetrics.java
@@ -25,38 +25,57 @@ import com.codahale.metrics.MetricRegistry;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.neo4j.function.Predicate;
+import org.neo4j.function.Predicates;
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.cluster.member.ClusterMembers;
 import org.neo4j.kernel.ha.SlaveUpdatePuller;
+import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.metrics.MetricsSettings;
 
 import static com.codahale.metrics.MetricRegistry.name;
+import static org.neo4j.kernel.ha.cluster.modeswitch.HighAvailabilityModeSwitcher.MASTER;
+import static org.neo4j.kernel.ha.cluster.modeswitch.HighAvailabilityModeSwitcher.UNKNOWN;
+
 
 public class ClusterMetrics extends LifecycleAdapter
 {
     private static final String NAME_PREFIX = "neo4j.cluster";
     private static final String SLAVE_PULL_UPDATES = name( NAME_PREFIX, "slave_pull_updates" );
     private static final String SLAVE_PULL_UPDATE_UP_TO_TX = name( NAME_PREFIX, "slave_pull_update_up_to_tx" );
+    static final String IS_MASTER = name( NAME_PREFIX, "is_master" );
+    static final String IS_AVAILABLE = name( NAME_PREFIX, "is_available" );
 
     private final Config config;
     private final Monitors monitors;
     private final MetricRegistry registry;
+    private final DependencyResolver dependencyResolver;
+    private final LogService logService;
     private final SlaveUpdatePullerMonitor monitor = new SlaveUpdatePullerMonitor();
+    private ClusterMembers clusterMembers = null;
 
-    public ClusterMetrics( Config config, Monitors monitors, MetricRegistry registry )
+    public ClusterMetrics( Config config, Monitors monitors, MetricRegistry registry,
+            DependencyResolver dependencyResolver, LogService logService )
     {
         this.config = config;
         this.monitors = monitors;
         this.registry = registry;
+        this.dependencyResolver = dependencyResolver;
+        this.logService = logService;
     }
 
     @Override
     public void start() throws Throwable
     {
-        if ( config.get( MetricsSettings.neoClusterEnabled ) )
+        if ( config.get( MetricsSettings.neoClusterEnabled ) && resolveClusterMembersDependencyOrLogWarning() )
         {
             monitors.addMonitorListener( monitor );
+
+            registry.register( IS_MASTER, new RoleGauge( Predicates.equalTo( MASTER ) ) );
+            registry.register( IS_AVAILABLE, new RoleGauge( Predicates.not( Predicates.equalTo( UNKNOWN ) ) ) );
 
             registry.register( SLAVE_PULL_UPDATES, new Gauge<Long>()
             {
@@ -75,16 +94,35 @@ public class ClusterMetrics extends LifecycleAdapter
                     return monitor.lastAppliedTxId;
                 }
             } );
+
+        }
+    }
+
+    private boolean resolveClusterMembersDependencyOrLogWarning()
+    {
+        try
+        {
+            clusterMembers = dependencyResolver.resolveDependency( ClusterMembers.class );
+            return true;
+        }
+        catch ( IllegalArgumentException e )
+        {
+            logService.getUserLog( getClass() ).warn( "Cluster metrics was enabled but the graph database" +
+                    " is not in HA mode." );
+            return false;
         }
     }
 
     @Override
     public void stop() throws IOException
     {
-        if ( config.get( MetricsSettings.neoClusterEnabled ) )
+        if ( config.get( MetricsSettings.neoClusterEnabled ) && (clusterMembers != null) )
         {
             registry.remove( SLAVE_PULL_UPDATES );
             registry.remove( SLAVE_PULL_UPDATE_UP_TO_TX );
+
+            registry.remove( IS_MASTER );
+            registry.remove( IS_AVAILABLE );
 
             monitors.removeMonitorListener( monitor );
         }
@@ -100,6 +138,26 @@ public class ClusterMetrics extends LifecycleAdapter
         {
             events.incrementAndGet();
             this.lastAppliedTxId = lastAppliedTxId;
+        }
+    }
+
+    private class RoleGauge implements Gauge<Integer>
+    {
+        private Predicate<String> rolePredicate;
+
+        public RoleGauge( Predicate<String> rolePredicate )
+        {
+            this.rolePredicate = rolePredicate;
+        }
+
+        public Integer getValue()
+        {
+            int value = 0;
+            if ( clusterMembers != null )
+            {
+                value = rolePredicate.test( clusterMembers.getCurrentMemberRole() ) ? 1 : 0;
+            }
+            return value;
         }
     }
 }

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/source/ClusterMetricsTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/source/ClusterMetricsTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.metrics.source;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Timer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState;
+import org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachine;
+import org.neo4j.kernel.ha.cluster.modeswitch.HighAvailabilityModeSwitcher;
+import org.neo4j.kernel.ha.cluster.member.ClusterMember;
+import org.neo4j.kernel.ha.cluster.member.ClusterMembers;
+import org.neo4j.kernel.ha.cluster.member.ObservedClusterMembers;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.metrics.MetricsSettings;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+
+public class ClusterMetricsTest
+{
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void clusterMetricsReportMasterAvailable()
+    {
+        // given
+        MetricRegistry metricRegistry = new MetricRegistry();
+        Config config = new Config( stringMap( MetricsSettings.neoClusterEnabled.name(), Settings.TRUE ) );
+        Monitors monitors = new Monitors();
+        LifeSupport life = new LifeSupport();
+        ClusterMembers clusterMembers =
+                getClusterMembers( HighAvailabilityModeSwitcher.MASTER, HighAvailabilityMemberState.MASTER );
+        DependencyResolver dependencyResolver = mock( DependencyResolver.class );
+        when( dependencyResolver.resolveDependency( ClusterMembers.class ) ).thenReturn( clusterMembers );
+        LogService logService = mock( LogService.class );
+
+        life.add( new ClusterMetrics( config, monitors, metricRegistry, dependencyResolver, logService ) );
+        life.start();
+
+        // when
+        TestReporter reporter = new TestReporter( metricRegistry );
+        reporter.start( 10, TimeUnit.MILLISECONDS );
+
+        // then wait for the reporter to get a report
+        reporter.report();
+        assertEquals( 1, reporter.isMasterValue );
+        assertEquals( 1, reporter.isAvailableValue );
+    }
+
+    @Test
+    public void clusterMetricsReportSlaveAvailable()
+    {
+        // given
+        MetricRegistry metricRegistry = new MetricRegistry();
+        Config config = new Config( stringMap( MetricsSettings.neoClusterEnabled.name(), Settings.TRUE ) );
+        ClusterMembers clusterMembers =
+                getClusterMembers( HighAvailabilityModeSwitcher.SLAVE, HighAvailabilityMemberState.SLAVE );
+        DependencyResolver dependencyResolver = mock( DependencyResolver.class );
+        when( dependencyResolver.resolveDependency( ClusterMembers.class ) ).thenReturn( clusterMembers );
+        LogService logService = mock( LogService.class );
+
+        Monitors monitors = new Monitors();
+        LifeSupport life = new LifeSupport();
+        life.add( new ClusterMetrics( config, monitors, metricRegistry, dependencyResolver, logService ) );
+        life.start();
+
+        // when
+        TestReporter reporter = new TestReporter( metricRegistry );
+        reporter.start( 10, TimeUnit.MILLISECONDS );
+
+        //then wait for the reporter to get a report
+        reporter.report();
+        assertEquals( 0, reporter.isMasterValue );
+        assertEquals( 1, reporter.isAvailableValue );
+    }
+
+    @Test
+    public void testClusterMemberNotEnabled()
+    {
+        // given
+        MetricRegistry metricRegistry = new MetricRegistry();
+        Config config = new Config( stringMap( MetricsSettings.neoClusterEnabled.name(), Settings.FALSE ) );
+        ClusterMembers clusterMembers =
+                getClusterMembers( HighAvailabilityModeSwitcher.SLAVE, HighAvailabilityMemberState.SLAVE );
+        DependencyResolver dependencyResolver = mock( DependencyResolver.class );
+        when( dependencyResolver.resolveDependency( ClusterMembers.class ) ).thenReturn( clusterMembers );
+        LogService logService = mock( LogService.class );
+
+        Monitors monitors = new Monitors();
+        LifeSupport life = new LifeSupport();
+        life.add( new ClusterMetrics( config, monitors, metricRegistry, dependencyResolver, logService ) );
+        life.start();
+
+        // when
+        TestReporter reporter = new TestReporter( metricRegistry );
+        reporter.start( 10, TimeUnit.MILLISECONDS );
+
+        //then the reporter should fail
+        thrown.expect( NullPointerException.class );
+        reporter.report();
+    }
+
+    @Test
+    public void testClusterMembersNull()
+    {
+        // given
+        MetricRegistry metricRegistry = new MetricRegistry();
+        Config config = new Config( stringMap( MetricsSettings.neoClusterEnabled.name(), Settings.TRUE ) );
+        ClusterMembers clusterMembers = null;
+        DependencyResolver dependencyResolver = mock( DependencyResolver.class );
+        when( dependencyResolver.resolveDependency( ClusterMembers.class ) ).thenReturn( clusterMembers );
+        LogService logService = mock( LogService.class );
+
+        Monitors monitors = new Monitors();
+        LifeSupport life = new LifeSupport();
+        life.add( new ClusterMetrics( config, monitors, metricRegistry, dependencyResolver, logService ) );
+        life.start();
+
+        // when
+        TestReporter reporter = new TestReporter( metricRegistry );
+        reporter.start( 10, TimeUnit.MILLISECONDS );
+
+        //then the reporter should fail
+        reporter.report();
+        assertEquals( 0, reporter.isMasterValue );
+        assertEquals( 0, reporter.isAvailableValue );
+    }
+
+    ClusterMembers getClusterMembers( String memberRole, HighAvailabilityMemberState memberState )
+    {
+        HighAvailabilityMemberStateMachine stateMachine = mock( HighAvailabilityMemberStateMachine.class );
+        when( stateMachine.getCurrentState() ).thenReturn( memberState );
+        ClusterMember clusterMember = spy( new ClusterMember( new InstanceId( 1 ) ) );
+        when( clusterMember.getHARole() ).thenReturn( memberRole );
+        ObservedClusterMembers observedClusterMembers = mock( ObservedClusterMembers.class );
+        when( observedClusterMembers.getCurrentMember() ).thenReturn( clusterMember );
+        return new ClusterMembers( observedClusterMembers, stateMachine );
+    }
+
+    class TestReporter extends ScheduledReporter
+    {
+        private int isMasterValue, isAvailableValue;
+
+        protected TestReporter( MetricRegistry registry )
+        {
+            super( registry, "TestReporter", MetricFilter.ALL, TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS );
+        }
+
+        @Override
+        public void report( SortedMap<String,Gauge> gauges, SortedMap<String,Counter> counters,
+                SortedMap<String,Histogram> histograms, SortedMap<String,Meter> meters, SortedMap<String,Timer> timers )
+        {
+            isMasterValue = (Integer) gauges.get( ClusterMetrics.IS_MASTER ).getValue();
+            isAvailableValue = (Integer) gauges.get( ClusterMetrics.IS_AVAILABLE ).getValue();
+        }
+    }
+
+}


### PR DESCRIPTION
Implemented metrics reporting the IS_MASTER and IS_AVAILABLE status of a cluster member.

Same as the last PR, now rebased onto 3.0.
