### PR TITLE
CREATE should not recreate nodes from MERGE

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
@@ -686,4 +686,16 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     result.getCause shouldBe a [UniquePropertyConstraintViolationKernelException]
     result.getMessage should equal(s"""Node ${node.getId} already exists with label L and property "prop"=[42]""")
   }
+
+  test("merge followed by multiple creates") {
+    val query =
+      """MERGE (t:T {id:42})
+        |CREATE (f:R)
+        |CREATE (t)-[:REL]->(f)
+      """.stripMargin
+
+    val result = updateWithBothPlanners(query)
+
+    assertStats(result, nodesCreated = 2, labelsAdded = 2, relationshipsCreated = 1, propertiesSet = 1)
+  }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/PlannerQueryBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/PlannerQueryBuilder.scala
@@ -57,7 +57,11 @@ case class PlannerQueryBuilder(private val q: PlannerQuery, semanticTable: Seman
     val all = q.allPlannerQueries.toSet
 
     all.flatMap(_.queryGraph.patternNodes) ++
-      all.flatMap(_.updateGraph.createNodePatterns.map(_.nodeName))
+      all.flatMap { pq =>
+        val ug = pq.updateGraph
+        ug.createNodePatterns.map(_.nodeName) ++
+          ug.mergeNodePatterns.map(_.createNodePattern.nodeName)
+      }
   }
 
   def readOnly: Boolean = q.updateGraph.isEmpty

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/UpdateGraph.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/UpdateGraph.scala
@@ -39,6 +39,11 @@ case class UpdateGraph(mutatingPatterns: Seq[MutatingPattern] = Seq.empty) {
     case p: CreateNodePattern => p
   }
 
+
+  def mergeNodePatterns = mutatingPatterns.collect {
+    case m: MergeNodePattern => m
+  }
+
   /*
    * Finds all nodes being created with CREATE ()-[r]->()
    */
@@ -272,10 +277,6 @@ case class UpdateGraph(mutatingPatterns: Seq[MutatingPattern] = Seq.empty) {
   private def setRelationshipPropertyPatterns = mutatingPatterns.collect {
     case p: SetRelationshipPropertyPattern => p
     case p: SetRelationshipPropertiesFromMapPattern => p
-  }
-
-  private def mergeNodePatterns = mutatingPatterns.collect {
-    case m: MergeNodePattern => m
   }
 }
 


### PR DESCRIPTION
In `MERGE (a) CREATE (a)-[:R]->(b)` we must keep track
of identifiers introduced by `MERGE` so that `a` is only created once.
