### PR TITLE
Correct status code when using hint with no index

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -98,12 +98,12 @@ class UnknownLabelException(labelName: String) extends CypherException(s"The pro
 
 class HintException( message: String)
   extends CypherException(message) {
-  val status = Status.Schema.NoSuchIndex
+  val status = Status.Statement.ExecutionFailure
 }
 
 class IndexHintException(identifier: String, label: String, property: String, message: String)
   extends CypherException(s"$message\nLabel: `$label`\nProperty name: `$property`") {
-  val status = Status.Statement.ExecutionFailure
+  val status = Status.Schema.NoSuchIndex
 }
 
 class LabelScanHintException(identifier: String, label: String, message: String)


### PR DESCRIPTION
When using `USING INDEX` without there being any index the returned status
code should be a `Neo.ClientError.Schema.NoSuchIndex`

fixes #5902
