### PR TITLE
Deprecate metrics reporting into a single csv file

### DIFF
--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -26,6 +26,7 @@ import org.neo4j.graphdb.factory.Description;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Obsoleted;
 
 import static org.neo4j.helpers.Settings.basePath;
 import static org.neo4j.helpers.Settings.setting;
@@ -101,6 +102,8 @@ public class MetricsSettings
                   "will be intepreted relative to the configured Neo4j store directory." )
     public static Setting<File> csvPath = setting(
             "metrics.csv.path", Settings.PATH, "metrics.csv" , basePath( GraphDatabaseSettings.store_dir ) );
+    @Deprecated
+    @Obsoleted( "This setting will be removed in the next major release." )
     @Description( "Write to a single CSV file or to multiple files. " +
                   "Set to `single` (the default) for reporting the metrics in a single CSV file (given by " +
                   "metrics.csv.path), with a column per metrics field. Or set to `split` to produce a CSV file for " +

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/CsvReporterSingle.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/CsvReporterSingle.java
@@ -48,7 +48,11 @@ import static java.lang.String.format;
  * Version of CSV reporter that logs all metrics into a single file.
  * Restriction is that all metrics must be set up before starting it,
  * as it cannot handle changing sets of metrics at runtime.
+ *
+ * @deprecated please use {@code com.codahale.metrics.CsvReporter} instead. This reporter is incompatible with the
+ * event based reporting that will be introduced in the next major release, hence it will be removed.
  */
+@Deprecated
 public class CsvReporterSingle extends ScheduledReporter
 {
     // CSV separator


### PR DESCRIPTION
Since the next major release will support event based reporting of
metrics, writing all the metrics into a single file is not feasible
anymore.  Indeed the metrics reported at different times cannot be
correlated to each others anylonger, hence having all of the
aggregated in the same file could be confusing.

In the future the only supported csv reporter will report each metric
in its own csv file.
