### PR TITLE
Revert ClusterUri changes to fix tyre-kicking

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupKernelExtension.java
@@ -29,6 +29,7 @@ import org.neo4j.cluster.com.BindingNotifier;
 import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.cluster.member.ClusterMemberEvents;
 import org.neo4j.cluster.member.ClusterMemberListener;
+import org.neo4j.com.ServerUtil;
 import org.neo4j.com.monitor.RequestMonitor;
 import org.neo4j.com.storecopy.StoreCopyServer;
 import org.neo4j.function.Supplier;
@@ -244,7 +245,7 @@ public class OnlineBackupKernelExtension implements Lifecycle
     }
 
     private URI createBackupURI() {
-        String hostString = server.getSocketAddress().getHostString();
+        String hostString = ServerUtil.getHostString( server.getSocketAddress() );
         String host = hostString.contains( INADDR_ANY ) ? me.getHost() : hostString;
         int port = server.getSocketAddress().getPort();
         return URI.create("backup://" + host + ":" + port);

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkReceiver.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/com/NetworkReceiver.java
@@ -243,14 +243,19 @@ public class NetworkReceiver
 
     private URI getURI( InetSocketAddress address )
     {
-        // Socket.toString() already prepends a '/'
-        String uri = CLUSTER_SCHEME + "://" + address.getHostString() + ":" + address.getPort();
+        String uri;
+
+        if ( address.getAddress().getHostAddress().startsWith( "0" ) )
+            uri = CLUSTER_SCHEME + "://0.0.0.0:" + address.getPort(); // Socket.toString() already prepends a /
+        else
+        {
+            uri = CLUSTER_SCHEME + "://" + address.getAddress().getHostName() + ":" + address.getPort(); // Socket
+        }
+            // .toString() already prepends a /
 
         // Add name if given
-        if ( config.name() != null )
-        {
-            uri += "/?name=" + config.name();
-        }
+        if (config.name() != null)
+            uri += "/?name="+config.name();
 
         return URI.create( uri );
     }

--- a/enterprise/com/src/main/java/org/neo4j/com/ServerUtil.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ServerUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.com;
+
+import java.net.InetSocketAddress;
+
+public class ServerUtil
+{
+
+    /**
+     * Figure out the host string of a given socket address, similar to the Java 7 InetSocketAddress.getHostString().
+     *
+     * Calls to this should be replace once Neo4j is Java 7 only.
+     *
+     * @param socketAddress
+     * @return
+     */
+    public static String getHostString( InetSocketAddress socketAddress )
+    {
+        if ( socketAddress.isUnresolved() )
+        {
+            return socketAddress.getHostName();
+        }
+        else
+        {
+            return socketAddress.getAddress().getHostAddress();
+        }
+    }
+}

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToMaster.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.member.ClusterMemberAvailability;
+import org.neo4j.com.ServerUtil;
 import org.neo4j.function.BiFunction;
 import org.neo4j.function.Factory;
 import org.neo4j.function.Supplier;
@@ -124,9 +125,9 @@ public class SwitchToMaster implements AutoCloseable
 
     private URI getMasterUri( URI me, MasterServer masterServer )
     {
-        String hostname = config.get( HaSettings.ha_server ).getHost(
-                masterServer.getSocketAddress().getHostString().contains( "0.0.0.0" ) ? me.getHost()
-                        : masterServer.getSocketAddress().getHostString() );
+        String hostname = config.get( HaSettings.ha_server ).getHost( ServerUtil.getHostString( masterServer.getSocketAddress() ).contains( "0.0.0.0" ) ?
+                            me.getHost() :
+                            ServerUtil.getHostString( masterServer.getSocketAddress() ));
 
         int port = masterServer.getSocketAddress().getPort();
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SwitchToSlave.java
@@ -30,6 +30,7 @@ import org.neo4j.cluster.member.ClusterMemberAvailability;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
 import org.neo4j.com.Server;
+import org.neo4j.com.ServerUtil;
 import org.neo4j.com.storecopy.StoreCopyClient;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.com.storecopy.TransactionCommittingResponseUnpacker;
@@ -505,7 +506,7 @@ public class SwitchToSlave
 
     private URI createHaURI( URI me, Server<?,?> server )
     {
-        String hostString = server.getSocketAddress().getHostString();
+        String hostString = ServerUtil.getHostString( server.getSocketAddress() );
         int port = server.getSocketAddress().getPort();
         InstanceId serverId = config.get( ClusterSettings.server_id );
         String host = hostString.contains( HighAvailabilityModeSwitcher.INADDR_ANY ) ? me.getHost() : hostString;


### PR DESCRIPTION
Revert "Simplify cluster server address logic"

This reverts commit 596b65b3b56c63c340839f53d3a388f2ce9517ff.

Revert "Remove ServerUtil"

This reverts commit c05c691b253aee56a5e97f6207486a936154eaaa.

Revert "Fix cluster uri resolution"

This reverts commit 577e84523b637df035fc11c2bb00771660d777df.
