### PR TITLE
Prevent lost updates on concurrent set property

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
@@ -236,4 +236,83 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     b should haveProperty("x").withValue("X")
     c should haveProperty("x").withValue("X")
   }
+
+  test("Lost updates should not happen on set node property") {
+    val init: () => Unit = () => createNode("prop" -> 0)
+    val query = "MATCH (n) SET n.prop = n.prop + 1"
+    val resultQuery = "MATCH (n) RETURN n.prop"
+    testLostUpdatesWithBothPlanners(init, query, resultQuery, 10, 10)
+  }
+
+  test("Lost updates should not happen on set node property with an entangled expression") {
+    val init: () => Unit = () => createNode("prop" -> 0)
+    val query = "MATCH (n) SET n.prop = 2 + (10 * n.prop) / 10 - 1"
+    val resultQuery = "MATCH (n) RETURN n.prop"
+    testLostUpdatesWithBothPlanners(init, query, resultQuery, 10, 10)
+  }
+
+  test("Lost updates should not happen for set node property with map") {
+    val init: () => Unit = () => createNode("prop" -> 0)
+    val query = "MATCH (n) SET n = {prop: n.prop + 1}"
+    val resultQuery = "MATCH (n) RETURN n.prop"
+    testLostUpdatesWithBothPlanners(init, query, resultQuery, 10, 10)
+  }
+
+  test("Lost updates should not happen on set relationship property") {
+    val init: () => Unit = () => relate(createNode(), createNode(), "prop" -> 0)
+    val query = "MATCH ()-[r]->() SET r.prop = r.prop + 1"
+    val resultQuery = "MATCH ()-[r]->() RETURN r.prop"
+    testLostUpdatesWithBothPlanners(init, query, resultQuery, 10, 10)
+  }
+
+  test("Lost updates should not happen on set relationship property with an entangled expression") {
+    val init: () => Unit = () => relate(createNode(), createNode(), "prop" -> 0)
+    val query = "MATCH ()-[r]->() SET r.prop = 2 + (10 * r.prop) / 10 - 1"
+    val resultQuery = "MATCH ()-[r]->() RETURN r.prop"
+    testLostUpdatesWithBothPlanners(init, query, resultQuery, 10, 10)
+  }
+
+  test("Lost updates should not happen for set relationship property with map") {
+    val init: () => Unit = () => relate(createNode(), createNode(), "prop" -> 0)
+    val query = "MATCH ()-[r]->() SET r = {prop: r.prop + 1}"
+    val resultQuery = "MATCH ()-[r]->() RETURN r.prop"
+    testLostUpdatesWithBothPlanners(init, query, resultQuery, 10, 10)
+  }
+
+  // We do not support this because, even though the test is just a simple case,
+  // in general we would have to solve a complex data flow equation in order
+  // to solve this without being too conservative and do unnecessary exclusive locking
+  // (which could be really bad for concurrency in bad cases)
+  ignore("Lost updates should not happen on set node property with the read in a preceding statement") {
+    val init: () => Unit = () => createNode("prop" -> 0)
+    val query = "MATCH (n) WITH n.prop as p SET n.prop = p + 1"
+    val resultQuery = "MATCH (n) RETURN n.prop"
+    testLostUpdatesWithBothPlanners(init, query, resultQuery, 10, 10)
+  }
+
+  private def testLostUpdatesWithBothPlanners(init: () => Unit,
+                                              query: String,
+                                              resultQuery: String,
+                                              updates: Int,
+                                              resultValue: Int) = {
+    Seq("rule", "cost").foreach { planner =>
+      init()
+      val queryWithPlanner = s"CYPHER planner=$planner $query"
+      val threads = (0 until updates).map { i =>
+        new Thread(new Runnable {
+          override def run(): Unit = {
+            eengine.execute(queryWithPlanner)
+          }
+        })
+      }
+      threads.foreach(_.start())
+      threads.foreach(_.join())
+
+      val result = executeScalar[Long](resultQuery)
+      assert(result == resultValue, s": we lost updates with $planner planner!")
+
+      // Reset for run on next planner
+      eengine.execute("MATCH (n) DETACH DELETE n")
+    }
+  }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/Expression.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/Expression.scala
@@ -139,3 +139,17 @@ trait ExpressionWInnerExpression extends Expression {
     myType
   }
 }
