### PR TITLE
Fix duplicate setting

### DIFF
--- a/community/kernel/src/docs/ops/logical-logs.asciidoc
+++ b/community/kernel/src/docs/ops/logical-logs.asciidoc
@@ -2,12 +2,14 @@
 Logical logs
 ============
 
-Logical logs in Neo4j are the journal of which operations happens and are the source of truth in scenarios where the database needs to be recovered after a crash or similar.
-Logs are rotated every now and then (defaults to when they surpass 25 Mb in size) and the amount of legacy logs to keep can be configured.
-Purpose of keeping a history of logical logs include being able to serve incremental backups as well as keeping an HA cluster running.
+Logical logs in Neo4j are the journal of which operations happens and are the source of truth in scenarios where the
+database needs to be recovered after a crash or similar. Logs are rotated every now and then (defaults to when they
+surpass 250 Mb in size) and the amount of legacy logs to keep can be configured. Purpose of keeping a history of
+logical logs include being able to serve incremental backups as well as keeping an HA cluster running.
 
-For any given configuration at least the latest non-empty logical log will be kept, but configuration can be supplied to control how much more to keep.
-There are several different means of controlling it and the format in which configuration is supplied is:
+For any given configuration at least the latest non-empty logical log will be kept, but configuration can be supplied
+to control how much more to keep. There are several different means of controlling it and the format in which
+configuration is supplied is:
 
 [source]
 ----

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -181,9 +181,9 @@ public abstract class GraphDatabaseSettings
     public static final Setting<Long> store_interval_log_rotation_wait_time =
             setting( "store.interval.log.rotation", DURATION, "10m" );
 
-    @Description( "Minimum time (in seconds) after last rotation of the internal log before it may be rotated again." )
-    public static final Setting<Integer> store_internal_log_rotation_delay =
-            setting("store.internal_log.rotation_delay", INTEGER, "300", min(0), max( Integer.MAX_VALUE ) );
+    @Description( "Minimum time interval after last rotation of the internal log before it may be rotated again." )
+    public static final Setting<Long> store_internal_log_rotation_delay =
+            setting("store.internal_log.rotation_delay", DURATION, "300s" );
 
     @Description( "Maximum number of history files for the internal log." )
     public static final Setting<Integer> store_internal_log_max_archives = setting("store.internal_log.max_archives", INTEGER, "7", min(1) );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -182,7 +182,8 @@ public abstract class GraphDatabaseSettings
             setting( "store.interval.log.rotation", DURATION, "10m" );
 
     @Description( "Minimum time (in seconds) after last rotation of the internal log before it may be rotated again." )
-    public static final Setting<Integer> store_internal_log_rotation_delay = setting("store.internal_log.rotation_threshold", INTEGER, "300", min(0), max( Integer.MAX_VALUE ) );
+    public static final Setting<Integer> store_internal_log_rotation_delay =
+            setting("store.internal_log.rotation_delay", INTEGER, "300", min(0), max( Integer.MAX_VALUE ) );
 
     @Description( "Maximum number of history files for the internal log." )
     public static final Setting<Integer> store_internal_log_max_archives = setting("store.internal_log.max_archives", INTEGER, "7", min(1) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -216,7 +216,7 @@ public class PlatformModule
     protected LogService createLogService( LogProvider userLogProvider )
     {
         long internalLogRotationThreshold = config.get( GraphDatabaseSettings.store_internal_log_rotation_threshold );
-        int internalLogRotationDelay = config.get( GraphDatabaseSettings.store_internal_log_rotation_delay );
+        long internalLogRotationDelay = config.get( GraphDatabaseSettings.store_internal_log_rotation_delay );
         int internalLogMaxArchives = config.get( GraphDatabaseSettings.store_internal_log_max_archives );
 
         final StoreLogService.Builder builder =

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -49,7 +49,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
         private LogProvider userLogProvider = NullLogProvider.getInstance();
         private Executor rotationExecutor;
         private long internalLogRotationThreshold = 0L;
-        private int internalLogRotationDelay = 0;
+        private long internalLogRotationDelay = 0L;
         private int maxInternalLogArchives = 0;
         private Consumer<LogProvider> rotationListener = Consumers.noop();
         private Map<String, Level> logLevels = new HashMap<>();
@@ -65,15 +65,15 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
             return this;
         }
 
-        public Builder withRotation( long internalLogRotationThreshold, int internalLogRotationDelay, int maxInternalLogArchives,
-                JobScheduler jobScheduler )
+        public Builder withRotation( long internalLogRotationThreshold, long internalLogRotationDelay,
+                int maxInternalLogArchives, JobScheduler jobScheduler )
         {
             return withRotation( internalLogRotationThreshold, internalLogRotationDelay, maxInternalLogArchives,
                     jobScheduler.executor( JobScheduler.Groups.internalLogRotation ) );
         }
 
-        public Builder withRotation( long internalLogRotationThreshold, int internalLogRotationDelay, int maxInternalLogArchives,
-                Executor rotationExecutor )
+        public Builder withRotation( long internalLogRotationThreshold, long internalLogRotationDelay,
+                int maxInternalLogArchives, Executor rotationExecutor )
         {
             this.internalLogRotationThreshold = internalLogRotationThreshold;
             this.internalLogRotationDelay = internalLogRotationDelay;
@@ -119,7 +119,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
         return new Builder().withUserLogProvider( userLogProvider );
     }
 
-    public static Builder withRotation( long internalLogRotationThreshold, int internalLogRotationDelay, int maxInternalLogArchives, JobScheduler jobScheduler )
+    public static Builder withRotation( long internalLogRotationThreshold, long internalLogRotationDelay, int maxInternalLogArchives, JobScheduler jobScheduler )
     {
         return new Builder().withRotation( internalLogRotationThreshold, internalLogRotationDelay, maxInternalLogArchives, jobScheduler );
     }
@@ -138,7 +138,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
             Map<String, Level> logLevels,
             Level defaultLevel,
             long internalLogRotationThreshold,
-            int internalLogRotationDelay,
+            long internalLogRotationDelay,
             int maxInternalLogArchives,
             Executor rotationExecutor,
             final Consumer<LogProvider> rotationListener ) throws IOException

--- a/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
+++ b/community/logging/src/test/java/org/neo4j/logging/RotatingFileOutputStreamSupplierTest.java
@@ -169,7 +169,8 @@ public class RotatingFileOutputStreamSupplierTest
     public void shouldNotRotatesLogWhenSizeExceededByNotDelay() throws Exception
     {
         UpdatableLongSupplier clock = new UpdatableLongSupplier( System.currentTimeMillis() );
-        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( clock, fileSystem, logFile, 10, 60, 10, DIRECT_EXECUTOR, new RotationListener() );
+        RotatingFileOutputStreamSupplier supplier = new RotatingFileOutputStreamSupplier( clock, fileSystem, logFile,
+                10, SECONDS.toMillis( 60 ), 10, DIRECT_EXECUTOR, new RotationListener() );
         OutputStream outputStream = supplier.get();
         assertThat( fileSystem.fileExists( logFile ), is( true ) );
         assertThat( fileSystem.fileExists( archiveLogFile1 ), is( false ) );


### PR DESCRIPTION
Seems like `rotation_delay` has never been an accessible configuration option. It doesn't seem to be in the manual either. Trying to configure the `threshold` option with a valid suffixed value (like `20m`) doesn't work either since `rotation_delay` will try the same value as an integer.

Also added a test to check for duplicates.
