### PR TITLE
Fixed issue with last committed tx id in query planning

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/ExecutionPlanBuilder.scala
@@ -70,7 +70,7 @@ class ExecutionPlanBuilder(graph: GraphDatabaseService, statsDivergenceThreshold
 
       def isPeriodicCommit = periodicCommitInfo.isDefined
       def plannerUsed = planner
-      def isStale(lastTxId: () => Long, statistics: GraphStatistics) = fingerprint.isStale(lastTxId, statistics)
+      def isStale(lastCommittedTxId: () => Long, statistics: GraphStatistics) = fingerprint.isStale(lastCommittedTxId, statistics)
     }
   }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/PlanFingerprint.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/PlanFingerprint.scala
@@ -27,10 +27,10 @@ case class PlanFingerprint(creationTimeMillis: Long, txId: Long, snapshot: Graph
 case class PlanFingerprintReference(clock: Clock, ttl: Long, statsDivergenceThreshold : Double,
                                     var fingerprint: Option[PlanFingerprint])
 {
-  def isStale(lastTxId: () => Long, statistics: GraphStatistics): Boolean = {
+  def isStale(lastCommittedTxId: () => Long, statistics: GraphStatistics): Boolean = {
     fingerprint.fold(false) { f =>
       lazy val currentTimeMillis = clock.currentTimeMillis()
-      lazy val currentTxId = lastTxId()
+      lazy val currentTxId = lastCommittedTxId()
 
       check(f.creationTimeMillis + ttl <= currentTimeMillis, {}) &&
       check(currentTxId != f.txId, { fingerprint = Some(f.copy(creationTimeMillis = currentTimeMillis)) }) &&

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/LastCommittedTxIdProvider.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/LastCommittedTxIdProvider.scala
@@ -19,19 +19,16 @@
  */
 package org.neo4j.cypher.internal
 
-import org.neo4j.cypher.ExtendedExecutionResult
-import org.neo4j.cypher.internal.compiler.v2_2.ExecutionMode
-import org.neo4j.graphdb.Transaction
+import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.GraphDatabaseAPI
-import org.neo4j.kernel.api.Statement
-import org.neo4j.kernel.impl.query.QuerySession
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore
 
-final case class TransactionInfo(tx: Transaction, isTopLevelTx: Boolean, statement: Statement)
+case class LastCommittedTxIdProvider(db: GraphDatabaseService) extends (() => Long) {
 
-trait ExecutionPlan {
-  def run(graph: GraphDatabaseAPI, txInfo: TransactionInfo, executionMode: ExecutionMode, params: Map[String, Any], session: QuerySession): ExtendedExecutionResult
+  private val resolver = db.asInstanceOf[GraphDatabaseAPI].getDependencyResolver
 
-  def isPeriodicCommit: Boolean
-
-  def isStale(lastCommittedTxId: LastCommittedTxIdProvider, statement: Statement): Boolean
+  override def apply(): Long = {
+    val txIdStore = resolver.resolveDependency(classOf[TransactionIdStore])
+    txIdStore.getLastCommittedTransactionId
+  }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor1_9.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor1_9.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.CypherVersion
 import org.neo4j.cypher.internal._
 import org.neo4j.cypher.internal.compiler.v1_9.executionplan.{ExecutionPlan => ExecutionPlan_v1_9}
 import org.neo4j.cypher.internal.compiler.v1_9.{CypherCompiler => CypherCompiler1_9}
-import org.neo4j.cypher.internal.compiler.v2_2.{ProfileMode, NormalMode, ExecutionMode}
+import org.neo4j.cypher.internal.compiler.v2_2.{ExecutionMode, NormalMode, ProfileMode}
 import org.neo4j.cypher.internal.spi.v1_9.{GDSBackedQueryContext => QueryContext_v1_9}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.GraphDatabaseAPI
@@ -71,6 +71,6 @@ case class CompatibilityFor1_9(graph: GraphDatabaseService, queryCacheSize: Int,
 
     def isPeriodicCommit = false
 
-    def isStale(lastTxId: () => Long, statement: Statement): Boolean = false
+    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, statement: Statement): Boolean = false
   }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_0.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal._
 import org.neo4j.cypher.internal.compiler.v2_0.CypherCompiler
 import org.neo4j.cypher.internal.compiler.v2_0.executionplan.{ExecutionPlan => ExecutionPlan_v2_0}
 import org.neo4j.cypher.internal.compiler.v2_0.spi.{ExceptionTranslatingQueryContext => ExceptionTranslatingQueryContext_v2_0}
-import org.neo4j.cypher.internal.compiler.v2_2.{ProfileMode, NormalMode, ExecutionMode}
+import org.neo4j.cypher.internal.compiler.v2_2.{ExecutionMode, NormalMode, ProfileMode}
 import org.neo4j.cypher.internal.spi.v2_0.{TransactionBoundPlanContext => PlanContext_v2_0, TransactionBoundQueryContext => QueryContext_v2_0}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.GraphDatabaseAPI
@@ -74,6 +74,6 @@ case class CompatibilityFor2_0(graph: GraphDatabaseService, queryCacheSize: Int,
 
     def isPeriodicCommit = false
 
-    def isStale(lastTxId: () => Long, statement: Statement): Boolean = false
+    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, statement: Statement): Boolean = false
   }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_1.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_1.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal._
 import org.neo4j.cypher.internal.compiler.v2_1.CypherCompilerFactory
 import org.neo4j.cypher.internal.compiler.v2_1.executionplan.{ExecutionPlan => ExecutionPlan_v2_1}
 import org.neo4j.cypher.internal.compiler.v2_1.spi.{ExceptionTranslatingQueryContext => ExceptionTranslatingQueryContext_v2_1}
-import org.neo4j.cypher.internal.compiler.v2_2.{ProfileMode, NormalMode, ExecutionMode}
+import org.neo4j.cypher.internal.compiler.v2_2.{ExecutionMode, NormalMode, ProfileMode}
 import org.neo4j.cypher.internal.spi.v2_1.{TransactionBoundPlanContext => PlanContext_v2_1, TransactionBoundQueryContext => QueryContext_v2_1}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.GraphDatabaseAPI
@@ -77,6 +77,6 @@ case class CompatibilityFor2_1(graph: GraphDatabaseService, queryCacheSize: Int,
 
     def isPeriodicCommit = inner.isPeriodicCommit
 
-    def isStale(lastTxId: () => Long, statement: Statement): Boolean = false
+    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, statement: Statement): Boolean = false
   }
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -32,7 +32,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.RewriterStepSeq
 import org.neo4j.cypher.internal.compiler.v2_2.{CypherException => CypherException_v2_2, _}
 import org.neo4j.cypher.internal.spi.v2_2.{TransactionBoundGraphStatistics, TransactionBoundPlanContext, TransactionBoundQueryContext}
 import org.neo4j.cypher.javacompat.ProfilerStatistics
-import org.neo4j.cypher.{ArithmeticException, CypherTypeException, EntityNotFoundException, FailedIndexException, IncomparableValuesException, IndexHintException, InternalException, InvalidArgumentException, InvalidSemanticsException, LabelScanHintException, LoadCsvStatusWrapCypherException, LoadExternalResourceException, MergeConstraintConflictException, NodeStillHasRelationshipsException, ParameterNotFoundException, ParameterWrongTypeException, PatternException, PeriodicCommitInOpenTransactionException, ProfilerStatisticsNotReadyException, SyntaxException, UniquePathNotUniqueException, UnknownLabelException, HintException,  _}
+import org.neo4j.cypher.{ArithmeticException, CypherTypeException, EntityNotFoundException, FailedIndexException, HintException, IncomparableValuesException, IndexHintException, InternalException, InvalidArgumentException, InvalidSemanticsException, LabelScanHintException, LoadCsvStatusWrapCypherException, LoadExternalResourceException, MergeConstraintConflictException, NodeStillHasRelationshipsException, ParameterNotFoundException, ParameterWrongTypeException, PatternException, PeriodicCommitInOpenTransactionException, ProfilerStatisticsNotReadyException, SyntaxException, UniquePathNotUniqueException, UnknownLabelException, _}
 import org.neo4j.graphdb.{GraphDatabaseService, QueryExecutionType, ResourceIterator}
 import org.neo4j.helpers.{Assertion, Clock}
 import org.neo4j.kernel.GraphDatabaseAPI
@@ -181,8 +181,8 @@ trait CompatibilityFor2_2 {
 
     def isPeriodicCommit = inner.isPeriodicCommit
 
-    def isStale(lastTxId: () => Long, statement: Statement) =
-      inner.isStale(lastTxId, TransactionBoundGraphStatistics(statement))
+    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, statement: Statement) =
+      inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(statement))
   }
 }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundPlanContext.scala
@@ -20,15 +20,14 @@
 package org.neo4j.cypher.internal.spi.v2_2
 
 import org.neo4j.cypher.MissingIndexException
+import org.neo4j.cypher.internal.LastCommittedTxIdProvider
 import org.neo4j.cypher.internal.compiler.v2_2.spi._
 import org.neo4j.graphdb.GraphDatabaseService
-import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.Statement
 import org.neo4j.kernel.api.constraints.UniquenessConstraint
 import org.neo4j.kernel.api.exceptions.KernelException
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
-import org.neo4j.kernel.impl.transaction.log.TransactionIdStore
 
 class TransactionBoundPlanContext(someStatement: Statement, val gdb: GraphDatabaseService)
   extends TransactionBoundTokenContext(someStatement) with PlanContext {
@@ -89,8 +88,5 @@ class TransactionBoundPlanContext(someStatement: Statement, val gdb: GraphDataba
   val statistics: GraphStatistics =
     InstrumentedGraphStatistics(TransactionBoundGraphStatistics(statement), MutableGraphStatisticsSnapshot())
 
-  val txIdProvider: () => Long = gdb.asInstanceOf[GraphDatabaseAPI]
-    .getDependencyResolver
-    .resolveDependency(classOf[TransactionIdStore])
-    .getLastCommittedTransactionId
+  val txIdProvider = LastCommittedTxIdProvider(gdb)
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/LastCommittedTxIdProviderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/LastCommittedTxIdProviderTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal
+
+import org.neo4j.cypher.internal.commons.CypherFunSuite
+import org.neo4j.kernel.NeoStoreDataSource
+import org.neo4j.test.ImpermanentGraphDatabase
+import org.scalatest.BeforeAndAfterAll
+
+class LastCommittedTxIdProviderTest extends CypherFunSuite with BeforeAndAfterAll {
+
+  var db: ImpermanentGraphDatabase = null
+  var lastCommittedTxIdProvider: LastCommittedTxIdProvider = null
+
+  override protected def beforeAll(): Unit = {
+    db = new ImpermanentGraphDatabase()
+    lastCommittedTxIdProvider = LastCommittedTxIdProvider(db)
+  }
+
+  override protected def afterAll(): Unit = db.shutdown()
+
+  test("should return correct last committed tx id") {
+    val startingTxId = lastCommittedTxIdProvider()
+
+    (1 to 42).foreach(_ => createNode())
+
+    val endingTxId = lastCommittedTxIdProvider()
+    endingTxId shouldBe (startingTxId + 42)
+  }
+
+  test("should return correct last committed tx id after datasource restart") {
+    val startingTxId = lastCommittedTxIdProvider()
+
+    restartDataSource()
+    (1 to 42).foreach(_ => createNode())
+
+    val endingTxId = lastCommittedTxIdProvider()
+    endingTxId shouldBe (startingTxId + 42)
+  }
+
+  private def createNode(): Unit = {
+    val tx = db.beginTx()
+    try {
+      db.createNode()
+      tx.success()
+    }
+    finally {
+      tx.close()
+    }
+  }
+
+  private def restartDataSource(): Unit = {
+    val ds = db.getDependencyResolver.resolveDependency(classOf[NeoStoreDataSource])
+    ds.stop()
+    ds.start()
+  }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStore.java
@@ -51,7 +51,6 @@ import org.neo4j.kernel.impl.util.StringLogger.LineLogger;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.neo4j.io.pagecache.PagedFile.PF_EXCLUSIVE_LOCK;
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
 import static org.neo4j.kernel.impl.util.CappedOperation.time;
@@ -440,6 +439,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
 
     public long getUpgradeTime()
     {
+        assertNotClosed();
         checkInitialized( upgradeTimeField );
         return upgradeTimeField;
     }
@@ -460,6 +460,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
 
     public long getCreationTime()
     {
+        assertNotClosed();
         checkInitialized( creationTimeField );
         return creationTimeField;
     }
@@ -472,6 +473,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
 
     public long getRandomNumber()
     {
+        assertNotClosed();
         checkInitialized( randomNumberField );
         return randomNumberField;
     }
@@ -485,6 +487,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
     @Override
     public long getCurrentLogVersion()
     {
+        assertNotClosed();
         checkInitialized( versionField );
         return versionField;
     }
@@ -531,6 +534,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
 
     public long getStoreVersion()
     {
+        assertNotClosed();
         checkInitialized( storeVersionField );
         return storeVersionField;
 
@@ -544,6 +548,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
 
     public long getGraphNextProp()
     {
+        assertNotClosed();
         checkInitialized( graphNextPropField );
         return graphNextPropField;
     }
@@ -556,6 +561,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
 
     public long getLatestConstraintIntroducingTx()
     {
+        assertNotClosed();
         checkInitialized( latestConstraintIntroducingTxField );
         return latestConstraintIntroducingTxField;
     }
@@ -895,6 +901,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
     @Override
     public long nextCommittingTransactionId()
     {
+        assertNotClosed();
         checkInitialized( lastCommittingTxField.get() );
         return lastCommittingTxField.incrementAndGet();
     }
@@ -902,6 +909,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
     @Override
     public void transactionCommitted( long transactionId, long checksum )
     {
+        assertNotClosed();
         checkInitialized( lastCommittingTxField.get() );
         if ( highestCommittedTransaction.offer( transactionId, checksum ) )
         {
@@ -926,6 +934,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
     @Override
     public long getLastCommittedTransactionId()
     {
+        assertNotClosed();
         checkInitialized( lastCommittingTxField.get() );
         return highestCommittedTransaction.get().transactionId();
     }
@@ -933,6 +942,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
     @Override
     public TransactionId getLastCommittedTransaction()
     {
+        assertNotClosed();
         checkInitialized( lastCommittingTxField.get() );
         return highestCommittedTransaction.get();
     }
@@ -940,6 +950,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
     @Override
     public TransactionId getUpgradeTransaction()
     {
+        assertNotClosed();
         checkInitialized( upgradeTxChecksumField );
         return new TransactionId( upgradeTxIdField, upgradeTxChecksumField );
     }
@@ -947,11 +958,17 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
     @Override
     public long getLastClosedTransactionId()
     {
+        assertNotClosed();
         checkInitialized( lastCommittingTxField.get() );
         return lastClosedTx.getHighestGapFreeNumber();
     }
 
-    // Ensures that all fields are read from the store, by checking the initial value of the field in question
+
+    /**
+     * Ensures that all fields are read from the store, by checking the initial value of the field in question
+     *
+     * @param field the value
+     */
     private void checkInitialized( long field )
     {
         if ( field == FIELD_NOT_INITIALIZED )
@@ -964,6 +981,7 @@ public class NeoStore extends AbstractStore implements TransactionIdStore, LogVe
     @Override
     public void setLastCommittedAndClosedTransactionId( long transactionId, long checksum )
     {
+        assertNotClosed();
         setRecord( Position.LAST_TRANSACTION_ID, transactionId );
         setRecord( Position.LAST_TRANSACTION_CHECKSUM, checksum );
         checkInitialized( lastCommittingTxField.get() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoreTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.util.StringLogger;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.PageCacheRule;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class NeoStoreTest
+{
+    @ClassRule
+    public static final EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+
+    @ClassRule
+    public static final PageCacheRule pageCacheRule = new PageCacheRule();
+
+    @Test
+    public void getCreationTimeShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getCreationTime();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getCurrentLogVersionShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getCurrentLogVersion();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getGraphNextPropShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getGraphNextProp();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getLastClosedTransactionIdShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getLastClosedTransactionId();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getLastCommittedTransactionShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getLastCommittedTransaction();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getLastCommittedTransactionIdShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getLastCommittedTransactionId();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getLatestConstraintIntroducingTxShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getLatestConstraintIntroducingTx();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getRandomNumberShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getRandomNumber();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getStoreVersionShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getStoreVersion();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getUpgradeTimeShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getUpgradeTime();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void getUpgradeTransactionShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.getUpgradeTransaction();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void nextCommittingTransactionIdShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.nextCommittingTransactionId();
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void setLastCommittedAndClosedTransactionIdShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.setLastCommittedAndClosedTransactionId( 1, 1 );
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    @Test
+    public void transactionCommittedShouldFailWhenStoreIsClosed() throws IOException
+    {
+        NeoStore neoStore = newNeoStore();
+        neoStore.close();
+        try
+        {
+            neoStore.transactionCommitted( 1, 1 );
+            fail( "Expected exception reading from NeoStore after being closed." );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalStateException.class ) );
+        }
+    }
+
+    private static NeoStore newNeoStore() throws IOException
+    {
+        EphemeralFileSystemAbstraction fs = NeoStoreTest.fsRule.get();
+        PageCache pageCache = pageCacheRule.getPageCache( fs );
+        File dir = new File( "store" );
+        StoreFactory storeFactory = new StoreFactory( fs, dir, pageCache, StringLogger.DEV_NULL, new Monitors() );
+        return storeFactory.newNeoStore( true );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestNeoStore.java
@@ -82,7 +82,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.store.StoreFactory.configForStoreDir;
 
@@ -1191,8 +1190,10 @@ public class TestNeoStore
             channel.write( ByteBuffer.wrap( trailer ) );
         }
 
+        neoStore = factory.newNeoStore( false );
         assertNotEquals( 10, neoStore.getUpgradeTransaction().transactionId() );
         assertNotEquals( 11, neoStore.getUpgradeTime() );
+        neoStore.close();
 
         NeoStore.setRecord( fileSystem, file, Position.UPGRADE_TRANSACTION_ID, 10 );
         NeoStore.setRecord( fileSystem, file, Position.UPGRADE_TRANSACTION_CHECKSUM, 11 );


### PR DESCRIPTION
This issue could result in slaves never re-planing queries after a mode switch or even directly after the startup. It occurred because function that resolved last committed transaction id held a reference to a stale TransactionIdStore. `TransactionIdStore` is re-initialized after the `NeoStoreDataSource` restart which happens after mode switch in HA.

Introduced `LastCommittedTxIdProvider` that is able to take last committed transaction id from the given GraphDatabaseService.
