### PR TITLE
Remove RRD4J library from distriubtion

### DIFF
--- a/advanced/server-advanced/LICENSES.txt
+++ b/advanced/server-advanced/LICENSES.txt
@@ -27,7 +27,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/advanced/server-advanced/NOTICE.txt
+++ b/advanced/server-advanced/NOTICE.txt
@@ -49,7 +49,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 
 BSD - Scala License
   Scala Library

--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -27,7 +27,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -50,7 +50,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 
 BSD - Scala License
   Scala Library

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -27,7 +27,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -50,7 +50,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 
 BSD - Scala License
   Scala Library

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -215,11 +215,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.rrd4j</groupId>
-      <artifactId>rrd4j</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.mozilla</groupId>
       <artifactId>rhino</artifactId>
     </dependency>

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -30,7 +30,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
   The Netty Project
 ------------------------------------------------------------------------------
 

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -52,7 +52,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
   The Netty Project
 
 BSD - Scala License

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -30,7 +30,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
   The Netty Project
 ------------------------------------------------------------------------------
 

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -52,7 +52,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
   The Netty Project
 
 BSD - Scala License

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
@@ -29,7 +29,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
@@ -52,7 +52,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 
 BSD - Scala License
   Scala Library

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/LICENSES.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/LICENSES.txt
@@ -29,7 +29,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/NOTICE.txt
+++ b/packaging/standalone/standalone-advanced/src/main/distribution/text/advanced/NOTICE.txt
@@ -51,7 +51,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 
 BSD - Scala License
   Scala Library

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -29,7 +29,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -52,7 +52,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
 
 BSD - Scala License
   Scala Library

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
@@ -32,7 +32,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
   The Netty Project
 ------------------------------------------------------------------------------
 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -54,7 +54,6 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
-  RRD4J
   The Netty Project
 
 BSD - Scala License

--- a/pom.xml
+++ b/pom.xml
@@ -639,11 +639,6 @@
         <version>9.2.10.v20150310</version>
       </dependency>
       <dependency>
-        <groupId>org.rrd4j</groupId>
-        <artifactId>rrd4j</artifactId>
-        <version>2.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.mozilla</groupId>
         <artifactId>rhino</artifactId>
         <version>1.7R4</version>


### PR DESCRIPTION
RRD was removed but library was still part of distribution.
This PR removes it also from distributions.
