### PR TITLE
Expressions should be resolved in DistinctPipe

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/execution/PipeExecutionPlanBuilder.scala
@@ -187,7 +187,7 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors) {
         // TODO: Maybe we shouldn't encode distinct as an empty aggregation.
         case Aggregation(Projection(source, expressions), groupingExpressions, aggregatingExpressions)
           if aggregatingExpressions.isEmpty && expressions == groupingExpressions =>
-          DistinctPipe(buildPipe(source), groupingExpressions.mapValues(toCommandExpression))()
+          DistinctPipe(buildPipe(source), Eagerly.immutableMapValues(groupingExpressions, buildExpression))()
 
         case Aggregation(source, groupingExpressions, aggregatingExpressions) if aggregatingExpressions.isEmpty =>
           DistinctPipe(buildPipe(source), groupingExpressions.mapValues(toCommandExpression))()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -529,6 +529,18 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     assertRows(1)(result)("NodeByLabelScan")
   }
 
+  test("distinct should not look up properties every time") {
+    // GIVEN
+    createNode("prop"-> 42)
+    createNode("prop"-> 42)
+
+    // WHEN
+    val result = profileWithAllPlanners("MATCH (n) RETURN DISTINCT n.prop")
+
+    // THEN
+    assertDbHits(2)(result)("Distinct")
+  }
+
   private def assertRows(expectedRows: Int)(result: InternalExecutionResult)(names: String*) {
     getPlanDescriptions(result, names).foreach {
       plan => assert(expectedRows === getArgument[Rows](plan).value, s" wrong row count for plan: ${plan.name}")


### PR DESCRIPTION
Make sure we resolve expressions before creating a `DistinctPipe` even in
cases where we drop the `ProjectionPipe`
