### PR TITLE
Fix cardinality estimation of LIMIT with SKIP

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/StatisticsBackedCardinalityModel.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/StatisticsBackedCardinalityModel.scala
@@ -42,11 +42,11 @@ class StatisticsBackedCardinalityModel(queryGraphCardinalityModel: QueryGraphCar
 
   private def calculateCardinalityForQueryHorizon(in: Cardinality, horizon: QueryHorizon): Cardinality = horizon match {
     // Normal projection with LIMIT integer literal
-    case RegularQueryProjection(_, QueryShuffle(_, None, Some(limit: IntegerLiteral))) =>
+    case RegularQueryProjection(_, QueryShuffle(_, _, Some(limit: IntegerLiteral))) =>
       Cardinality.min(in, limit.value.toDouble)
 
     // Normal projection with LIMIT
-    case RegularQueryProjection(_, QueryShuffle(_, None, Some(limit))) =>
+    case RegularQueryProjection(_, QueryShuffle(_, _, Some(limit))) =>
       val cannotEvaluateStableValue =
         simpleExpressionEvaluator.hasParameters(limit) ||
           simpleExpressionEvaluator.isNonDeterministic(limit)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/StatisticsBackedCardinalityModelTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/StatisticsBackedCardinalityModelTest.scala
@@ -95,6 +95,27 @@ class StatisticsBackedCardinalityModelTest extends CypherFunSuite with LogicalPl
       shouldHavePlannerQueryCardinality(produceCardinalityModel)(2.5)
   }
 
+  test("query containing both SKIP and LIMIT") {
+    val i = personCount
+    givenPattern( "MATCH (n:Person) WITH n SKIP 5 LIMIT 10").
+      withGraphNodes(allNodes).
+      withLabel('Person -> i).
+      shouldHavePlannerQueryCardinality(produceCardinalityModel)(
+        Math.min(allNodes * (i / allNodes), 10.0)
+      )
+  }
+
+  // We do not improve in this case
+  ignore("query containing both SKIP and LIMIT with large skip, so skip + limit exceeds total row count boundary") {
+    val i = personCount
+    givenPattern( s"MATCH (n:Person) WITH n SKIP ${personCount - 5} LIMIT 10").
+      withGraphNodes(allNodes).
+      withLabel('Person -> i).
+      shouldHavePlannerQueryCardinality(produceCardinalityModel)(
+        Math.min(allNodes * (i / allNodes), 5.0)
+      )
+  }
+
   def produceCardinalityModel(in: QueryGraphCardinalityModel): Metrics.CardinalityModel =
     new StatisticsBackedCardinalityModel(in)
 


### PR DESCRIPTION
If SKIP is used in combination with LIMIT, the cardinality estimation of LIMIT
should still be used
