### PR TITLE
Make `mvn verify` run integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,17 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <argLine>${test.runner.jvm.settings}</argLine>
         </configuration>


### PR DESCRIPTION
Apparently the failsafe plugin needs to be explicitly told to run the `integration-test` and `verify` goals for this to work; at least for it to work inside submodules.

@lassewesth @nawroth Please let me know if this has unintended consequences for our builds.