+
+object Expression {
+  def doesMapExpressionReadSameProperty(mapEntityName: String, mapExpression: Expression): Boolean =
+    mapExpression match {
+      case LiteralMap(map) => map.exists {
+        case (k, v) => v.subExpressions.exists {
+          case Property(Identifier(entityName), propertyKey) =>
+            entityName == mapEntityName && propertyKey.name == k
+          case _ => false
+        }
+      }
+      case _ => false
+    }
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/Expression.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/Expression.scala
@@ -141,7 +141,7 @@ trait ExpressionWInnerExpression extends Expression {
 }
 
 object Expression {
-  def doesMapExpressionReadSameProperty(mapEntityName: String, mapExpression: Expression): Boolean =
+  def mapExpressionHasPropertyReadDependency(mapEntityName: String, mapExpression: Expression): Boolean =
     mapExpression match {
       case LiteralMap(map) => map.exists {
         case (k, v) => v.subExpressions.exists {
@@ -151,5 +151,13 @@ object Expression {
         }
       }
       case _ => false
+    }
+
+  def hasPropertyReadDependency(entityName: String, expression: Expression, propertyKey: String): Boolean =
+    expression.subExpressions.exists {
+      case Property(Identifier(name), key) =>
+        name == entityName && key.name == propertyKey
+      case _ =>
+        false
     }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/mutation/MapPropertySetAction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/mutation/MapPropertySetAction.scala
@@ -35,11 +35,11 @@ import scala.collection.Map
 case class MapPropertySetAction(element: Expression, mapExpression: Expression, removeOtherProps:Boolean)
   extends SetAction with MapSupport {
 
-  private val elementName = element match {
-    case Identifier(name) => name
-    case _ => ""
+  private val needsExclusiveLock = element match {
+    case Identifier(elementName) =>
+      Expression.mapExpressionHasPropertyReadDependency(elementName, mapExpression)
+    case _ => false
   }
-  private val needsExclusiveLock = Expression.mapExpressionHasPropertyReadDependency(elementName, mapExpression)
 
   def exec(context: ExecutionContext, state: QueryState) = {
     val qtx = state.query

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/mutation/PropertySetAction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/mutation/PropertySetAction.scala
@@ -32,6 +32,11 @@ case class PropertySetAction(prop: Property, valueExpression: Expression)
 
   val Property(mapExpr, propertyKey) = prop
 
+  private val needsExclusiveLock = valueExpression.subExpressions.exists {
+    case Property(_, key) if key.name == propertyKey.name => true
+    case _ => false
+  }
+
   def localEffects(symbols: SymbolTable) = Effects.propertyWrite(mapExpr, symbols)(propertyKey.name)
 
   def exec(context: ExecutionContext, state: QueryState) = {
@@ -47,10 +52,14 @@ case class PropertySetAction(prop: Property, valueExpression: Expression)
         case _ => throw new ThisShouldNotHappenError("Stefan", "This should be a node or a relationship")
       }
 
+      if (needsExclusiveLock) ops.acquireExclusiveLock(id)
+
       makeValueNeoSafe(valueExpression(context)) match {
         case null => propertyKey.getOptId(qtx).foreach(ops.removeProperty(id, _))
         case value => ops.setProperty(id, propertyKey.getOrCreateId(qtx), value)
       }
+
+      if (needsExclusiveLock) ops.releaseExclusiveLock(id)
     }
 
     Iterator(context)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/mutation/PropertySetAction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/mutation/PropertySetAction.scala
@@ -32,10 +32,8 @@ case class PropertySetAction(prop: Property, valueExpression: Expression)
 
   val Property(mapExpr, propertyKey) = prop
 
-  private val needsExclusiveLock = valueExpression.subExpressions.exists {
-    case Property(_, key) if key.name == propertyKey.name => true
-    case _ => false
-  }
+  private val needsExclusiveLock =
+    Expression.hasPropertyReadDependency(mapExpr.asInstanceOf[Identifier].entityName, valueExpression, propertyKey.name)
 
   def localEffects(symbols: SymbolTable) = Effects.propertyWrite(mapExpr, symbols)(propertyKey.name)
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LazyPropertyKey.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LazyPropertyKey.scala
@@ -23,20 +23,20 @@ import org.neo4j.cypher.internal.compiler.v3_0.spi.TokenContext
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{PropertyKeyName, LabelName}
 import org.neo4j.cypher.internal.frontend.v3_0.{PropertyKeyId, SemanticTable}
 
-case class LazyPropertyKey(name:String) {
-  private var id : Option[PropertyKeyId] = None
+case class LazyPropertyKey(name: String) {
+  private var id: Option[PropertyKeyId] = None
 
   def id(context: TokenContext): Option[PropertyKeyId] = id match {
-    case None => {
+    case None =>
       id = context.getOptPropertyKeyId(name).map(PropertyKeyId)
       id
-    }
-    case x    => x
+    case x => x
   }
 }
 
 object LazyPropertyKey {
-  def apply(name: PropertyKeyName)(implicit table:SemanticTable): LazyPropertyKey = {
+
+  def apply(name: PropertyKeyName)(implicit table: SemanticTable): LazyPropertyKey = {
     val property = new LazyPropertyKey(name.name)
     property.id = name.id
     property

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/SetPropertiesFromMapPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/SetPropertiesFromMapPipe.scala
@@ -56,7 +56,7 @@ abstract class SetPropertiesFromMapPipe[T <: PropertyContainer](src: Pipe, name:
         }
 
         /*Find the property container we'll be working on*/
-        setProperties(qtx, operations(qtx), itemId, map)
+        setProperties(qtx, ops, itemId, map)
 
         if (needsExclusiveLock) ops.releaseExclusiveLock(itemId)
       }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -310,7 +310,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe)
     case SetLabels(_, IdName(name), labels) =>
       SetLabelsPipe(source, name, labels)()
 
-    case SetNodePropery(_, idName, propertyKey, expression) =>
+    case SetNodeProperty(_, idName, propertyKey, expression) =>
       SetNodePropertyPipe(source, idName.name, LazyPropertyKey(propertyKey),
         toCommandExpression(expression))()
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/SetNodeProperty.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/SetNodeProperty.scala
@@ -22,9 +22,9 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{Expression, PropertyKeyName}
 
-case class SetNodePropery(source: LogicalPlan, idName: IdName, propertyKey: PropertyKeyName,
-                          expression: Expression)
-                    (val solved: PlannerQuery with CardinalityEstimation)
+case class SetNodeProperty(source: LogicalPlan, idName: IdName, propertyKey: PropertyKeyName,
+                           expression: Expression)
+                          (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalPlan with LogicalPlanWithoutExpressions {
 
   override def lhs: Option[LogicalPlan] = Some(source)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
@@ -495,7 +495,7 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends Colle
 
     val solved = inner.solved.amendUpdateGraph(_.addMutatingPatterns(pattern))
 
-    SetNodePropery(inner, pattern.idName, pattern.propertyKey,  pattern.expression)(solved)
+    SetNodeProperty(inner, pattern.idName, pattern.propertyKey, pattern.expression)(solved)
   }
 
   def planSetNodePropertiesFromMap(inner: LogicalPlan,

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
@@ -179,4 +179,8 @@ class DelegatingOperations[T <: PropertyContainer](protected val inner: Operatio
   def all: Iterator[T] = manyDbHits(inner.all)
 
   def isDeleted(obj: T): Boolean = inner.isDeleted(obj)
+
+  override def acquireExclusiveLock(obj: Long): Unit = inner.acquireExclusiveLock(obj)
+
+  override def releaseExclusiveLock(obj: Long): Unit = inner.releaseExclusiveLock(obj)
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
@@ -170,4 +170,8 @@ trait Operations[T <: PropertyContainer] {
   def isDeleted(obj: T): Boolean
 
   def all: Iterator[T]
+
+  def acquireExclusiveLock(obj: Long): Unit
+
+  def releaseExclusiveLock(obj: Long): Unit
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/SetPropertyPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/SetPropertyPipeTest.scala
@@ -79,8 +79,8 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
     when(qtx.nodeOps).thenReturn(nodeOps)
 
     pipe.createResults(state).toVector
-    verify(nodeOps, times(0)).acquireExclusiveLock(10)
-    verify(nodeOps, times(0)).releaseExclusiveLock(10)
+    verify(nodeOps, never()).acquireExclusiveLock(10)
+    verify(nodeOps, never()).releaseExclusiveLock(10)
   }
 
   // match ()-[r]-() set r.prop2 = r.prop + 1
@@ -93,8 +93,8 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
     when(qtx.relationshipOps).thenReturn(relOps)
 
     pipe.createResults(state).toVector
-    verify(relOps, times(0)).acquireExclusiveLock(10)
-    verify(relOps, times(0)).releaseExclusiveLock(10)
+    verify(relOps, never()).acquireExclusiveLock(10)
+    verify(relOps, never()).releaseExclusiveLock(10)
   }
 
   // match (n), (n2) set n2.prop = n.prop + 1
@@ -107,10 +107,10 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
     when(qtx.nodeOps).thenReturn(nodeOps)
 
     pipe.createResults(state).toVector
-    verify(nodeOps, times(0)).acquireExclusiveLock(10)
-    verify(nodeOps, times(0)).releaseExclusiveLock(10)
-    verify(nodeOps, times(0)).acquireExclusiveLock(20)
-    verify(nodeOps, times(0)).releaseExclusiveLock(20)
+    verify(nodeOps, never()).acquireExclusiveLock(10)
+    verify(nodeOps, never()).releaseExclusiveLock(10)
+    verify(nodeOps, never()).acquireExclusiveLock(20)
+    verify(nodeOps, never()).releaseExclusiveLock(20)
   }
 
   // match ()-[r]-(), ()-[r2]-() set r2.prop = r.prop + 1
@@ -124,10 +124,10 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
     when(qtx.relationshipOps).thenReturn(relOps)
 
     pipe.createResults(state).toVector
-    verify(relOps, times(0)).acquireExclusiveLock(10)
-    verify(relOps, times(0)).releaseExclusiveLock(10)
-    verify(relOps, times(0)).acquireExclusiveLock(20)
-    verify(relOps, times(0)).releaseExclusiveLock(20)
+    verify(relOps, never()).acquireExclusiveLock(10)
+    verify(relOps, never()).releaseExclusiveLock(10)
+    verify(relOps, never()).acquireExclusiveLock(20)
+    verify(relOps, never()).releaseExclusiveLock(20)
   }
 
   // match n set n += { prop: n.prop + 1 }
@@ -174,10 +174,10 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
     when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
 
     pipe.createResults(state).toVector
-    verify(nodeOps, times(0)).acquireExclusiveLock(10)
-    verify(nodeOps, times(0)).releaseExclusiveLock(10)
-    verify(nodeOps, times(0)).acquireExclusiveLock(20)
-    verify(nodeOps, times(0)).releaseExclusiveLock(20)
+    verify(nodeOps, never()).acquireExclusiveLock(10)
+    verify(nodeOps, never()).releaseExclusiveLock(10)
+    verify(nodeOps, never()).acquireExclusiveLock(20)
+    verify(nodeOps, never()).releaseExclusiveLock(20)
 
   }
 
@@ -194,10 +194,10 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
     when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
 
     pipe.createResults(state).toVector
-    verify(relOps, times(0)).acquireExclusiveLock(10)
-    verify(relOps, times(0)).releaseExclusiveLock(10)
-    verify(relOps, times(0)).acquireExclusiveLock(20)
-    verify(relOps, times(0)).releaseExclusiveLock(20)
+    verify(relOps, never()).acquireExclusiveLock(10)
+    verify(relOps, never()).releaseExclusiveLock(10)
+    verify(relOps, never()).acquireExclusiveLock(20)
+    verify(relOps, never()).releaseExclusiveLock(20)
   }
 
   // match (n) set n += { prop: n.prop2 + 1 }
@@ -212,8 +212,8 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
     when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
 
     pipe.createResults(state).toVector
-    verify(nodeOps, times(0)).acquireExclusiveLock(10)
-    verify(nodeOps, times(0)).releaseExclusiveLock(10)
+    verify(nodeOps, never()).acquireExclusiveLock(10)
+    verify(nodeOps, never()).releaseExclusiveLock(10)
 
   }
 
@@ -229,8 +229,8 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
     when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
 
     pipe.createResults(state).toVector
-    verify(relOps, times(0)).acquireExclusiveLock(10)
-    verify(relOps, times(0)).releaseExclusiveLock(10)
+    verify(relOps, never()).acquireExclusiveLock(10)
+    verify(relOps, never()).releaseExclusiveLock(10)
   }
 
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/SetPropertyPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/SetPropertyPipeTest.scala
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.pipes
+
+import org.mockito.Mockito._
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions._
+import org.neo4j.cypher.internal.compiler.v3_0.commands.values.{KeyToken, TokenType}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.{Operations, QueryContext}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.PropertyKeyName
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_0.{InputPosition, PropertyKeyId, SemanticTable}
+import org.neo4j.graphdb.{Node, Relationship}
+
+class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
+
+  implicit val table = new SemanticTable()
+  table.resolvedPropertyKeyNames.put("prop", PropertyKeyId(1))
+  table.resolvedPropertyKeyNames.put("prop2", PropertyKeyId(2))
+
+  val state = mock[QueryState]
+  val qtx = mock[QueryContext]
+  when(state.query).thenReturn(qtx)
+  when(state.decorator).thenReturn(NullPipeDecorator)
+  val emptyExpression = mock[Expression]
+  when(emptyExpression.children).thenReturn(Seq.empty)
+
+  // match (n) set n.prop = n.prop + 1
+  test("should grab an exclusive lock if the rhs reads from the same node property") {
+    val rhs = Add(Property(Identifier("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
+    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
+    val pipe = SetNodePropertyPipe(mockedSource, "n", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs)()
+
+    val nodeOps = mock[Operations[Node]]
+    when(qtx.nodeOps).thenReturn(nodeOps)
+
+    pipe.createResults(state).toVector
+    verify(nodeOps).acquireExclusiveLock(10)
+    verify(nodeOps).releaseExclusiveLock(10)
+  }
+
+  // match ()-[r]-() set r.prop = r.prop + 1
+  test("should grab an exclusive lock if the rhs reads from the same relationship property") {
+    val rhs = Add(Property(Identifier("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
+    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
+    val pipe = SetRelationshipPropertyPipe(mockedSource, "r", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs)()
+
+    val relOps = mock[Operations[Relationship]]
+    when(qtx.relationshipOps).thenReturn(relOps)
+
+    pipe.createResults(state).toVector
+    verify(relOps).acquireExclusiveLock(10)
+    verify(relOps).releaseExclusiveLock(10)
+  }
+
+  // match (n) set n.prop2 = n.prop + 1
+  test("should not grab an exclusive lock if the rhs reads from another node property") {
+    val rhs = Add(Property(Identifier("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
+    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
+    val pipe = SetNodePropertyPipe(mockedSource, "n", LazyPropertyKey(PropertyKeyName("prop2")(InputPosition.NONE)), rhs)()
+
+    val nodeOps = mock[Operations[Node]]
+    when(qtx.nodeOps).thenReturn(nodeOps)
+
+    pipe.createResults(state).toVector
+    verify(nodeOps, times(0)).acquireExclusiveLock(10)
+    verify(nodeOps, times(0)).releaseExclusiveLock(10)
+  }
+
+  // match ()-[r]-() set r.prop2 = r.prop + 1
+  test("should not grab an exclusive lock if the rhs reads from another relationship property") {
+    val rhs = Add(Property(Identifier("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
+    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
+    val pipe = SetRelationshipPropertyPipe(mockedSource, "r", LazyPropertyKey(PropertyKeyName("prop2")(InputPosition.NONE)), rhs)()
+
+    val relOps = mock[Operations[Relationship]]
+    when(qtx.relationshipOps).thenReturn(relOps)
+
+    pipe.createResults(state).toVector
+    verify(relOps, times(0)).acquireExclusiveLock(10)
+    verify(relOps, times(0)).releaseExclusiveLock(10)
+  }
+
+  // match (n), (n2) set n2.prop = n.prop + 1
+  test("should not grab an exclusive lock if the rhs reads from the same node property on another node") {
+    val rhs = Add(Property(Identifier("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
+    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10), "n2" -> newMockedNode(20)))
+    val pipe = SetNodePropertyPipe(mockedSource, "n2", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs)()
+
+    val nodeOps = mock[Operations[Node]]
+    when(qtx.nodeOps).thenReturn(nodeOps)
+
+    pipe.createResults(state).toVector
+    verify(nodeOps, times(0)).acquireExclusiveLock(10)
+    verify(nodeOps, times(0)).releaseExclusiveLock(10)
+    verify(nodeOps, times(0)).acquireExclusiveLock(20)
+    verify(nodeOps, times(0)).releaseExclusiveLock(20)
+  }
+
+  // match ()-[r]-(), ()-[r2]-() set r2.prop = r.prop + 1
+  test("should not grab an exclusive lock if the rhs reads from the same relationship property on another relationship") {
+    val rhs = Add(Property(Identifier("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
+    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node]),
+                                              "r2" -> newMockedRelationship(20, mock[Node], mock[Node])))
+    val pipe = SetRelationshipPropertyPipe(mockedSource, "r2", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs)()
+
+    val relOps = mock[Operations[Relationship]]
+    when(qtx.relationshipOps).thenReturn(relOps)
+
+    pipe.createResults(state).toVector
+    verify(relOps, times(0)).acquireExclusiveLock(10)
+    verify(relOps, times(0)).releaseExclusiveLock(10)
+    verify(relOps, times(0)).acquireExclusiveLock(20)
+    verify(relOps, times(0)).releaseExclusiveLock(20)
+  }
+
+  // match n set n += { prop: n.prop + 1 }
+  test("should grab an exclusive lock when setting node props from a map with dependencies") {
+    val rhs = LiteralMap(Map("prop" -> Add(Property(Identifier("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
+    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
+    val pipe = SetNodePropertiesFromMapPipe(mockedSource, "n", rhs, removeOtherProps = false)()
+
+    val nodeOps = mock[Operations[Node]]
+    when(qtx.nodeOps).thenReturn(nodeOps)
+    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    pipe.createResults(state).toVector
+    verify(nodeOps).acquireExclusiveLock(10)
+    verify(nodeOps).releaseExclusiveLock(10)
+  }
+
+  // match ()-[r]-() set r = { prop: r.prop + 1 }
+  test("should grab an exclusive lock when setting rel props from a map with dependencies") {
+    val rhs = LiteralMap(Map("prop" -> Add(Property(Identifier("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
+    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
+    val pipe = SetRelationshipPropertiesFromMapPipe(mockedSource, "r", rhs, removeOtherProps = true)()
+
+    val relOps = mock[Operations[Relationship]]
+    when(qtx.relationshipOps).thenReturn(relOps)
+    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    pipe.createResults(state).toVector
+    verify(relOps).acquireExclusiveLock(10)
+    verify(relOps).releaseExclusiveLock(10)
+  }
+
+  // match (n), (n2) set n += { prop: n2.prop + 1 }
+  test("should not grab an exclusive lock when setting node props from a map with same prop but other node") {
+    val rhs = LiteralMap(Map("prop" -> Add(Property(Identifier("n2"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
+    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10), "n2" -> newMockedNode(20)))
+    val pipe = SetNodePropertiesFromMapPipe(mockedSource, "n", rhs, removeOtherProps = false)()
+
+    val nodeOps = mock[Operations[Node]]
+    when(qtx.nodeOps).thenReturn(nodeOps)
+    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    pipe.createResults(state).toVector
+    verify(nodeOps, times(0)).acquireExclusiveLock(10)
+    verify(nodeOps, times(0)).releaseExclusiveLock(10)
+    verify(nodeOps, times(0)).acquireExclusiveLock(20)
+    verify(nodeOps, times(0)).releaseExclusiveLock(20)
+
+  }
+
+  // match ()-[r]-(), ()-[r2]-() set r = { prop: r2.prop + 1 }
+  test("should not grab an exclusive lock when setting rel props from a map with same prop but other rel") {
+    val rhs = LiteralMap(Map("prop" -> Add(Property(Identifier("r2"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
+    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node]),
+                                              "r2" -> newMockedRelationship(20, mock[Node], mock[Node])))
+    val pipe = SetRelationshipPropertiesFromMapPipe(mockedSource, "r", rhs, removeOtherProps = true)()
+
+    val relOps = mock[Operations[Relationship]]
+    when(qtx.relationshipOps).thenReturn(relOps)
+    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    pipe.createResults(state).toVector
+    verify(relOps, times(0)).acquireExclusiveLock(10)
+    verify(relOps, times(0)).releaseExclusiveLock(10)
+    verify(relOps, times(0)).acquireExclusiveLock(20)
+    verify(relOps, times(0)).releaseExclusiveLock(20)
+  }
+
+  // match (n) set n += { prop: n.prop2 + 1 }
+  test("should not grab an exclusive lock when setting node props from a map with same node but other prop") {
+    val rhs = LiteralMap(Map("prop" -> Add(Property(Identifier("n"), KeyToken.Resolved("prop2", 2, TokenType.PropertyKey)), Literal(1))))
+    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
+    val pipe = SetNodePropertiesFromMapPipe(mockedSource, "n", rhs, removeOtherProps = false)()
+
+    val nodeOps = mock[Operations[Node]]
+    when(qtx.nodeOps).thenReturn(nodeOps)
+    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    pipe.createResults(state).toVector
+    verify(nodeOps, times(0)).acquireExclusiveLock(10)
+    verify(nodeOps, times(0)).releaseExclusiveLock(10)
+
+  }
+
+  // match ()-[r]-() set r = { prop: r.prop2 + 1 }
+  test("should not grab an exclusive lock when setting rel props from a map with same rel but other prop") {
+    val rhs = LiteralMap(Map("prop" -> Add(Property(Identifier("r"), KeyToken.Resolved("prop2", 2, TokenType.PropertyKey)), Literal(1))))
+    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
+    val pipe = SetRelationshipPropertiesFromMapPipe(mockedSource, "r", rhs, removeOtherProps = true)()
+
+    val relOps = mock[Operations[Relationship]]
+    when(qtx.relationshipOps).thenReturn(relOps)
+    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    pipe.createResults(state).toVector
+    verify(relOps, times(0)).acquireExclusiveLock(10)
+    verify(relOps, times(0)).releaseExclusiveLock(10)
+  }
+
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -42,6 +42,7 @@ import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, Alre
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
 import org.neo4j.kernel.impl.api.KernelStatement
 import org.neo4j.kernel.impl.core.{RelationshipProxy, ThreadToStatementContextBridge}
+import org.neo4j.kernel.impl.locking.ResourceTypes
 import org.neo4j.kernel.security.URLAccessValidationError
 import org.neo4j.kernel.{GraphDatabaseAPI, Traversal, Uniqueness}
 import org.neo4j.tooling.GlobalGraphOperations
@@ -339,6 +340,12 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
 
     def isDeleted(n: Node): Boolean =
       kernelStatement.txState().nodeIsDeletedInThisTx(n.getId)
+
+    override def acquireExclusiveLock(obj: Long) =
+      statement.readOperations().acquireExclusive(ResourceTypes.NODE, obj)
+
+    override def releaseExclusiveLock(obj: Long) =
+      statement.readOperations().releaseExclusive(ResourceTypes.NODE, obj)
   }
 
   class RelationshipOperations extends BaseOperations[Relationship] {
@@ -380,6 +387,12 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
 
     def isDeleted(r: Relationship): Boolean =
       kernelStatement.txState().relationshipIsDeletedInThisTx(r.getId)
+
+    override def acquireExclusiveLock(obj: Long) =
+      statement.readOperations().acquireExclusive(ResourceTypes.RELATIONSHIP, obj)
+
+    override def releaseExclusiveLock(obj: Long) =
+      statement.readOperations().acquireExclusive(ResourceTypes.RELATIONSHIP, obj)
   }
 
   def getOrCreatePropertyKeyId(propertyKey: String) =

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherIsolationIntegrationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherIsolationIntegrationTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.graphdb.Node
 
 class CypherIsolationIntegrationTest extends ExecutionEngineFunSuite {
 
-  val THREADS = 100
+  val THREADS = 50
   val UPDATES = 100
 
   test("Should work around read isolation limitations using multiple set") {
@@ -39,8 +39,7 @@ class CypherIsolationIntegrationTest extends ExecutionEngineFunSuite {
     locked1 should equal(THREADS * UPDATES)
     locked2 should equal(THREADS * UPDATES)
 
-    // In some glorious future with increased isolation levels the following should fail and we should re-write this test
-    unlocked should be < locked1
+    unlocked should equal(locked1)
   }
 
   def updateAndCount(node: Node, property: String, query: String): Long = {

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/symbols/package.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/symbols/package.scala
@@ -20,18 +20,18 @@
 package org.neo4j.cypher.internal.frontend.v3_0
 
 package object symbols {
-  val CTAny = AnyType.instance
-  val CTBoolean = BooleanType.instance
-  val CTString = StringType.instance
-  val CTNumber = NumberType.instance
-  val CTFloat = FloatType.instance
-  val CTInteger = IntegerType.instance
-  val CTMap = MapType.instance
-  val CTNode = NodeType.instance
-  val CTRelationship = RelationshipType.instance
-  val CTPoint = PointType.instance
-  val CTPath = PathType.instance
-  def CTCollection(inner: CypherType) = CollectionType(inner)
+  val CTAny: AnyType = AnyType.instance
+  val CTBoolean: BooleanType = BooleanType.instance
+  val CTString: StringType = StringType.instance
+  val CTNumber: NumberType = NumberType.instance
+  val CTFloat: FloatType = FloatType.instance
+  val CTInteger: IntegerType = IntegerType.instance
+  val CTMap: MapType = MapType.instance
+  val CTNode: NodeType = NodeType.instance
+  val CTRelationship: RelationshipType = RelationshipType.instance
+  val CTPoint: PointType = PointType.instance
+  val CTPath: PathType = PathType.instance
+  def CTCollection(inner: CypherType): CollectionType = CollectionType(inner)
 
   implicit def invariantTypeSpec(that: CypherType): TypeSpec = that.invariant
 }

--- a/community/kernel/src/docs/dev/transactions.asciidoc
+++ b/community/kernel/src/docs/dev/transactions.asciidoc
@@ -65,28 +65,57 @@ For example, if a write lock is taken on a common node or relationship, then all
 
 In Cypher it is possible to acquire write locks to simulate improved isolation in some cases.
 Consider the case where multiple concurrent Cypher queries increment the value of a property.
-Due to the limitations of the read-committed isolation level, the increments will not result in a deterministic final value.
+Due to the limitations of the read-committed isolation level, the increments might not result in a deterministic final value.
+If there is a direct dependency, Cypher will automatically acquire a write lock before reading.
+A direct dependency is when the right-hand side of a `SET` has a dependent property read in the expression, or in the value of a key-value pair in a literal map.
 
-For example, the following query, if run by one hundred concurrent clients, will very likely not increment the property `n.prop` to 100, but some value lower than 100.
+For example, the following query, if run by one hundred concurrent clients, will very likely not increment the property `n.prop` to 100, unless a write lock is acquired before reading the property value.
+This is because all queries would read the value of `n.prop` within their own transaction, and would not see the incremented value from any other transaction that has not yet committed.
+In the worst case scenario the final value would be as low as 1, if all threads perform the read before any has committed their transaction.
 
+.Requires a write lock, and Cypher automatically acquires one.
 [source,cypher]
 ----
 MATCH (n:X {id: 42})
 SET n.prop = n.prop + 1
 ----
 
-This is because all queries will read the value of `n.prop` within their own transaction.
-They will not see the incremented value from any other transaction that has not yet committed.
-In the worst case scenario the final value could be as low as 1, if all threads perform the read before any has committed their transaction.
+.Also requires a write lock, and Cypher automatically acquires one.
+[source,cypher]
+----
+MATCH (n)
+SET n += { prop: n.prop + 1 }
+----
 
-To ensure deterministic behavior, it is necessary to grab a write lock on the node in question.
-In Cypher there is no explicit support for this, but we can work around this limitation by writing to a temporary property.
+Due to the complexity of determining such a dependency in the general case, Cypher does not cover any of the below example cases:
 
+.Variable depending on results from reading the property in an earlier statement.
+[source,cypher]
+----
+MATCH (n)
+WITH n.prop as p
+// ... operations depending on p, producing k
+SET n.prop = k + 1
+----
+
+.Circular dependency between properties read and written in the same query.
+[source,cypher]
+----
+MATCH (n)
+SET n += { propA: n.propB + 1, propB: n.propA + 1 }
+----
+
+To ensure deterministic behavior also in the more complex cases, it is necessary to explicitly acquire a write lock on the node in question.
+In Cypher there is no explicit support for this, but it is possible to work around this limitation by writing to a temporary property.
+
+.Acquires a write lock for the node by writing to a dummy property before reading the requested value.
 [source,cypher]
 ----
 MATCH (n:X {id: 42})
 SET n._LOCK_ = true
-SET n.prop = n.prop + 1
+WITH n.prop as p
+// ... operations depending on p, producing k
+SET n.prop = k + 1
 REMOVE n._LOCK_
 ----
 


### PR DESCRIPTION
Running multiple queries in parallel that writes a property with a value
that is based on reading the same property risks having an unpredictable result,
e.g. increment  "MATCH (n) SET n.prop = n.prop + 1".
We now make SET behave atomically by taking an exclusive lock on the entity
that we are going to write to before reading the value.
This decision is taken at runtime in the set property pipes.
