### PR TITLE
LockResult clean up

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/MasterImpl.java
@@ -311,7 +311,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
         }
         catch ( NoSuchEntryException | ConcurrentAccessException e)
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( "Unable to acquire exclusive lock: " + e.getMessage() ) );
+            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.NOT_LOCKED, "Unable to acquire exclusive lock: " + e.getMessage() ) );
         }
         try
         {
@@ -323,7 +323,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
         }
         catch ( DeadlockDetectedException e )
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( "Can't acquire exclusive lock, because it would have caused a deadlock: " + e.getMessage() ) );
+            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.DEAD_LOCKED,"Can't acquire exclusive lock, because it would have caused a deadlock: " + e.getMessage() ) );
         }
         catch ( IllegalResourceException e )
         {
@@ -347,7 +347,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
         }
         catch ( NoSuchEntryException | ConcurrentAccessException e)
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( "Unable to acquire shared lock: " + e.getMessage() ) );
+            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.NOT_LOCKED, "Unable to acquire shared lock: " + e.getMessage() ) );
         }
         try
         {
@@ -360,7 +360,7 @@ public class MasterImpl extends LifecycleAdapter implements Master
         }
         catch ( DeadlockDetectedException e )
         {
-            return spi.packTransactionObligationResponse( context, new LockResult( e.getMessage() ) );
+            return spi.packTransactionObligationResponse( context, new LockResult( LockStatus.DEAD_LOCKED, e.getMessage() ) );
         }
         catch ( IllegalResourceException e )
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClient.java
@@ -57,7 +57,7 @@ public interface MasterClient extends Master
             result.writeByte( responseObject.getStatus().ordinal() );
             if ( responseObject.getStatus().hasMessage() )
             {
-                writeString( result, responseObject.getDeadlockMessage() );
+                writeString( result, responseObject.getMessage() );
             }
         }
     };
@@ -79,7 +79,7 @@ public interface MasterClient extends Master
                 throw Exceptions.withMessage( e, format( "%s | read invalid ordinal %d. First %db of this channel buffer is:%n%s",
                         e.getMessage(), statusOrdinal, maxBytesToPrint, beginningOfBufferAsHexString( buffer, maxBytesToPrint ) ) );
             }
-            return status.hasMessage() ? new LockResult( readString( buffer ) ) : new LockResult( status );
+            return status.hasMessage() ? new LockResult( LockStatus.DEAD_LOCKED, readString( buffer ) ) : new LockResult( status );
         }
 
         private String beginningOfBufferAsHexString( ChannelBuffer buffer, int maxBytesToPrint )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockResult.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockResult.java
@@ -22,18 +22,18 @@ package org.neo4j.kernel.ha.lock;
 public class LockResult
 {
     private final LockStatus status;
-    private final String deadlockMessage;
-    
+    private final String message;
+
     public LockResult( LockStatus status )
     {
         this.status = status;
-        this.deadlockMessage = null;
+        this.message = null;
     }
-    
-    public LockResult( String deadlockMessage )
+
+    public LockResult( LockStatus status, String message )
     {
-        this.status = LockStatus.DEAD_LOCKED;
-        this.deadlockMessage = deadlockMessage;
+        this.status = status;
+        this.message = message;
     }
 
     public LockStatus getStatus()
@@ -41,14 +41,14 @@ public class LockResult
         return status;
     }
 
-    public String getDeadlockMessage()
+    public String getMessage()
     {
-        return deadlockMessage;
+        return message;
     }
-    
+
     @Override
     public String toString()
     {
-        return "LockResult[" + status + ", " + deadlockMessage + "]";
+        return "LockResult[" + status + ", " + message + "]";
     }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -258,7 +258,7 @@ class SlaveLocksClient implements Locks.Client
         switch ( result.getStatus() )
         {
             case DEAD_LOCKED:
-                throw new DeadlockDetectedException( result.getDeadlockMessage() );
+                throw new DeadlockDetectedException( result.getMessage() );
             case NOT_LOCKED:
                 throw new UnsupportedOperationException();
             case OK_LOCKED:


### PR DESCRIPTION
- Make the API more generic - it handles more lock results than
  just deadlocks
- Don't default to deadlock, have the status injected
