### PR TITLE
Initial commit for core-edge

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.transaction.log.entry;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
@@ -76,6 +77,14 @@ public class LogEntryWriter
     public void serialize( TransactionRepresentation tx ) throws IOException
     {
         tx.accept( serializer );
+    }
+
+    public void serialize( Collection<Command> commands ) throws IOException
+    {
+        for ( Command command : commands )
+        {
+            serializer.visit( command );
+        }
     }
 
     public void writeCheckPointEntry( LogPosition logPosition ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/udc/UsageDataKeys.java
+++ b/community/kernel/src/main/java/org/neo4j/udc/UsageDataKeys.java
@@ -58,12 +58,13 @@ public class UsageDataKeys
 
     public enum OperationalMode
     {
-        // Note, these are sent verbatum via UDC if UDC is enabled
+        // Note, these are sent verbatim via UDC if UDC is enabled
         unknown,
         single,
-        ha
+        ha,
+        core,
+        edge
     }
-
     public enum Edition
     {
         // Note, these are sent verbatum via UDC if UDC is enabled

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -152,12 +152,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.neo4j.app</groupId>
-      <artifactId>neo4j-browser</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-shell</artifactId>
       <version>${project.version}</version>
@@ -861,6 +855,23 @@
         </repository>
       </repositories>
     </profile>
+
+    <profile>
+      <id>include-browser</id>
+      <activation>
+        <property>
+          <name>!skipBrowser</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.neo4j.app</groupId>
+          <artifactId>neo4j-browser</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
   </profiles>
 
   <repositories>

--- a/enterprise/core-edge/.gitignore
+++ b/enterprise/core-edge/.gitignore
@@ -1,0 +1,1 @@
+hs_err*.log

--- a/enterprise/core-edge/LICENSES.txt
+++ b/enterprise/core-edge/LICENSES.txt
@@ -1,0 +1,215 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+------------------------------------------------------------------------------
+Apache Software License, Version 2.0
+  hazelcast-all
+  Lucene Core
+  Netty/All-in-One
+  The Netty Project
+------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+

--- a/enterprise/core-edge/NOTICE.txt
+++ b/enterprise/core-edge/NOTICE.txt
@@ -1,0 +1,32 @@
+Neo4j
+Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+in this notice as "Neo Technology")
+   [http://neotechnology.com]
+
+This product includes software ("Software") developed by Neo Technology.
+
+The software ("Software") is developed and owned by Network Engine
+for Objects in Lund AB (referred to in this notice as "Neo Technology").
+If you have executed an End User Software License and Services Agreement,
+an OEM Software License and Support Services Agreement, or another
+commercial license agreement (including an Evaluation Agreement) with
+Neo Technology or one of its affiliates (each, a "Commercial Agreement"),
+you may use the Software solely pursuant to the terms of the relevant
+Commercial Agreement.
+
+If you have not executed a Commercial Agreement with Neo Technology, the
+Software is subject to the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3 (http://www.fsf.org/licensing/licenses/agpl-3.0.html), included
+in the LICENSE.txt file.
+
+Full license texts are found in LICENSES.txt.
+
+Third-party licenses
+--------------------
+
+Apache Software License, Version 2.0
+  hazelcast-all
+  Lucene Core
+  Netty/All-in-One
+  The Netty Project
+

--- a/enterprise/core-edge/pom.xml
+++ b/enterprise/core-edge/pom.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.neo4j</groupId>
+        <artifactId>parent</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>neo4j-core-edge</artifactId>
+    <name>Neo4j - Core Edge</name>
+    <version>3.0.0-SNAPSHOT</version>
+
+    <description>This component provides the means to set up a cluster of Neo4j instances that act together
+        as a cluster, providing Core-Edge cluster with RAFT consensus for the core machines and eventual
+        consistency for the edge servers.
+    </description>
+    <url>http://components.neo4j.org/${project.artifactId}/${project.version}/</url>
+    <packaging>jar</packaging>
+
+
+    <scm>
+        <url>https://github.com/neo4j/neo4j/tree/master/enterprise/ha</url>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>GNU Affero General Public License, Version 3</name>
+            <url>http://www.gnu.org/licenses/agpl-3.0-standalone.html</url>
+            <comments>The software ("Software") developed and owned by Network Engine for
+                Objects in Lund AB (referred to in this notice as "Neo Technology") is
+                licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3 to all
+                third parties and that license is included below.
+
+                However, if you have executed an End User Software License and Services
+                Agreement or an OEM Software License and Support Services Agreement, or
+                another commercial license agreement with Neo Technology or one of its
+                affiliates (each, a "Commercial Agreement"), the terms of the license in
+                such Commercial Agreement will supersede the GNU AFFERO GENERAL PUBLIC
+                LICENSE Version 3 and you may use the Software solely pursuant to the
+                terms of the relevant Commercial Agreement.
+            </comments>
+        </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-source-based-documentation-ha</id>
+                        <phase>${generate-config-docs-phase}</phase>
+                        <configuration>
+                            <target>
+                                <java classname="org.neo4j.tooling.GenerateConfigDocumentation"
+                                      classpathref="maven.compile.classpath" failonerror="true">
+                                    <arg value="org.neo4j.kernel.ha.HaSettings"/>
+                                    <arg value="${project.build.directory}/docs/ops/ha-configuration-attributes.asciidoc"/>
+                                </java>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-ha</artifactId>
+            <version>${project.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.neo4j</groupId>
+              <artifactId>neo4j-backup</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-kernel</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+      <dependency>
+        <groupId>org.neo4j</groupId>
+        <artifactId>neo4j-consistency-check</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-all</artifactId>
+            <version>3.5.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.sourceforge.findbugs</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-io</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+        </dependency>
+
+      <dependency>
+        <groupId>org.neo4j</groupId>
+        <artifactId>neo4j-logging</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+      <profile>
+        <id>core-edge-tests-only</id>
+        <properties>
+          <test-phase>test</test-phase>
+          <integration-test-phase>integration-test</integration-test-phase>
+          <integration-verify-phase>verify</integration-verify-phase>
+        </properties>
+      </profile>
+    </profiles>
+</project>

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchupClientProtocol.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchupClientProtocol.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+public class CatchupClientProtocol
+{
+    private NextMessage nextMessage = NextMessage.MESSAGE_TYPE;
+
+    public void expect( NextMessage nextMessage )
+    {
+        this.nextMessage = nextMessage;
+    }
+
+    public boolean isExpecting( NextMessage message )
+    {
+        return this.nextMessage == message;
+    }
+
+    public enum NextMessage
+    {
+        MESSAGE_TYPE,
+        STORE_ID,
+        TX_PULL_RESPONSE,
+        STORE_COPY_FINISHED,
+        TX_STREAM_FINISHED,
+        FILE_HEADER,
+        FILE_CONTENTS,
+        LOCK_RESPONSE
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchupServer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchupServer.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.stream.ChunkedWriteHandler;
+
+import org.neo4j.coreedge.catchup.storecopy.core.GetStoreRequestHandler;
+import org.neo4j.coreedge.catchup.storecopy.core.StoreCopyFinishedResponseEncoder;
+import org.neo4j.coreedge.catchup.tx.core.TxPullRequestDecoder;
+import org.neo4j.coreedge.catchup.tx.core.TxPullRequestHandler;
+import org.neo4j.coreedge.catchup.tx.core.TxPullResponseEncoder;
+import org.neo4j.coreedge.server.ListenSocketAddress;
+import org.neo4j.coreedge.catchup.storecopy.edge.GetStoreRequestDecoder;
+import org.neo4j.coreedge.raft.locks.LockRequestDecoder;
+import org.neo4j.coreedge.raft.locks.LockResponseEncoder;
+import org.neo4j.coreedge.server.logging.ExceptionLoggingHandler;
+import org.neo4j.coreedge.catchup.tx.edge.TxStreamFinishedResponseEncoder;
+import org.neo4j.coreedge.catchup.storecopy.FileHeaderEncoder;
+import org.neo4j.function.Supplier;
+import org.neo4j.helpers.NamedThreadFactory;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+public class CatchupServer extends LifecycleAdapter
+{
+    private final LogProvider logProvider;
+//    private final CoreServerLocks remoteLocks;
+
+    private final Supplier<StoreId> storeIdSupplier;
+    private final Supplier<TransactionIdStore> transactionIdStoreSupplier;
+    private final Supplier<LogicalTransactionStore> logicalTransactionStoreSupplier;
+    private final Supplier<NeoStoreDataSource> dataSourceSupplier;
+
+    private final NamedThreadFactory threadFactory = new NamedThreadFactory( "core-server" );
+    private final ListenSocketAddress listenAddress;
+
+    private EventLoopGroup workerGroup;
+    private Channel channel;
+    private Supplier<CheckPointer> checkPointerSupplier;
+    private Log log;
+
+    public CatchupServer( LogProvider logProvider,
+                          Supplier<StoreId> storeIdSupplier,
+                          Supplier<TransactionIdStore> transactionIdStoreSupplier,
+                          Supplier<LogicalTransactionStore> logicalTransactionStoreSupplier,
+                          Supplier<NeoStoreDataSource> dataSourceSupplier,
+                          Supplier<CheckPointer> checkPointerSupplier,
+                          ListenSocketAddress listenAddress )
+    {
+        this.listenAddress = listenAddress;
+        this.transactionIdStoreSupplier = transactionIdStoreSupplier;
+        this.storeIdSupplier = storeIdSupplier;
+        this.logicalTransactionStoreSupplier = logicalTransactionStoreSupplier;
+        this.logProvider = logProvider;
+        this.log = logProvider.getLog( getClass() );
+        this.dataSourceSupplier = dataSourceSupplier;
+        this.checkPointerSupplier = checkPointerSupplier;
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        startNettyServer();
+    }
+
+    private void startNettyServer()
+    {
+        workerGroup = new NioEventLoopGroup( 0, threadFactory );
+
+        ServerBootstrap bootstrap = new ServerBootstrap()
+                .group( workerGroup )
+                .channel( NioServerSocketChannel.class )
+                .localAddress( listenAddress.socketAddress() )
+                .childHandler( new ChannelInitializer<SocketChannel>()
+                {
+                    @Override
+                    protected void initChannel( SocketChannel ch ) throws Exception
+                    {
+                        CatchupServerProtocol protocol = new CatchupServerProtocol();
+
+                        ChannelPipeline pipeline = ch.pipeline();
+                        pipeline.addLast( new LengthFieldBasedFrameDecoder( Integer.MAX_VALUE, 0, 4, 0, 4 ) );
+                        pipeline.addLast( new LengthFieldPrepender( 4 ) );
+
+                        pipeline.addLast( new ResponseMessageTypeEncoder() );
+                        pipeline.addLast( new RequestMessageTypeEncoder() );
+                        pipeline.addLast( new TxPullResponseEncoder() );
+                        pipeline.addLast( new StoreCopyFinishedResponseEncoder() );
+                        pipeline.addLast( new TxStreamFinishedResponseEncoder() );
+                        pipeline.addLast( new FileHeaderEncoder() );
+                        pipeline.addLast( new LockResponseEncoder() );
+
+                        pipeline.addLast( new ServerMessageTypeHandler( protocol, logProvider ) );
+
+                        pipeline.addLast( new TxPullRequestDecoder( protocol ) );
+                        pipeline.addLast( new TxPullRequestHandler( protocol, storeIdSupplier,
+                                transactionIdStoreSupplier, logicalTransactionStoreSupplier ) );
+
+                        pipeline.addLast( new ChunkedWriteHandler() );
+                        pipeline.addLast( new GetStoreRequestDecoder( protocol ) );
+                        pipeline.addLast( new GetStoreRequestHandler( protocol, dataSourceSupplier,
+                                checkPointerSupplier ) );
+
+                        pipeline.addLast( new LockRequestDecoder( protocol ) );
+//                        pipeline.addLast( new LockRequestHandler( protocol, remoteLocks ) );
+
+                        pipeline.addLast( new ExceptionLoggingHandler( log ) );
+                    }
+                } );
+
+        channel = bootstrap.bind().syncUninterruptibly().channel();
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        try
+        {
+            channel.close().sync();
+            workerGroup.shutdownGracefully().sync();
+        }
+        catch( InterruptedException e )
+        {
+            log.warn( "Interrupted while stopping core server." );
+        }
+    }
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchupServerProtocol.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CatchupServerProtocol.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+public class CatchupServerProtocol
+{
+    private NextMessage nextMessage = NextMessage.MESSAGE_TYPE;
+
+    public void expect( NextMessage nextMessage )
+    {
+        this.nextMessage = nextMessage;
+    }
+
+    public boolean isExpecting( NextMessage message )
+    {
+        return this.nextMessage == message;
+    }
+
+    public enum NextMessage
+    {
+        MESSAGE_TYPE, GET_STORE, TX_PULL, LOCK_REQUEST
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CheckpointerSupplier.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/CheckpointerSupplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import org.neo4j.function.Supplier;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.util.Dependencies;
+
+public class CheckpointerSupplier implements Supplier<CheckPointer>
+{
+    private final Dependencies dependencies;
+
+    public CheckpointerSupplier( Dependencies dependencies )
+    {
+        this.dependencies = dependencies;
+    }
+
+    @Override
+    public CheckPointer get()
+    {
+        return dependencies.resolveDependency( CheckPointer.class );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ClientMessageTypeHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ClientMessageTypeHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.ResponseMessageType;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+import static org.neo4j.coreedge.catchup.ResponseMessageType.from;
+
+public class ClientMessageTypeHandler extends ChannelInboundHandlerAdapter
+{
+    private final Log log;
+    private final CatchupClientProtocol protocol;
+
+    public ClientMessageTypeHandler( CatchupClientProtocol protocol, LogProvider logProvider )
+    {
+        this.protocol = protocol;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    @Override
+    public void channelRead( ChannelHandlerContext ctx, Object msg ) throws Exception
+    {
+        if ( protocol.isExpecting( NextMessage.MESSAGE_TYPE ) )
+        {
+            ResponseMessageType responseMessageType = from( ((ByteBuf) msg).readByte() );
+
+            switch ( responseMessageType )
+            {
+                case STORE_ID:
+                    protocol.expect( NextMessage.STORE_ID );
+                    break;
+                case TX:
+                    protocol.expect( NextMessage.TX_PULL_RESPONSE );
+                    break;
+                case FILE:
+                    protocol.expect( NextMessage.FILE_HEADER );
+                    break;
+                case STORY_COPY_FINISHED:
+                    protocol.expect( NextMessage.STORE_COPY_FINISHED );
+                    break;
+                case TX_STREAM_FINISHED:
+                    protocol.expect( NextMessage.TX_STREAM_FINISHED );
+                    break;
+                case LOCK:
+                    protocol.expect( NextMessage.LOCK_RESPONSE );
+                    break;
+                default:
+                    log.warn( "No handler found for message type %s", responseMessageType );
+            }
+
+            ReferenceCountUtil.release( msg );
+        }
+        else
+        {
+            ctx.fireChannelRead( msg );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/DataSourceSupplier.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/DataSourceSupplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import org.neo4j.function.Supplier;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+
+public class DataSourceSupplier implements Supplier<NeoStoreDataSource>
+{
+    private final PlatformModule platformModule;
+
+    public DataSourceSupplier( PlatformModule platformModule )
+    {
+        this.platformModule = platformModule;
+    }
+
+    @Override
+    public NeoStoreDataSource get()
+    {
+        return platformModule.dataSourceManager.getDataSource();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/RequestMessageType.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/RequestMessageType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import static java.lang.String.format;
+
+public enum RequestMessageType
+{
+    TX_PULL_REQUEST( (byte) 1 ),
+    STORE( (byte) 2 ),
+    LOCK( (byte) 3 ),
+    UNKNOWN( (byte) 404 );
+
+    private byte messageType;
+
+    RequestMessageType( byte messageType )
+    {
+        this.messageType = messageType;
+    }
+
+    public static RequestMessageType from( byte b )
+    {
+        for ( RequestMessageType responseMessageType : values() )
+        {
+            if ( responseMessageType.messageType == b )
+            {
+                return responseMessageType;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    public byte messageType()
+    {
+        return messageType;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "RequestMessageType{messageType=%s}", messageType );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/RequestMessageTypeEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/RequestMessageTypeEncoder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+public class RequestMessageTypeEncoder extends MessageToMessageEncoder<RequestMessageType>
+{
+    @Override
+    protected void encode( ChannelHandlerContext ctx, RequestMessageType request, List<Object> out ) throws Exception
+    {
+        ByteBuf encoded = ctx.alloc().buffer();
+        encoded.writeByte( request.messageType() );
+        out.add( encoded );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ResponseMessageType.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ResponseMessageType.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import static java.lang.String.format;
+
+public enum ResponseMessageType
+{
+    TX( (byte) 1 ),
+    STORE_ID( (byte) 2 ),
+    FILE( (byte) 3 ),
+    STORY_COPY_FINISHED( (byte) 4 ),
+    TX_STREAM_FINISHED( (byte) 5 ),
+    LOCK( (byte) 6 ),
+    UNKNOWN( (byte) 200 ),;
+
+    private byte messageType;
+
+    ResponseMessageType( byte messageType )
+    {
+        this.messageType = messageType;
+    }
+
+    public static ResponseMessageType from( byte b )
+    {
+        for ( ResponseMessageType responseMessageType : values() )
+        {
+            if ( responseMessageType.messageType == b )
+            {
+                return responseMessageType;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    public byte messageType()
+    {
+        return messageType;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "ResponseMessageType{messageType=%s}", messageType );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ResponseMessageTypeEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ResponseMessageTypeEncoder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+public class ResponseMessageTypeEncoder extends MessageToMessageEncoder<ResponseMessageType>
+{
+    @Override
+    protected void encode( ChannelHandlerContext ctx, ResponseMessageType response, List<Object> out ) throws Exception
+    {
+        ByteBuf encoded = ctx.alloc().buffer();
+        encoded.writeByte( response.messageType() );
+        out.add( encoded );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ServerMessageTypeHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ServerMessageTypeHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
+
+import org.neo4j.coreedge.catchup.CatchupServerProtocol;
+import org.neo4j.coreedge.catchup.RequestMessageType;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static org.neo4j.coreedge.catchup.CatchupServerProtocol.NextMessage;
+
+public class ServerMessageTypeHandler extends ChannelInboundHandlerAdapter
+{
+    private final Log log;
+    private final CatchupServerProtocol protocol;
+
+    public ServerMessageTypeHandler( CatchupServerProtocol protocol, LogProvider logProvider )
+    {
+        this.protocol = protocol;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    @Override
+    public void channelRead( ChannelHandlerContext ctx, Object msg ) throws Exception
+    {
+        if ( protocol.isExpecting( NextMessage.MESSAGE_TYPE ) )
+        {
+            RequestMessageType requestMessageType = RequestMessageType.from( ((ByteBuf) msg).readByte() );
+
+            if ( requestMessageType.equals( RequestMessageType.TX_PULL_REQUEST ) )
+            {
+                protocol.expect( NextMessage.TX_PULL );
+            }
+            else if ( requestMessageType.equals( RequestMessageType.STORE ) )
+            {
+                protocol.expect( NextMessage.GET_STORE );
+            }
+            else if ( requestMessageType.equals( RequestMessageType.LOCK ) )
+            {
+                protocol.expect( NextMessage.LOCK_REQUEST );
+            }
+            else
+            {
+                log.warn( "No handler found for message type %s", requestMessageType );
+            }
+
+            ReferenceCountUtil.release( msg );
+        }
+        else
+        {
+            ctx.fireChannelRead( msg );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/StoreIdSupplier.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/StoreIdSupplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+import org.neo4j.function.Supplier;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.store.StoreId;
+
+public class StoreIdSupplier implements Supplier<StoreId>
+{
+    private final PlatformModule platformModule;
+
+    public StoreIdSupplier( PlatformModule platformModule )
+    {
+        this.platformModule = platformModule;
+    }
+
+    @Override
+    public StoreId get()
+    {
+        return platformModule.dataSourceManager.getDataSource().getStoreId();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileContentHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileContentHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+import java.io.OutputStream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreFileReceiver;
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class FileContentHandler extends SimpleChannelInboundHandler<ByteBuf>
+{
+    private final CatchupClientProtocol protocol;
+    private long expectedBytes = 0;
+
+    private StoreFileReceiver location;
+    private String destination;
+
+    public FileContentHandler( CatchupClientProtocol protocol, StoreFileReceiver location )
+    {
+        this.protocol = protocol;
+        this.location = location;
+    }
+
+    public void setExpectedFile( FileHeader fileHeader )
+    {
+        this.expectedBytes = fileHeader.fileLength();
+        this.destination = fileHeader.fileName();
+    }
+
+    @Override
+    protected void channelRead0( ChannelHandlerContext ctx, ByteBuf msg ) throws Exception
+    {
+        if ( protocol.isExpecting( NextMessage.FILE_CONTENTS ) )
+        {
+            int bytesInMessage = msg.readableBytes();
+            try ( OutputStream outputStream = location.getStoreFileStreams().createStream( destination ) )
+            {
+                msg.readBytes( outputStream, bytesInMessage );
+            }
+
+            expectedBytes -= bytesInMessage;
+
+            if ( expectedBytes <= 0 )
+            {
+                protocol.expect( NextMessage.MESSAGE_TYPE );
+            }
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileHeader.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileHeader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+public class FileHeader
+{
+    private final String fileName;
+    private final long fileLength;
+
+    public FileHeader( String fileName, long fileLength )
+    {
+        this.fileName = fileName;
+        this.fileLength = fileLength;
+    }
+
+    public long fileLength()
+    {
+        return fileLength;
+    }
+
+    public String fileName()
+    {
+        return fileName;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "FileHeader{fileName='%s', fileLength=%d}", fileName, fileLength );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileHeaderDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileHeaderDecoder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class FileHeaderDecoder extends MessageToMessageDecoder<ByteBuf>
+{
+    private final CatchupClientProtocol protocol;
+
+    public FileHeaderDecoder( CatchupClientProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Override
+    protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
+    {
+        if ( protocol.isExpecting( NextMessage.FILE_HEADER ) )
+        {
+            int nameLength = msg.readInt();
+            byte[] name = new byte[nameLength];
+            msg.readBytes( name );
+
+            long fileLength = msg.readLong();
+
+            out.add( new FileHeader( new String( name ), fileLength ) );
+        }
+        else
+        {
+            out.add( Unpooled.copiedBuffer( msg ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileHeaderEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileHeaderEncoder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+public class FileHeaderEncoder extends MessageToMessageEncoder<FileHeader>
+{
+
+    @Override
+    protected void encode( ChannelHandlerContext ctx, FileHeader msg, List<Object> out ) throws Exception
+    {
+        ByteBuf buffer = ctx.alloc().buffer();
+
+        String name = msg.fileName();
+
+        buffer.writeInt( name.length() );
+        buffer.writeBytes( name.getBytes() );
+        buffer.writeLong( msg.fileLength() );
+
+        out.add( buffer );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileHeaderHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/FileHeaderHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class FileHeaderHandler extends SimpleChannelInboundHandler<FileHeader>
+{
+    private final CatchupClientProtocol protocol;
+
+    public FileHeaderHandler( CatchupClientProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Override
+    protected void channelRead0( ChannelHandlerContext ctx, FileHeader msg ) throws Exception
+    {
+        ctx.pipeline().get( FileContentHandler.class ).setExpectedFile( msg );
+        protocol.expect( NextMessage.FILE_CONTENTS );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/LocalDatabase.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/LocalDatabase.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.catchup.storecopy.edge.CopiedStoreRecovery;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreFetcher;
+import org.neo4j.function.Supplier;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+
+public class LocalDatabase
+{
+    private final File storeDir;
+
+    private final CopiedStoreRecovery copiedStoreRecovery;
+    private final StoreFiles storeFiles;
+    private Supplier<NeoStoreDataSource> neoDataSourceSupplier;
+    private final Supplier<TransactionIdStore> transactionIdStoreSupplier;
+
+    public LocalDatabase( File storeDir,
+                          CopiedStoreRecovery copiedStoreRecovery, StoreFiles storeFiles,
+                          Supplier<NeoStoreDataSource> neoDataSourceSupplier,
+                          Supplier<TransactionIdStore> transactionIdStoreSupplier )
+    {
+        this.storeDir = storeDir;
+        this.copiedStoreRecovery = copiedStoreRecovery;
+        this.storeFiles = storeFiles;
+        this.neoDataSourceSupplier = neoDataSourceSupplier;
+        this.transactionIdStoreSupplier = transactionIdStoreSupplier;
+    }
+
+    public StoreId storeId()
+    {
+        return neoDataSourceSupplier.get().getStoreId();
+    }
+
+    public void deleteStore() throws IOException
+    {
+        storeFiles.delete( storeDir );
+    }
+
+    public void copyStoreFrom( AdvertisedSocketAddress from, StoreFetcher storeFetcher ) throws Throwable
+    {
+        storeFiles.delete( storeDir );
+
+        TemporaryStoreDirectory tempStore = new TemporaryStoreDirectory( storeDir );
+        storeFetcher.copyStore( from, tempStore.storeDir() );
+        copiedStoreRecovery.recoverCopiedStore( tempStore.storeDir() );
+        storeFiles.moveTo( tempStore.storeDir(), storeDir );
+    }
+
+    public boolean isEmpty()
+    {
+        return transactionIdStoreSupplier.get().getLastCommittedTransactionId() == TransactionIdStore.BASE_TX_ID;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreCopyFinishedResponse.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreCopyFinishedResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+public class StoreCopyFinishedResponse
+{
+    private final long lastCommittedTxBeforeStoreCopy;
+
+    public StoreCopyFinishedResponse( long lastCommittedTxBeforeStoreCopy )
+    {
+        this.lastCommittedTxBeforeStoreCopy = lastCommittedTxBeforeStoreCopy;
+    }
+
+    public long lastCommittedTxBeforeStoreCopy()
+    {
+        return lastCommittedTxBeforeStoreCopy;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        StoreCopyFinishedResponse that = (StoreCopyFinishedResponse) o;
+
+        if ( lastCommittedTxBeforeStoreCopy != that.lastCommittedTxBeforeStoreCopy )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (int) (lastCommittedTxBeforeStoreCopy ^ (lastCommittedTxBeforeStoreCopy >>> 32));
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFiles.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFiles.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.FileUtils;
+
+public class StoreFiles
+{
+    private static final FilenameFilter STORE_FILE_FILTER = new FilenameFilter()
+    {
+        @Override
+        public boolean accept( File dir, String name )
+        {
+            // Skip log files and tx files from temporary database
+            return !(
+                    name.startsWith( "metrics" ) ||
+                            name.startsWith( "raft-messages." ) ||
+                            name.startsWith( "messages." ) ||
+                            name.startsWith( "raft-logs" )
+            );
+        }
+    };
+    private FileSystemAbstraction fs;
+
+    public StoreFiles( FileSystemAbstraction fs )
+    {
+        this.fs = fs;
+    }
+
+    public void delete( File storeDir ) throws IOException
+    {
+        for ( File file : fs.listFiles( storeDir, STORE_FILE_FILTER ) )
+        {
+            FileUtils.deleteRecursively( file );
+        }
+
+    }
+
+    public void moveTo( File source, File target ) throws IOException
+    {
+        for ( File candidate : fs.listFiles( source, STORE_FILE_FILTER ) )
+        {
+            FileUtils.moveFileToDirectory( candidate, target );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/TemporaryStoreDirectory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/TemporaryStoreDirectory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.io.fs.FileUtils;
+
+public class TemporaryStoreDirectory
+{
+    private static final String TEMP_COPY_DIRECTORY_NAME = "temp-copy";
+
+    private final File storeDir;
+
+    TemporaryStoreDirectory( File parent ) throws IOException
+    {
+        this.storeDir = new File( parent, TEMP_COPY_DIRECTORY_NAME );
+        cleanDirectory();
+    }
+
+    private void cleanDirectory() throws IOException
+    {
+        if ( !storeDir.mkdir() )
+        {
+            FileUtils.deleteRecursively( storeDir );
+            storeDir.mkdir();
+        }
+    }
+
+    public File storeDir()
+    {
+        return storeDir;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/core/GetStoreRequestHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/core/GetStoreRequestHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.core;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.stream.ChunkedNioStream;
+
+import org.neo4j.coreedge.catchup.ResponseMessageType;
+import org.neo4j.coreedge.catchup.CatchupServerProtocol;
+import org.neo4j.coreedge.catchup.storecopy.edge.GetStoreRequest;
+import org.neo4j.coreedge.catchup.storecopy.FileHeader;
+import org.neo4j.coreedge.catchup.storecopy.StoreCopyFinishedResponse;
+import org.neo4j.function.Supplier;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+
+import static org.neo4j.coreedge.catchup.CatchupServerProtocol.NextMessage;
+
+public class GetStoreRequestHandler extends SimpleChannelInboundHandler<GetStoreRequest>
+{
+    private final CatchupServerProtocol protocol;
+    private final Supplier<NeoStoreDataSource> dataSource;
+
+    private Supplier<CheckPointer> checkPointerSupplier;
+
+    public GetStoreRequestHandler( CatchupServerProtocol protocol,
+                                   Supplier<NeoStoreDataSource> dataSource,
+                                   Supplier<CheckPointer> checkPointerSupplier )
+    {
+        this.protocol = protocol;
+        this.dataSource = dataSource;
+        this.checkPointerSupplier = checkPointerSupplier;
+    }
+
+    @Override
+    protected void channelRead0( ChannelHandlerContext ctx, GetStoreRequest msg ) throws Exception
+    {
+        long lastCheckPointedTx = checkPointerSupplier.get().tryCheckPoint(new SimpleTriggerInfo("Store copy"));
+        sendFiles( ctx );
+        endStoreCopy( ctx, lastCheckPointedTx );
+        protocol.expect( NextMessage.MESSAGE_TYPE );
+    }
+
+    private void sendFiles( ChannelHandlerContext ctx ) throws IOException
+    {
+        ResourceIterator<File> files = dataSource.get().listStoreFiles( false );
+        while ( files.hasNext() )
+        {
+            sendFile( ctx, files.next() );
+        }
+    }
+
+    private void sendFile( ChannelHandlerContext ctx, File file ) throws FileNotFoundException
+    {
+        ctx.writeAndFlush( ResponseMessageType.FILE );
+        ctx.writeAndFlush( new FileHeader( file.getName(), file.length() ) );
+        ctx.writeAndFlush( new ChunkedNioStream( new FileInputStream( file ).getChannel() ) );
+    }
+
+    private void endStoreCopy( ChannelHandlerContext ctx, long lastCommittedTxBeforeStoreCopy )
+    {
+        ctx.write( ResponseMessageType.STORY_COPY_FINISHED );
+        ctx.writeAndFlush( new StoreCopyFinishedResponse( lastCommittedTxBeforeStoreCopy ) );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/core/NetworkWritableLogByteBuf.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/core/NetworkWritableLogByteBuf.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.core;
+
+import java.io.Flushable;
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
+import org.neo4j.kernel.impl.transaction.log.WritableLogChannel;
+
+public class NetworkWritableLogByteBuf implements WritableLogChannel
+{
+    private final ByteBuf delegate;
+
+    public NetworkWritableLogByteBuf( ByteBuf byteBuf )
+    {
+        this.delegate = byteBuf;
+    }
+
+
+    @Override
+    public WritableLogChannel put( byte value ) throws IOException
+    {
+        delegate.writeByte( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putShort( short value ) throws IOException
+    {
+        delegate.writeShort( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putInt( int value ) throws IOException
+    {
+        delegate.writeInt( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putLong( long value ) throws IOException
+    {
+        delegate.writeLong( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putFloat( float value ) throws IOException
+    {
+        delegate.writeFloat( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putDouble( double value ) throws IOException
+    {
+        delegate.writeDouble( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel put( byte[] value, int length ) throws IOException
+    {
+        delegate.writeBytes( value, 0, length );
+        return this;
+    }
+
+    @Override
+    public LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
+    {
+        positionMarker.unspecified();
+        return positionMarker;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+    }
+
+    @Override
+    public Flushable emptyBufferIntoChannelAndClearIt()
+    {
+        return null;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/core/StoreCopyFinishedResponseEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/core/StoreCopyFinishedResponseEncoder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.core;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+import org.neo4j.coreedge.catchup.storecopy.StoreCopyFinishedResponse;
+
+public class StoreCopyFinishedResponseEncoder extends MessageToMessageEncoder<StoreCopyFinishedResponse>
+{
+
+    @Override
+    protected void encode( ChannelHandlerContext ctx, StoreCopyFinishedResponse msg, List<Object> out ) throws Exception
+    {
+        ByteBuf buffer = ctx.alloc().buffer();
+        buffer.writeLong( msg.lastCommittedTxBeforeStoreCopy() );
+        out.add( buffer );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/CopiedStoreRecovery.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/CopiedStoreRecovery.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.io.File;
+
+import org.neo4j.com.storecopy.ExternallyManagedPageCache;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Settings;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.logging.NullLogProvider;
+
+public class CopiedStoreRecovery
+{
+    private final Config config;
+    private final Iterable<KernelExtensionFactory<?>> kernelExtensions;
+    private final PageCache pageCache;
+
+    public CopiedStoreRecovery( Config config, Iterable<KernelExtensionFactory<?>> kernelExtensions,
+                                PageCache pageCache )
+    {
+        this.config = config;
+        this.kernelExtensions = kernelExtensions;
+        this.pageCache = pageCache;
+    }
+
+    public void recoverCopiedStore( File tempStore )
+    {
+        GraphDatabaseService graphDatabaseService = newTempDatabase( tempStore );
+        graphDatabaseService.shutdown();
+    }
+
+    private GraphDatabaseService newTempDatabase( File tempStore )
+    {
+        GraphDatabaseFactory factory = ExternallyManagedPageCache.graphDatabaseFactoryWithPageCache( pageCache );
+        return factory
+                .setUserLogProvider( NullLogProvider.getInstance() )
+                .setKernelExtensions( kernelExtensions )
+                .newEmbeddedDatabaseBuilder( tempStore.getAbsolutePath() )
+                .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.allow_store_upgrade,
+                        config.get( GraphDatabaseSettings.allow_store_upgrade ).toString() )
+                .newGraphDatabase();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/CoreClient.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/CoreClient.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import io.netty.channel.ChannelInitializer;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.catchup.RequestMessageType;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponseListener;
+import org.neo4j.coreedge.catchup.tx.edge.TxStreamCompleteListener;
+import org.neo4j.coreedge.server.Expiration;
+import org.neo4j.coreedge.server.SenderService;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullRequest;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponse;
+import org.neo4j.coreedge.server.ExpiryScheduler;
+import org.neo4j.helpers.Listeners;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.LogProvider;
+
+public abstract class CoreClient extends LifecycleAdapter implements StoreFileReceiver, StoreFileStreamingCompleteListener,
+                                                                     TxStreamCompleteListener, TxPullResponseListener
+{
+    private final LogProvider logProvider;
+    private StoreFileStreams storeFileStreams = null;
+    private Iterable<StoreFileStreamingCompleteListener> storeFileStreamingCompleteListeners = Listeners.newListeners();
+    private Iterable<TxStreamCompleteListener> txStreamCompleteListeners = Listeners.newListeners();
+    private Iterable<TxPullResponseListener> txPullResponseListeners = Listeners.newListeners();
+
+    private SenderService senderService;
+
+    public CoreClient( LogProvider logProvider, ExpiryScheduler expiryScheduler, Expiration expiration, ChannelInitializer channelInitializer )
+    {
+        this.logProvider = logProvider;
+        this.senderService = new SenderService( expiryScheduler, expiration, channelInitializer, logProvider );
+    }
+
+    public void requestStore( AdvertisedSocketAddress from )
+    {
+        GetStoreRequest getStoreRequest = new GetStoreRequest();
+        send( from, RequestMessageType.STORE, getStoreRequest );
+    }
+
+    public void pollForTransactions( AdvertisedSocketAddress from, long lastTransactionId )
+    {
+        TxPullRequest txPullRequest = new TxPullRequest( lastTransactionId );
+        send( from, RequestMessageType.TX_PULL_REQUEST, txPullRequest );
+    }
+
+    protected void send( AdvertisedSocketAddress to, RequestMessageType messageType, Serializable contentMessage )
+    {
+        senderService.send( to, messageType, contentMessage );
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        senderService.start();
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        senderService.stop();
+    }
+
+    public void addTxPullResponseListener( TxPullResponseListener listener )
+    {
+        txPullResponseListeners = Listeners.addListener( listener, txPullResponseListeners );
+    }
+
+    public void removeTxPullResponseListener( TxPullResponseListener listener )
+    {
+        txPullResponseListeners = Listeners.removeListener( listener, txPullResponseListeners );
+    }
+
+    public void addStoreFileStreamingCompleteListener( StoreFileStreamingCompleteListener listener )
+    {
+        storeFileStreamingCompleteListeners = Listeners.addListener( listener, storeFileStreamingCompleteListeners );
+    }
+
+    public void removeStoreFileStreamingCompleteListener( StoreFileStreamingCompleteListener listener )
+    {
+        storeFileStreamingCompleteListeners = Listeners.removeListener( listener, storeFileStreamingCompleteListeners );
+    }
+
+    @Override
+    public StoreFileStreams getStoreFileStreams()
+    {
+        return storeFileStreams;
+    }
+
+    public void setStoreFileStreams( StoreFileStreams storeFileStreams )
+    {
+        this.storeFileStreams = storeFileStreams;
+    }
+
+    @Override
+    public void onFileStreamingComplete( final long lastCommittedTxBeforeStoreCopy )
+    {
+        Listeners.notifyListeners( storeFileStreamingCompleteListeners,
+                listener -> listener.onFileStreamingComplete( lastCommittedTxBeforeStoreCopy ) );
+    }
+
+    @Override
+    public void onTxStreamingComplete( final long lastTransactionId )
+    {
+        Listeners.notifyListeners( txStreamCompleteListeners,
+                listener -> listener.onTxStreamingComplete( lastTransactionId ) );
+    }
+
+    @Override
+    public void onTxReceived( final TxPullResponse tx ) throws IOException
+    {
+        Listeners.notifyListeners( txPullResponseListeners,
+                listener -> {
+                    try
+                    {
+                        listener.onTxReceived( tx );
+                    }
+                    catch ( IOException e )
+                    {
+                        throw new RuntimeException( e );
+                    }
+                } );
+    }
+
+
+
+    public void addTxStreamCompleteListener( TxStreamCompleteListener listener )
+    {
+        txStreamCompleteListeners = Listeners.addListener( listener, txStreamCompleteListeners );
+    }
+
+    public void removeTxStreamCompleteListener( TxStreamCompleteListener listener )
+    {
+        txStreamCompleteListeners = Listeners.removeListener( listener, txStreamCompleteListeners );
+    }
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/EdgeToCoreClient.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/EdgeToCoreClient.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+
+import org.neo4j.coreedge.catchup.RequestMessageTypeEncoder;
+import org.neo4j.coreedge.catchup.ResponseMessageTypeEncoder;
+import org.neo4j.coreedge.catchup.storecopy.FileHeaderDecoder;
+import org.neo4j.coreedge.raft.locks.LockRequestEncoder;
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponseHandler;
+import org.neo4j.coreedge.catchup.tx.edge.TxStreamFinishedResponseDecoder;
+import org.neo4j.coreedge.catchup.tx.edge.TxStreamFinishedResponseHandler;
+import org.neo4j.coreedge.catchup.ClientMessageTypeHandler;
+import org.neo4j.coreedge.server.logging.ExceptionLoggingHandler;
+import org.neo4j.coreedge.server.Expiration;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullRequestEncoder;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponseDecoder;
+import org.neo4j.coreedge.server.ExpiryScheduler;
+import org.neo4j.coreedge.catchup.storecopy.FileContentHandler;
+import org.neo4j.coreedge.catchup.storecopy.FileHeaderHandler;
+import org.neo4j.logging.LogProvider;
+
+public class EdgeToCoreClient extends CoreClient
+{
+    public EdgeToCoreClient( LogProvider logProvider, ExpiryScheduler expiryScheduler, Expiration expiration, ChannelInitializer channelInitializer )
+    {
+        super( logProvider, expiryScheduler, expiration, channelInitializer );
+    }
+
+    public static class ChannelInitializer extends io.netty.channel.ChannelInitializer<SocketChannel>
+    {
+        private final LogProvider logProvider;
+        private EdgeToCoreClient owner;
+
+        public ChannelInitializer( LogProvider logProvider )
+        {
+            this.logProvider = logProvider;
+        }
+
+        public void setOwner( EdgeToCoreClient client )
+        {
+            this.owner = client;
+        }
+
+        @Override
+        protected void initChannel( SocketChannel ch ) throws Exception
+        {
+            CatchupClientProtocol protocol = new CatchupClientProtocol();
+
+            ChannelPipeline pipeline = ch.pipeline();
+            pipeline.addLast( new LengthFieldBasedFrameDecoder( Integer.MAX_VALUE, 0, 4, 0, 4 ) );
+            pipeline.addLast( new LengthFieldPrepender( 4 ) );
+
+            pipeline.addLast( new TxPullRequestEncoder() );
+            pipeline.addLast( new GetStoreRequestEncoder() );
+            pipeline.addLast( new LockRequestEncoder() );
+            pipeline.addLast( new ResponseMessageTypeEncoder() );
+            pipeline.addLast( new RequestMessageTypeEncoder() );
+
+            pipeline.addLast( new ClientMessageTypeHandler( protocol, logProvider ) );
+
+            pipeline.addLast( new TxPullResponseDecoder( protocol ) );
+            pipeline.addLast( new TxPullResponseHandler( protocol, owner ) );
+
+            pipeline.addLast( new StoreCopyFinishedResponseDecoder( protocol ) );
+            pipeline.addLast( new StoreCopyFinishedResponseHandler( protocol, owner ) );
+
+            pipeline.addLast( new TxStreamFinishedResponseDecoder( protocol ) );
+            pipeline.addLast( new TxStreamFinishedResponseHandler( protocol, owner ) );
+
+            // keep these after type-specific handlers since they process ByteBufs
+            pipeline.addLast( new FileHeaderDecoder( protocol ) );
+            pipeline.addLast( new FileHeaderHandler( protocol ) );
+            pipeline.addLast( new FileContentHandler( protocol, owner ) );
+
+            pipeline.addLast( new ExceptionLoggingHandler( logProvider.getLog( getClass() ) ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/GetStoreRequest.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/GetStoreRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.io.Serializable;
+
+import org.neo4j.coreedge.catchup.RequestMessageType;
+
+public class GetStoreRequest implements Serializable
+{
+    public static final RequestMessageType MESSAGE_TYPE = RequestMessageType.STORE;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/GetStoreRequestDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/GetStoreRequestDecoder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import org.neo4j.coreedge.catchup.CatchupServerProtocol;
+
+public class GetStoreRequestDecoder extends MessageToMessageDecoder<ByteBuf>
+{
+    private final CatchupServerProtocol protocol;
+
+    public GetStoreRequestDecoder( CatchupServerProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Override
+    protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
+    {
+        if ( protocol.isExpecting( CatchupServerProtocol.NextMessage.GET_STORE ) )
+        {
+            out.add( new GetStoreRequest() );
+        }
+        else
+        {
+            out.add( Unpooled.copiedBuffer( msg ) );
+        }
+
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/GetStoreRequestEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/GetStoreRequestEncoder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+public class GetStoreRequestEncoder extends MessageToMessageEncoder<GetStoreRequest>
+{
+    @Override
+    protected void encode( ChannelHandlerContext ctx, GetStoreRequest msg, List<Object> out ) throws Exception
+    {
+        ByteBuf buffer = ctx.alloc().buffer();
+        buffer.writeByte( 0 );
+        out.add( buffer );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreCopyClient.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreCopyClient.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.util.concurrent.ExecutionException;
+
+import org.neo4j.concurrent.CompletableFuture;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+
+public class StoreCopyClient
+{
+    private final CoreClient coreClient;
+
+    public StoreCopyClient( CoreClient coreClient )
+    {
+        this.coreClient = coreClient;
+    }
+
+    public long copyStoreFiles( AdvertisedSocketAddress from, StoreFileStreams storeFileStreams ) throws StoreCopyFailedException
+    {
+        coreClient.setStoreFileStreams( storeFileStreams );
+
+        final CompletableFuture<Long> txId = new CompletableFuture<>();
+        StoreFileStreamingCompleteListener fileStreamingCompleteListener = txId::complete;
+
+        coreClient.addStoreFileStreamingCompleteListener( fileStreamingCompleteListener );
+
+        try
+        {
+            coreClient.requestStore( from );
+            return txId.get();
+        }
+        catch ( InterruptedException | ExecutionException e )
+        {
+            throw new StoreCopyFailedException( e );
+        }
+        finally
+        {
+            coreClient.removeStoreFileStreamingCompleteListener( fileStreamingCompleteListener );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreCopyFailedException.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreCopyFailedException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+public class StoreCopyFailedException extends Exception
+{
+    public StoreCopyFailedException( Throwable cause )
+    {
+        super( cause );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreCopyFinishedResponseDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreCopyFinishedResponseDecoder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import org.neo4j.coreedge.catchup.storecopy.StoreCopyFinishedResponse;
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+
+public class StoreCopyFinishedResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+{
+    private final CatchupClientProtocol protocol;
+
+    public StoreCopyFinishedResponseDecoder( CatchupClientProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Override
+    protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
+    {
+        if ( protocol.isExpecting( CatchupClientProtocol.NextMessage.STORE_COPY_FINISHED ) )
+        {
+            out.add( new StoreCopyFinishedResponse( msg.readLong() ) );
+        }
+        else
+        {
+            out.add( Unpooled.copiedBuffer( msg ) );
+        }
+
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreCopyFinishedResponseHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreCopyFinishedResponseHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import org.neo4j.coreedge.catchup.storecopy.StoreCopyFinishedResponse;
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class StoreCopyFinishedResponseHandler extends SimpleChannelInboundHandler<StoreCopyFinishedResponse>
+{
+    private final CatchupClientProtocol protocol;
+    private StoreFileStreamingCompleteListener storeFileStreamingCompleteListener;
+
+    public StoreCopyFinishedResponseHandler( CatchupClientProtocol protocol,
+                                             StoreFileStreamingCompleteListener storeFileStreamingCompleteListener )
+    {
+        this.protocol = protocol;
+        this.storeFileStreamingCompleteListener = storeFileStreamingCompleteListener;
+    }
+
+    @Override
+    protected void channelRead0( ChannelHandlerContext ctx, final StoreCopyFinishedResponse msg ) throws Exception
+    {
+        storeFileStreamingCompleteListener.onFileStreamingComplete( msg.lastCommittedTxBeforeStoreCopy() );
+        protocol.expect( NextMessage.MESSAGE_TYPE );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFetcher.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFetcher.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.catchup.tx.edge.TransactionLogCatchUpFactory;
+import org.neo4j.coreedge.catchup.tx.edge.TransactionLogCatchUpWriter;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullClient;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+public class StoreFetcher
+{
+    private final Log log;
+    private FileSystemAbstraction fs;
+    private PageCache pageCache;
+    private StoreCopyClient storeCopyClient;
+    private TxPullClient txPullClient;
+    private TransactionLogCatchUpFactory transactionLogFactory;
+
+    public StoreFetcher( LogProvider logProvider,
+                         FileSystemAbstraction fs, PageCache pageCache,
+                         StoreCopyClient storeCopyClient, TxPullClient txPullClient,
+                         TransactionLogCatchUpFactory transactionLogFactory )
+    {
+        this.storeCopyClient = storeCopyClient;
+        this.txPullClient = txPullClient;
+        this.fs = fs;
+        this.pageCache = pageCache;
+        this.transactionLogFactory = transactionLogFactory;
+        log = logProvider.getLog( getClass() );
+    }
+
+    public void copyStore( AdvertisedSocketAddress from, File storeDir ) throws StoreCopyFailedException
+    {
+        try
+        {
+            log.info( "Copying store from %s", from );
+            long lastFlushedTxId = storeCopyClient.copyStoreFiles( from, new StreamToDisk( storeDir, fs ) );
+            log.info( "Store files streamed up to %d", lastFlushedTxId );
+
+            try ( TransactionLogCatchUpWriter writer = transactionLogFactory.create( storeDir, fs, pageCache ) )
+            {
+                long lastPulledTxId = txPullClient.pullTransactions( from, lastFlushedTxId, writer );
+                log.info( "Txs streamed up to %d", lastPulledTxId );
+                writer.setCorrectTransactionId( lastPulledTxId );
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new StoreCopyFailedException( e );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFileReceiver.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFileReceiver.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+public interface StoreFileReceiver
+{
+    StoreFileStreams getStoreFileStreams();
+}
+
+
+

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFileStreamingCompleteListener.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFileStreamingCompleteListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+public interface StoreFileStreamingCompleteListener
+{
+    void onFileStreamingComplete( long lastCommittedTxBeforeStoreCopy );
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFileStreams.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFileStreams.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public interface StoreFileStreams
+{
+    OutputStream createStream( String destination ) throws IOException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StreamToDisk.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/edge/StreamToDisk.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreFileStreams;
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+public class StreamToDisk implements StoreFileStreams
+{
+    private final File storeDir;
+    private final FileSystemAbstraction fs;
+
+    public StreamToDisk( File storeDir, FileSystemAbstraction fs ) throws IOException
+    {
+        this.storeDir = storeDir;
+        this.fs = fs;
+        fs.mkdirs( storeDir );
+    }
+
+    @Override
+    public OutputStream createStream( String destination ) throws IOException
+    {
+        return fs.openAsOutputStream( new File( storeDir, destination ), true );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/core/TxPullRequestDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/core/TxPullRequestDecoder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.core;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import org.neo4j.coreedge.catchup.CatchupServerProtocol;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullRequest;
+
+import static org.neo4j.coreedge.catchup.CatchupServerProtocol.NextMessage.TX_PULL;
+
+public class TxPullRequestDecoder extends MessageToMessageDecoder<ByteBuf>
+{
+    private final CatchupServerProtocol protocol;
+
+    public TxPullRequestDecoder( CatchupServerProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Override
+    protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
+    {
+        if ( protocol.isExpecting( TX_PULL ) )
+        {
+            long txId = msg.readLong();
+            out.add( new TxPullRequest( txId ) );
+        }
+        else
+        {
+            out.add( Unpooled.copiedBuffer( msg ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/core/TxPullRequestHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/core/TxPullRequestHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.core;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import org.neo4j.coreedge.catchup.ResponseMessageType;
+import org.neo4j.coreedge.catchup.CatchupServerProtocol;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullRequest;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponse;
+import org.neo4j.function.Supplier;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.IOCursor;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+
+import static org.neo4j.coreedge.catchup.CatchupServerProtocol.NextMessage;
+
+public class TxPullRequestHandler extends SimpleChannelInboundHandler<TxPullRequest>
+{
+    private final CatchupServerProtocol protocol;
+    private final StoreId storeId;
+    private final TransactionIdStore transactionIdStore;
+    private final LogicalTransactionStore logicalTransactionStore;
+
+    public TxPullRequestHandler( CatchupServerProtocol protocol,
+                                 Supplier<StoreId> storeIdSupplier,
+                                 Supplier<TransactionIdStore> transactionIdStoreSupplier,
+                                 Supplier<LogicalTransactionStore> logicalTransactionStoreSupplier )
+    {
+        this.protocol = protocol;
+        this.storeId = storeIdSupplier.get();
+        this.transactionIdStore = transactionIdStoreSupplier.get();
+        this.logicalTransactionStore = logicalTransactionStoreSupplier.get();
+    }
+
+    @Override
+    protected void channelRead0( ChannelHandlerContext ctx, final TxPullRequest msg ) throws Exception
+    {
+        long startTxId = msg.txId();
+        long endTxId = startTxId;
+
+        if ( transactionIdStore.getLastCommittedTransactionId() > startTxId )
+        {
+            IOCursor<CommittedTransactionRepresentation> cursor =
+                    logicalTransactionStore.getTransactions( startTxId + 1 );
+
+            while ( cursor.next() )
+            {
+                ctx.write( ResponseMessageType.TX );
+                CommittedTransactionRepresentation tx = cursor.get();
+                endTxId = tx.getCommitEntry().getTxId();
+                ctx.write( new TxPullResponse( storeId, tx ) );
+            }
+            ctx.flush();
+        }
+
+        ctx.write( ResponseMessageType.TX_STREAM_FINISHED );
+        ctx.write( new TxStreamFinishedResponse( endTxId ) );
+        ctx.flush();
+
+        protocol.expect( NextMessage.MESSAGE_TYPE );
+    }
+
+    @Override
+    public void exceptionCaught( ChannelHandlerContext ctx, Throwable cause )
+    {
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/core/TxPullResponseEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/core/TxPullResponseEncoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.core;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+import org.neo4j.com.CommittedTransactionSerializer;
+import org.neo4j.coreedge.catchup.storecopy.core.NetworkWritableLogByteBuf;
+import org.neo4j.coreedge.raft.replication.storeid.StoreIdEncoder;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponse;
+
+public class TxPullResponseEncoder extends MessageToMessageEncoder<TxPullResponse>
+{
+    @Override
+    protected void encode( ChannelHandlerContext ctx, TxPullResponse response, List<Object> out ) throws Exception
+    {
+        ByteBuf encoded = ctx.alloc().buffer();
+        new StoreIdEncoder().encode( response.storeId(), encoded );
+        new CommittedTransactionSerializer( new NetworkWritableLogByteBuf( encoded ) ).visit( response.tx() );
+        out.add( encoded );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/core/TxStreamFinishedResponse.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/core/TxStreamFinishedResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.core;
+
+public class TxStreamFinishedResponse
+{
+    private final long lastTransactionIdSent;
+
+    public TxStreamFinishedResponse( long lastTransactionIdSent )
+    {
+        this.lastTransactionIdSent = lastTransactionIdSent;
+    }
+
+    public long lastTransactionIdSent()
+    {
+        return lastTransactionIdSent;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        TxStreamFinishedResponse that = (TxStreamFinishedResponse) o;
+
+        return lastTransactionIdSent == that.lastTransactionIdSent;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (int) (lastTransactionIdSent ^ (lastTransactionIdSent >>> 32));
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/ApplyPulledTransactions.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/ApplyPulledTransactions.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.io.IOException;
+
+import org.neo4j.function.Supplier;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+public class ApplyPulledTransactions implements TxPullResponseListener
+{
+    private final Supplier<TransactionApplier> transactionApplierSupplier;
+    private final Log log;
+
+    public ApplyPulledTransactions( LogProvider logProvider, Supplier<TransactionApplier> transactionApplierSupplier )
+    {
+        this.transactionApplierSupplier = transactionApplierSupplier;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    @Override
+    public void onTxReceived( TxPullResponse tx )
+    {
+        try
+        {
+            transactionApplierSupplier.get().appendToLogAndApplyToStore( tx.tx() );
+        }
+        catch ( IOException e )
+        {
+            log.error( "Failed to apply transaction.", e );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/NetworkReadableLogByteBuf.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/NetworkReadableLogByteBuf.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
+import org.neo4j.kernel.impl.transaction.log.ReadPastEndException;
+import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
+
+public class NetworkReadableLogByteBuf implements ReadableLogChannel
+{
+    private final ByteBuf delegate;
+
+    public NetworkReadableLogByteBuf( ByteBuf input )
+    {
+        this.delegate = input;
+    }
+
+    @Override
+    public byte get() throws IOException
+    {
+        try
+        {
+            return delegate.readByte();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public short getShort() throws IOException
+    {
+        try
+        {
+            return delegate.readShort();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public int getInt() throws IOException
+    {
+        try
+        {
+            return delegate.readInt();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public long getLong() throws IOException
+    {
+        try
+        {
+            return delegate.readLong();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public float getFloat() throws IOException
+    {
+        try
+        {
+            return delegate.readFloat();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public double getDouble() throws IOException
+    {
+        try
+        {
+            return delegate.readDouble();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public void get( byte[] bytes, int length ) throws IOException
+    {
+        try
+        {
+            delegate.readBytes( bytes, 0, length );
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
+    {
+        positionMarker.unspecified();
+        return positionMarker;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        // no op
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TransactionApplier.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TransactionApplier.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.io.IOException;
+
+import org.neo4j.com.Response;
+import org.neo4j.com.TransactionStream;
+import org.neo4j.com.TransactionStreamResponse;
+import org.neo4j.com.storecopy.TransactionObligationFulfiller;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.kernel.KernelHealth;
+import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
+import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.Commitment;
+import org.neo4j.kernel.impl.transaction.log.LogFile;
+import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
+import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
+import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
+
+import static org.neo4j.kernel.impl.api.TransactionApplicationMode.EXTERNAL;
+
+/**
+ * Receives and unpacks {@link Response responses}.
+ * Transaction obligations are handled by {@link TransactionObligationFulfiller} and
+ * {@link TransactionStream transaction streams} are {@link TransactionRepresentationStoreApplier applied to the
+ * store},
+ * in batches.
+ * <p/>
+ * It is assumed that any {@link TransactionStreamResponse response carrying transaction data} comes from the one
+ * and same thread.
+ */
+public class TransactionApplier
+{
+    private final TransactionAppender appender;
+    private final TransactionRepresentationStoreApplier storeApplier;
+    private final IndexUpdatesValidator indexUpdatesValidator;
+    private final LogFile logFile;
+    private final LogRotation logRotation;
+    private final KernelHealth kernelHealth;
+
+    public TransactionApplier( DependencyResolver resolver )
+    {
+        this.appender = resolver.resolveDependency( TransactionAppender.class );
+        this.storeApplier = resolver.resolveDependency( TransactionRepresentationStoreApplier.class );
+        this.indexUpdatesValidator = resolver.resolveDependency( IndexUpdatesValidator.class );
+        this.logFile = resolver.resolveDependency( LogFile.class );
+        this.logRotation = resolver.resolveDependency( LogRotation.class );
+        this.kernelHealth = resolver.resolveDependency( KernelHealth.class );
+    }
+
+    public void appendToLogAndApplyToStore( CommittedTransactionRepresentation tx ) throws IOException
+    {
+        // Synchronize to guard for concurrent shutdown
+        synchronized ( logFile )
+        {
+            // Check rotation explicitly, since the version of append that we're calling isn't doing that.
+            logRotation.rotateLogIfNeeded( LogAppendEvent.NULL );
+
+            try
+            {
+                LogEntryCommit commitEntry = tx.getCommitEntry();
+
+                Commitment commitment = appender.append( tx.getTransactionRepresentation(), commitEntry.getTxId() );
+
+                appender.force();
+
+                long transactionId = commitEntry.getTxId();
+                TransactionRepresentation representation = tx.getTransactionRepresentation();
+                try
+                {
+                    commitment.publishAsCommitted();
+                    try ( LockGroup locks = new LockGroup();
+                          ValidatedIndexUpdates indexUpdates = indexUpdatesValidator.validate( representation) )
+                    {
+                        storeApplier.apply( representation, indexUpdates, locks, transactionId, EXTERNAL );
+                    }
+                }
+                finally
+                {
+                    commitment.publishAsApplied();
+                }
+            }
+            catch ( IOException e )
+            {
+                // Kernel panic is done on this level, i.e. append and apply doesn't do that themselves.
+                kernelHealth.panic( e );
+                throw e;
+            }
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TransactionLogCatchUpFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TransactionLogCatchUpFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+
+public class TransactionLogCatchUpFactory
+{
+    public TransactionLogCatchUpWriter create( File storeDir, FileSystemAbstraction fs, PageCache pageCache ) throws IOException
+    {
+        return new TransactionLogCatchUpWriter( storeDir, fs, pageCache );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TransactionLogCatchUpWriter.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TransactionLogCatchUpWriter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.CommandWriter;
+import org.neo4j.kernel.impl.transaction.log.LogFile;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
+import org.neo4j.kernel.impl.transaction.log.ReadOnlyLogVersionRepository;
+import org.neo4j.kernel.impl.transaction.log.ReadOnlyTransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionLogWriter;
+import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache;
+import org.neo4j.kernel.impl.transaction.log.WritableLogChannel;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static java.lang.Math.max;
+
+import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter.writeLogHeader;
+
+public class TransactionLogCatchUpWriter implements TxPullResponseListener, AutoCloseable
+{
+    private final FileSystemAbstraction fs;
+    private final LifeSupport life;
+    private final PhysicalLogFiles logFiles;
+    private final ReadOnlyLogVersionRepository logVersionRepository;
+    private final TransactionLogWriter writer;
+
+    public TransactionLogCatchUpWriter( File storeDir, FileSystemAbstraction fs, PageCache pageCache ) throws
+            IOException
+    {
+        this.fs = fs;
+        this.life = new LifeSupport();
+
+        logFiles = new PhysicalLogFiles( storeDir, fs );
+        logVersionRepository = new ReadOnlyLogVersionRepository( pageCache, storeDir );
+        LogFile logFile = life.add( new PhysicalLogFile( fs, logFiles, Long.MAX_VALUE /*don't rotate*/,
+                new ReadOnlyTransactionIdStore( pageCache, storeDir ), logVersionRepository,
+                new Monitors().newMonitor( PhysicalLogFile.Monitor.class ),
+                new TransactionMetadataCache( 10, 100 ) ) );
+        life.start();
+
+        WritableLogChannel channel = logFile.getWriter();
+        this.writer = new TransactionLogWriter( new LogEntryWriter( channel, new CommandWriter( channel ) ) );
+    }
+
+    @Override
+    public void onTxReceived( TxPullResponse txPullResponse ) throws IOException
+    {
+        CommittedTransactionRepresentation tx = txPullResponse.tx();
+        writer.append( tx.getTransactionRepresentation(), tx.getCommitEntry().getTxId() );
+    }
+
+    public void setCorrectTransactionId( long endTxId ) throws IOException
+    {
+        long currentLogVersion = logVersionRepository.getCurrentLogVersion();
+        writer.checkPoint( new LogPosition( currentLogVersion, LOG_HEADER_SIZE ) );
+
+        File currentLogFile = logFiles.getLogFileForVersion( currentLogVersion );
+        writeLogHeader( fs, currentLogFile, currentLogVersion, max( BASE_TX_ID, endTxId ) );
+    }
+
+    @Override
+    public void close()
+    {
+        life.stop();
+        life.shutdown();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPollingClient.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPollingClient.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import org.neo4j.coreedge.catchup.storecopy.edge.CoreClient;
+import org.neo4j.coreedge.discovery.EdgeDiscoveryService;
+import org.neo4j.function.Supplier;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.pullUpdates;
+
+public class TxPollingClient extends LifecycleAdapter
+{
+    private final JobScheduler jobScheduler;
+    private final Supplier<TransactionIdStore> transactionIdStoreSupplier;
+    private final EdgeDiscoveryService edgeDiscoveryService;
+    private final long pollingInterval;
+    private final CoreClient coreClient;
+    private final TxPullResponseListener txPullResponseListener;
+
+    public TxPollingClient( JobScheduler jobScheduler, long pollingInterval,
+                            Supplier<TransactionIdStore> transactionIdStoreSupplier,
+                            CoreClient coreClient, TxPullResponseListener txPullResponseListener,
+                            EdgeDiscoveryService edgeDiscoveryService )
+    {
+        this.coreClient = coreClient;
+        this.txPullResponseListener = txPullResponseListener;
+
+        this.jobScheduler = jobScheduler;
+        this.pollingInterval = pollingInterval;
+
+        this.transactionIdStoreSupplier = transactionIdStoreSupplier;
+        this.edgeDiscoveryService = edgeDiscoveryService;
+    }
+
+    public void startPolling()
+    {
+        coreClient.addTxPullResponseListener( txPullResponseListener );
+        final TransactionIdStore transactionIdStore = transactionIdStoreSupplier.get();
+        jobScheduler.scheduleRecurring( pullUpdates, new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                coreClient.pollForTransactions( first( edgeDiscoveryService.currentTopology().getMembers() )
+                        .getCoreAddress(), transactionIdStore.getLastCommittedTransactionId() );
+            }
+        }, pollingInterval, MILLISECONDS );
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        coreClient.removeTxPullResponseListener( txPullResponseListener );
+        jobScheduler.shutdown();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullClient.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullClient.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.util.concurrent.ExecutionException;
+
+import org.neo4j.concurrent.CompletableFuture;
+import org.neo4j.coreedge.catchup.storecopy.edge.CoreClient;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreCopyFailedException;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+
+public class TxPullClient
+{
+    private final CoreClient coreClient;
+
+    public TxPullClient( CoreClient coreClient )
+    {
+        this.coreClient = coreClient;
+    }
+
+    public long pullTransactions( AdvertisedSocketAddress from, long startTxId, TxPullResponseListener txPullResponseListener )
+            throws StoreCopyFailedException
+    {
+        coreClient.addTxPullResponseListener( txPullResponseListener );
+
+        final CompletableFuture<Long> txId = new CompletableFuture<>();
+
+        TxStreamCompleteListener streamCompleteListener = lastTransactionId -> txId.complete( lastTransactionId );
+        coreClient.addTxStreamCompleteListener( streamCompleteListener );
+
+        try
+        {
+            coreClient.pollForTransactions( from, startTxId );
+            return txId.get();
+        }
+        catch ( InterruptedException | ExecutionException e )
+        {
+            throw new StoreCopyFailedException( e );
+        }
+        finally
+        {
+            coreClient.removeTxPullResponseListener( txPullResponseListener );
+            coreClient.removeTxStreamCompleteListener( streamCompleteListener );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullRequest.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullRequest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.io.Serializable;
+
+import org.neo4j.coreedge.catchup.RequestMessageType;
+
+import static java.lang.String.format;
+
+public class TxPullRequest implements Serializable
+{
+    public static final RequestMessageType MESSAGE_TYPE = RequestMessageType.TX_PULL_REQUEST;
+
+    private final long txId;
+
+    public TxPullRequest( long txId )
+    {
+        this.txId = txId;
+    }
+
+    public long txId()
+    {
+        return txId;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        TxPullRequest that = (TxPullRequest) o;
+
+        return txId == that.txId;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = (int) (txId ^ (txId >>> 32));
+        result = 31 * result;
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "TxPullRequest{txId=%d}", txId );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullRequestEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullRequestEncoder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+public class TxPullRequestEncoder extends MessageToMessageEncoder<TxPullRequest>
+{
+    @Override
+    protected void encode( ChannelHandlerContext ctx, TxPullRequest request, List<Object> out ) throws Exception
+    {
+        ByteBuf encoded = ctx.alloc().buffer();
+        encoded.writeLong( request.txId() );
+        out.add( encoded );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullResponse.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullResponse.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+
+public class TxPullResponse
+{
+    private final StoreId storeId;
+    private final CommittedTransactionRepresentation tx;
+
+    public TxPullResponse( StoreId storeId, CommittedTransactionRepresentation tx )
+    {
+        this.storeId = storeId;
+        this.tx = tx;
+    }
+
+    public StoreId storeId()
+    {
+        return storeId;
+    }
+
+    public CommittedTransactionRepresentation tx()
+    {
+        return tx;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        TxPullResponse that = (TxPullResponse) o;
+
+        return (storeId != null ? storeId.equals( that.storeId ) : that.storeId == null) &&
+                (tx != null ? tx.equals( that.tx ) : that.tx == null);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = storeId != null ? storeId.hashCode() : 0;
+        result = 31 * result + (tx != null ? tx.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "TxPullResponse{storeId=%s, tx=%s}", storeId, tx );
+    }
+
+    public boolean isEndOfTxStreamMarker()
+    {
+        return storeId.equals( StoreId.DEFAULT );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullResponseDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullResponseDecoder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.raft.replication.storeid.StoreIdDecoder;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionCursor;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
+import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class TxPullResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+{
+    private final CatchupClientProtocol protocol;
+
+    public TxPullResponseDecoder( CatchupClientProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Override
+    protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
+    {
+        if ( protocol.isExpecting( NextMessage.TX_PULL_RESPONSE ) )
+        {
+            StoreId storeId = new StoreIdDecoder().decode( msg );
+
+            NetworkReadableLogByteBuf logChannel = new NetworkReadableLogByteBuf( msg );
+            LogEntryReader<NetworkReadableLogByteBuf> reader = new VersionAwareLogEntryReader<>();
+            PhysicalTransactionCursor<NetworkReadableLogByteBuf> transactionCursor =
+                    new PhysicalTransactionCursor<>( logChannel, reader );
+
+            transactionCursor.next();
+            CommittedTransactionRepresentation tx = transactionCursor.get();
+
+            if ( tx != null )
+            {
+                out.add( new TxPullResponse( storeId, tx ) );
+            }
+        }
+        else
+        {
+            out.add( Unpooled.copiedBuffer( msg ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullResponseHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullResponseHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+
+public class TxPullResponseHandler extends SimpleChannelInboundHandler<TxPullResponse>
+{
+    private final CatchupClientProtocol protocol;
+    private final TxPullResponseListener listener;
+
+    public TxPullResponseHandler( CatchupClientProtocol protocol,
+                                  TxPullResponseListener listener )
+    {
+        this.protocol = protocol;
+        this.listener = listener;
+    }
+
+    @Override
+    protected void channelRead0( ChannelHandlerContext ctx, final TxPullResponse msg ) throws Exception
+    {
+        if ( protocol.isExpecting( CatchupClientProtocol.NextMessage.TX_PULL_RESPONSE ) )
+        {
+            listener.onTxReceived( msg );
+            protocol.expect( CatchupClientProtocol.NextMessage.MESSAGE_TYPE );
+        }
+        else
+        {
+            ctx.fireChannelRead( msg );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullResponseListener.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPullResponseListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.io.IOException;
+
+public interface TxPullResponseListener
+{
+    void onTxReceived( TxPullResponse tx ) throws IOException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxStreamCompleteListener.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxStreamCompleteListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+public interface TxStreamCompleteListener
+{
+    void onTxStreamingComplete( long lastTransactionId );
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxStreamFinishedResponseDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxStreamFinishedResponseDecoder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.tx.core.TxStreamFinishedResponse;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class TxStreamFinishedResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+{
+    private final CatchupClientProtocol protocol;
+
+    public TxStreamFinishedResponseDecoder( CatchupClientProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Override
+    protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
+    {
+        if ( protocol.isExpecting( NextMessage.TX_STREAM_FINISHED ) )
+        {
+            long lastTransactionIdSent = msg.readLong();
+            out.add( new TxStreamFinishedResponse( lastTransactionIdSent ) );
+        }
+        else
+        {
+            out.add( Unpooled.copiedBuffer( msg ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxStreamFinishedResponseEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxStreamFinishedResponseEncoder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+import org.neo4j.coreedge.catchup.tx.core.TxStreamFinishedResponse;
+
+public class TxStreamFinishedResponseEncoder extends MessageToMessageEncoder<TxStreamFinishedResponse>
+{
+    @Override
+    protected void encode( ChannelHandlerContext ctx, TxStreamFinishedResponse response, List<Object> out ) throws
+            Exception
+    {
+        ByteBuf encoded = ctx.alloc().buffer();
+        encoded.writeLong( response.lastTransactionIdSent() );
+        out.add( encoded );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxStreamFinishedResponseHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxStreamFinishedResponseHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.tx.core.TxStreamFinishedResponse;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class TxStreamFinishedResponseHandler extends SimpleChannelInboundHandler<TxStreamFinishedResponse>
+{
+    private final CatchupClientProtocol protocol;
+    private final TxStreamCompleteListener listener;
+
+    public TxStreamFinishedResponseHandler( CatchupClientProtocol protocol, TxStreamCompleteListener
+            streamingListener )
+    {
+        this.protocol = protocol;
+        this.listener = streamingListener;
+    }
+
+    @Override
+    protected void channelRead0( ChannelHandlerContext ctx, TxStreamFinishedResponse msg ) throws Exception
+    {
+        listener.onTxStreamingComplete( msg.lastTransactionIdSent() );
+        protocol.expect( NextMessage.MESSAGE_TYPE );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/ClusterTopology.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/ClusterTopology.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import java.util.Set;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.CoreMember;
+
+public interface ClusterTopology
+{
+    AdvertisedSocketAddress firstTransactionServer();
+
+    int getNumberOfEdgeServers();
+    int getNumberOfCoreServers();
+
+    Set<CoreMember> getMembers();
+
+    boolean bootstrappable();
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreDiscoveryService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/CoreDiscoveryService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+public interface CoreDiscoveryService extends EdgeDiscoveryService
+{
+    void addMembershipListener( Listener listener );
+
+    void removeMembershipListener( Listener listener );
+
+    interface Listener
+    {
+        void onTopologyChange( ClusterTopology clusterTopology );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/DiscoveryServiceFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/DiscoveryServiceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+
+import org.neo4j.coreedge.discovery.CoreDiscoveryService;
+import org.neo4j.coreedge.discovery.EdgeDiscoveryService;
+import org.neo4j.kernel.configuration.Config;
+
+public interface DiscoveryServiceFactory
+{
+    CoreDiscoveryService coreDiscoveryService( Config config );
+
+    EdgeDiscoveryService edgeDiscoveryService( Config config );
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/EdgeDiscoveryService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/EdgeDiscoveryService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import org.neo4j.kernel.lifecycle.Lifecycle;
+
+public interface EdgeDiscoveryService extends Lifecycle
+{
+    ClusterTopology currentTopology();
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/EdgeServerConnectionException.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/EdgeServerConnectionException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+public class EdgeServerConnectionException extends Throwable
+{
+    public EdgeServerConnectionException( IllegalStateException e )
+    {
+        super( e );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClientLifecycle.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClientLifecycle.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.HazelcastInstance;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.coreedge.server.CoreEdgeClusterSettings;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public class HazelcastClientLifecycle extends LifecycleAdapter implements EdgeDiscoveryService
+{
+    private Config config;
+    private HazelcastInstance hazelcastInstance;
+
+    public HazelcastClientLifecycle( Config config )
+    {
+        this.config = config;
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        ClientConfig clientConfig = clientConfig();
+
+        try
+        {
+            hazelcastInstance = HazelcastClient.newHazelcastClient( clientConfig );
+        }
+        catch ( IllegalStateException e )
+        {
+            // assume that IllegalStateExceptions only occur on connection failure
+            throw new EdgeServerConnectionException( e );
+        }
+
+        addToClusterMap();
+    }
+
+    private void addToClusterMap()
+    {
+        hazelcastInstance
+                .getMap( HazelcastClusterTopology.EDGE_SERVERS )
+                .put( config.get( ClusterSettings.server_id ), 1 );
+    }
+
+    private ClientConfig clientConfig()
+    {
+        ClientConfig clientConfig = new ClientConfig();
+
+        clientConfig.getGroupConfig().setName( config.get( ClusterSettings.cluster_name ) );
+
+
+        for ( AdvertisedSocketAddress address : config.get( CoreEdgeClusterSettings.initial_core_cluster_members ) )
+        {
+            clientConfig.getNetworkConfig().addAddress( address.toString() );
+        }
+        return clientConfig;
+    }
+
+    @Override
+    public void stop()
+    {
+        try
+        {
+            hazelcastInstance
+                    .getMap( HazelcastClusterTopology.EDGE_SERVERS )
+                    .remove( config.get( ClusterSettings.server_id ) );
+            hazelcastInstance.shutdown();
+        }
+        catch ( RuntimeException ignored )
+        {
+            // this can happen if the edge server is trying to shutdown but
+            // the core is gone
+        }
+    }
+
+    @Override
+    public ClusterTopology currentTopology()
+    {
+        return new HazelcastClusterTopology( hazelcastInstance );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClusterTopology.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastClusterTopology.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.CoreMember;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+import static org.neo4j.coreedge.discovery.HazelcastServerLifecycle.TRANSACTION_SERVER;
+import static org.neo4j.coreedge.discovery.HazelcastServerLifecycle.RAFT_SERVER;
+
+public class HazelcastClusterTopology implements ClusterTopology
+{
+    public static final String EDGE_SERVERS = "edge-servers";
+    private HazelcastInstance hazelcast;
+
+    public HazelcastClusterTopology( HazelcastInstance hazelcast )
+    {
+        this.hazelcast = hazelcast;
+    }
+
+    @Override
+    public boolean bootstrappable()
+    {
+        Member firstMember = hazelcast.getCluster().getMembers().iterator().next();
+        return firstMember.localMember();
+    }
+
+    @Override
+    public int getNumberOfCoreServers()
+    {
+        return hazelcast.getCluster().getMembers().size();
+    }
+
+    @Override
+    public Set<CoreMember> getMembers()
+    {
+        return toCoreMembers( hazelcast.getCluster().getMembers() );
+    }
+
+    private Set<CoreMember> toCoreMembers( Set<Member> members )
+    {
+        HashSet<CoreMember> coreMembers = new HashSet<>();
+
+        for ( Member member : members )
+        {
+            coreMembers.add( new CoreMember(
+                    address( member.getStringAttribute( TRANSACTION_SERVER ) ),
+                    address( member.getStringAttribute( RAFT_SERVER ) )
+            ));
+        }
+
+        return coreMembers;
+    }
+
+    @Override
+    public int getNumberOfEdgeServers()
+    {
+        return hazelcast.getMap( EDGE_SERVERS ).size();
+    }
+
+    @Override
+    public AdvertisedSocketAddress firstTransactionServer()
+    {
+        Member member = hazelcast.getCluster().getMembers().iterator().next();
+        return address( member.getStringAttribute( TRANSACTION_SERVER ) );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastDiscoveryServiceFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastDiscoveryServiceFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import org.neo4j.kernel.configuration.Config;
+
+public class HazelcastDiscoveryServiceFactory implements DiscoveryServiceFactory
+{
+    @Override
+    public CoreDiscoveryService coreDiscoveryService( Config config )
+    {
+        return new HazelcastServerLifecycle( config );
+    }
+
+    @Override
+    public EdgeDiscoveryService edgeDiscoveryService( Config config )
+    {
+        return new HazelcastClientLifecycle( config );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastServerLifecycle.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/HazelcastServerLifecycle.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.MemberAttributeConfig;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.config.TcpIpConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MemberAttributeEvent;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.core.MembershipListener;
+import com.hazelcast.instance.GroupProperties;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.coreedge.server.CoreEdgeClusterSettings;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.ListenSocketAddress;
+import org.neo4j.helpers.Listeners;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public class HazelcastServerLifecycle extends LifecycleAdapter implements CoreDiscoveryService
+{
+    public static final String CLUSTER_SERVER = "cluster_server";
+    public static final String TRANSACTION_SERVER = "transaction_server";
+    public static final String SERVER_ID = "server_id";
+    public static final String RAFT_SERVER = "raft_server";
+
+    private Config config;
+    private HazelcastInstance hazelcastInstance;
+
+    private List<StartupListener> startupListeners = new ArrayList<>();
+    private List<MembershipListener> membershipListeners = new ArrayList<>();
+    private Map<MembershipListener, String> membershipRegistrationId = new ConcurrentHashMap<>();
+
+    public HazelcastServerLifecycle( Config config )
+    {
+        this.config = config;
+    }
+
+    @Override
+    public void addMembershipListener( Listener listener )
+    {
+        MembershipListenerAdapter hazelcastListener = new MembershipListenerAdapter( listener );
+        membershipListeners.add( hazelcastListener );
+
+        if ( hazelcastInstance != null )
+        {
+            String registrationId = hazelcastInstance.getCluster().addMembershipListener( hazelcastListener );
+            membershipRegistrationId.put( hazelcastListener, registrationId );
+        }
+    }
+
+    @Override
+    public void removeMembershipListener( Listener listener )
+    {
+        MembershipListenerAdapter hazelcastListener = new MembershipListenerAdapter( listener );
+        membershipListeners.remove( hazelcastListener );
+        String registrationId = membershipRegistrationId.remove( hazelcastListener );
+
+        if ( hazelcastInstance != null && registrationId != null )
+        {
+            hazelcastInstance.getCluster().removeMembershipListener( registrationId );
+        }
+    }
+
+    public Set<Member> getMembers()
+    {
+        return hazelcastInstance.getCluster().getMembers();
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        hazelcastInstance = createHazelcastInstance();
+
+        Listeners.notifyListeners( startupListeners, listener -> listener.hazelcastStarted( hazelcastInstance ) );
+
+        for ( MembershipListener membershipListener : membershipListeners )
+        {
+            String registrationId = hazelcastInstance.getCluster().addMembershipListener( membershipListener );
+            membershipRegistrationId.put( membershipListener, registrationId );
+        }
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        try
+        {
+            hazelcastInstance.shutdown();
+        }
+        catch ( Throwable ignored )
+        {
+            // TODO: log something if important
+        }
+    }
+
+    private HazelcastInstance createHazelcastInstance()
+    {
+        System.setProperty( GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "1" );
+
+        JoinConfig joinConfig = new JoinConfig();
+        joinConfig.getMulticastConfig().setEnabled( false );
+        TcpIpConfig tcpIpConfig = joinConfig.getTcpIpConfig();
+        tcpIpConfig.setEnabled( true );
+
+        for ( AdvertisedSocketAddress address : config.get( CoreEdgeClusterSettings.initial_core_cluster_members ) )
+        {
+            tcpIpConfig.addMember( address.toString() );
+        }
+
+        NetworkConfig networkConfig = new NetworkConfig();
+        ListenSocketAddress address = config.get( CoreEdgeClusterSettings.cluster_listen_address );
+        networkConfig.setPort( address.socketAddress().getPort() );
+        networkConfig.setJoin( joinConfig );
+        String instanceName = String.valueOf( config.get( ClusterSettings.server_id ).toIntegerIndex() );
+
+        com.hazelcast.config.Config c = new com.hazelcast.config.Config( instanceName );
+        c.setProperty( GroupProperties.PROP_INITIAL_MIN_CLUSTER_SIZE,
+                String.valueOf( minimumClusterSizeThatCanTolerateOneFaultForExpectedClusterSize() ) );
+        c.setProperty( GroupProperties.PROP_LOGGING_TYPE, "none" );
+
+        c.setNetworkConfig( networkConfig );
+        c.getGroupConfig().setName( config.get( ClusterSettings.cluster_name ) );
+
+        MemberAttributeConfig memberAttributeConfig = new MemberAttributeConfig();
+        memberAttributeConfig.setIntAttribute( SERVER_ID, config.get( ClusterSettings.server_id ).toIntegerIndex() );
+
+        memberAttributeConfig.setStringAttribute( CLUSTER_SERVER, address.toString() );
+
+        AdvertisedSocketAddress transactionSource = config.get( CoreEdgeClusterSettings.transaction_advertised_address );
+        memberAttributeConfig.setStringAttribute( TRANSACTION_SERVER, transactionSource.toString() );
+
+        AdvertisedSocketAddress advertisedAddress = config.get( CoreEdgeClusterSettings.raft_advertised_address );
+        memberAttributeConfig.setStringAttribute( RAFT_SERVER, advertisedAddress.toString() );
+
+        c.setMemberAttributeConfig( memberAttributeConfig );
+
+        return Hazelcast.newHazelcastInstance( c );
+    }
+
+    private Integer minimumClusterSizeThatCanTolerateOneFaultForExpectedClusterSize()
+    {
+        return config.get( CoreEdgeClusterSettings.expected_core_cluster_size ) / 2 + 1;
+    }
+
+    @Override
+    public HazelcastClusterTopology currentTopology()
+    {
+        return new HazelcastClusterTopology( hazelcastInstance );
+    }
+
+    public interface StartupListener
+    {
+        void hazelcastStarted( HazelcastInstance hazelcastInstance );
+    }
+
+    private class MembershipListenerAdapter implements MembershipListener
+    {
+        private final Listener listener;
+
+        public MembershipListenerAdapter( Listener listener )
+        {
+            this.listener = listener;
+        }
+
+        @Override
+        public void memberAdded( MembershipEvent membershipEvent )
+        {
+            HazelcastClusterTopology clusterTopology = new HazelcastClusterTopology( hazelcastInstance );
+            listener.onTopologyChange( clusterTopology );
+        }
+
+        @Override
+        public void memberRemoved( MembershipEvent membershipEvent )
+        {
+            HazelcastClusterTopology clusterTopology = new HazelcastClusterTopology( hazelcastInstance );
+            listener.onTopologyChange( clusterTopology );
+        }
+
+        @Override
+        public void memberAttributeChanged( MemberAttributeEvent memberAttributeEvent )
+        {
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/RaftDiscoveryServiceConnector.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/discovery/RaftDiscoveryServiceConnector.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import java.util.Set;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.RaftInstance;
+import org.neo4j.coreedge.raft.membership.CoreMemberSet;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public class RaftDiscoveryServiceConnector extends LifecycleAdapter implements CoreDiscoveryService.Listener
+{
+    private final CoreDiscoveryService discoveryService;
+    private final RaftInstance<CoreMember> raftInstance;
+
+    public RaftDiscoveryServiceConnector( CoreDiscoveryService discoveryService,
+                                            RaftInstance<CoreMember> raftInstance )
+    {
+        this.discoveryService = discoveryService;
+        this.raftInstance = raftInstance;
+    }
+
+    @Override
+    public void start() throws RaftInstance.BootstrapException
+    {
+        discoveryService.addMembershipListener( this );
+
+        ClusterTopology clusterTopology = discoveryService.currentTopology();
+        Set<CoreMember> initialMembers = clusterTopology.getMembers();
+
+        if ( clusterTopology.bootstrappable() )
+        {
+            raftInstance.bootstrapWithInitialMembers( new CoreMemberSet( initialMembers ) );
+        }
+
+        onTopologyChange( clusterTopology );
+    }
+
+    @Override
+    public void stop()
+    {
+        discoveryService.removeMembershipListener( this );
+    }
+
+    @Override
+    public void onTopologyChange( ClusterTopology clusterTopology )
+    {
+        raftInstance.setTargetMembershipSet( clusterTopology.getMembers() );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/Ballot.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/Ballot.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public class Ballot
+{
+    public static <MEMBER> boolean shouldVoteFor( MEMBER candidate, long requestTerm, long contextTerm,
+                                                  long contextLastAppended, long requestLastLogIndex,
+                                                  long contextLastLogTerm, long requestLastLogTerm,
+                                                  MEMBER votedFor )
+    {
+        if ( requestTerm < contextTerm )
+        {
+            return false;
+        }
+
+        boolean termOk = contextLastLogTerm <= requestLastLogTerm;
+        boolean appendedOk = contextLastAppended <= requestLastLogIndex;
+        boolean requesterLogUpToDate = termOk && appendedOk;
+        boolean votedForOtherInSameTerm = (requestTerm == contextTerm &&
+                !(votedFor == null || votedFor.equals( candidate )));
+
+        return requesterLogUpToDate && !votedForOtherInSameTerm;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/Followers.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/Followers.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.neo4j.coreedge.raft.state.FollowerStates;
+
+public class Followers
+{
+    // TODO: This method is inefficient.. we should not have to update this state by a complete
+    // TODO: iteration each time. Instead it should be updated as a direct response to each
+    // TODO: append response.
+    public static <MEMBER> long quorumAppendIndex( Set<MEMBER> votingMembers, FollowerStates<MEMBER> states )
+    {
+        /*
+         * Build up a map of tx id -> number of instances that have appended,
+         * sorted by tx id.
+         *
+         * This allows us to then iterate backwards over the values in the map,
+         * adding up a total count of how many have appended, until we reach a majority.
+         * Once we do, the tx id at the current entry in the map will be the highest one
+         * with a majority appended.
+         */
+
+        TreeMap</* txId */Long, /* numAppended */Integer> appendedCounts = new TreeMap<>();
+        for ( MEMBER member : votingMembers )
+        {
+            long txId = states.get( member ).getMatchIndex();
+            Integer currentCount = appendedCounts.get( txId );
+            if ( currentCount == null )
+            {
+                appendedCounts.put( txId, 1 );
+            }
+            else
+            {
+                appendedCounts.put( txId, currentCount + 1 );
+            }
+        }
+
+        // Iterate over it until we find a majority
+        int total = 0;
+        for ( Map.Entry<Long, Integer> entry : appendedCounts.descendingMap().entrySet() )
+        {
+            total += entry.getValue();
+            if ( MajorityIncludingSelfQuorum.isQuorum( votingMembers.size(), total ) )
+            {
+                return entry.getKey();
+            }
+        }
+
+        // No majority for any appended entry
+        return -1;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/LeaderContext.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/LeaderContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import static java.lang.String.*;
+
+/**
+ * Consistent leader state at a point in time.
+ */
+public class LeaderContext
+{
+    public final long term;
+    public final long commitIndex;
+
+    public LeaderContext( long term, long commitIndex )
+    {
+        this.term = term;
+        this.commitIndex = commitIndex;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        LeaderContext that = (LeaderContext) o;
+
+        if ( term != that.term )
+        { return false; }
+        return commitIndex == that.commitIndex;
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = (int) (term ^ (term >>> 32));
+        result = 31 * result + (int) (commitIndex ^ (commitIndex >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "LeaderContext{term=%d, commitIndex=%d}", term, commitIndex );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/LeaderLocator.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/LeaderLocator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public interface LeaderLocator<MEMBER>
+{
+    MEMBER getLeader() throws NoLeaderTimeoutException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/LeadershipChange.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/LeadershipChange.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public class LeadershipChange<MEMBER>
+{
+    private final MEMBER leader;
+
+    public LeadershipChange( MEMBER leader )
+    {
+        this.leader = leader;
+    }
+
+    public MEMBER leader()
+    {
+        return leader;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/MajorityIncludingSelfQuorum.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/MajorityIncludingSelfQuorum.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public class MajorityIncludingSelfQuorum
+{
+    private static final int MIN_QUORUM = 2;
+
+    public static boolean isQuorum( int clusterSize, int countNotIncludingSelf )
+    {
+        return isQuorum( MIN_QUORUM, clusterSize, countNotIncludingSelf );
+    }
+
+    public static boolean isQuorum( int minQuorum, int clusterSize, int countNotIncludingSelf )
+    {
+        return (countNotIncludingSelf + 1) >= minQuorum &&
+                countNotIncludingSelf >= clusterSize / 2;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/NoLeaderTimeoutException.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/NoLeaderTimeoutException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public class NoLeaderTimeoutException extends Exception
+{
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.locks.LockSupport;
+
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.membership.RaftGroup;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.replication.shipping.RaftLogShippingManager;
+import org.neo4j.coreedge.raft.membership.RaftMembershipManager;
+import org.neo4j.coreedge.raft.net.Inbound;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.coreedge.raft.state.RaftState;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+import org.neo4j.coreedge.raft.state.TermStore;
+import org.neo4j.coreedge.raft.state.VoteStore;
+import org.neo4j.kernel.impl.util.Listener;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import static org.neo4j.coreedge.raft.roles.Role.LEADER;
+
+/**
+ * The core raft class representing a member of the raft group. The main interactions are
+ * with the network and the entry log.
+ * <p/>
+ * The network is represented by the inbound and outbound classes, and inbound messages are
+ * handled by the core state machine, which in turn can generate outbound messages in
+ * response.
+ * <p/>
+ * The raft entry log persists the user data which the raft system safely replicates. The raft
+ * algorithm ensures that these logs eventually are fed with the exact same entries, even in
+ * the face of failures.
+ * <p/>
+ * The main entry point for adding a new entry is the sendToLeader() function, which starts of
+ * the process of safe replication. The new entry will be safely replicated and eventually
+ * added to the local log through a call to the append() function of the entry log. Eventually
+ * the leader will have replicated it safely, and at a later point in time the commit() function
+ * of the entry log will be called.
+ *
+ * @param <MEMBER> The membership type.
+ */
+public class RaftInstance<MEMBER> implements LeaderLocator<MEMBER>, Inbound.MessageHandler
+{
+    public enum Timeouts implements TimeoutService.TimeoutName
+    {
+        ELECTION, HEARTBEAT
+    }
+
+    private final RaftState<MEMBER> state;
+    private final MEMBER myself;
+    private final RaftLog entryLog;
+
+    private final TimeoutService timeoutService;
+    private final long heartbeatInterval;
+    private TimeoutService.Timeout electionTimer;
+    private RaftMembershipManager<MEMBER> membershipManager;
+
+    private final long electionTimeout;
+    private final long leaderWaitTimeout;
+
+    private final Outbound<MEMBER> outbound;
+    private final Log log;
+    volatile boolean handlingMessage = false;
+    private Role currentRole = Role.FOLLOWER;
+
+    private RaftLogShippingManager<MEMBER> logShipping;
+    private Set<Listener<LeadershipChange<MEMBER>>> leadershipChangeListeners = new HashSet<>();
+
+    public RaftInstance( MEMBER myself, TermStore termStore, VoteStore<MEMBER> voteStore, RaftLog entryLog, long electionTimeout,
+            long heartbeatInterval, TimeoutService timeoutService, final Inbound inbound, final Outbound<MEMBER> outbound,
+            long leaderWaitTimeout, LogProvider logProvider, RaftMembershipManager<MEMBER> membershipManager,
+            RaftLogShippingManager<MEMBER> logShipping )
+    {
+        this.myself = myself;
+        this.entryLog = entryLog;
+        this.electionTimeout = electionTimeout;
+        this.heartbeatInterval = heartbeatInterval;
+
+        this.timeoutService = timeoutService;
+
+        this.leaderWaitTimeout = leaderWaitTimeout;
+        this.outbound = outbound;
+        this.logShipping = logShipping;
+        this.log = logProvider.getLog( getClass() );
+
+        this.membershipManager = membershipManager;
+
+        this.state = new RaftState<>( myself, termStore, membershipManager, entryLog, voteStore );
+
+        initTimers();
+
+        inbound.registerHandler( this );
+    }
+
+    private void initTimers()
+    {
+        electionTimer = timeoutService.create(
+                Timeouts.ELECTION, electionTimeout, randomTimeoutRange(), timeout -> {
+                    handle( new RaftMessages.Timeout.Election<>( myself ) );
+                    timeout.renew();
+                } );
+        timeoutService.create(
+                Timeouts.HEARTBEAT, heartbeatInterval, 0, timeout -> {
+                    handle( new RaftMessages.Timeout.Heartbeat<>( myself ) );
+                    timeout.renew();
+                } );
+    }
+
+    /**
+     * All members must be bootstrapped with the exact same set of initial members. Bootstrapping
+     * requires an empty log as input and will seed it with the initial group entry in term 0.
+     *
+     * @param memberSet The other members.
+     */
+    public synchronized void bootstrapWithInitialMembers( RaftGroup<MEMBER> memberSet ) throws BootstrapException
+    {
+        if ( entryLog.appendIndex() >= 0 )
+        {
+            return;
+        }
+
+        RaftLogEntry membershipLogEntry = new RaftLogEntry( 0, memberSet );
+
+        try
+        {
+            entryLog.append( membershipLogEntry );
+            entryLog.commit( 0 );
+        }
+        catch ( RaftStorageException e )
+        {
+            throw new BootstrapException( e );
+        }
+    }
+
+    public void setTargetMembershipSet( Set<MEMBER> targetMembers )
+    {
+        membershipManager.setTargetMembershipSet( targetMembers );
+
+        if ( currentRole == LEADER )
+        {
+            membershipManager.onFollowerStateChange( state.followerStates() );
+        }
+    }
+
+    @Override
+    public MEMBER getLeader() throws NoLeaderTimeoutException
+    {
+        long leaderWaitEndTime = leaderWaitTimeout + System.currentTimeMillis();
+        while ( state.leader() == null && (System.currentTimeMillis() < leaderWaitEndTime) )
+        {
+            LockSupport.parkNanos( MILLISECONDS.toNanos( electionTimeout ) / 2 );
+        }
+
+        if ( state.leader() == null )
+        {
+            throw new NoLeaderTimeoutException();
+        }
+
+        return state.leader();
+    }
+
+    public ReadableRaftState<MEMBER> state()
+    {
+        return state;
+    }
+
+    /**
+     * These listeners will be notified from within the raft, so they should be short, efficient and
+     * not have dependencies on raft. Any substantial work must be scheduled on a some other thread.
+     */
+    public void registerLeadershipChangeListener( Listener<LeadershipChange<MEMBER>> listener )
+    {
+        leadershipChangeListeners.add( listener );
+    }
+
+    private void notifyListenersOnLeadershipChange( MEMBER newLeader )
+    {
+        for ( Listener<LeadershipChange<MEMBER>> listener : leadershipChangeListeners )
+        {
+            listener.receive( new LeadershipChange<>( newLeader ) );
+        }
+    }
+
+    protected void handleOutcome( Outcome<MEMBER> outcome ) throws RaftStorageException
+    {
+        // Save interesting pre-state
+        MEMBER oldLeader = state.leader();
+
+        if( outcome.leader != null && outcome.leader.equals( myself ) )
+        {
+            LeaderContext leaderContext = new LeaderContext( outcome.newTerm, outcome.leaderCommit );
+
+            if ( oldLeader == null || !oldLeader.equals( myself ) )
+            {
+                // We became leader, start the log shipping.
+                logShipping.start( leaderContext );
+            }
+
+            logShipping.handleCommands( outcome.shipCommands, leaderContext );
+        }
+        else if ( oldLeader != null && oldLeader.equals( myself ) && !outcome.leader.equals( myself ) ) // TODO: inspect the reported issue
+        {
+            logShipping.stop();
+        }
+
+        // Update state
+        state.update( outcome );
+
+        // Act after updating state
+        if ( oldLeader != state.leader() )
+        {
+            notifyListenersOnLeadershipChange( state.leader() );
+        }
+    }
+
+    public synchronized void handle( Serializable incomingMessage )
+    {
+        if ( handlingMessage )
+        {
+            throw new IllegalStateException( "recursive use" );
+        }
+
+        try
+        {
+            handlingMessage = true;
+            Outcome<MEMBER> outcome = currentRole.role.handle( (RaftMessages.Message<MEMBER>) incomingMessage, state, log );
+
+            handleOutcome( outcome );
+            currentRole = outcome.newRole;
+
+            for ( RaftMessages.Directed<MEMBER> outgoingMessage : outcome.outgoingMessages )
+            {
+                outbound.send( outgoingMessage.to(), outgoingMessage.message() );
+            }
+            if ( outcome.renewElectionTimeout )
+            {
+                electionTimer.renew();
+            }
+
+            membershipManager.onRole( currentRole );
+
+            if ( currentRole == LEADER )
+            {
+                membershipManager.onFollowerStateChange( state.followerStates() );
+            }
+        }
+        catch ( Exception e )
+        {
+            log.error( "Failed to process RAFT message " + incomingMessage, e );
+            throw new RuntimeException(e);
+        }
+        finally
+        {
+            handlingMessage = false;
+        }
+    }
+
+    public boolean isLeader()
+    {
+        return currentRole == LEADER;
+    }
+
+    public Role currentRole()
+    {
+        return currentRole;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "RaftInstance{role=%s, term=%d, currentMembers=%s}", currentRole, term(), votingMembers() );
+    }
+
+    public static class BootstrapException extends Exception
+    {
+        public BootstrapException( Throwable cause )
+        {
+            super( cause );
+        }
+    }
+
+    public long term()
+    {
+        return state.term();
+    }
+
+    private long randomTimeoutRange()
+    {
+        return electionTimeout / 3;
+    }
+
+    public Set<MEMBER> votingMembers()
+    {
+        return membershipManager.votingMembers();
+    }
+
+    public Set<MEMBER> replicationMembers()
+    {
+        return membershipManager.replicationMembers();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.membership.RaftGroup;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.replication.LocalReplicator;
+import org.neo4j.coreedge.raft.replication.shipping.RaftLogShippingManager;
+import org.neo4j.coreedge.raft.membership.RaftMembershipManager;
+import org.neo4j.coreedge.raft.net.Inbound;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.raft.state.InMemoryTermStore;
+import org.neo4j.coreedge.raft.state.InMemoryVoteStore;
+import org.neo4j.coreedge.raft.state.TermStore;
+import org.neo4j.coreedge.raft.state.VoteStore;
+import org.neo4j.helpers.Clock;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+
+public class RaftInstanceBuilder<MEMBER>
+{
+    private final MEMBER member;
+
+    private int expectedClusterSize;
+    private RaftGroup.Builder<MEMBER> memberSetBuilder;
+
+    private TermStore termStore = new InMemoryTermStore();
+    private VoteStore<MEMBER> voteStore = new InMemoryVoteStore<>();
+    private RaftLog raftLog = new InMemoryRaftLog();
+    private TimeoutService timeoutService = new ScheduledTimeoutService();
+
+    private Inbound inbound = handler -> {};
+    private Outbound<MEMBER> outbound = ( advertisedSocketAddress, messages ) -> {};
+
+    private LogProvider logProvider = NullLogProvider.getInstance();
+    private Clock clock = Clock.SYSTEM_CLOCK;
+
+    private long electionTimeout = 500;
+    private long heartbeatInterval = 150;
+    private long leaderWaitTimeout = 10000;
+    private long catchupTimeout = 30000;
+    private long retryTimeMillis = electionTimeout/2;
+
+    public RaftInstanceBuilder( MEMBER member, int expectedClusterSize, RaftGroup.Builder<MEMBER> memberSetBuilder )
+    {
+        this.member = member;
+        this.expectedClusterSize = expectedClusterSize;
+        this.memberSetBuilder = memberSetBuilder;
+    }
+
+    public RaftInstance<MEMBER> build()
+    {
+        LocalReplicator<MEMBER,MEMBER> localReplicator = new LocalReplicator<>( member, member, outbound );
+        RaftMembershipManager<MEMBER> membershipManager = new RaftMembershipManager<>( localReplicator, memberSetBuilder, raftLog, logProvider, expectedClusterSize, electionTimeout, clock, catchupTimeout );
+        RaftLogShippingManager<MEMBER> logShipping = new RaftLogShippingManager<>( outbound, logProvider, raftLog, clock, member, membershipManager, retryTimeMillis );
+
+        return new RaftInstance<>( member, termStore, voteStore, raftLog, electionTimeout, heartbeatInterval,
+                timeoutService, inbound, outbound, leaderWaitTimeout, logProvider, membershipManager, logShipping );
+    }
+
+    public RaftInstanceBuilder<MEMBER> timeoutService( TimeoutService timeoutService )
+    {
+        this.timeoutService = timeoutService;
+        return this;
+    }
+
+    public RaftInstanceBuilder<MEMBER> outbound( Outbound<MEMBER> outbound )
+    {
+        this.outbound = outbound;
+        return this;
+    }
+
+    public RaftInstanceBuilder<MEMBER> inbound( Inbound inbound )
+    {
+        this.inbound = inbound;
+        return this;
+    }
+
+    public RaftInstanceBuilder<MEMBER> raftLog( RaftLog raftLog )
+    {
+        this.raftLog = raftLog;
+        return this;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessageHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessageHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+import org.neo4j.logging.Log;
+
+public interface RaftMessageHandler
+{
+    <MEMBER> Outcome<MEMBER> handle( RaftMessages.Message<MEMBER> message, ReadableRaftState<MEMBER> context, Log log )
+            throws RaftStorageException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessages.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessages.java
@@ -1,0 +1,561 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+import static java.lang.String.format;
+
+public interface RaftMessages
+{
+    enum Type
+    {
+        VOTE_REQUEST,
+        VOTE_RESPONSE,
+
+        APPEND_ENTRIES_REQUEST,
+        APPEND_ENTRIES_RESPONSE,
+
+        HEARTBEAT,
+
+        // Timeouts
+        ELECTION_TIMEOUT,
+        HEARTBEAT_TIMEOUT,
+
+        // TODO: Refactor, these are client-facing messages / api. Perhaps not public and instantiated through an api
+        // TODO: method instead?
+        NEW_ENTRY_REQUEST,
+
+        NEW_MEMBERSHIP_TARGET,
+    }
+
+    interface Message<MEMBER> extends Serializable
+    {
+        MEMBER from();
+
+        Type type();
+    }
+
+    class Directed<MEMBER>
+    {
+        MEMBER to;
+        Message<MEMBER> message;
+
+        public Directed( MEMBER to, Message<MEMBER> message )
+        {
+            this.to = to;
+            this.message = message;
+        }
+
+        public MEMBER to()
+        {
+            return to;
+        }
+
+        public Message<MEMBER> message()
+        {
+            return message;
+        }
+    }
+
+    interface Vote
+    {
+        class Request<MEMBER> extends BaseMessage<MEMBER>
+        {
+            private long term;
+            private MEMBER candidate;
+            private long lastLogIndex;
+            private long lastLogTerm;
+
+            public Request( MEMBER from, long term, MEMBER candidate, long lastLogIndex, long lastLogTerm )
+            {
+                super( from, Type.VOTE_REQUEST );
+                this.term = term;
+                this.candidate = candidate;
+                this.lastLogIndex = lastLogIndex;
+                this.lastLogTerm = lastLogTerm;
+            }
+
+            public long term()
+            {
+                return term;
+            }
+
+            @Override
+            public boolean equals( Object o )
+            {
+                if ( this == o )
+                {
+                    return true;
+                }
+                if ( o == null || getClass() != o.getClass() )
+                {
+                    return false;
+                }
+                Request request = (Request) o;
+                return lastLogIndex == request.lastLogIndex &&
+                        lastLogTerm == request.lastLogTerm &&
+                        term == request.term &&
+                        candidate.equals( request.candidate );
+            }
+
+            @Override
+            public int hashCode()
+            {
+                int result = (int) term;
+                result = 31 * result + candidate.hashCode();
+                result = 31 * result + (int) (lastLogIndex ^ (lastLogIndex >>> 32));
+                result = 31 * result + (int) (lastLogTerm ^ (lastLogTerm >>> 32));
+                return result;
+            }
+
+            @Override
+            public String toString()
+            {
+                return format( "Vote.Request{term=%d, candidate=%s, lastAppended=%d, lastLogTerm=%d}",
+                        term, candidate, lastLogIndex, lastLogTerm );
+            }
+
+            public long lastLogTerm()
+            {
+                return lastLogTerm;
+            }
+
+            public long lastLogIndex()
+            {
+                return lastLogIndex;
+            }
+
+            public MEMBER candidate()
+            {
+                return candidate;
+            }
+        }
+
+        class Response<MEMBER> extends BaseMessage<MEMBER>
+        {
+            private long term;
+            private boolean voteGranted;
+
+            public Response( MEMBER from, long term, boolean voteGranted )
+            {
+                super( from, Type.VOTE_RESPONSE );
+                this.term = term;
+                this.voteGranted = voteGranted;
+            }
+
+            @Override
+            public boolean equals( Object o )
+            {
+                if ( this == o )
+                {
+                    return true;
+                }
+                if ( o == null || getClass() != o.getClass() )
+                {
+                    return false;
+                }
+
+                Response response = (Response) o;
+
+                return term == response.term && voteGranted == response.voteGranted;
+
+            }
+
+            @Override
+            public int hashCode()
+            {
+                int result = (int) term;
+                result = 31 * result + (voteGranted ? 1 : 0);
+                return result;
+            }
+
+            @Override
+            public String toString()
+            {
+                return format( "Vote.Response{from=%s, term=%d, voteGranted=%s}", from(), term, voteGranted );
+            }
+
+            public long term()
+            {
+                return term;
+            }
+
+            public boolean voteGranted()
+            {
+                return voteGranted;
+            }
+        }
+    }
+
+    interface AppendEntries
+    {
+        class Request<MEMBER> extends BaseMessage<MEMBER>
+        {
+            private long leaderTerm;
+            private long prevLogIndex;
+            private long prevLogTerm;
+            private RaftLogEntry[] entries;
+            private long leaderCommit;
+
+            public Request( MEMBER from, long leaderTerm, long prevLogIndex, long prevLogTerm,
+                            RaftLogEntry[] entries, long leaderCommit )
+            {
+                super( from, Type.APPEND_ENTRIES_REQUEST );
+                Objects.requireNonNull( entries );
+                assert !((prevLogIndex == -1 && prevLogTerm != -1) || (prevLogTerm == -1 && prevLogIndex != -1));
+                this.entries = entries;
+                this.leaderTerm = leaderTerm;
+                this.prevLogIndex = prevLogIndex;
+                this.prevLogTerm = prevLogTerm;
+
+
+                this.leaderCommit = leaderCommit;
+            }
+
+            public long leaderTerm()
+            {
+                return leaderTerm;
+            }
+
+            public long prevLogIndex()
+            {
+                return prevLogIndex;
+            }
+
+            public long prevLogTerm()
+            {
+                return prevLogTerm;
+            }
+
+            public RaftLogEntry[] entries()
+            {
+                return entries;
+            }
+
+            public long leaderCommit()
+            {
+                return leaderCommit;
+            }
+
+            @Override
+            public boolean equals( Object o )
+            {
+                if ( this == o )
+                {
+                    return true;
+                }
+                if ( o == null || getClass() != o.getClass() )
+                {
+                    return false;
+                }
+                Request<?> request = (Request<?>) o;
+                return Objects.equals( leaderTerm, request.leaderTerm ) &&
+                        Objects.equals( prevLogIndex, request.prevLogIndex ) &&
+                        Objects.equals( prevLogTerm, request.prevLogTerm ) &&
+                        Objects.equals( leaderCommit, request.leaderCommit ) &&
+                        Arrays.equals( entries, request.entries );
+            }
+
+            @Override
+            public int hashCode()
+            {
+                return Objects.hash( leaderTerm, prevLogIndex, prevLogTerm, entries, leaderCommit );
+            }
+
+            @Override
+            public String toString()
+            {
+                return format( "AppendEntries.Request from %s {leaderTerm=%d, prevLogIndex=%d, " +
+                                "prevLogTerm=%d, entry=%s, leaderCommit=%d}",
+                        super.from(), leaderTerm, prevLogIndex, prevLogTerm, Arrays.toString( entries ), leaderCommit );
+            }
+        }
+
+        class Response<MEMBER> extends BaseMessage<MEMBER>
+        {
+            private long term;
+            private boolean success;
+            private long matchIndex;
+
+            public Response( MEMBER from, long term, boolean success, long matchIndex )
+            {
+                super( from, Type.APPEND_ENTRIES_RESPONSE );
+                this.term = term;
+                this.success = success;
+                this.matchIndex = matchIndex;
+            }
+
+            public long term()
+            {
+                return term;
+            }
+
+            public long matchIndex()
+            {
+                return matchIndex;
+            }
+
+            @Override
+            public boolean equals( Object o )
+            {
+                if ( this == o )
+                {
+                    return true;
+                }
+                if ( o == null || getClass() != o.getClass() )
+                {
+                    return false;
+                }
+
+                Response<?> response = (Response<?>) o;
+
+                return term == response.term && success == response.success;
+            }
+
+            @Override
+            public int hashCode()
+            {
+                int result = (int) (term ^ (term >>> 32));
+                result = 31 * result + (success ? 1 : 0);
+                return result;
+            }
+
+            @Override
+            public String toString()
+            {
+                return format( "AppendEntries.Response from %s {term=%d, success=%s, matchIndex=%d}",
+                        super.from(), term, success, matchIndex );
+            }
+
+            public boolean success()
+            {
+                return success;
+            }
+        }
+    }
+
+    class Heartbeat<MEMBER> extends BaseMessage<MEMBER>
+    {
+        private final long leaderTerm;
+        private final long commitIndex;
+        private final long commitIndexTerm;
+
+        public Heartbeat( MEMBER from, long leaderTerm, long commitIndex, long commitIndexTerm )
+        {
+            super( from, Type.HEARTBEAT );
+            this.leaderTerm = leaderTerm;
+            this.commitIndex = commitIndex;
+            this.commitIndexTerm = commitIndexTerm;
+        }
+
+        public long leaderTerm()
+        {
+            return leaderTerm;
+        }
+
+        public long commitIndex()
+        {
+            return commitIndex;
+        }
+
+        public long commitIndexTerm()
+        {
+            return commitIndexTerm;
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+            if ( !super.equals( o ) )
+            {
+                return false;
+            }
+
+            Heartbeat<?> heartbeat = (Heartbeat<?>) o;
+
+            if ( leaderTerm != heartbeat.leaderTerm )
+            {
+                return false;
+            }
+            if ( commitIndex != heartbeat.commitIndex )
+            {
+                return false;
+            }
+            return commitIndexTerm == heartbeat.commitIndexTerm;
+
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = super.hashCode();
+            result = 31 * result + (int) (leaderTerm ^ (leaderTerm >>> 32));
+            result = 31 * result + (int) (commitIndex ^ (commitIndex >>> 32));
+            result = 31 * result + (int) (commitIndexTerm ^ (commitIndexTerm >>> 32));
+            return result;
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "Heartbeat{leaderTerm=%d, commitIndex=%d, commitIndexTerm=%d}", leaderTerm,
+                    commitIndex, commitIndexTerm );
+        }
+    }
+
+    interface Timeout
+    {
+        class Election<MEMBER> extends BaseMessage<MEMBER>
+        {
+            public Election( MEMBER from )
+            {
+                super( from, Type.ELECTION_TIMEOUT );
+            }
+
+            @Override
+            public String toString()
+            {
+                return "Timeout.Election{}";
+            }
+        }
+
+        class Heartbeat<MEMBER> extends BaseMessage<MEMBER>
+        {
+            public Heartbeat( MEMBER from )
+            {
+                super( from, Type.HEARTBEAT_TIMEOUT );
+            }
+
+            @Override
+            public String toString()
+            {
+                return "Timeout.Heartbeat{}";
+            }
+        }
+    }
+
+    interface NewEntry
+    {
+        class Request<MEMBER> extends BaseMessage<MEMBER>
+        {
+            private ReplicatedContent content;
+
+            public Request( MEMBER from, ReplicatedContent content )
+            {
+                super( from, Type.NEW_ENTRY_REQUEST );
+                this.content = content;
+            }
+
+            @Override
+            public String toString()
+            {
+                return format( "NewEntry.Request{content=%s}", content );
+            }
+
+            @Override
+            public boolean equals( Object o )
+            {
+                if ( this == o )
+                {
+                    return true;
+                }
+                if ( o == null || getClass() != o.getClass() )
+                {
+                    return false;
+                }
+
+                Request request = (Request) o;
+
+                return !(content != null ? !content.equals( request.content ) : request.content != null);
+            }
+
+            @Override
+            public int hashCode()
+            {
+                return content != null ? content.hashCode() : 0;
+            }
+
+            public ReplicatedContent content()
+            {
+                return content;
+            }
+        }
+    }
+
+    abstract class BaseMessage<MEMBER> implements Message<MEMBER>
+    {
+        private MEMBER from;
+        private Type type;
+
+        public BaseMessage( MEMBER from, Type type )
+        {
+            this.from = from;
+            this.type = type;
+        }
+
+        @Override
+        public MEMBER from()
+        {
+            return from;
+        }
+
+        @Override
+        public Type type()
+        {
+            return type;
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+            BaseMessage<?> that = (BaseMessage<?>) o;
+            return Objects.equals( from, that.from ) &&
+                    Objects.equals( type, that.type );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash( from, type );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftServer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftServer.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+
+import org.neo4j.coreedge.raft.net.Inbound;
+import org.neo4j.coreedge.server.ListenSocketAddress;
+import org.neo4j.coreedge.server.logging.ExceptionLoggingHandler;
+import org.neo4j.coreedge.raft.net.codecs.RaftMessageDecoder;
+import org.neo4j.coreedge.raft.replication.ReplicatedContentMarshal;
+import org.neo4j.helpers.NamedThreadFactory;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+public class RaftServer<MEMBER> extends LifecycleAdapter implements Inbound
+{
+    private final ListenSocketAddress listenAddress;
+    private final Log log;
+    private final ReplicatedContentMarshal<ByteBuf> serializer;
+    private MessageHandler messageHandler;
+    private EventLoopGroup workerGroup;
+    private Channel channel;
+
+    private final NamedThreadFactory threadFactory = new NamedThreadFactory( "raft-server" );
+
+    public RaftServer( ReplicatedContentMarshal<ByteBuf> serializer, ListenSocketAddress listenAddress, LogProvider logProvider )
+    {
+        this.serializer = serializer;
+        this.listenAddress = listenAddress;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        startNettyServer();
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        try
+        {
+            channel.close().sync();
+            workerGroup.shutdownGracefully().sync();
+        }
+        catch( InterruptedException e )
+        {
+            log.warn( "Interrupted while stopping raft server." );
+        }
+    }
+
+    private void startNettyServer()
+    {
+        workerGroup = new NioEventLoopGroup( 0, threadFactory );
+
+        log.info( "Starting server at: " + listenAddress );
+
+        ServerBootstrap bootstrap = new ServerBootstrap()
+                .group( workerGroup )
+                .channel( NioServerSocketChannel.class )
+                .option( ChannelOption.SO_REUSEADDR, true )
+                .localAddress( listenAddress.socketAddress() )
+                .childHandler( new ChannelInitializer<SocketChannel>()
+                {
+                    @Override
+                    protected void initChannel( SocketChannel ch ) throws Exception
+                    {
+                        ChannelPipeline pipeline = ch.pipeline();
+                        pipeline.addLast( new LengthFieldBasedFrameDecoder( Integer.MAX_VALUE, 0, 4, 0, 4 ) );
+                        pipeline.addLast( new LengthFieldPrepender( 4 ) );
+                        pipeline.addLast( new RaftMessageDecoder( serializer ) );
+                        pipeline.addLast( new RaftMessageHandler() );
+                        pipeline.addLast( new ExceptionLoggingHandler( log ) );
+                    }
+                } );
+
+        channel = bootstrap.bind().syncUninterruptibly().channel();
+    }
+
+    @Override
+    public void registerHandler( Inbound.MessageHandler handler )
+    {
+        this.messageHandler = handler;
+    }
+
+    private class RaftMessageHandler extends SimpleChannelInboundHandler<RaftMessages.Message<MEMBER>>
+    {
+        @Override
+        protected void channelRead0( ChannelHandlerContext channelHandlerContext, RaftMessages.Message<MEMBER>
+                message ) throws Exception
+        {
+            messageHandler.handle( message );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/ScheduledTimeoutService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/ScheduledTimeoutService.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.helpers.Clock;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static java.lang.System.nanoTime;
+
+import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.POOLED;
+
+public class ScheduledTimeoutService extends LifecycleAdapter implements Runnable, TimeoutService
+{
+    /**
+     * Sorted by next-to-trigger.
+     */
+    private final SortedSet<ScheduledTimeout> timeouts = new TreeSet<>();
+    private final Queue<ScheduledTimeout> pendingRenewals = new ConcurrentLinkedDeque<>();
+    private final Clock clock;
+    private final Random random;
+    private final JobScheduler scheduler;
+    private JobScheduler.JobHandle jobHandle;
+
+    public ScheduledTimeoutService()
+    {
+        this.clock = Clock.SYSTEM_CLOCK;
+        this.random = new Random( nanoTime() );
+        this.scheduler = new Neo4jJobScheduler();
+    }
+
+    /**
+     * Set up a new timeout. The attachment is optional data to pass along to the trigger, and can be set to Object
+     * and null if you don't care about it.
+     * <p/>
+     * The randomRange attribute allows you to introduce a bit of arbitrariness in when the timeout is triggered, which
+     * is a useful way to avoid "thundering herds" when multiple timeouts are likely to trigger at the same time.
+     * <p/>
+     * If you don't want randomness, set randomRange to 0.
+     */
+    @Override
+    public Timeout create( TimeoutName name, long milliseconds, long randomRange, TimeoutHandler handler )
+    {
+        ScheduledTimeout timeout = new ScheduledTimeout(
+                calcTimeoutTimestamp( milliseconds, randomRange ),
+                milliseconds, randomRange, handler, this );
+
+        synchronized ( timeouts )
+        {
+            timeouts.add( timeout );
+        }
+
+        return timeout;
+    }
+
+    public void renew( ScheduledTimeout timeout )
+    {
+        pendingRenewals.offer( timeout );
+    }
+
+    public void cancel( ScheduledTimeout timeout )
+    {
+        synchronized ( timeouts )
+        {
+            timeouts.remove( timeout );
+        }
+    }
+
+    private long calcTimeoutTimestamp( long milliseconds, long randomRange )
+    {
+        int randomness = randomRange != 0 ? random.nextInt( (int) randomRange ) : 0;
+        return clock.currentTimeMillis() + milliseconds + randomness;
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            long now = clock.currentTimeMillis();
+            Collection<ScheduledTimeout> triggered = new LinkedList<>();
+
+            synchronized ( timeouts )
+            {
+                // Handle renewals
+                ScheduledTimeout renew;
+                while ( (renew = pendingRenewals.poll()) != null )
+                {
+                    timeouts.remove( renew );
+                    renew.setTimeoutTimestamp( calcTimeoutTimestamp( renew.timeoutLength, renew.randomRange ) );
+                    timeouts.add( renew );
+                }
+
+                // Trigger timeouts
+                for ( ScheduledTimeout timeout : timeouts )
+                {
+                    if ( timeout.shouldTrigger( now ) )
+                    {
+                        triggered.add( timeout );
+                        timeout.trigger();
+                    }
+                    else
+                    {
+                        // Since the timeouts are sorted, the first timeout we hit that should not be triggered means
+                        // there are no others that should either, so we bail.
+                        break;
+                    }
+                }
+
+                timeouts.removeAll( triggered );
+            }
+        }
+        catch ( Throwable e )
+        {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void init() throws Throwable
+    {
+        scheduler.init();
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        jobHandle = scheduler.scheduleRecurring( new JobScheduler.Group( "Scheduler", POOLED ), this, 1,
+                TimeUnit.MILLISECONDS );
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        jobHandle.cancel( true );
+        scheduler.shutdown();
+    }
+
+    public static class ScheduledTimeout implements Timeout, Comparable<ScheduledTimeout>
+    {
+        private static final AtomicLong idGen = new AtomicLong();
+        private final long id = idGen.getAndIncrement();
+        private final long timeoutLength;
+        private final long randomRange;
+        private final TimeoutHandler handler;
+        private final ScheduledTimeoutService timeouts;
+        private long timeoutTimestampMillis;
+
+        public ScheduledTimeout( long timeoutTimestampMillis, long timeoutLength, long randomRange, TimeoutHandler
+                handler, ScheduledTimeoutService timeouts )
+        {
+            this.timeoutTimestampMillis = timeoutTimestampMillis;
+            this.timeoutLength = timeoutLength;
+            this.randomRange = randomRange;
+            this.handler = handler;
+            this.timeouts = timeouts;
+        }
+
+        private void trigger()
+        {
+            handler.onTimeout( this );
+        }
+
+        private boolean shouldTrigger( long currentTime )
+        {
+            return currentTime >= timeoutTimestampMillis;
+        }
+
+        @Override
+        public void renew()
+        {
+            timeouts.renew( this );
+        }
+
+        @Override
+        public void cancel()
+        {
+            timeouts.cancel( this );
+        }
+
+        public void setTimeoutTimestamp( long newTimestamp )
+        {
+            this.timeoutTimestampMillis = newTimestamp;
+        }
+
+        @Override
+        public int compareTo( ScheduledTimeout o )
+        {
+            if ( timeoutTimestampMillis == o.timeoutTimestampMillis )
+            {
+                // Timeouts are set to trigger at the same time.
+                // Order them by id instead.
+                return (int) (id - o.id);
+            }
+
+            return (int) (timeoutTimestampMillis - o.timeoutTimestampMillis);
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+
+            ScheduledTimeout timeout = (ScheduledTimeout) o;
+
+            return id == timeout.id;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return (int) (id ^ (id >>> 32));
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Timeout{" +
+                    "id=" + id +
+                    ", randomRange=" + randomRange +
+                    ", timeoutLength=" + timeoutLength +
+                    ", timeoutTimestampMillis=" + timeoutTimestampMillis +
+                    ", handler=" + handler +
+                    '}';
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/TimeoutService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/TimeoutService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public interface TimeoutService
+{
+    Timeout create( TimeoutName timeoutName, long milliseconds, long randomRange, TimeoutHandler handler );
+
+    interface TimeoutName
+    {
+        String name();
+    }
+
+    interface Timeout
+    {
+        void renew();
+
+        void cancel();
+    }
+
+    interface TimeoutHandler
+    {
+        void onTimeout( Timeout timeout );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/CoreServiceAssignment.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/CoreServiceAssignment.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.server.CoreMember;
+
+import static java.lang.String.format;
+
+public class CoreServiceAssignment implements ReplicatedContent
+{
+    private final CoreServiceRegistry.ServiceType serviceType;
+    private final CoreMember provider;
+    private UUID assignmentId;
+
+    public CoreServiceAssignment( CoreServiceRegistry.ServiceType serviceType, CoreMember provider, UUID assignmentId )
+    {
+        this.serviceType = serviceType;
+        this.provider = provider;
+        this.assignmentId = assignmentId;
+    }
+
+    public CoreServiceRegistry.ServiceType serviceType()
+    {
+        return serviceType;
+    }
+
+    public CoreMember provider()
+    {
+        return provider;
+    }
+
+    public UUID assignmentId()
+    {
+        return assignmentId;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "CoreServiceAssignment{serviceType=%s, provider=%s, assignmentId=%s}",
+                serviceType, provider, assignmentId );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        CoreServiceAssignment that = (CoreServiceAssignment) o;
+        return Objects.equals( serviceType, that.serviceType ) &&
+                Objects.equals( provider, that.provider ) &&
+                Objects.equals( assignmentId, that.assignmentId );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( serviceType, provider, assignmentId );
+    }
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/CoreServiceAssignmentSerializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/CoreServiceAssignmentSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.util.UUID;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.raft.membership.CoreMemberMarshal;
+import org.neo4j.coreedge.server.CoreMember;
+
+public class CoreServiceAssignmentSerializer
+{
+    public static void serialize( CoreServiceAssignment serviceAssignment, ByteBuf buffer )
+    {
+        buffer.writeByte( serviceAssignment.serviceType().ordinal() );
+        CoreMemberMarshal.serialize( serviceAssignment.provider(), buffer );
+
+        UUID assignmentId = serviceAssignment.assignmentId();
+        buffer.writeLong( assignmentId.getMostSignificantBits() );
+        buffer.writeLong( assignmentId.getLeastSignificantBits() );
+    }
+
+    public static CoreServiceAssignment deserialize( ByteBuf buffer )
+    {
+        CoreServiceRegistry.ServiceType serviceType = CoreServiceRegistry.ServiceType.values()[buffer.readByte()];
+        CoreMember coreMember = CoreMemberMarshal.deserialize( buffer );
+
+        long uuidMSB = buffer.readLong();
+        long uuidLSB = buffer.readLong();
+        UUID assignmentId = new UUID( uuidMSB, uuidLSB );
+
+        return new CoreServiceAssignment( serviceType, coreMember, assignmentId );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/CoreServiceManager.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/CoreServiceManager.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.neo4j.coreedge.raft.LeadershipChange;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.kernel.impl.util.Listener;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static java.util.UUID.randomUUID;
+
+/**
+ * The core service manager manages the local core service registry. The core service registry
+ * contains the local view of service assignment within the core group, and allows for core
+ * services to be looked up.
+ *
+ * The core service manager listens to and spawns core service assignments over the replicator.
+ *
+ * Currently only one policy for assignment is in effect:
+ *      when this node becomes leader => assign it as the lock manager
+ */
+public class CoreServiceManager implements Listener<LeadershipChange<CoreMember>>, Replicator.ReplicatedContentListener
+{
+    final private Replicator replicator;
+    final private CoreServiceRegistry serviceRegistry;
+    private final CoreMember myself;
+    final private ExecutorService executor = Executors.newCachedThreadPool();
+    private final Log log;
+
+    public CoreServiceManager( Replicator replicator, CoreServiceRegistry serviceRegistry,
+                               CoreMember myself, LogProvider logProvider )
+    {
+        this.replicator = replicator;
+        this.serviceRegistry = serviceRegistry;
+        this.myself = myself;
+        this.log = logProvider.getLog( getClass() );
+
+        replicator.subscribe( this );
+    }
+
+    @Override
+    public void onReplicated( ReplicatedContent content )
+    {
+        if ( content instanceof CoreServiceAssignment )
+        {
+            CoreServiceAssignment serviceAssignment = (CoreServiceAssignment) content;
+            log.info( "Committed assignment: " + serviceAssignment );
+            serviceRegistry.registerProvider( serviceAssignment.serviceType(), serviceAssignment );
+        }
+    }
+
+    @Override
+    public void receive( final LeadershipChange<CoreMember> leadershipChange )
+    {
+        final CoreMember leader = leadershipChange.leader();
+
+        if ( leader == myself )
+        {
+            executor.execute( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    assignLockManager( leader );
+                }
+            } );
+        }
+    }
+
+    private void assignLockManager( CoreMember lockManager )
+    {
+        CoreServiceAssignment assignment = new CoreServiceAssignment( CoreServiceRegistry.ServiceType.LOCK_MANAGER, lockManager, randomUUID() );
+
+        serviceRegistry.registerProvider( CoreServiceRegistry.ServiceType.LOCK_MANAGER, assignment );
+
+        try
+        {
+            replicator.replicate( assignment );
+        }
+        catch ( Replicator.ReplicationFailedException e )
+        {
+            e.printStackTrace();
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/CoreServiceRegistry.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/CoreServiceRegistry.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.helpers.Clock;
+
+public class CoreServiceRegistry
+{
+    private final Clock clock;
+
+    public enum ServiceType
+    {
+        LOCK_MANAGER, ;
+
+    }
+
+    private HashMap<ServiceType,CoreServiceAssignment> serviceMap = new HashMap<>();
+
+    public CoreServiceRegistry( Clock clock )
+    {
+        this.clock = clock;
+    }
+
+    public synchronized void registerProvider( ServiceType serviceType, CoreServiceAssignment assignment )
+    {
+        serviceMap.put( serviceType, assignment );
+        notifyAll();
+    }
+
+    synchronized public CoreServiceAssignment lookupService( ServiceType serviceType, long time, TimeUnit unit ) throws TimeoutException
+    {
+        CoreServiceAssignment assignment;
+        long endTime = clock.currentTimeMillis() + unit.toMillis( time );
+
+        while ( (assignment = serviceMap.get( serviceType )) == null )
+        {
+            if ( clock.currentTimeMillis() >= endTime )
+            {
+                throw new TimeoutException();
+            }
+
+            try
+            {
+                wait( 1000 );
+            }
+            catch ( InterruptedException e )
+            {
+                throw new TimeoutException( e.getMessage() );
+            }
+        }
+
+        return assignment;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockMessage.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockMessage.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.neo4j.kernel.ha.lock.LockResult;
+import org.neo4j.kernel.impl.locking.Locks;
+
+import static java.lang.String.format;
+
+public interface LockMessage
+{
+    enum Action
+    {
+        NEW_SESSION, END_SESSION, ACQUIRE_EXCLUSIVE, ACQUIRE_SHARED
+    }
+
+    class Request implements Serializable
+    {
+        public final Action action;
+        public final LockSession lockSession;
+        public final Locks.ResourceType type;
+        public final long[] resourceIds;
+
+        private Request( Action action, LockSession lockSession, Locks.ResourceType type, long[] resourceIds )
+        {
+            this.action = action;
+            this.lockSession = lockSession;
+            this.type = type;
+            this.resourceIds = resourceIds;
+        }
+
+        public static Request newLockSession(LockSession lockSession)
+        {
+            return new Request( Action.NEW_SESSION, lockSession, null, new long[0] );
+        }
+
+        public static Request endLockSession(LockSession lockSession)
+        {
+            return new Request( Action.END_SESSION, lockSession, null, new long[0] );
+        }
+
+        public static Request acquireExclusiveLock( LockSession lockSession, Locks.ResourceType type, long... resourceIds )
+        {
+            return new Request( Action.ACQUIRE_EXCLUSIVE, lockSession, type, resourceIds );
+        }
+
+        public static Request acquireSharedLock( LockSession lockSession, Locks.ResourceType type, long... resourceIds )
+        {
+            return new Request( Action.ACQUIRE_SHARED, lockSession, type, resourceIds );
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "LockRequest{action=%s, lockSession=%s, type=%s, resourceIds=%s}",
+                    action, lockSession, type, Arrays.toString( resourceIds ) );
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+            Request request = (Request) o;
+            return Objects.equals( lockSession, request.lockSession ) &&
+                    Objects.equals( action, request.action ) &&
+                    Objects.equals( type, request.type ) &&
+                    Arrays.equals( resourceIds, request.resourceIds );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash( action, lockSession, type, resourceIds );
+        }
+    }
+
+    class Response
+    {
+        public final Request request;
+        public final LockResult result;
+
+        Response( Request request, LockResult result )
+        {
+            this.request = request;
+            this.result = result;
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "Response{request=%s, result=%s}", request, result );
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+            Response response = (Response) o;
+            return Objects.equals( request, response.request ) &&
+                    Objects.equals( result, response.result );
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash( request, result );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockMessageMarshall.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockMessageMarshall.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.membership.CoreMemberMarshal;
+import org.neo4j.coreedge.raft.replication.StringMarshal;
+import org.neo4j.kernel.ha.lock.LockResult;
+import org.neo4j.kernel.ha.lock.LockStatus;
+
+import static org.neo4j.kernel.impl.locking.ResourceTypes.fromId;
+
+public class LockMessageMarshall
+{
+    public static void serialize( ByteBuf buffer, LockMessage.Request msg )
+    {
+        buffer.writeInt( msg.action.ordinal() );
+        CoreMemberMarshal.serialize( msg.lockSession.owner, buffer );
+        buffer.writeInt( msg.lockSession.localSessionId );
+        if ( msg.type == null )
+        {
+            buffer.writeInt( -1 );
+        }
+        else
+        {
+            buffer.writeInt( msg.type.typeId() );
+        }
+        buffer.writeInt( msg.resourceIds.length );
+        for ( long resourceId : msg.resourceIds )
+        {
+            buffer.writeLong( resourceId );
+        }
+    }
+    
+    public static LockMessage.Request deserializeRequest( ByteBuf buffer )
+    {
+        int actionOrdinal = buffer.readInt();
+        CoreMember owner = CoreMemberMarshal.deserialize( buffer );
+        int localSessionId = buffer.readInt();
+        int typeId = buffer.readInt();
+        int resourceIdCount = buffer.readInt();
+        long[] resourceIds = new long[resourceIdCount];
+        for ( int i = 0; i < resourceIdCount; i++ )
+        {
+            resourceIds[i] = buffer.readLong();
+        }
+
+        LockMessage.Action action = LockMessage.Action.values()[actionOrdinal];
+        LockSession lockSession = new LockSession( owner, localSessionId );
+        switch ( action )
+        {
+            case NEW_SESSION:
+                return LockMessage.Request.newLockSession( lockSession );
+
+            case END_SESSION:
+                return LockMessage.Request.endLockSession( lockSession );
+
+            case ACQUIRE_EXCLUSIVE:
+                return LockMessage.Request.acquireExclusiveLock( lockSession, fromId( typeId ), resourceIds );
+
+            case ACQUIRE_SHARED:
+                return LockMessage.Request.acquireSharedLock( lockSession, fromId( typeId ), resourceIds );
+
+            default:
+                throw new IllegalArgumentException( "Unknown action: " + action );
+        }
+    }
+
+    public static void serialize( ByteBuf buffer, LockMessage.Response msg )
+    {
+        serialize( buffer, msg.request );
+        buffer.writeInt( msg.result.getStatus().ordinal() );
+        StringMarshal.serialize( buffer, msg.result.getMessage() );
+    }
+
+    public static LockMessage.Response deserializeResponse( ByteBuf buffer )
+    {
+        LockMessage.Request request = deserializeRequest( buffer );
+
+        int lockStatusOrdinal = buffer.readInt();
+        String message = StringMarshal.deserialize( buffer );
+
+        LockResult lockResult = new LockResult( LockStatus.values()[lockStatusOrdinal], message );
+
+        return new LockMessage.Response( request, lockResult );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockRequestDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockRequestDecoder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import org.neo4j.coreedge.catchup.CatchupServerProtocol;
+
+import static org.neo4j.coreedge.catchup.CatchupServerProtocol.NextMessage.LOCK_REQUEST;
+
+public class LockRequestDecoder extends MessageToMessageDecoder<ByteBuf>
+{
+    private final CatchupServerProtocol protocol;
+
+    public LockRequestDecoder( CatchupServerProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Override
+    protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
+    {
+        if ( protocol.isExpecting( LOCK_REQUEST ) )
+        {
+            out.add( LockMessageMarshall.deserializeRequest( msg ) );
+        }
+        else
+        {
+            out.add( Unpooled.copiedBuffer( msg ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockRequestEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockRequestEncoder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+public class LockRequestEncoder extends MessageToMessageEncoder<LockMessage.Request>
+{
+    @Override
+    protected void encode( ChannelHandlerContext ctx, LockMessage.Request msg, List<Object> out ) throws Exception
+    {
+        ByteBuf buffer = ctx.alloc().buffer();
+        LockMessageMarshall.serialize( buffer, msg );
+
+        out.add( buffer );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockResponseDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockResponseDecoder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import java.util.List;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class LockResponseDecoder extends MessageToMessageDecoder<ByteBuf>
+{
+    private final CatchupClientProtocol protocol;
+
+    public LockResponseDecoder( CatchupClientProtocol protocol )
+    {
+        this.protocol = protocol;
+    }
+
+    @Override
+    protected void decode( ChannelHandlerContext ctx, ByteBuf msg, List<Object> out ) throws Exception
+    {
+        if ( protocol.isExpecting( NextMessage.LOCK_RESPONSE ) )
+        {
+            out.add( LockMessageMarshall.deserializeResponse( msg ) );
+            protocol.expect( NextMessage.MESSAGE_TYPE );
+        }
+        else
+        {
+            out.add( Unpooled.copiedBuffer( msg ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockResponseEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockResponseEncoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+import org.neo4j.coreedge.raft.replication.StringMarshal;
+
+public class LockResponseEncoder extends MessageToMessageEncoder<LockMessage.Response>
+{
+    @Override
+    protected void encode( ChannelHandlerContext ctx, LockMessage.Response msg, List<Object> out ) throws Exception
+    {
+        ByteBuf buffer = ctx.alloc().buffer();
+        LockMessageMarshall.serialize( buffer, msg.request );
+
+        buffer.writeInt( msg.result.getStatus().ordinal() );
+        StringMarshal.serialize( buffer, msg.result.getMessage() );
+
+        out.add( buffer );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockResponseHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockResponseHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class LockResponseHandler extends SimpleChannelInboundHandler<LockMessage.Response>
+{
+    private final CatchupClientProtocol protocol;
+    private LockResultListener lockResultListener;
+
+    public LockResponseHandler( CatchupClientProtocol protocol,
+                                LockResultListener lockResultListener )
+    {
+        this.protocol = protocol;
+        this.lockResultListener = lockResultListener;
+    }
+
+    @Override
+    protected void channelRead0( ChannelHandlerContext ctx, final LockMessage.Response msg ) throws Exception
+    {
+        lockResultListener.onLockResponses( msg );
+        protocol.expect( NextMessage.MESSAGE_TYPE );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockResultListener.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockResultListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.io.IOException;
+
+public interface LockResultListener
+{
+    void onLockResponses( LockMessage.Response response ) throws IOException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockSession.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/locks/LockSession.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.util.Objects;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+import static java.lang.String.format;
+
+public class LockSession
+{
+    public final CoreMember owner;
+    public final int localSessionId;
+
+    public LockSession( CoreMember owner, int localSessionId )
+    {
+        this.owner = owner;
+        this.localSessionId = localSessionId;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "LockSession{owner=%s, localSessionId=%d}", owner, localSessionId );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        LockSession that = (LockSession) o;
+        return Objects.equals( localSessionId, that.localSessionId ) &&
+                Objects.equals( owner, that.owner );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( owner, localSessionId );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/InMemoryRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/InMemoryRaftLog.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+public class InMemoryRaftLog implements RaftLog
+{
+    private final Set<Listener> listeners = new CopyOnWriteArraySet<>();
+    private final Map<Long, RaftLogEntry> raftLog = new HashMap<>();
+
+    private long appendIndex = -1;
+    private long commitIndex = -1;
+    private long term = -1;
+
+    @Override
+    public void replay() throws Throwable
+    {
+        int i = 0;
+        for ( ; i <= commitIndex; i++ )
+        {
+            ReplicatedContent content = readEntryContent( i );
+            for ( Listener listener : listeners )
+            {
+                listener.onAppended( content );
+                listener.onCommitted( content );
+            }
+        }
+        for ( ; i <= appendIndex; i++ )
+        {
+            ReplicatedContent content = readEntryContent( i );
+            for ( Listener listener : listeners )
+            {
+                listener.onAppended( content );
+            }
+        }
+    }
+
+    @Override
+    public void registerListener( Listener listener )
+    {
+        listeners.add( listener );
+    }
+
+    @Override
+    public long append( RaftLogEntry logEntry ) throws RaftStorageException
+    {
+        Objects.requireNonNull( logEntry );
+        if ( logEntry.term() >= term )
+        {
+            term = logEntry.term();
+        }
+        else
+        {
+            throw new RaftStorageException( String.format( "Non-monotonic term %d for in entry %s in term %d",
+                    logEntry.term(), logEntry.toString(), term ) );
+        }
+
+        for ( Listener listener : listeners )
+        {
+            listener.onAppended( logEntry.content() );
+        }
+        raftLog.put( ++appendIndex, logEntry );
+        return appendIndex;
+    }
+
+    @Override
+    public void commit( long commitIndex )
+    {
+        if ( commitIndex > appendIndex )
+        {
+            commitIndex = appendIndex;
+        }
+        while ( this.commitIndex < commitIndex )
+        {
+            long nextCommitIndex = this.commitIndex + 1;
+
+            RaftLogEntry logEntry = raftLog.get( nextCommitIndex );
+            for ( Listener listener : listeners )
+            {
+                listener.onCommitted( logEntry.content() );
+            }
+            this.commitIndex = nextCommitIndex;
+        }
+    }
+
+    @Override
+    public long appendIndex()
+    {
+        return appendIndex;
+    }
+
+    @Override
+    public long commitIndex()
+    {
+        return commitIndex;
+    }
+
+    @Override
+    public RaftLogEntry readLogEntry( long logIndex )
+    {
+        if ( logIndex < 0 )
+        {
+            throw new IllegalArgumentException( "logIndex must not be negative" );
+        }
+        if ( logIndex > appendIndex )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "cannot read past last appended index (lastAppended=%d, readIndex=%d)",
+                            appendIndex, logIndex ) );
+        }
+        return raftLog.get( logIndex );
+    }
+
+    @Override
+    public ReplicatedContent readEntryContent( long logIndex )
+    {
+        return readLogEntry( logIndex ).content();
+    }
+
+    @Override
+    public long readEntryTerm( long logIndex )
+    {
+        if ( logIndex < 0 || logIndex > appendIndex )
+        {
+            return -1;
+        }
+        return readLogEntry( logIndex ).term();
+    }
+
+    @Override
+    public synchronized void truncate( long fromIndex )
+    {
+        if ( fromIndex <= commitIndex )
+        {
+            throw new IllegalArgumentException( "cannot truncate before the commit index" );
+        }
+
+        for ( long i = appendIndex; i >= fromIndex; --i )
+        {
+            raftLog.remove( i );
+        }
+
+        if ( appendIndex >= fromIndex )
+        {
+            appendIndex = fromIndex - 1;
+
+            for ( Listener listener : listeners )
+            {
+                listener.onTruncated( fromIndex );
+            }
+        }
+        term = readEntryTerm( appendIndex );
+    }
+
+    @Override
+    public boolean entryExists( long logIndex )
+    {
+        return raftLog.containsKey( logIndex );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        InMemoryRaftLog that = (InMemoryRaftLog) o;
+        return Objects.equals( appendIndex, that.appendIndex ) &&
+                Objects.equals( commitIndex, that.commitIndex ) &&
+                Objects.equals( term, that.term ) &&
+                Objects.equals( raftLog, that.raftLog );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( raftLog, appendIndex, commitIndex, term );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/NaiveDurableRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/NaiveDurableRaftLog.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.neo4j.coreedge.raft.log.monitoring.RaftLogAppendIndexMonitor;
+import org.neo4j.coreedge.raft.log.monitoring.RaftLogCommitIndexMonitor;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.MarshallingException;
+import org.neo4j.coreedge.raft.replication.Serializer;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.monitoring.Monitors;
+
+/**
+ * Writes a raft log to disk using 3 files:
+ * <p/>
+ * 1. entries.log
+ * ┌─────────────────────────────┐
+ * │term                  8 bytes│
+ * │contentPointer        8 bytes│
+ * ├─────────────────────────────┤
+ * │record length        16 bytes│
+ * └─────────────────────────────┘
+ * <p/>
+ * 2. content.log
+ * ┌─────────────────────────────┐
+ * │contentLength         4 bytes│
+ * ├─────────────────────────────┤
+ * │contentType           1 bytes│
+ * │content              variable│
+ * ├─────────────────────────────┤
+ * │record length        variable│
+ * └─────────────────────────────┘
+ * <p/>
+ * 3. commit.log
+ * ┌─────────────────────────────┐
+ * │committedIndex        8 bytes│
+ * ├─────────────────────────────┤
+ * │record length         8 bytes│
+ * └─────────────────────────────┘
+ */
+public class NaiveDurableRaftLog implements RaftLog
+{
+    public static final int ENTRY_RECORD_LENGTH = 16;
+    public static final int CONTENT_LENGTH_BYTES = 4;
+    public static final int COMMIT_INDEX_BYTES = 8;
+
+    private final Set<Listener> listeners = new CopyOnWriteArraySet<>();
+
+    private final StoreChannel entriesChannel;
+    private final StoreChannel contentChannel;
+    private final StoreChannel commitChannel;
+
+    private final Serializer serializer;
+    private long appendIndex = -1;
+    private long contentOffset;
+    private long commitIndex = -1;
+    private long term = -1;
+
+    private final RaftLogAppendIndexMonitor appendIndexMonitor;
+    private final RaftLogCommitIndexMonitor commitIndexMonitor;
+
+    public NaiveDurableRaftLog( FileSystemAbstraction fileSystem, File directory, Serializer serializer,
+                                Monitors monitors )
+    {
+        this.serializer = serializer;
+        this.appendIndexMonitor = monitors.newMonitor( RaftLogAppendIndexMonitor.class, getClass(), RaftLog.APPEND_INDEX_TAG );
+        this.commitIndexMonitor = monitors.newMonitor( RaftLogCommitIndexMonitor.class, getClass(), RaftLog.COMMIT_INDEX_TAG );
+
+        try
+        {
+            entriesChannel = fileSystem.open( new File( directory, "entries.log" ), "rw" );
+            contentChannel = fileSystem.open( new File( directory, "content.log" ), "rw" );
+            commitChannel = fileSystem.open( new File( directory, "commit.log" ), "rw" );
+            appendIndex = entriesChannel.size() / ENTRY_RECORD_LENGTH - 1;
+            contentOffset = contentChannel.size();
+            commitIndex = readCommitIndex();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+
+    }
+
+    @Override
+    public void replay() throws Throwable
+    {
+        int i = 0;
+        for ( ; i <= commitIndex; i++ )
+        {
+            ReplicatedContent content = readEntryContent( i );
+            for ( Listener listener : listeners )
+            {
+                listener.onAppended( content );
+                listener.onCommitted( content );
+            }
+        }
+        for ( ; i <= appendIndex; i++ )
+        {
+            ReplicatedContent content = readEntryContent( i );
+            for ( Listener listener : listeners )
+            {
+                listener.onAppended( content );
+            }
+        }
+    }
+
+    @Override
+    public void registerListener( Listener listener )
+    {
+        listeners.add( listener );
+    }
+
+    @Override
+    public long append( RaftLogEntry logEntry ) throws RaftStorageException
+    {
+        if ( logEntry.term() >= term )
+        {
+            term = logEntry.term();
+        }
+        else
+        {
+            throw new RaftStorageException( String.format( "Non-monotonic term %d for in entry %s in term %d",
+                    logEntry.term(), logEntry.toString(), term ) );
+        }
+
+        try
+        {
+            int length = writeContent( logEntry );
+            writeEntry( new Entry( logEntry.term(), contentOffset ) );
+            contentOffset += length;
+            for ( Listener listener : listeners )
+            {
+                listener.onAppended( logEntry.content() );
+            }
+            return ++appendIndex;
+        }
+        catch ( MarshallingException | IOException e )
+        {
+            throw new RaftStorageException( "Failed to append log entry", e );
+        }
+
+    }
+
+    @Override
+    public void truncate( long fromIndex ) throws RaftStorageException
+    {
+        try
+        {
+            if ( fromIndex <= commitIndex )
+            {
+                throw new IllegalArgumentException( "cannot truncate before the commit index" );
+            }
+
+            if ( appendIndex >= fromIndex )
+            {
+                Entry entry = readEntry( fromIndex );
+                contentChannel.truncate( entry.contentPointer );
+                contentOffset = entry.contentPointer;
+
+                entriesChannel.truncate( ENTRY_RECORD_LENGTH * fromIndex );
+                entriesChannel.force( false );
+
+                appendIndex = fromIndex - 1;
+
+                for ( Listener listener : listeners )
+                {
+                    listener.onTruncated( fromIndex );
+                }
+            }
+            term = readEntryTerm( appendIndex ) ;
+        }
+        catch ( IOException e )
+        {
+            throw new RaftStorageException( "Failed to truncate", e );
+        }
+    }
+
+    @Override
+    public void commit( final long newCommitIndex ) throws RaftStorageException
+    {
+        if ( commitIndex == appendIndex )
+        {
+            return;
+        }
+        long actualNewCommitIndex = newCommitIndex;
+        if ( newCommitIndex > appendIndex )
+        {
+            actualNewCommitIndex = appendIndex;
+        }
+
+        for ( long index = this.commitIndex + 1; index <= actualNewCommitIndex; index++ )
+        {
+            for ( Listener listener : listeners )
+            {
+                ReplicatedContent content = readEntryContent( index );
+                listener.onCommitted( content );
+            }
+            this.commitIndex = actualNewCommitIndex;
+        }
+        // INVARIANT: If newCommitIndex was greater than appendIndex, commitIndex is equal to appendIndex
+        try
+        {
+            storeCommitIndex( actualNewCommitIndex );
+        }
+        catch ( IOException e )
+        {
+            throw new RaftStorageException( "Failed to commit", e );
+        }
+    }
+
+    @Override
+    public long appendIndex()
+    {
+        appendIndexMonitor.appendIndex(appendIndex);
+        return appendIndex;
+    }
+
+    @Override
+    public long commitIndex()
+    {
+        commitIndexMonitor.commitIndex(commitIndex);
+        return commitIndex;
+    }
+
+    @Override
+    public RaftLogEntry readLogEntry( long logIndex ) throws RaftStorageException
+    {
+        try
+        {
+            Entry entry = readEntry( logIndex );
+            ReplicatedContent content = readContentFrom( entry.contentPointer );
+
+            return new RaftLogEntry( entry.term, content );
+        }
+        catch ( IOException | MarshallingException e )
+        {
+            throw new RaftStorageException( "Failed to read log entry", e );
+        }
+    }
+
+    @Override
+    public ReplicatedContent readEntryContent( long logIndex ) throws RaftStorageException
+    {
+        return readLogEntry( logIndex ).content();
+    }
+
+    @Override
+    public long readEntryTerm( long logIndex ) throws RaftStorageException
+    {
+        try
+        {
+            return readEntry( logIndex ).term;
+        }
+        catch ( IOException e )
+        {
+            throw new RaftStorageException( "Failed to read term", e );
+        }
+    }
+
+    @Override
+    public boolean entryExists( long logIndex )
+    {
+        return appendIndex >= logIndex;
+    }
+
+    private static class Entry
+    {
+        private final long term;
+        private final long contentPointer;
+
+        public Entry( long term, long contentPointer )
+        {
+            this.term = term;
+            this.contentPointer = contentPointer;
+        }
+    }
+
+    private void writeEntry( Entry entry ) throws IOException
+    {
+        ByteBuffer buffer = ByteBuffer.allocate( ENTRY_RECORD_LENGTH );
+        buffer.putLong( entry.term );
+        buffer.putLong( entry.contentPointer );
+        buffer.flip();
+
+        entriesChannel.write( buffer, (appendIndex + 1) * ENTRY_RECORD_LENGTH );
+        entriesChannel.force( false );
+    }
+
+    private Entry readEntry( long logIndex ) throws IOException
+    {
+        if ( logIndex < 0 || logIndex > appendIndex )
+        {
+            return new Entry( -1, -1 );
+        }
+
+        ByteBuffer buffer = ByteBuffer.allocate( ENTRY_RECORD_LENGTH );
+        entriesChannel.read( buffer, logIndex * ENTRY_RECORD_LENGTH );
+        buffer.flip();
+        long term = buffer.getLong();
+        long contentPointer = buffer.getLong();
+        return new Entry( term, contentPointer );
+    }
+
+    private int writeContent( RaftLogEntry logEntry ) throws MarshallingException, IOException
+    {
+        ByteBuffer contentBuffer = serializer.serialize( logEntry.content() );
+        int length = CONTENT_LENGTH_BYTES + contentBuffer.remaining();
+
+        ByteBuffer contentLengthBuffer = ByteBuffer.allocate( CONTENT_LENGTH_BYTES );
+        contentLengthBuffer.putInt( length );
+        contentLengthBuffer.flip();
+        contentChannel.write( contentLengthBuffer, contentOffset );
+        contentChannel.write( contentBuffer, contentOffset + CONTENT_LENGTH_BYTES );
+        contentChannel.force( false );
+
+        return length;
+    }
+
+    private ReplicatedContent readContentFrom( long contentPointer ) throws IOException, MarshallingException
+    {
+        ByteBuffer lengthBuffer = ByteBuffer.allocate( CONTENT_LENGTH_BYTES );
+        contentChannel.read( lengthBuffer, contentPointer );
+        lengthBuffer.flip();
+        int contentLength = lengthBuffer.getInt();
+
+        ByteBuffer contentBuffer = ByteBuffer.allocate( contentLength - CONTENT_LENGTH_BYTES );
+        contentChannel.read( contentBuffer, contentPointer + CONTENT_LENGTH_BYTES );
+        contentBuffer.flip();
+        return serializer.deserialize( contentBuffer );
+    }
+
+    private void storeCommitIndex( long commitIndex ) throws IOException
+    {
+        ByteBuffer buffer = ByteBuffer.allocate( COMMIT_INDEX_BYTES );
+        buffer.putLong( commitIndex );
+        buffer.flip();
+        commitChannel.write( buffer, 0 );
+        commitChannel.force( false );
+    }
+
+    private long readCommitIndex() throws IOException
+    {
+        if ( commitChannel.size() < COMMIT_INDEX_BYTES )
+        {
+            return -1;
+        }
+        ByteBuffer buffer = ByteBuffer.allocate( COMMIT_INDEX_BYTES );
+        commitChannel.read( buffer, 0 );
+        buffer.flip();
+        return buffer.getLong();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftLog.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+/**
+ * Persists entries that are coordinated through RAFT, i.e. this is the log
+ * of user data.
+ * <p/>
+ * All write operations in this interface must be durably persisted before
+ * returning from the respective functions.
+ * <p/>
+ * Entries are appended during the RAFT replication phase, and when safely
+ * replicated they will be committed. The consumer of the raft entry log
+ * can then safely apply the committed entry, typically to a state machine
+ * with the entry representing a state transition to be performed.
+ */
+public interface RaftLog extends ReadableRaftLog
+{
+    String APPEND_INDEX_TAG = "appendIndex";
+    String COMMIT_INDEX_TAG = "commitIndex";
+
+    void replay() throws Throwable;
+
+    void registerListener( Listener consumer );
+
+    interface Listener
+    {
+        void onAppended( ReplicatedContent content );
+
+        void onCommitted( ReplicatedContent content );
+
+        void onTruncated( long fromIndex );
+    }
+
+    /**
+     * Appends entry to the end of the log. The first log index is 0.
+     * <p/>
+     * The entries must be uniquely identifiable and already appended
+     * entries must not be re-appended (unless they have been removed
+     * through truncation).
+     *
+     * @param entry The log entry.
+     * @return Returns the index at which the entry was appended, or -1
+     * if the entry was not accepted.
+     */
+    long append( RaftLogEntry entry ) throws RaftStorageException;
+
+    /**
+     * Truncates the log starting from the supplied index. Committed
+     * entries can never be truncated.
+     *
+     * @param fromIndex The start index (inclusive).
+     */
+    void truncate( long fromIndex ) throws RaftStorageException;
+
+    /**
+     * Signals the safe replication of any entries previously appended up to and
+     * including the supplied commitIndex. These entries can now be applied.
+     * <p/>
+     * The implementation must remember which committed entries have already been
+     * applied so that they are not applied multiple times.
+     *
+     * @param commitIndex The end index (inclusive).
+     */
+    void commit( long commitIndex ) throws RaftStorageException;
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftLogEntry.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftLogEntry.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.util.Objects;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+public class RaftLogEntry
+{
+
+    public static final RaftLogEntry[] empty = new RaftLogEntry[0];
+    private final long term;
+    private final ReplicatedContent content;
+
+    public RaftLogEntry( long term, ReplicatedContent content )
+    {
+        Objects.requireNonNull( content );
+        this.term = term;
+        this.content = content;
+    }
+
+    public long term()
+    {
+        return this.term;
+    }
+
+    public ReplicatedContent content()
+    {
+        return this.content;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        RaftLogEntry that = (RaftLogEntry) o;
+
+        return term == that.term && content.equals( that.content );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = (int) (term ^ (term >>> 32));
+        result = 31 * result + content.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "RaftLogEntry{term=%d, content=%s}", term, content );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftStorageException.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftStorageException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+public class RaftStorageException extends Exception
+{
+    public RaftStorageException( String message, Exception cause )
+    {
+        super( message, cause );
+    }
+
+    public RaftStorageException( String message )
+    {
+        super( message );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftableContentAppender.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftableContentAppender.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.impl.transaction.log.Commitment;
+import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
+
+public interface RaftableContentAppender
+{
+    Commitment append( RaftLogEntry transaction, LogAppendEvent logAppendEvent ) throws IOException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/ReadableRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/ReadableRaftLog.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+public interface ReadableRaftLog
+{
+    /**
+     * @return The index of the last appended entry.
+     */
+    long appendIndex();
+
+    /**
+     * @return The index of the last committed entry.
+     */
+    long commitIndex();
+
+    /**
+     * Reads the log entry at the supplied index.
+     *
+     * @param logIndex The index of the log entry.
+     * @return The log entry.
+     */
+    RaftLogEntry readLogEntry( long logIndex ) throws RaftStorageException;
+
+    /**
+     * Reads the content of the log entry at the supplied index.
+     *
+     * @param logIndex The index of the log entry.
+     * @return The log entry content.
+     */
+    ReplicatedContent readEntryContent( long logIndex ) throws RaftStorageException;
+
+    /**
+     * Reads the term associated with the entry at the supplied index.
+     *
+     * @param logIndex The index of the log entry.
+     * @return The term of the entry, or -1 if the entry does not exist
+     */
+    long readEntryTerm( long logIndex ) throws RaftStorageException;
+
+    /**
+     * Tells if a entry exists in the log at the supplied index.
+     *
+     * @param logIndex The index of the log entry.
+     * @return True if the entry exists, otherwise false.
+     */
+    boolean entryExists( long logIndex );
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/monitoring/RaftLogAppendIndexMonitor.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/monitoring/RaftLogAppendIndexMonitor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.monitoring;
+
+public interface RaftLogAppendIndexMonitor
+{
+    long appendIndex();
+    void appendIndex(long appendIndex);
+}
+

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/monitoring/RaftLogCommitIndexMonitor.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/monitoring/RaftLogCommitIndexMonitor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.monitoring;
+
+public interface RaftLogCommitIndexMonitor
+{
+    long commitIndex();
+    void commitIndex(long commitIndex);
+}
+

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CatchupGoal.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CatchupGoal.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.state.FollowerState;
+import org.neo4j.helpers.Clock;
+
+public class CatchupGoal
+{
+    private static final long MAX_ROUNDS = 10;
+
+    private final ReadableRaftLog raftLog;
+    private final Clock clock;
+    private final long electionTimeout;
+
+    private long targetIndex;
+    private long roundCount;
+    private long startTime;
+
+    public CatchupGoal( ReadableRaftLog raftLog, Clock clock, long electionTimeout )
+    {
+        this.raftLog = raftLog;
+        this.clock = clock;
+        this.electionTimeout = electionTimeout;
+        this.targetIndex = raftLog.appendIndex();
+        this.startTime = clock.currentTimeMillis();
+
+        this.roundCount = 1;
+    }
+
+    boolean achieved( FollowerState followerState )
+    {
+        if ( followerState.getMatchIndex() >= targetIndex )
+        {
+            if ( (clock.currentTimeMillis() - startTime) <= electionTimeout )
+            {
+                return true;
+            }
+            else if ( roundCount <  MAX_ROUNDS )
+            {
+                roundCount++;
+                startTime = clock.currentTimeMillis();
+                targetIndex = raftLog.appendIndex();
+            }
+        }
+        return false;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CatchupGoalTracker.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CatchupGoalTracker.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.state.FollowerState;
+import org.neo4j.helpers.Clock;
+
+public class CatchupGoalTracker
+{
+    public static final long MAX_ROUNDS = 10;
+
+    private final ReadableRaftLog raftLog;
+    private final Clock clock;
+
+    private long startTime;
+    private  long roundStartTime;
+    private final long roundTimeout;
+    private long roundCount;
+    private long catchupTimeout;
+
+    private long targetIndex;
+    private boolean finished;
+    private boolean goalAchieved;
+
+    public CatchupGoalTracker( ReadableRaftLog raftLog, Clock clock, long roundTimeout, long catchupTimeout )
+    {
+        this.raftLog = raftLog;
+        this.clock = clock;
+        this.roundTimeout = roundTimeout;
+        this.catchupTimeout = catchupTimeout;
+        this.targetIndex = raftLog.appendIndex();
+        this.startTime = clock.currentTimeMillis();
+        this.roundStartTime = clock.currentTimeMillis();
+
+        this.roundCount = 1;
+    }
+
+    void updateProgress( FollowerState followerState )
+    {
+        if ( finished )
+        {
+            return;
+        }
+
+        boolean achievedTarget = followerState.getMatchIndex() >= targetIndex;
+        if ( achievedTarget && (clock.currentTimeMillis() - roundStartTime) <= roundTimeout )
+        {
+            goalAchieved = true;
+            finished = true;
+        }
+        else if ( clock.currentTimeMillis() > (startTime + catchupTimeout) )
+        {
+            finished = true;
+        }
+        else if ( achievedTarget )
+        {
+            if( roundCount < MAX_ROUNDS )
+            {
+                roundCount++;
+                roundStartTime = clock.currentTimeMillis();
+                targetIndex = raftLog.appendIndex();
+            }
+            else
+            {
+                finished = true;
+            }
+        }
+    }
+
+    boolean isFinished()
+    {
+        return finished;
+    }
+
+    boolean isGoalAchieved()
+    {
+        return goalAchieved;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "CatchupGoalTracker{startTime=%d, roundStartTime=%d, roundTimeout=%d, roundCount=%d, " +
+                "catchupTimeout=%d, targetIndex=%d, finished=%s, goalAchieved=%s}", startTime, roundStartTime,
+                roundTimeout, roundCount, catchupTimeout, targetIndex, finished, goalAchieved );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CoreMemberMarshal.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CoreMemberMarshal.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.server.AdvertisedSocketAddressDecoder;
+import org.neo4j.coreedge.server.AdvertisedSocketAddressEncoder;
+
+/**
+ * Format:
+ * ┌────────────────────────────────────────────┐
+ * │core address ┌─────────────────────────────┐│
+ * │             │hostnameLength        4 bytes││
+ * │             │hostnameBytes        variable││
+ * │             │port                  4 bytes││
+ * │             └─────────────────────────────┘│
+ * │raft address ┌─────────────────────────────┐│
+ * │             │hostnameLength        4 bytes││
+ * │             │hostnameBytes        variable││
+ * │             │port                  4 bytes││
+ * │             └─────────────────────────────┘│
+ * └────────────────────────────────────────────┘
+ */
+public class CoreMemberMarshal
+{
+    static public void serialize( CoreMember member, ByteBuf buffer )
+    {
+        AdvertisedSocketAddressEncoder encoder = new AdvertisedSocketAddressEncoder();
+        encoder.encode( member.getCoreAddress(), buffer );
+        encoder.encode( member.getRaftAddress(), buffer );
+    }
+
+    static public CoreMember deserialize( ByteBuf buffer )
+    {
+        AdvertisedSocketAddressDecoder decoder = new AdvertisedSocketAddressDecoder();
+        AdvertisedSocketAddress coreAddress = decoder.decode( buffer );
+        AdvertisedSocketAddress raftAddress = decoder.decode( buffer );
+        return new CoreMember( coreAddress, raftAddress );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CoreMemberSet.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CoreMemberSet.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.Set;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+public class CoreMemberSet implements RaftGroup<CoreMember>
+{
+    private final Set<CoreMember> members;
+
+    public CoreMemberSet( Set<CoreMember> members )
+    {
+        this.members = members;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "CoreMemberMemberSet{ members=" + members + '}';
+    }
+
+    @Override
+    public Set<CoreMember> getMembers()
+    {
+        return members;
+    }
+
+    @Override public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        CoreMemberSet that = (CoreMemberSet) o;
+
+        return !(members != null ? !members.equals( that.members ) : that.members != null);
+
+    }
+
+    @Override public int hashCode()
+    {
+        return members != null ? members.hashCode() : 0;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CoreMemberSetBuilder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CoreMemberSetBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.Set;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+public class CoreMemberSetBuilder implements RaftGroup.Builder<CoreMember>
+{
+    @Override
+    public RaftGroup<CoreMember> build( Set<CoreMember> members )
+    {
+        return new CoreMemberSet( members );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CoreMemberSetSerializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/CoreMemberSetSerializer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+/**
+ * Format:
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │contentLength                                                  8 bytes   │
+ * │contentType                                                    1 bytes   │
+ * │content      ┌──────────────────────────────────────────────────────────┐│
+ * │             │ memberCount                                     4 bytes  ││
+ * │             │ member 0   ┌────────────────────────────────────────────┐││
+ * │             │            │core address ┌─────────────────────────────┐│││
+ * │             │            │             │hostnameLength        4 bytes││││
+ * │             │            │             │hostnameBytes        variable││││
+ * │             │            │             │port                  4 bytes││││
+ * │             │            │             └─────────────────────────────┘│││
+ * │             │            │raft address ┌─────────────────────────────┐│││
+ * │             │            │             │hostnameLength        4 bytes││││
+ * │             │            │             │hostnameBytes        variable││││
+ * │             │            │             │port                  4 bytes││││
+ * │             │            │             └─────────────────────────────┘│││
+ * │             │            └────────────────────────────────────────────┘││
+ * │             │ ...                                                      ││
+ * │             │ member n   ┌────────────────────────────────────────────┐││
+ * │             │            │core address ┌─────────────────────────────┐│││
+ * │             │            │             │hostnameLength        4 bytes││││
+ * │             │            │             │hostnameBytes        variable││││
+ * │             │            │             │port                  4 bytes││││
+ * │             │            │             └─────────────────────────────┘│││
+ * │             │            │raft address ┌─────────────────────────────┐│││
+ * │             │            │             │hostnameLength        4 bytes││││
+ * │             │            │             │hostnameBytes        variable││││
+ * │             │            │             │port                  4 bytes││││
+ * │             │            │             └─────────────────────────────┘│││
+ * │             │            └────────────────────────────────────────────┘││
+ * │             └──────────────────────────────────────────────────────────┘│
+ * └─────────────────────────────────────────────────────────────────────────┘
+ */
+public class CoreMemberSetSerializer
+{
+    public static void serialize( CoreMemberSet memberSet, ByteBuf buffer )
+    {
+        Set<CoreMember> members = memberSet.getMembers();
+        buffer.writeInt( members.size() );
+
+        for ( CoreMember member : members )
+        {
+            CoreMemberMarshal.serialize( member, buffer );
+        }
+    }
+
+    public static CoreMemberSet deserialize( ByteBuf buffer )
+    {
+        HashSet<CoreMember> members = new HashSet<>();
+        int memberCount = buffer.readInt();
+
+        for ( int i = 0; i < memberCount; i++ )
+        {
+            members.add( CoreMemberMarshal.deserialize( buffer ) );
+        }
+
+        return new CoreMemberSet( members );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/MembershipDriver.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/MembershipDriver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.Set;
+
+public interface MembershipDriver<MEMBER>
+{
+    void doConsensus( Set<MEMBER> newVotingMemberSet );
+
+    boolean uncommittedMemberChangeInLog();
+
+    void stateChanged();
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/MembershipWaiter.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/MembershipWaiter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+import org.neo4j.kernel.impl.util.JobScheduler;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.POOLED;
+
+public class MembershipWaiter<MEMBER>
+{
+    private final MEMBER myself;
+    private final JobScheduler jobScheduler;
+    private final long maxCatchupLag;
+
+    public MembershipWaiter( MEMBER myself, JobScheduler jobScheduler, long maxCatchupLag )
+    {
+        this.myself = myself;
+        this.jobScheduler = jobScheduler;
+        this.maxCatchupLag = maxCatchupLag;
+    }
+
+    public CompletableFuture<Boolean> waitUntilCaughtUpMember( ReadableRaftState<MEMBER> raftState )
+    {
+        CompletableFuture<Boolean> catchUpFuture = new CompletableFuture<>();
+
+        JobScheduler.JobHandle jobHandle = jobScheduler.scheduleRecurring(
+                new JobScheduler.Group( getClass().toString(), POOLED ),
+                new Evaluator<>( raftState, myself, catchUpFuture ), maxCatchupLag, MILLISECONDS );
+
+        catchUpFuture.whenComplete( ( result, e ) -> jobHandle.cancel( true ) );
+
+        return catchUpFuture;
+    }
+
+    private static class Evaluator<MEMBER> implements Runnable
+    {
+        private final ReadableRaftState<MEMBER> raftState;
+        private final MEMBER myself;
+        private final CompletableFuture<Boolean> catchUpFuture;
+
+        private long lastLeaderCommit;
+
+        private Evaluator( ReadableRaftState<MEMBER> raftState, MEMBER myself, CompletableFuture<Boolean> catchUpFuture )
+        {
+            this.raftState = raftState;
+            this.myself = myself;
+            this.catchUpFuture = catchUpFuture;
+            this.lastLeaderCommit = raftState.leaderCommit();
+        }
+
+        public void run()
+        {
+            if ( iAmAVotingMember() && caughtUpWithLeader())
+            {
+                catchUpFuture.complete( true );
+            }
+        }
+
+        private boolean iAmAVotingMember()
+        {
+            return raftState.votingMembers().contains( myself );
+        }
+
+        private boolean caughtUpWithLeader()
+        {
+            boolean caughtUpWithLeader = false;
+
+            if ( lastLeaderCommit != -1 )
+            {
+                caughtUpWithLeader = raftState.entryLog().commitIndex() >= lastLeaderCommit;
+            }
+            lastLeaderCommit = raftState.leaderCommit();
+            System.out.printf( "%s CATCHUP: %d => %d (%d behind)%n",
+                    myself,
+                    raftState.entryLog().commitIndex(), raftState.leaderCommit(),
+                    raftState.leaderCommit() - raftState.entryLog().commitIndex() );
+
+            return caughtUpWithLeader;
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftGroup.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftGroup.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+public interface RaftGroup<MEMBER> extends ReplicatedContent
+{
+    Set<MEMBER> getMembers();
+
+    interface Builder<MEMBER>
+    {
+        RaftGroup<MEMBER> build( Set<MEMBER> members );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembership.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembership.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.Set;
+
+public interface RaftMembership<MEMBER>
+{
+    /**
+     * @return members whose votes count towards consensus.
+     */
+    Set<MEMBER> votingMembers();
+
+    /**
+     * @return members to which replication should be attempted.
+     */
+    Set<MEMBER> replicationMembers();
+
+    /**
+     * Register a membership listener.
+     *
+     * @param listener The listener.
+     */
+    void registerListener( RaftMembership.Listener listener );
+
+    void deregisterListener( RaftMembership.Listener listener );
+
+    interface Listener
+    {
+        void onMembershipChanged();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembershipImpl.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembershipImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+public class RaftMembershipImpl<MEMBER> implements RaftMembership<MEMBER>
+{
+    private Set<MEMBER> additionalReplicationMembers = new HashSet<>();
+
+    private volatile Set<MEMBER> votingMembers = new HashSet<>();
+    private volatile Set<MEMBER> replicationMembers = new HashSet<>(); // votingMembers + additionalReplicationMembers
+
+    private final Set<Listener> listeners = new HashSet<>();
+
+    private final Log log;
+
+    public RaftMembershipImpl( LogProvider logProvider )
+    {
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    public synchronized void setVotingMembers( Set<MEMBER> newVotingMembers )
+    {
+        this.votingMembers = new HashSet<>( newVotingMembers );
+
+        updateReplicationMembers();
+        notifyListeners();
+
+        log.info( "Voting members: " + votingMembers );
+    }
+
+    public synchronized void addAdditionalReplicationMember( MEMBER member )
+    {
+        additionalReplicationMembers.add( member );
+
+        updateReplicationMembers();
+        notifyListeners();
+    }
+
+    public synchronized void removeAdditionalReplicationMember( MEMBER member )
+    {
+        additionalReplicationMembers.remove( member );
+
+        updateReplicationMembers();
+        notifyListeners();
+    }
+
+    private void updateReplicationMembers()
+    {
+        HashSet<MEMBER> newReplicationMembers = new HashSet<>( votingMembers );
+
+        newReplicationMembers.addAll( additionalReplicationMembers );
+        this.replicationMembers = newReplicationMembers;
+
+        log.info( "Replication members: " + newReplicationMembers );
+    }
+
+    @Override
+    public Set<MEMBER> votingMembers()
+    {
+        return votingMembers;
+    }
+
+    @Override
+    public Set<MEMBER> replicationMembers()
+    {
+        return replicationMembers;
+    }
+
+    @Override
+    public synchronized void registerListener( Listener listener )
+    {
+        listeners.add( listener );
+    }
+
+    @Override
+    public synchronized void deregisterListener( Listener listener )
+    {
+        listeners.remove( listener );
+    }
+
+    private void notifyListeners()
+    {
+        listeners.forEach( Listener::onMembershipChanged );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembershipManager.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembershipManager.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.coreedge.raft.state.FollowerStates;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.helpers.Clock;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static java.util.Collections.emptySet;
+import static org.neo4j.helpers.collection.IteratorUtil.first;
+
+/**
+ * This class drives raft membership changes by glueing together various components:
+ *  - target membership from hazelcast
+ *  - raft membership state machine
+ *  - raft log events
+ */
+public class RaftMembershipManager<MEMBER> extends RaftMembershipImpl<MEMBER> implements RaftLog.Listener, MembershipDriver<MEMBER>
+{
+    private RaftMembershipStateMachine<MEMBER> membershipStateMachine;
+
+    private Set<MEMBER> targetMembers = null;
+
+    private int uncommittedMemberChanges = 0;
+
+    private final Replicator replicator;
+    private final RaftGroup.Builder<MEMBER> memberSetBuilder;
+    private final ReadableRaftLog entryLog;
+    private final Log log;
+    private final int expectedClusterSize;
+
+    public RaftMembershipManager( Replicator replicator, RaftGroup.Builder<MEMBER> memberSetBuilder, RaftLog entryLog,
+            LogProvider logProvider, int expectedClusterSize, long electionTimeout,
+            Clock clock, long catchupTimeout )
+    {
+        super( logProvider );
+        this.replicator = replicator;
+        this.memberSetBuilder = memberSetBuilder;
+        this.entryLog = entryLog;
+        this.expectedClusterSize = expectedClusterSize;
+        this.log = logProvider.getLog( getClass() );
+
+        this.membershipStateMachine = new RaftMembershipStateMachine<>( entryLog, clock, electionTimeout, this,
+                logProvider, catchupTimeout, this );
+
+        entryLog.registerListener( this );
+    }
+
+    @Override
+    public void onAppended( ReplicatedContent content )
+    {
+        if ( content instanceof RaftGroup )
+        {
+            assert uncommittedMemberChanges >= 0;
+
+            uncommittedMemberChanges++;
+
+            RaftGroup<MEMBER> raftGroup = (RaftGroup) content;
+            setVotingMembers( raftGroup.getMembers() );
+        }
+    }
+
+    @Override
+    public void onCommitted( ReplicatedContent content )
+    {
+        if ( content instanceof RaftGroup )
+        {
+            assert uncommittedMemberChanges > 0;
+
+            uncommittedMemberChanges--;
+
+            if ( uncommittedMemberChanges == 0 )
+            {
+                membershipStateMachine.onRaftGroupCommitted();
+            }
+        }
+    }
+
+    @Override
+    public void onTruncated( long fromIndex )
+    {
+        try
+        {
+            Long logIndex = findLastMembershipEntry();
+
+            if ( logIndex != null )
+            {
+                RaftGroup<MEMBER> lastMembershipEntry = (RaftGroup<MEMBER>) entryLog.readEntryContent( logIndex );
+                setVotingMembers( lastMembershipEntry.getMembers() );
+            }
+            else
+            {
+                setVotingMembers( Collections.<MEMBER>emptySet() );
+            }
+
+            uncommittedMemberChanges = 0;
+            for ( long i = entryLog.commitIndex() + 1; i <= entryLog.appendIndex(); i++ )
+            {
+                ReplicatedContent content = entryLog.readEntryContent( i );
+                if ( content instanceof RaftGroup )
+                {
+                    uncommittedMemberChanges++;
+                }
+            }
+        }
+        catch ( RaftStorageException e )
+        {
+            log.error( "Unable to find last membership entry after RAFT log truncation", e );
+        }
+    }
+
+    private Long findLastMembershipEntry() throws RaftStorageException
+    {
+        for ( long logIndex = entryLog.appendIndex(); logIndex >= 0; logIndex-- )
+        {
+            RaftLogEntry raftLogEntry = entryLog.readLogEntry( logIndex );
+
+            ReplicatedContent content = raftLogEntry.content();
+
+            if ( content instanceof RaftGroup )
+            {
+                return logIndex;
+            }
+        }
+        return null;
+    }
+
+    public void setTargetMembershipSet( Set<MEMBER> targetMembers )
+    {
+        this.targetMembers = new HashSet<>( targetMembers );
+
+        log.info( "Target membership: " + targetMembers );
+        membershipStateMachine.onTargetChanged( targetMembers );
+
+        checkForStartCondition();
+    }
+
+    private Set<MEMBER> missingMembers()
+    {
+        if ( targetMembers == null || votingMembers() == null )
+        {
+            return emptySet();
+        }
+        Set<MEMBER> missingMembers = new HashSet<>( targetMembers );
+        missingMembers.removeAll( votingMembers() );
+
+        return missingMembers;
+    }
+
+    private boolean isSafeToRemoveMember()
+    {
+        return votingMembers() != null && votingMembers().size() > expectedClusterSize;
+    }
+
+    private Set<MEMBER> superfluousMembers()
+    {
+        if ( targetMembers == null || votingMembers() == null )
+        {
+            return emptySet();
+        }
+        Set<MEMBER> superfluousMembers = new HashSet<>( votingMembers() );
+        superfluousMembers.removeAll( targetMembers );
+
+        return superfluousMembers;
+    }
+
+    private void checkForStartCondition()
+    {
+        if ( missingMembers().size() > 0 )
+        {
+            membershipStateMachine.onMissingMember( first( missingMembers() ) );
+        }
+        else if ( isSafeToRemoveMember() && superfluousMembers().size() > 0 )
+        {
+            membershipStateMachine.onSuperfluousMember( first( superfluousMembers() ) );
+        }
+    }
+
+    @Override
+    public void doConsensus( Set<MEMBER> newVotingMemberSet )
+    {
+        try
+        {
+            replicator.replicate( memberSetBuilder.build( newVotingMemberSet ) );
+        }
+        catch ( Replicator.ReplicationFailedException e )
+        {
+            // TODO: log
+        }
+    }
+
+    @Override
+    public boolean uncommittedMemberChangeInLog()
+    {
+        return uncommittedMemberChanges > 0;
+    }
+
+    @Override
+    public void stateChanged()
+    {
+        checkForStartCondition();
+    }
+
+    public void onFollowerStateChange( FollowerStates<MEMBER> followerStates )
+    {
+        membershipStateMachine.onFollowerStateChange( followerStates );
+    }
+
+    public void onRole( Role role )
+    {
+        membershipStateMachine.onRole( role );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembershipStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembershipStateMachine.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.coreedge.raft.state.FollowerStates;
+import org.neo4j.helpers.Clock;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static java.lang.String.format;
+
+/**
+ * This class carries the core raft membership change state machine, which defines the
+ * legal state transitions when adding or removing members from the raft voting group.
+ *
+ * The state machine has these 4 states:
+ *
+ * <pre>
+ *   INACTIVE                    completely inactive, not leader
+ *
+ *   IDLE,                       leader, but idle, no work to do
+ *   CATCHUP IN PROGRESS,        member catching up
+ *   CONSENSUS IN PROGRESS       caught up member being added to voting group
+ * </pre>
+ *
+ * The normal progression when adding a member is:
+ * <pre>
+ *   IDLE->CATCHUP->CONSENSUS->IDLE
+ * </pre>
+ *
+ * the normal progression when removing a member is:
+ * <pre>
+ *   IDLE->CONSENSUS->IDLE
+ * </pre>
+ *
+ * Only a single member change is handled at a time.
+ */
+public class RaftMembershipStateMachine<MEMBER>
+{
+    private final Log log;
+    public RaftMembershipStateMachineEventHandler<MEMBER> state = new Inactive();
+
+    private final ReadableRaftLog raftLog;
+    private final Clock clock;
+    private final long electionTimeout;
+
+    private final MembershipDriver<MEMBER> membershipDriver;
+    private long catchupTimeout;
+    private final RaftMembershipImpl<MEMBER> membershipState;
+
+    private MEMBER catchingUpMember;
+
+    public RaftMembershipStateMachine( ReadableRaftLog raftLog, Clock clock, long electionTimeout,
+                                       MembershipDriver<MEMBER> membershipDriver, LogProvider logProvider,
+                                       long catchupTimeout, RaftMembershipImpl<MEMBER> membershipState )
+    {
+        this.raftLog = raftLog;
+        this.clock = clock;
+        this.electionTimeout = electionTimeout;
+        this.membershipDriver = membershipDriver;
+        this.catchupTimeout = catchupTimeout;
+        this.membershipState = membershipState;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    synchronized void handleState( RaftMembershipStateMachineEventHandler<MEMBER> newState )
+    {
+        RaftMembershipStateMachineEventHandler oldState = state;
+        this.state = newState;
+
+        if ( oldState != newState )
+        {
+            oldState.onExit();
+            newState.onEntry();
+
+            log.info( newState.toString() );
+            membershipDriver.stateChanged();
+        }
+    }
+
+    public void onRole( Role role )
+    {
+        handleState( state.onRole( role ) );
+    }
+
+    public void onRaftGroupCommitted()
+    {
+        handleState( state.onRaftGroupCommitted() );
+    }
+
+    public void onFollowerStateChange( FollowerStates<MEMBER> followerStates )
+    {
+        handleState( state.onFollowerStateChange( followerStates ) );
+    }
+
+    public void onMissingMember( MEMBER member )
+    {
+        handleState( state.onMissingMember( member ) );
+    }
+
+    public void onSuperfluousMember( MEMBER member )
+    {
+        handleState( state.onSuperfluousMember( member ) );
+    }
+
+    public void onTargetChanged( Set<MEMBER> targetMembers )
+    {
+        handleState( state.onTargetChanged( targetMembers ) );
+    }
+
+    public class Inactive extends RaftMembershipStateMachineEventHandler.Adapter<MEMBER>
+    {
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onRole( Role role )
+        {
+            if ( role == Role.LEADER )
+            {
+                if ( membershipDriver.uncommittedMemberChangeInLog() )
+                {
+                    return new ConsensusInProgress();
+                }
+                else
+                {
+                    return new Idle();
+                }
+            }
+            return this;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Inactive{}";
+        }
+    }
+
+    public abstract class ActiveBaseState extends RaftMembershipStateMachineEventHandler.Adapter<MEMBER>
+    {
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onRole( Role role )
+        {
+            if ( role != Role.LEADER )
+            {
+                return new Inactive();
+            }
+            else
+            {
+                return this;
+            }
+        }
+    }
+
+    public class Idle extends ActiveBaseState
+    {
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onMissingMember( MEMBER member )
+        {
+            return new CatchingUp( member );
+        }
+
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onSuperfluousMember( MEMBER member )
+        {
+            Set<MEMBER> updatedVotingMembers = new HashSet<>( membershipState.votingMembers() );
+            updatedVotingMembers.remove( member );
+            membershipDriver.doConsensus( updatedVotingMembers );
+
+            return new ConsensusInProgress();
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Idle{}";
+        }
+    }
+
+    public class CatchingUp extends ActiveBaseState
+    {
+        private final CatchupGoalTracker catchupGoalTracker;
+        boolean movingToConsensus;
+
+        public CatchingUp( MEMBER member )
+        {
+            this.catchupGoalTracker = new CatchupGoalTracker( raftLog, clock, electionTimeout, catchupTimeout );
+            catchingUpMember = member;
+        }
+
+        @Override
+        public void onEntry()
+        {
+            membershipState.addAdditionalReplicationMember( catchingUpMember );
+        }
+
+        @Override
+        public void onExit()
+        {
+            if( !movingToConsensus )
+            {
+                membershipState.removeAdditionalReplicationMember( catchingUpMember );
+            }
+        }
+
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onRole( Role role )
+        {
+            if ( role != Role.LEADER )
+            {
+                return new Inactive();
+            }
+            else
+            {
+                return this;
+            }
+        }
+
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onFollowerStateChange( FollowerStates<MEMBER> followerStates )
+        {
+            catchupGoalTracker.updateProgress( followerStates.get( catchingUpMember ) );
+
+            if ( catchupGoalTracker.isFinished() )
+            {
+                if ( catchupGoalTracker.isGoalAchieved() )
+                {
+                    Set<MEMBER> updatedVotingMembers = new HashSet<>( membershipState.votingMembers() );
+                    updatedVotingMembers.add( catchingUpMember );
+                    membershipDriver.doConsensus( updatedVotingMembers );
+
+                    movingToConsensus = true;
+                    return new ConsensusInProgress();
+                }
+                else
+                {
+                    return new Idle();
+                }
+            }
+            return this;
+        }
+
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onTargetChanged( Set<MEMBER> targetMembers )
+        {
+            if ( !targetMembers.contains( catchingUpMember ) )
+            {
+                return new Idle();
+            }
+            else
+            {
+                return this;
+            }
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "CatchingUp{catchupGoalTracker=%s, catchingUpMember=%s}", catchupGoalTracker,
+                    catchingUpMember );
+        }
+    }
+
+    private class ConsensusInProgress extends ActiveBaseState
+    {
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onRaftGroupCommitted()
+        {
+            return new Idle();
+        }
+
+        @Override
+        public void onEntry()
+        {
+        }
+
+        @Override
+        public void onExit()
+        {
+            membershipState.removeAdditionalReplicationMember( catchingUpMember );
+        }
+
+        @Override
+        public String toString()
+        {
+            return "ConsensusInProgress{}";
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembershipStateMachineEventHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/RaftMembershipStateMachineEventHandler.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.coreedge.raft.state.FollowerStates;
+
+interface RaftMembershipStateMachineEventHandler<MEMBER>
+{
+    RaftMembershipStateMachineEventHandler<MEMBER> onRole( Role role );
+
+    RaftMembershipStateMachineEventHandler<MEMBER> onRaftGroupCommitted();
+
+    RaftMembershipStateMachineEventHandler<MEMBER> onFollowerStateChange( FollowerStates<MEMBER> followerStates );
+
+    RaftMembershipStateMachineEventHandler<MEMBER> onMissingMember( MEMBER member );
+
+    RaftMembershipStateMachineEventHandler<MEMBER> onSuperfluousMember( MEMBER member );
+
+    RaftMembershipStateMachineEventHandler<MEMBER> onTargetChanged( Set<MEMBER> targetMembers );
+
+    void onExit();
+
+    void onEntry();
+
+    abstract class Adapter<MEMBER> implements RaftMembershipStateMachineEventHandler<MEMBER>
+    {
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onRole( Role role )
+        {
+            return this;
+        }
+
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onRaftGroupCommitted()
+        {
+            return this;
+        }
+
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onMissingMember( MEMBER member )
+        {
+            return this;
+        }
+
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onSuperfluousMember( MEMBER member )
+        {
+            return this;
+        }
+
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onFollowerStateChange( FollowerStates<MEMBER> followerStates )
+        {
+            return this;
+        }
+
+        @Override
+        public RaftMembershipStateMachineEventHandler<MEMBER> onTargetChanged( Set<MEMBER> targetMembers )
+        {
+            return this;
+        }
+
+        @Override
+        public void onExit() {};
+
+        @Override
+        public void onEntry() {};
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/CoreReplicatedContentMarshal.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/CoreReplicatedContentMarshal.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.raft.locks.CoreServiceAssignment;
+import org.neo4j.coreedge.raft.locks.CoreServiceAssignmentSerializer;
+import org.neo4j.coreedge.raft.membership.CoreMemberSet;
+import org.neo4j.coreedge.raft.membership.CoreMemberSetSerializer;
+import org.neo4j.coreedge.raft.replication.MarshallingException;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.ReplicatedContentMarshal;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdAllocationRequest;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdAllocationRequestSerializer;
+import org.neo4j.coreedge.raft.replication.storeid.SeedStoreId;
+import org.neo4j.coreedge.raft.replication.storeid.SeedStoreIdSerializer;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedTokenRequest;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedTokenRequestSerializer;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransaction;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransactionSerializer;
+
+public class CoreReplicatedContentMarshal implements ReplicatedContentMarshal<ByteBuf>
+{
+    private static final byte TX_CONTENT_TYPE = 0;
+    private static final byte RAFT_MEMBER_SET_TYPE = 1;
+    private static final byte ID_RANGE_REQUEST_TYPE = 2;
+    private static final byte SEED_STORE_ID_TYPE = 3;
+    private static final byte TOKEN_REQUEST_TYPE = 4;
+    private static final byte SERVICE_ASSIGNMENT_TYPE = 5;
+
+    @Override
+    public void serialize( ReplicatedContent content, ByteBuf buffer ) throws MarshallingException
+    {
+        if ( content instanceof ReplicatedTransaction )
+        {
+            buffer.writeByte( TX_CONTENT_TYPE );
+            ReplicatedTransactionSerializer.serialize( (ReplicatedTransaction) content, buffer );
+        }
+        else if ( content instanceof CoreMemberSet )
+        {
+            buffer.writeByte( RAFT_MEMBER_SET_TYPE );
+            CoreMemberSetSerializer.serialize( (CoreMemberSet) content, buffer );
+        }
+        else if ( content instanceof ReplicatedIdAllocationRequest )
+        {
+            buffer.writeByte( ID_RANGE_REQUEST_TYPE );
+            ReplicatedIdAllocationRequestSerializer.serialize( (ReplicatedIdAllocationRequest) content, buffer );
+        }
+        else if ( content instanceof SeedStoreId )
+        {
+            buffer.writeByte( SEED_STORE_ID_TYPE );
+            SeedStoreIdSerializer.serialize( (SeedStoreId) content, buffer );
+        }
+        else if ( content instanceof ReplicatedTokenRequest )
+        {
+            buffer.writeByte( TOKEN_REQUEST_TYPE );
+            ReplicatedTokenRequestSerializer.serialize( (ReplicatedTokenRequest) content, buffer );
+        }
+        else if ( content instanceof CoreServiceAssignment )
+        {
+            buffer.writeByte( SERVICE_ASSIGNMENT_TYPE );
+            CoreServiceAssignmentSerializer.serialize( (CoreServiceAssignment) content, buffer );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Unknown content type " + content.getClass() );
+        }
+    }
+
+    @Override
+    public ReplicatedContent deserialize( ByteBuf buffer ) throws MarshallingException
+    {
+        if ( buffer.readableBytes() < 1 )
+        {
+            throw new MarshallingException( "Cannot read content type" );
+        }
+
+        byte type = buffer.readByte();
+        final ReplicatedContent content;
+        switch ( type )
+        {
+            case TX_CONTENT_TYPE:
+                content = ReplicatedTransactionSerializer.deserialize( buffer );
+                break;
+            case RAFT_MEMBER_SET_TYPE:
+                content = CoreMemberSetSerializer.deserialize( buffer );
+                break;
+            case ID_RANGE_REQUEST_TYPE:
+                content = ReplicatedIdAllocationRequestSerializer.deserialize( buffer );
+                break;
+            case SEED_STORE_ID_TYPE:
+                content = SeedStoreIdSerializer.deserialize( buffer );
+                break;
+            case TOKEN_REQUEST_TYPE:
+                content = ReplicatedTokenRequestSerializer.deserialize( buffer );
+                break;
+            case SERVICE_ASSIGNMENT_TYPE:
+                content = (CoreServiceAssignment) CoreServiceAssignmentSerializer.deserialize( buffer );
+                break;
+            default:
+                throw new MarshallingException( String.format( "Unknown content type 0x%x", type ) );
+        }
+
+        return content;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/Inbound.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/Inbound.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import java.io.Serializable;
+
+public interface Inbound
+{
+    void registerHandler( MessageHandler handler );
+
+    interface MessageHandler
+    {
+        void handle( Serializable message );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/LoggingInbound.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/LoggingInbound.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import java.io.Serializable;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.logging.MessageLogger;
+
+public class LoggingInbound implements Inbound
+{
+    private final Inbound inbound;
+    private final MessageLogger<AdvertisedSocketAddress> messageLogger;
+    private final AdvertisedSocketAddress me;
+
+    public LoggingInbound( Inbound inbound, MessageLogger<AdvertisedSocketAddress> messageLogger,
+                           AdvertisedSocketAddress me )
+    {
+        this.inbound = inbound;
+        this.messageLogger = messageLogger;
+        this.me = me;
+    }
+
+    @Override
+    public void registerHandler( final MessageHandler handler )
+    {
+        inbound.registerHandler( new MessageHandler()
+        {
+            public synchronized void handle( Serializable message )
+            {
+                messageLogger.log( me, message );
+                handler.handle( message );
+            }
+        } );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/LoggingOutbound.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/LoggingOutbound.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import java.io.Serializable;
+
+import org.neo4j.coreedge.server.logging.MessageLogger;
+
+public class LoggingOutbound<MEMBER> implements Outbound<MEMBER>
+{
+    private final Outbound<MEMBER> outbound;
+    private final MEMBER me;
+    private final MessageLogger<MEMBER> messageLogger;
+
+    public LoggingOutbound( Outbound<MEMBER> outbound, MEMBER me, MessageLogger<MEMBER> messageLogger )
+    {
+        this.outbound = outbound;
+        this.me = me;
+        this.messageLogger = messageLogger;
+    }
+
+    @Override
+    public void send( MEMBER to, Serializable... messages )
+    {
+        messageLogger.log( me, to, messages );
+        outbound.send( to, messages );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/NetworkReadableLogChannelNetty4.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/NetworkReadableLogChannelNetty4.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
+import org.neo4j.kernel.impl.transaction.log.ReadPastEndException;
+import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
+
+public class NetworkReadableLogChannelNetty4 implements ReadableLogChannel
+{
+    private final ByteBuf delegate;
+
+    public NetworkReadableLogChannelNetty4( ByteBuf input )
+    {
+        this.delegate = input;
+    }
+
+    @Override
+    public byte get() throws IOException
+    {
+        try
+        {
+            return delegate.readByte();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public short getShort() throws IOException
+    {
+        try
+        {
+            return delegate.readShort();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public int getInt() throws IOException
+    {
+        try
+        {
+            return delegate.readInt();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public long getLong() throws IOException
+    {
+        try
+        {
+            return delegate.readLong();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public float getFloat() throws IOException
+    {
+        try
+        {
+            return delegate.readFloat();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public double getDouble() throws IOException
+    {
+        try
+        {
+            return delegate.readDouble();
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public void get( byte[] bytes, int length ) throws IOException
+    {
+        try
+        {
+            delegate.readBytes( bytes, 0, length );
+        }
+        catch ( IndexOutOfBoundsException e )
+        {
+            throw ReadPastEndException.INSTANCE;
+        }
+    }
+
+    @Override
+    public LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
+    {
+        positionMarker.unspecified();
+        return positionMarker;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        // no op
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/NetworkWritableLogChannelNetty4.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/NetworkWritableLogChannelNetty4.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import java.io.Flushable;
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
+import org.neo4j.kernel.impl.transaction.log.WritableLogChannel;
+
+public class NetworkWritableLogChannelNetty4 implements WritableLogChannel
+{
+    private final ByteBuf delegate;
+
+    public NetworkWritableLogChannelNetty4( ByteBuf delegate )
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Flushable emptyBufferIntoChannelAndClearIt() throws IOException
+    {
+        return null;
+    }
+
+    @Override
+    public WritableLogChannel put( byte value ) throws IOException
+    {
+        delegate.writeByte( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putShort( short value ) throws IOException
+    {
+        delegate.writeShort( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putInt( int value ) throws IOException
+    {
+        delegate.writeInt( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putLong( long value ) throws IOException
+    {
+        delegate.writeLong( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putFloat( float value ) throws IOException
+    {
+        delegate.writeFloat( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel putDouble( double value ) throws IOException
+    {
+        delegate.writeDouble( value );
+        return this;
+    }
+
+    @Override
+    public WritableLogChannel put( byte[] value, int length ) throws IOException
+    {
+        delegate.writeBytes( value, 0, length );
+        return this;
+    }
+
+    @Override
+    public LogPositionMarker getCurrentPosition( LogPositionMarker positionMarker ) throws IOException
+    {
+        positionMarker.unspecified();
+        return positionMarker;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+    }
+
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/NonBlockingChannel.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/NonBlockingChannel.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.locks.LockSupport;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.util.concurrent.FutureListener;
+
+import org.neo4j.coreedge.server.Disposable;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.logging.Log;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+
+public class NonBlockingChannel implements Disposable
+{
+    private static final int MAX_QUEUE_SIZE = 64;
+    private static final int CONNECT_BACKOFF_IN_MS = 250;
+    /* This pause is a maximum for retrying in case of a park/unpark race as well as for any other abnormal
+    situations. */
+    private static final int RETRY_DELAY_MS = 100;
+    private final Thread messageSendingThread;
+    private Channel nettyChannel;
+    private Bootstrap bootstrap;
+    private InetSocketAddress destination;
+    private Queue<Object> messageQueue = new ConcurrentLinkedQueue<>();
+    private volatile boolean stillRunning = true;
+    private ChannelHandler keepAliveHandler;
+    FutureListener<Void> errorListener;
+
+    public NonBlockingChannel( Bootstrap bootstrap, final InetSocketAddress destination, ChannelHandler keepAliveHandler, final Log log )
+    {
+        this.bootstrap = bootstrap;
+        this.destination = destination;
+        this.keepAliveHandler = keepAliveHandler;
+
+        this.errorListener = future -> {
+            if ( !future.isSuccess() )
+            {
+                log.error( "Failed to send message to " + destination, future.cause() );
+            }
+        };
+
+        messageSendingThread = new Thread( this::messageSendingThreadWork );
+        messageSendingThread.start();
+    }
+
+    private void messageSendingThreadWork()
+    {
+        while ( stillRunning )
+        {
+            try
+            {
+                ensureConnected();
+
+                if ( sendMessages() )
+                {
+                    nettyChannel.flush();
+                }
+            }
+            catch ( IOException e )
+            {
+                /* IO-exceptions from inside netty are dealt with by closing any existing channel and retrying with a
+                 fresh one. */
+                if ( nettyChannel != null )
+                {
+                    nettyChannel.close();
+                    nettyChannel = null;
+                }
+            }
+
+            parkNanos( MILLISECONDS.toNanos( RETRY_DELAY_MS ) );
+        }
+
+        if ( nettyChannel != null )
+        {
+            nettyChannel.close();
+            messageQueue.clear();
+        }
+    }
+
+    @Override
+    public void dispose()
+    {
+        stillRunning = false;
+
+        while ( messageSendingThread.isAlive() )
+        {
+            messageSendingThread.interrupt();
+
+            try
+            {
+                messageSendingThread.join( 100 );
+            }
+            catch ( InterruptedException e )
+            {
+                // Do nothing
+            }
+        }
+    }
+
+    public void send( Object msg )
+    {
+        if ( !stillRunning )
+        {
+            throw new IllegalStateException( "sending on disposed channel" );
+        }
+
+        if ( messageQueue.size() < MAX_QUEUE_SIZE )
+        {
+            messageQueue.offer( msg );
+            LockSupport.unpark( messageSendingThread );
+        }
+    }
+
+    private boolean sendMessages() throws IOException
+    {
+        if ( nettyChannel == null )
+        {
+            return false;
+        }
+
+        boolean sentSomething = false;
+        Object message;
+        while ( (message = messageQueue.peek()) != null )
+        {
+            ChannelFuture write = nettyChannel.write( message );
+            write.addListener( errorListener );
+
+            messageQueue.poll();
+            sentSomething = true;
+        }
+
+        return sentSomething;
+    }
+
+    private void ensureConnected() throws IOException
+    {
+        if ( nettyChannel != null && !nettyChannel.isOpen() )
+        {
+            nettyChannel = null;
+        }
+
+        while ( nettyChannel == null && stillRunning )
+        {
+            ChannelFuture channelFuture = bootstrap.connect( destination );
+
+            Channel channel = channelFuture.awaitUninterruptibly().channel();
+            if ( channelFuture.isSuccess() )
+            {
+                Map.Entry<String, ChannelHandler> lastHandler = IteratorUtil.last( channel.pipeline().iterator() );
+                channel.pipeline().addBefore( lastHandler.getKey(), "keepAlive", this.keepAliveHandler );
+                channel.flush();
+                nettyChannel = channel;
+            }
+            else
+            {
+                channel.close();
+                parkNanos( MILLISECONDS.toNanos( CONNECT_BACKOFF_IN_MS ) );
+            }
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/Outbound.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/Outbound.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import java.io.Serializable;
+
+/**
+ * A best effort service for delivery of messages to members. No guarantees are made about any of the methods
+ * in terms of eventual delivery. The only non trivial promises is that no messages get duplicated and nothing gets
+ * delivered to the wrong host.
+ * @param <MEMBER> The type of members that messages will be sent to.
+ */
+public interface Outbound<MEMBER> extends Serializable
+{
+    /**
+     * Asynchronous, best effort delivery to destination.
+     * @param to
+     * @param messages The messages to send
+     */
+    void send( MEMBER to, Serializable... messages );
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/RaftChannelInitializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/RaftChannelInitializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.LengthFieldPrepender;
+
+import org.neo4j.coreedge.raft.net.codecs.RaftMessageEncoder;
+import org.neo4j.coreedge.raft.replication.ReplicatedContentMarshal;
+
+public class RaftChannelInitializer extends ChannelInitializer<SocketChannel>
+{
+    private final ReplicatedContentMarshal<ByteBuf> marshal;
+
+    public RaftChannelInitializer( ReplicatedContentMarshal<ByteBuf> marshal )
+    {
+        this.marshal = marshal;
+    }
+
+    @Override
+    protected void initChannel( SocketChannel ch ) throws Exception
+    {
+        ChannelPipeline pipeline = ch.pipeline();
+        pipeline.addLast( "frameEncoder", new LengthFieldPrepender( 4 ) );
+        pipeline.addLast( "raftMessageEncoder", new RaftMessageEncoder( marshal ) );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/RaftOutbound.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/RaftOutbound.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import java.io.Serializable;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.CoreMember;
+
+public class RaftOutbound implements Outbound<CoreMember>
+{
+    private final Outbound<AdvertisedSocketAddress> outbound;
+
+    public RaftOutbound( Outbound<AdvertisedSocketAddress> outbound )
+    {
+        this.outbound = outbound;
+    }
+
+    @Override
+    public void send( CoreMember to, Serializable... message )
+    {
+        outbound.send( to.getRaftAddress(), message );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageDecoder.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net.codecs;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.server.AdvertisedSocketAddressDecoder;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.ReplicatedContentMarshal;
+
+import static org.neo4j.coreedge.raft.RaftMessages.Type.APPEND_ENTRIES_REQUEST;
+import static org.neo4j.coreedge.raft.RaftMessages.Type.APPEND_ENTRIES_RESPONSE;
+import static org.neo4j.coreedge.raft.RaftMessages.Type.HEARTBEAT;
+import static org.neo4j.coreedge.raft.RaftMessages.Type.NEW_ENTRY_REQUEST;
+import static org.neo4j.coreedge.raft.RaftMessages.Type.VOTE_REQUEST;
+import static org.neo4j.coreedge.raft.RaftMessages.Type.VOTE_RESPONSE;
+
+public class RaftMessageDecoder extends MessageToMessageDecoder<ByteBuf>
+{
+    private final ReplicatedContentMarshal<ByteBuf> marshal;
+
+    public RaftMessageDecoder( ReplicatedContentMarshal<ByteBuf> marshal )
+    {
+        this.marshal = marshal;
+    }
+
+    @Override
+    protected void decode( ChannelHandlerContext ctx, ByteBuf buffer, List<Object> list ) throws Exception
+    {
+        int messageTypeWire = buffer.readInt();
+
+        RaftMessages.Type[] values = RaftMessages.Type.values();
+        RaftMessages.Type messageType = values[messageTypeWire];
+
+        CoreMember from = retrieveMember( buffer );
+
+        if ( messageType.equals( VOTE_REQUEST ) )
+        {
+            CoreMember candidate = retrieveMember( buffer );
+
+            long term = buffer.readLong();
+            long lastLogIndex = buffer.readLong();
+            long lastLogTerm = buffer.readLong();
+
+            RaftMessages.Vote.Request<CoreMember> request = new RaftMessages.Vote.Request<>(
+                    from, term, candidate, lastLogIndex, lastLogTerm );
+            list.add( request );
+        }
+        else if ( messageType.equals( VOTE_RESPONSE ) )
+        {
+            long term = buffer.readLong();
+            boolean voteGranted = buffer.readBoolean();
+
+            RaftMessages.Vote.Response<CoreMember> response = new RaftMessages.Vote.Response<>( from, term,
+                    voteGranted );
+            list.add( response );
+        }
+        else if ( messageType.equals( APPEND_ENTRIES_REQUEST ) )
+        {
+            // how many
+            long term = buffer.readLong();
+            long prevLogIndex = buffer.readLong();
+            long prevLogTerm = buffer.readLong();
+
+            long leaderCommit = buffer.readLong();
+            long count = buffer.readLong();
+
+            RaftLogEntry[] entries = new RaftLogEntry[(int) count];
+            for ( int i = 0; i < count; i++ )
+            {
+                long entryTerm = buffer.readLong();
+                final ReplicatedContent content = marshal.deserialize( buffer );
+                entries[i] = new RaftLogEntry( entryTerm, content );
+            }
+
+            // TODO: This currently needs to be last, because tx-content doesn't know its length and will just read
+            // to exhaustion.
+            list.add( new RaftMessages.AppendEntries.Request<>( from, term, prevLogIndex, prevLogTerm,
+                    entries, leaderCommit ) );
+        }
+        else if ( messageType.equals( APPEND_ENTRIES_RESPONSE ) )
+        {
+            long term = buffer.readLong();
+            boolean success = buffer.readBoolean();
+            long matchIndex = buffer.readLong();
+
+            list.add( new RaftMessages.AppendEntries.Response<>( from, term, success, matchIndex ) );
+        }
+        else if ( messageType.equals( NEW_ENTRY_REQUEST ) )
+        {
+            ReplicatedContent content = marshal.deserialize( buffer );
+
+            list.add( new RaftMessages.NewEntry.Request<>( from, content ) );
+        }
+        else if ( messageType.equals( HEARTBEAT ) )
+        {
+            long leaderTerm = buffer.readLong();
+            long commitIndexTerm = buffer.readLong();
+            long commitIndex = buffer.readLong();
+
+            list.add( new RaftMessages.Heartbeat<>( from, leaderTerm, commitIndex, commitIndexTerm ) );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Unknown message type" );
+        }
+    }
+
+    private CoreMember retrieveMember( ByteBuf buffer ) throws UnsupportedEncodingException
+    {
+        AdvertisedSocketAddressDecoder decoder = new AdvertisedSocketAddressDecoder();
+        AdvertisedSocketAddress coreAddress = decoder.decode( buffer );
+        AdvertisedSocketAddress raftAddress = decoder.decode( buffer );
+        return new CoreMember( coreAddress, raftAddress );
+    }
+
+    @Override
+    public void channelReadComplete( ChannelHandlerContext ctx ) throws Exception
+    {
+        // TODO: Should we use this?
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageEncoder.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net.codecs;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.server.AdvertisedSocketAddressEncoder;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.replication.ReplicatedContentMarshal;
+
+public class RaftMessageEncoder extends MessageToMessageEncoder<RaftMessages.Message<CoreMember>>
+{
+    private final ReplicatedContentMarshal<ByteBuf> marshal;
+
+    public RaftMessageEncoder( ReplicatedContentMarshal<ByteBuf> marshal )
+    {
+        this.marshal = marshal;
+    }
+
+    @Override
+    protected synchronized void encode( ChannelHandlerContext ctx, RaftMessages.Message<CoreMember> message,
+                                        List<Object> list ) throws Exception
+    {
+        ByteBuf buf = ctx.alloc().buffer();
+
+        buf.writeInt( message.type().ordinal() );
+        writeMember( message.from(), buf );
+
+        if ( message instanceof RaftMessages.Vote.Request )
+        {
+            RaftMessages.Vote.Request<CoreMember> voteRequest = (RaftMessages.Vote.Request<CoreMember>) message;
+            writeMember( voteRequest.candidate(), buf );
+            buf.writeLong( voteRequest.term() );
+            buf.writeLong( voteRequest.lastLogIndex() );
+            buf.writeLong( voteRequest.lastLogTerm() );
+        }
+        else if ( message instanceof RaftMessages.Vote.Response )
+        {
+            RaftMessages.Vote.Response<CoreMember> voteResponse = (RaftMessages.Vote.Response<CoreMember>) message;
+            buf.writeLong( voteResponse.term() );
+            buf.writeBoolean( voteResponse.voteGranted() );
+        }
+        else if ( message instanceof RaftMessages.AppendEntries.Request )
+        {
+            RaftMessages.AppendEntries.Request<CoreMember> appendRequest = (RaftMessages.AppendEntries
+                    .Request<CoreMember>) message;
+
+            buf.writeLong( appendRequest.leaderTerm() );
+            buf.writeLong( appendRequest.prevLogIndex() );
+            buf.writeLong( appendRequest.prevLogTerm() );
+            buf.writeLong( appendRequest.leaderCommit() );
+
+            buf.writeLong( appendRequest.entries().length );
+
+            for ( RaftLogEntry raftLogEntry : appendRequest.entries() )
+            {
+                buf.writeLong( raftLogEntry.term() );
+                marshal.serialize( raftLogEntry.content(), buf );
+            }
+        }
+        else if ( message instanceof RaftMessages.AppendEntries.Response )
+        {
+            RaftMessages.AppendEntries.Response<CoreMember> appendResponse = (RaftMessages.AppendEntries
+                    .Response<CoreMember>) message;
+
+            buf.writeLong( appendResponse.term() );
+            buf.writeBoolean( appendResponse.success() );
+            buf.writeLong( appendResponse.matchIndex() );
+        }
+        else if ( message instanceof RaftMessages.NewEntry.Request )
+        {
+            RaftMessages.NewEntry.Request<CoreMember> newEntryRequest = (RaftMessages.NewEntry
+                    .Request<CoreMember>) message;
+            marshal.serialize( newEntryRequest.content(), buf );
+        }
+        else if ( message instanceof RaftMessages.Heartbeat )
+        {
+            RaftMessages.Heartbeat<CoreMember> heartbeat = (RaftMessages.Heartbeat<CoreMember>) message;
+            buf.writeLong( heartbeat.leaderTerm() );
+            buf.writeLong( heartbeat.commitIndexTerm() );
+            buf.writeLong( heartbeat.commitIndex() );
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Unknown message type" );
+        }
+
+        list.add( buf );
+    }
+
+    private void writeMember( CoreMember member, ByteBuf buffer ) throws UnsupportedEncodingException
+    {
+        AdvertisedSocketAddressEncoder encoder = new AdvertisedSocketAddressEncoder();
+        encoder.encode( member.getCoreAddress(), buffer );
+        encoder.encode( member.getRaftAddress(), buffer );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/AppendLogEntry.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/AppendLogEntry.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+
+public class AppendLogEntry implements LogCommand
+{
+    public final long index;
+    public final RaftLogEntry entry;
+
+    public AppendLogEntry( long index, RaftLogEntry entry )
+    {
+        this.index = index;
+        this.entry = entry;
+    }
+
+    @Override
+    public void applyTo( RaftLog raftLog ) throws RaftStorageException
+    {
+        if ( raftLog.entryExists( index ) )
+        {
+            throw new IllegalStateException( "Attempted to append over an existing entry at index " + index );
+        }
+
+        raftLog.append( entry );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AppendLogEntry{" +
+                "index=" + index +
+                ", entry=" + entry +
+                '}';
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/BatchAppendLogEntries.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/BatchAppendLogEntries.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import java.util.Arrays;
+
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+
+import static java.lang.String.format;
+
+public class BatchAppendLogEntries implements LogCommand
+{
+    public final long baseIndex;
+    public final int offset;
+    public final RaftLogEntry[] entries;
+
+    public BatchAppendLogEntries( long baseIndex, int offset, RaftLogEntry[] entries )
+    {
+        this.baseIndex = baseIndex;
+        this.offset = offset;
+        this.entries = entries;
+    }
+
+    @Override
+    public void applyTo( RaftLog raftLog ) throws RaftStorageException
+    {
+        if ( raftLog.entryExists( baseIndex + offset ) )
+        {
+            throw new IllegalStateException( "Attempted to append over an existing entry starting at index " + baseIndex + offset );
+        }
+
+        for ( int i = offset; i < entries.length; i++ )
+        {
+            raftLog.append( entries[i] );
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "BatchAppendLogEntries{baseIndex=%d, offset=%d, entries=%s}", baseIndex, offset, Arrays.toString( entries ) );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/CommitCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/CommitCommand.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+
+public class CommitCommand implements LogCommand
+{
+    private final long commitIndex;
+
+    public CommitCommand( long commitIndex )
+    {
+        this.commitIndex = commitIndex;
+    }
+
+    @Override
+    public void applyTo( RaftLog raftLog ) throws RaftStorageException
+    {
+        raftLog.commit( commitIndex );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "CommitCommand{" +
+                "commitIndex=" + commitIndex +
+                '}';
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/LogCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/LogCommand.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+
+public interface LogCommand
+{
+    void applyTo( RaftLog raftLog ) throws RaftStorageException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/Messages.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/Messages.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.neo4j.coreedge.raft.RaftMessages;
+
+public class Messages<MEMBER> implements Iterable<Map.Entry<MEMBER, RaftMessages.Message<MEMBER>>>
+{
+    private final Map<MEMBER, RaftMessages.Message<MEMBER>> map;
+
+    Messages( Map<MEMBER, RaftMessages.Message<MEMBER>> map )
+    {
+        this.map = map;
+    }
+
+    public boolean hasMessageFor( MEMBER member )
+    {
+        return map.containsKey( member );
+    }
+
+    public RaftMessages.Message<MEMBER> messageFor( MEMBER member )
+    {
+        return map.get( member );
+    }
+
+    @Override
+    public Iterator<Map.Entry<MEMBER, RaftMessages.Message<MEMBER>>> iterator()
+    {
+        return map.entrySet().iterator();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/Outcome.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/Outcome.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.coreedge.raft.state.FollowerStates;
+
+public class Outcome<MEMBER> implements Serializable
+{
+    public final Role newRole;
+    public final long newTerm;
+    public final MEMBER leader;
+    public final long leaderCommit;
+    public final MEMBER votedFor;
+    public final Set<MEMBER> votesForMe;
+    public final long lastLogIndexBeforeWeBecameLeader;
+    public final FollowerStates<MEMBER> followerStates;
+    public final boolean renewElectionTimeout;
+    public final Iterable<LogCommand> logCommands;
+    public final Iterable<ShipCommand> shipCommands;
+    public final Collection<RaftMessages.Directed<MEMBER>> outgoingMessages;
+
+    public Outcome(Role newRole, long newTerm, MEMBER leader, long leaderCommit, MEMBER votedFor,
+                   Set<MEMBER> votesForMe, long lastLogIndexBeforeWeBecameLeader,
+                   FollowerStates<MEMBER> followerStates, boolean renewElectionTimeout,
+                   Iterable<LogCommand> logCommands, Collection<RaftMessages.Directed<MEMBER>> outgoingMessages,
+                   Iterable<ShipCommand> shipCommands )
+    {
+        this.newRole = newRole;
+        this.newTerm = newTerm;
+        this.leader = leader;
+        this.leaderCommit = leaderCommit;
+        this.votedFor = votedFor;
+        this.votesForMe = votesForMe;
+        this.lastLogIndexBeforeWeBecameLeader = lastLogIndexBeforeWeBecameLeader;
+        this.followerStates = followerStates;
+        this.renewElectionTimeout = renewElectionTimeout;
+        this.logCommands = logCommands;
+        this.outgoingMessages = outgoingMessages;
+        this.shipCommands = shipCommands;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Outcome{" +
+               "newRole=" + newRole +
+               ", newTerm=" + newTerm +
+               ", leader=" + leader +
+               ", leaderCommit=" + leaderCommit +
+               ", logCommands=" + logCommands +
+               ", shipCommands=" + shipCommands +
+               ", votedFor=" + votedFor +
+               ", updatedVotesForMe=" + votesForMe +
+               ", lastLogIndexBeforeWeBecameLeader=" + lastLogIndexBeforeWeBecameLeader +
+               ", updatedFollowerStates=" + followerStates +
+               ", renewElectionTimeout=" + renewElectionTimeout +
+               ", outgoingMessages=" + outgoingMessages +
+               '}';
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/ShipCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/ShipCommand.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import org.neo4j.coreedge.raft.LeaderContext;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.replication.shipping.RaftLogShipper;
+
+import static java.lang.String.format;
+
+public abstract class ShipCommand
+{
+    public abstract <MEMBER> void applyTo( RaftLogShipper<MEMBER> raftLogShipper, LeaderContext leaderContext )
+            throws RaftStorageException;
+
+    public static class Mismatch extends ShipCommand
+    {
+        private final long lastRemoteAppendIndex;
+        private final Object target;
+
+        public Mismatch( long lastRemoteAppendIndex, Object target )
+        {
+            this.lastRemoteAppendIndex = lastRemoteAppendIndex;
+            this.target = target;
+        }
+
+        @Override
+        public void applyTo( RaftLogShipper raftLogShipper, LeaderContext leaderContext ) throws RaftStorageException
+        {
+            if ( raftLogShipper.identity().equals( target ) )
+            {
+                raftLogShipper.onMismatch( lastRemoteAppendIndex, leaderContext );
+            }
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+
+            Mismatch mismatch = (Mismatch) o;
+
+            if ( lastRemoteAppendIndex != mismatch.lastRemoteAppendIndex )
+            {
+                return false;
+            }
+            return target.equals( mismatch.target );
+
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = (int) (lastRemoteAppendIndex ^ (lastRemoteAppendIndex >>> 32));
+            result = 31 * result + target.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "Mismatch{lastRemoteAppendIndex=%d, target=%s}", lastRemoteAppendIndex, target );
+        }
+    }
+
+    public static class Match extends ShipCommand
+    {
+        private final long newMatchIndex;
+        private final Object target;
+
+        public Match( long newMatchIndex, Object target )
+        {
+            this.newMatchIndex = newMatchIndex;
+            this.target = target;
+        }
+
+        public <MEMBER> void applyTo( RaftLogShipper<MEMBER> raftLogShipper, LeaderContext leaderContext ) throws
+                RaftStorageException
+        {
+            if ( raftLogShipper.identity().equals( target ) )
+            {
+                raftLogShipper.onMatch( newMatchIndex, leaderContext );
+            }
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+
+            Match match = (Match) o;
+
+            if ( newMatchIndex != match.newMatchIndex )
+            {
+                return false;
+            }
+            return target.equals( match.target );
+
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = (int) (newMatchIndex ^ (newMatchIndex >>> 32));
+            result = 31 * result + target.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "Match{newMatchIndex=%d, target=%s}", newMatchIndex, target );
+        }
+    }
+
+    public static class NewEntry extends ShipCommand
+    {
+        private final long prevLogIndex;
+        private final long prevLogTerm;
+        private final RaftLogEntry newLogEntry;
+
+        public NewEntry( long prevLogIndex, long prevLogTerm, RaftLogEntry newLogEntry )
+        {
+            this.prevLogIndex = prevLogIndex;
+            this.prevLogTerm = prevLogTerm;
+            this.newLogEntry = newLogEntry;
+        }
+
+        @Override
+        public <MEMBER> void applyTo( RaftLogShipper<MEMBER> raftLogShipper, LeaderContext leaderContext ) throws RaftStorageException
+        {
+            raftLogShipper.onNewEntry( prevLogIndex, prevLogTerm, newLogEntry, leaderContext );
+        }
+
+        @Override
+        public boolean equals( Object o )
+        {
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+
+            NewEntry newEntry = (NewEntry) o;
+
+            if ( prevLogIndex != newEntry.prevLogIndex )
+            {
+                return false;
+            }
+            if ( prevLogTerm != newEntry.prevLogTerm )
+            {
+                return false;
+            }
+            return newLogEntry.equals( newEntry.newLogEntry );
+
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = (int) (prevLogIndex ^ (prevLogIndex >>> 32));
+            result = 31 * result + (int) (prevLogTerm ^ (prevLogTerm >>> 32));
+            result = 31 * result + newLogEntry.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "NewEntry{prevLogIndex=%d, prevLogTerm=%d, newLogEntry=%s}", prevLogIndex, prevLogTerm,
+                    newLogEntry );
+        }
+    }
+
+    public static class CommitUpdate extends ShipCommand
+    {
+        @Override
+        public <MEMBER> void applyTo( RaftLogShipper<MEMBER> raftLogShipper, LeaderContext leaderContext ) throws RaftStorageException
+        {
+            raftLogShipper.onCommitUpdate( leaderContext );
+        }
+
+        @Override
+        public String toString()
+        {
+            return "CommitUpdate{}";
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/TruncateLogCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/TruncateLogCommand.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+
+public class TruncateLogCommand implements LogCommand
+{
+    private final long fromIndex;
+
+    public TruncateLogCommand( long fromIndex )
+    {
+        this.fromIndex = fromIndex;
+    }
+
+    @Override
+    public void applyTo( RaftLog raftLog ) throws RaftStorageException
+    {
+        raftLog.truncate( fromIndex );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TruncateLogCommand{" +
+                "fromIndex=" + fromIndex +
+                '}';
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/LocalReplicator.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/LocalReplicator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+
+public class LocalReplicator<MEMBER,SOCKET> implements Replicator
+{
+    private final MEMBER source;
+    private final SOCKET target;
+    private final Outbound<SOCKET> outbound;
+
+    public LocalReplicator( MEMBER source, SOCKET target, Outbound<SOCKET> outbound )
+    {
+        this.source = source;
+        this.target = target;
+        this.outbound = outbound;
+    }
+
+    @Override
+    public void replicate( ReplicatedContent content ) throws ReplicationFailedException
+    {
+        outbound.send( target, new RaftMessages.NewEntry.Request<>( source, content ) );
+    }
+
+    @Override
+    public void subscribe( ReplicatedContentListener listener )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unsubscribe( ReplicatedContentListener listener )
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/MarshallingException.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/MarshallingException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+public class MarshallingException extends Exception
+{
+    public MarshallingException( String message )
+    {
+        super( message );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/RaftContentSerializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/RaftContentSerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import org.neo4j.coreedge.raft.net.CoreReplicatedContentMarshal;
+
+public class RaftContentSerializer implements Serializer
+{
+    @Override
+    public ByteBuffer serialize( ReplicatedContent content ) throws MarshallingException
+    {
+        ByteBuf buffer = Unpooled.buffer();
+        new CoreReplicatedContentMarshal().serialize( content, buffer );
+        return buffer.nioBuffer();
+    }
+
+    @Override
+    public ReplicatedContent deserialize( ByteBuffer buffer ) throws MarshallingException
+    {
+        return new CoreReplicatedContentMarshal().deserialize( Unpooled.wrappedBuffer( buffer ) );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/RaftReplicator.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/RaftReplicator.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.neo4j.coreedge.raft.LeaderLocator;
+import org.neo4j.coreedge.raft.NoLeaderTimeoutException;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+
+public class RaftReplicator<MEMBER> implements Replicator, RaftLog.Listener
+{
+    private final LeaderLocator<MEMBER> leaderLocator;
+    private final MEMBER me;
+    private final Outbound<MEMBER> outbound;
+    private final Set<ReplicatedContentListener> listeners = new CopyOnWriteArraySet<>();
+    private boolean contentHasStarted;
+
+    public RaftReplicator( LeaderLocator<MEMBER> leaderLocator, MEMBER me, Outbound<MEMBER> outbound )
+    {
+        this.leaderLocator = leaderLocator;
+        this.me = me;
+        this.outbound = outbound;
+    }
+
+    @Override
+    public synchronized void replicate( ReplicatedContent content ) throws ReplicationFailedException
+    {
+        contentHasStarted = true;
+        MEMBER leader;
+        try
+        {
+            leader = leaderLocator.getLeader();
+        }
+        catch ( NoLeaderTimeoutException e )
+        {
+            throw new ReplicationFailedException( e );
+        }
+
+        if ( !leader.equals( me ) )
+        {
+            throw new ReplicationFailedException( "Only leader is allowed to replicate" );
+        }
+
+        outbound.send( me, new RaftMessages.NewEntry.Request<>( me, content ) );
+    }
+
+    @Override
+    public synchronized void subscribe( ReplicatedContentListener listener )
+    {
+        if ( contentHasStarted )
+        {
+            System.out.println( "WARNING: Late subscription: " + listener );
+        }
+        listeners.add( listener );
+    }
+
+    @Override
+    public void unsubscribe( ReplicatedContentListener listener )
+    {
+        listeners.remove( listener );
+    }
+
+    @Override
+    public void onAppended( ReplicatedContent content )
+    {
+    }
+
+    @Override
+    public void onCommitted( ReplicatedContent content )
+    {
+        for ( ReplicatedContentListener listener : listeners )
+        {
+            listener.onReplicated( content );
+        }
+    }
+
+    @Override
+    public void onTruncated( long fromIndex )
+    {
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/ReplicatedContent.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/ReplicatedContent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+/**
+ * Marker interface for types that are
+ */
+public interface ReplicatedContent
+{
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/ReplicatedContentMarshal.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/ReplicatedContentMarshal.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+public interface ReplicatedContentMarshal<T>
+{
+    /**
+     * Serialize content into bytes
+     *
+     * @param content the content to serialize
+     * @param buffer  the buffer to serialize into
+     */
+    void serialize( ReplicatedContent content, T buffer ) throws MarshallingException;
+
+    /**
+     * Deserialize content from a buffer. The buffer is consumed when this method returns.
+     *
+     * @param buffer the buffer to deserialize from
+     * @return the deserialized content
+     * @throws MarshallingException when the buffer cannot be correctly deserialized
+     */
+    ReplicatedContent deserialize( T buffer ) throws MarshallingException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/Replicator.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/Replicator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+public interface Replicator
+{
+    void replicate( ReplicatedContent content ) throws ReplicationFailedException;
+
+    void subscribe( ReplicatedContentListener listener );
+
+    void unsubscribe( ReplicatedContentListener listener );
+
+    interface ReplicatedContentListener
+    {
+        void onReplicated( ReplicatedContent content );
+    }
+
+    class ReplicationFailedException extends Exception
+    {
+        public ReplicationFailedException( Throwable cause )
+        {
+            super( cause );
+        }
+
+        public ReplicationFailedException( String message )
+        {
+            super( message );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/Serializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/Serializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+import java.nio.ByteBuffer;
+
+import org.neo4j.coreedge.raft.replication.MarshallingException;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+public interface Serializer
+{
+    ByteBuffer serialize( ReplicatedContent content ) throws MarshallingException;
+
+    ReplicatedContent deserialize( ByteBuffer buffer ) throws MarshallingException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/StringMarshal.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/StringMarshal.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+import java.io.UnsupportedEncodingException;
+
+import io.netty.buffer.ByteBuf;
+
+public class StringMarshal
+{
+    public static final String DEFAULT_CHARSET = "UTF-8";
+    public static final int NULL_STRING_LENGTH = -1;
+
+    public static void serialize( ByteBuf buffer, String string )
+    {
+        try
+        {
+            if ( string == null )
+            {
+                buffer.writeInt( NULL_STRING_LENGTH );
+            }
+            else
+            {
+                byte[] bytes = string.getBytes( DEFAULT_CHARSET );
+                buffer.writeInt( bytes.length );
+                buffer.writeBytes( bytes );
+            }
+
+        }
+        catch ( UnsupportedEncodingException e )
+        {
+            throw new RuntimeException( "UTF-8 should be supported by all java platforms." );
+        }
+    }
+
+    public static String deserialize( ByteBuf buffer )
+    {
+        try
+        {
+            int len = buffer.readInt();
+            if ( len == NULL_STRING_LENGTH )
+            {
+                return null;
+            }
+            ByteBuf stringBytes = buffer.readBytes( len );
+
+            return new String( stringBytes.array(), DEFAULT_CHARSET );
+        }
+        catch ( UnsupportedEncodingException e )
+        {
+            throw new RuntimeException( "UTF-8 should be supported by all java platforms." );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/IdGenerationException.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/IdGenerationException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import org.neo4j.kernel.impl.store.StoreFailureException;
+
+public class IdGenerationException extends StoreFailureException
+{
+    public IdGenerationException( Throwable cause )
+    {
+        super( "Failed to generate record id", cause );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationRequest.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationRequest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.kernel.IdType;
+
+import static java.lang.String.format;
+
+/**
+ * This type is handled by the ReplicatedIdAllocationStateMachine. */
+public class ReplicatedIdAllocationRequest implements ReplicatedContent
+{
+    private final CoreMember owner;
+    private final IdType idType;
+    private final long idRangeStart;
+    private final int idRangeLength;
+
+    public ReplicatedIdAllocationRequest( CoreMember owner, IdType idType, long idRangeStart, int idRangeLength )
+    {
+        this.owner = owner;
+        this.idType = idType;
+        this.idRangeStart = idRangeStart;
+        this.idRangeLength = idRangeLength;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        ReplicatedIdAllocationRequest that = (ReplicatedIdAllocationRequest) o;
+
+        if ( idRangeStart != that.idRangeStart )
+        { return false; }
+        if ( idRangeLength != that.idRangeLength )
+        { return false; }
+        if ( !owner.equals( that.owner ) )
+        { return false; }
+        return idType == that.idType;
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = owner.hashCode();
+        result = 31 * result + idType.hashCode();
+        result = 31 * result + (int) (idRangeStart ^ (idRangeStart >>> 32));
+        result = 31 * result + idRangeLength;
+        return result;
+    }
+
+    public CoreMember owner()
+    {
+        return owner;
+    }
+
+    public IdType idType()
+    {
+        return idType;
+    }
+
+    public long idRangeStart()
+    {
+        return idRangeStart;
+    }
+
+    public int idRangeLength()
+    {
+        return idRangeLength;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "ReplicatedIdAllocationRequest{owner=%s, idType=%s, idRangeStart=%d, idRangeLength=%d}", owner, idType, idRangeStart, idRangeLength );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationRequestSerializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationRequestSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.raft.membership.CoreMemberMarshal;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdAllocationRequest;
+import org.neo4j.kernel.IdType;
+
+public class ReplicatedIdAllocationRequestSerializer
+{
+    public static void serialize( ReplicatedIdAllocationRequest idRangeRequest, ByteBuf buffer )
+    {
+        CoreMemberMarshal.serialize( idRangeRequest.owner(), buffer );
+        buffer.writeInt( idRangeRequest.idType().ordinal() );
+        buffer.writeLong( idRangeRequest.idRangeStart() );
+        buffer.writeInt( idRangeRequest.idRangeLength() );
+    }
+
+    public static ReplicatedIdAllocationRequest deserialize( ByteBuf buffer )
+    {
+        CoreMember owner = CoreMemberMarshal.deserialize( buffer );
+        IdType idType = IdType.values()[buffer.readInt()];
+        long idRangeStart = buffer.readLong();
+        int idRangeLength = buffer.readInt();
+
+        return new ReplicatedIdAllocationRequest( owner, idType, idRangeStart, idRangeLength );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationStateMachine.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.store.id.IdRange;
+
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
+
+/**
+ * This state machine keeps a track of all id-allocations for all id-types and allows a local
+ * user to wait for any changes to the state.
+ *
+ * The responsibilities of the state machine are to:
+ *  - keep state
+ *  - update state on events
+ *  - support waiting for changes to the state
+ *
+ *  Users of this state machine should in general act in accordance with the following formula:
+ *    1) trigger update of replicated state
+ *    2) wait for change to propagate
+ *    3) if state is not sufficient goto 1)
+ *    4) state sufficient => done
+ */
+public class ReplicatedIdAllocationStateMachine implements Replicator.ReplicatedContentListener
+{
+    private final CoreMember me;
+
+    private final long[] firstNotAllocated = new long[IdType.values().length];
+    private final long[] lastIdRangeStartForMe = new long[IdType.values().length];
+    private final int[] lastIdRangeLengthForMe = new int[IdType.values().length];
+
+    public ReplicatedIdAllocationStateMachine( CoreMember me )
+    {
+        this.me = me;
+    }
+
+    public synchronized long getFirstNotAllocated( IdType idType )
+    {
+        return firstNotAllocated[idType.ordinal()];
+    }
+
+    public synchronized IdRange getHighestIdRange( CoreMember owner, IdType idType )
+    {
+        if ( owner != me )
+        {
+            /* We just keep our own latest id-range for simplicity and efficiency. */
+            throw new UnsupportedOperationException();
+        }
+
+        int typeOrdinal = idType.ordinal();
+        int idRangeLength = lastIdRangeLengthForMe[typeOrdinal];
+
+        if ( idRangeLength > 0 )
+        {
+            return new IdRange( EMPTY_LONG_ARRAY, lastIdRangeStartForMe[typeOrdinal], idRangeLength );
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    private synchronized void updateFirstNotAllocated( int typeOrdinal, long idRangeEnd )
+    {
+        firstNotAllocated[typeOrdinal] = idRangeEnd;
+        notifyAll();
+    }
+
+    @Override
+    public synchronized void onReplicated( ReplicatedContent content )
+    {
+        if ( content instanceof ReplicatedIdAllocationRequest )
+        {
+            ReplicatedIdAllocationRequest request = (ReplicatedIdAllocationRequest) content;
+
+            int typeOrdinal = request.idType().ordinal();
+
+            if ( request.idRangeStart() == firstNotAllocated[typeOrdinal] )
+            {
+                if( request.owner().equals( me ) )
+                {
+                    lastIdRangeStartForMe[typeOrdinal] = request.idRangeStart();
+                    lastIdRangeLengthForMe[typeOrdinal] = request.idRangeLength();
+                }
+                updateFirstNotAllocated( typeOrdinal, request.idRangeStart() + request.idRangeLength() );
+            }
+        }
+    }
+
+    public synchronized void waitForAnyChange( long timeoutMillis ) throws InterruptedException
+    {
+        wait( timeoutMillis );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdGenerator.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdGenerator.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.ha.id.IdAllocation;
+import org.neo4j.kernel.ha.id.IdRangeIterator;
+import org.neo4j.kernel.impl.store.id.IdGenerator;
+import org.neo4j.kernel.impl.store.id.IdRange;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static java.lang.Math.max;
+
+import static org.neo4j.kernel.ha.id.IdRangeIterator.EMPTY_ID_RANGE_ITERATOR;
+import static org.neo4j.kernel.ha.id.IdRangeIterator.VALUE_REPRESENTING_NULL;
+
+public class ReplicatedIdGenerator implements IdGenerator
+{
+    private final IdType idType;
+    private final Log log;
+    private final ReplicatedIdRangeAcquirer acquirer;
+    private volatile long highId;
+    private volatile long defragCount;
+    private volatile IdRangeIterator idQueue = EMPTY_ID_RANGE_ITERATOR;
+
+    public ReplicatedIdGenerator( IdType idType, long highId, ReplicatedIdRangeAcquirer acquirer, LogProvider
+            logProvider )
+    {
+        this.idType = idType;
+        this.highId = highId;
+        this.acquirer = acquirer;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    @Override
+    public void close()
+    {
+    }
+
+    @Override
+    public void freeId( long id )
+    {
+    }
+
+    @Override
+    public long getHighId()
+    {
+        return highId;
+    }
+
+    @Override
+    public void setHighId( long id )
+    {
+        this.highId = max( this.highId, id );
+    }
+
+    @Override
+    public long getHighestPossibleIdInUse()
+    {
+        return highId - 1;
+    }
+
+    @Override
+    public long getNumberOfIdsInUse()
+    {
+        return highId - defragCount;
+    }
+
+    @Override
+    public synchronized long nextId()
+    {
+        long nextId = nextLocalId();
+        if ( nextId == VALUE_REPRESENTING_NULL )
+        {
+            IdAllocation allocation = acquirer.acquireIds( idType );
+            log.info( "Received id allocation " + allocation + " for " + idType );
+            nextId = storeLocally( allocation );
+        }
+        highId = max( highId, nextId + 1 );
+        return nextId;
+    }
+
+    @Override
+    public IdRange nextIdBatch( int size )
+    {
+        throw new UnsupportedOperationException( "Should never be called" );
+    }
+
+    private long storeLocally( IdAllocation allocation )
+    {
+        setHighId( allocation.getHighestIdInUse() + 1 ); // high id is certainly bigger than the highest id in use
+        this.defragCount = allocation.getDefragCount();
+        this.idQueue = new IdRangeIterator( respectingHighId( allocation.getIdRange() ) );
+        return idQueue.next();
+    }
+
+    private IdRange respectingHighId( IdRange idRange )
+    {
+        int adjustment = 0;
+        if ( highId > idRange.getRangeStart() )
+        {
+            adjustment = (int) (highId - idRange.getRangeStart());
+        }
+        IdRange adjustedForLocalHighId = new IdRange( idRange.getDefragIds(),
+                max( this.highId, idRange.getRangeStart() ), idRange.getRangeLength() - adjustment );
+        return adjustedForLocalHighId;
+
+    }
+
+    private long nextLocalId()
+    {
+        return this.idQueue.next();
+    }
+
+    @Override
+    public long getDefragCount()
+    {
+        return this.defragCount;
+    }
+
+    @Override
+    public void delete()
+    {
+    }
+
+    @Override
+    public String toString()
+    {
+        return getClass().getSimpleName() + "[" + this.idQueue + "]";
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdGeneratorFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdGeneratorFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.store.id.IdGenerator;
+import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.LogProvider;
+
+public class ReplicatedIdGeneratorFactory extends LifecycleAdapter implements IdGeneratorFactory
+{
+    private final Map<IdType, SwitchableRaftIdGenerator> generators = new HashMap<>();
+    private final FileSystemAbstraction fs;
+    private final ReplicatedIdRangeAcquirer idRangeAcquirer;
+    private final LogProvider logProvider;
+    private boolean replicatedMode = false;
+
+    public ReplicatedIdGeneratorFactory( FileSystemAbstraction fs, ReplicatedIdRangeAcquirer idRangeAcquirer,
+                                   LogProvider logProvider )
+    {
+        this.fs = fs;
+        this.idRangeAcquirer = idRangeAcquirer;
+        this.logProvider = logProvider;
+    }
+
+    @Override
+    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId )
+    {
+        SwitchableRaftIdGenerator previous = generators.remove( idType );
+        if ( previous != null )
+        {
+            previous.close();
+        }
+
+        long maxValue = idType.getMaxValue();
+        boolean aggressiveReuse = idType.allowAggressiveReuse();
+        IdGenerator initialIdGenerator =
+                new IdGeneratorImpl( fs, fileName, grabSize, maxValue, aggressiveReuse, highId );
+        SwitchableRaftIdGenerator switchableIdGenerator =
+                new SwitchableRaftIdGenerator( initialIdGenerator, idType, idRangeAcquirer, logProvider );
+        if ( replicatedMode )
+        {
+            switchableIdGenerator.switchToRaft();
+        }
+
+        generators.put( idType, switchableIdGenerator );
+        return switchableIdGenerator;
+    }
+
+    @Override
+    public IdGenerator get( IdType idType )
+    {
+        return generators.get( idType );
+    }
+
+    @Override
+    public void create( File fileName, long highId, boolean throwIfFileExists )
+    {
+        IdGeneratorImpl.createGenerator( fs, fileName, highId, throwIfFileExists );
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        replicatedMode = true;
+        for ( SwitchableRaftIdGenerator switchableRaftIdGenerator : generators.values() )
+        {
+            switchableRaftIdGenerator.switchToRaft();
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdRangeAcquirer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdRangeAcquirer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.ha.id.IdAllocation;
+import org.neo4j.kernel.impl.store.id.IdRange;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static java.lang.String.format;
+
+public class ReplicatedIdRangeAcquirer
+{
+    private final Replicator replicator;
+    private final ReplicatedIdAllocationStateMachine idAllocationStateMachine;
+
+    private final int allocationChunk;
+    private final long retryTimeoutMillis;
+
+    private final CoreMember me;
+    private final Log log;
+
+    public ReplicatedIdRangeAcquirer( Replicator replicator, ReplicatedIdAllocationStateMachine idAllocationStateMachine, int allocationChunk, long retryTimeoutMillis, CoreMember me, LogProvider logProvider )
+    {
+        this.replicator = replicator;
+        this.idAllocationStateMachine = idAllocationStateMachine;
+        this.allocationChunk = allocationChunk;
+        this.retryTimeoutMillis = retryTimeoutMillis;
+        this.me = me;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    public IdAllocation acquireIds( IdType idType )
+    {
+        while ( true )
+        {
+            long firstNotAllocated = idAllocationStateMachine.getFirstNotAllocated( idType );
+            ReplicatedIdAllocationRequest idAllocationRequest = new ReplicatedIdAllocationRequest( me, idType, firstNotAllocated, allocationChunk );
+
+            try
+            {
+                replicator.replicate( idAllocationRequest );
+            }
+            catch ( Replicator.ReplicationFailedException e )
+            {
+                log.error( format( "Failed to acquire id range for idType %s", idType ), e );
+                throw new IdGenerationException( e );
+            }
+
+            try
+            {
+                idAllocationStateMachine.waitForAnyChange( retryTimeoutMillis );
+            }
+            catch ( InterruptedException e )
+            {
+                log.error( format( "Failed to acquire id range for idType %s", idType ), e );
+                throw new IdGenerationException( e );
+            }
+
+            IdRange myHighestIdRange = idAllocationStateMachine.getHighestIdRange( me, idType );
+
+            if ( myHighestIdRange != null && myHighestIdRange.getRangeStart() == idAllocationRequest.idRangeStart() )
+            {
+                // TODO why are we subtracting 1?
+                return new IdAllocation( myHighestIdRange, myHighestIdRange.getRangeStart() - 1, 0 );
+            }
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/SwitchableRaftIdGenerator.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/SwitchableRaftIdGenerator.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.store.id.IdGenerator;
+import org.neo4j.kernel.impl.store.id.IdRange;
+import org.neo4j.logging.LogProvider;
+
+public class SwitchableRaftIdGenerator implements IdGenerator
+{
+    private final IdType idType;
+    private final ReplicatedIdRangeAcquirer acquirer;
+    private final LogProvider logProvider;
+    private volatile IdGenerator delegate;
+
+    SwitchableRaftIdGenerator( IdGenerator initialDelegate, IdType idType, ReplicatedIdRangeAcquirer acquirer, LogProvider
+            logProvider )
+    {
+        delegate = initialDelegate;
+        this.idType = idType;
+        this.acquirer = acquirer;
+        this.logProvider = logProvider;
+    }
+
+    public void switchToRaft()
+    {
+        long highId = delegate.getHighId();
+        delegate.close();
+        delegate = new ReplicatedIdGenerator( idType, highId, acquirer, logProvider );
+    }
+
+    @Override
+    public IdRange nextIdBatch( int size )
+    {
+        return delegate.nextIdBatch( size );
+    }
+
+    @Override
+    public long nextId()
+    {
+        return delegate.nextId();
+    }
+
+    @Override
+    public long getHighId()
+    {
+        return delegate.getHighId();
+    }
+
+    @Override
+    public void setHighId( long id )
+    {
+        delegate.setHighId( id );
+    }
+
+    @Override
+    public long getHighestPossibleIdInUse()
+    {
+        return delegate.getHighestPossibleIdInUse();
+    }
+
+    @Override
+    public void freeId( long id )
+    {
+        delegate.freeId( id );
+    }
+
+    @Override
+    public void close()
+    {
+        delegate.close();
+    }
+
+    @Override
+    public long getNumberOfIdsInUse()
+    {
+        return delegate.getNumberOfIdsInUse();
+    }
+
+    @Override
+    public long getDefragCount()
+    {
+        return delegate.getDefragCount();
+    }
+
+    @Override
+    public void delete()
+    {
+        delegate.delete();
+    }
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/GlobalSession.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/GlobalSession.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.session;
+
+import java.util.UUID;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+import static java.lang.String.format;
+
+public class GlobalSession
+{
+    private final UUID sessionId;
+    private final CoreMember owner;
+
+    public GlobalSession( UUID sessionId, CoreMember owner )
+    {
+        this.sessionId = sessionId;
+        this.owner = owner;
+    }
+
+    public UUID sessionId()
+    {
+        return sessionId;
+    }
+
+    public CoreMember owner()
+    {
+        return owner;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        GlobalSession that = (GlobalSession) o;
+
+        if ( !sessionId.equals( that.sessionId ) )
+        { return false; }
+        return owner.equals( that.owner );
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = sessionId.hashCode();
+        result = 31 * result + owner.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "GlobalSession{sessionId=%s, owner=%s}", sessionId, owner );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/GlobalSessionTracker.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/GlobalSessionTracker.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.session;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+/**
+ * Each instance has a global session as well as several local sessions. Each local session
+ * tracks its operation by assigning a unique sequence number to each operation. This allows
+ * an operation originating from an instance to be uniquely identified and duplicate attempts
+ * at performing that operation can be filtered out.
+ *
+ * The session tracker defines the strategy for which local operations are allowed to be performed
+ * and the strategy is to only allow operations to occur in strict order, that is with no gaps,
+ * starting with sequence number zero. This is done for reasons of efficiency and creates a very
+ * direct coupling between session tracking and operation validation. This class is in charge
+ * of both.
+ */
+public class GlobalSessionTracker
+{
+    class LocalSessionTracker
+    {
+        UUID globalSessionId;
+        Map<Long,Long> lastSequenceNumberPerSession = new HashMap<>(); /* localSessionId -> lastSequenceNumber */
+
+        LocalSessionTracker( UUID globalSessionId )
+        {
+            this.globalSessionId = globalSessionId;
+        }
+
+        boolean validateAndTrackOperation( LocalOperationId operationId )
+        {
+            if ( !isValidOperation( operationId ) )
+            {
+                return false;
+            }
+
+            lastSequenceNumberPerSession.put( operationId.localSessionId(), operationId.sequenceNumber() );
+            return true;
+        }
+
+        /**
+         * The sequence numbers under a single local session must come strictly in order
+         * and are only valid exactly once.*/
+        private boolean isValidOperation( LocalOperationId operationId )
+        {
+            Long lastSequenceNumber = lastSequenceNumberPerSession.get( operationId.localSessionId() );
+
+            if ( lastSequenceNumber == null )
+            {
+                if ( operationId.sequenceNumber() != 0 )
+                {
+                    return false;
+                }
+            }
+            else if ( operationId.sequenceNumber() != lastSequenceNumber + 1 )
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    /** Each owner can only have one local session tracker, identified by the unique global session ID. */
+    Map<CoreMember,LocalSessionTracker> sessionTrackers = new HashMap<>();
+
+    /** Tracks the operation and returns whether or not this operation should be allowed. */
+    public boolean validateAndTrackOperation( GlobalSession globalSession, LocalOperationId localOperationId )
+    {
+        LocalSessionTracker localSessionTracker = validateGlobalSessionAndGetLocalSessionTracker( globalSession );
+        return localSessionTracker.validateAndTrackOperation( localOperationId );
+    }
+
+    private LocalSessionTracker validateGlobalSessionAndGetLocalSessionTracker( GlobalSession globalSession )
+    {
+        LocalSessionTracker localSessionTracker = sessionTrackers.get( globalSession.owner() );
+
+        if( localSessionTracker == null )
+        {
+            localSessionTracker = new LocalSessionTracker( globalSession.sessionId() );
+            sessionTrackers.put( globalSession.owner(), localSessionTracker );
+        }
+        else if ( !localSessionTracker.globalSessionId.equals( globalSession.sessionId() ) )
+        {
+            localSessionTracker = new LocalSessionTracker( globalSession.sessionId() );
+            sessionTrackers.put( globalSession.owner(), localSessionTracker );
+        }
+
+        return localSessionTracker;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/LocalOperationId.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/LocalOperationId.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.session;
+
+import static java.lang.String.format;
+
+/** Uniquely identifies an operation as performed under a global session. */
+public class LocalOperationId
+{
+    final private long localSessionId;
+    final private long sequenceNumber;
+
+    public LocalOperationId( long localSessionId, long sequenceNumber )
+    {
+        this.localSessionId = localSessionId;
+        this.sequenceNumber = sequenceNumber;
+    }
+
+    public long localSessionId()
+    {
+        return localSessionId;
+    }
+
+    public long sequenceNumber()
+    {
+        return sequenceNumber;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        LocalOperationId that = (LocalOperationId) o;
+
+        if ( localSessionId != that.localSessionId )
+        { return false; }
+        return sequenceNumber == that.sequenceNumber;
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = (int) (localSessionId ^ (localSessionId >>> 32));
+        result = 31 * result + (int) (sequenceNumber ^ (sequenceNumber >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "LocalOperationId{localSessionId=%d, sequenceNumber=%d}", localSessionId, sequenceNumber );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/LocalSession.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/LocalSession.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.session;
+
+import static java.lang.String.format;
+
+/** Holds the state for a local session. */
+public class LocalSession
+{
+    private long localSessionId;
+    private long currentSequenceNumber;
+
+    public LocalSession( long localSessionId )
+    {
+        this.localSessionId = localSessionId;
+    }
+
+    /** Consumes and returns an operation id under this session. */
+    protected LocalOperationId nextOperationId()
+    {
+        return new LocalOperationId( localSessionId, currentSequenceNumber++ );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        LocalSession that = (LocalSession) o;
+
+        return localSessionId == that.localSessionId;
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (int) (localSessionId ^ (localSessionId >>> 32));
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "LocalSession{localSessionId=%d, sequenceNumber=%d}", localSessionId, currentSequenceNumber );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/LocalSessionPool.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/LocalSessionPool.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.session;
+
+import java.util.EmptyStackException;
+import java.util.Stack;
+import java.util.UUID;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+/** Keeps a pool of local sub-sessions, to be used under a single global session. */
+public class LocalSessionPool
+{
+    private final Stack<LocalSession> sessionStack = new Stack<>();
+
+    private final GlobalSession globalSession;
+    private long nextLocalSessionId;
+
+    public LocalSessionPool( CoreMember owner )
+    {
+        globalSession = new GlobalSession( UUID.randomUUID(), owner );
+    }
+
+    private LocalSession createSession()
+    {
+        return new LocalSession( nextLocalSessionId++ );
+    }
+
+    public GlobalSession getGlobalSession()
+    {
+        return globalSession;
+    }
+
+    /**
+     * Acquires a session and returns the next unique operation context
+     * within that session. The session must be released when the operation
+     * has been successfully finished. */
+    public synchronized OperationContext acquireSession()
+    {
+        LocalSession localSession;
+        try
+        {
+            localSession = sessionStack.pop();
+        }
+        catch( EmptyStackException e )
+        {
+            localSession = createSession();
+        }
+
+        return new OperationContext( globalSession, localSession.nextOperationId(), localSession );
+    }
+
+    /**
+     * Releases a previously acquired session using the operation context
+     * as a key. An unsuccessful operation should not be released, but it
+     * will leak a local session.
+     *
+     * The reason for not releasing an unsuccessful session is that operation
+     * handlers might restrict sequence numbers to occur in strict order, and
+     * thus an operation that it hasn't handled will block any future
+     * operations under that session.
+     *
+     * In general all operations should be retried until they do succeed, or
+     * the entire session manager should eventually be restarted, thus
+     * allocating a new global session to operate under.
+     */
+    public synchronized void releaseSession( OperationContext operationContext )
+    {
+        sessionStack.push( operationContext.localSession() );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/OperationContext.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/OperationContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.session;
+
+/** Context for operation. Used for acquirement and release. */
+public class OperationContext
+{
+    private final GlobalSession globalSession;
+    private final LocalOperationId localOperationId;
+
+    private final LocalSession localSession;
+
+    public OperationContext( GlobalSession globalSession, LocalOperationId localOperationId, LocalSession localSession )
+    {
+        this.globalSession = globalSession;
+        this.localOperationId = localOperationId;
+        this.localSession = localSession;
+    }
+
+    public GlobalSession globalSession()
+    {
+        return globalSession;
+    }
+
+    public LocalOperationId localOperationId()
+    {
+        return localOperationId;
+    }
+
+    protected LocalSession localSession()
+    {
+        return localSession;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipper.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipper.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.shipping;
+
+import org.neo4j.coreedge.raft.LeaderContext;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.raft.ScheduledTimeoutService;
+import org.neo4j.coreedge.raft.TimeoutService.TimeoutName;
+import org.neo4j.helpers.Clock;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static java.lang.Long.max;
+import static java.lang.Long.min;
+import static java.lang.String.format;
+import static org.neo4j.coreedge.raft.TimeoutService.*;
+
+/// Optimizations
+// TODO: Have several outstanding batches in catchup mode, to bridge the latency gap.
+// TODO: Bisect search for mismatch.
+// TODO: Maximum bound on size of batch in bytes, not just entry count.
+
+// Production ready
+// TODO: Make configuration configurable (batch size, outstanding, retry time).
+
+// TODO: Replace sender service with something more appropriate. No need for queue and multiplex capability, in fact is it bad to have?
+//  TODO Should we drop messages to unconnected channels instead? Use UDP? Because we are not allowed to go below a certain cluster size (safety)
+//  TODO then leader will keep trying to replicate to gone members, thus queuing things up is hurtful.
+
+// TODO: Replace the timeout service with something better. More efficient for the constantly rescheduling use case and also useful for deterministic unit tests.
+
+// Core functionality
+// TODO: Consider making even CommitUpdate a raft-message of its own.
+
+/**
+ * This class handles the shipping of raft logs from this node when it is the leader to the followers.
+ * Each instance handles a single follower and acts on events and associated state updates originating
+ * within the main raft state machine.
+ *
+ * It is crucial that all actions happen within the context of the leaders state at some point in time.
+ *
+ * @param <MEMBER> The member type.
+ */
+public class RaftLogShipper<MEMBER>
+{
+    enum Mode
+    {
+        /**
+         * In the mismatch mode we are unsure about the follower state, thus
+         * we tread with caution, going backwards trying to find the point where
+         * our logs match.
+         */
+        MISMATCH,
+        /**
+         * In the catchup mode we are trying to catch up the follower as quickly
+         * as possible. The follower receives batches of entries in series until
+         * it is fully caught up.
+         */
+        CATCHUP,
+        /**
+         * In the pipeline mode the follower is treated as caught up and we
+         * optimistically ship any latest entries without waiting for responses,
+         * expecting successful responses.
+         */
+        PIPELINE
+    }
+
+    public static final int MAX_BATCH_SIZE = 16;
+    public static final int MAX_OUTSTANDING = 64;
+
+    private final Outbound<MEMBER> outbound;
+    private final Log log;
+    private final ReadableRaftLog raftLog;
+    private final Clock clock;
+
+    private final MEMBER follower;
+    private final MEMBER leader;
+
+    private ScheduledTimeoutService timeoutService;
+    private final TimeoutName timeoutName = () -> "RESEND";
+    private final long retryTimeMillis;
+    private Timeout timeout;
+
+    private long timeoutAbsoluteMillis;
+    private long lastSentIndex;
+
+    private long matchIndex = -1;
+
+    private LeaderContext lastLeaderContext;
+
+    private Mode mode = Mode.MISMATCH;
+
+    public RaftLogShipper( Outbound<MEMBER> outbound, LogProvider logProvider, ReadableRaftLog raftLog, Clock clock, MEMBER leader, MEMBER follower,
+                           long leaderTerm, long leaderCommit, long retryTimeMillis )
+    {
+        this.outbound = outbound;
+        this.log = logProvider.getLog( getClass() );
+        this.raftLog = raftLog;
+        this.clock = clock;
+        this.follower = follower;
+        this.leader = leader;
+        this.retryTimeMillis = retryTimeMillis;
+        this.lastLeaderContext = new LeaderContext( leaderTerm, leaderCommit );
+    }
+
+    public Object identity()
+    {
+        return follower;
+    }
+
+    public synchronized void start()
+    {
+        log.info( "Starting log shipper to: " + follower );
+
+        try
+        {
+            timeoutService = new ScheduledTimeoutService();
+            timeoutService.init();
+            timeoutService.start();
+        }
+        catch ( Throwable e )
+        {
+            // TODO: Think about how to handle this. We cannot be allowed to throw when
+            // TODO: starting the log shippers from the main RAFT handling. The timeout
+            // TODO: service is a LifeCycle.
+            // TODO: Should we have and use one system level timeout service instead?
+
+            log.error( "Failed to start log shipper to: " + follower, e );
+        }
+
+        try
+        {
+            sendSingle( raftLog.appendIndex(), lastLeaderContext );
+        }
+        catch ( RaftStorageException e )
+        {
+            log.error( "Exception during send: " + follower, e );
+        }
+    }
+
+    public synchronized void stop()
+    {
+        log.info( "Stopping log shipper to: " + follower );
+
+        try
+        {
+            timeoutService.stop();
+            timeoutService.shutdown();
+        }
+        catch ( Throwable e )
+        {
+            log.error( "Failed to start log shipper to: " + follower, e );
+        }
+        abortTimeout();
+    }
+
+    public synchronized void onMismatch( long lastRemoteAppendIndex, LeaderContext leaderContext ) throws RaftStorageException
+    {
+        switch ( mode )
+        {
+        case MISMATCH:
+            long logIndex = max( min( lastSentIndex - 1, lastRemoteAppendIndex ), 0 );
+            sendSingle( logIndex, leaderContext );
+            break;
+        case PIPELINE:
+        case CATCHUP:
+            log.info( format( "Mismatch in mode %s from follower %s", mode, follower ) );
+            mode = Mode.MISMATCH;
+            sendSingle( lastSentIndex, leaderContext );
+            break;
+        }
+
+        lastLeaderContext = leaderContext;
+    }
+
+    public synchronized void onMatch( long newMatchIndex, LeaderContext leaderContext ) throws RaftStorageException
+    {
+        boolean progress = newMatchIndex > matchIndex;
+        matchIndex = max ( newMatchIndex, matchIndex );
+
+        switch ( mode )
+        {
+        case MISMATCH:
+            if( sendNextBatchAfterMatch( leaderContext ) )
+            {
+                log.info( format( "Caught up after mismatch: %s", follower ) );
+                mode = Mode.PIPELINE;
+            }
+            else
+            {
+                log.info( format( "Starting catch up after mismatch: %s", follower ) );
+                mode = Mode.CATCHUP;
+            }
+            break;
+        case CATCHUP:
+            if ( matchIndex >= lastSentIndex )
+            {
+                if ( sendNextBatchAfterMatch( leaderContext ) )
+                {
+                    log.info( format( "Caught up: %s", follower ) );
+                    mode = Mode.PIPELINE;
+                }
+            }
+            break;
+        case PIPELINE:
+            if ( matchIndex == lastSentIndex )
+            {
+                abortTimeout();
+            }
+            else if ( progress )
+            {
+                scheduleTimeout( retryTimeMillis );
+            }
+            break;
+        }
+
+        lastLeaderContext = leaderContext;
+    }
+
+    public synchronized void onNewEntry( long prevLogIndex, long prevLogTerm, RaftLogEntry newLogEntry, LeaderContext leaderContext ) throws RaftStorageException
+    {
+        switch ( mode )
+        {
+        case PIPELINE:
+            while( lastSentIndex <= prevLogIndex )
+            {
+                if ( prevLogIndex - matchIndex <= MAX_OUTSTANDING )
+                {
+                    sendNewEntry( prevLogIndex, prevLogTerm, newLogEntry, leaderContext ); // all sending functions update lastSentIndex
+                }
+                else
+                {
+                    /* The timer is still set at this point. Either we will send the next batch
+                     * as soon as the follower has caught up with the last pipelined entry,
+                     * or when we timeout and resend. */
+                    mode = Mode.CATCHUP;
+                    break;
+                }
+            }
+            break;
+        }
+
+        lastLeaderContext = leaderContext;
+    }
+
+    public synchronized void onCommitUpdate( LeaderContext leaderContext ) throws RaftStorageException
+    {
+        switch ( mode )
+        {
+        case PIPELINE:
+            sendCommitUpdate( leaderContext );
+            break;
+        }
+
+        lastLeaderContext = leaderContext;
+    }
+
+    public synchronized void onScheduledTimeoutExpiry()
+    {
+        try
+        {
+            if ( timedOut() )
+            {
+                onTimeout();
+            }
+            else if ( timeoutAbsoluteMillis != 0 )
+            {
+                long timeLeft = timeoutAbsoluteMillis - clock.currentTimeMillis();
+
+                if ( timeLeft > 0 )
+                {
+                    scheduleTimeout( timeLeft );
+                }
+                else
+                {
+                    onTimeout();
+                }
+            }
+        }
+        catch ( RaftStorageException e )
+        {
+            log.error( "Exception during timeout handling: " + follower, e );
+        }
+    }
+
+    private void onTimeout() throws RaftStorageException
+    {
+        switch ( mode )
+        {
+        case PIPELINE:
+            /* we leave pipelined mode here, because the follower seems
+             * unresponsive and we do not want to spam it with new entries */
+            mode = Mode.CATCHUP;
+            /* fallthrough */
+        case CATCHUP:
+        case MISMATCH:
+            if ( lastLeaderContext != null )
+            {
+                sendSingle( lastSentIndex, lastLeaderContext );
+            }
+            break;
+        }
+    }
+
+    private boolean timedOut()
+    {
+        return timeoutAbsoluteMillis != 0 && (clock.currentTimeMillis() - timeoutAbsoluteMillis) >= 0;
+    }
+
+    private void scheduleTimeout( long deltaMillis )
+    {
+        // TODO: This cancel/create dance is a bit inefficient... consider something better.
+
+        timeoutAbsoluteMillis = clock.currentTimeMillis() + deltaMillis;
+
+        if ( timeout != null )
+        {
+            timeout.cancel();
+        }
+        timeout = timeoutService.create( timeoutName, deltaMillis, 0, timeout -> onScheduledTimeoutExpiry() );
+    }
+
+    private void abortTimeout()
+    {
+        if ( timeout != null )
+        {
+            timeout.cancel();
+        }
+        timeoutAbsoluteMillis = 0;
+    }
+
+    /** Returns true if this sent the last batch. */
+    private boolean sendNextBatchAfterMatch( LeaderContext leaderContext ) throws RaftStorageException
+    {
+        long lastIndex = raftLog.appendIndex();
+
+        if ( lastIndex > matchIndex )
+        {
+            long endIndex = min( lastIndex, matchIndex + MAX_BATCH_SIZE );
+
+            scheduleTimeout( retryTimeMillis );
+            sendRange( matchIndex + 1, endIndex, leaderContext );
+            return endIndex == lastIndex;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    private void sendCommitUpdate( LeaderContext leaderContext ) throws RaftStorageException
+    {
+        /*
+         * This is a commit update. That means that we just received enough success responses to an append
+         * request to allow us to send a commit. By Raft invariants, this means that the term for the committed
+         * entry is the current term.
+         */
+        RaftMessages.Heartbeat<MEMBER> appendRequest = new RaftMessages.Heartbeat<>(
+                leader, leaderContext.term, leaderContext.commitIndex, leaderContext.term );
+
+        outbound.send( follower, appendRequest );
+    }
+
+    private void sendSingle( long logIndex, LeaderContext leaderContext ) throws RaftStorageException
+    {
+        scheduleTimeout( retryTimeMillis );
+
+        lastSentIndex = logIndex;
+
+        long prevLogIndex = logIndex - 1;
+        long prevLogTerm = raftLog.readEntryTerm( prevLogIndex );
+
+        if ( prevLogTerm > leaderContext.term )
+        {
+            log.warn( format( "Aborting send. Not leader anymore? %s, prevLogTerm=%d", leaderContext, prevLogTerm ) );
+            return;
+        }
+
+        RaftLogEntry logEntry = null;
+        if ( raftLog.entryExists( logIndex ) )
+        {
+            logEntry = raftLog.readLogEntry( logIndex );
+        }
+
+        RaftMessages.AppendEntries.Request<MEMBER> appendRequest = new RaftMessages.AppendEntries.Request<>(
+                leader, leaderContext.term, prevLogIndex, prevLogTerm, new RaftLogEntry[] { logEntry }, leaderContext.commitIndex );
+
+        outbound.send( follower, appendRequest );
+
+    }
+
+    private void sendNewEntry( long prevLogIndex, long prevLogTerm, RaftLogEntry newEntry, LeaderContext leaderContext ) throws RaftStorageException
+    {
+        scheduleTimeout( retryTimeMillis );
+
+        lastSentIndex = prevLogIndex + 1;
+
+        RaftMessages.AppendEntries.Request<MEMBER> appendRequest = new RaftMessages.AppendEntries.Request<>(
+                leader, leaderContext.term, prevLogIndex, prevLogTerm, new RaftLogEntry[] { newEntry }, leaderContext.commitIndex );
+
+        outbound.send( follower, appendRequest );
+
+    }
+
+    private void sendRange( long startIndex, long endIndex, LeaderContext leaderContext ) throws RaftStorageException
+    {
+        if ( startIndex > endIndex )
+            return;
+
+        lastSentIndex = endIndex;
+
+        int batchSize = (int) (endIndex - startIndex + 1);
+        RaftLogEntry[] entries = new RaftLogEntry[batchSize];
+
+        long prevLogIndex = startIndex - 1;
+        long prevLogTerm = raftLog.readEntryTerm( prevLogIndex );
+
+        if ( prevLogTerm > leaderContext.term )
+        {
+            log.warn( format( "Aborting send. Not leader anymore? %s, prevLogTerm=%d", leaderContext, prevLogTerm ) );
+            return;
+        }
+
+        RaftMessages.AppendEntries.Request<MEMBER> appendRequest = new RaftMessages.AppendEntries.Request<>(
+                leader, leaderContext.term, prevLogIndex, prevLogTerm, entries, leaderContext.commitIndex );
+
+        int offset = 0;
+        while( offset < batchSize )
+        {
+            entries[offset] = raftLog.readLogEntry( startIndex + offset );
+
+            if( entries[offset].term() > leaderContext.term )
+            {
+                log.warn( format( "Aborting send. Not leader anymore? %s, entryTerm=%d", leaderContext, entries[offset].term() ) );
+                return;
+            }
+
+            offset++;
+        }
+
+        outbound.send( follower, appendRequest );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShippingManager.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShippingManager.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.shipping;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.neo4j.coreedge.raft.LeaderContext;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.membership.RaftMembership;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.raft.outcome.ShipCommand;
+import org.neo4j.helpers.Clock;
+import org.neo4j.logging.LogProvider;
+
+import static java.lang.String.*;
+
+public class RaftLogShippingManager<MEMBER> implements RaftMembership.Listener
+{
+    private final Outbound<MEMBER> outbound;
+    private final LogProvider logProvider;
+    private final ReadableRaftLog raftLog;
+    private final Clock clock;
+    private final MEMBER myself;
+
+    private final RaftMembership<MEMBER> membership;
+    private final long retryTimeMillis;
+    private Map<MEMBER,RaftLogShipper> logShippers = new HashMap<>();
+    private LeaderContext lastLeaderContext;
+
+    private boolean running;
+
+    public RaftLogShippingManager( Outbound<MEMBER> outbound, LogProvider logProvider, ReadableRaftLog raftLog,
+            Clock clock, MEMBER myself, RaftMembership<MEMBER> membership, long retryTimeMillis )
+    {
+        this.outbound = outbound;
+        this.logProvider = logProvider;
+        this.raftLog = raftLog;
+        this.clock = clock;
+        this.myself = myself;
+        this.membership = membership;
+        this.retryTimeMillis = retryTimeMillis;
+
+        membership.registerListener( this );
+    }
+
+    public synchronized void start( LeaderContext initialLeaderContext )
+    {
+        running = true;
+
+        for ( MEMBER member : membership.replicationMembers() )
+        {
+            ensureLogShipperRunning( member, initialLeaderContext );
+        }
+
+        lastLeaderContext = initialLeaderContext;
+    }
+
+    public synchronized void stop()
+    {
+        running = false;
+
+        logShippers.values().forEach( RaftLogShipper::stop );
+        logShippers.clear();
+    }
+
+    private RaftLogShipper ensureLogShipperRunning( MEMBER member, LeaderContext leaderContext )
+    {
+        RaftLogShipper logShipper = logShippers.get( member );
+        if ( logShipper == null && !member.equals( myself ) )
+        {
+            logShipper = new RaftLogShipper<>( outbound, logProvider, raftLog, clock, myself, member,
+                    leaderContext.term, leaderContext.commitIndex, retryTimeMillis );
+
+            logShippers.put( member, logShipper );
+
+            logShipper.start();
+        }
+        return logShipper;
+    }
+
+    public synchronized void handleCommands( Iterable<ShipCommand> shipCommands, LeaderContext leaderContext )
+    {
+        for ( ShipCommand shipCommand : shipCommands )
+        {
+            for ( RaftLogShipper logShipper : logShippers.values() )
+            {
+                try
+                {
+                    shipCommand.applyTo( logShipper, leaderContext );
+                }
+                catch ( RaftStorageException e )
+                {
+                    // TODO: handle
+                }
+            }
+        }
+
+        lastLeaderContext = leaderContext;
+    }
+
+    @Override
+    public synchronized void onMembershipChanged()
+    {
+        if ( lastLeaderContext == null || !running )
+            return;
+
+        HashSet<MEMBER> toBeRemoved = new HashSet<>( logShippers.keySet() );
+        toBeRemoved.removeAll( membership.replicationMembers() );
+
+        for ( MEMBER member : toBeRemoved )
+        {
+            RaftLogShipper logShipper = logShippers.remove( member );
+            if( logShipper != null )
+            {
+                logShipper.stop();
+            }
+        }
+
+        for ( MEMBER replicationMember : membership.replicationMembers() )
+        {
+            ensureLogShipperRunning( replicationMember, lastLeaderContext );
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "RaftLogShippingManager{logShippers=%s, myself=%s}", logShippers, myself );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/storeid/SeedStoreId.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/storeid/SeedStoreId.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.storeid;
+
+import java.util.Objects;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.kernel.impl.store.StoreId;
+
+import static java.lang.String.format;
+
+public class SeedStoreId implements ReplicatedContent
+{
+    private final StoreId storeId;
+
+    public SeedStoreId( StoreId storeId )
+    {
+        this.storeId = storeId;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        SeedStoreId that = (SeedStoreId) o;
+        return Objects.equals( storeId, that.storeId );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( storeId );
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "SeedStoreId{storeId=%s}", storeId );
+    }
+
+    public StoreId storeId()
+    {
+        return storeId;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/storeid/SeedStoreIdSerializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/storeid/SeedStoreIdSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.storeid;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.raft.replication.storeid.SeedStoreId;
+import org.neo4j.coreedge.raft.replication.storeid.StoreIdDecoder;
+import org.neo4j.coreedge.raft.replication.storeid.StoreIdEncoder;
+import org.neo4j.kernel.impl.store.StoreId;
+
+/**
+ * Format:
+ * ┌──────────────────────────────────────────┐
+ * │contentLength                     4 bytes │
+ * │contentType                       1 bytes │
+ * │content       ┌──────────────────────────┐│
+ * │              │creationTime       8 bytes││
+ * │              │randomId           8 bytes││
+ * │              │storeVersion       8 bytes││
+ * │              │upgradeTime        8 bytes││
+ * │              │upgradeId          8 bytes││
+ * │              └──────────────────────────┘│
+ * └──────────────────────────────────────────┘
+ */
+public class SeedStoreIdSerializer
+{
+    public static void serialize( SeedStoreId memberSet, ByteBuf byteBuf )
+    {
+        new StoreIdEncoder().encode( memberSet.storeId(), byteBuf );
+    }
+
+    public static SeedStoreId deserialize( ByteBuf buffer )
+    {
+        StoreId storeId = new StoreIdDecoder().decode( buffer );
+        return new SeedStoreId( storeId );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/storeid/StoreIdDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/storeid/StoreIdDecoder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.storeid;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.kernel.impl.store.StoreId;
+
+public class StoreIdDecoder
+{
+    public StoreId decode( ByteBuf msg )
+    {
+        long creationTime = msg.readLong();
+        long randomId = msg.readLong();
+        long storeVersion = msg.readLong();
+        long upgradeTime = msg.readLong();
+        long upgradeId = msg.readLong();
+        return new StoreId( creationTime, randomId, storeVersion, upgradeTime, upgradeId );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/storeid/StoreIdEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/storeid/StoreIdEncoder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.storeid;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.kernel.impl.store.StoreId;
+
+public class StoreIdEncoder
+{
+    public void encode( StoreId storeId, ByteBuf encoded )
+    {
+        encoded.writeLong( storeId.getCreationTime() );
+        encoded.writeLong( storeId.getRandomId() );
+        encoded.writeLong( storeId.getStoreVersion() );
+        encoded.writeLong( storeId.getUpgradeTime() );
+        encoded.writeLong( storeId.getUpgradeId() );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedLabelTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedLabelTokenHolder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.token;
+
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.core.LabelTokenHolder;
+import org.neo4j.kernel.impl.core.Token;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.TokenStore;
+import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.state.Loaders;
+import org.neo4j.kernel.impl.transaction.state.RecordAccess;
+import org.neo4j.kernel.impl.util.Dependencies;
+
+public class ReplicatedLabelTokenHolder extends ReplicatedTokenHolder<Token,LabelTokenRecord> implements LabelTokenHolder
+{
+    public ReplicatedLabelTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies )
+    {
+        super( replicator, idGeneratorFactory, IdType.LABEL_TOKEN, dependencies, new Token.Factory(), TokenType.LABEL );
+    }
+
+    @Override
+    protected RecordAccess.Loader<Integer,LabelTokenRecord,Void> resolveLoader( TokenStore<LabelTokenRecord,Token> tokenStore )
+    {
+        return Loaders.labelTokenLoader( tokenStore );
+    }
+
+    @Override
+    protected TokenStore<LabelTokenRecord,Token> resolveStore()
+    {
+        return dependencies.resolveDependency( NeoStores.class ).getLabelTokenStore();
+    }
+
+    protected Command.TokenCommand<LabelTokenRecord> createCommand()
+    {
+        return new Command.LabelTokenCommand();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedPropertyKeyTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedPropertyKeyTokenHolder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.token;
+
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
+import org.neo4j.kernel.impl.core.Token;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.TokenStore;
+import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.state.Loaders;
+import org.neo4j.kernel.impl.transaction.state.RecordAccess;
+import org.neo4j.kernel.impl.util.Dependencies;
+
+public class ReplicatedPropertyKeyTokenHolder extends ReplicatedTokenHolder<Token,PropertyKeyTokenRecord> implements PropertyKeyTokenHolder
+{
+    public ReplicatedPropertyKeyTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies )
+    {
+        super( replicator, idGeneratorFactory, IdType.PROPERTY_KEY_TOKEN, dependencies, new Token.Factory(), TokenType.PROPERTY );
+    }
+
+    @Override
+    protected RecordAccess.Loader<Integer,PropertyKeyTokenRecord,Void> resolveLoader( TokenStore<PropertyKeyTokenRecord,Token> tokenStore )
+    {
+        return Loaders.propertyKeyTokenLoader( tokenStore );
+    }
+
+    @Override
+    protected TokenStore<PropertyKeyTokenRecord,Token> resolveStore()
+    {
+        return dependencies.resolveDependency( NeoStores.class ).getPropertyKeyTokenStore();
+    }
+
+    protected Command.TokenCommand<PropertyKeyTokenRecord> createCommand()
+    {
+        return new Command.PropertyKeyTokenCommand();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedRelationshipTypeTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedRelationshipTypeTokenHolder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.token;
+
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.core.RelationshipTypeToken;
+import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.TokenStore;
+import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.state.Loaders;
+import org.neo4j.kernel.impl.transaction.state.RecordAccess;
+import org.neo4j.kernel.impl.util.Dependencies;
+
+public class ReplicatedRelationshipTypeTokenHolder extends ReplicatedTokenHolder<RelationshipTypeToken,RelationshipTypeTokenRecord> implements RelationshipTypeTokenHolder
+{
+    public ReplicatedRelationshipTypeTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies )
+    {
+        super( replicator, idGeneratorFactory, IdType.RELATIONSHIP_TYPE_TOKEN, dependencies, new RelationshipTypeToken.Factory(), TokenType.RELATIONSHIP );
+    }
+
+    @Override
+    protected RecordAccess.Loader<Integer,RelationshipTypeTokenRecord,Void> resolveLoader( TokenStore<RelationshipTypeTokenRecord,RelationshipTypeToken> tokenStore )
+    {
+        return Loaders.relationshipTypeTokenLoader( tokenStore );
+    }
+
+    @Override
+    protected TokenStore<RelationshipTypeTokenRecord,RelationshipTypeToken> resolveStore()
+    {
+        return dependencies.resolveDependency( NeoStores.class ).getRelationshipTypeTokenStore();
+    }
+
+    protected Command.TokenCommand<RelationshipTypeTokenRecord> createCommand()
+    {
+        return new Command.RelationshipTypeTokenCommand();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenHolder.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.token;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
+import org.neo4j.kernel.impl.core.InMemoryTokenCache;
+import org.neo4j.kernel.impl.core.NonUniqueTokenException;
+import org.neo4j.kernel.impl.core.Token;
+import org.neo4j.kernel.impl.core.TokenFactory;
+import org.neo4j.kernel.impl.core.TokenHolder;
+import org.neo4j.kernel.impl.core.TokenNotFoundException;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.store.TokenStore;
+import org.neo4j.kernel.impl.store.record.TokenRecord;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.state.RecordAccess;
+import org.neo4j.kernel.impl.transaction.state.RecordChanges;
+import org.neo4j.kernel.impl.transaction.state.TokenCreator;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.impl.util.collection.NoSuchEntryException;
+import org.neo4j.kernel.impl.util.statistics.IntCounter;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public abstract class ReplicatedTokenHolder<TOKEN extends Token, RECORD extends TokenRecord> extends LifecycleAdapter
+        implements TokenHolder<TOKEN>, Replicator.ReplicatedContentListener
+{
+    protected final Dependencies dependencies;
+
+    private final InMemoryTokenCache<TOKEN> tokenCache;
+    private final Replicator replicator;
+    private final IdGeneratorFactory idGeneratorFactory;
+    private final IdType tokenIdType;
+    private final TokenFactory<TOKEN> tokenFactory;
+    private final TokenType type;
+
+    private final TokenFutures tokenFutures = new TokenFutures();
+
+    // TODO: Clean up all the resolving, which now happens every time with special selection strategies.
+
+    public ReplicatedTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, IdType tokenIdType,
+            Dependencies dependencies, TokenFactory<TOKEN> tokenFactory, TokenType type )
+    {
+        this.replicator = replicator;
+        this.idGeneratorFactory = idGeneratorFactory;
+        this.tokenIdType = tokenIdType;
+        this.dependencies = dependencies;
+        this.tokenFactory = tokenFactory;
+        this.type = type;
+        this.tokenCache = new InMemoryTokenCache<>( this.getClass() );
+    }
+
+    @Override
+    public void start()
+    {
+        tokenCache.clear();
+        replicator.subscribe( this );
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        replicator.unsubscribe( this );
+    }
+
+    @Override
+    public void setInitialTokens( List<TOKEN> tokens ) throws NonUniqueTokenException
+    {
+        // TODO: There is no need to initialize tokens until we have implemented raft log compression.
+        // TODO: at the moment, we receive all token allocations since the beginning of time.
+    }
+
+    @Override
+    public void addToken( TOKEN token ) throws NonUniqueTokenException
+    {
+        tokenCache.put( token );
+    }
+
+    @Override
+    public int getOrCreateId( String tokenName )
+    {
+        {
+            Integer tokenId = tokenCache.getId( tokenName );
+            if ( tokenId != null )
+            {
+                return tokenId;
+            }
+        }
+
+        return requestToken( tokenName );
+    }
+
+    private int requestToken( String tokenName )
+    {
+        ReplicatedTokenRequest tokenRequest = new ReplicatedTokenRequest( type, tokenName, createCommands( tokenName ) );
+
+        try( TokenFutures.CompletableFutureTokenId tokenFuture = tokenFutures.createFuture( tokenName ) )
+        {
+            try
+            {
+                replicator.replicate( tokenRequest );
+            }
+            catch ( Replicator.ReplicationFailedException e )
+            {
+                // TODO: This is really a NoLeaderTimeoutException... should clarify exception and semantics of the
+                // TODO: replicator interface. e.g. who is responsible for retry, does the exception imply that replication
+                // TODO: might have occurred, etc.
+                throw new RuntimeException( "Replication failures not currently handled." );
+            }
+
+            try
+            {
+                return tokenFuture.get();
+            }
+            catch ( InterruptedException | ExecutionException e )
+            {
+                // TODO: Handle exceptions.
+                throw new RuntimeException( "Future exceptions currently not handled." );
+            }
+        }
+        catch ( Exception e )
+        {
+            throw new RuntimeException( "Error closing future.", e );
+        }
+    }
+
+    private byte[] createCommands( String tokenName )
+    {
+        long tokenId = idGeneratorFactory.get( tokenIdType ).nextId();
+
+        TokenStore<RECORD,TOKEN> tokenStore = resolveStore();
+        RecordAccess.Loader<Integer,RECORD,Void> recordLoader = resolveLoader( tokenStore );
+
+        RecordChanges<Integer,RECORD,Void> recordAccess = new RecordChanges<>( recordLoader, false, new IntCounter() );
+        TokenCreator<RECORD,TOKEN> tokenCreator = new TokenCreator<>( tokenStore );
+        tokenCreator.createToken( tokenName, (int) tokenId, recordAccess );
+
+        Collection<Command> commands = new ArrayList<>();
+        for ( RecordAccess.RecordProxy<Integer,RECORD, Void> record : recordAccess.changes() )
+        {
+            Command.TokenCommand<RECORD> command = createCommand();
+            command.init( record.forReadingLinkage() );
+            commands.add( command );
+        }
+
+        return ReplicatedTokenRequestSerializer.createCommandBytes( commands );
+    }
+
+    @Override
+    public TOKEN getTokenById( int id ) throws TokenNotFoundException
+    {
+        TOKEN result = getTokenByIdOrNull( id );
+        if ( result == null )
+        {
+            throw new TokenNotFoundException( "Token for id " + id );
+        }
+        return result;
+    }
+
+    @Override
+    public TOKEN getTokenByIdOrNull( int id )
+    {
+        return tokenCache.getToken( id );
+    }
+
+    @Override
+    public int getIdByName( String name )
+    {
+        Integer id = tokenCache.getId( name );
+        if ( id == null )
+        {
+            return NO_ID;
+        }
+        return id;
+    }
+
+    @Override
+    public Iterable<TOKEN> getAllTokens()
+    {
+        return tokenCache.allTokens();
+    }
+
+    @Override
+    public void onReplicated( ReplicatedContent content )
+    {
+        if ( content instanceof ReplicatedTokenRequest && ((ReplicatedTokenRequest) content).type().equals( type ) )
+        {
+            ReplicatedTokenRequest tokenRequest = (ReplicatedTokenRequest) content;
+
+            Integer tokenId = tokenCache.getId( tokenRequest.tokenName() );
+
+            if ( tokenId == null )
+            {
+                try
+                {
+                    Collection<Command> commands =  ReplicatedTokenRequestSerializer.extractCommands( tokenRequest.commandBytes() );
+                    tokenId = applyToStore( commands );
+                }
+                catch ( NoSuchEntryException e )
+                {
+                    throw new IllegalStateException( "Commands did not contain token command" );
+                }
+
+                tokenCache.put( tokenFactory.newToken( tokenRequest.tokenName(), tokenId ) );
+            }
+
+            tokenFutures.complete( tokenRequest.tokenName(), tokenId );
+        }
+    }
+
+    private int applyToStore( Collection<Command> commands ) throws NoSuchEntryException
+    {
+        int tokenId = extractTokenId( commands );
+
+        PhysicalTransactionRepresentation representation = new PhysicalTransactionRepresentation( commands );
+        representation.setHeader( new byte[0], 0, 0, 0, 0l, 0l, 0 );
+
+        TransactionCommitProcess commitProcess = dependencies.resolveDependency(
+                TransactionRepresentationCommitProcess.class );
+
+        try ( LockGroup lockGroup = new LockGroup() )
+        {
+            commitProcess.commit( representation, lockGroup, CommitEvent.NULL, TransactionApplicationMode.EXTERNAL );
+        }
+        catch ( TransactionFailureException e )
+        {
+            throw new RuntimeException( e );
+        }
+
+        return tokenId;
+    }
+
+    private int extractTokenId( Collection<Command> commands ) throws NoSuchEntryException
+    {
+        for ( Command command : commands )
+        {
+            if( command instanceof Command.TokenCommand )
+            {
+                return ((Command.TokenCommand) command).getRecord().getId();
+            }
+        }
+        throw new NoSuchEntryException( "Expected command not found" );
+    }
+
+    protected abstract RecordAccess.Loader<Integer,RECORD,Void> resolveLoader( TokenStore<RECORD,TOKEN> tokenStore );
+
+    protected abstract TokenStore<RECORD,TOKEN> resolveStore();
+
+    protected abstract Command.TokenCommand<RECORD> createCommand();
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenRequest.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenRequest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.token;
+
+import java.util.Arrays;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+public class ReplicatedTokenRequest implements ReplicatedContent
+{
+    private final TokenType type;
+    private final String tokenName;
+    private final byte[] commandBytes;
+
+    public ReplicatedTokenRequest( TokenType type, String tokenName, byte[] commandBytes )
+    {
+        this.type = type;
+        this.tokenName = tokenName;
+        this.commandBytes = commandBytes;
+    }
+
+    public TokenType type()
+    {
+        return type;
+    }
+
+    public String tokenName()
+    {
+        return tokenName;
+    }
+
+    public byte[] commandBytes()
+    {
+        return commandBytes;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        ReplicatedTokenRequest that = (ReplicatedTokenRequest) o;
+
+        if ( type != that.type )
+        { return false; }
+        if ( !tokenName.equals( that.tokenName ) )
+        { return false; }
+        return Arrays.equals( commandBytes, that.commandBytes );
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = type.hashCode();
+        result = 31 * result + tokenName.hashCode();
+        result = 31 * result + Arrays.hashCode( commandBytes );
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "ReplicatedTokenRequest{type='%s', name='%s'}",
+                type, tokenName );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenRequestSerializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenRequestSerializer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.token;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.neo4j.coreedge.raft.net.NetworkReadableLogChannelNetty4;
+import org.neo4j.coreedge.raft.net.NetworkWritableLogChannelNetty4;
+import org.neo4j.coreedge.raft.replication.StringMarshal;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.CommandWriter;
+import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommand;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
+import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+
+public class ReplicatedTokenRequestSerializer
+{
+    public static void serialize( ReplicatedTokenRequest content, ByteBuf buffer )
+    {
+        buffer.writeInt( content.type().ordinal() );
+        StringMarshal.serialize( buffer, content.tokenName() );
+
+        buffer.writeInt( content.commandBytes().length );
+        buffer.writeBytes( content.commandBytes() );
+    }
+
+    public static ReplicatedTokenRequest deserialize( ByteBuf buffer )
+    {
+        TokenType type = TokenType.values()[buffer.readInt()];
+        String tokenName = StringMarshal.deserialize( buffer );
+
+        int commandBytesLength = buffer.readInt();
+        byte[] commandBytes = new  byte[commandBytesLength];
+        buffer.readBytes( commandBytes, 0, commandBytesLength );
+
+        return new ReplicatedTokenRequest( type, tokenName, commandBytes );
+    }
+
+    public static byte[] createCommandBytes( Collection<Command> commands )
+    {
+        ByteBuf commandBuffer = Unpooled.buffer();
+        NetworkWritableLogChannelNetty4 channel = new NetworkWritableLogChannelNetty4( commandBuffer );
+
+        try
+        {
+            new LogEntryWriter( channel, new CommandWriter( channel ) ).serialize( commands );
+        }
+        catch ( IOException e )
+        {
+            e.printStackTrace(); // TODO: Handle or throw.
+        }
+
+        byte[] commandsBytes = commandBuffer.array().clone();
+        commandBuffer.release();
+
+        return commandsBytes;
+    }
+
+    public static Collection<Command> extractCommands( byte[] commandBytes )
+    {
+        ByteBuf txBuffer = Unpooled.wrappedBuffer( commandBytes );
+        NetworkReadableLogChannelNetty4 channel = new NetworkReadableLogChannelNetty4( txBuffer );
+
+        LogEntryReader<ReadableLogChannel> reader = new VersionAwareLogEntryReader<>();
+
+        LogEntryCommand entryRead;
+        List<Command> commands = new LinkedList<>();
+
+        try
+        {
+            while ( (entryRead = (LogEntryCommand) reader.readLogEntry( channel )) != null )
+            {
+                commands.add( entryRead.getXaCommand() );
+            }
+        }
+        catch ( IOException e )
+        {
+            e.printStackTrace(); // TODO: Handle or throw.
+        }
+
+        return commands;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/TokenFutures.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/TokenFutures.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.token;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class TokenFutures
+{
+    private final ReadWriteLock waitListLock = new ReentrantReadWriteLock();
+    private final Map<String, ArrayList<CompletableFuture<Integer>>> waitLists = new HashMap<>();
+
+    // TODO: Consider returning a context for more efficiently disposing the future.
+    public CompletableFutureTokenId createFuture( final String key )
+    {
+        CompletableFutureTokenId completableFutureTokenId = new CompletableFutureTokenId()
+        {
+            @Override
+            public void close() throws Exception
+            {
+                disposeFuture( key, this );
+            }
+        };
+
+        waitListLock.writeLock().lock();
+        try
+        {
+            ArrayList<CompletableFuture<Integer>> waitList = waitLists.get( key );
+            if ( waitList == null )
+            {
+                waitList = new ArrayList<>();
+                waitLists.put( key, waitList );
+            }
+
+            waitList.add( completableFutureTokenId );
+        }
+        finally
+        {
+            waitListLock.writeLock().unlock();
+        }
+
+        return completableFutureTokenId;
+    }
+
+    private void disposeFuture( String key, Future<Integer> future )
+    {
+        waitListLock.writeLock().lock();
+        try
+        {
+            ArrayList<CompletableFuture<Integer>> waitList = waitLists.get( key );
+
+            ListIterator<CompletableFuture<Integer>> waitListIterator = waitList.listIterator();
+            while ( waitListIterator.hasNext() )
+            {
+                if ( waitListIterator.next() == future )
+                {
+                    waitListIterator.remove();
+                    if ( waitList.size() == 0 )
+                    {
+                        waitLists.remove( key );
+                    }
+                    return;
+                }
+            }
+
+            throw new IllegalStateException( "Future to dispose was not found." );
+        }
+        finally
+        {
+            waitListLock.writeLock().unlock();
+        }
+    }
+
+    public void complete( String key, Integer result )
+    {
+        waitListLock.readLock().lock();
+        try
+        {
+            ArrayList<CompletableFuture<Integer>> waitList = waitLists.get( key );
+            if ( waitList == null )
+            {
+                return;
+            }
+            for ( CompletableFuture<Integer> future : waitList )
+            {
+                future.complete( result );
+            }
+        }
+        finally
+        {
+            waitListLock.readLock().unlock();
+        }
+    }
+
+    public abstract static class CompletableFutureTokenId extends CompletableFuture<Integer> implements FutureTokenId
+    {
+    }
+
+    public interface FutureTokenId extends java.lang.AutoCloseable, Future<Integer>
+    {
+    }
+
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/TokenType.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/TokenType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.token;
+
+public enum TokenType
+{
+    PROPERTY,
+    RELATIONSHIP,
+    LABEL
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/NeoStoreTransactionCounter.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/NeoStoreTransactionCounter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import org.neo4j.kernel.impl.store.NeoStores;
+
+public class NeoStoreTransactionCounter implements TransactionCounter
+{
+    private final NeoStores neoStore;
+
+    public NeoStoreTransactionCounter( NeoStores neoStore )
+    {
+        this.neoStore = neoStore;
+    }
+
+    @Override
+    public long lastCommittedTransactionId()
+    {
+        throw new IllegalArgumentException(  );
+    }
+
+//    @Override
+//    public long lastCommittedTransactionId()
+//    {
+//        return neoStore.getLastCommittedTransactionId();
+//    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplayableCommitProcess.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplayableCommitProcess.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+
+/**
+ * Counts transactions, and only applies new transactions once it has already seen enough transactions to reproduce
+ * the current state of the store.
+ */
+public class ReplayableCommitProcess implements TransactionCommitProcess
+{
+    private final AtomicLong lastLocalTxId = new AtomicLong( 1 );
+    private final TransactionCommitProcess localCommitProcess;
+    private final TransactionCounter transactionCounter;
+
+    public ReplayableCommitProcess( TransactionCommitProcess localCommitProcess, TransactionCounter transactionCounter )
+    {
+        this.localCommitProcess = localCommitProcess;
+        this.transactionCounter = transactionCounter;
+    }
+
+    @Override
+    public long commit( TransactionRepresentation representation, LockGroup locks,
+                        CommitEvent commitEvent,
+                        TransactionApplicationMode mode ) throws TransactionFailureException
+    {
+        long txId = lastLocalTxId.incrementAndGet();
+        if ( txId > transactionCounter.lastCommittedTransactionId() )
+        {
+            return localCommitProcess.commit( representation, locks, commitEvent, mode );
+        }
+        return txId;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransaction.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransaction.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.util.Objects;
+
+import org.neo4j.coreedge.raft.replication.session.GlobalSession;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+import static java.lang.String.format;
+
+public class ReplicatedTransaction implements ReplicatedContent
+{
+    private final byte[] txBytes;
+    private final GlobalSession globalSession;
+    private final LocalOperationId localOperationId;
+
+    public ReplicatedTransaction( byte[] txBytes, GlobalSession globalSession, LocalOperationId localOperationId )
+    {
+        this.txBytes = txBytes;
+        this.globalSession = globalSession;
+        this.localOperationId = localOperationId;
+    }
+
+    public byte[] getTxBytes()
+    {
+        return txBytes;
+    }
+
+    public GlobalSession globalSession()
+    {
+        return globalSession;
+    }
+
+    public LocalOperationId localOperationId()
+    {
+        return localOperationId;
+    }
+
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        ReplicatedTransaction that = (ReplicatedTransaction) o;
+        return Objects.equals( globalSession, that.globalSession ) &&
+                Objects.equals( localOperationId, that.localOperationId );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( globalSession, localOperationId );
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "ReplicatedTransaction{globalSession=%s, localOperationId=%s}", globalSession, localOperationId );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionCommitProcess.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionCommitProcess.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.coreedge.raft.replication.session.LocalSessionPool;
+import org.neo4j.coreedge.raft.replication.session.OperationContext;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.coreedge.raft.replication.Replicator.ReplicationFailedException;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static org.neo4j.coreedge.raft.replication.tx.ReplicatedTransactionFactory.createImmutableReplicatedTransaction;
+
+public class ReplicatedTransactionCommitProcess extends LifecycleAdapter implements TransactionCommitProcess
+{
+    private final Replicator replicator;
+    private ReplicatedTransactionStateMachine replicatedTxListener;
+    private final LocalSessionPool sessionPool;
+
+    public ReplicatedTransactionCommitProcess( Replicator replicator,
+                                               LocalSessionPool sessionPool,
+                                               ReplicatedTransactionStateMachine replicatedTxListener )
+    {
+        this.sessionPool = sessionPool;
+        this.replicatedTxListener = replicatedTxListener;
+        this.replicator = replicator;
+        replicator.subscribe( this.replicatedTxListener );
+    }
+
+    @Override
+    public long commit( final TransactionRepresentation tx, final LockGroup locks,
+                        final CommitEvent commitEvent,
+                        TransactionApplicationMode mode ) throws TransactionFailureException
+    {
+        OperationContext operationContext = sessionPool.acquireSession();
+
+        ReplicatedTransaction transaction;
+        try
+        {
+            transaction = createImmutableReplicatedTransaction( tx, operationContext.globalSession(), operationContext.localOperationId() );
+        }
+        catch ( IOException e )
+        {
+            throw new TransactionFailureException( "Could not create immutable object for replication", e );
+        }
+
+        while ( true )
+        {
+            final Future<Long> futureTxId = replicatedTxListener.getFutureTxId( operationContext.localOperationId() );
+            try
+            {
+                replicator.replicate( transaction );
+
+                Long txId = futureTxId.get( 60, TimeUnit.SECONDS );
+                sessionPool.releaseSession( operationContext );
+
+                return txId;
+            }
+            catch ( InterruptedException | TimeoutException  e )
+            {
+                futureTxId.cancel( false );
+            }
+            catch ( ReplicationFailedException | ExecutionException e )
+            {
+                throw new TransactionFailureException( "Failed to commit transaction", e );
+            }
+            System.out.println( "Retrying replication" );
+        }
+
+    }
+
+    @Override
+    public void stop()
+    {
+        replicator.unsubscribe( replicatedTxListener );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionFactory.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import org.neo4j.coreedge.raft.replication.session.GlobalSession;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.coreedge.raft.net.NetworkReadableLogChannelNetty4;
+import org.neo4j.coreedge.raft.net.NetworkWritableLogChannelNetty4;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.CommandWriter;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommand;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
+import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+
+public class ReplicatedTransactionFactory
+{
+    public static ReplicatedTransaction createImmutableReplicatedTransaction( TransactionRepresentation tx, GlobalSession globalSession, LocalOperationId localOperationId ) throws IOException
+    {
+        ByteBuf transactionBuffer = Unpooled.buffer();
+
+        NetworkWritableLogChannelNetty4 channel = new NetworkWritableLogChannelNetty4( transactionBuffer );
+        ReplicatedTransactionFactory.TransactionSerializer.write( tx, channel );
+
+        byte[] txBytes = transactionBuffer.array().clone();
+        transactionBuffer.release();
+
+        return new ReplicatedTransaction( txBytes, globalSession, localOperationId );
+    }
+
+    public static TransactionRepresentation extractTransactionRepresentation( ReplicatedTransaction replicatedTransaction ) throws IOException
+    {
+        ByteBuf txBuffer = Unpooled.wrappedBuffer( replicatedTransaction.getTxBytes() );
+        NetworkReadableLogChannelNetty4 channel = new NetworkReadableLogChannelNetty4( txBuffer );
+
+        return TransactionDeserializer.read( channel );
+    }
+
+    public static class TransactionSerializer
+    {
+        public static void write( TransactionRepresentation tx, NetworkWritableLogChannelNetty4 channel ) throws
+                IOException
+        {
+            channel.putInt( tx.getAuthorId() );
+            channel.putInt( tx.getMasterId() );
+            channel.putLong( tx.getLatestCommittedTxWhenStarted() );
+            channel.putLong( tx.getTimeStarted() );
+            channel.putLong( tx.getTimeCommitted() );
+            channel.putInt( tx.getLockSessionId() );
+
+            byte[] additionalHeader = tx.additionalHeader();
+            if ( additionalHeader != null )
+            {
+                channel.putInt( additionalHeader.length );
+                channel.put( additionalHeader, additionalHeader.length );
+            }
+            else
+            {
+                channel.putInt( 0 );
+            }
+
+            new LogEntryWriter( channel, new CommandWriter( channel ) ).serialize( tx );
+        }
+    }
+
+    public static class TransactionDeserializer
+    {
+        public static TransactionRepresentation read( NetworkReadableLogChannelNetty4 channel ) throws IOException
+        {
+            LogEntryReader<ReadableLogChannel> reader = new VersionAwareLogEntryReader<>();
+
+            int authorId = channel.getInt();
+            int masterId = channel.getInt();
+            long latestCommittedTxWhenStarted = channel.getLong();
+            long timeStarted = channel.getLong();
+            long timeCommitted = channel.getLong();
+            int lockSessionId = channel.getInt();
+
+            int headerLength = channel.getInt();
+            byte[] header = new byte[headerLength];
+
+            channel.get( header, headerLength );
+
+            if ( headerLength == 0 )
+            {
+                header = null;
+            }
+
+            LogEntryCommand entryRead;
+            List<Command> commands = new LinkedList<>();
+
+            while ( (entryRead = (LogEntryCommand) reader.readLogEntry( channel )) != null )
+            {
+                commands.add( entryRead.getXaCommand() );
+            }
+
+            PhysicalTransactionRepresentation tx = new PhysicalTransactionRepresentation( commands );
+            tx.setHeader( header, masterId, authorId, timeStarted, latestCommittedTxWhenStarted, timeCommitted, lockSessionId );
+
+            return tx;
+        }
+    }
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionSerializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionSerializer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.util.UUID;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.raft.membership.CoreMemberMarshal;
+import org.neo4j.coreedge.raft.replication.MarshallingException;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.replication.session.GlobalSession;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransaction;
+
+public class ReplicatedTransactionSerializer
+{
+    public static void serialize( ReplicatedTransaction transaction, ByteBuf buffer ) throws MarshallingException
+    {
+        UUID globalSessionId = transaction.globalSession().sessionId();
+        buffer.writeLong( globalSessionId.getMostSignificantBits() );
+        buffer.writeLong( globalSessionId.getLeastSignificantBits() );
+
+        CoreMemberMarshal.serialize( transaction.globalSession().owner(), buffer );
+
+        buffer.writeLong( transaction.localOperationId().localSessionId() );
+        buffer.writeLong( transaction.localOperationId().sequenceNumber() );
+
+        byte[] txBytes = transaction.getTxBytes();
+        buffer.writeInt( txBytes.length );
+        buffer.writeBytes( txBytes );
+    }
+
+    public static ReplicatedTransaction deserialize( ByteBuf buffer ) throws MarshallingException
+    {
+        long uuidMSB = buffer.readLong();
+        long uuidLSB = buffer.readLong();
+        UUID globalSessionId = new UUID( uuidMSB, uuidLSB );
+
+        CoreMember owner = CoreMemberMarshal.deserialize( buffer );
+
+        long localSessionId = buffer.readLong();
+        long sequenceNumber = buffer.readLong();
+
+        int txBytesLength = buffer.readInt();
+        byte[] txBytes = new  byte[txBytesLength];
+        buffer.readBytes( txBytes, 0, txBytesLength );
+
+        return new ReplicatedTransaction( txBytes, new GlobalSession( globalSessionId, owner ), new LocalOperationId( localSessionId, sequenceNumber ) );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachine.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+
+import org.neo4j.concurrent.CompletableFuture;
+import org.neo4j.coreedge.raft.locks.CoreServiceAssignment;
+import org.neo4j.coreedge.raft.replication.session.GlobalSession;
+import org.neo4j.coreedge.raft.replication.session.GlobalSessionTracker;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.graphdb.TransientTransactionFailureException;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+
+public class ReplicatedTransactionStateMachine implements Replicator.ReplicatedContentListener
+{
+    private final TransactionCommitProcess localCommitProcess;
+    private final GlobalSessionTracker sessionTracker;
+    private final GlobalSession myGlobalSession;
+
+    private final Map<LocalOperationId, FutureTxId> outstanding = new ConcurrentHashMap<>();
+    private long lastCommittedTxId; // Maintains the last committed tx id, used to set the next field
+    private long lastTxIdForPreviousAssignment; // Maintains the last txid committed under the previous service assignment
+
+    public ReplicatedTransactionStateMachine( TransactionCommitProcess localCommitProcess, GlobalSessionTracker
+            sessionTracker, GlobalSession myGlobalSession )
+    {
+        this.localCommitProcess = localCommitProcess;
+        this.sessionTracker = sessionTracker;
+        this.myGlobalSession = myGlobalSession;
+    }
+
+    public Future<Long> getFutureTxId( LocalOperationId localOperationId )
+    {
+        final FutureTxId future = new FutureTxId( localOperationId );
+        outstanding.put( localOperationId, future );
+        return future;
+    }
+
+    @Override
+    public void onReplicated( ReplicatedContent content )
+    {
+        if ( content instanceof ReplicatedTransaction )
+        {
+            handleTransaction( (ReplicatedTransaction) content );
+        }
+        else if ( content instanceof CoreServiceAssignment )
+        {
+            // This essentially signifies a leader switch. We should properly name the content class
+            lastTxIdForPreviousAssignment = lastCommittedTxId;
+        }
+    }
+
+    private void handleTransaction( ReplicatedTransaction replicatedTransaction )
+    {
+        try
+        {
+            synchronized ( this )
+            {
+
+                if ( sessionTracker.validateAndTrackOperation( replicatedTransaction.globalSession(),
+                        replicatedTransaction.localOperationId() ) )
+                {
+                    TransactionRepresentation tx = ReplicatedTransactionFactory.extractTransactionRepresentation(
+                            replicatedTransaction );
+                    boolean shouldReject = false;
+                    if ( tx.getLatestCommittedTxWhenStarted() < lastTxIdForPreviousAssignment )
+                    {
+                        // This means the transaction started before the last transaction for the previous term. Reject.
+                        shouldReject = true;
+                    }
+
+                    long txId = -1;
+                    if ( !shouldReject )
+                    {
+                        try ( LockGroup lockGroup = new LockGroup() )
+                        {
+                            txId = localCommitProcess.commit( tx, lockGroup, CommitEvent.NULL,
+                                    TransactionApplicationMode.EXTERNAL );
+                            lastCommittedTxId = txId;
+                        }
+                    }
+
+                    if ( replicatedTransaction.globalSession().equals( myGlobalSession ) )
+                    {
+                        CompletableFuture<Long> future = outstanding.remove( replicatedTransaction.localOperationId() );
+                        if ( future != null )
+                        {
+                            if ( shouldReject )
+                            {
+                                future.completeExceptionally( new TransientTransactionFailureException(
+                                        "Attempt to commit transaction that was started on a different leader term. " +
+                                                "Please retry the transaction." ) );
+                            }
+                            else
+                            {
+                                future.complete( txId );
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+        catch ( TransactionFailureException | IOException e )
+        {
+            throw new IllegalStateException( "Failed to locally commit a transaction that has already been " +
+                    "committed to the RAFT log. This server cannot process later transactions and needs to be " +
+                    "restarted once the underlying cause has been addressed.", e );
+        }
+    }
+
+    private class FutureTxId extends CompletableFuture<Long>
+    {
+        private final LocalOperationId localOperationId;
+
+        FutureTxId( LocalOperationId localOperationId )
+        {
+            this.localOperationId = localOperationId;
+        }
+
+        @Override
+        public boolean cancel( boolean mayInterruptIfRunning )
+        {
+            if ( !super.cancel( mayInterruptIfRunning ) )
+            {
+                return false;
+            }
+            outstanding.remove( localOperationId );
+            return true;
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/TransactionCounter.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/TransactionCounter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+public interface TransactionCounter
+{
+    long lastCommittedTransactionId();
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.outcome.ShipCommand;
+import org.neo4j.coreedge.raft.RaftMessageHandler;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.RaftMessages.AppendEntries;
+import org.neo4j.coreedge.raft.RaftMessages.AppendEntries.Response;
+import org.neo4j.coreedge.raft.RaftMessages.Heartbeat;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.BatchAppendLogEntries;
+import org.neo4j.coreedge.raft.outcome.CommitCommand;
+import org.neo4j.coreedge.raft.outcome.LogCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.outcome.TruncateLogCommand;
+import org.neo4j.coreedge.raft.state.FollowerStates;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+import org.neo4j.logging.Log;
+
+import static java.lang.Long.min;
+import static org.neo4j.coreedge.raft.Ballot.shouldVoteFor;
+import static org.neo4j.coreedge.raft.roles.Role.CANDIDATE;
+import static org.neo4j.coreedge.raft.roles.Role.FOLLOWER;
+
+public class Follower implements RaftMessageHandler
+{
+    private static <MEMBER> boolean logHistoryMatches( ReadableRaftState<MEMBER> ctx, AppendEntries
+            .Request<MEMBER> req ) throws RaftStorageException
+    {
+        // note that the entry term for a non existing log index is defined as -1.
+        // Therefore, the history for a non existing log entry never matches.
+        return req.prevLogIndex() == -1 || ctx.entryLog().readEntryTerm( req.prevLogIndex() ) == req.prevLogTerm();
+    }
+
+    private static <MEMBER> boolean logHistoryMatches( ReadableRaftState<MEMBER> ctx, Heartbeat<MEMBER> req )
+            throws RaftStorageException
+    {
+        return req.commitIndex() == -1 || ctx.entryLog().readEntryTerm( req.commitIndex() ) == req.commitIndexTerm();
+    }
+
+    private static <MEMBER> boolean generateCommitIfNecessary( ReadableRaftState<MEMBER> ctx, AppendEntries
+            .Request<MEMBER> req, List<LogCommand> commands )
+    {
+        long localCommit = ctx.entryLog().commitIndex();
+        long newCommitIndex = min( req.leaderCommit(), req.prevLogIndex() + req.entries().length );
+        if ( newCommitIndex > localCommit )
+        {
+            commands.add( new CommitCommand( newCommitIndex ) );
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public <MEMBER> Outcome<MEMBER> handle( RaftMessages.Message<MEMBER> message, ReadableRaftState<MEMBER> ctx, Log log )
+            throws RaftStorageException
+    {
+        Role nextRole = FOLLOWER;
+        MEMBER leader = ctx.leader();
+        long leaderCommit = ctx.leaderCommit();
+        Collection<RaftMessages.Directed<MEMBER>> outgoingMessages = new ArrayList<>();
+        List<LogCommand> logCommands = new ArrayList<>();
+        ArrayList<ShipCommand> shipCommands = new ArrayList<>();
+        MEMBER votedFor = ctx.votedFor();
+        long newTerm = ctx.term();
+        boolean renewElectionTimeout = false;
+
+        switch ( message.type() )
+        {
+            case HEARTBEAT:
+            {
+                Heartbeat<MEMBER> req = (Heartbeat<MEMBER>) message;
+
+                if ( req.leaderTerm() < ctx.term() )
+                {
+                    break;
+                }
+
+                if ( logHistoryMatches( ctx, req ) )
+                {
+                    logCommands.add( new CommitCommand( req.commitIndex() ) );
+                }
+
+                renewElectionTimeout = true;
+                break;
+            }
+
+            case APPEND_ENTRIES_REQUEST:
+            {
+                AppendEntries.Request<MEMBER> req = (AppendEntries.Request<MEMBER>) message;
+
+                if ( req.leaderTerm() < ctx.term() )
+                {
+                    Response<MEMBER> appendResponse =
+                            new Response<>( ctx.myself(), ctx.term(), false, req.prevLogIndex() );
+                    outgoingMessages.add( new RaftMessages.Directed<>( req.from(), appendResponse ) );
+                    break;
+                }
+
+                renewElectionTimeout = true;
+                newTerm = req.leaderTerm();
+                leader = req.from();
+                leaderCommit = req.leaderCommit();
+
+                if ( !logHistoryMatches( ctx, req ) )
+                {
+                    assert req.prevLogIndex() > -1 && req.prevLogTerm() > -1;
+                    Response<MEMBER> appendResponse = new Response<>( ctx.myself(), newTerm, false, -1 );
+                    outgoingMessages.add( new RaftMessages.Directed<>( req.from(), appendResponse ) );
+                    break;
+                }
+
+                long baseIndex = req.prevLogIndex() + 1;
+                int offset;
+
+                /* Find possible truncation point. */
+                for ( offset = 0; offset < req.entries().length; offset++ )
+                {
+                    long logTerm = ctx.entryLog().readEntryTerm( baseIndex + offset );
+
+                    if( baseIndex + offset > ctx.entryLog().appendIndex() )
+                    {
+                        /* entry doesn't exist */
+                        break;
+                    }
+                    else if ( logTerm != req.entries()[offset].term() )
+                    {
+                        logCommands.add( new TruncateLogCommand( baseIndex + offset ) );
+                        break;
+                    }
+                }
+
+                if( offset < req.entries().length )
+                {
+                    logCommands.add( new BatchAppendLogEntries( baseIndex, offset, req.entries() ) );
+                }
+                generateCommitIfNecessary( ctx, req, logCommands );
+
+                long endMatchIndex = req.prevLogIndex() + req.entries().length; // this is the index of the last incoming entry
+                if ( endMatchIndex >= 0 )
+                {
+                    Response<MEMBER> appendResponse = new Response<>( ctx.myself(), newTerm, true, endMatchIndex );
+                    outgoingMessages.add( new RaftMessages.Directed<>( req.from(), appendResponse ) );
+                }
+                break;
+            }
+
+            case VOTE_REQUEST:
+            {
+                RaftMessages.Vote.Request<MEMBER> req = (RaftMessages.Vote.Request<MEMBER>) message;
+
+                if ( req.term() > ctx.term() )
+                {
+                    newTerm = req.term();
+                    votedFor = null;
+                }
+
+                boolean willVoteForCandidate = shouldVoteFor( req.candidate(), req.term(), newTerm, ctx
+                                .entryLog().appendIndex(),
+                        req.lastLogIndex(), ctx.entryLog().readEntryTerm( ctx.entryLog().appendIndex() ),
+                        req.lastLogTerm(), votedFor );
+
+                if ( willVoteForCandidate )
+                {
+                    votedFor = req.from();
+                    renewElectionTimeout = true;
+                }
+
+                outgoingMessages.add( new RaftMessages.Directed<>( req.from(), new RaftMessages.Vote.Response<>(
+                        ctx.myself(), newTerm,
+                        willVoteForCandidate ) ) );
+                break;
+            }
+
+            case ELECTION_TIMEOUT:
+            {
+                Set<MEMBER> currentMembers = ctx.votingMembers();
+                if ( currentMembers == null || !currentMembers.contains( ctx.myself() ) )
+                {
+                    break;
+                }
+
+                newTerm++;
+
+                RaftMessages.Vote.Request<MEMBER> voteForMe =
+                        new RaftMessages.Vote.Request<>( ctx.myself(), newTerm, ctx.myself(), ctx.entryLog()
+                                .appendIndex(), ctx.entryLog().readEntryTerm( ctx.entryLog().appendIndex() ) );
+
+                for ( MEMBER member : currentMembers )
+                {
+                    if ( !member.equals( ctx.myself() ) )
+                    {
+                        outgoingMessages.add( new RaftMessages.Directed<>( member, voteForMe ) );
+                    }
+                }
+
+                votedFor = ctx.myself();
+                nextRole = CANDIDATE;
+                break;
+            }
+        }
+
+        return new Outcome<>( nextRole, newTerm, leader, leaderCommit, votedFor, Collections.<MEMBER>emptySet(), -1,
+                new FollowerStates<>(), renewElectionTimeout, logCommands, outgoingMessages, shipCommands );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Leader.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Leader.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.neo4j.coreedge.raft.outcome.ShipCommand;
+import org.neo4j.coreedge.raft.Followers;
+import org.neo4j.coreedge.raft.RaftMessageHandler;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.RaftMessages.Heartbeat;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.AppendLogEntry;
+import org.neo4j.coreedge.raft.outcome.CommitCommand;
+import org.neo4j.coreedge.raft.outcome.LogCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.FollowerState;
+import org.neo4j.coreedge.raft.state.FollowerStates;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.function.Predicate;
+import org.neo4j.helpers.collection.FilteringIterable;
+import org.neo4j.logging.Log;
+
+import static java.lang.Math.max;
+
+import static org.neo4j.coreedge.raft.roles.Role.FOLLOWER;
+import static org.neo4j.coreedge.raft.roles.Role.LEADER;
+
+public class Leader implements RaftMessageHandler
+{
+    public static <MEMBER> Iterable<MEMBER> replicationTargets( final ReadableRaftState<MEMBER> ctx )
+    {
+        return new FilteringIterable<>( ctx.replicationMembers(), (Predicate<MEMBER>) member -> !member.equals( ctx.myself() ) );
+    }
+
+    static <MEMBER> void sendHeartbeats( ReadableRaftState<MEMBER> ctx, Collection<RaftMessages.Directed<MEMBER>>
+            outgoingMessages ) throws RaftStorageException
+    {
+        for ( MEMBER to : replicationTargets( ctx ) )
+        {
+            long commitIndex = ctx.leaderCommit();
+            long commitIndexTerm = ctx.entryLog().readEntryTerm( commitIndex );
+            Heartbeat<MEMBER> heartbeat = new Heartbeat<>( ctx.myself(), ctx.term(), commitIndex, commitIndexTerm );
+            outgoingMessages.add( new RaftMessages.Directed<>( to, heartbeat ) );
+        }
+    }
+
+    @Override
+    public <MEMBER> Outcome<MEMBER> handle( RaftMessages.Message<MEMBER> message,
+                                            ReadableRaftState<MEMBER> ctx, Log log ) throws RaftStorageException
+    {
+        Role nextRole = LEADER;
+        long leaderCommit = ctx.entryLog().commitIndex();
+        Collection<RaftMessages.Directed<MEMBER>> outgoingMessages = new ArrayList<>();
+        ArrayList<LogCommand> logCommands = new ArrayList<>();
+        ArrayList<ShipCommand> shipCommands = new ArrayList<>();
+        long newTerm = ctx.term();
+        FollowerStates<MEMBER> updatedFollowerStates = ctx.followerStates();
+
+        switch ( message.type() )
+        {
+            case HEARTBEAT:
+            {
+                Heartbeat<MEMBER> req = (Heartbeat<MEMBER>) message;
+
+                if ( req.leaderTerm() < ctx.term() )
+                {
+                    break;
+                }
+
+                nextRole = FOLLOWER;
+                outgoingMessages.add( new RaftMessages.Directed<>( ctx.myself(), message ) );
+                break;
+            }
+
+            case HEARTBEAT_TIMEOUT:
+            {
+                sendHeartbeats( ctx, outgoingMessages );
+                break;
+            }
+
+            case APPEND_ENTRIES_REQUEST:
+            {
+                RaftMessages.AppendEntries.Request<MEMBER> req = (RaftMessages.AppendEntries.Request<MEMBER>) message;
+
+                if ( req.leaderTerm() < ctx.term() )
+                {
+                    RaftMessages.AppendEntries.Response<MEMBER> appendResponse =
+                            new RaftMessages.AppendEntries.Response<>( ctx.myself(), ctx.term(), false, req.prevLogIndex() );
+
+                    outgoingMessages.add( new RaftMessages.Directed<>( req.from(), appendResponse ) );
+                    break;
+                }
+                else if ( req.leaderTerm() == ctx.term() )
+                {
+                    throw new IllegalStateException( "Two leaders in the same term." );
+                }
+                else
+                {
+                    // There is a new leader in a later term, we should revert to follower. (§5.1)
+                    nextRole = FOLLOWER;
+                    outgoingMessages.add( new RaftMessages.Directed<>( ctx.myself(), message ) );
+                    break;
+                }
+            }
+
+            case APPEND_ENTRIES_RESPONSE:
+            {
+                RaftMessages.AppendEntries.Response<MEMBER> res = (RaftMessages.AppendEntries.Response<MEMBER>) message;
+
+                if ( res.term() < ctx.term() )
+                {
+                    /* Ignore responses from old terms! */
+                    break;
+                }
+                else if ( res.term() > ctx.term() )
+                {
+                    newTerm = res.term();
+                    nextRole = FOLLOWER;
+                    updatedFollowerStates = new FollowerStates<>();
+                    break;
+                }
+
+                FollowerState follower = ctx.followerStates().get( res.from() );
+
+                if ( res.success() )
+                {
+                    assert res.matchIndex() <= ctx.entryLog().appendIndex();
+
+                    boolean followerProgressed = res.matchIndex() > follower.getMatchIndex();
+
+                    updatedFollowerStates = updatedFollowerStates.onSuccessResponse( res.from(),
+                            max( res.matchIndex(), follower.getMatchIndex() ) );
+
+                    shipCommands.add( new ShipCommand.Match( res.matchIndex(), res.from() ) );
+
+                    /*
+                     * Matches from older terms can in complicated leadership change / log truncation scenarios
+                     * be overwritten, even if they were replicated to a majority of instances. Thus we must only
+                     * consider matches from this leader's term when figuring out which have been safely replicated
+                     * and are ready for commit.
+                     * This is explained nicely in Figure 3.7 of the thesis
+                     */
+                    boolean matchInCurrentTerm = ctx.entryLog().readEntryTerm( res.matchIndex() ) == ctx.term();
+
+                    /*
+                     * The quorum situation may have changed only if the follower actually progressed.
+                     */
+                    if ( followerProgressed && matchInCurrentTerm )
+                    {
+                        // TODO: Test that mismatch between voting and participating members affects commit outcome
+
+                        long quorumAppendIndex = Followers.quorumAppendIndex( ctx.votingMembers(), updatedFollowerStates );
+                        if ( quorumAppendIndex > ctx.entryLog().commitIndex() )
+                        {
+                            leaderCommit = quorumAppendIndex;
+
+                            logCommands.add( new CommitCommand( quorumAppendIndex ) );
+                            shipCommands.add( new ShipCommand.CommitUpdate() );
+                        }
+                    }
+                }
+                else // Response indicated failure. Must go back a log entry and retry - this is where catchup happens
+                {
+                    shipCommands.add ( new ShipCommand.Mismatch( ctx.entryLog().appendIndex(), res.from() ) ); // TODO: Fix remote last appended parameter.
+                }
+
+                break;
+            }
+
+            case VOTE_REQUEST:
+            {
+                RaftMessages.Vote.Request<MEMBER> req = (RaftMessages.Vote.Request<MEMBER>) message;
+
+                if ( req.term() > ctx.term() )
+                {
+                    newTerm = req.term();
+
+                    nextRole = FOLLOWER;
+                    outgoingMessages.add( new RaftMessages.Directed<>( ctx.myself(), req ) );
+                    break;
+                }
+
+                outgoingMessages.add( new RaftMessages.Directed<>( req.from(), new RaftMessages.Vote.Response<>( ctx.myself(), ctx.term(), false ) ) );
+                break;
+            }
+
+            case NEW_ENTRY_REQUEST:
+            {
+                RaftMessages.NewEntry.Request<MEMBER> req = (RaftMessages.NewEntry.Request<MEMBER>) message;
+                ReplicatedContent content = req.content();
+
+                long prevLogIndex = ctx.entryLog().appendIndex();
+                long prevLogTerm = prevLogIndex == -1 ? -1 :
+                                        prevLogIndex > ctx.lastLogIndexBeforeWeBecameLeader() ?
+                                                ctx.term() :
+                                                ctx.entryLog().readLogEntry( prevLogIndex ).term();
+
+                RaftLogEntry newLogEntry = new RaftLogEntry( ctx.term(), content );
+
+                shipCommands.add( new ShipCommand.NewEntry( prevLogIndex, prevLogTerm, newLogEntry ) );
+                logCommands.add( new AppendLogEntry( prevLogIndex + 1, newLogEntry ) );
+                break;
+            }
+        }
+
+        return new Outcome<>( nextRole, newTerm, ctx.leader(), leaderCommit, null,
+                Collections.<MEMBER>emptySet(), ctx.lastLogIndexBeforeWeBecameLeader(), updatedFollowerStates, false,
+                logCommands, outgoingMessages, shipCommands );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Role.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Role.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import org.neo4j.coreedge.raft.RaftMessageHandler;
+
+public enum Role
+{
+    FOLLOWER( new Follower() ),
+    CANDIDATE( new Candidate() ),
+    LEADER( new Leader() );
+
+    public final RaftMessageHandler role;
+
+    Role( RaftMessageHandler role )
+    {
+        this.role = role;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/DurableTermStore.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/DurableTermStore.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
+
+public class DurableTermStore implements TermStore
+{
+    public static final int TERM_BYTES = 8;
+
+    private final StoreChannel channel;
+    private long term;
+
+    public DurableTermStore( FileSystemAbstraction fileSystem, File directory )
+    {
+        try
+        {
+            channel = fileSystem.open( new File( directory, "term.state" ), "rw" );
+            term = readTerm();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    public long currentTerm()
+    {
+        return term;
+    }
+
+    @Override
+    public void update( long newTerm ) throws RaftStorageException
+    {
+        if ( newTerm < term )
+        {
+            throw new IllegalArgumentException( "Cannot move to a lower term" );
+        }
+
+        try
+        {
+            ByteBuffer buffer = ByteBuffer.allocate( TERM_BYTES );
+            buffer.putLong( newTerm );
+            buffer.flip();
+
+            channel.write( buffer, 0 );
+            channel.force( false );
+        }
+        catch ( IOException e )
+        {
+            throw new RaftStorageException( "Failed to update term", e );
+        }
+        term = newTerm;
+    }
+
+    private long readTerm() throws IOException
+    {
+        if ( channel.size() < TERM_BYTES )
+        {
+            return 0;
+        }
+        ByteBuffer buffer = ByteBuffer.allocate( TERM_BYTES );
+        channel.read( buffer, 0 );
+        buffer.flip();
+        return buffer.getLong();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/DurableVoteStore.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/DurableVoteStore.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.membership.CoreMemberMarshal;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
+
+public class DurableVoteStore implements VoteStore<CoreMember>
+{
+    private final StoreChannel channel;
+    private CoreMember votedFor;
+
+    public DurableVoteStore( FileSystemAbstraction fileSystem, File directory )
+    {
+        try
+        {
+            channel = fileSystem.open( new File( directory, "vote.state" ), "rw" );
+            votedFor = readVote();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    public CoreMember votedFor()
+    {
+        return votedFor;
+    }
+
+    @Override
+    public void update( CoreMember votedFor ) throws RaftStorageException
+    {
+        try
+        {
+            if ( votedFor == null )
+            {
+                channel.truncate( 0 );
+            }
+            else
+            {
+                ByteBuf byteBuf = Unpooled.buffer();
+                CoreMemberMarshal.serialize( votedFor, byteBuf );
+                ByteBuffer buffer = byteBuf.nioBuffer();
+
+                channel.write( buffer, 0 );
+            }
+            channel.force( false );
+        }
+        catch ( IOException e )
+        {
+            throw new RaftStorageException( "Failed to update votedFor", e );
+        }
+        this.votedFor = votedFor;
+    }
+
+    private CoreMember readVote() throws IOException
+    {
+        if ( channel.size() == 0 )
+        {
+            return null;
+        }
+
+        ByteBuffer buffer = ByteBuffer.allocate( (int) channel.size() );
+        channel.read( buffer, 0 );
+        buffer.flip();
+
+        return CoreMemberMarshal.deserialize( Unpooled.wrappedBuffer( buffer ) );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/FollowerState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/FollowerState.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import static java.lang.String.format;
+
+/**
+ * Things the leader thinks it knows about a follower.
+ */
+public class FollowerState
+{
+    // We know that the follower agrees with our (leader) log up until this index. Only updated by the leader when:
+    // * increased when it receives a successful AppendEntries.Response
+    private final long matchIndex;
+
+    public FollowerState()
+    {
+        this( -1 );
+    }
+
+    private FollowerState( long matchIndex )
+    {
+        assert matchIndex >= -1 : format( "Match index can never be less than -1. Was %d", matchIndex );
+        this.matchIndex = matchIndex;
+    }
+
+    public long getMatchIndex()
+    {
+        return matchIndex;
+    }
+
+    public FollowerState onSuccessResponse( long newMatchIndex )
+    {
+        return new FollowerState( newMatchIndex );
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "State{matchIndex=%d}", matchIndex );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/FollowerStates.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/FollowerStates.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * This presents a read only view over the map of members to their states. Instances that are not present
+ * in the map will have the default FollowerState returned.
+ * @param <MEMBER> The type of member id
+ */
+public class FollowerStates<MEMBER>
+{
+    private final Map<MEMBER, FollowerState> states;
+
+    public FollowerStates( FollowerStates<MEMBER> original, MEMBER updatedMember, FollowerState updatedState )
+    {
+        this.states = new HashMap<>( original.states );
+        states.put( updatedMember, updatedState );
+    }
+
+    public FollowerStates()
+    {
+        states = new HashMap<>();
+    }
+
+    public FollowerState get( MEMBER member )
+    {
+        FollowerState result = states.get( member );
+        if ( result == null )
+        {
+            result = new FollowerState();
+        }
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "FollowerStates%s", states );
+    }
+
+    public int size()
+    {
+        return states.size();
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        FollowerStates that = (FollowerStates) o;
+
+        return !(states != null ? !states.equals( that.states ) : that.states != null);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return states != null ? states.hashCode() : 0;
+    }
+
+    public FollowerStates<MEMBER> onSuccessResponse( MEMBER member, long newMatchIndex )
+    {
+        return new FollowerStates<>( this, member, get( member ).onSuccessResponse( newMatchIndex ) );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/InMemoryTermStore.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/InMemoryTermStore.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+public class InMemoryTermStore implements TermStore
+{
+    private long term = 0;
+
+    @Override
+    public long currentTerm()
+    {
+        return term;
+    }
+
+    @Override
+    public void update( long newTerm )
+    {
+        if ( newTerm < term )
+        {
+            throw new IllegalArgumentException( "Cannot move to a lower term" );
+        }
+        term = newTerm;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/InMemoryVoteStore.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/InMemoryVoteStore.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+public class InMemoryVoteStore<MEMBER> implements VoteStore<MEMBER>
+{
+    MEMBER votedFor;
+
+    @Override
+    public MEMBER votedFor()
+    {
+        return votedFor;
+    }
+
+    @Override
+    public void update( MEMBER votedFor )
+    {
+        this.votedFor = votedFor;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/RaftState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/RaftState.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.membership.RaftMembership;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.outcome.LogCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+
+public class RaftState<MEMBER> implements ReadableRaftState<MEMBER>
+{
+    private final MEMBER myself;
+    private final RaftMembership<MEMBER> membership;
+    private final TermStore termStore;
+    private MEMBER leader;
+    private long leaderCommit = -1;
+    private final VoteStore<MEMBER> voteStore;
+    private Set<MEMBER> votesForMe = new HashSet<>();
+    private long lastLogIndexBeforeWeBecameLeader = -1;
+    private FollowerStates<MEMBER> followerStates = new FollowerStates<>();
+    private final RaftLog entryLog;
+
+    public RaftState( MEMBER myself, TermStore termStore, RaftMembership<MEMBER> membership,
+                      RaftLog entryLog, VoteStore<MEMBER> voteStore )
+    {
+        this.myself = myself;
+        this.termStore = termStore;
+        this.voteStore = voteStore;
+        this.membership = membership;
+        this.entryLog = entryLog;
+    }
+
+    @Override
+    public MEMBER myself()
+    {
+        return myself;
+    }
+
+    @Override
+    public Set<MEMBER> votingMembers()
+    {
+        return membership.votingMembers();
+    }
+
+    @Override
+    public Set<MEMBER> replicationMembers()
+    {
+        return membership.replicationMembers();
+    }
+
+    @Override
+    public long term()
+    {
+        return termStore.currentTerm();
+    }
+
+    @Override
+    public MEMBER leader()
+    {
+        return leader;
+    }
+
+    @Override
+    public long leaderCommit()
+    {
+        return leaderCommit;
+    }
+
+    @Override
+    public MEMBER votedFor()
+    {
+        return voteStore.votedFor();
+    }
+
+    @Override
+    public Set<MEMBER> votesForMe()
+    {
+        return votesForMe;
+    }
+
+    @Override
+    public long lastLogIndexBeforeWeBecameLeader()
+    {
+        return lastLogIndexBeforeWeBecameLeader;
+    }
+
+    @Override
+    public FollowerStates<MEMBER> followerStates()
+    {
+        return followerStates;
+    }
+
+    @Override
+    public ReadableRaftLog entryLog()
+    {
+        return entryLog;
+    }
+
+    public void update( Outcome<MEMBER> outcome ) throws RaftStorageException
+    {
+        termStore.update( outcome.newTerm );
+        voteStore.update( outcome.votedFor );
+        leader = outcome.leader;
+        leaderCommit = outcome.leaderCommit;
+        votesForMe = outcome.votesForMe;
+        lastLogIndexBeforeWeBecameLeader = outcome.lastLogIndexBeforeWeBecameLeader;
+        followerStates = outcome.followerStates;
+
+        for ( LogCommand logCommand : outcome.logCommands )
+        {
+            logCommand.applyTo( entryLog );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/ReadableRaftState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/ReadableRaftState.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+
+public interface ReadableRaftState<MEMBER>
+{
+    MEMBER myself();
+
+    Set<MEMBER> votingMembers();
+
+    Set<MEMBER> replicationMembers();
+
+    long term();
+
+    MEMBER leader();
+
+    long leaderCommit();
+
+    MEMBER votedFor();
+
+    Set<MEMBER> votesForMe();
+
+    long lastLogIndexBeforeWeBecameLeader();
+
+    FollowerStates<MEMBER> followerStates();
+
+    ReadableRaftLog entryLog();
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/TermStore.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/TermStore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+
+public interface TermStore
+{
+    long currentTerm();
+
+    void update( long newTerm ) throws RaftStorageException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/VoteStore.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/VoteStore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+
+public interface VoteStore<MEMBER>
+{
+    MEMBER votedFor();
+
+    void update( MEMBER votedFor ) throws RaftStorageException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/AdvertisedSocketAddress.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/AdvertisedSocketAddress.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.net.InetSocketAddress;
+import java.util.Objects;
+
+public class AdvertisedSocketAddress
+{
+    private final InetSocketAddress address;
+
+    public AdvertisedSocketAddress( InetSocketAddress address )
+    {
+        this.address = address;
+    }
+
+    public static AdvertisedSocketAddress address( String address )
+    {
+        String[] split = address.split( ":" );
+        return new AdvertisedSocketAddress( new InetSocketAddress( split[0], Integer.valueOf( split[1] ) ) );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        AdvertisedSocketAddress that = (AdvertisedSocketAddress) o;
+        return Objects.equals( address, that.address );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( address );
+    }
+
+    public String toString()
+    {
+        return address.getHostName() + ":" + address.getPort();
+    }
+
+    public InetSocketAddress socketAddress()
+    {
+        return address;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/AdvertisedSocketAddressDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/AdvertisedSocketAddressDecoder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.raft.replication.StringMarshal;
+
+public class AdvertisedSocketAddressDecoder
+{
+    public AdvertisedSocketAddress decode( ByteBuf buffer )
+    {
+        String host = StringMarshal.deserialize( buffer );
+        int port = buffer.readInt();
+
+        return AdvertisedSocketAddress.address( host + ":" + port );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/AdvertisedSocketAddressEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/AdvertisedSocketAddressEncoder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.net.InetSocketAddress;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.raft.replication.StringMarshal;
+
+public class AdvertisedSocketAddressEncoder
+{
+    public void encode( AdvertisedSocketAddress socketAddress, ByteBuf buffer )
+    {
+        InetSocketAddress inetSocketAddress = socketAddress.socketAddress();
+        StringMarshal.serialize( buffer, inetSocketAddress.getHostString() );
+        buffer.writeInt( inetSocketAddress.getPort() );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.ListenSocketAddress;
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.Description;
+import org.neo4j.helpers.Function;
+
+import static org.neo4j.helpers.Settings.BOOLEAN;
+import static org.neo4j.helpers.Settings.DURATION;
+import static org.neo4j.helpers.Settings.INTEGER;
+import static org.neo4j.helpers.Settings.MANDATORY;
+import static org.neo4j.helpers.Settings.TRUE;
+import static org.neo4j.helpers.Settings.list;
+import static org.neo4j.helpers.Settings.setting;
+
+@Description( "Settings for Core-Edge Clusters" )
+public class CoreEdgeClusterSettings
+{
+    public static final Function<String, ListenSocketAddress> LISTEN_SOCKET_ADDRESS = new Function<String, ListenSocketAddress>()
+    {
+        @Override
+        public ListenSocketAddress apply( String value )
+        {
+            String[] split = value.split( ":" );
+            return new ListenSocketAddress(new InetSocketAddress( split[0], Integer.valueOf( split[1] ) ));
+        }
+
+        @Override
+        public String toString()
+        {
+            return "a socket address";
+        }
+    };
+
+    public static final Function<String, AdvertisedSocketAddress> ADVERTISED_SOCKET_ADDRESS = new Function<String, AdvertisedSocketAddress>()
+    {
+        @Override
+        public AdvertisedSocketAddress apply( String value )
+        {
+            String[] split = value.split( ":" );
+            return new AdvertisedSocketAddress(new InetSocketAddress( split[0], Integer.valueOf( split[1] ) ));
+        }
+
+        @Override
+        public String toString()
+        {
+            return "a socket address";
+        }
+    };
+
+    @Description( "Time out for a new member to catch up" )
+    public static final Setting<Long> join_catch_up_timeout =
+            setting( "core_edge.join_catch_up_timeout", DURATION, "10m" );
+
+    @Description( "Leader election timeout" )
+    public static final Setting<Long> leader_election_timeout =
+            setting( "core_edge.leader_election_timeout", DURATION, "500ms" );
+
+    @Description( "Leader wait timeout" )
+    public static final Setting<Long> leader_wait_timeout =
+            setting( "core_edge.leader_wait_timeout", DURATION, "30s" );
+
+    @Description( "Expected size of core cluster" )
+    public static final Setting<Integer> expected_core_cluster_size =
+            setting( "core_edge.expected_core_cluster_size", INTEGER, "3" );
+
+    @Description( "Timeout for taking remote (write) locks on slaves. Defaults to ha.read_timeout." )
+    public static final Setting<Long> lock_read_timeout =
+            setting( "core_edge.lock_read_timeout", DURATION, "20s" );
+
+    @Description( "Network interface and port for the RAFT server to listen on." )
+    public static final Setting<ListenSocketAddress> transaction_listen_address =
+            setting( "core_edge.transaction_listen_address", LISTEN_SOCKET_ADDRESS, "0.0.0.0:6001" );
+
+    @Description( "Hostname/IP address and port that other RAFT servers can use to communicate with us." )
+    public static final Setting<AdvertisedSocketAddress> transaction_advertised_address =
+            setting( "core_edge.transaction_advertised_address", ADVERTISED_SOCKET_ADDRESS, "localhost:6001" );
+
+    @Description( "Network interface and port for the RAFT server to listen on." )
+    public static final Setting<ListenSocketAddress> raft_listen_address =
+            setting( "core_edge.raft_listen_address", LISTEN_SOCKET_ADDRESS, "0.0.0.0:7400" );
+
+    @Description( "Hostname/IP address and port that other RAFT servers can use to communicate with us." )
+    public static final Setting<AdvertisedSocketAddress> raft_advertised_address =
+            setting( "core_edge.raft_advertised_address", ADVERTISED_SOCKET_ADDRESS, "localhost:7400" );
+
+    @Description( "Host and port to bind the cluster management communication." )
+    public static final Setting<ListenSocketAddress> cluster_listen_address =
+            setting( "core_edge.cluster_listen_address", LISTEN_SOCKET_ADDRESS, "0.0.0.0:5001" );
+
+    @Description( "A comma-separated list of other members of the cluster to join." )
+    public static final Setting<List<AdvertisedSocketAddress>> initial_core_cluster_members =
+            setting( "core_edge.initial_core_cluster_members", list( ",", ADVERTISED_SOCKET_ADDRESS ), MANDATORY );
+
+    @Description( "Prevents the network middleware from dumping its own logs. Defaults to true." )
+    public static final Setting<Boolean> disable_middleware_logging =
+            setting( "core_edge.disable_middleware_logging", BOOLEAN, TRUE );
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreMember.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreMember.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class CoreMember
+{
+    private final AdvertisedSocketAddress coreAddress;
+    private final AdvertisedSocketAddress raftAddress;
+
+    public CoreMember( AdvertisedSocketAddress coreAddress, AdvertisedSocketAddress raftAddress )
+    {
+        this.coreAddress = coreAddress;
+        this.raftAddress = raftAddress;
+    }
+
+    @Override public String toString()
+    {
+        return format( "CoreMember{coreAddress=%s, raftAddress=%s}", coreAddress, raftAddress );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        CoreMember that = (CoreMember) o;
+        return Objects.equals( coreAddress, that.coreAddress ) &&
+                Objects.equals( raftAddress, that.raftAddress );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( coreAddress, raftAddress );
+    }
+
+    public AdvertisedSocketAddress getCoreAddress()
+    {
+        return coreAddress;
+    }
+
+    public AdvertisedSocketAddress getRaftAddress()
+    {
+        return raftAddress;
+    }
+}
+

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/Disposable.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/Disposable.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+public interface Disposable
+{
+    void dispose();
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/EnterpriseCoreEdgeFacadeFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/EnterpriseCoreEdgeFacadeFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.coreedge.server.CoreEdgeClusterSettings;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+
+/**
+ * This facade creates instances of the Enterprise Core-Edge edition of Neo4j.
+ */
+abstract class EnterpriseCoreEdgeFacadeFactory extends GraphDatabaseFacadeFactory
+{
+    @Override
+    public GraphDatabaseFacade newFacade( File storeDir, Map<String, String> params, Dependencies dependencies,
+                                          GraphDatabaseFacade graphDatabaseFacade )
+    {
+        params.put( Configuration.editionName.name(), "Enterprise" );
+        return super.newFacade( storeDir, params, dependencies, graphDatabaseFacade );
+    }
+
+    protected void makeHazelcastQuiet( PlatformModule platformModule )
+    {
+        // Make hazelcast quiet for core and edge servers
+        if ( platformModule.config.get( CoreEdgeClusterSettings.disable_middleware_logging ) )
+        {
+            // This is clunky, but the documented programmtic way doesn't seem to work
+            System.setProperty( "hazelcast.logging.type", "none" );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/EnterpriseCoreFacadeFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/EnterpriseCoreFacadeFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import org.neo4j.coreedge.discovery.DiscoveryServiceFactory;
+import org.neo4j.coreedge.server.core.EnterpriseCoreEditionModule;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+
+public class EnterpriseCoreFacadeFactory extends EnterpriseCoreEdgeFacadeFactory
+{
+    private final DiscoveryServiceFactory discoveryServiceFactory;
+
+    public EnterpriseCoreFacadeFactory( DiscoveryServiceFactory discoveryServiceFactory )
+    {
+        this.discoveryServiceFactory = discoveryServiceFactory;
+    }
+
+    @Override
+    protected EditionModule createEdition( PlatformModule platformModule )
+    {
+        makeHazelcastQuiet( platformModule );
+        return new EnterpriseCoreEditionModule( platformModule, discoveryServiceFactory );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/EnterpriseEdgeFacadeFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/EnterpriseEdgeFacadeFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import org.neo4j.coreedge.discovery.DiscoveryServiceFactory;
+import org.neo4j.coreedge.server.edge.EnterpriseEdgeEditionModule;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+
+public class EnterpriseEdgeFacadeFactory extends EnterpriseCoreEdgeFacadeFactory
+{
+    private final DiscoveryServiceFactory discoveryServiceFactory;
+
+    public EnterpriseEdgeFacadeFactory( DiscoveryServiceFactory discoveryServiceFactory )
+    {
+        this.discoveryServiceFactory = discoveryServiceFactory;
+    }
+
+    @Override
+    protected EditionModule createEdition( PlatformModule platformModule )
+    {
+        makeHazelcastQuiet( platformModule );
+        return new EnterpriseEdgeEditionModule( platformModule, discoveryServiceFactory );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/Expiration.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/Expiration.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.helpers.Clock;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class Expiration
+{
+    private final Clock clock;
+    private final long timeout;
+
+    /**
+     * Objects associated with this Expiration will expire after 2 minutes by default.
+     * This is a reasonable time limit for resources like outbound socket connections etc.
+     */
+    public Expiration( Clock clock )
+    {
+        this( clock, 2, MINUTES );
+    }
+
+    public Expiration( Clock clock, long timeout, TimeUnit timeUnit )
+    {
+        this.clock = clock;
+        this.timeout = timeUnit.toMillis( timeout );
+    }
+
+    class ExpirationTime
+    {
+        private volatile long expires;
+
+        ExpirationTime()
+        {
+            renew();
+        }
+
+        boolean expired()
+        {
+            return clock.currentTimeMillis() > expires;
+        }
+
+        void renew()
+        {
+            expires = clock.currentTimeMillis() + timeout;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format( "ExpirationTime{expires=%d}", expires );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/ExpiryScheduler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/ExpiryScheduler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class ExpiryScheduler
+{
+    private final JobScheduler scheduler;
+    private final long reclamationIntervalTime;
+    private final TimeUnit reclamationIntervalTimeUnit;
+
+    /**
+     * Checking for expired items every 2 minutes by default.
+     */
+    public ExpiryScheduler( JobScheduler scheduler )
+    {
+        this( scheduler, 2, MINUTES );
+    }
+
+    public ExpiryScheduler( JobScheduler scheduler,
+                            long reclamationIntervalTime,
+                            TimeUnit reclamationIntervalTimeUnit )
+    {
+        this.scheduler = scheduler;
+        this.reclamationIntervalTime = reclamationIntervalTime;
+        this.reclamationIntervalTimeUnit = reclamationIntervalTimeUnit;
+    }
+
+    public JobScheduler.JobHandle schedule( Runnable runnable )
+    {
+        return scheduler.scheduleRecurring( new JobScheduler.Group( "LazyChannelsGarbageCollection",
+                        Neo4jJobScheduler.SchedulingStrategy.POOLED ),
+                runnable, reclamationIntervalTime, reclamationIntervalTimeUnit );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/ListenSocketAddress.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/ListenSocketAddress.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.net.InetSocketAddress;
+import java.util.Objects;
+
+public class ListenSocketAddress
+{
+    private final InetSocketAddress address;
+
+    public ListenSocketAddress( InetSocketAddress address )
+    {
+        this.address = address;
+    }
+
+    @Override public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        ListenSocketAddress that = (ListenSocketAddress) o;
+        return Objects.equals( address, that.address );
+    }
+
+    @Override public int hashCode()
+    {
+        return Objects.hash( address );
+    }
+
+    public InetSocketAddress socketAddress()
+    {
+        return address;
+    }
+
+    @Override
+    public String toString()
+    {
+        return address.getHostName() + ":" + address.getPort();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/SenderService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/SenderService.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+import org.neo4j.coreedge.raft.net.NonBlockingChannel;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.helpers.NamedThreadFactory;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+public class SenderService extends LifecycleAdapter implements Outbound<AdvertisedSocketAddress>
+{
+    private final Expiration expiration;
+    private final ConcurrentHashMap<AdvertisedSocketAddress,Timestamped<NonBlockingChannel>> lazyChannelMap =
+            new ConcurrentHashMap<>();
+    private final ExpiryScheduler scheduler;
+    private final ChannelInitializer<SocketChannel> channelInitializer;
+    private final ReadWriteLock serviceLock = new ReentrantReadWriteLock();
+    private final Log log;
+
+    private JobScheduler.JobHandle jobHandle;
+    private boolean senderServiceRunning;
+    private Bootstrap bootstrap;
+    private NioEventLoopGroup eventLoopGroup;
+
+    public SenderService( ExpiryScheduler expiryScheduler,
+            Expiration expiration,
+            ChannelInitializer<SocketChannel> channelInitializer,
+            LogProvider logProvider )
+    {
+        this.expiration = expiration;
+        this.scheduler = expiryScheduler;
+        this.channelInitializer = channelInitializer;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    @Override
+    public void send( AdvertisedSocketAddress to, Serializable... messages )
+    {
+        serviceLock.readLock().lock();
+        try
+        {
+            if ( !senderServiceRunning )
+            {
+                return;
+            }
+
+            Timestamped<NonBlockingChannel> lazyChannel = getAndUpdateLife( to );
+            NonBlockingChannel nonBlockingChannel = lazyChannel.get();
+            for ( Object msg : messages )
+            {
+                nonBlockingChannel.send( msg );
+            }
+        }
+        finally
+        {
+            serviceLock.readLock().unlock();
+        }
+    }
+
+    public int activeChannelCount()
+    {
+        return lazyChannelMap.size();
+    }
+
+    private Timestamped<NonBlockingChannel> getAndUpdateLife( AdvertisedSocketAddress to )
+    {
+        Timestamped<NonBlockingChannel> timestampedLazyChannel = lazyChannelMap.get( to );
+
+        if ( timestampedLazyChannel == null )
+        {
+            Expiration.ExpirationTime expirationTime = expiration.new ExpirationTime();
+            timestampedLazyChannel = new Timestamped<>( expirationTime,
+                    new NonBlockingChannel( bootstrap, to.socketAddress(),
+                            new InboundKeepAliveHandler( expirationTime ), log ) );
+
+            Timestamped<NonBlockingChannel> existingTimestampedLazyChannel =
+                    lazyChannelMap.putIfAbsent( to, timestampedLazyChannel );
+
+            if ( existingTimestampedLazyChannel != null )
+            {
+                timestampedLazyChannel.get().dispose();
+                timestampedLazyChannel = existingTimestampedLazyChannel;
+            }
+        }
+
+        timestampedLazyChannel.getEndOfLife().renew();
+
+        return timestampedLazyChannel;
+    }
+
+    @Override
+    public synchronized void start()
+    {
+        serviceLock.writeLock().lock();
+        try
+        {
+            eventLoopGroup = new NioEventLoopGroup( 0, new NamedThreadFactory( "sender-service" ) );
+            bootstrap = new Bootstrap()
+                    .group( eventLoopGroup )
+                    .channel( NioSocketChannel.class )
+                    .handler( channelInitializer );
+
+            if ( scheduler != null )
+            {
+                jobHandle = scheduler.schedule( this::reapDeadChannels );
+            }
+
+            senderServiceRunning = true;
+        }
+        finally
+        {
+            serviceLock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public synchronized void stop()
+    {
+        serviceLock.writeLock().lock();
+        try
+        {
+            senderServiceRunning = false;
+
+            if ( jobHandle != null )
+            {
+                jobHandle.cancel( true );
+                jobHandle = null;
+            }
+
+            Iterator<Timestamped<NonBlockingChannel>> itr = lazyChannelMap.values().iterator();
+            while ( itr.hasNext() )
+            {
+                Timestamped<NonBlockingChannel> timestampedChannel = itr.next();
+                timestampedChannel.get().dispose();
+                itr.remove();
+            }
+
+            try
+            {
+                eventLoopGroup.shutdownGracefully( 0, 0, MICROSECONDS ).sync();
+            }
+            catch ( InterruptedException e )
+            {
+                log.warn( "Interrupted while stopping sender service." );
+            }
+        }
+        finally
+        {
+            serviceLock.writeLock().unlock();
+        }
+    }
+
+    private synchronized void reapDeadChannels()
+    {
+        Iterator<Timestamped<NonBlockingChannel>> itr = lazyChannelMap.values().iterator();
+        while ( itr.hasNext() )
+        {
+            Timestamped<NonBlockingChannel> timestampedChannel = itr.next();
+
+            serviceLock.writeLock().lock();
+            try
+            {
+                if ( timestampedChannel.getEndOfLife().expired() )
+                {
+                    timestampedChannel.get().dispose();
+                    itr.remove();
+                }
+            }
+            finally
+            {
+                serviceLock.writeLock().unlock();
+            }
+        }
+    }
+
+    private final class Timestamped<T extends Disposable>
+    {
+        private final Expiration.ExpirationTime endOfLife;
+        private T timestampedThing;
+
+        public Timestamped( Expiration.ExpirationTime endOfLife, T timestampedThing )
+        {
+            this.endOfLife = endOfLife;
+            this.timestampedThing = timestampedThing;
+        }
+
+        public T get()
+        {
+            return timestampedThing;
+        }
+
+        public Expiration.ExpirationTime getEndOfLife()
+        {
+            return endOfLife;
+        }
+    }
+
+    @ChannelHandler.Sharable
+    private class InboundKeepAliveHandler extends ChannelInboundHandlerAdapter
+    {
+        private final Expiration.ExpirationTime expirationTime;
+
+        public InboundKeepAliveHandler( Expiration.ExpirationTime expirationTime )
+        {
+            this.expirationTime = expirationTime;
+        }
+
+        @Override
+        public void channelRead( ChannelHandlerContext ctx, Object msg ) throws Exception
+        {
+            expirationTime.renew();
+            super.channelRead( ctx, msg );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/CoreGraphDatabase.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/CoreGraphDatabase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.core;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.coreedge.server.EnterpriseCoreFacadeFactory;
+import org.neo4j.coreedge.discovery.DiscoveryServiceFactory;
+import org.neo4j.coreedge.discovery.HazelcastDiscoveryServiceFactory;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.kernel.impl.factory.DataSourceModule;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+
+public class CoreGraphDatabase extends GraphDatabaseFacade
+{
+    private EnterpriseCoreEditionModule coreEditionModule;
+
+    public CoreGraphDatabase( File storeDir, Map<String, String> params,
+                              GraphDatabaseFacadeFactory.Dependencies dependencies, DiscoveryServiceFactory
+                                      discoveryServiceFactory )
+    {
+        new EnterpriseCoreFacadeFactory( discoveryServiceFactory ).newFacade( storeDir, params, dependencies, this );
+    }
+
+    public CoreGraphDatabase( File storeDir, Map<String, String> params,
+                              GraphDatabaseFacadeFactory.Dependencies dependencies )
+    {
+        this( storeDir, params, dependencies, new HazelcastDiscoveryServiceFactory() );
+    }
+
+    @Override
+    public void init( PlatformModule platformModule, EditionModule editionModule, DataSourceModule dataSourceModule )
+    {
+        super.init( platformModule, editionModule, dataSourceModule );
+        this.coreEditionModule = (EnterpriseCoreEditionModule) editionModule;
+    }
+
+    public Role getRole()
+    {
+        return coreEditionModule.raft().currentRole();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/CoreServerStartupProcess.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/CoreServerStartupProcess.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.core;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
+import org.neo4j.coreedge.raft.membership.MembershipWaiter;
+import org.neo4j.coreedge.raft.RaftInstance;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.RaftServer;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdGeneratorFactory;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.ScheduledTimeoutService;
+import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.kernel.lifecycle.LifecycleException;
+
+import org.neo4j.coreedge.catchup.CatchupServer;
+
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class CoreServerStartupProcess implements Lifecycle
+{
+    private final LifeSupport services = new LifeSupport();
+
+    public CoreServerStartupProcess( LocalDatabase localDatabase, DataSourceManager dataSourceManager,
+                                     ReplicatedIdGeneratorFactory idGeneratorFactory,
+                                     RaftInstance<CoreMember> raft, RaftLog raftLog, RaftServer<CoreMember> raftServer,
+                                     CatchupServer catchupServer,
+                                     ScheduledTimeoutService raftTimeoutService,
+                                     MembershipWaiter<CoreMember> membershipWaiter,
+                                     long joinCatchupTimeout )
+    {
+        services.add( new LifecycleAdapter() {
+            @Override
+            public void start() throws Throwable
+            {
+                localDatabase.deleteStore();
+            }
+        });
+        services.add( dataSourceManager );
+        services.add( idGeneratorFactory );
+        services.add( new LifecycleAdapter( ) {
+            @Override
+            public void start() throws Throwable
+            {
+                raftLog.replay();
+            }
+        } );
+        services.add( raftServer );
+        services.add( raftTimeoutService );
+        services.add( catchupServer );
+        services.add( new MembershipWaiterLifecycle<>(membershipWaiter, joinCatchupTimeout, raft ) );
+    }
+
+    @Override
+    public void init() throws LifecycleException
+    {
+        services.init();
+    }
+
+    @Override
+    public void start() throws LifecycleException
+    {
+        services.start();
+    }
+
+    @Override
+    public void stop() throws LifecycleException
+    {
+        services.stop();
+    }
+
+    @Override
+    public void shutdown() throws LifecycleException
+    {
+        services.shutdown();
+    }
+
+    private static class MembershipWaiterLifecycle<MEMBER> extends LifecycleAdapter
+    {
+        private final MembershipWaiter<MEMBER> membershipWaiter;
+        private final Long joinCatchupTimeout;
+        private final RaftInstance<MEMBER> raft;
+
+        private MembershipWaiterLifecycle( MembershipWaiter<MEMBER> membershipWaiter, Long joinCatchupTimeout, RaftInstance<MEMBER> raft )
+        {
+            this.membershipWaiter = membershipWaiter;
+            this.joinCatchupTimeout = joinCatchupTimeout;
+            this.raft = raft;
+        }
+
+        @Override
+        public void start() throws Throwable
+        {
+            CompletableFuture<Boolean> caughtUp = membershipWaiter.waitUntilCaughtUpMember( raft.state() );
+
+            try
+            {
+                caughtUp.get( joinCatchupTimeout, MILLISECONDS );
+            }
+            catch ( InterruptedException | ExecutionException | TimeoutException e )
+            {
+                throw new RuntimeException( format( "Server failed to join cluster within catchup time limit [%d ms]",
+                        joinCatchupTimeout ), e );
+            }
+            finally
+            {
+                caughtUp.cancel( true );
+            }
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/CoreToCoreClient.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/CoreToCoreClient.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.core;
+
+import java.io.IOException;
+
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+
+import org.neo4j.coreedge.catchup.storecopy.edge.CoreClient;
+import org.neo4j.coreedge.catchup.RequestMessageType;
+import org.neo4j.coreedge.catchup.RequestMessageTypeEncoder;
+import org.neo4j.coreedge.catchup.ResponseMessageTypeEncoder;
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.storecopy.edge.GetStoreRequestEncoder;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreCopyFinishedResponseDecoder;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreCopyFinishedResponseHandler;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponseHandler;
+import org.neo4j.coreedge.catchup.tx.edge.TxStreamFinishedResponseDecoder;
+import org.neo4j.coreedge.catchup.tx.edge.TxStreamFinishedResponseHandler;
+import org.neo4j.coreedge.raft.locks.LockMessage;
+import org.neo4j.coreedge.raft.locks.LockRequestEncoder;
+import org.neo4j.coreedge.raft.locks.LockResponseDecoder;
+import org.neo4j.coreedge.raft.locks.LockResponseHandler;
+import org.neo4j.coreedge.raft.locks.LockResultListener;
+import org.neo4j.coreedge.catchup.ClientMessageTypeHandler;
+import org.neo4j.coreedge.server.logging.ExceptionLoggingHandler;
+import org.neo4j.coreedge.server.Expiration;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullRequestEncoder;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponseDecoder;
+import org.neo4j.coreedge.server.ExpiryScheduler;
+import org.neo4j.coreedge.catchup.storecopy.FileHeaderDecoder;
+import org.neo4j.coreedge.catchup.storecopy.FileContentHandler;
+import org.neo4j.coreedge.catchup.storecopy.FileHeaderHandler;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.helpers.Listeners;
+import org.neo4j.logging.LogProvider;
+
+public class CoreToCoreClient extends CoreClient implements LockResultListener
+{
+    private Iterable<LockResultListener> lockResultListeners = Listeners.newListeners();
+
+    public CoreToCoreClient( LogProvider logProvider, ExpiryScheduler expiryScheduler, Expiration expiration, ChannelInitializer channelInitializer )
+    {
+        super( logProvider, expiryScheduler, expiration, channelInitializer );
+    }
+
+    public void sendLockRequest( AdvertisedSocketAddress to, LockMessage.Request lockRequest )
+    {
+        send( to, RequestMessageType.LOCK, lockRequest );
+    }
+
+    public void addLockResultListener( LockResultListener listener )
+    {
+        lockResultListeners = Listeners.addListener( listener, lockResultListeners );
+    }
+
+    public void removeLockResultListener( LockResultListener listener )
+    {
+        lockResultListeners = Listeners.removeListener( listener, lockResultListeners );
+    }
+
+    @Override
+    public void onLockResponses( final LockMessage.Response lockResult ) throws IOException
+    {
+        Listeners.notifyListeners( lockResultListeners,
+                listener -> {
+                    try
+                    {
+                        listener.onLockResponses( lockResult );
+                    }
+                    catch ( IOException e )
+                    {
+                        throw new RuntimeException( e );
+                    }
+                } );
+    }
+
+    public static class ChannelInitializer extends io.netty.channel.ChannelInitializer<SocketChannel>
+    {
+        private final LogProvider logProvider;
+        private CoreToCoreClient owner;
+
+        public ChannelInitializer( LogProvider logProvider )
+        {
+            this.logProvider = logProvider;
+        }
+
+        public void setOwner( CoreToCoreClient coreToCoreClient )
+        {
+            this.owner = coreToCoreClient;
+        }
+
+        @Override
+        protected void initChannel( SocketChannel ch ) throws Exception
+        {
+            CatchupClientProtocol protocol = new CatchupClientProtocol();
+
+            ChannelPipeline pipeline = ch.pipeline();
+            pipeline.addLast( new LengthFieldBasedFrameDecoder( Integer.MAX_VALUE, 0, 4, 0, 4 ) );
+            pipeline.addLast( new LengthFieldPrepender( 4 ) );
+
+            pipeline.addLast( new TxPullRequestEncoder() );
+            pipeline.addLast( new GetStoreRequestEncoder() );
+            pipeline.addLast( new LockRequestEncoder() );
+            pipeline.addLast( new ResponseMessageTypeEncoder() );
+            pipeline.addLast( new RequestMessageTypeEncoder() );
+
+            pipeline.addLast( new ClientMessageTypeHandler( protocol, logProvider ) );
+
+            pipeline.addLast( new TxPullResponseDecoder( protocol ) );
+            pipeline.addLast( new TxPullResponseHandler( protocol, owner ) );
+
+            pipeline.addLast( new StoreCopyFinishedResponseDecoder( protocol ) );
+            pipeline.addLast( new StoreCopyFinishedResponseHandler( protocol, owner ) );
+
+            pipeline.addLast( new LockResponseDecoder( protocol ) );
+            pipeline.addLast( new LockResponseHandler( protocol, owner ) );
+
+            pipeline.addLast( new TxStreamFinishedResponseDecoder( protocol ) );
+            pipeline.addLast( new TxStreamFinishedResponseHandler( protocol, owner ) );
+
+            // keep these after type-specific handlers since they process ByteBufs
+            pipeline.addLast( new FileHeaderDecoder( protocol ) );
+            pipeline.addLast( new FileHeaderHandler( protocol ) );
+            pipeline.addLast( new FileContentHandler( protocol, owner ) );
+
+            pipeline.addLast( new ExceptionLoggingHandler( logProvider.getLog( getClass() ) ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.core;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.neo4j.coreedge.catchup.StoreIdSupplier;
+import org.neo4j.coreedge.catchup.CatchupServer;
+import org.neo4j.coreedge.server.CoreEdgeClusterSettings;
+import org.neo4j.coreedge.catchup.CheckpointerSupplier;
+import org.neo4j.coreedge.catchup.DataSourceSupplier;
+import org.neo4j.coreedge.discovery.CoreDiscoveryService;
+import org.neo4j.coreedge.discovery.DiscoveryServiceFactory;
+import org.neo4j.coreedge.discovery.RaftDiscoveryServiceConnector;
+import org.neo4j.coreedge.raft.net.CoreReplicatedContentMarshal;
+import org.neo4j.coreedge.raft.locks.CoreServiceManager;
+import org.neo4j.coreedge.raft.locks.CoreServiceRegistry;
+import org.neo4j.coreedge.raft.replication.LocalReplicator;
+import org.neo4j.coreedge.raft.membership.MembershipWaiter;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdAllocationStateMachine;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdGeneratorFactory;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdRangeAcquirer;
+import org.neo4j.coreedge.raft.replication.session.GlobalSessionTracker;
+import org.neo4j.coreedge.raft.replication.session.LocalSessionPool;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedLabelTokenHolder;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedPropertyKeyTokenHolder;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedRelationshipTypeTokenHolder;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransactionCommitProcess;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransactionStateMachine;
+import org.neo4j.coreedge.server.Expiration;
+import org.neo4j.coreedge.server.SenderService;
+import org.neo4j.coreedge.raft.RaftInstance;
+import org.neo4j.coreedge.raft.replication.RaftReplicator;
+import org.neo4j.coreedge.raft.membership.CoreMemberSetBuilder;
+import org.neo4j.coreedge.raft.log.NaiveDurableRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.replication.shipping.RaftLogShippingManager;
+import org.neo4j.coreedge.raft.membership.RaftMembershipManager;
+import org.neo4j.coreedge.server.ExpiryScheduler;
+import org.neo4j.coreedge.raft.net.LoggingInbound;
+import org.neo4j.coreedge.raft.net.LoggingOutbound;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.raft.net.RaftChannelInitializer;
+import org.neo4j.coreedge.raft.net.RaftOutbound;
+import org.neo4j.coreedge.raft.RaftServer;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.coreedge.raft.replication.RaftContentSerializer;
+import org.neo4j.coreedge.raft.state.DurableTermStore;
+import org.neo4j.coreedge.raft.state.DurableVoteStore;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.coreedge.catchup.storecopy.edge.CopiedStoreRecovery;
+import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
+import org.neo4j.coreedge.catchup.storecopy.StoreFiles;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.server.ListenSocketAddress;
+import org.neo4j.coreedge.server.logging.BetterMessageLogger;
+import org.neo4j.coreedge.server.logging.MessageLogger;
+import org.neo4j.coreedge.raft.ScheduledTimeoutService;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.DatabaseAvailability;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.KernelData;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.Version;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.CommitProcessFactory;
+import org.neo4j.kernel.impl.api.SchemaWriteGuard;
+import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
+import org.neo4j.kernel.impl.api.index.RemoveOrphanConstraintIndexesOnStartup;
+import org.neo4j.kernel.impl.enterprise.EnterpriseConstraintSemantics;
+import org.neo4j.kernel.impl.factory.CommunityEditionModule;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.storemigration.ConfigMapUpgradeConfiguration;
+import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleStatus;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.udc.UsageData;
+import org.neo4j.udc.UsageDataKeys;
+
+import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
+
+/**
+ * This implementation of {@link org.neo4j.kernel.impl.factory.EditionModule} creates the implementations of services
+ * that are specific to the Enterprise Core edition that provides a core cluster.
+ */
+public class EnterpriseCoreEditionModule
+        extends EditionModule
+{
+    private final RaftInstance<CoreMember> raft;
+
+    public RaftInstance<CoreMember> raft()
+    {
+        return raft;
+    }
+
+    public EnterpriseCoreEditionModule( final PlatformModule platformModule,
+                                        DiscoveryServiceFactory discoveryServiceFactory )
+    {
+        org.neo4j.kernel.impl.util.Dependencies dependencies = platformModule.dependencies;
+        Config config = platformModule.config;
+        LogService logging = platformModule.logging;
+        FileSystemAbstraction fileSystem = platformModule.fileSystem;
+        File storeDir = platformModule.storeDir;
+        LifeSupport life = platformModule.life;
+        GraphDatabaseFacade graphDatabaseFacade = platformModule.graphDatabaseFacade;
+
+        LogProvider logProvider = logging.getInternalLogProvider();
+
+        CoreDiscoveryService discoveryService =
+                discoveryServiceFactory.coreDiscoveryService( config );
+        life.add( dependencies.satisfyDependency( discoveryService ) );
+
+        final CoreReplicatedContentMarshal marshall = new CoreReplicatedContentMarshal();
+        final SenderService senderService = new SenderService(
+                new ExpiryScheduler( platformModule.jobScheduler ), new Expiration( SYSTEM_CLOCK ),
+                new RaftChannelInitializer( marshall ), logProvider );
+        life.add( senderService );
+
+        final CoreMember myself = new CoreMember(
+                config.get( CoreEdgeClusterSettings.transaction_advertised_address ),
+                config.get( CoreEdgeClusterSettings.raft_advertised_address ) );
+
+        final MessageLogger<AdvertisedSocketAddress> messageLogger =
+                new BetterMessageLogger<>( myself.getRaftAddress(), raftMessagesLog( storeDir ) );
+
+        LoggingOutbound<AdvertisedSocketAddress> loggingOutbound = new LoggingOutbound<>(
+                senderService, myself.getRaftAddress(), messageLogger );
+
+        File raftLogsDirectory = createRaftLogsDirectory( platformModule.storeDir, fileSystem );
+
+        RaftLog raftLog = new NaiveDurableRaftLog( fileSystem, raftLogsDirectory, new RaftContentSerializer(),
+                platformModule.monitors );
+        dependencies.satisfyDependencies( raftLog );
+
+        ListenSocketAddress raftListenAddress = config.get( CoreEdgeClusterSettings.raft_listen_address );
+        RaftServer<CoreMember> raftServer = new RaftServer<>( marshall, raftListenAddress, logProvider );
+
+        final ScheduledTimeoutService raftTimeoutService = new ScheduledTimeoutService();
+
+        raft = createRaft( life, loggingOutbound, discoveryService, config,
+                messageLogger, raftLog, myself, raftLogsDirectory, fileSystem, logProvider, raftServer,
+                raftTimeoutService );
+
+        RaftReplicator<CoreMember> replicator = new RaftReplicator<>( raft, myself,
+                new RaftOutbound( loggingOutbound ) );
+
+        LocalSessionPool localSessionPool = new LocalSessionPool( myself );
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+
+        commitProcessFactory = createCommitProcessFactory( replicator, localSessionPool, sessionTracker, dependencies );
+
+        ReplicatedIdAllocationStateMachine idAllocationStateMachine = new ReplicatedIdAllocationStateMachine( myself );
+        replicator.subscribe( idAllocationStateMachine );
+
+        // TODO: AllocationChunk should be configurable and per type. The retry timeout should also be configurable.
+        ReplicatedIdRangeAcquirer idRangeAcquirer = new ReplicatedIdRangeAcquirer( replicator,
+                idAllocationStateMachine, 1024, 1000, myself, logProvider );
+
+        raftLog.registerListener( replicator );
+
+        long electionTimeout = config.get( CoreEdgeClusterSettings.leader_election_timeout );
+        MembershipWaiter<CoreMember> membershipWaiter =
+                new MembershipWaiter<>( myself, platformModule.jobScheduler, electionTimeout );
+
+        CoreServiceRegistry coreServices = new CoreServiceRegistry( SYSTEM_CLOCK );
+
+        raft.registerLeadershipChangeListener(
+                new CoreServiceManager( replicator, coreServices, myself, logProvider ) );
+
+        ReplicatedIdGeneratorFactory replicatedIdGeneratorFactory =
+                createIdGeneratorFactory( fileSystem, idRangeAcquirer, logProvider );
+
+        this.idGeneratorFactory = dependencies.satisfyDependency( replicatedIdGeneratorFactory );
+
+        this.relationshipTypeTokenHolder = life.add( dependencies.satisfyDependency( new
+                ReplicatedRelationshipTypeTokenHolder( replicator, this.idGeneratorFactory, dependencies ) ) );
+        this.propertyKeyTokenHolder = life.add( dependencies.satisfyDependency( new ReplicatedPropertyKeyTokenHolder(
+                replicator, this.idGeneratorFactory, dependencies ) ) );
+        this.labelTokenHolder = life.add( dependencies.satisfyDependency( new ReplicatedLabelTokenHolder( replicator,
+                this.idGeneratorFactory, dependencies ) ) );
+
+        dependencies.satisfyDependency( createKernelData( fileSystem, platformModule.pageCache, storeDir,
+                config, graphDatabaseFacade, life ) );
+
+        headerInformationFactory = createHeaderInformationFactory();
+
+        schemaWriteGuard = createSchemaWriteGuard();
+
+        transactionStartTimeout = config.get( GraphDatabaseSettings.transaction_start_timeout );
+
+        upgradeConfiguration = new ConfigMapUpgradeConfiguration( config );
+
+        constraintSemantics = new EnterpriseConstraintSemantics();
+
+        registerRecovery( config.get( GraphDatabaseFacadeFactory.Configuration.editionName ), life, dependencies );
+
+        publishEditionInfo( dependencies.resolveDependency( UsageData.class ) );
+
+        ExpiryScheduler expiryScheduler = new ExpiryScheduler( platformModule.jobScheduler );
+        Expiration expiration = new Expiration( SYSTEM_CLOCK );
+
+        CoreToCoreClient.ChannelInitializer channelInitializer = new CoreToCoreClient.ChannelInitializer( logProvider );
+        CoreToCoreClient coreToCoreClient = life.add( new CoreToCoreClient( logProvider, expiryScheduler, expiration,
+                channelInitializer ) );
+        channelInitializer.setOwner( coreToCoreClient );
+
+        lockManager = dependencies.satisfyDependency( createLockManager( config, logging ) );
+
+        LocalDatabase localDatabase =
+                new LocalDatabase( platformModule.storeDir,
+                        new CopiedStoreRecovery( config, platformModule.kernelExtensions.listFactories(),
+                                platformModule.pageCache ),
+                        new StoreFiles( new DefaultFileSystemAbstraction() ),
+                        dependencies.provideDependency( NeoStoreDataSource.class ),
+                        platformModule.dependencies.provideDependency( TransactionIdStore.class ) );
+
+        CatchupServer catchupServer = new CatchupServer( logProvider,
+                new StoreIdSupplier( platformModule ),
+                platformModule.dependencies.provideDependency( TransactionIdStore.class ),
+                platformModule.dependencies.provideDependency( LogicalTransactionStore.class ),
+                new DataSourceSupplier( platformModule ),
+                new CheckpointerSupplier( platformModule.dependencies ),
+                config.get( CoreEdgeClusterSettings.transaction_listen_address ) );
+
+        life.add( new CoreServerStartupProcess( localDatabase,
+                platformModule.dataSourceManager, replicatedIdGeneratorFactory, raft, raftLog, raftServer,
+                catchupServer, raftTimeoutService, membershipWaiter,
+                config.get( CoreEdgeClusterSettings.join_catch_up_timeout ) ) );
+    }
+
+    public boolean isLeader()
+    {
+        return raft.currentRole() == Role.LEADER;
+    }
+
+    private File createRaftLogsDirectory( File dir, FileSystemAbstraction fileSystem )
+    {
+        File raftLogDir = new File( dir, "raft-logs" );
+
+        try
+        {
+            fileSystem.mkdirs( raftLogDir );
+            return raftLogDir;
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+
+    }
+
+    public static CommitProcessFactory createCommitProcessFactory( final Replicator replicator,
+                                                                   final LocalSessionPool localSessionPool, final
+                                                                   GlobalSessionTracker sessionTracker, final
+                                                                   Dependencies dependencies )
+    {
+        return ( appender, applier, indexUpdatesValidator, config ) -> {
+            TransactionRepresentationCommitProcess localCommit =
+                    new TransactionRepresentationCommitProcess( appender, applier, indexUpdatesValidator );
+            dependencies.satisfyDependencies( localCommit );
+
+            ReplicatedTransactionStateMachine replicatedTxListener = new ReplicatedTransactionStateMachine(
+                    localCommit, sessionTracker, localSessionPool.getGlobalSession() );
+
+            return new ReplicatedTransactionCommitProcess( replicator, localSessionPool, replicatedTxListener );
+        };
+    }
+
+    private static RaftInstance<CoreMember> createRaft( LifeSupport life,
+                                                        Outbound<AdvertisedSocketAddress> outbound,
+                                                        CoreDiscoveryService discoveryService,
+                                                        Config config,
+                                                        MessageLogger<AdvertisedSocketAddress> messageLogger,
+                                                        RaftLog raftLog,
+                                                        CoreMember myself,
+                                                        File raftLogsDirectory,
+                                                        FileSystemAbstraction fileSystem,
+                                                        LogProvider logProvider,
+                                                        RaftServer<CoreMember> raftServer,
+                                                        ScheduledTimeoutService raftTimeoutService )
+    {
+        LoggingInbound loggingRaftInbound = new LoggingInbound( raftServer, messageLogger, myself.getRaftAddress() );
+
+        long electionTimeout = config.get( CoreEdgeClusterSettings.leader_election_timeout );
+        long heartbeatInterval = electionTimeout / 3;
+
+        long leaderWaitTimeout = config.get( CoreEdgeClusterSettings.leader_wait_timeout );
+
+        Integer expectedClusterSize = config.get( CoreEdgeClusterSettings.expected_core_cluster_size );
+
+        CoreMemberSetBuilder memberSetBuilder = new CoreMemberSetBuilder();
+
+        DurableTermStore termStore = new DurableTermStore( fileSystem, raftLogsDirectory );
+        DurableVoteStore voteStore = new DurableVoteStore( fileSystem, raftLogsDirectory );
+
+        Replicator localReplicator = new LocalReplicator<>( myself, myself.getRaftAddress(), outbound );
+
+        RaftMembershipManager<CoreMember> raftMembershipManager = new RaftMembershipManager<>( localReplicator, memberSetBuilder, raftLog,
+                logProvider, expectedClusterSize, electionTimeout, SYSTEM_CLOCK, config.get( CoreEdgeClusterSettings.join_catch_up_timeout ) );
+
+        RaftLogShippingManager<CoreMember> logShipping = new RaftLogShippingManager<>( new RaftOutbound( outbound ), logProvider, raftLog,
+                SYSTEM_CLOCK, myself, raftMembershipManager, electionTimeout );
+
+        RaftInstance<CoreMember> raftInstance = new RaftInstance<>(
+                myself, termStore, voteStore, raftLog, electionTimeout, heartbeatInterval,
+                raftTimeoutService, loggingRaftInbound,
+                new RaftOutbound( outbound ), leaderWaitTimeout, logProvider,
+                raftMembershipManager, logShipping );
+
+        life.add( new RaftDiscoveryServiceConnector( discoveryService, raftInstance ) );
+
+        return raftInstance;
+    }
+
+    private static PrintWriter raftMessagesLog( File storeDir )
+    {
+        storeDir.mkdirs();
+        try
+        {
+            return new PrintWriter( new FileOutputStream( new File( storeDir, "raft-messages.log" ), true ) );
+        }
+        catch ( FileNotFoundException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    private void publishEditionInfo( UsageData sysInfo )
+    {
+        sysInfo.set( UsageDataKeys.edition, UsageDataKeys.Edition.enterprise );
+        sysInfo.set( UsageDataKeys.operationalMode, UsageDataKeys.OperationalMode.core );
+    }
+
+    protected SchemaWriteGuard createSchemaWriteGuard()
+    {
+        return () -> {};
+    }
+
+    protected KernelData createKernelData( FileSystemAbstraction fileSystem, PageCache pageCache, File storeDir,
+                                           Config config, GraphDatabaseAPI graphAPI, LifeSupport life )
+    {
+        DefaultKernelData kernelData = new DefaultKernelData( fileSystem, pageCache, storeDir, config, graphAPI );
+        return life.add( kernelData );
+    }
+
+    protected ReplicatedIdGeneratorFactory createIdGeneratorFactory( FileSystemAbstraction fileSystem,
+                                                                     final ReplicatedIdRangeAcquirer idRangeAcquirer,
+                                                                     final LogProvider logProvider )
+    {
+        return new ReplicatedIdGeneratorFactory( fileSystem, idRangeAcquirer, logProvider );
+    }
+
+    protected Locks createLockManager( final Config config, final LogService logging )
+    {
+        Locks local = CommunityEditionModule.createLockManager( config, logging );
+
+        return local;
+    }
+
+    protected TransactionHeaderInformationFactory createHeaderInformationFactory()
+    {
+        return TransactionHeaderInformationFactory.DEFAULT;
+    }
+
+    protected void registerRecovery( final String editionName, LifeSupport life,
+                                     final DependencyResolver dependencyResolver )
+    {
+        life.addLifecycleListener( ( instance, from, to ) -> {
+            if ( instance instanceof DatabaseAvailability && to.equals( LifecycleStatus.STARTED ) )
+            {
+                doAfterRecoveryAndStartup( editionName, dependencyResolver );
+            }
+        } );
+    }
+
+    @Override
+    protected void doAfterRecoveryAndStartup( String editionName, DependencyResolver dependencyResolver )
+    {
+        super.doAfterRecoveryAndStartup( editionName, dependencyResolver );
+
+        new RemoveOrphanConstraintIndexesOnStartup( dependencyResolver.resolveDependency( NeoStoreDataSource.class )
+                .getKernel(), dependencyResolver.resolveDependency( LogService.class ).getInternalLogProvider() )
+                .perform();
+    }
+
+    protected final class DefaultKernelData extends KernelData implements Lifecycle
+    {
+        private final GraphDatabaseAPI graphDb;
+
+        public DefaultKernelData( FileSystemAbstraction fileSystem, PageCache pageCache, File storeDir,
+                                  Config config, GraphDatabaseAPI graphDb )
+        {
+            super( fileSystem, pageCache, storeDir, config );
+            this.graphDb = graphDb;
+        }
+
+        @Override
+        public Version version()
+        {
+            return Version.getKernel();
+        }
+
+        @Override
+        public GraphDatabaseAPI graphDatabase()
+        {
+            return graphDb;
+        }
+
+        @Override
+        public void init() throws Throwable
+        {
+        }
+
+        @Override
+        public void start() throws Throwable
+        {
+        }
+
+        @Override
+        public void stop() throws Throwable
+        {
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EdgeGraphDatabase.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EdgeGraphDatabase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.edge;
+
+import java.io.File;
+import java.util.Map;
+
+import org.neo4j.coreedge.server.EnterpriseEdgeFacadeFactory;
+import org.neo4j.coreedge.discovery.DiscoveryServiceFactory;
+import org.neo4j.coreedge.discovery.HazelcastDiscoveryServiceFactory;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Dependencies;
+
+public class EdgeGraphDatabase extends GraphDatabaseFacade
+{
+    public EdgeGraphDatabase( File storeDir, Map<String, String> params, Dependencies dependencies )
+    {
+        this( storeDir, params, dependencies, new HazelcastDiscoveryServiceFactory() );
+    }
+
+    public EdgeGraphDatabase( File storeDir, Map<String, String> params, Dependencies
+            dependencies, DiscoveryServiceFactory discoveryServiceFactory )
+    {
+        new EnterpriseEdgeFacadeFactory( discoveryServiceFactory ).newFacade( storeDir, params, dependencies, this );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EdgeServerStartupProcess.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EdgeServerStartupProcess.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.edge;
+
+import org.neo4j.coreedge.discovery.ClusterTopology;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreFetcher;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.catchup.tx.edge.TxPollingClient;
+import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
+import org.neo4j.coreedge.discovery.EdgeDiscoveryService;
+import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+
+public class EdgeServerStartupProcess implements Lifecycle
+{
+    private final StoreFetcher storeFetcher;
+    private final LocalDatabase localDatabase;
+    private final TxPollingClient txPuller;
+    private final EdgeDiscoveryService discoveryService;
+    private final DataSourceManager dataSourceManager;
+
+    public EdgeServerStartupProcess( StoreFetcher storeFetcher, LocalDatabase localDatabase,
+                                     TxPollingClient txPuller, EdgeDiscoveryService discoveryService,
+                                     DataSourceManager dataSourceManager )
+
+
+    {
+        this.storeFetcher = storeFetcher;
+        this.localDatabase = localDatabase;
+        this.txPuller = txPuller;
+        this.discoveryService = discoveryService;
+        this.dataSourceManager = dataSourceManager;
+    }
+
+    @Override
+    public void init() throws Throwable
+    {
+        dataSourceManager.init();
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        ClusterTopology clusterTopology = discoveryService.currentTopology();
+
+        AdvertisedSocketAddress transactionServer = clusterTopology.firstTransactionServer();
+        localDatabase.copyStoreFrom( transactionServer, storeFetcher );
+
+        dataSourceManager.start();
+        txPuller.startPolling();
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        txPuller.stop();
+        dataSourceManager.stop();
+    }
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+        dataSourceManager.shutdown();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EnterpriseEdgeEditionModule.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.edge;
+
+import java.io.File;
+
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreFetcher;
+import org.neo4j.coreedge.catchup.tx.edge.TransactionLogCatchUpFactory;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullClient;
+import org.neo4j.coreedge.discovery.DiscoveryServiceFactory;
+import org.neo4j.coreedge.catchup.storecopy.edge.EdgeToCoreClient;
+import org.neo4j.coreedge.discovery.EdgeDiscoveryService;
+import org.neo4j.coreedge.server.Expiration;
+import org.neo4j.coreedge.catchup.tx.edge.ApplyPulledTransactions;
+import org.neo4j.coreedge.catchup.tx.edge.TxPollingClient;
+import org.neo4j.coreedge.server.ExpiryScheduler;
+import org.neo4j.coreedge.catchup.storecopy.edge.CopiedStoreRecovery;
+import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreCopyClient;
+import org.neo4j.coreedge.catchup.storecopy.StoreFiles;
+import org.neo4j.coreedge.catchup.tx.edge.TransactionApplier;
+import org.neo4j.function.Supplier;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.DatabaseAvailability;
+import org.neo4j.kernel.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.KernelData;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.Version;
+import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.kernel.impl.api.CommitProcessFactory;
+import org.neo4j.kernel.impl.api.ReadOnlyTransactionCommitProcess;
+import org.neo4j.kernel.impl.api.SchemaWriteGuard;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionRepresentationStoreApplier;
+import org.neo4j.kernel.impl.api.index.IndexUpdatesValidator;
+import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
+import org.neo4j.kernel.impl.core.DelegatingLabelTokenHolder;
+import org.neo4j.kernel.impl.core.DelegatingPropertyKeyTokenHolder;
+import org.neo4j.kernel.impl.core.DelegatingRelationshipTypeTokenHolder;
+import org.neo4j.kernel.impl.core.ReadOnlyTokenCreator;
+import org.neo4j.kernel.impl.factory.EditionModule;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.storemigration.ConfigMapUpgradeConfiguration;
+import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
+import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.lifecycle.LifecycleListener;
+import org.neo4j.kernel.lifecycle.LifecycleStatus;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.udc.UsageData;
+import org.neo4j.udc.UsageDataKeys;
+
+import static org.neo4j.helpers.Clock.SYSTEM_CLOCK;
+import static org.neo4j.kernel.impl.factory.CommunityEditionModule.createLockManager;
+
+/**
+ * This implementation of {@link org.neo4j.kernel.impl.factory.EditionModule} creates the implementations of services
+ * that are specific to the Enterprise Edge edition that provides an edge cluster.
+ */
+public class EnterpriseEdgeEditionModule extends EditionModule
+{
+    public EnterpriseEdgeEditionModule( final PlatformModule platformModule,
+                                        DiscoveryServiceFactory discoveryServiceFactory )
+    {
+        org.neo4j.kernel.impl.util.Dependencies dependencies = platformModule.dependencies;
+        Config config = platformModule.config;
+        LogService logging = platformModule.logging;
+        FileSystemAbstraction fileSystem = platformModule.fileSystem;
+        PageCache pageCache = platformModule.pageCache;
+        File storeDir = platformModule.storeDir;
+        LifeSupport life = platformModule.life;
+
+        GraphDatabaseFacade graphDatabaseFacade = platformModule.graphDatabaseFacade;
+
+        lockManager = dependencies.satisfyDependency( createLockManager( config, logging ) );
+
+        idGeneratorFactory = dependencies.satisfyDependency( new DefaultIdGeneratorFactory( fileSystem ) );
+
+        propertyKeyTokenHolder = life.add( dependencies.satisfyDependency(
+                new DelegatingPropertyKeyTokenHolder( new ReadOnlyTokenCreator() ) ) );
+        labelTokenHolder = life.add( dependencies.satisfyDependency(
+                new DelegatingLabelTokenHolder( new ReadOnlyTokenCreator() ) ) );
+        relationshipTypeTokenHolder = life.add( dependencies.satisfyDependency(
+                new DelegatingRelationshipTypeTokenHolder( new ReadOnlyTokenCreator() ) ) );
+
+        life.add( dependencies.satisfyDependency(
+                new DefaultKernelData( fileSystem, pageCache, storeDir, config, graphDatabaseFacade ) ) );
+
+        headerInformationFactory = TransactionHeaderInformationFactory.DEFAULT;
+
+        schemaWriteGuard = new SchemaWriteGuard()
+        {
+            @Override
+            public void assertSchemaWritesAllowed() throws InvalidTransactionTypeKernelException
+            {
+            }
+        };
+
+        transactionStartTimeout = config.get( GraphDatabaseSettings.transaction_start_timeout );
+
+        upgradeConfiguration = new ConfigMapUpgradeConfiguration( config );
+
+        constraintSemantics = new StandardConstraintSemantics();
+
+        registerRecovery( config.get( GraphDatabaseFacadeFactory.Configuration.editionName ), life, dependencies );
+
+        publishEditionInfo( dependencies.resolveDependency( UsageData.class ) );
+        commitProcessFactory = readOnly();
+
+        LogProvider logProvider = platformModule.logging.getInternalLogProvider();
+
+        EdgeDiscoveryService discoveryService = discoveryServiceFactory.edgeDiscoveryService( config );
+        life.add(dependencies.satisfyDependency( discoveryService ));
+
+        Supplier<TransactionApplier> transactionApplierSupplier =
+                () -> new TransactionApplier( platformModule.dependencies );
+
+        ExpiryScheduler expiryScheduler = new ExpiryScheduler( platformModule.jobScheduler );
+        Expiration expiration = new Expiration( SYSTEM_CLOCK );
+
+        EdgeToCoreClient.ChannelInitializer channelInitializer = new EdgeToCoreClient.ChannelInitializer( logProvider );
+        EdgeToCoreClient edgeToCoreClient = life.add( new EdgeToCoreClient( logProvider, expiryScheduler, expiration,
+                channelInitializer ) );
+        channelInitializer.setOwner( edgeToCoreClient );
+
+        ApplyPulledTransactions applyPulledTransactions =
+                new ApplyPulledTransactions( logProvider, transactionApplierSupplier );
+
+        TxPollingClient txPollingClient = life.add(
+                new TxPollingClient( platformModule.jobScheduler, config.get( HaSettings.pull_interval ),
+                        platformModule.dependencies.provideDependency( TransactionIdStore.class ), edgeToCoreClient,
+                        applyPulledTransactions, discoveryService ) );
+
+        StoreFetcher storeFetcher = new StoreFetcher( platformModule.logging.getInternalLogProvider(),
+                new DefaultFileSystemAbstraction(), platformModule.pageCache,
+                new StoreCopyClient( edgeToCoreClient ), new TxPullClient( edgeToCoreClient ),
+                new TransactionLogCatchUpFactory() );
+
+        life.add( new EdgeServerStartupProcess( storeFetcher,
+                new LocalDatabase( platformModule.storeDir,
+                        new CopiedStoreRecovery( config, platformModule.kernelExtensions.listFactories(),
+                                platformModule.pageCache ),
+                        new StoreFiles( new DefaultFileSystemAbstraction() ),
+                        dependencies.provideDependency( NeoStoreDataSource.class ), platformModule.dependencies
+                        .provideDependency( TransactionIdStore.class ) ),
+                txPollingClient, discoveryService, platformModule.dataSourceManager ) );
+    }
+
+    private void publishEditionInfo( UsageData sysInfo )
+    {
+        sysInfo.set( UsageDataKeys.edition, UsageDataKeys.Edition.enterprise );
+        sysInfo.set( UsageDataKeys.operationalMode, UsageDataKeys.OperationalMode.edge );
+    }
+
+    protected void registerRecovery( final String editionName, LifeSupport life,
+                                     final DependencyResolver dependencyResolver )
+    {
+        life.addLifecycleListener( new LifecycleListener()
+        {
+            @Override
+            public void notifyStatusChanged( Object instance, LifecycleStatus from, LifecycleStatus to )
+            {
+                if ( instance instanceof DatabaseAvailability && to.equals( LifecycleStatus.STARTED ) )
+                {
+                    doAfterRecoveryAndStartup( editionName, dependencyResolver );
+                }
+            }
+        } );
+    }
+
+    private CommitProcessFactory readOnly()
+    {
+        return new CommitProcessFactory()
+        {
+            @Override
+            public TransactionCommitProcess create( TransactionAppender appender, TransactionRepresentationStoreApplier applier, IndexUpdatesValidator indexUpdatesValidator, Config config )
+            {
+                return new ReadOnlyTransactionCommitProcess();
+            }
+
+        };
+    }
+
+    protected final class DefaultKernelData extends KernelData implements Lifecycle
+    {
+        private final GraphDatabaseAPI graphDb;
+
+        public DefaultKernelData( FileSystemAbstraction fileSystem, PageCache pageCache, File storeDir,
+                                  Config config, GraphDatabaseAPI graphDb )
+        {
+            super( fileSystem, pageCache, storeDir, config );
+            this.graphDb = graphDb;
+        }
+
+        @Override
+        public Version version()
+        {
+            return Version.getKernel();
+        }
+
+        @Override
+        public GraphDatabaseAPI graphDatabase()
+        {
+            return graphDb;
+        }
+
+        @Override
+        public void init() throws Throwable
+        {
+        }
+
+        @Override
+        public void start() throws Throwable
+        {
+        }
+
+        @Override
+        public void stop() throws Throwable
+        {
+        }
+    }
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/BetterMessageLogger.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/BetterMessageLogger.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.logging;
+
+import java.io.PrintWriter;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+
+public class BetterMessageLogger<MEMBER> implements MessageLogger<MEMBER>
+{
+    private final PrintWriter printWriter;
+    private DateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+
+    public BetterMessageLogger( MEMBER myself, PrintWriter printWriter )
+    {
+        this.printWriter = printWriter;
+        printWriter.println( "I am " + myself );
+        printWriter.flush();
+    }
+
+    private void log( MEMBER from, MEMBER to, Object message )
+    {
+        printWriter.println( format( "%s -->%s: %s: %s",
+                dateFormat.format( new Date() ), to, message.getClass().getSimpleName(), valueOf( message ) ) );
+        printWriter.flush();
+    }
+
+    @Override
+    public void log( MEMBER from, MEMBER to, Object... messages )
+    {
+        for ( Object message : messages )
+        {
+            log( from, to, message );
+        }
+    }
+
+    @Override
+    public void log( MEMBER to, Object message )
+    {
+        printWriter.println( format( "%s <--%s: %s",
+                dateFormat.format( new Date() ), message.getClass().getSimpleName(), valueOf( message ) ) );
+        printWriter.flush();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/ExceptionLoggingHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/ExceptionLoggingHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.logging;
+
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+
+import org.neo4j.logging.Log;
+
+import static java.lang.String.format;
+
+public class ExceptionLoggingHandler extends ChannelHandlerAdapter
+{
+    private final Log log;
+
+    public ExceptionLoggingHandler( Log log )
+    {
+        this.log = log;
+    }
+
+    @Override
+    public void exceptionCaught( ChannelHandlerContext ctx, Throwable cause ) throws Exception
+    {
+        log.error( format( "Failed to process message on channel %s.", ctx.channel() ), cause );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/MessageLogger.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/MessageLogger.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.logging;
+
+public interface MessageLogger<MEMBER>
+{
+    void log( MEMBER from, MEMBER to, Object... message );
+
+    void log( MEMBER to, Object message );
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/NullMessageLogger.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/NullMessageLogger.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.logging;
+
+public class NullMessageLogger<MEMBER> implements MessageLogger<MEMBER>
+{
+    @Override
+    public void log( MEMBER from, MEMBER to, Object... messages )
+    {
+
+    }
+
+    @Override
+    public void log( MEMBER to, Object message )
+    {
+    }
+}
+
+

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/PrettyMessageLogger.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/PrettyMessageLogger.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.logging;
+
+import java.io.PrintWriter;
+
+import org.neo4j.coreedge.raft.RaftMessages;
+
+public class PrettyMessageLogger<MEMBER> implements MessageLogger<MEMBER>
+{
+    private final PrintWriter printWriter;
+
+    public PrettyMessageLogger( PrintWriter printWriter )
+    {
+        this.printWriter = printWriter;
+    }
+
+    public static String wrapString( String string, int charWrap )
+    {
+        int lastBreak = 0;
+        int nextBreak = charWrap;
+        if ( string.length() > charWrap )
+        {
+            String setString = "";
+            do
+            {
+                while ( string.charAt( nextBreak ) != ' ' && nextBreak > lastBreak )
+                {
+                    nextBreak--;
+                }
+                if ( nextBreak == lastBreak )
+                {
+                    nextBreak = lastBreak + charWrap;
+                }
+                setString += string.substring( lastBreak, nextBreak ).trim() + "\\n";
+                lastBreak = nextBreak;
+                nextBreak += charWrap;
+
+            } while ( nextBreak < string.length() );
+            setString += string.substring( lastBreak ).trim();
+            return setString;
+        }
+        else
+        {
+            return string;
+        }
+    }
+
+    @Override
+    public void log( MEMBER from, MEMBER to, Object... messages )
+    {
+        for ( Object message : messages )
+        {
+            log( from, to, message );
+        }
+    }
+
+
+    private void log( MEMBER from, MEMBER to, Object message )
+    {
+        String prettyFrom = pretty( from );
+        String prettyTo = pretty( to );
+        if ( message instanceof RaftMessages.NewEntry.Request && from.equals( to ) )
+        {
+            prettyFrom = "Client";
+        }
+
+        String note = String.format( "Note over %s,%s: %s", prettyFrom, prettyTo, wrapString( String.valueOf( message ),
+                100 ) );
+
+
+        printWriter.println( note );
+        printWriter.println( prettyFrom + "->" + prettyTo + ": " + message.getClass().getSimpleName() );
+        printWriter.flush();
+    }
+
+    @Override
+    public void log( MEMBER to, Object message )
+    {
+        // Do nothing?
+    }
+
+    private String pretty( MEMBER from )
+    {
+        return String.valueOf( from ).replace( ":", "/" );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/CoreServerStartupProcessTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/CoreServerStartupProcessTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.catchup.CatchupServer;
+import org.neo4j.coreedge.raft.membership.MembershipWaiter;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdGeneratorFactory;
+import org.neo4j.coreedge.raft.RaftInstance;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.RaftServer;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.server.core.CoreServerStartupProcess;
+import org.neo4j.coreedge.raft.ScheduledTimeoutService;
+import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CoreServerStartupProcessTest
+{
+    @Test
+    public void startShouldDeleteStoreAndStartNewDatabase() throws Throwable
+    {
+        // given
+        LocalDatabase localDatabase = mock( LocalDatabase.class );
+        DataSourceManager dataSourceManager = mock( DataSourceManager.class );
+        ReplicatedIdGeneratorFactory idGeneratorFactory = mock( ReplicatedIdGeneratorFactory.class );
+        RaftLog raftLog = mock( RaftLog.class );
+        RaftServer<CoreMember> raftServer = mock( RaftServer.class );
+        CatchupServer catchupServer = mock( CatchupServer.class );
+        ScheduledTimeoutService timeoutService = mock( ScheduledTimeoutService.class );
+        MembershipWaiter<CoreMember> membershipWaiter = mock( MembershipWaiter.class );
+        when(membershipWaiter.waitUntilCaughtUpMember( any(ReadableRaftState.class) ))
+                .thenReturn( mock( CompletableFuture.class ) );
+
+        CoreServerStartupProcess leaderProcess = new CoreServerStartupProcess(
+                localDatabase, dataSourceManager, idGeneratorFactory, mock( RaftInstance.class ), raftLog, raftServer,
+                catchupServer, timeoutService, membershipWaiter, 1000 );
+
+        // when
+        leaderProcess.start();
+
+        // then
+        verify( localDatabase ).deleteStore();
+        verify( dataSourceManager ).start();
+        verify( idGeneratorFactory ).start();
+    }
+
+    @Test
+    public void stopShouldStopDatabase() throws Throwable
+    {
+        // given
+        LocalDatabase localDatabase = mock( LocalDatabase.class );
+        DataSourceManager dataSourceManager = mock( DataSourceManager.class );
+        ReplicatedIdGeneratorFactory idGeneratorFactory = mock( ReplicatedIdGeneratorFactory.class );
+        RaftLog raftLog = mock( RaftLog.class );
+        RaftServer<CoreMember> raftServer = mock( RaftServer.class );
+        CatchupServer catchupServer = mock( CatchupServer.class );
+        ScheduledTimeoutService timeoutService = mock( ScheduledTimeoutService.class );
+        MembershipWaiter<CoreMember> membershipListener = mock( MembershipWaiter.class );
+        when(membershipListener.waitUntilCaughtUpMember( any(ReadableRaftState.class) )).thenReturn( mock(CompletableFuture.class) );
+
+        CoreServerStartupProcess leaderProcess = new CoreServerStartupProcess(
+                localDatabase, dataSourceManager, idGeneratorFactory, mock( RaftInstance.class ), raftLog, raftServer,
+                catchupServer, timeoutService, membershipListener, 1000 );
+
+        // when
+        leaderProcess.start();
+        leaderProcess.stop();
+
+        // then
+        verify( dataSourceManager ).stop();
+        verify( idGeneratorFactory ).stop();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/EdgeServerStartupProcessTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/EdgeServerStartupProcessTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreFetcher;
+import org.neo4j.coreedge.discovery.HazelcastClusterTopology;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.discovery.CoreDiscoveryService;
+import org.neo4j.coreedge.catchup.tx.edge.TxPollingClient;
+import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
+import org.neo4j.coreedge.server.edge.EdgeServerStartupProcess;
+import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class EdgeServerStartupProcessTest
+{
+    @Test
+    public void startShouldReplaceLocalStoreWithStoreFromCoreServerAndStartPolling() throws Throwable
+    {
+        // given
+        StoreFetcher storeFetcher = mock( StoreFetcher.class );
+        LocalDatabase localDatabase = mock( LocalDatabase.class );
+
+        AdvertisedSocketAddress coreServerAddress = address( "localhost:1999" );
+        CoreDiscoveryService hazelcastTopology = mock( CoreDiscoveryService.class );
+        HazelcastClusterTopology clusterTopology = mock( HazelcastClusterTopology.class );
+        when( clusterTopology.firstTransactionServer() ).thenReturn( coreServerAddress );
+
+        when( hazelcastTopology.currentTopology() ).thenReturn( clusterTopology );
+        when( localDatabase.isEmpty() ).thenReturn( true );
+
+        DataSourceManager dataSourceManager = mock( DataSourceManager.class );
+        TxPollingClient txPuller = mock( TxPollingClient.class );
+        EdgeServerStartupProcess edgeServerStartupProcess = new EdgeServerStartupProcess( storeFetcher, localDatabase,
+                txPuller, hazelcastTopology, dataSourceManager );
+
+        // when
+        edgeServerStartupProcess.start();
+
+        // then
+        verify( localDatabase ).copyStoreFrom( coreServerAddress, storeFetcher );
+        verify( dataSourceManager ).start();
+        verify( txPuller ).startPolling();
+    }
+
+    @Test
+    public void stopShouldStopTheDatabaseAndStopPolling() throws Throwable
+    {
+        // given
+        StoreFetcher storeFetcher = mock( StoreFetcher.class );
+        LocalDatabase localDatabase = mock( LocalDatabase.class );
+
+        AdvertisedSocketAddress coreServerAddress = address( "localhost:1999" );
+        CoreDiscoveryService hazelcastTopology = mock( CoreDiscoveryService.class );
+        HazelcastClusterTopology clusterTopology = mock( HazelcastClusterTopology.class );
+        when( clusterTopology.firstTransactionServer() ).thenReturn( coreServerAddress );
+
+        when( hazelcastTopology.currentTopology() ).thenReturn( clusterTopology );
+        when( localDatabase.isEmpty() ).thenReturn( true );
+
+        DataSourceManager dataSourceManager = mock( DataSourceManager.class );
+        TxPollingClient txPuller = mock( TxPollingClient.class );
+        EdgeServerStartupProcess edgeServerStartupProcess = new EdgeServerStartupProcess( storeFetcher, localDatabase,
+                txPuller, hazelcastTopology, dataSourceManager );
+
+        // when
+        edgeServerStartupProcess.stop();
+
+        // then
+        verify( txPuller ).stop();
+        verify( dataSourceManager ).stop();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/PortsForIntegrationTesting.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/PortsForIntegrationTesting.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
+public class PortsForIntegrationTesting
+{
+    public static InetSocketAddress findFreeAddress() throws IOException
+    {
+        InetSocketAddress address = null;
+        IOException ex = null;
+        for ( int port = 7200; port <= 7300; port++ )
+        {
+            address = new InetSocketAddress( "localhost", port );
+
+            try
+            {
+                new ServerSocket( address.getPort(), 100, address.getAddress() ).close();
+                ex = null;
+                break;
+            }
+            catch ( IOException e )
+            {
+                ex = e;
+            }
+        }
+        if ( ex != null )
+        {
+            throw ex;
+        }
+        return address;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/storecopy/LocalDatabaseTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/storecopy/LocalDatabaseTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.catchup.storecopy.edge.CopiedStoreRecovery;
+import org.neo4j.coreedge.catchup.storecopy.LocalDatabase;
+import org.neo4j.coreedge.catchup.storecopy.StoreFiles;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.function.Suppliers.singleton;
+
+public class LocalDatabaseTest
+{
+    @Test
+    public void shouldRetrieveStoreId() throws Throwable
+    {
+        // given
+        StoreId storeId = new StoreId();
+
+        // when
+        NeoStoreDataSource neoStoreDataSource = mock( NeoStoreDataSource.class );
+        when( neoStoreDataSource.getStoreId() ).thenReturn( storeId );
+
+        LocalDatabase localDatabase = new LocalDatabase( new File( "directory" ),
+                mock( CopiedStoreRecovery.class ),
+                new StoreFiles( mock( FileSystemAbstraction.class ) ),
+                singleton( neoStoreDataSource ), singleton( mock( TransactionIdStore.class ) ) );
+
+        // then
+        assertEquals( storeId, localDatabase.storeId() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/storecopy/StoreCopyFinishedResponseEncodeDecodeTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/storecopy/StoreCopyFinishedResponseEncodeDecodeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreCopyFinishedResponseDecoder;
+import org.neo4j.coreedge.catchup.storecopy.StoreCopyFinishedResponse;
+import org.neo4j.coreedge.catchup.storecopy.core.StoreCopyFinishedResponseEncoder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class StoreCopyFinishedResponseEncodeDecodeTest
+{
+    @Test
+    public void shouldEncodeAndDecodePullRequestMessage()
+    {
+        CatchupClientProtocol protocol = new CatchupClientProtocol();
+        protocol.expect( NextMessage.STORE_COPY_FINISHED );
+
+        EmbeddedChannel channel = new EmbeddedChannel( new StoreCopyFinishedResponseEncoder(),
+                new StoreCopyFinishedResponseDecoder( protocol ) );
+
+        // given
+        final long arbitraryId = 23;
+        StoreCopyFinishedResponse sent = new StoreCopyFinishedResponse( arbitraryId );
+
+        // when
+        channel.writeOutbound( sent );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        StoreCopyFinishedResponse received = (StoreCopyFinishedResponse) channel.readInbound();
+        assertNotSame( sent, received );
+        assertEquals( sent, received );
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFetcherTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/storecopy/edge/StoreFetcherTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.storecopy.edge;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreCopyFailedException;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreFetcher;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreFileStreams;
+import org.neo4j.coreedge.catchup.tx.edge.TransactionLogCatchUpFactory;
+import org.neo4j.coreedge.catchup.tx.edge.TransactionLogCatchUpWriter;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullClient;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponseListener;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.catchup.storecopy.edge.StoreCopyClient;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class StoreFetcherTest
+{
+    @Test
+    public void shouldCopyStoreFilesAndPullTransactions() throws Exception
+    {
+        // given
+        StoreCopyClient storeCopyClient = mock( StoreCopyClient.class );
+        TxPullClient txPullClient = mock( TxPullClient.class );
+        TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
+
+        StoreFetcher fetcher = new StoreFetcher( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
+                null,
+                storeCopyClient, txPullClient, factory( writer ) );
+
+        // when
+        AdvertisedSocketAddress localhost = address( "localhost:1980" );
+        fetcher.copyStore( localhost, new File( "destination" ) );
+
+        // then
+        verify( storeCopyClient ).copyStoreFiles( eq( localhost ), any( StoreFileStreams.class ) );
+        verify( txPullClient ).pullTransactions( eq( localhost ), anyLong(), any( TxPullResponseListener.class ) );
+    }
+
+    @Test
+    public void shouldSetLastPulledTransactionId() throws Exception
+    {
+        // given
+        long lastFlushedTxId = 12;
+        long lastPulledTxId = 34;
+
+        AdvertisedSocketAddress localhost = address( "localhost:2001" );
+
+        StoreCopyClient storeCopyClient = mock( StoreCopyClient.class );
+        when( storeCopyClient.copyStoreFiles( eq( localhost ), any( StoreFileStreams.class ) ) )
+                .thenReturn( lastFlushedTxId );
+
+        TxPullClient txPullClient = mock( TxPullClient.class );
+        when( txPullClient.pullTransactions( eq( localhost ), anyLong(), any( TxPullResponseListener.class ) ) )
+                .thenReturn( lastPulledTxId );
+
+        TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
+
+        StoreFetcher fetcher = new StoreFetcher( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
+                null,
+                storeCopyClient, txPullClient, factory( writer ) );
+
+        // when
+        fetcher.copyStore( localhost, new File( "destination" ) );
+
+        // then
+        verify( txPullClient ).pullTransactions( eq( localhost ), eq( lastFlushedTxId ), any( TxPullResponseListener.class ) );
+        verify( writer ).setCorrectTransactionId( lastPulledTxId );
+    }
+
+    @Test
+    public void shouldCloseDownTxLogWriterIfTxStreamingFails() throws Exception
+    {
+        // given
+        StoreCopyClient storeCopyClient = mock( StoreCopyClient.class );
+        TxPullClient txPullClient = mock( TxPullClient.class );
+        TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
+
+        StoreFetcher fetcher = new StoreFetcher( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
+                null,
+                storeCopyClient, txPullClient, factory( writer ) );
+
+        doThrow( StoreCopyFailedException.class ).when( txPullClient )
+                .pullTransactions( any( AdvertisedSocketAddress.class ), anyLong(), any( TransactionLogCatchUpWriter.class ) );
+
+        // when
+        try
+        {
+            fetcher.copyStore( null, null );
+        }
+        catch ( StoreCopyFailedException e )
+        {
+            // expected
+        }
+
+        // then
+        verify( writer ).close();
+    }
+
+    private TransactionLogCatchUpFactory factory( TransactionLogCatchUpWriter writer ) throws IOException
+    {
+        TransactionLogCatchUpFactory factory = mock( TransactionLogCatchUpFactory.class );
+        when( factory.create( any( File.class ), any( FileSystemAbstraction.class ),
+                any( PageCache.class ) ) ).thenReturn( writer );
+        return factory;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/TxPullRequestEncodeDecodeTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/TxPullRequestEncodeDecodeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import org.neo4j.coreedge.catchup.CatchupServerProtocol;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullRequestEncoder;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullRequest;
+import org.neo4j.coreedge.catchup.tx.core.TxPullRequestDecoder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import static org.neo4j.coreedge.catchup.CatchupServerProtocol.NextMessage;
+
+public class TxPullRequestEncodeDecodeTest
+{
+    @Test
+    public void shouldEncodeAndDecodePullRequestMessage()
+    {
+        CatchupServerProtocol protocol = new CatchupServerProtocol();
+        protocol.expect( NextMessage.TX_PULL );
+
+        EmbeddedChannel channel = new EmbeddedChannel( new TxPullRequestEncoder(),
+                new TxPullRequestDecoder( protocol ) );
+
+        // given
+        final long arbitraryId = 23;
+        TxPullRequest sent = new TxPullRequest( arbitraryId );
+
+        // when
+        channel.writeOutbound( sent );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        TxPullRequest received = (TxPullRequest) channel.readInbound();
+        assertNotSame( sent, received );
+        assertEquals( sent, received );
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/TxPullResponseEncodeDecodeTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/TxPullResponseEncodeDecodeTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponseDecoder;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponse;
+import org.neo4j.coreedge.catchup.tx.core.TxPullResponseEncoder;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommand;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
+import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
+
+import static java.util.Arrays.asList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class TxPullResponseEncodeDecodeTest
+{
+    @Test
+    public void shouldEncodeAndDecodePullResponseMessage()
+    {
+        CatchupClientProtocol protocol = new CatchupClientProtocol();
+        protocol.expect( NextMessage.TX_PULL_RESPONSE );
+
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new TxPullResponseEncoder(),
+                new TxPullResponseDecoder( protocol ) );
+
+        // given
+        TxPullResponse sent = new TxPullResponse( new StoreId(), newCommittedTransactionRepresentation() );
+
+        // when
+        channel.writeOutbound( sent );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        TxPullResponse received = (TxPullResponse) channel.readInbound();
+        assertNotSame( sent, received );
+        assertEquals( sent, received );
+    }
+
+    private CommittedTransactionRepresentation newCommittedTransactionRepresentation()
+    {
+        final long arbitraryRecordId = 27l;
+        Command.NodeCommand command = new Command.NodeCommand();
+        command.init( new NodeRecord( arbitraryRecordId ), new NodeRecord( arbitraryRecordId ) );
+
+        PhysicalTransactionRepresentation physicalTransactionRepresentation =
+                new PhysicalTransactionRepresentation( asList( new LogEntryCommand( command ).getXaCommand() ) );
+        physicalTransactionRepresentation.setHeader( new byte[]{}, 0, 0, 0, 0, 0, 0 );
+
+        LogEntryStart startEntry = new LogEntryStart( 0, 0, 0l, 0l, new byte[]{}, LogPosition.UNSPECIFIED );
+        OnePhaseCommit commitEntry = new OnePhaseCommit( 42, 0 );
+
+        return new CommittedTransactionRepresentation( startEntry, physicalTransactionRepresentation, commitEntry );
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/TxStreamFinishedResponseEncodeDecodeTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/TxStreamFinishedResponseEncodeDecodeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.tx.edge.TxStreamFinishedResponseDecoder;
+import org.neo4j.coreedge.catchup.tx.edge.TxStreamFinishedResponseEncoder;
+import org.neo4j.coreedge.catchup.tx.core.TxStreamFinishedResponse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import static org.neo4j.coreedge.catchup.CatchupClientProtocol.NextMessage;
+
+public class TxStreamFinishedResponseEncodeDecodeTest
+{
+    @Test
+    public void shouldEncodeAndDecodePullRequestMessage()
+    {
+        CatchupClientProtocol protocol = new CatchupClientProtocol();
+        protocol.expect( NextMessage.TX_STREAM_FINISHED );
+
+        EmbeddedChannel channel = new EmbeddedChannel( new TxStreamFinishedResponseEncoder(),
+                new TxStreamFinishedResponseDecoder( protocol ) );
+
+        // given
+        final long arbitraryId = 23;
+        TxStreamFinishedResponse sent = new TxStreamFinishedResponse( arbitraryId );
+
+        // when
+        channel.writeOutbound( sent );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        TxStreamFinishedResponse received = (TxStreamFinishedResponse) channel.readInbound();
+        assertNotSame( sent, received );
+        assertEquals( sent, received );
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/edge/ApplyPulledTransactionsTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/catchup/tx/edge/ApplyPulledTransactionsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup.tx.edge;
+
+import java.io.IOException;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import org.junit.Test;
+
+import org.neo4j.coreedge.catchup.tx.edge.ApplyPulledTransactions;
+import org.neo4j.coreedge.catchup.tx.edge.TxPullResponse;
+import org.neo4j.coreedge.catchup.tx.edge.TransactionApplier;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.function.Suppliers.singleton;
+
+public class ApplyPulledTransactionsTest
+{
+    @Test
+    public void shouldApplyTransaction() throws Exception
+    {
+        // given
+        StoreId storeId = new StoreId( 1, 1, 1, 1 );
+
+        TransactionApplier transactionApplier = mock( TransactionApplier.class );
+        ApplyPulledTransactions handler = new ApplyPulledTransactions( mock( LogProvider.class ),
+                singleton( transactionApplier ) );
+
+        // when
+        ChannelHandlerContext channelHandlerContext = mock( ChannelHandlerContext.class );
+        when( channelHandlerContext.pipeline() ).thenReturn( mock( ChannelPipeline.class ) );
+
+        handler.onTxReceived( new TxPullResponse( storeId, mock( CommittedTransactionRepresentation.class ) ) );
+
+        // then
+        verify( transactionApplier ).appendToLogAndApplyToStore( any( CommittedTransactionRepresentation.class ) );
+    }
+
+    @Test
+    public void shouldLogIfTransactionCannotBeApplied() throws Exception
+    {
+        // given
+        StoreId storeId = new StoreId( 1, 1, 1, 1 );
+
+        TransactionApplier transactionApplier = mock( TransactionApplier.class );
+        doThrow( IOException.class ).when( transactionApplier ).appendToLogAndApplyToStore( any(
+                CommittedTransactionRepresentation.class ) );
+
+
+        LogProvider logProvider = mock( LogProvider.class );
+        Log log = mock( Log.class );
+        when( logProvider.getLog( ApplyPulledTransactions.class ) ).thenReturn( log );
+
+        ApplyPulledTransactions handler = new ApplyPulledTransactions( logProvider, singleton( transactionApplier )
+        );
+
+        // when
+        handler.onTxReceived( new TxPullResponse( storeId, mock( CommittedTransactionRepresentation.class ) ) );
+
+        // then
+        verify( log ).error( anyString(), any( Throwable.class ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/Cluster.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/Cluster.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.locks.LockSupport;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.coreedge.server.CoreEdgeClusterSettings;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.core.CoreGraphDatabase;
+import org.neo4j.coreedge.server.edge.EdgeGraphDatabase;
+import org.neo4j.coreedge.raft.NoLeaderTimeoutException;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.GraphDatabaseDependencies;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.joining;
+
+import static org.neo4j.concurrent.Futures.combine;
+import static org.neo4j.helpers.collection.Iterables.first;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class Cluster
+{
+    public static final String CLUSTER_NAME = "core-neo4j";
+
+    private final File parentDir;
+    private final DiscoveryServiceFactory discoveryServiceFactory;
+    private Set<CoreGraphDatabase> coreServers = new HashSet<>();
+    private Set<EdgeGraphDatabase> edgeServers = new HashSet<>();
+
+    Cluster( File parentDir, int noOfCoreServers, int noOfEdgeServers, DiscoveryServiceFactory discoveryServiceFactory )
+            throws ExecutionException, InterruptedException
+    {
+        this.discoveryServiceFactory = discoveryServiceFactory;
+        List<AdvertisedSocketAddress> initialHosts = buildAddresses( noOfCoreServers );
+        this.parentDir = parentDir;
+
+        ExecutorService executor = Executors.newCachedThreadPool();
+        try
+        {
+            startCoreServers( executor, noOfCoreServers, initialHosts );
+            startEdgeServers( executor, noOfEdgeServers, initialHosts );
+        }
+        finally
+        {
+            executor.shutdownNow();
+        }
+    }
+
+    public static Cluster start( File parentDir, int noOfCoreServers, int noOfEdgeServers,
+                                 DiscoveryServiceFactory discoveryServiceFactory )
+            throws ExecutionException, InterruptedException
+    {
+        return new Cluster( parentDir, noOfCoreServers, noOfEdgeServers, discoveryServiceFactory );
+    }
+
+    public static Cluster start( File parentDir, int noOfCoreServers, int noOfEdgeServers )
+            throws ExecutionException, InterruptedException
+    {
+        return new Cluster( parentDir, noOfCoreServers, noOfEdgeServers, new HazelcastDiscoveryServiceFactory() );
+    }
+
+    private static File coreServerStoreDirectory( File parentDir, int serverId )
+    {
+        return new File( parentDir, "server-core-" + serverId );
+    }
+
+    public static File edgeSeverStoreDirectory( File parentDir, int serverId )
+    {
+        return new File( parentDir, "server-edge-" + serverId );
+    }
+
+    private static Map<String, String> serverParams( String serverType, int serverId, String initialHosts )
+    {
+        Map<String, String> params = stringMap();
+        params.put( "org.neo4j.server.database.mode", serverType );
+        params.put( ClusterSettings.cluster_name.name(), CLUSTER_NAME );
+        params.put( ClusterSettings.server_id.name(), String.valueOf( serverId ) );
+        params.put( CoreEdgeClusterSettings.initial_core_cluster_members.name(), initialHosts );
+        return params;
+    }
+
+    private static List<AdvertisedSocketAddress> buildAddresses( int noOfCoreServers )
+    {
+        List<AdvertisedSocketAddress> addresses = new ArrayList<>();
+        for ( int i = 0; i < noOfCoreServers; i++ )
+        {
+            int port = 5000 + i;
+            addresses.add( new AdvertisedSocketAddress( new InetSocketAddress( "localhost", port ) ) );
+        }
+        return addresses;
+    }
+
+    private void startCoreServers( ExecutorService executor, final int noOfCoreServers, List<AdvertisedSocketAddress>
+            addresses )
+            throws InterruptedException, ExecutionException
+    {
+        List<Callable<CoreGraphDatabase>> coreServerSuppliers = new ArrayList<>();
+        for ( int i = 0; i < noOfCoreServers; i++ )
+        {
+            // start up a core server
+            final int serverId = i;
+            coreServerSuppliers.add( () -> startCoreServer( serverId, noOfCoreServers, addresses ) );
+        }
+
+        Future<List<CoreGraphDatabase>> coreServerFutures = combine( executor.invokeAll( coreServerSuppliers ) );
+        this.coreServers.addAll( coreServerFutures.get() );
+    }
+
+    private void startEdgeServers( ExecutorService executor, int noOfEdgeServers, final List<AdvertisedSocketAddress>
+            addresses )
+            throws InterruptedException, ExecutionException
+    {
+        List<Callable<EdgeGraphDatabase>> edgeServerSuppliers = new ArrayList<>();
+
+        for ( int i = 0; i < noOfEdgeServers; i++ )
+        {
+            // start up an edge server
+            final int serverId = i;
+            edgeServerSuppliers.add( () -> startEdgeServer( serverId, addresses ) );
+        }
+
+        Future<List<EdgeGraphDatabase>> edgeServerFutures = combine( executor.invokeAll( edgeServerSuppliers ) );
+        this.edgeServers.addAll( edgeServerFutures.get() );
+    }
+
+    public CoreGraphDatabase startCoreServer( int serverId, int clusterSize, List<AdvertisedSocketAddress> addresses )
+    {
+        int clusterPort = 5000 + serverId;
+        int txPort = 6000 + serverId;
+        int raftPort = 7000 + serverId;
+
+        String initialHosts = addresses.stream().map( AdvertisedSocketAddress::toString ).collect( joining( "," ) );
+
+        final Map<String, String> params = serverParams( "CORE", serverId, initialHosts );
+        params.put( CoreEdgeClusterSettings.cluster_listen_address.name(), "localhost:" + clusterPort );
+
+        params.put( CoreEdgeClusterSettings.transaction_advertised_address.name(), "localhost:" + txPort );
+        params.put( CoreEdgeClusterSettings.transaction_listen_address.name(), "127.0.0.1:" + txPort );
+        params.put( CoreEdgeClusterSettings.raft_advertised_address.name(), "localhost:" + raftPort );
+        params.put( CoreEdgeClusterSettings.raft_listen_address.name(), "127.0.0.1:" + raftPort );
+
+        params.put( CoreEdgeClusterSettings.expected_core_cluster_size.name(), String.valueOf( clusterSize ) );
+        params.put( HaSettings.pull_interval.name(), String.valueOf( 5 ) );
+        params.put( GraphDatabaseSettings.pagecache_memory.name(), "100M" );
+
+        final File storeDir = coreServerStoreDirectory( parentDir, serverId );
+        return new CoreGraphDatabase( storeDir, params, GraphDatabaseDependencies.newDependencies(),
+                discoveryServiceFactory );
+    }
+
+    public EdgeGraphDatabase startEdgeServer( int serverId, List<AdvertisedSocketAddress> addresses )
+    {
+        final File storeDir = edgeSeverStoreDirectory( parentDir, serverId );
+        return startEdgeServer( serverId, storeDir, addresses );
+    }
+
+    private EdgeGraphDatabase startEdgeServer( int serverId, File storeDir, List<AdvertisedSocketAddress> addresses )
+    {
+        String initialHosts = addresses.stream().map( AdvertisedSocketAddress::toString ).collect( joining( "," ) );
+
+        final Map<String, String> params = serverParams( "EDGE", serverId, initialHosts );
+        params.put( HaSettings.pull_interval.name(), String.valueOf( 5 ) );
+        params.put( GraphDatabaseSettings.pagecache_memory.name(), "100M" );
+        return new EdgeGraphDatabase( storeDir, params, GraphDatabaseDependencies.newDependencies(),
+                discoveryServiceFactory );
+    }
+
+    public void shutdown()
+    {
+        ExecutorService executor = Executors.newCachedThreadPool();
+        List<Callable<Object>> serverShutdownSuppliers = new ArrayList<>();
+        for ( final CoreGraphDatabase coreServer : coreServers )
+        {
+            serverShutdownSuppliers.add( () -> {
+                coreServer.shutdown();
+                return null;
+            } );
+        }
+
+        try
+        {
+            combine( executor.invokeAll( serverShutdownSuppliers ) ).get();
+        }
+        catch ( InterruptedException | ExecutionException e )
+        {
+            e.printStackTrace();
+        }
+        finally
+        {
+            executor.shutdown();
+        }
+
+        for ( EdgeGraphDatabase edgeServer : edgeServers )
+        {
+            edgeServer.shutdown();
+        }
+    }
+
+    public CoreGraphDatabase getCoreServerById( int serverId )
+    {
+        for ( CoreGraphDatabase coreServer : coreServers )
+        {
+            if ( serverIdFor( coreServer ).toIntegerIndex() == serverId )
+            {
+                return coreServer;
+            }
+        }
+        return null;
+    }
+
+    public void removeCoreServerWithServerId( int serverId )
+    {
+        CoreGraphDatabase serverToRemove = getCoreServerById( serverId );
+
+        if (serverToRemove != null )
+        {
+            removeCoreServer( serverToRemove );
+        }
+        else
+        {
+            throw new RuntimeException( "Could not remove core server with server id " + serverId );
+        }
+    }
+
+    public void removeCoreServer( CoreGraphDatabase serverToRemove )
+    {
+        serverToRemove.shutdown();
+        coreServers.remove( serverToRemove );
+    }
+
+    public void removeEdgeServerWithServerId( int serverId )
+    {
+        EdgeGraphDatabase serverToRemove = null;
+        for ( EdgeGraphDatabase edgeServer : edgeServers )
+        {
+            if ( serverIdFor( edgeServer ).toIntegerIndex() == serverId )
+            {
+                edgeServer.shutdown();
+                serverToRemove = edgeServer;
+            }
+        }
+
+        if ( serverToRemove == null )
+        {
+            throw new RuntimeException( "Could not remove edge server with server id " + serverId );
+        }
+        else
+        {
+            edgeServers.remove( serverToRemove );
+        }
+    }
+
+    public void addCoreServerWithServerId( int serverId, int intendedClusterSize )
+    {
+        Config config = first( coreServers ).getDependencyResolver().resolveDependency( Config.class );
+        List<AdvertisedSocketAddress> advertisedAddress = config.get( CoreEdgeClusterSettings
+                .initial_core_cluster_members );
+
+        coreServers.add( startCoreServer( serverId, intendedClusterSize, advertisedAddress ) );
+    }
+
+    public void addEdgeServerWithFileLocation( int serverId )
+    {
+        Config config = coreServers.iterator().next().getDependencyResolver().resolveDependency( Config.class );
+        List<AdvertisedSocketAddress> advertisedAddresses = config.get( CoreEdgeClusterSettings
+                .initial_core_cluster_members );
+
+        edgeServers.add( startEdgeServer( serverId, advertisedAddresses ) );
+    }
+
+    private InstanceId serverIdFor( GraphDatabaseFacade graphDatabaseFacade )
+    {
+        return graphDatabaseFacade.getDependencyResolver().resolveDependency( Config.class )
+                .get( ClusterSettings.server_id );
+    }
+
+    public Set<CoreGraphDatabase> coreServers()
+    {
+        return coreServers;
+    }
+
+    public Set<EdgeGraphDatabase> edgeServers()
+    {
+        return edgeServers;
+    }
+
+    public GraphDatabaseService findAnEdgeServer()
+    {
+        return edgeServers.iterator().next();
+    }
+
+    public CoreGraphDatabase getLeader()
+    {
+        for ( CoreGraphDatabase coreServer : coreServers )
+        {
+            if ( coreServer.getRole().equals( Role.LEADER ) )
+            {
+                return coreServer;
+            }
+        }
+        return null;
+    }
+
+    public CoreGraphDatabase findLeader( long leaderWaitTimeout ) throws NoLeaderTimeoutException
+    {
+        long leaderWaitEndTime = leaderWaitTimeout + System.currentTimeMillis();
+        CoreGraphDatabase leader;
+        while ( (leader = getLeader()) == null && (System.currentTimeMillis() < leaderWaitEndTime) )
+        {
+            LockSupport.parkNanos( MILLISECONDS.toNanos( 1000 ) );
+        }
+
+        if ( leader == null )
+        {
+            throw new NoLeaderTimeoutException();
+        }
+
+        return leader;
+    }
+
+    public int numberOfCoreServers()
+    {
+        CoreGraphDatabase aCoreGraphDb = coreServers.iterator().next();
+        CoreDiscoveryService coreDiscoveryService = aCoreGraphDb.getDependencyResolver()
+                .resolveDependency( CoreDiscoveryService.class );
+        return coreDiscoveryService.currentTopology().getNumberOfCoreServers();
+    }
+
+    public int numberOfEdgeServers()
+    {
+        EdgeGraphDatabase edge = edgeServers.iterator().next();
+        EdgeDiscoveryService lifecycle = edge.getDependencyResolver()
+                .resolveDependency( EdgeDiscoveryService.class );
+        return lifecycle.currentTopology().getNumberOfEdgeServers();
+    }
+
+    public void addEdgeServerWithFileLocation( File edgeDatabaseStoreFileLocation )
+    {
+        Config config = coreServers.iterator().next().getDependencyResolver().resolveDependency( Config.class );
+        List<AdvertisedSocketAddress> advertisedAddresses = config.get( CoreEdgeClusterSettings
+                .initial_core_cluster_members );
+
+
+        edgeServers.add( startEdgeServer( 999, edgeDatabaseStoreFileLocation, advertisedAddresses ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/HazelcastClusterTopologyTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/HazelcastClusterTopologyTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+public class HazelcastClusterTopologyTest
+{
+  // TODO: write a test that creates a cluster with Hazelcast to check that it works end to end
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/TestOnlyClusterTopology.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/TestOnlyClusterTopology.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import java.util.ArrayList;
+import java.util.Set;
+
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.coreedge.discovery.ClusterTopology;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.CoreMember;
+
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+public class TestOnlyClusterTopology implements ClusterTopology
+{
+    private final ArrayList<CoreMember> coreMembers;
+    private final Set<InstanceId> edgeMembers;
+    private final boolean canBeBootstrapped;
+
+    public TestOnlyClusterTopology( boolean canBeBootstrapped, Set<CoreMember> coreMembers, Set<InstanceId> edgeMembers )
+    {
+        this.canBeBootstrapped = canBeBootstrapped;
+        this.edgeMembers = edgeMembers;
+        this.coreMembers = new ArrayList<>( coreMembers );
+    }
+
+    @Override
+    public AdvertisedSocketAddress firstTransactionServer()
+    {
+        return coreMembers.size() > 0 ? coreMembers.get( 0 ).getCoreAddress() : null;
+    }
+
+    @Override
+    public int getNumberOfEdgeServers()
+    {
+        return edgeMembers.size();
+    }
+
+    @Override
+    public int getNumberOfCoreServers()
+    {
+        return coreMembers.size();
+    }
+
+    @Override
+    public Set<CoreMember> getMembers()
+    {
+        return asSet( coreMembers );
+    }
+
+    @Override
+    public boolean bootstrappable()
+    {
+        return canBeBootstrapped;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TestOnlyClusterTopology{" +
+                "coreMembers.size()=" + coreMembers.size() +
+                ", bootstrappable=" + bootstrappable() +
+                ", edgeMembers.size()=" + edgeMembers.size() +
+                '}';
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/TestOnlyCoreDiscoveryService.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/TestOnlyCoreDiscoveryService.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import org.neo4j.coreedge.server.CoreEdgeClusterSettings;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static org.neo4j.helpers.Listeners.notifyListeners;
+import static org.neo4j.helpers.collection.Iterables.first;
+
+public class TestOnlyCoreDiscoveryService extends LifecycleAdapter implements CoreDiscoveryService
+{
+    private final CoreMember me;
+    private final TestOnlyDiscoveryServiceFactory cluster;
+
+    public TestOnlyCoreDiscoveryService( Config config, TestOnlyDiscoveryServiceFactory cluster )
+    {
+        this.cluster = cluster;
+        synchronized ( cluster.coreMembers )
+        {
+            this.me = toCoreMember( config );
+            cluster.coreMembers.add( me );
+
+            if ( cluster.bootstrappable == null )
+            {
+                cluster.bootstrappable = me;
+            }
+
+            notifyListeners( cluster.membershipListeners, listener -> listener.onTopologyChange( currentTopology() ) );
+        }
+    }
+
+    private CoreMember toCoreMember( Config config )
+    {
+        return new CoreMember(
+                config.get( CoreEdgeClusterSettings.transaction_advertised_address ),
+                config.get( CoreEdgeClusterSettings.raft_advertised_address ) );
+    }
+
+    @Override
+    public synchronized void addMembershipListener( Listener listener )
+    {
+        cluster.membershipListeners.add( listener );
+    }
+
+    @Override
+    public synchronized void removeMembershipListener( Listener listener )
+    {
+        cluster.membershipListeners.remove( listener );
+    }
+
+    @Override
+    public synchronized void start() throws Throwable
+    {
+        notifyListeners( cluster.membershipListeners, listener -> listener.onTopologyChange( currentTopology() ) );
+    }
+
+    @Override
+    public synchronized void stop()
+    {
+        cluster.coreMembers.remove( me );
+
+        // Move the bootstrappable instance, if necessary
+        if ( cluster.bootstrappable == me )
+        {
+            cluster.bootstrappable = first( cluster.coreMembers );
+        }
+
+        notifyListeners( cluster.membershipListeners, listener -> listener.onTopologyChange( currentTopology() ) );
+    }
+
+    @Override
+    public synchronized ClusterTopology currentTopology()
+    {
+        CoreMember firstMember = first( cluster.coreMembers );
+        return new TestOnlyClusterTopology( firstMember != null && firstMember.equals( me ),
+                cluster.coreMembers, cluster.edgeMembers );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/TestOnlyDiscoveryServiceFactory.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/TestOnlyDiscoveryServiceFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.kernel.configuration.Config;
+
+public class TestOnlyDiscoveryServiceFactory implements DiscoveryServiceFactory
+{
+    protected final Set<CoreMember> coreMembers = new TreeSet<>( ( o1, o2 ) -> {
+        if ( o1 == null && o2 == null )
+        {
+            return 0;
+        }
+        if ( o1 == null )
+        {
+            return -1;
+        }
+        if ( o2 == null )
+        {
+            return 1;
+        }
+
+        int port1 = o1.getCoreAddress().socketAddress().getPort();
+        int port2 = o2.getCoreAddress().socketAddress().getPort();
+        if ( port1 < port2 )
+        {
+            return -1;
+        }
+        else if ( port1 == port2 )
+        {
+            return 0;
+        }
+        else
+        {
+            return 1;
+        }
+    } );
+
+    protected Set<CoreDiscoveryService.Listener> membershipListeners = new CopyOnWriteArraySet<>();
+    protected CoreMember bootstrappable;
+
+    protected final Set<InstanceId> edgeMembers = new CopyOnWriteArraySet<>();
+
+    @Override
+    public CoreDiscoveryService coreDiscoveryService( Config config )
+    {
+        return new TestOnlyCoreDiscoveryService( config, this );
+    }
+
+    @Override
+    public EdgeDiscoveryService edgeDiscoveryService( Config config )
+    {
+        return new TestOnlyEdgeDiscoveryService( config, this );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/TestOnlyEdgeDiscoveryService.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/TestOnlyEdgeDiscoveryService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.discovery;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public class TestOnlyEdgeDiscoveryService extends LifecycleAdapter implements EdgeDiscoveryService
+{
+    private final InstanceId edgeMe;
+    private final TestOnlyDiscoveryServiceFactory cluster;
+
+    public TestOnlyEdgeDiscoveryService( Config config, TestOnlyDiscoveryServiceFactory cluster )
+    {
+        this.cluster = cluster;
+        this.edgeMe = toEdge( config );
+        cluster.edgeMembers.add( edgeMe );
+    }
+
+    private InstanceId toEdge( Config config )
+    {
+        return new InstanceId( Integer.valueOf( config.getParams().get( ClusterSettings.server_id.name() ) ) );
+    }
+
+    @Override
+    public void stop()
+    {
+        cluster.edgeMembers.remove( edgeMe );
+    }
+
+    @Override
+    public ClusterTopology currentTopology()
+    {
+        return new TestOnlyClusterTopology( false, cluster.coreMembers, cluster.edgeMembers );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesMessageFlowTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesMessageFlowTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.server.RaftTestMemberSetBuilder;
+import org.neo4j.coreedge.raft.net.Outbound;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesRequest;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AppendEntriesMessageFlowTest
+{
+    private RaftTestMember myself = member( 0 );
+    private RaftTestMember otherMember = member( 1 );
+
+    private ReplicatedInteger data = ReplicatedInteger.valueOf( 1 );
+
+    @Mock
+    private Outbound<RaftTestMember> outbound;
+
+    ReplicatedInteger data( int value )
+    {
+        return ReplicatedInteger.valueOf( value );
+    }
+
+    private RaftInstance<RaftTestMember> raft;
+
+    @Before
+    public void setup()
+    {
+        // given
+        raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .outbound( outbound )
+                .build();
+    }
+
+    @Test
+    public void shouldReturnFalseOnAppendRequestFromOlderTerm()
+    {
+        // when
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( -1 ).leader( myself ).prevLogIndex( 0 )
+                .prevLogTerm( 0 ).leaderCommit( 0 ).build() );
+
+        // then
+        verify( outbound ).send( same( otherMember ), eq( appendEntriesResponse().from( myself ).term( 0 ).failure()
+                .build() ) );
+    }
+
+    @Test
+    public void shouldReturnTrueOnAppendRequestWithFirstLogEntry()
+    {
+        // when
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 0 ).leader( myself ).prevLogIndex( -1 )
+                .prevLogTerm( -1 ).logEntry( new RaftLogEntry( 0, data ) ).leaderCommit( -1 ).build() );
+
+        // then
+        verify( outbound ).send( same( otherMember ), eq( appendEntriesResponse().from( myself ).term( 0 ).success()
+                .build() ) );
+    }
+
+    @Test
+    public void shouldReturnTrueOnAppendRequestWithFirstLogEntryAndIgnorePrevTerm()
+    {
+        // when
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 0 ).leader( myself ).prevLogIndex( -1 )
+                .prevLogTerm( -1 ).logEntry( new RaftLogEntry( 0, data ) ).build() );
+
+        // then
+        verify( outbound ).send( same( otherMember ), eq( appendEntriesResponse().from( myself ).term( 0 ).success()
+                .build() ) );
+    }
+
+    @Test
+    public void shouldReturnFalseOnAppendRequestWhenPrevLogEntryNotMatched()
+    {
+        // when
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 0 ).leader( myself ).prevLogIndex( 0 )
+                .prevLogTerm( 0 ).logEntry( new RaftLogEntry( 0, data ) ).build() );
+
+        // then
+        verify( outbound ).send( same( otherMember ), eq( appendEntriesResponse().from( myself ).term( 0 ).failure()
+                .build() ) );
+    }
+
+    @Test
+    public void shouldAcceptSequenceOfAppendEntries()
+    {
+        // when
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 0 ).leader( myself ).prevLogIndex( -1 )
+                .prevLogTerm( -1 ).logEntry( new RaftLogEntry( 0, data( 1 ) ) ).leaderCommit( -1 ).build() );
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 0 ).leader( myself ).prevLogIndex( 0 )
+                .prevLogTerm( 0 ).logEntry( new RaftLogEntry( 0, data( 2 ) ) ).leaderCommit( -1 ).build() );
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 0 ).leader( myself ).prevLogIndex( 1 )
+                .prevLogTerm( 0 ).logEntry( new RaftLogEntry( 0, data( 3 ) ) ).leaderCommit( 0 ).build() );
+
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 1 ).leader( myself ).prevLogIndex( 2 )
+                .prevLogTerm( 0 ).logEntry( new RaftLogEntry( 1, data( 4 ) ) ).leaderCommit( 1 ).build() );
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 1 ).leader( myself ).prevLogIndex( 3 )
+                .prevLogTerm( 1 ).logEntry( new RaftLogEntry( 1, data( 5 ) ) ).leaderCommit( 2 ).build() );
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 1 ).leader( myself ).prevLogIndex( 4 )
+                .prevLogTerm( 1 ).logEntry( new RaftLogEntry( 1, data( 6 ) ) ).leaderCommit( 4 ).build() );
+
+        // then
+        InOrder invocationOrder = inOrder( outbound );
+        invocationOrder.verify( outbound, times( 3 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 0 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 3 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 1 ).success().build() ) );
+    }
+
+    @Test
+    public void shouldReturnFalseIfLogHistoryDoesNotMatch()
+    {
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 0 ).leader( myself ).prevLogIndex( -1 )
+                .prevLogTerm( -1 ).logEntry( new RaftLogEntry( 0, data( 1 ) ) ).build() );
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 0 ).leader( myself ).prevLogIndex( 0 )
+                .prevLogTerm( 0 ).logEntry( new RaftLogEntry( 0, data( 2 ) ) ).build() );
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 0 ).leader( myself ).prevLogIndex( 1 )
+                .prevLogTerm( 0 ).logEntry( new RaftLogEntry( 0, data( 3 ) ) ).build() ); // will conflict
+
+        // when
+        raft.handle( appendEntriesRequest().from( otherMember ).leaderTerm( 2 ).leader( myself ).prevLogIndex( 2 )
+                .prevLogTerm( 1 ).logEntry( new RaftLogEntry( 2, data( 4 ) ) ).build() ); // should reply false
+        // because of prevLogTerm
+
+        // then
+        InOrder invocationOrder = inOrder( outbound );
+        invocationOrder.verify( outbound, times( 3 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 0 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 2 ).failure().build() ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesRequestBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesRequestBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+
+public class AppendEntriesRequestBuilder<MEMBER>
+{
+    private List<RaftLogEntry> logEntries = new LinkedList<>();
+    private long leaderCommit = -1;
+    private long prevLogTerm = -1;
+    private long prevLogIndex = -1;
+    private MEMBER leader = null;
+    private long leaderTerm = -1;
+    private MEMBER from = null;
+    private UUID correlationId = new UUID( 0, 0 );
+
+    public RaftMessages.AppendEntries.Request<MEMBER> build()
+    {
+        return new RaftMessages.AppendEntries.Request<>( from, leaderTerm, prevLogIndex, prevLogTerm,
+                logEntries.toArray( new RaftLogEntry[logEntries.size()] ), leaderCommit );
+    }
+
+    public AppendEntriesRequestBuilder<MEMBER> from( MEMBER from )
+    {
+        this.from = from;
+        return this;
+    }
+
+    public AppendEntriesRequestBuilder<MEMBER> leaderTerm( long leaderTerm )
+    {
+        this.leaderTerm = leaderTerm;
+        return this;
+    }
+
+    public AppendEntriesRequestBuilder<MEMBER> prevLogIndex( long prevLogIndex )
+    {
+        this.prevLogIndex = prevLogIndex;
+        return this;
+    }
+
+    public AppendEntriesRequestBuilder<MEMBER> prevLogTerm( long prevLogTerm )
+    {
+        this.prevLogTerm = prevLogTerm;
+        return this;
+    }
+
+    public AppendEntriesRequestBuilder<MEMBER> logEntry( RaftLogEntry logEntry )
+    {
+        logEntries.add( logEntry );
+        return this;
+    }
+
+    public AppendEntriesRequestBuilder<MEMBER> leaderCommit( long leaderCommit )
+    {
+        this.leaderCommit = leaderCommit;
+        return this;
+    }
+
+    public AppendEntriesRequestBuilder<MEMBER> leader( MEMBER leader )
+    {
+        this.leader = leader;
+        return this;
+    }
+
+    public AppendEntriesRequestBuilder<MEMBER> correlationId( UUID correlationId )
+    {
+        this.correlationId = correlationId;
+        return this;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesResponseBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesResponseBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public class AppendEntriesResponseBuilder<MEMBER>
+{
+    boolean success;
+    private long term = -1;
+    private MEMBER from = null;
+    private long matchIndex = -1;
+
+    public RaftMessages.AppendEntries.Response<MEMBER> build()
+    {
+        // a response of false should always have a match index of -1
+        assert !( success == false && matchIndex != -1 );
+        return new RaftMessages.AppendEntries.Response<>( from, term, success, matchIndex );
+    }
+
+    public AppendEntriesResponseBuilder<MEMBER> from( MEMBER from )
+    {
+        this.from = from;
+        return this;
+    }
+
+    public AppendEntriesResponseBuilder<MEMBER> term( long term )
+    {
+        this.term = term;
+        return this;
+    }
+
+    public AppendEntriesResponseBuilder<MEMBER> matchIndex( long matchIndex )
+    {
+        this.matchIndex = matchIndex;
+        return this;
+    }
+
+    public AppendEntriesResponseBuilder<MEMBER> success()
+    {
+        this.success = true;
+        return this;
+    }
+
+    public AppendEntriesResponseBuilder<MEMBER> failure()
+    {
+        this.success = false;
+        return this;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/BallotTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/BallotTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BallotTest
+{
+    Object A = new Object();
+    Object B = new Object();
+
+    @Test
+    public void shouldVoteFalseInOldTerm()
+    {
+        // when + then
+        assertFalse( Ballot.shouldVoteFor( A, 4 /*request term */, 5 /*context term */, -1, -1, -1, -1, null ) );
+    }
+
+    @Test
+    public void shouldVoteFalseIfLogNotUpToDateBecauseOfTerm()
+    {
+        // when + then
+        assertFalse( Ballot.shouldVoteFor( A, 0, 0, 0, 0, 1 /*context last log term */, 0 /*request last log term */,
+                null ) );
+    }
+
+    @Test
+    public void shouldVoteFalseIfLogNotUpToDateBecauseOfIndex()
+    {
+        // when + then
+        assertFalse( Ballot.shouldVoteFor( A, 0, 0, 1/*context last appended */, 0/*request last log index*/, 0, 0,
+                null ) );
+    }
+
+    @Test
+    public void shouldVoteFalseIfAlreadyVotedForOtherCandidate()
+    {
+        // when + then
+        assertFalse( Ballot.shouldVoteFor( A, 0, 0, 0, 0, 0, 0, B ) );
+    }
+
+    @Test
+    public void shouldVoteTrueIfAlreadyVotedForCandidate()
+    {
+        // when + then
+        assertTrue( Ballot.shouldVoteFor( A, 0, 0, 0, 0, 0, 0, A ) );
+    }
+
+    @Test
+    public void shouldVoteTrueForNewCandidateWithUpToDateLog()
+    {
+        // when + then
+        assertTrue( Ballot.shouldVoteFor( A, 0, 0, 0, 0, 0, 0, null ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/CatchUpTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/CatchUpTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.RaftMessages.NewEntry.Request;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.membership.RaftTestGroup;
+import org.neo4j.coreedge.server.RaftTestMember;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.coreedge.raft.ReplicatedInteger.valueOf;
+
+public class CatchUpTest
+{
+    @Test
+    public void happyClusterPropagatesUpdates() throws Throwable
+    {
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leader = 0;
+        final long[] allMembers = {leader, 1, 2};
+
+        final RaftTestFixture fixture = new RaftTestFixture( net, 3, allMembers );
+        fixture.members().withId( leader ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( allMembers ) );
+        final RaftTestMember leaderMember = fixture.members().withId( leader ).member();
+
+        // when
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( RaftInstance.Timeouts.ELECTION );
+        net.processMessages();
+        fixture.members().withId( leader ).raftInstance().handle( new Request<>( leaderMember, valueOf( 42 ) ) );
+        net.processMessages();
+
+        // then
+        for ( long aMember : allMembers )
+        {
+            assertLogEntries( 1, fixture.members().withId( aMember ).raftLog(), 42 );
+        }
+    }
+
+    @Test
+    public void newMemberWithNoLogShouldCatchUpFromPeers() throws Throwable
+    {
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leaderId = 0;
+        final long sleepyId = 2;
+
+        final long[] awakeMembers = {leaderId, 1};
+        final long[] allMembers = {leaderId, 1, sleepyId};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 3, allMembers );
+        fixture.members().withId( leaderId ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( allMembers ) );
+
+        fixture.members().withId( leaderId ).timeoutService().invokeTimeout( RaftInstance.Timeouts.ELECTION );
+        net.processMessages();
+
+        final RaftTestMember leader = fixture.members().withId( leaderId ).member();
+
+        net.disconnect( sleepyId );
+
+        // when
+        fixture.members().withId( leaderId ).raftInstance().handle( new Request<>( leader, valueOf( 10 ) ) );
+        fixture.members().withId( leaderId ).raftInstance().handle( new Request<>( leader, valueOf( 20 ) ) );
+        fixture.members().withId( leaderId ).raftInstance().handle( new Request<>( leader, valueOf( 30 ) ) );
+        fixture.members().withId( leaderId ).raftInstance().handle( new Request<>( leader, valueOf( 40 ) ) );
+        net.processMessages();
+
+        // then
+        for ( long awakeMember : awakeMembers )
+        {
+            assertLogEntries( 1, fixture.members().withId( awakeMember ).raftLog(), 10, 20, 30, 40 );
+        }
+
+        assertEquals( 0, fixture.members().withId( sleepyId ).raftLog().appendIndex() );
+
+        // when
+        net.reconnect( sleepyId );
+        Thread.sleep( 500 ); // TODO: This needs an injectable/controllable timeout service for the log shipper.
+        net.processMessages();
+
+        // then
+        assertLogEntries( 1, fixture.members().withId( sleepyId ).raftLog(), 10, 20, 30, 40 );
+        assertEquals( 4, fixture.members().withId( sleepyId ).raftLog().appendIndex() );
+    }
+
+    private void assertLogEntries( final int startIndex, ReadableRaftLog log, int... expectedValues ) throws RaftStorageException
+    {
+        long logIndex = startIndex;
+
+        for ( int expectedValue : expectedValues )
+        {
+            assertTrue( "Missing entry for logIndex " + logIndex, log.entryExists( logIndex ) );
+            assertEquals( ((ReplicatedInteger) log.readEntryContent( logIndex )).get(), expectedValue );
+
+            logIndex++;
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/ControlledTimeoutService.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/ControlledTimeoutService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.helpers.Pair;
+
+import static org.mockito.Mockito.mock;
+
+public class ControlledTimeoutService implements TimeoutService
+{
+    private Map<TimeoutName, Pair<TimeoutHandler, Timeout>> handlers = new HashMap<>();
+
+    @Override
+    public Timeout create( TimeoutName name, long milliseconds, long randomRange, TimeoutHandler handler )
+    {
+        Timeout timeout = mock( Timeout.class );
+        handlers.put( name, Pair.of( handler, timeout ) );
+        return timeout;
+    }
+
+    public void invokeTimeout( TimeoutName name )
+    {
+        Pair<TimeoutHandler, Timeout> pair = handlers.get( name );
+        pair.first().onTimeout( pair.other() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/DirectNetworking.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/DirectNetworking.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+
+public class DirectNetworking
+{
+    private final Map<Long, org.neo4j.coreedge.raft.net.Inbound.MessageHandler> handlers = new HashMap<>();
+    private final Map<Long, Queue<Serializable>> messageQueues = new HashMap<>();
+    private final Set<Long> disconnectedMembers = Collections.newSetFromMap( new ConcurrentHashMap<>() );
+
+    public void processMessages()
+    {
+        while ( messagesToBeProcessed() )
+        {
+            for ( Map.Entry<Long, Queue<Serializable>> entry : messageQueues.entrySet() )
+            {
+                Long id = entry.getKey();
+                Queue<Serializable> queue = entry.getValue();
+                if ( !queue.isEmpty() )
+                {
+                    Serializable message = queue.remove();
+                    handlers.get( id ).handle( message );
+                }
+            }
+        }
+    }
+
+    private boolean messagesToBeProcessed()
+    {
+        for ( Queue<Serializable> queue : messageQueues.values() )
+        {
+            if ( !queue.isEmpty() )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void disconnect( long id )
+    {
+        disconnectedMembers.add( id );
+    }
+
+    public void reconnect( long id )
+    {
+        disconnectedMembers.remove( id );
+    }
+
+    public class Outbound implements org.neo4j.coreedge.raft.net.Outbound<RaftTestMember>
+    {
+        private final long me;
+
+        public Outbound( long me )
+        {
+            this.me = me;
+        }
+
+        @Override
+        public synchronized void send( RaftTestMember to, final Serializable... messages )
+        {
+            if ( !messageQueues.containsKey( to.getId() ) ||
+                    disconnectedMembers.contains( to.getId() ) ||
+                    disconnectedMembers.contains( me ) )
+            {
+                return;
+            }
+
+            for ( Serializable message : messages )
+            {
+                messageQueues.get( to.getId() ).add( message );
+            }
+        }
+    }
+
+    public class Inbound implements org.neo4j.coreedge.raft.net.Inbound
+    {
+        private final long id;
+
+        public Inbound( long id )
+        {
+            this.id = id;
+        }
+
+        @Override
+        public void registerHandler( MessageHandler handler )
+        {
+            handlers.put( id, handler );
+            messageQueues.put( id, new LinkedList<>() );
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/HeartbeatBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/HeartbeatBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public class HeartbeatBuilder<MEMBER>
+{
+    private long commitIndex = -1;
+    private long leaderTerm = -1;
+    private long commitIndexTerm = -1;
+    private MEMBER from = null;
+
+    public RaftMessages.Heartbeat<MEMBER> build()
+    {
+        return new RaftMessages.Heartbeat<>( from, leaderTerm, commitIndex, commitIndexTerm );
+    }
+
+    public HeartbeatBuilder<MEMBER> from( MEMBER from )
+    {
+        this.from = from;
+        return this;
+    }
+
+    public HeartbeatBuilder<MEMBER> leaderTerm( long leaderTerm )
+    {
+        this.leaderTerm = leaderTerm;
+        return this;
+    }
+
+    public HeartbeatBuilder<MEMBER> commitIndex( long commitIndex )
+    {
+        this.commitIndex = commitIndex;
+        return this;
+    }
+
+    public HeartbeatBuilder<MEMBER> commitIndexTerm( long commitIndexTerm )
+    {
+        this.commitIndexTerm = commitIndexTerm;
+        return this;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/MessageUtils.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/MessageUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.function.Predicate;
+import org.neo4j.helpers.collection.FilteringIterable;
+import org.neo4j.helpers.collection.IteratorUtil;
+
+public class MessageUtils
+{
+    public static RaftMessages.Message<RaftTestMember> messageFor( Outcome<RaftTestMember> outcome, final RaftTestMember member )
+    {
+        Predicate<RaftMessages.Directed<RaftTestMember>> selectMember = message -> message.to() == member;
+        return IteratorUtil.single( new FilteringIterable<>( outcome.outgoingMessages, selectMember ) ).message();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/OutboundMessageCollector.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/OutboundMessageCollector.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.net.Outbound;
+
+public class OutboundMessageCollector implements Outbound<RaftTestMember>
+{
+    Map<RaftTestMember, List<Serializable>> sentMessages = new HashMap<>();
+
+    public void clear()
+    {
+        sentMessages.clear();
+    }
+
+    @Override
+    public void send( RaftTestMember to, Serializable... messages )
+    {
+        List<Serializable> messagesToMember = sentMessages.get( to );
+        if ( messagesToMember == null )
+        {
+            messagesToMember = new ArrayList<>();
+            sentMessages.put( to, messagesToMember );
+        }
+
+        Collections.addAll( messagesToMember, messages );
+    }
+
+    public List<Serializable> sentTo( RaftTestMember member )
+    {
+        List<Serializable> messages = sentMessages.get( member );
+
+        if ( messages == null )
+        {
+            messages = new ArrayList<>();
+        }
+
+        return messages;
+    }
+
+    public boolean hasEntriesTo( RaftTestMember member, RaftLogEntry... expectedMessages )
+    {
+        List<RaftLogEntry> actualMessages = new ArrayList<>();
+
+        for ( Serializable message : sentTo( member ) )
+        {
+            if( message instanceof RaftMessages.AppendEntries.Request )
+            {
+                for ( RaftLogEntry actualEntry : ((RaftMessages.AppendEntries.Request) message).entries() )
+                {
+                    actualMessages.add( actualEntry );
+                }
+            }
+        }
+
+        return actualMessages.containsAll( Arrays.asList( expectedMessages ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/QuorumStrategyTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/QuorumStrategyTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.coreedge.raft.MajorityIncludingSelfQuorum.isQuorum;
+
+public class QuorumStrategyTest
+{
+    @Test
+    public void shouldDecideIfWeHaveAMajorityCorrectly()
+    {
+        // the assumption in these tests is that we always vote for ourselves
+        assertTrue( isQuorum( 0, 1, 0 ) );
+
+        assertFalse( isQuorum( 0, 2, 0 ) );
+        assertTrue( isQuorum( 0, 2, 1 ) );
+
+        assertFalse( isQuorum( 0, 3, 0 ) );
+        assertTrue( isQuorum( 0, 3, 1 ) );
+        assertTrue( isQuorum( 0, 3, 2 ) );
+
+        assertFalse( isQuorum( 0, 4, 0 ) );
+        assertFalse( isQuorum( 0, 4, 1 ) );
+        assertTrue( isQuorum( 0, 4, 2 ) );
+        assertTrue( isQuorum( 0, 4, 3 ) );
+
+        assertFalse( isQuorum( 0, 5, 0 ) );
+        assertFalse( isQuorum( 0, 5, 1 ) );
+        assertTrue( isQuorum( 0, 5, 2 ) );
+        assertTrue( isQuorum( 0, 5, 3 ) );
+        assertTrue( isQuorum( 0, 5, 4 ) );
+    }
+
+    @Test
+    public void shouldDecideIfWeHaveAMajorityCorrectlyUsingMinQuorum()
+    {
+        // Then
+        assertFalse( isQuorum( 2, 1, 0 ) );
+
+        assertFalse( isQuorum( 2, 2, 0 ) );
+        assertTrue( isQuorum( 2, 2, 1 ) );
+
+        assertFalse( isQuorum( 2, 3, 0 ) );
+        assertTrue( isQuorum( 2, 3, 1 ) );
+        assertTrue( isQuorum( 2, 3, 2 ) );
+
+        assertFalse( isQuorum( 2, 4, 0 ) );
+        assertFalse( isQuorum( 2, 4, 1 ) );
+        assertTrue( isQuorum( 2, 4, 2 ) );
+        assertTrue( isQuorum( 2, 4, 3 ) );
+
+        assertFalse( isQuorum( 2, 5, 0 ) );
+        assertFalse( isQuorum( 2, 5, 1 ) );
+        assertTrue( isQuorum( 2, 5, 2 ) );
+        assertTrue( isQuorum( 2, 5, 3 ) );
+        assertTrue( isQuorum( 2, 5, 4 ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceTest.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.coreedge.raft.ControlledTimeoutService;
+import org.neo4j.coreedge.raft.DirectNetworking;
+import org.neo4j.coreedge.raft.NoLeaderTimeoutException;
+import org.neo4j.coreedge.raft.OutboundMessageCollector;
+import org.neo4j.coreedge.raft.RaftInstance;
+import org.neo4j.coreedge.raft.RaftInstanceBuilder;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.membership.RaftTestGroup;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.server.RaftTestMemberSetBuilder;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.coreedge.raft.RaftInstance.Timeouts.ELECTION;
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesRequest;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.voteRequest;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.voteResponse;
+import static org.neo4j.coreedge.raft.roles.Role.FOLLOWER;
+import static org.neo4j.helpers.collection.Iterables.last;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RaftInstanceTest
+{
+    private RaftTestMember myself = member( 0 );
+
+    /* A few members that we use at will in tests. */
+    private RaftTestMember member1 = member( 1 );
+    private RaftTestMember member2 = member( 2 );
+    private RaftTestMember member3 = member( 3 );
+    private RaftTestMember member4 = member( 4 );
+
+    private ReplicatedInteger data1 = ReplicatedInteger.valueOf( 1 );
+
+    private RaftLog raftLog = new InMemoryRaftLog();
+
+    @Test
+    public void shouldAlwaysStartAsFollower() throws Exception
+    {
+        // when
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE ).build();
+
+        // then
+        assertEquals( FOLLOWER, raft.currentRole() );
+    }
+
+    @Test
+    public void shouldRequestVotesOnElectionTimeout() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        OutboundMessageCollector messages = new OutboundMessageCollector();
+
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .timeoutService( timeouts )
+                .outbound( messages )
+                .build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) );
+
+        // When
+        timeouts.invokeTimeout( ELECTION );
+
+        // Then
+        assertThat( messages.sentTo( myself ).size(), equalTo( 0 ) );
+
+        assertThat( messages.sentTo( member1 ).size(), equalTo( 1 ) );
+        assertThat( messages.sentTo( member1 ).get( 0 ), instanceOf( RaftMessages.Vote.Request.class ) );
+
+        assertThat( messages.sentTo( member2 ).size(), equalTo( 1 ) );
+        assertThat( messages.sentTo( member2 ).get( 0 ), instanceOf( RaftMessages.Vote.Request.class ) );
+    }
+
+    @Test
+    public void shouldBecomeLeaderInMajorityOf3() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE ).timeoutService( timeouts ).build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) ); // @logIndex=0
+
+        timeouts.invokeTimeout( ELECTION );
+        assertThat( raft.isLeader(), is( false ) );
+
+        // When
+        raft.handle( voteResponse().from( member1 ).term( 1 ).grant().build() );
+
+        // Then
+        assertThat( raft.isLeader(), is( true ) );
+    }
+
+    @Test
+    public void shouldBecomeLeaderInMajorityOf5() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE ).timeoutService( timeouts ).build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2, member3, member4 ) ) );
+        // @logIndex=0
+
+        timeouts.invokeTimeout( ELECTION );
+
+        raft.handle( voteResponse().from( member1 ).term( 1 ).grant().build() );
+        assertThat( raft.isLeader(), is( false ) );
+
+        // When
+        raft.handle( voteResponse().from( member2 ).term( 1 ).grant().build() );
+
+        // Then
+        assertThat( raft.isLeader(), is( true ) );
+    }
+
+    @Test
+    public void shouldNotBecomeLeaderOnMultipleVotesFromSameMember() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE ).timeoutService( timeouts ).build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2, member3, member4 ) ) );
+        // @logIndex=0
+
+        timeouts.invokeTimeout( ELECTION );
+
+        // When
+        raft.handle( voteResponse().from( member1 ).term( 1 ).grant().build() );
+        raft.handle( voteResponse().from( member1 ).term( 1 ).grant().build() );
+
+        // Then
+        assertThat( raft.isLeader(), is( false ) );
+    }
+
+    @Test
+    public void shouldNotBecomeLeaderWhenVotingOnItself() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE ).timeoutService( timeouts ).build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) ); // @logIndex=0
+
+        timeouts.invokeTimeout( ELECTION );
+
+        // When
+        raft.handle( voteResponse().from( myself ).term( 1 ).grant().build() );
+
+        // Then
+        assertThat( raft.isLeader(), is( false ) );
+    }
+
+    @Test
+    public void shouldNotBecomeLeaderWhenMembersVoteNo() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE ).timeoutService( timeouts ).build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) ); // @logIndex=0
+
+        timeouts.invokeTimeout( ELECTION );
+
+        // When
+        raft.handle( voteResponse().from( member1 ).term( 1 ).deny().build() );
+        raft.handle( voteResponse().from( member2 ).term( 1 ).deny().build() );
+
+        // Then
+        assertThat( raft.isLeader(), is( false ) );
+    }
+
+    @Test
+    public void shouldNotBecomeLeaderByVotesFromOldTerm() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE ).timeoutService( timeouts ).build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) ); // @logIndex=0
+
+        timeouts.invokeTimeout( ELECTION );
+        // When
+        raft.handle( voteResponse().from( member1 ).term( 0 ).grant().build() );
+        raft.handle( voteResponse().from( member2 ).term( 0 ).grant().build() );
+
+        // Then
+        assertThat( raft.isLeader(), is( false ) );
+    }
+
+    @Test
+    public void shouldVoteFalseForCandidateInOldTerm() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        OutboundMessageCollector messages = new OutboundMessageCollector();
+
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .timeoutService( timeouts )
+                .outbound( messages )
+                .build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) ); // @logIndex=0
+
+        // When
+        raft.handle( voteRequest().from( member1 ).term( -1 ).candidate( member1 ).lastLogIndex( 0 ).lastLogTerm( -1
+        ).build() );
+
+        // Then
+        assertThat( messages.sentTo( member1 ).size(), equalTo( 1 ) );
+        assertThat( messages.sentTo( member1 ), hasItem( voteResponse().from( myself ).term( 0 ).deny().build() ) );
+    }
+
+    @Test
+    public void shouldNotBecomeLeaderByVotesFromFutureTerm() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE ).timeoutService( timeouts ).build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) ); // @logIndex=0
+
+        timeouts.invokeTimeout( ELECTION );
+
+        // When
+        raft.handle( voteResponse().from( member1 ).term( 2 ).grant().build() );
+        raft.handle( voteResponse().from( member2 ).term( 2 ).grant().build() );
+
+        assertThat( raft.isLeader(), is( false ) );
+        assertEquals( raft.term(), 2l );
+    }
+
+    @Test
+    public void shouldSendHeartBeatsAfterBecomingLeader() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        OutboundMessageCollector messages = new OutboundMessageCollector();
+
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .timeoutService( timeouts )
+                .outbound( messages )
+                .build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) );
+
+        // When
+        timeouts.invokeTimeout( ELECTION );
+        raft.handle( voteResponse().from( member1 ).term( 1 ).grant().build() );
+
+        // Then
+        assertTrue( last( messages.sentTo( member1 ) ) instanceof RaftMessages.Heartbeat );
+        assertTrue( last( messages.sentTo( member2 ) ) instanceof RaftMessages.Heartbeat );
+    }
+
+    @Test
+    public void leaderShouldSendHeartBeatsOnHeartbeatTimeout() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        OutboundMessageCollector messages = new OutboundMessageCollector();
+
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .timeoutService( timeouts )
+                .outbound( messages )
+                .build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) );
+
+        timeouts.invokeTimeout( ELECTION );
+        raft.handle( voteResponse().from( member1 ).term( 1 ).grant().build() );
+
+        // When
+        timeouts.invokeTimeout( RaftInstance.Timeouts.HEARTBEAT );
+
+        // Then
+        assertTrue( last( messages.sentTo( member1 ) ) instanceof RaftMessages.Heartbeat );
+        assertTrue( last( messages.sentTo( member2 ) ) instanceof RaftMessages.Heartbeat );
+    }
+
+    @Test
+    public void shouldThrowExceptionIfReceivesClientRequestWithNoLeaderElected() throws Exception
+    {
+        // Given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE ).timeoutService( timeouts ).build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) ); // @logIndex=0
+
+        try
+        {
+            // When
+            // There is no leader
+            raft.getLeader();
+            fail( "Should have thrown exception" );
+        }
+        // Then
+        catch ( NoLeaderTimeoutException e )
+        {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldPersistAtSpecifiedLogIndex() throws Exception
+    {
+        // given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .timeoutService( timeouts )
+                .raftLog( raftLog )
+                .build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) ); // @logIndex=0
+
+        // when
+        raft.handle(
+                appendEntriesRequest().from( member1 ).leaderTerm( 0 ).leader( myself ).prevLogIndex( 0 )
+                        .prevLogTerm( 0 ).logEntry( new RaftLogEntry( 0, data1 ) ).leaderCommit( -1 ).build() );
+
+        // then
+        assertEquals( 1, raftLog.appendIndex() );
+        assertEquals( data1, raftLog.readEntryContent( 1 ) );
+    }
+
+    @Test
+    public void newMembersShouldBeIncludedInHeartbeatMessages() throws Exception
+    {
+        // Given
+        DirectNetworking network = new DirectNetworking();
+        final RaftTestMember newMember = member( 99 );
+        DirectNetworking.Inbound newMemberInbound = network.new Inbound( 99 );
+        final OutboundMessageCollector messages = new OutboundMessageCollector();
+        newMemberInbound.registerHandler( message -> messages.send( newMember, message ) );
+
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .timeoutService( timeouts )
+                .outbound( messages )
+                .build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) );
+
+        // We make ourselves the leader
+        timeouts.invokeTimeout( ELECTION );
+        raft.handle( voteResponse().from( member1 ).term( 1 ).grant().build() );
+
+        // When
+        raft.setTargetMembershipSet( asSet( myself, member1, member2, newMember ) );
+        network.processMessages();
+
+        timeouts.invokeTimeout( RaftInstance.Timeouts.HEARTBEAT );
+        network.processMessages();
+
+        // Then
+        assertEquals( RaftMessages.AppendEntries.Request.class, messages.sentTo( newMember ).get( 0 ).getClass() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftTestFixture.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftTestFixture.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.membership.RaftTestGroup;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.server.RaftTestMemberSetBuilder;
+import org.neo4j.coreedge.raft.net.LoggingOutbound;
+import org.neo4j.coreedge.raft.net.Inbound;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.coreedge.server.logging.MessageLogger;
+import org.neo4j.coreedge.server.logging.NullMessageLogger;
+import org.neo4j.helpers.Clock;
+
+import static java.lang.String.format;
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+
+public class RaftTestFixture
+{
+    private Members members = new Members();
+
+    public RaftTestFixture( DirectNetworking net, int expectedClusterSize, long... ids )
+    {
+        this( Clock.SYSTEM_CLOCK, net, new NullMessageLogger<>(), expectedClusterSize, ids );
+    }
+
+    public RaftTestFixture( Clock clock, DirectNetworking net, int expectedClusterSize, long... ids )
+    {
+        this( clock, net, new NullMessageLogger<>(), expectedClusterSize, ids );
+    }
+
+    public RaftTestFixture( Clock clock, DirectNetworking net, MessageLogger<RaftTestMember> logger,
+                            int expectedClusterSize, long... ids )
+    {
+        for ( long id : ids )
+        {
+            MemberFixture fixtureMember = new MemberFixture();
+
+            fixtureMember.timeoutService = new ControlledTimeoutService();
+
+            fixtureMember.raftLog = new InMemoryRaftLog();
+            fixtureMember.member = member( id );
+
+            Inbound inbound = net.new Inbound( id );
+            Outbound<RaftTestMember> outbound = new LoggingOutbound<>( net.new Outbound( id ), fixtureMember.member, new NullMessageLogger<>() );
+
+            fixtureMember.raftInstance = new RaftInstanceBuilder<>( fixtureMember.member, expectedClusterSize,
+                    RaftTestMemberSetBuilder.INSTANCE )
+                    .inbound( inbound )
+                    .outbound( outbound )
+                    .raftLog ( fixtureMember.raftLog )
+                    .timeoutService( fixtureMember.timeoutService )
+                    .build();
+
+            members.put( id, fixtureMember );
+        }
+    }
+
+    public Members members()
+    {
+        return members;
+    }
+
+    public static class Members implements Iterable<MemberFixture>
+    {
+        private Map<Long, MemberFixture> memberMap = new HashMap<>();
+
+        private MemberFixture put( Long key, MemberFixture value )
+        {
+            return memberMap.put( key, value );
+        }
+
+        public MemberFixture withId( long id )
+        {
+            return memberMap.get( id );
+        }
+
+        public Members withIds( long... ids )
+        {
+            Members filteredMembers = new Members();
+            for ( long id : ids )
+            {
+                if ( memberMap.containsKey( id ) )
+                {
+                    filteredMembers.put( id, memberMap.get( id ) );
+                }
+            }
+            return filteredMembers;
+        }
+
+        public Members withRole( Role role )
+        {
+            Members filteredMembers = new Members();
+
+            for ( Map.Entry<Long, MemberFixture> entry : memberMap.entrySet() )
+            {
+                if ( entry.getValue().raftInstance().currentRole() == role )
+                {
+                    filteredMembers.put( entry.getKey(), entry.getValue() );
+                }
+            }
+            return filteredMembers;
+        }
+
+        public void setTargetMembershipSet( Set<RaftTestMember> targetMembershipSet )
+        {
+            for ( MemberFixture memberFixture : memberMap.values() )
+            {
+                memberFixture.raftInstance.setTargetMembershipSet( targetMembershipSet );
+            }
+        }
+
+        public void invokeTimeout( TimeoutService.TimeoutName name )
+        {
+            for ( MemberFixture memberFixture : memberMap.values() )
+            {
+                memberFixture.timeoutService.invokeTimeout( name );
+            }
+        }
+
+        public void bootstrapWithInitialMembers( RaftTestGroup raftTestGroup ) throws RaftInstance.BootstrapException
+        {
+            for ( MemberFixture memberFixture : memberMap.values() )
+            {
+                memberFixture.raftInstance.bootstrapWithInitialMembers( raftTestGroup );
+            }
+        }
+
+        @Override
+        public Iterator<MemberFixture> iterator()
+        {
+            return memberMap.values().iterator();
+        }
+
+        public int size()
+        {
+            return memberMap.size();
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "Members%s", memberMap );
+        }
+    }
+
+    public class MemberFixture
+    {
+        private RaftTestMember member;
+        private RaftInstance<RaftTestMember> raftInstance;
+        private ControlledTimeoutService timeoutService;
+        private RaftLog raftLog;
+
+        public RaftTestMember member()
+        {
+            return member;
+        }
+
+        public RaftInstance<RaftTestMember> raftInstance()
+        {
+            return raftInstance;
+        }
+
+        public ControlledTimeoutService timeoutService()
+        {
+            return timeoutService;
+        }
+
+        public RaftLog raftLog()
+        {
+            return raftLog;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "FixtureMember{" +
+                    "raftInstance=" + raftInstance +
+                    ", timeoutService=" + timeoutService +
+                    ", raftLog=" + raftLog +
+                    '}';
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/ReplicatedInteger.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/ReplicatedInteger.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.util.Objects;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+import static java.lang.String.format;
+
+public class ReplicatedInteger implements ReplicatedContent
+{
+    private final Integer value;
+
+    private ReplicatedInteger( Integer data )
+    {
+        Objects.requireNonNull( data );
+        this.value = data;
+    }
+
+    public static ReplicatedInteger valueOf( Integer value )
+    {
+        return new ReplicatedInteger( value );
+    }
+
+    public int get()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        ReplicatedInteger that = (ReplicatedInteger) o;
+        return value.equals( that.value );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "ReplicatedInteger{data=%d}", value );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/ReplicatedString.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/ReplicatedString.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+import static java.lang.String.format;
+
+public class ReplicatedString implements ReplicatedContent
+{
+    private final String value;
+
+    public ReplicatedString( String data )
+    {
+        this.value = data;
+    }
+
+    public static ReplicatedString valueOf( String value )
+    {
+        return new ReplicatedString( value );
+    }
+
+    public String get()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        ReplicatedString that = (ReplicatedString) o;
+        return value.equals( that.value );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "ReplicatedString{data=%s}", value );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/ScheduledTimeoutServiceTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/ScheduledTimeoutServiceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.coreedge.raft.ScheduledTimeoutServiceTest.Timeouts.FOOBAR;
+
+public class ScheduledTimeoutServiceTest
+{
+    enum Timeouts implements TimeoutService.TimeoutName
+    {
+        FOOBAR
+    }
+
+    @Test
+    public void shouldTimeOutAfterTimeoutPeriod() throws Throwable
+    {
+        // given
+        final AtomicLong timeoutCount = new AtomicLong();
+
+        ScheduledTimeoutService timeoutService = new ScheduledTimeoutService();
+
+        timeoutService.create( FOOBAR, 1000, 0, new TimeoutService.TimeoutHandler()
+        {
+            @Override
+            public void onTimeout( TimeoutService.Timeout timeout )
+            {
+                timeoutCount.incrementAndGet();
+            }
+        } );
+
+        timeoutService.init();
+        timeoutService.start();
+
+        // when
+        Thread.sleep( 500 );
+        //then
+        assertThat( timeoutCount.get(), equalTo( 0L ) );
+        //when
+        Thread.sleep( 750 );
+        // then
+        assertThat( timeoutCount.get(), equalTo( 1L ) );
+    }
+
+    @Test
+    public void shouldNotTimeOutWhenRenewedWithinTimeoutPeriod() throws Throwable
+    {
+        // given
+        final AtomicLong timeoutCount = new AtomicLong();
+
+        ScheduledTimeoutService timeoutService = new ScheduledTimeoutService();
+
+        TimeoutService.Timeout timeout = timeoutService.create( FOOBAR, 1000, 0, new TimeoutService.TimeoutHandler()
+        {
+            @Override
+            public void onTimeout( TimeoutService.Timeout timeout )
+            {
+                timeoutCount.incrementAndGet();
+            }
+        } );
+
+        timeoutService.init();
+        timeoutService.start();
+
+        // when
+        Thread.sleep( 700 );
+        timeout.renew();
+        Thread.sleep( 500 );
+
+        // then
+        assertThat( timeoutCount.get(), equalTo( 0L ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/TestMessageBuilders.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/TestMessageBuilders.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+
+public class TestMessageBuilders
+{
+    public static AppendEntriesRequestBuilder<RaftTestMember> appendEntriesRequest()
+    {
+        return new AppendEntriesRequestBuilder<>();
+    }
+
+    public static AppendEntriesResponseBuilder<RaftTestMember> appendEntriesResponse()
+    {
+        return new AppendEntriesResponseBuilder<>();
+    }
+
+    public static HeartbeatBuilder<RaftTestMember> heartbeat()
+    {
+        return new HeartbeatBuilder<>();
+    }
+
+    public static VoteRequestBuilder<RaftTestMember> voteRequest()
+    {
+        return new VoteRequestBuilder<>();
+    }
+
+    public static VoteResponseBuilder<RaftTestMember> voteResponse()
+    {
+        return new VoteResponseBuilder<>();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/VoteRequestBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/VoteRequestBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public class VoteRequestBuilder<MEMBER>
+{
+    private long term = -1;
+    private MEMBER from = null;
+    private MEMBER candidate;
+    private long lastLogIndex;
+    private long lastLogTerm;
+
+    public RaftMessages.Vote.Request<MEMBER> build()
+    {
+        return new RaftMessages.Vote.Request<>( from, term, candidate, lastLogIndex, lastLogTerm );
+    }
+
+    public VoteRequestBuilder<MEMBER> from( MEMBER from )
+    {
+        this.from = from;
+        return this;
+    }
+
+    public VoteRequestBuilder<MEMBER> term( long term )
+    {
+        this.term = term;
+        return this;
+    }
+
+    public VoteRequestBuilder<MEMBER> candidate( MEMBER candidate )
+    {
+        this.candidate = candidate;
+        return this;
+    }
+
+    public VoteRequestBuilder<MEMBER> lastLogIndex( long lastLogIndex )
+    {
+        this.lastLogIndex = lastLogIndex;
+        return this;
+    }
+
+    public VoteRequestBuilder<MEMBER> lastLogTerm( long lastLogTerm )
+    {
+        this.lastLogTerm = lastLogTerm;
+        return this;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/VoteResponseBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/VoteResponseBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft;
+
+public class VoteResponseBuilder<MEMBER>
+{
+    boolean voteGranted = false;
+    private long term = -1;
+    private MEMBER from = null;
+
+    public RaftMessages.Vote.Response<MEMBER> build()
+    {
+        return new RaftMessages.Vote.Response<>( from, term, voteGranted );
+    }
+
+    public VoteResponseBuilder<MEMBER> from( MEMBER from )
+    {
+        this.from = from;
+        return this;
+    }
+
+    public VoteResponseBuilder<MEMBER> term( long term )
+    {
+        this.term = term;
+        return this;
+    }
+
+
+    public VoteResponseBuilder<MEMBER> grant()
+    {
+        this.voteGranted = true;
+        return this;
+    }
+
+    public VoteResponseBuilder<MEMBER> deny()
+    {
+        this.voteGranted = false;
+        return this;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/locks/CoreServiceAssignmentSerializerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/locks/CoreServiceAssignmentSerializerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import java.util.UUID;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.locks.CoreServiceAssignment;
+import org.neo4j.coreedge.raft.locks.CoreServiceAssignmentSerializer;
+import org.neo4j.coreedge.server.CoreMember;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.coreedge.raft.locks.CoreServiceRegistry.ServiceType.LOCK_MANAGER;
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class CoreServiceAssignmentSerializerTest
+{
+    @Test
+    public void shouldSerializeCoreServiceAssignment() throws Exception
+    {
+        // given
+        CoreMember member = new CoreMember( address( "host1:20" ), address( "host1:30" ) );
+        CoreServiceAssignment input = new CoreServiceAssignment( LOCK_MANAGER, member, UUID.randomUUID() );
+        ByteBuf buffer = Unpooled.buffer();
+
+        // when
+        CoreServiceAssignmentSerializer.serialize( input, buffer );
+        CoreServiceAssignment output = CoreServiceAssignmentSerializer.deserialize( buffer );
+
+        // then
+        assertEquals( input, output );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/locks/LockMessageEncodeDecodeTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/locks/LockMessageEncodeDecodeTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.catchup.CatchupClientProtocol;
+import org.neo4j.coreedge.catchup.CatchupServerProtocol;
+import org.neo4j.coreedge.raft.locks.LockMessage.Request;
+import org.neo4j.coreedge.raft.locks.LockMessage.Response;
+import org.neo4j.kernel.ha.lock.LockResult;
+import org.neo4j.kernel.ha.lock.LockStatus;
+import org.neo4j.kernel.impl.locking.ResourceTypes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+import static org.neo4j.coreedge.catchup.CatchupServerProtocol.NextMessage;
+
+public class LockMessageEncodeDecodeTest
+{
+    @Test
+    public void shouldEncodeAndDecodeNewLockSessionRequest()
+    {
+        CatchupServerProtocol protocol = new CatchupServerProtocol();
+        protocol.expect( NextMessage.LOCK_REQUEST );
+
+        EmbeddedChannel channel = new EmbeddedChannel( new LockRequestEncoder(),
+                new LockRequestDecoder( protocol ) );
+
+        // given
+        LockSession lockSession = new LockSession(
+                new CoreMember( address( "host1:1001" ), address( "host1:2001" ) ), 23 );
+        Request sent = Request.newLockSession( lockSession );
+
+        // when
+        channel.writeOutbound( sent );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        Request received = (Request) channel.readInbound();
+        assertNotSame( sent, received );
+        assertEquals( sent, received );
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeAcquireExclusiveLockRequest()
+    {
+        CatchupServerProtocol protocol = new CatchupServerProtocol();
+        protocol.expect( NextMessage.LOCK_REQUEST );
+
+        EmbeddedChannel channel = new EmbeddedChannel( new LockRequestEncoder(),
+                new LockRequestDecoder( protocol ) );
+
+        // given
+        LockSession lockSession = new LockSession(
+                new CoreMember( address( "host1:1001" ), address( "host1:2001" ) ), 23 );
+        Request sent = Request.acquireExclusiveLock( lockSession, ResourceTypes.NODE, 2001 );
+
+        // when
+        channel.writeOutbound( sent );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        Request received = (Request) channel.readInbound();
+        assertNotSame( sent, received );
+        assertEquals( sent, received );
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeAcquireExclusiveLockResponse()
+    {
+        CatchupClientProtocol protocol = new CatchupClientProtocol();
+        protocol.expect( CatchupClientProtocol.NextMessage.LOCK_RESPONSE );
+
+        EmbeddedChannel channel = new EmbeddedChannel( new LockResponseEncoder(),
+                new LockResponseDecoder( protocol ) );
+
+        // given
+        LockSession lockSession = new LockSession(
+                new CoreMember( address( "host1:1001" ), address( "host1:2001" ) ), 23 );
+        Request request = Request.acquireExclusiveLock( lockSession, ResourceTypes.NODE, 2001 );
+        Response sent = new Response( request, new LockResult( LockStatus.OK_LOCKED ) );
+
+        // when
+        channel.writeOutbound( sent );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        Response received = (Response) channel.readInbound();
+        assertNotSame( sent, received );
+        assertEquals( sent, received );
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/locks/LockMessageMarshallTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/locks/LockMessageMarshallTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.locks;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.kernel.ha.lock.LockResult;
+import org.neo4j.kernel.ha.lock.LockStatus;
+import org.neo4j.kernel.impl.locking.ResourceTypes;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class LockMessageMarshallTest
+{
+    @Test
+    public void shouldSerializeAcquireExclusiveLockRequest()
+    {
+        ByteBuf buffer = Unpooled.buffer();
+        // given
+        CoreMember owner = new CoreMember( address( "localhost:1000" ), address( "localhost:2000" ) );
+
+        // when
+        LockMessage.Request original = LockMessage.Request.acquireExclusiveLock( new LockSession( owner, 0 ), ResourceTypes.NODE, 0 );
+        LockMessageMarshall.serialize( buffer, original );
+        LockMessage.Request lockRequest = LockMessageMarshall.deserializeRequest( buffer );
+
+        // then
+        assertEquals( original, lockRequest );
+    }
+
+    @Test
+    public void shouldSerializeAcquireSharedLockRequest()
+    {
+        ByteBuf buffer = Unpooled.buffer();
+        // given
+        CoreMember owner = new CoreMember( address( "localhost:1000" ), address( "localhost:2000" ) );
+
+        // when
+        LockMessage.Request original = LockMessage.Request.acquireSharedLock( new LockSession( owner, 0 ), ResourceTypes.NODE, 0 );
+        LockMessageMarshall.serialize( buffer, original );
+        LockMessage.Request lockRequest = LockMessageMarshall.deserializeRequest( buffer );
+
+        // then
+        assertEquals( original, lockRequest );
+    }
+
+    @Test
+    public void shouldSerializeNewLockSessionRequest()
+    {
+        ByteBuf buffer = Unpooled.buffer();
+        // given
+        CoreMember owner = new CoreMember( address( "localhost:1000" ), address( "localhost:2000" ) );
+
+        // when
+        LockMessage.Request original = LockMessage.Request.newLockSession( new LockSession( owner, 0 ) );
+        LockMessageMarshall.serialize( buffer, original );
+        LockMessage.Request lockRequest = LockMessageMarshall.deserializeRequest( buffer );
+
+        // then
+        assertEquals( original, lockRequest );
+    }
+
+    @Test
+    public void shouldSerializeEndLockSessionRequest()
+    {
+        ByteBuf buffer = Unpooled.buffer();
+        // given
+        CoreMember owner = new CoreMember( address( "localhost:1000" ), address( "localhost:2000" ) );
+
+        // when
+        LockMessage.Request original = LockMessage.Request.endLockSession( new LockSession( owner, 0 ) );
+        LockMessageMarshall.serialize( buffer, original );
+        LockMessage.Request lockRequest = LockMessageMarshall.deserializeRequest( buffer );
+
+        // then
+        assertEquals( original, lockRequest );
+    }
+
+    @Test
+    public void shouldSerializeAcquireExclusiveLockResponse()
+    {
+        ByteBuf buffer = Unpooled.buffer();
+        // given
+        CoreMember owner = new CoreMember( address( "localhost:1000" ), address( "localhost:2000" ) );
+
+        // when
+        LockMessage.Request request = LockMessage.Request.acquireExclusiveLock( new LockSession( owner, 0 ), ResourceTypes.NODE, 0 );
+        LockMessage.Response original = new LockMessage.Response( request, new LockResult( LockStatus.OK_LOCKED ) );
+
+
+        LockMessageMarshall.serialize( buffer, original );
+        LockMessage.Response lockResponse = LockMessageMarshall.deserializeResponse( buffer );
+
+        // then
+        assertEquals( original, lockResponse );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/DummyRaftableContentSerializer.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/DummyRaftableContentSerializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.nio.ByteBuffer;
+
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.ReplicatedString;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Serializer;
+
+public class DummyRaftableContentSerializer implements Serializer
+{
+    @Override
+    public ByteBuffer serialize( ReplicatedContent content )
+    {
+        if ( content instanceof ReplicatedInteger )
+        {
+            ByteBuffer buffer = ByteBuffer.allocate( 1 + 4 );
+            buffer.put( (byte) 0 );
+            buffer.putInt( ((ReplicatedInteger) content).get() );
+            buffer.flip();
+            return buffer;
+        }
+        else if ( content instanceof ReplicatedString )
+        {
+            String value = ((ReplicatedString) content).get();
+            byte[] stringBytes = value.getBytes();
+            ByteBuffer buffer = ByteBuffer.allocate( 1 + stringBytes.length );
+            buffer.put( (byte) 1 );
+            buffer.put( stringBytes );
+            buffer.flip();
+            return buffer;
+        }
+        throw new IllegalArgumentException( "Unknown content type: " + content );
+    }
+
+    @Override
+    public ReplicatedContent deserialize( ByteBuffer buffer )
+    {
+        byte type = buffer.get();
+
+        if ( type == (byte) 0 )
+        {
+            return ReplicatedInteger.valueOf( buffer.getInt() );
+        }
+        else if ( type == (byte) 1 )
+        {
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get( bytes );
+            return ReplicatedString.valueOf( new String( bytes ) );
+        }
+        throw new IllegalArgumentException( "Unknown content type: " + type );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/InMemoryRaftLogTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/InMemoryRaftLogTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+public class InMemoryRaftLogTest extends RaftLogTest
+{
+    @Override
+    public RaftLog createRaftLog()
+    {
+        return new InMemoryRaftLog();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/NaiveDurableRaftLogTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/NaiveDurableRaftLogTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.monitoring.Monitors;
+
+public class NaiveDurableRaftLogTest extends RaftLogTest
+{
+    @Override
+    public RaftLog createRaftLog() throws IOException
+    {
+        FileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        File directory = new File( "raft-log" );
+        fileSystem.mkdir( directory );
+
+        return new NaiveDurableRaftLog( fileSystem, directory, new DummyRaftableContentSerializer(), new Monitors() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftContentSerializerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftContentSerializerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.membership.CoreMemberSet;
+import org.neo4j.coreedge.raft.replication.RaftContentSerializer;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.replication.storeid.SeedStoreId;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdAllocationRequest;
+import org.neo4j.coreedge.raft.replication.session.GlobalSession;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransaction;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransactionFactory;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.index.IndexCommand;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class RaftContentSerializerTest
+{
+    CoreMember coreMember = new CoreMember( address( "core:1" ), address( "raft:1" ) );
+    GlobalSession globalSession = new GlobalSession( UUID.randomUUID(), coreMember );
+
+    @Test
+    public void shouldSerializeMemberSet() throws Exception
+    {
+        // given
+        RaftContentSerializer serializer = new RaftContentSerializer();
+        CoreMemberSet in = new CoreMemberSet( asSet(
+                new CoreMember( address( "host1:1001" ), address( "host1:1002" ) ),
+                new CoreMember( address( "host2:1002" ), address( "host2:1002" ) )
+        ) );
+
+        // when
+        ByteBuffer buffer = serializer.serialize( in );
+        ReplicatedContent out = serializer.deserialize( buffer );
+
+        // then
+        assertEquals( in, out );
+    }
+
+    @Test
+    public void shouldSerializeSeedStoreId() throws Exception
+    {
+        // given
+        RaftContentSerializer serializer = new RaftContentSerializer();
+        SeedStoreId in = new SeedStoreId( new StoreId() );
+
+        // when
+        ByteBuffer buffer = serializer.serialize( in );
+        ReplicatedContent out = serializer.deserialize( buffer );
+
+        // then
+        assertEquals( in, out );
+    }
+
+    @Test
+    public void shouldSerializeTransactionRepresentation() throws Exception
+    {
+        // given
+        RaftContentSerializer serializer = new RaftContentSerializer();
+        Collection<Command> commands = new ArrayList<>(  );
+
+        IndexCommand.AddNodeCommand addNodeCommand = new IndexCommand.AddNodeCommand();
+        addNodeCommand.init( 0, 0, 0, 0 );
+
+        commands.add(  addNodeCommand);
+
+        PhysicalTransactionRepresentation txIn = new PhysicalTransactionRepresentation( commands );
+        ReplicatedTransaction in = ReplicatedTransactionFactory.createImmutableReplicatedTransaction( txIn, globalSession, new LocalOperationId( 0, 0 ) );
+
+        // when
+        ByteBuffer buffer = serializer.serialize( in );
+        ReplicatedTransaction out = (ReplicatedTransaction)serializer.deserialize( buffer );
+
+        TransactionRepresentation txOut = ReplicatedTransactionFactory.extractTransactionRepresentation( out );
+
+        // then
+        assertEquals( in, out );
+        assertEquals( txIn, txOut );
+    }
+
+    @Test
+    public void shouldSerializeIdRangeRequest() throws Exception
+    {
+        // given
+        RaftContentSerializer serializer = new RaftContentSerializer();
+        ReplicatedContent in = new ReplicatedIdAllocationRequest( coreMember, IdType.NODE, 100, 200 );
+
+        // when
+        ByteBuffer buffer = serializer.serialize( in );
+        ReplicatedContent out = serializer.deserialize( buffer );
+
+        // then
+        assertEquals( in, out );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftInstanceLogTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftInstanceLogTest.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.coreedge.raft.RaftInstance;
+import org.neo4j.coreedge.raft.RaftInstanceBuilder;
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.server.RaftTestMemberSetBuilder;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.coreedge.raft.ReplicatedInteger.valueOf;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RaftInstanceLogTest
+{
+    @Mock
+    RaftLog.Listener entryConsumer;
+
+    private RaftTestMember myself = member( 0 );
+    private ReplicatedContent content = ReplicatedInteger.valueOf( 1 );
+    private RaftLog testEntryLog;
+
+    private RaftInstance<RaftTestMember> raft;
+
+    @Before
+    public void before() throws Exception
+    {
+        // given
+        testEntryLog = new InMemoryRaftLog();
+        testEntryLog.registerListener( entryConsumer );
+
+        raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .raftLog( testEntryLog )
+                .build();
+    }
+
+    @Test
+    public void shouldPersistAtSpecifiedLogIndex() throws Exception
+    {
+        // when
+        raft.handle( appendEntriesRequest().leaderTerm( 0 ).prevLogIndex( -1 ).prevLogTerm( -1 )
+                .logEntry( new RaftLogEntry( 0, content ) ).build() );
+
+        // then
+        assertEquals( 0, testEntryLog.appendIndex() );
+        assertEquals( content, testEntryLog.readEntryContent( 0 ) );
+    }
+
+    @Test
+    public void shouldOnlyPersistSameLogEntryOnce() throws Exception
+    {
+        // when
+        raft.handle( appendEntriesRequest().leaderTerm( 0 ).prevLogIndex( -1 ).prevLogTerm( -1 )
+                .logEntry( new RaftLogEntry( 0, content ) ).build() );
+        raft.handle( appendEntriesRequest().leaderTerm( 0 ).prevLogIndex( -1 ).prevLogTerm( -1 )
+                .logEntry( new RaftLogEntry( 0, content ) ).build() );
+
+        // then
+        assertEquals( 0, testEntryLog.appendIndex() );
+        assertEquals( content, testEntryLog.readEntryContent( 0 ) );
+    }
+
+    @Test
+    public void shouldRemoveFirstEntryConflictingWithNewEntry() throws Exception
+    {
+        // given
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) ) );
+
+        // when
+        ReplicatedInteger newData = valueOf( 2 );
+        raft.handle( appendEntriesRequest().leaderTerm( 2 ).prevLogIndex( -1 ).prevLogTerm( -1 )
+                .logEntry( new RaftLogEntry( 2, newData ) ).build() );
+
+        // then
+        assertEquals( 0, testEntryLog.appendIndex() );
+        assertEquals( newData, testEntryLog.readEntryContent( 0 ) );
+    }
+
+    @Test
+    public void shouldRemoveLaterEntryFromLogConflictingWithNewEntry() throws Exception
+    {
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 4 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 7 ) ) ); /* conflicting entry */
+
+        // when
+        ReplicatedInteger newData = valueOf( 11 );
+        raft.handle( appendEntriesRequest().leaderTerm( 2 ).prevLogIndex( 1 ).prevLogTerm( 1 )
+                .logEntry( new RaftLogEntry( 2, newData ) ).build() );
+
+        // then
+        assertEquals( 2, testEntryLog.appendIndex() );
+        assertEquals( newData, testEntryLog.readEntryContent( 2 ) );
+    }
+
+    @Test
+    public void shouldNotTouchTheLogIfWeDoMatchEverywhere() throws Exception
+    {
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) ); // 0
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) ); // 1
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) ); // 5
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) ); // 10
+
+        // when instance A as leader
+        ReplicatedInteger newData = valueOf( 99 );
+
+        // Matches everything in the given range
+        raft.handle( appendEntriesRequest().leaderTerm( 8 ).prevLogIndex( 4 ).prevLogTerm( 2 )
+                .logEntry( new RaftLogEntry( 2, newData ) )
+                .logEntry( new RaftLogEntry( 3, newData ) )
+                .logEntry( new RaftLogEntry( 3, newData ) )
+                .logEntry( new RaftLogEntry( 3, newData ) )
+                .build() );
+
+        // then
+        assertEquals( 10, testEntryLog.appendIndex() );
+        assertEquals( 3, testEntryLog.readEntryTerm( 10 ) );
+    }
+
+    /* Figure 3.6 */
+    @Test
+    public void shouldNotTouchTheLogIfWeDoNotMatchAnywhere() throws Exception
+    {
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+
+        // when instance A as leader
+        ReplicatedInteger newData = valueOf( 99 );
+
+        // Will not match as the entry at index 5 has term  2
+        raft.handle( appendEntriesRequest().leaderTerm( 8 ).prevLogIndex( 5 ).prevLogTerm( 5 )
+                .logEntry( new RaftLogEntry( 5, newData ) )
+                .logEntry( new RaftLogEntry( 5, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .build() );
+
+        // then
+        assertEquals( 10, testEntryLog.appendIndex() );
+        assertEquals( 3, testEntryLog.readEntryTerm( 10 ) );
+    }
+
+    @Test
+    public void shouldTruncateOnFirstMismatchAndThenAppendOtherEntries() throws Exception
+    {
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+
+        // when instance A as leader
+        ReplicatedInteger newData = valueOf( 99 );
+
+        // Will not match as the entry at index 5 has term  2
+        raft.handle( appendEntriesRequest().leaderTerm( 8 ).prevLogIndex( -1 ).prevLogTerm( -1 )
+                .logEntry( new RaftLogEntry( 1, newData ) )
+                .logEntry( new RaftLogEntry( 1, newData ) )
+                .logEntry( new RaftLogEntry( 1, newData ) )
+                .logEntry( new RaftLogEntry( 4, newData ) )
+                .logEntry( new RaftLogEntry( 4, newData ) )
+                .logEntry( new RaftLogEntry( 5, newData ) )
+                .logEntry( new RaftLogEntry( 5, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .build() );
+
+        // then
+        assertEquals( 9, testEntryLog.appendIndex() );
+        assertEquals( 1, testEntryLog.readEntryTerm(0) );
+        assertEquals( 1, testEntryLog.readEntryTerm(1) );
+        assertEquals( 1, testEntryLog.readEntryTerm(2) );
+        assertEquals( 4, testEntryLog.readEntryTerm(3) );
+        assertEquals( 4, testEntryLog.readEntryTerm(4) );
+        assertEquals( 5, testEntryLog.readEntryTerm(5) );
+        assertEquals( 5, testEntryLog.readEntryTerm(6) );
+        assertEquals( 6, testEntryLog.readEntryTerm(7) );
+        assertEquals( 6, testEntryLog.readEntryTerm(8) );
+        assertEquals( 6, testEntryLog.readEntryTerm(9) );
+    }
+
+    @Test
+    public void shouldNotTruncateLogIfHistoryDoesNotMatch() throws Exception
+    {
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+
+        // when instance A as leader
+        ReplicatedInteger newData = valueOf( 99 );
+        raft.handle( appendEntriesRequest().leaderTerm( 8 ).prevLogIndex( 3 ).prevLogTerm( 4 )
+                .logEntry( new RaftLogEntry( 4, newData ) ) /* conflict */
+                .logEntry( new RaftLogEntry( 5, newData ) )
+                .logEntry( new RaftLogEntry( 5, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .build() );
+
+        // then
+        assertEquals( 10, testEntryLog.appendIndex() );
+    }
+
+    @Test
+    public void shouldTruncateLogIfFirstEntryMatchesAndSecondEntryMismatchesOnTerm() throws Exception
+    {
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 2, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+        testEntryLog.append( new RaftLogEntry( 3, ReplicatedInteger.valueOf( 99 ) ) );
+
+        // when instance A as leader
+        ReplicatedInteger newData = valueOf( 99 );
+        raft.handle( appendEntriesRequest().leaderTerm( 8 ).prevLogIndex( 1 ).prevLogTerm( 1 )
+                .logEntry( new RaftLogEntry( 1, newData ) )
+                .logEntry( new RaftLogEntry( 4, newData ) ) /* conflict */
+                .logEntry( new RaftLogEntry( 4, newData ) )
+                .logEntry( new RaftLogEntry( 5, newData ) )
+                .logEntry( new RaftLogEntry( 5, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .logEntry( new RaftLogEntry( 6, newData ) )
+                .build() );
+
+        // then
+        assertEquals( 9, testEntryLog.appendIndex() );
+
+        // stay the same
+        assertEquals( 1, testEntryLog.readEntryTerm( 0 ) );
+        assertEquals( 1, testEntryLog.readEntryTerm( 1 ) );
+        assertEquals( 1, testEntryLog.readEntryTerm( 2 ) );
+
+        // replaced
+        assertEquals( 4, testEntryLog.readEntryTerm( 3 ) );
+        assertEquals( 4, testEntryLog.readEntryTerm( 4 ) );
+        assertEquals( 5, testEntryLog.readEntryTerm( 5 ) );
+        assertEquals( 5, testEntryLog.readEntryTerm( 6 ) );
+        assertEquals( 6, testEntryLog.readEntryTerm( 7 ) );
+        assertEquals( 6, testEntryLog.readEntryTerm( 8 ) );
+        assertEquals( 6, testEntryLog.readEntryTerm( 9 ) );
+    }
+
+    // throw exception if trying to overwrite a position where a truncate hasn't happened
+    @Test
+    public void shouldThrowAnExceptionIfOverwritingTheLog() throws Exception
+    {
+        // given
+        // Follower[ 1 2 2 3 ]
+        // Leader  [ 1 4 4 ]
+        // Follower will end up as [1 4 4 3 ]  [ 1 2 2 3 4 4 ]
+
+        // when
+
+        // then
+    }
+
+
+    // Leader   C-1 A3  [1,2,2,2] sends [1-3]
+    // Follower C-1 A3  [1,1,1,1] => [1,2,2,2]
+
+    // Match = Same term, Same index
+    // None of the entries match
+    // Some of the entries match
+    // All of the entries match
+
+    @Test
+    public void shouldUpdateCommitIndexIfNecessary() throws Exception
+    {
+        //  If leaderCommit > commitIndex, set commitIndex = min(leaderCommit, index of last new entry)
+
+        // given
+
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 4 ) ) );
+        testEntryLog.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 7 ) ) );
+
+        testEntryLog.commit( 1 );
+
+        // when
+        raft.handle(
+                appendEntriesRequest().leaderTerm( 2 ).prevLogIndex( 2 ).prevLogTerm( 1 ).leaderCommit( 2 ).build() );
+
+        // then
+        assertEquals( 2, testEntryLog.commitIndex() );
+        verify( entryConsumer ).onCommitted( ReplicatedInteger.valueOf( 1 ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogAdversarialTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogAdversarialTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import org.neo4j.adversaries.ClassGuardedAdversary;
+import org.neo4j.adversaries.CountingAdversary;
+import org.neo4j.adversaries.fs.AdversarialFileSystemAbstraction;
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.graphdb.mockfs.SelectiveFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class RaftLogAdversarialTest
+{
+    public RaftLog createRaftLog( FileSystemAbstraction fileSystem )
+    {
+        File directory = new File( "raft-log" );
+        fileSystem.mkdir( directory );
+        return new NaiveDurableRaftLog( fileSystem, directory, new DummyRaftableContentSerializer(), new Monitors() );
+    }
+
+    @Test
+    public void shouldNotUpdateCommitIndexIfConsumerFails() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        RaftLog log = createRaftLog( fileSystem );
+        log.registerListener( new RaftLog.Listener()
+        {
+            @Override
+            public void onAppended( ReplicatedContent content )
+            {
+            }
+
+            @Override
+            public void onCommitted( ReplicatedContent raftableContent )
+            {
+                throw new RuntimeException( "Fail to accept the content" );
+            }
+
+            @Override
+            public void onTruncated( long fromIndex )
+            {
+            }
+        } );
+
+        RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        log.append( logEntry );
+        try
+        {
+            log.commit( 0 );
+            fail( "Should have thrown exception" );
+        }
+        catch ( Exception e )
+        {
+            // expected
+        }
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( log, fileSystem, new LogVerifier()
+        {
+            public void verifyLog( ReadableRaftLog log )
+            {
+                assertThat( log.appendIndex(), is( 0L ) );
+                assertThat( log.commitIndex(), is( -1L ) );
+                assertThat( log.entryExists( 0 ), is( true ) );
+            }
+        } );
+    }
+
+    @Test
+    public void shouldDiscardEntryIfEntryChannelFails() throws Exception
+    {
+        ClassGuardedAdversary adversary = new ClassGuardedAdversary( new CountingAdversary( 1, false ),
+                NaiveDurableRaftLog.class.getName() );
+        adversary.disable();
+
+        EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+        FileSystemAbstraction fileSystem = new SelectiveFileSystemAbstraction(
+                new File( "raft-log/entries.log" ), new AdversarialFileSystemAbstraction( adversary, fs ), fs );
+        RaftLog log = createRaftLog( fileSystem );
+
+        RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        adversary.enable();
+        try
+        {
+            log.append( logEntry );
+            fail( "Should have thrown exception" );
+        }
+        catch ( Exception e )
+        {
+            // expected
+        }
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( log, fileSystem, new LogVerifier()
+        {
+            public void verifyLog( ReadableRaftLog log )
+            {
+                assertThat( log.appendIndex(), is( -1L ) );
+                assertThat( log.commitIndex(), is( -1L ) );
+                assertThat( log.entryExists( 0 ), is( false ) );
+            }
+        } );
+    }
+
+    @Test
+    public void shouldDiscardEntryIfContentChannelFails() throws Exception
+    {
+        ClassGuardedAdversary adversary = new ClassGuardedAdversary( new CountingAdversary( 1, false ),
+                NaiveDurableRaftLog.class.getName() );
+        adversary.disable();
+
+        EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+        FileSystemAbstraction fileSystem = new SelectiveFileSystemAbstraction(
+                new File( "raft-log/content.log" ), new AdversarialFileSystemAbstraction( adversary, fs ), fs );
+        RaftLog log = createRaftLog( fileSystem );
+
+        RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        adversary.enable();
+        try
+        {
+            log.append( logEntry );
+            fail( "Should have thrown exception" );
+        }
+        catch ( Exception e )
+        {
+            // expected
+        }
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( log, fileSystem, new LogVerifier()
+        {
+            public void verifyLog( ReadableRaftLog log )
+            {
+                assertThat( log.appendIndex(), is( -1L ) );
+                assertThat( log.commitIndex(), is( -1L ) );
+                assertThat( log.entryExists( 0 ), is( false ) );
+            }
+        } );
+    }
+
+    private void verifyCurrentLogAndNewLogLoadedFromFileSystem(
+            ReadableRaftLog log, FileSystemAbstraction fileSystem, LogVerifier logVerifier )
+    {
+        logVerifier.verifyLog( log );
+        logVerifier.verifyLog( createRaftLog( fileSystem ) );
+    }
+
+    private interface LogVerifier
+    {
+        void verifyLog( ReadableRaftLog log );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogDurabilityTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogDurabilityTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.ReplicatedString;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RaftLogDurabilityTest
+{
+    public RaftLog createRaftLog( EphemeralFileSystemAbstraction fileSystem )
+    {
+        File directory = new File( "raft-log" );
+        fileSystem.mkdir( directory );
+        return new NaiveDurableRaftLog( fileSystem, directory, new DummyRaftableContentSerializer(), new Monitors() );
+    }
+
+    @Test
+    public void shouldAppendDataAndNotCommitImmediately() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        RaftLog log = createRaftLog( fileSystem );
+
+        final RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        log.append( logEntry );
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( log, fileSystem, myLog -> {
+            assertThat( myLog.appendIndex(), is( 0L ) );
+            assertThat( myLog.commitIndex(), is( -1L ) );
+            assertThat( myLog.entryExists( 0 ), is( true ) );
+            assertThat( myLog.readLogEntry( 0 ), equalTo( logEntry ) );
+        } );
+    }
+
+    @Test
+    public void shouldAppendAndCommit() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        RaftLog log = createRaftLog( fileSystem );
+
+        RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        log.append( logEntry );
+        log.commit( 0 );
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( log, fileSystem, myLog -> {
+            assertThat( myLog.appendIndex(), is( 0L ) );
+            assertThat( myLog.commitIndex(), is( 0L ) );
+            assertThat( myLog.entryExists( 0 ), is( true ) );
+        } );
+    }
+
+    @Test
+    public void shouldAppendAfterReloadingFromFileSystem() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        RaftLog log = createRaftLog( fileSystem );
+
+        RaftLogEntry logEntryA = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        log.append( logEntryA );
+
+        fileSystem.crash();
+        log = createRaftLog( fileSystem );
+
+        RaftLogEntry logEntryB = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 2 ) );
+        log.append( logEntryB );
+
+        assertThat( log.appendIndex(), is( 1L ) );
+
+        assertThat( log.entryExists( 0 ), is( true ) );
+        assertThat( log.readLogEntry( 0 ), is( logEntryA ) );
+
+        assertThat( log.entryExists( 1 ), is( true ) );
+        assertThat( log.readLogEntry( 1 ), is( logEntryB ) );
+
+        assertThat( log.entryExists( 2 ), is( false ) );
+    }
+
+    @Test
+    public void shouldTruncatePreviouslyAppendedEntries() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        RaftLog log = createRaftLog( fileSystem );
+
+        RaftLogEntry logEntryA = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        RaftLogEntry logEntryB = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 2 ) );
+
+        log.append( logEntryA );
+        log.append( logEntryB );
+        log.truncate( 1 );
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( log, fileSystem, myLog -> {
+            assertThat( myLog.appendIndex(), is( 0L ) );
+            assertThat( myLog.entryExists( 0 ), is( true ) );
+            assertThat( myLog.entryExists( 1 ), is( false ) );
+        } );
+    }
+
+    @Test
+    public void shouldReplacePreviouslyAppendedEntries() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        RaftLog log = createRaftLog( fileSystem );
+
+        final RaftLogEntry logEntryA = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        final RaftLogEntry logEntryB = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 2 ) );
+        final RaftLogEntry logEntryC = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 3 ) );
+        final RaftLogEntry logEntryD = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 4 ) );
+        final RaftLogEntry logEntryE = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 5 ) );
+
+        log.append( logEntryA );
+        log.append( logEntryB );
+        log.append( logEntryC );
+
+        log.truncate( 1 );
+
+        log.append( logEntryD );
+        log.append( logEntryE );
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( log, fileSystem, myLog -> {
+            assertThat( myLog.appendIndex(), is( 2L ) );
+            assertThat( myLog.readLogEntry( 0 ), equalTo( logEntryA ) );
+            assertThat( myLog.readLogEntry( 1 ), equalTo( logEntryD ) );
+            assertThat( myLog.readLogEntry( 2 ), equalTo( logEntryE ) );
+            assertThat( myLog.entryExists( 0 ), is( true ) );
+            assertThat( myLog.entryExists( 1 ), is( true ) );
+            assertThat( myLog.entryExists( 2 ), is( true ) );
+            assertThat( myLog.entryExists( 3 ), is( false ) );
+        } );
+    }
+
+    @Test
+    public void shouldLogDifferentContentTypes() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        RaftLog log = createRaftLog( fileSystem );
+
+        final RaftLogEntry logEntryA = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        final RaftLogEntry logEntryB = new RaftLogEntry( 1, ReplicatedString.valueOf( "hejzxcjkzhxcjkxz" ) );
+
+        log.append( logEntryA );
+        log.append( logEntryB );
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( log, fileSystem, myLog -> {
+            assertThat( myLog.appendIndex(), is( 1L ) );
+            assertThat( myLog.readLogEntry( 0 ), equalTo( logEntryA ) );
+            assertThat( myLog.readLogEntry( 1 ), equalTo( logEntryB ) );
+        } );
+    }
+
+    private void verifyCurrentLogAndNewLogLoadedFromFileSystem(
+            RaftLog log, EphemeralFileSystemAbstraction fileSystem, LogVerifier logVerifier ) throws RaftStorageException
+    {
+        logVerifier.verifyLog( log );
+        logVerifier.verifyLog( createRaftLog( fileSystem ) );
+        fileSystem.crash();
+        logVerifier.verifyLog( createRaftLog( fileSystem ) );
+    }
+
+    private interface LogVerifier
+    {
+        void verifyLog( RaftLog log ) throws RaftStorageException;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.ReplicatedString;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public abstract class RaftLogTest
+{
+    public abstract RaftLog createRaftLog() throws Exception;
+
+    @Test
+    public void shouldCorrectReportOnEmptyLog() throws Exception
+    {
+        // given
+        ReadableRaftLog log = createRaftLog();
+
+        // then
+        assertThat( log.appendIndex(), is( -1L ) );
+        assertThat( log.commitIndex(), is( -1L ) );
+        assertThat( log.entryExists( 0 ), is( false ) );
+        assertThat( log.readEntryTerm( 0 ), is( -1L ) );
+        assertThat( log.readEntryTerm( -1 ), is( -1L ) );
+    }
+
+    @Test
+    public void shouldResetHighTermOnTruncate() throws Exception
+    {
+        // given
+        RaftLog log = createRaftLog();
+        log.append( new RaftLogEntry( 45, ReplicatedInteger.valueOf(99) ) );
+        log.append( new RaftLogEntry( 46, ReplicatedInteger.valueOf(99) ) );
+        log.append( new RaftLogEntry( 47, ReplicatedInteger.valueOf(99) ) );
+
+        // truncate the last 2
+        log.truncate( 1 );
+
+        // then
+        log.append( new RaftLogEntry( 46, ReplicatedInteger.valueOf(9999) ) );
+
+        assertThat(log.readEntryTerm( 1 ), is(46L));
+        assertThat(log.appendIndex(), is(1L));
+    }
+
+    @Test
+    public void shouldAppendDataAndNotCommitImmediately() throws Exception
+    {
+        RaftLog log = createRaftLog();
+
+        RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        log.append( logEntry );
+
+        assertThat( log.appendIndex(), is( 0L ) );
+        assertThat( log.commitIndex(), is( -1L ) );
+        assertThat( log.entryExists( 0 ), is( true ) );
+        assertThat( log.readLogEntry( 0 ), equalTo( logEntry ) );
+    }
+
+    @Test
+    public void shouldNotCommitWhenNoAppendedData() throws Exception
+    {
+        RaftLog log = createRaftLog();
+
+        RaftLog.Listener listener = mock( RaftLog.Listener.class );
+        log.registerListener( listener );
+
+        log.commit( 10 );
+
+        assertThat( log.appendIndex(), is( -1L ) );
+        assertThat( log.commitIndex(), is( -1L ) );
+        assertThat( log.entryExists( 0 ), is( false ) );
+        verify( listener, never() ).onCommitted( any( ReplicatedContent.class ) );
+    }
+
+    @Test
+    public void shouldCommitOutOfOrderAppend() throws Exception
+    {
+        RaftLog log = createRaftLog();
+
+        RaftLog.Listener listener = mock( RaftLog.Listener.class );
+        log.registerListener( listener );
+
+        log.commit( 10 );
+
+        RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        log.append( logEntry );
+
+        log.commit( 10 );
+
+        assertThat( log.appendIndex(), is( 0L ) );
+        assertThat( log.commitIndex(), is( 0L ) );
+        assertThat( log.entryExists( 0 ), is( true ) );
+        verify( listener, times( 1 ) ).onCommitted( eq( logEntry.content() ) );
+    }
+
+    @Test
+    public void shouldTruncatePreviouslyAppendedEntries() throws Exception
+    {
+        RaftLog log = createRaftLog();
+
+        RaftLogEntry logEntryA = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        RaftLogEntry logEntryB = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 2 ) );
+
+        log.append( logEntryA );
+        log.append( logEntryB );
+
+        assertThat( log.appendIndex(), is( 1L ) );
+        assertThat( log.entryExists( 0 ), is( true ) );
+        assertThat( log.entryExists( 1 ), is( true ) );
+
+        log.truncate( 1 );
+
+        assertThat( log.appendIndex(), is( 0L ) );
+        assertThat( log.entryExists( 0 ), is( true ) );
+        assertThat( log.entryExists( 1 ), is( false ) );
+    }
+
+    @Test
+    public void shouldReplacePreviouslyAppendedEntries() throws Exception
+    {
+        RaftLog log = createRaftLog();
+
+        RaftLogEntry logEntryA = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        RaftLogEntry logEntryB = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 2 ) );
+        RaftLogEntry logEntryC = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 3 ) );
+        RaftLogEntry logEntryD = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 4 ) );
+        RaftLogEntry logEntryE = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 5 ) );
+
+        log.append( logEntryA );
+        log.append( logEntryB );
+        log.append( logEntryC );
+
+        log.truncate( 1 );
+
+        log.append( logEntryD );
+        log.append( logEntryE );
+
+        assertThat( log.appendIndex(), is( 2L ) );
+        assertThat( log.readLogEntry( 0 ), equalTo( logEntryA ) );
+        assertThat( log.readLogEntry( 1 ), equalTo( logEntryD ) );
+        assertThat( log.readLogEntry( 2 ), equalTo( logEntryE ) );
+        assertThat( log.entryExists( 0 ), is( true ) );
+        assertThat( log.entryExists( 1 ), is( true ) );
+        assertThat( log.entryExists( 2 ), is( true ) );
+        assertThat( log.entryExists( 3 ), is( false ) );
+    }
+
+    @Test
+    public void shouldHaveNoEffectWhenTruncatingNonExistingEntries() throws Exception
+    {
+        RaftLog log = createRaftLog();
+
+        RaftLogEntry logEntryA = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        RaftLogEntry logEntryB = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 2 ) );
+
+        log.append( logEntryA );
+        log.append( logEntryB );
+
+        log.truncate( 5 );
+
+        assertThat( log.appendIndex(), is( 1L ) );
+        assertThat( log.readLogEntry( 0 ), equalTo( logEntryA ) );
+        assertThat( log.readLogEntry( 1 ), equalTo( logEntryB ) );
+    }
+
+    @Test
+    public void shouldLogDifferentContentTypes() throws Exception
+    {
+        RaftLog log = createRaftLog();
+
+        RaftLogEntry logEntryA = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        RaftLogEntry logEntryB = new RaftLogEntry( 1, ReplicatedString.valueOf( "hejzxcjkzhxcjkxz" ) );
+
+        log.append( logEntryA );
+        log.append( logEntryB );
+
+        assertThat( log.appendIndex(), is( 1L ) );
+
+        assertThat( log.readLogEntry( 0 ), equalTo( logEntryA ) );
+        assertThat( log.readLogEntry( 1 ), equalTo( logEntryB ) );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNotifyAppendedEntryListener() throws Exception
+    {
+        RaftLog log = createRaftLog();
+
+        RaftLog.Listener listener = mock( RaftLog.Listener.class );
+        log.registerListener( listener );
+
+        RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        log.append( logEntry );
+
+        verify( listener, times( 1 ) ).onAppended( eq( logEntry.content() ) );
+    }
+
+    @Test
+    public void shouldNotifyTruncationListener() throws Exception
+    {
+        RaftLog log = createRaftLog();
+
+        RaftLog.Listener listener = mock( RaftLog.Listener.class );
+        log.registerListener( listener );
+
+        RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        log.append( logEntry );
+        log.truncate( 0 );
+
+        verify( listener, times( 1 ) ).onTruncated( eq( 0L ) );
+    }
+
+    @Test
+    public void shouldRejectNonMonotonicTermsForEntries() throws Exception
+    {
+        // given
+        RaftLog log = createRaftLog();
+
+        // when
+        try
+        {
+            log.append( new RaftLogEntry( 0, ReplicatedInteger.valueOf( 1 ) ) );
+            log.append( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 2 ) ) );
+            // then
+            log.append( new RaftLogEntry( 0, ReplicatedInteger.valueOf( 3 ) ) );
+            fail( "Should have failed because of non-monotonic terms" );
+        }
+        catch ( RaftStorageException expected )
+        {
+            // expected
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/debug/DumpRaftLog.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/debug/DumpRaftLog.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.debug;
+
+import java.io.File;
+
+import org.neo4j.coreedge.raft.log.NaiveDurableRaftLog;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.replication.RaftContentSerializer;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.monitoring.Monitors;
+
+public class DumpRaftLog
+{
+    public static void main( String[] args ) throws RaftStorageException
+    {
+        for ( String arg : args )
+        {
+            File logDirectory = new File( arg );
+            System.out.println( "logDirectory = " + logDirectory );
+            NaiveDurableRaftLog log = new NaiveDurableRaftLog( new DefaultFileSystemAbstraction(),
+                    logDirectory, new RaftContentSerializer(), new Monitors() );
+
+            new LogPrinter( log ).print( System.out );
+            System.out.println();
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/debug/LogPrinter.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/debug/LogPrinter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.debug;
+
+import java.io.PrintStream;
+
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+
+public class LogPrinter
+{
+    private final ReadableRaftLog raftLog;
+
+    public LogPrinter( ReadableRaftLog raftLog )
+    {
+        this.raftLog = raftLog;
+    }
+
+    public void print( PrintStream out ) throws RaftStorageException
+    {
+        out.println( String.format( "%1$8s %2$5s  %3$2s %4$s", "Index", "Term", "C?", "Content"));
+        for ( int i = 0; i <= raftLog.appendIndex(); i++ )
+        {
+            RaftLogEntry raftLogEntry = raftLog.readLogEntry( i );
+            out.printf("%8d %5d  %s %s%n", i, raftLogEntry.term(), i <= raftLog.commitIndex() ? "Y" : "N", raftLogEntry.content());
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/debug/ReplayRaftLog.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/debug/ReplayRaftLog.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.debug;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.coreedge.raft.log.NaiveDurableRaftLog;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.replication.RaftContentSerializer;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransaction;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransactionFactory;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.helpers.Args;
+import org.neo4j.helpers.collection.Visitor;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.monitoring.Monitors;
+
+public class ReplayRaftLog
+{
+    public static void main( String[] args ) throws RaftStorageException, IOException
+    {
+        Args arg = Args.parse( args );
+
+        String from = arg.get( "from" );
+        System.out.println("From is " + from);
+        String to = arg.get( "to" );
+        System.out.println("to is " + to);
+
+
+        File logDirectory = new File( from );
+        System.out.println( "logDirectory = " + logDirectory );
+        NaiveDurableRaftLog log = new NaiveDurableRaftLog( new DefaultFileSystemAbstraction(),
+                logDirectory, new RaftContentSerializer(), new Monitors() );
+
+        long totalCommittedEntries = log.commitIndex();
+
+
+//        File target = new File( to );
+//        RandomAccessFile newLog = new RandomAccessFile( target, "rw" );
+
+        for ( int i = 0; i <= totalCommittedEntries; i++ )
+        {
+            ReplicatedContent content = log.readLogEntry( i ).content();
+            if ( content instanceof ReplicatedTransaction )
+            {
+                ReplicatedTransaction tx = (ReplicatedTransaction) content;
+                ReplicatedTransactionFactory.extractTransactionRepresentation( tx ).accept(
+                        new Visitor<Command, IOException>()
+                        {
+                            @Override
+                            public boolean visit( Command element ) throws IOException
+                            {
+                                System.out.println(element);
+                                return false;
+                            }
+                        } );
+            }
+        }
+//        newLog.close();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/CatchupGoalTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/CatchupGoalTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.state.FollowerState;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.helpers.FakeClock;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CatchupGoalTest
+{
+    @Test
+    public void goalAchievedWhenCatchupRoundDurationLessThanTarget() throws Exception
+    {
+        FakeClock clock = new FakeClock();
+        long electionTimeout = 15;
+        StubLog log = new StubLog();
+
+        log.setAppendIndex( 10 );
+        CatchupGoal goal = new CatchupGoal( log, clock, electionTimeout );
+
+        log.setAppendIndex( 20 );
+        clock.forward( 10, MILLISECONDS );
+        assertFalse( goal.achieved( new FollowerState() ) );
+
+        log.setAppendIndex( 30 );
+        clock.forward( 10, MILLISECONDS );
+        assertFalse( goal.achieved( new FollowerState().onSuccessResponse( 10 ) ) );
+
+        log.setAppendIndex( 40 );
+        clock.forward( 10, MILLISECONDS );
+        assertTrue( goal.achieved( new FollowerState().onSuccessResponse( 30 ) ) );
+    }
+
+    private class StubLog implements ReadableRaftLog
+    {
+        private long appendIndex;
+
+        private void setAppendIndex( long index )
+        {
+            this.appendIndex = index;
+        }
+
+        @Override
+        public long appendIndex()
+        {
+            return appendIndex;
+        }
+
+        @Override public long commitIndex()
+        {
+            return 0;
+        }
+
+        @Override public RaftLogEntry readLogEntry( long logIndex ) throws RaftStorageException
+        {
+            return null;
+        }
+
+        @Override public ReplicatedContent readEntryContent( long logIndex ) throws RaftStorageException
+        {
+            return null;
+        }
+
+        @Override public long readEntryTerm( long logIndex ) throws RaftStorageException
+        {
+            return 0;
+        }
+
+        @Override public boolean entryExists( long logIndex )
+        {
+            return false;
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/CatchupGoalTrackerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/CatchupGoalTrackerTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.state.FollowerState;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.helpers.FakeClock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CatchupGoalTrackerTest
+{
+
+    public static final long ROUND_TIMEOUT = 15;
+    public static final long CATCHUP_TIMEOUT = 1_000;
+
+    @Test
+    public void shouldAchieveGoalIfWithinRoundTimeout() throws Exception
+    {
+        FakeClock clock = new FakeClock();
+        StubLog log = new StubLog();
+
+        log.setAppendIndex( 10 );
+        CatchupGoalTracker catchupGoalTracker = new CatchupGoalTracker( log, clock, ROUND_TIMEOUT, CATCHUP_TIMEOUT );
+
+        clock.forward( ROUND_TIMEOUT - 5, TimeUnit.MILLISECONDS );
+        catchupGoalTracker.updateProgress( new FollowerState().onSuccessResponse( 10 ) );
+
+        assertTrue( catchupGoalTracker.isGoalAchieved() );
+        assertTrue( catchupGoalTracker.isFinished() );
+    }
+
+    @Test
+    public void shouldNotAchieveGoalIfBeyondRoundTimeout() throws Exception
+    {
+        FakeClock clock = new FakeClock();
+        StubLog log = new StubLog();
+
+        log.setAppendIndex( 10 );
+        CatchupGoalTracker catchupGoalTracker = new CatchupGoalTracker( log, clock, ROUND_TIMEOUT, CATCHUP_TIMEOUT );
+
+        clock.forward( ROUND_TIMEOUT + 5, TimeUnit.MILLISECONDS );
+        catchupGoalTracker.updateProgress( new FollowerState().onSuccessResponse( 10 ) );
+
+        assertFalse( catchupGoalTracker.isGoalAchieved() );
+        assertFalse( catchupGoalTracker.isFinished() );
+    }
+
+    @Test
+    public void shouldFailToAchieveGoalDueToCatchupTimeoutExpiring() throws Exception
+    {
+        FakeClock clock = new FakeClock();
+        StubLog log = new StubLog();
+
+        log.setAppendIndex( 10 );
+        CatchupGoalTracker catchupGoalTracker = new CatchupGoalTracker( log, clock, ROUND_TIMEOUT, CATCHUP_TIMEOUT );
+
+        // when
+        clock.forward( CATCHUP_TIMEOUT + 10, TimeUnit.MILLISECONDS );
+        catchupGoalTracker.updateProgress( new FollowerState().onSuccessResponse( 4 ) );
+
+        // then
+        assertFalse( catchupGoalTracker.isGoalAchieved() );
+        assertTrue( catchupGoalTracker.isFinished() );
+    }
+
+    @Test
+    public void shouldFailToAchieveGoalDueToCatchupTimeoutExpiringEvenThoughWeDoEventuallyAchieveTarget() throws Exception
+    {
+        FakeClock clock = new FakeClock();
+        StubLog log = new StubLog();
+
+        log.setAppendIndex( 10 );
+        CatchupGoalTracker catchupGoalTracker = new CatchupGoalTracker( log, clock, ROUND_TIMEOUT, CATCHUP_TIMEOUT );
+
+        // when
+        clock.forward( CATCHUP_TIMEOUT + 10, TimeUnit.MILLISECONDS );
+        catchupGoalTracker.updateProgress( new FollowerState().onSuccessResponse( 10 ) );
+
+        // then
+        assertFalse( catchupGoalTracker.isGoalAchieved() );
+        assertTrue( catchupGoalTracker.isFinished() );
+    }
+
+    @Test
+    public void shouldFailToAchieveGoalDueToRoundExhaustion() throws Exception
+    {
+        FakeClock clock = new FakeClock();
+        StubLog log = new StubLog();
+
+        long appendIndex = 10;
+        log.setAppendIndex( appendIndex );
+        CatchupGoalTracker catchupGoalTracker = new CatchupGoalTracker( log, clock, ROUND_TIMEOUT, CATCHUP_TIMEOUT );
+
+        for ( int i = 0; i < CatchupGoalTracker.MAX_ROUNDS; i++ )
+        {
+            appendIndex += 10;
+            log.setAppendIndex( appendIndex );
+            clock.forward( ROUND_TIMEOUT + 1, TimeUnit.MILLISECONDS );
+            catchupGoalTracker.updateProgress( new FollowerState().onSuccessResponse( appendIndex ) );
+        }
+
+        // then
+        assertFalse( catchupGoalTracker.isGoalAchieved() );
+        assertTrue( catchupGoalTracker.isFinished() );
+    }
+
+    @Test
+    public void shouldNotFinishIfRoundsNotExhausted() throws Exception
+    {
+        FakeClock clock = new FakeClock();
+        StubLog log = new StubLog();
+
+        long appendIndex = 10;
+        log.setAppendIndex( appendIndex );
+        CatchupGoalTracker catchupGoalTracker = new CatchupGoalTracker( log, clock, ROUND_TIMEOUT, CATCHUP_TIMEOUT );
+
+        for ( int i = 0; i < CatchupGoalTracker.MAX_ROUNDS - 5; i++ )
+        {
+            appendIndex += 10;
+            log.setAppendIndex( appendIndex );
+            clock.forward( ROUND_TIMEOUT + 1, TimeUnit.MILLISECONDS );
+            catchupGoalTracker.updateProgress( new FollowerState().onSuccessResponse( appendIndex ) );
+        }
+
+        // then
+        assertFalse( catchupGoalTracker.isGoalAchieved() );
+        assertFalse( catchupGoalTracker.isFinished() );
+    }
+
+    private class StubLog implements ReadableRaftLog
+    {
+        private long appendIndex;
+
+        private void setAppendIndex( long index )
+        {
+            this.appendIndex = index;
+        }
+
+        @Override
+        public long appendIndex()
+        {
+            return appendIndex;
+        }
+
+        @Override public long commitIndex()
+        {
+            return 0;
+        }
+
+        @Override public RaftLogEntry readLogEntry( long logIndex ) throws RaftStorageException
+        {
+            return null;
+        }
+
+        @Override public ReplicatedContent readEntryContent( long logIndex ) throws RaftStorageException
+        {
+            return null;
+        }
+
+        @Override public long readEntryTerm( long logIndex ) throws RaftStorageException
+        {
+            return 0;
+        }
+
+        @Override public boolean entryExists( long logIndex )
+        {
+            return false;
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/MembershipWaiterTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/MembershipWaiterTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.state.RaftState;
+import org.neo4j.coreedge.raft.state.RaftStateBuilder;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.test.OnDemandJobScheduler;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import static org.junit.Assert.fail;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.coreedge.raft.ReplicatedInteger.valueOf;
+
+public class MembershipWaiterTest
+{
+    @Test
+    public void shouldReturnImmediatelyIfMemberAndCaughtUp() throws Exception
+    {
+        OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
+        MembershipWaiter<RaftTestMember> waiter = new MembershipWaiter<>( member( 0 ), jobScheduler, 500 );
+
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        raftLog.append( new RaftLogEntry( 0, valueOf( 0 ) ) );
+        raftLog.commit( 0 );
+        RaftState<RaftTestMember> raftState = RaftStateBuilder.raftState()
+                .votingMembers( member( 0 ) )
+                .leaderCommit( 0 )
+                .entryLog( raftLog )
+                .build();
+
+        CompletableFuture<Boolean> future = waiter.waitUntilCaughtUpMember( raftState );
+        jobScheduler.runJob();
+
+        future.get( 0, NANOSECONDS );
+    }
+
+    @Test
+    public void shouldTimeoutIfCaughtUpButNotMember() throws Exception
+    {
+        OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
+        MembershipWaiter<RaftTestMember> waiter = new MembershipWaiter<>( member( 0 ), jobScheduler, 1 );
+
+        RaftState<RaftTestMember> raftState = RaftStateBuilder.raftState()
+                .votingMembers( member( 1 ) )
+                .leaderCommit( 0 )
+                .build();
+
+        CompletableFuture<Boolean> future = waiter.waitUntilCaughtUpMember( raftState );
+        jobScheduler.runJob();
+        jobScheduler.runJob();
+
+        try
+        {
+            future.get( 10, MILLISECONDS );
+            fail( "Should have timed out." );
+        }
+        catch ( TimeoutException e )
+        {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldTimeoutIfMemberButNotCaughtUp() throws Exception
+    {
+        OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
+        MembershipWaiter<RaftTestMember> waiter = new MembershipWaiter<>( member( 0 ), jobScheduler, 1 );
+
+        RaftState<RaftTestMember> raftState = RaftStateBuilder.raftState()
+                .votingMembers( member( 0 ), member( 1 ) )
+                .leaderCommit( 0 )
+                .build();
+
+        CompletableFuture<Boolean> future = waiter.waitUntilCaughtUpMember( raftState );
+        jobScheduler.runJob();
+        jobScheduler.runJob();
+
+        try
+        {
+            future.get( 10, MILLISECONDS );
+            fail( "Should have timed out." );
+        }
+        catch ( TimeoutException e )
+        {
+            // expected
+        }
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/RaftGroupMembershipTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/RaftGroupMembershipTest.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.coreedge.raft.DirectNetworking;
+import org.neo4j.coreedge.raft.RaftTestFixture;
+import org.neo4j.coreedge.raft.net.Inbound;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.server.RaftTestMember;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.coreedge.raft.RaftInstance.Timeouts.ELECTION;
+import static org.neo4j.coreedge.raft.RaftInstance.Timeouts.HEARTBEAT;
+import static org.neo4j.coreedge.raft.roles.Role.FOLLOWER;
+import static org.neo4j.coreedge.raft.roles.Role.LEADER;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RaftGroupMembershipTest
+{
+    @Mock
+    private Outbound<RaftTestMember> outbound;
+
+    @Mock
+    private Inbound inbound;
+
+    @Test
+    public void shouldNotFormGroupWithoutAnyBootstrapping() throws Exception
+    {
+        // given
+        DirectNetworking net = new DirectNetworking();
+
+        final long[] ids = {0, 1, 2};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 3, ids );
+
+        fixture.members().setTargetMembershipSet( new RaftTestGroup( ids ).getMembers() );
+        fixture.members().invokeTimeout( ELECTION );
+
+        // when
+        net.processMessages();
+
+        // then
+        assertThat( fixture.members(), hasCurrentMembers( new RaftTestGroup() ) );
+        assertEquals( 0, fixture.members().withRole( LEADER ).size() );
+        assertEquals( 3, fixture.members().withRole( FOLLOWER ).size() );
+    }
+
+    @Test
+    public void shouldAddSingleInstanceToExistingRaftGroup() throws Exception
+    {
+        // given
+        DirectNetworking net = new DirectNetworking();
+
+        final long leader = 0;
+        final long stable1 = 1;
+        final long stable2 = 2;
+        final long toBeAdded = 3;
+
+        final long[] initialMembers = {leader, stable1, stable2};
+        final long[] finalMembers = {leader, stable1, stable2, toBeAdded};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 3, finalMembers );
+
+        fixture.members().withId( leader ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup(
+                initialMembers ) );
+
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        // when
+        fixture.members().withId( leader ).raftInstance()
+                .setTargetMembershipSet( new RaftTestGroup( finalMembers ).getMembers() );
+        net.processMessages();
+
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( HEARTBEAT );
+        net.processMessages();
+
+        // then
+        assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
+        assertEquals( 1, fixture.members().withRole( LEADER ).size() );
+        assertEquals( 3, fixture.members().withRole( FOLLOWER ).size() );
+    }
+
+    @Test
+    public void shouldAddMultipleInstancesToExistingRaftGroup() throws Exception
+    {
+        // given
+        DirectNetworking net = new DirectNetworking();
+
+        final long leader = 0;
+        final long stable1 = 1;
+        final long stable2 = 2;
+        final long toBeAdded1 = 3;
+        final long toBeAdded2 = 4;
+        final long toBeAdded3 = 5;
+
+        final long[] initialMembers = {leader, stable1, stable2};
+        final long[] finalMembers = {leader, stable1, stable2, toBeAdded1, toBeAdded2, toBeAdded3};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 3, finalMembers );
+
+        fixture.members().withId( leader ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( initialMembers ) );
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        // when
+        fixture.members().setTargetMembershipSet( new RaftTestGroup( finalMembers ).getMembers() );
+        net.processMessages();
+
+        // We need a heartbeat for every member we add. It is necessary to have the new members report their state
+        // so their membership change can be processed. We can probably do better here.
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( HEARTBEAT );
+        net.processMessages();
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( HEARTBEAT );
+        net.processMessages();
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( HEARTBEAT );
+        net.processMessages();
+
+        // then
+        assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
+        assertEquals( 1, fixture.members().withRole( LEADER ).size() );
+        assertEquals( 5, fixture.members().withRole( FOLLOWER ).size() );
+    }
+
+    @Test
+    public void shouldRemoveSingleInstanceFromExistingRaftGroup() throws Exception
+    {
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leader = 0;
+        final long stable = 1;
+        final long toBeRemoved = 2;
+
+        final long[] initialMembers = {leader, stable, toBeRemoved};
+        final long[] finalMembers = {leader, stable};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 2, initialMembers );
+
+        fixture.members().withId( leader ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( initialMembers ) );
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( ELECTION );
+
+        // when
+        fixture.members().setTargetMembershipSet( new RaftTestGroup( finalMembers ).getMembers() );
+        net.processMessages();
+
+        // then
+        assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
+        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( LEADER ).size() );
+        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( FOLLOWER ).size() );
+    }
+
+    @Test
+    public void shouldRemoveMultipleInstancesFromExistingRaftGroup() throws Exception
+    {
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leader = 0;
+        final long stable = 1;
+        final long toBeRemoved1 = 2;
+        final long toBeRemoved2 = 3;
+        final long toBeRemoved3 = 4;
+
+        final long[] initialMembers = {leader, stable, toBeRemoved1, toBeRemoved2, toBeRemoved3};
+        final long[] finalMembers = {leader, stable};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 2, initialMembers );
+
+        fixture.members().withId( leader ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( initialMembers ) );
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        // when
+        fixture.members().withId( leader ).raftInstance().setTargetMembershipSet( new RaftTestGroup( finalMembers ).getMembers() );
+        net.processMessages();
+
+        // then
+        assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
+        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( LEADER ).size() );
+        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( FOLLOWER ).size() );
+    }
+
+    @Test
+    public void shouldHandleMixedChangeToExistingRaftGroup() throws Exception
+    {
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leader = 0;
+        final long stable = 1;
+        final long toBeRemoved1 = 2;
+        final long toBeRemoved2 = 3;
+        final long toBeAdded1 = 4;
+        final long toBeAdded2 = 5;
+
+        final long[] everyone = {leader, stable, toBeRemoved1, toBeRemoved2, toBeAdded1, toBeAdded2};
+
+        final long[] initialMembers = {leader, stable, toBeRemoved1, toBeRemoved2};
+        final long[] finalMembers = {leader, stable, toBeAdded1, toBeAdded2};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 3, everyone );
+
+        fixture.members().withId( leader ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( initialMembers ) );
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        // when
+        fixture.members().withId( leader ).raftInstance().setTargetMembershipSet( new RaftTestGroup( finalMembers )
+                .getMembers() );
+        net.processMessages();
+
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( HEARTBEAT );
+        net.processMessages();
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( HEARTBEAT );
+        net.processMessages();
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( HEARTBEAT );
+        net.processMessages();
+
+        // then
+        assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
+        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( LEADER ).size() );
+        assertEquals( 3, fixture.members().withIds( finalMembers ).withRole( FOLLOWER ).size() );
+    }
+
+    @Test
+    public void shouldRemoveLeaderFromExistingRaftGroupAndActivelyTransferLeadership() throws Exception
+    {
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leader = 0;
+        final long stable1 = 1;
+        final long stable2 = 2;
+
+        final long[] initialMembers = {leader, stable1, stable2};
+        final long[] finalMembers = {stable1, stable2};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 2, initialMembers );
+
+        fixture.members().withId( leader ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( initialMembers ) );
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        // when
+        fixture.members().withId( leader ).raftInstance().setTargetMembershipSet( new RaftTestGroup( finalMembers ).getMembers() );
+        net.processMessages();
+
+        fixture.members().withId( stable1 ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        // then
+        assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
+        assertTrue( fixture.members().withId( stable1 ).raftInstance().isLeader() ||
+                fixture.members().withId( stable2 ).raftInstance().isLeader() );
+    }
+
+    @Test
+    public void shouldRemoveLeaderAndAddItBackIn() throws Exception
+    {
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leader1 = 0;
+        final long leader2 = 1;
+        final long stable1 = 2;
+        final long stable2 = 3;
+
+        final long[] allMembers = {leader1, leader2, stable1, stable2};
+        final long[] fewerMembers = {leader2, stable1, stable2};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 3, allMembers );
+
+        // when
+        fixture.members().withId( leader1 ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( allMembers ) );
+        fixture.members().withId( leader1 ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        fixture.members().withId( leader1 ).raftInstance().setTargetMembershipSet( new RaftTestGroup( fewerMembers )
+                .getMembers() );
+        net.processMessages();
+
+        fixture.members().withId( leader2 ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        fixture.members().withId( leader2 ).raftInstance().setTargetMembershipSet( new RaftTestGroup( allMembers )
+                .getMembers() );
+        net.processMessages();
+
+        fixture.members().withId( leader2 ).timeoutService().invokeTimeout( HEARTBEAT );
+        net.processMessages();
+
+        // then
+        assertTrue( fixture.members().withId( leader2 ).raftInstance().isLeader() );
+        assertThat( fixture.members().withIds( allMembers ), hasCurrentMembers( new RaftTestGroup( allMembers ) ) );
+    }
+
+    @Test
+    public void shouldRemoveFollowerAndAddItBackIn() throws Exception
+    {
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leader = 0;
+        final long unstable = 1;
+        final long stable1 = 2;
+        final long stable2 = 3;
+
+        final long[] allMembers = {leader, unstable, stable1, stable2};
+        final long[] fewerMembers = {leader, stable1, stable2};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 3, allMembers );
+
+        // when
+        fixture.members().withId( leader ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( allMembers ) );
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        fixture.members().withId( leader ).raftInstance().setTargetMembershipSet( new RaftTestGroup( fewerMembers ).getMembers() );
+        net.processMessages();
+
+        assertTrue( fixture.members().withId( leader ).raftInstance().isLeader() );
+        assertThat( fixture.members().withIds( fewerMembers ), hasCurrentMembers( new RaftTestGroup( fewerMembers ) ) );
+
+        fixture.members().withId( leader ).raftInstance().setTargetMembershipSet( new RaftTestGroup( allMembers ).getMembers() );
+        net.processMessages();
+
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( HEARTBEAT );
+        net.processMessages();
+
+        // then
+        assertTrue( fixture.members().withId( leader ).raftInstance().isLeader() );
+        assertThat( fixture.members().withIds( allMembers ), hasCurrentMembers( new RaftTestGroup( allMembers ) ) );
+    }
+
+    @Test
+    public void shouldElectNewLeaderWhenOldOneAbruptlyLeaves() throws Exception
+    {
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leader1 = 0;
+        final long leader2 = 1;
+        final long stable = 2;
+
+        final long[] initialMembers = {leader1, leader2, stable};
+
+        RaftTestFixture fixture = new RaftTestFixture( net, 2, initialMembers );
+
+        fixture.members().withId( leader1 ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( initialMembers ) );
+
+        fixture.members().withId( leader1 ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        // when
+        net.disconnect( leader1 );
+        fixture.members().withId( leader2 ).timeoutService().invokeTimeout( ELECTION );
+        net.processMessages();
+
+        // then
+        assertTrue( fixture.members().withId( leader2 ).raftInstance().isLeader() );
+        assertFalse( fixture.members().withId( stable ).raftInstance().isLeader() );
+        assertEquals( 1, fixture.members().withIds( leader2, stable ).withRole( LEADER ).size() );
+        assertEquals( 1, fixture.members().withIds( leader2, stable ).withRole( FOLLOWER ).size() );
+    }
+
+    private Matcher<? super RaftTestFixture.Members> hasCurrentMembers( final RaftTestGroup raftGroup )
+    {
+        return new TypeSafeMatcher<RaftTestFixture.Members>()
+        {
+            @Override
+            protected boolean matchesSafely( RaftTestFixture.Members members )
+            {
+                for ( RaftTestFixture.MemberFixture finalMember : members )
+                {
+                    if ( !raftGroup.equals( new RaftTestGroup( finalMember.raftInstance().replicationMembers() ) ) )
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( "Raft group: " ).appendValue( raftGroup );
+            }
+        };
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/RaftTestGroup.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/RaftTestGroup.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+
+import static java.lang.String.format;
+
+public class RaftTestGroup implements RaftGroup<RaftTestMember>
+{
+    private final Set<RaftTestMember> members = new HashSet<>();
+
+    public RaftTestGroup( Set<RaftTestMember> members )
+    {
+        this.members.addAll( members );
+    }
+
+    public RaftTestGroup( long... memberIds )
+    {
+        for ( long memberId : memberIds )
+        {
+            this.members.add( RaftTestMember.member( memberId ) );
+        }
+    }
+
+    @Override
+    public Set<RaftTestMember> getMembers()
+    {
+        return members;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        RaftTestGroup that = (RaftTestGroup) o;
+
+        return members.equals( that.members );
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return members.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "RaftTestGroup{members=%s}", members );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/net/RaftMessageProcessingTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/net/RaftMessageProcessingTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.replication.MarshallingException;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.net.codecs.RaftMessageDecoder;
+import org.neo4j.coreedge.raft.net.codecs.RaftMessageEncoder;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.ReplicatedContentMarshal;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RaftMessageProcessingTest
+{
+    private static ReplicatedContentMarshal<ByteBuf> serializer = new ReplicatedContentMarshal<ByteBuf>()
+    {
+        @Override
+        public void serialize( ReplicatedContent content, ByteBuf buffer ) throws MarshallingException
+        {
+            if ( content instanceof ReplicatedInteger )
+            {
+                buffer.writeByte( 1 );
+                buffer.writeInt( ((ReplicatedInteger) content).get() );
+            }
+            else
+            {
+                throw new IllegalArgumentException( "Unknown content type " + content.getClass() );
+            }
+        }
+
+        @Override
+        public ReplicatedContent deserialize( ByteBuf buffer ) throws MarshallingException
+        {
+            if ( buffer.readableBytes() < 1 )
+            {
+                throw new MarshallingException( "Cannot read content type" );
+            }
+            byte type = buffer.readByte();
+            final ReplicatedContent content;
+            switch ( type )
+            {
+                case 1:
+                    content = ReplicatedInteger.valueOf( buffer.readInt() );
+                    break;
+                default:
+                    throw new MarshallingException( String.format( "Unknown content type 0x%x", type ) );
+            }
+
+            if ( buffer.readableBytes() != 0 )
+            {
+                throw new MarshallingException( "Bytes remain in buffer after deserialization (" + buffer
+                        .readableBytes() + " bytes)" );
+            }
+            return content;
+        }
+    };
+
+    private EmbeddedChannel channel;
+
+    @Before
+    public void setup()
+    {
+        channel = new EmbeddedChannel( new RaftMessageEncoder( serializer ), new RaftMessageDecoder( serializer ) );
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeVoteRequest()
+    {
+        // given
+        CoreMember member = new CoreMember( address( "host1:9000" ), address( "host1:9001" ) );
+        RaftMessages.Vote.Request request = new RaftMessages.Vote.Request<>( member, 1, member, 1, 1 );
+
+        // when
+        channel.writeOutbound( request );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        assertEquals( request, channel.readInbound() );
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeVoteResponse()
+    {
+        // given
+        CoreMember member = new CoreMember( address( "host1:9000" ), address( "host1:9001" ) );
+        RaftMessages.Vote.Response response = new RaftMessages.Vote.Response<>( member, 1, true );
+
+        // when
+        channel.writeOutbound( response );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        assertEquals( response, channel.readInbound() );
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeAppendEntriesRequest()
+    {
+        // given
+        CoreMember member = new CoreMember( address( "host1:9000" ), address( "host1:9001" ) );
+        RaftLogEntry logEntry = new RaftLogEntry( 1, ReplicatedInteger.valueOf( 1 ) );
+        RaftMessages.AppendEntries.Request request =
+                new RaftMessages.AppendEntries.Request<>( member, 1, 1, 99, new RaftLogEntry[] { logEntry }, 1 );
+
+        // when
+        channel.writeOutbound( request );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        assertEquals( request, channel.readInbound() );
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeAppendEntriesResponse()
+    {
+        // given
+        CoreMember member = new CoreMember( address( "host1:9000" ), address( "host1:9001" ) );
+        RaftMessages.AppendEntries.Response response =
+                new RaftMessages.AppendEntries.Response<>( member, 1, false, -1 );
+
+        // when
+        channel.writeOutbound( response );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        assertEquals( response, channel.readInbound() );
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeNewEntryRequest()
+    {
+        // given
+        CoreMember member = new CoreMember( address( "host1:9000" ), address( "host1:9001" ) );
+        RaftMessages.NewEntry.Request request =
+                new RaftMessages.NewEntry.Request<>( member, ReplicatedInteger.valueOf( 12 ) );
+
+        // when
+        channel.writeOutbound( request );
+        channel.writeInbound( channel.readOutbound() );
+
+        // then
+        assertEquals( request, channel.readInbound() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageEncodingDecodingTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageEncodingDecodingTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net.codecs;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.AppendEntriesRequestBuilder;
+import org.neo4j.coreedge.raft.AppendEntriesResponseBuilder;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.VoteRequestBuilder;
+import org.neo4j.coreedge.raft.VoteResponseBuilder;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.replication.MarshallingException;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.ReplicatedContentMarshal;
+import org.neo4j.coreedge.server.CoreMember;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class RaftMessageEncodingDecodingTest
+{
+    @Test
+    public void shouldSerializeAppendRequestWithMultipleEntries() throws Exception
+    {
+        CoreMember sender = new CoreMember( address( "127.0.0.1:5001" ), address( "127.0.0.2:5001" ) );
+        RaftMessages.AppendEntries.Request<CoreMember> request = new AppendEntriesRequestBuilder<CoreMember>()
+                .from( sender )
+                .leader( sender )
+                .leaderCommit( 2 )
+                .leaderTerm( 4 )
+                .logEntry( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 2 ) ) )
+                .logEntry( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 3 ) ) )
+                .logEntry( new RaftLogEntry( 1, ReplicatedInteger.valueOf( 4 ) ) ).build();
+        serializeReadBackAndVerifyMessage( request );
+    }
+
+    @Test
+    public void shouldSerializeAppendRequestWithNoEntries() throws Exception
+    {
+        CoreMember sender = new CoreMember( address( "127.0.0.1:5001" ), address( "127.0.0.2:5001" ) );
+        RaftMessages.AppendEntries.Request<CoreMember> request = new AppendEntriesRequestBuilder<CoreMember>()
+                .from( sender )
+                .leader( sender )
+                .leaderCommit( 2 )
+                .leaderTerm( 4 )
+                .build();
+        serializeReadBackAndVerifyMessage( request );
+    }
+
+    @Test
+    public void shouldSerializeAppendResponse() throws Exception
+    {
+        CoreMember sender = new CoreMember( address( "127.0.0.1:5001" ), address( "127.0.0.2:5001" ) );
+        RaftMessages.AppendEntries.Response<CoreMember> request = new AppendEntriesResponseBuilder<CoreMember>()
+                .from( sender )
+                .success()
+                .matchIndex( 12 )
+                .build();
+        serializeReadBackAndVerifyMessage( request );
+    }
+
+    @Test
+    public void shouldSerializeHeartbeats(  ) throws Exception
+    {
+        // Given
+        RaftMessageEncoder encoder = new RaftMessageEncoder( serializer );
+        RaftMessageDecoder decoder = new RaftMessageDecoder( serializer );
+
+        // Netty puts buffers with serialized content in this list
+        LinkedList<Object> resultingBuffers = new LinkedList<>();
+        // Deserialization adds read objects in this list
+        ArrayList<Object> thingsRead = new ArrayList<>( 1 );
+
+        // When
+        CoreMember sender = new CoreMember( address( "127.0.0.1:5001" ), address( "127.0.0.2:5001" ) );
+        RaftMessages.Heartbeat<CoreMember> message = new RaftMessages.Heartbeat<>( sender, 1, 2, 3 );
+        encoder.encode( setupContext(), message, resultingBuffers );
+
+        // Then
+        assertEquals( 1, resultingBuffers.size() );
+
+        // When
+        decoder.decode( null, (ByteBuf) resultingBuffers.get( 0 ), thingsRead );
+
+        // Then
+        assertEquals( 1, thingsRead.size() );
+        assertEquals( message, thingsRead.get( 0 ) );
+    }
+
+    @Test
+    public void shouldSerializeVoteRequest() throws Exception
+    {
+        CoreMember sender = new CoreMember( address( "127.0.0.1:5001" ), address( "127.0.0.2:5001" ) );
+        RaftMessages.Vote.Request<Object> request = new VoteRequestBuilder<>()
+                .candidate( sender )
+                .from( sender )
+                .lastLogIndex( 2 )
+                .lastLogTerm( 1 )
+                .term( 3 )
+                .build();
+        serializeReadBackAndVerifyMessage( request );
+    }
+
+    @Test
+    public void shouldSerializeVoteResponse() throws Exception
+    {
+        CoreMember sender = new CoreMember( address( "127.0.0.1:5001" ), address( "127.0.0.2:5001" ) );
+        RaftMessages.Vote.Response<Object> request = new VoteResponseBuilder<>()
+                .from( sender )
+                .grant()
+                .term( 3 )
+                .build();
+        serializeReadBackAndVerifyMessage( request );
+    }
+
+    public void serializeReadBackAndVerifyMessage( RaftMessages.Message message ) throws Exception
+    {
+        // Given
+        RaftMessageEncoder encoder = new RaftMessageEncoder( serializer );
+        RaftMessageDecoder decoder = new RaftMessageDecoder( serializer );
+
+        // Netty puts buffers with serialized content in this list
+        LinkedList<Object> resultingBuffers = new LinkedList<>();
+        // Deserialization adds read objects in this list
+        ArrayList<Object> thingsRead = new ArrayList<>( 1 );
+
+        // When
+        encoder.encode( setupContext(), message, resultingBuffers );
+
+        // Then
+        assertEquals( 1, resultingBuffers.size() );
+
+        // When
+        decoder.decode( null, (ByteBuf) resultingBuffers.get( 0 ), thingsRead );
+
+        // Then
+        assertEquals( 1, thingsRead.size() );
+        assertEquals( message, thingsRead.get( 0 ) );
+    }
+
+    private static ChannelHandlerContext setupContext()
+    {
+        ChannelHandlerContext context = mock( ChannelHandlerContext.class );
+        when( context.alloc() ).thenReturn( ByteBufAllocator.DEFAULT );
+        return context;
+    }
+
+    /*
+     * Serializer for ReplicatedIntegers. Differs form the one in RaftMessageProcessingTest in that it does not
+     * assume that there is only a single entry in the stream, which allows for asserting no remaining bytes once the
+     * first entry is read from the buffer.
+     */
+    private static final ReplicatedContentMarshal<ByteBuf> serializer = new ReplicatedContentMarshal<ByteBuf>()
+    {
+        @Override
+        public void serialize( ReplicatedContent content, ByteBuf buffer ) throws MarshallingException
+        {
+            if ( content instanceof ReplicatedInteger )
+            {
+                buffer.writeByte( 1 );
+                buffer.writeInt( ((ReplicatedInteger) content).get() );
+            }
+            else
+            {
+                throw new IllegalArgumentException( "Unknown content type " + content.getClass() );
+            }
+        }
+
+        @Override
+        public ReplicatedContent deserialize( ByteBuf buffer ) throws MarshallingException
+        {
+            if ( buffer.readableBytes() < 1 )
+            {
+                throw new MarshallingException( "Cannot read content type" );
+            }
+            byte type = buffer.readByte();
+            final ReplicatedContent content;
+            switch ( type )
+            {
+                case 1:
+                    content = ReplicatedInteger.valueOf( buffer.readInt() );
+                    break;
+                default:
+                    throw new MarshallingException( String.format( "Unknown content type 0x%x", type ) );
+            }
+            return content;
+        }
+    };
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/CoreReplicatedContentMarshalTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/CoreReplicatedContentMarshalTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.UUID;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.membership.CoreMemberSet;
+import org.neo4j.coreedge.raft.net.CoreReplicatedContentMarshal;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.ReplicatedContentMarshal;
+import org.neo4j.coreedge.raft.replication.id.ReplicatedIdAllocationRequest;
+import org.neo4j.coreedge.raft.replication.session.GlobalSession;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.coreedge.raft.replication.storeid.SeedStoreId;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedTokenRequest;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedTokenRequestSerializer;
+import org.neo4j.coreedge.raft.replication.token.TokenType;
+import org.neo4j.coreedge.raft.replication.tx.ReplicatedTransactionFactory;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+public class CoreReplicatedContentMarshalTest
+{
+    private ReplicatedContentMarshal<ByteBuf> marshal = new CoreReplicatedContentMarshal();
+
+    CoreMember coreMember = new CoreMember( address( "core:1" ), address( "raft:1" ) );
+    GlobalSession globalSession = new GlobalSession( UUID.randomUUID(), coreMember );
+
+    @Test
+    public void shouldMarshalTransactionReference() throws Exception
+    {
+        ByteBuf buffer = Unpooled.buffer();
+        PhysicalTransactionRepresentation representation = new PhysicalTransactionRepresentation( Collections
+                .<Command>emptyList() );
+        representation.setHeader( new byte[]{0}, 1, 1, 1, 1, 1, 1 );
+
+        ReplicatedContent replicatedTx = ReplicatedTransactionFactory.createImmutableReplicatedTransaction( representation, globalSession, new LocalOperationId( 0, 0 ) );
+
+        marshal.serialize( replicatedTx, buffer );
+
+        assertThat( marshal.deserialize( buffer ), equalTo( replicatedTx ) );
+    }
+
+    @Test
+    public void shouldMarshalTransactionReferenceWithMissingHeader() throws Exception
+    {
+        ByteBuf buffer = Unpooled.buffer();
+        PhysicalTransactionRepresentation representation = new PhysicalTransactionRepresentation( Collections
+                .<Command>emptyList() );
+
+        ReplicatedContent replicatedTx = ReplicatedTransactionFactory.createImmutableReplicatedTransaction( representation, globalSession, new LocalOperationId( 0, 0 ) );
+        marshal.serialize( replicatedTx, buffer );
+
+        assertThat( marshal.deserialize( buffer ), equalTo( replicatedTx ) );
+    }
+
+    @Test
+    public void shouldMarshallMemberSet() throws Exception
+    {
+        // given
+        ByteBuf buffer = Unpooled.buffer();
+        ReplicatedContent message = new CoreMemberSet( asSet(
+                new CoreMember( address( "host_a:1" ), address( "host_a:2" ) ),
+                new CoreMember( address( "host_b:101" ), address( "host_b:102" ) )
+        ) );
+
+        // when
+        marshal.serialize( message, buffer );
+
+        // then
+        assertThat( marshal.deserialize( buffer ), equalTo( message ) );
+    }
+
+    @Test
+    public void shouldMarshallIdRangeRequest() throws Exception
+    {
+        // given
+        ByteBuf buffer = Unpooled.buffer();
+        ReplicatedContent message = new ReplicatedIdAllocationRequest(
+                new CoreMember( address( "host_a:1" ), address( "host_a:2" ) ), IdType.PROPERTY, 100, 200 );
+
+        // when
+        marshal.serialize( message, buffer );
+
+        // then
+        assertThat( marshal.deserialize( buffer ), equalTo( message ) );
+    }
+
+    @Test
+    public void shouldMarshallSeedStoreId() throws Exception
+    {
+        // given
+        ByteBuf buffer = Unpooled.buffer();
+        ReplicatedContent message = new SeedStoreId( new StoreId() );
+
+        // when
+        marshal.serialize( message, buffer );
+
+        // then
+        assertThat( marshal.deserialize( buffer ), equalTo( message ) );
+    }
+
+    @Test
+    public void shouldMarshallTokenRequest() throws Exception
+    {
+        // given
+        ByteBuf buffer = Unpooled.buffer();
+
+        ArrayList<Command> commands = new ArrayList<>();
+        Command.LabelTokenCommand labelTokenCommand = new Command.LabelTokenCommand();
+        labelTokenCommand.init( new LabelTokenRecord( 0 ) );
+        commands.add( labelTokenCommand );
+        ReplicatedContent message = new ReplicatedTokenRequest( TokenType.LABEL, "theLabel",
+                ReplicatedTokenRequestSerializer.createCommandBytes( commands ) );
+
+        // when
+        marshal.serialize( message, buffer );
+
+        // then
+        assertThat( marshal.deserialize( buffer ), equalTo( message ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/RaftReplicatorTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/RaftReplicatorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+
+import org.neo4j.concurrent.CompletableFuture;
+import org.neo4j.coreedge.raft.DirectNetworking;
+import org.neo4j.coreedge.raft.RaftInstance;
+import org.neo4j.coreedge.raft.replication.RaftReplicator;
+import org.neo4j.coreedge.raft.RaftTestFixture;
+import org.neo4j.coreedge.raft.membership.RaftTestGroup;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.ReplicatedString;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+
+public class RaftReplicatorTest
+{
+    private static final ReplicatedString CONTENT = new ReplicatedString( "la la la" );
+
+    @Test
+    public void shouldYieldEntryContentOnceLogsAreSafelyReplicated() throws Exception
+    {
+        // given
+        DirectNetworking net = new DirectNetworking();
+
+        // given
+        final long leader = 0;
+        final long[] allMembers = {leader, 1, 2};
+
+        final RaftTestFixture fixture = new RaftTestFixture( net, 3, allMembers );
+        fixture.members().withId( leader ).raftInstance().bootstrapWithInitialMembers( new RaftTestGroup( allMembers ) );
+        fixture.members().withId( leader ).timeoutService().invokeTimeout( RaftInstance.Timeouts.ELECTION );
+        net.processMessages();
+
+        RaftReplicator<RaftTestMember> replicator =
+                new RaftReplicator<>( fixture.members().withId( leader ).raftInstance(),
+                        member( 0 ), net.new Outbound( 0 ) );
+
+        fixture.members().withId( leader ).raftLog().registerListener( replicator );
+
+        ReplicatedContentListener listener = new ReplicatedContentListener();
+        replicator.subscribe( listener );
+
+        // when
+        replicator.replicate( CONTENT );
+        net.processMessages();
+
+        // then
+        assertEquals( CONTENT, listener.getContent().get( 3, SECONDS ) );
+    }
+
+    private class ReplicatedContentListener implements Replicator.ReplicatedContentListener
+    {
+        private CompletableFuture<ReplicatedContent> content = new CompletableFuture<>();
+
+        @Override
+        public void onReplicated( ReplicatedContent value )
+        {
+            this.content.complete( value );
+        }
+
+        public Future<ReplicatedContent> getContent()
+        {
+            return content;
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/StringMarshalTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/StringMarshalTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.replication.StringMarshal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
+public class StringMarshalTest
+{
+    @Test
+    public void shouldSerializeAndDeserializeString()
+    {
+        // given
+        final String TEST_STRING = "ABC123_?";
+        final ByteBuf buffer = UnpooledByteBufAllocator.DEFAULT.buffer();
+
+        // when
+        StringMarshal.serialize( buffer, TEST_STRING );
+        String reconstructed = StringMarshal.deserialize( buffer );
+
+        // then
+        assertNotSame( TEST_STRING, reconstructed );
+        assertEquals( TEST_STRING, reconstructed );
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeEmptyString()
+    {
+        // given
+        final String TEST_STRING = "";
+        final ByteBuf buffer = UnpooledByteBufAllocator.DEFAULT.buffer();
+
+        // when
+        StringMarshal.serialize( buffer, TEST_STRING );
+        String reconstructed = StringMarshal.deserialize( buffer );
+
+        // then
+        assertNotSame( TEST_STRING, reconstructed );
+        assertEquals( TEST_STRING, reconstructed );
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeNull() throws Exception
+    {
+        // given
+        final ByteBuf buffer = UnpooledByteBufAllocator.DEFAULT.buffer();
+
+        // when
+        StringMarshal.serialize( buffer, null );
+        String reconstructed = StringMarshal.deserialize( buffer );
+
+        // then
+        assertNull( reconstructed );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/StubReplicator.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/StubReplicator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+
+import static org.mockito.Mockito.mock;
+
+public class StubReplicator implements Replicator
+{
+    private Set<ReplicatedContentListener> listeners = new HashSet<>();
+
+    @Override
+    public void replicate( ReplicatedContent content ) throws ReplicationFailedException
+    {
+        for ( ReplicatedContentListener listener : listeners )
+        {
+            listener.onReplicated( content );
+        }
+    }
+
+    @Override
+    public void subscribe( ReplicatedContentListener listener )
+    {
+        listeners.add( listener );
+    }
+
+    @Override
+    public void unsubscribe( ReplicatedContentListener listener )
+    {
+        listeners.remove( listener );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationStateMachineTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationStateMachineTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.store.id.IdRange;
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class ReplicatedIdAllocationStateMachineTest
+{
+    CoreMember me = new CoreMember( address( "a:1" ), address( "a:2" ) );
+    CoreMember someoneElse = new CoreMember( address( "b:1" ), address( "b:2" ) );
+
+    IdType someType = IdType.NODE;
+    IdType someOtherType = IdType.RELATIONSHIP;
+
+    @Test
+    public void shouldNotHaveAnyIdsInitially()
+    {
+        // given
+        ReplicatedIdAllocationStateMachine idAllocationStateMachine = new ReplicatedIdAllocationStateMachine( me );
+
+        // when
+        IdRange myHighestIdRange = idAllocationStateMachine.getHighestIdRange( me, someType );
+        long firstNotAllocated = idAllocationStateMachine.getFirstNotAllocated( someType );
+
+        // then
+        assertEquals( null, myHighestIdRange );
+        assertEquals( 0, firstNotAllocated );
+    }
+
+    @Test
+    public void shouldUpdateStateOnlyForTypeRequested()
+    {
+        // given
+        ReplicatedIdAllocationStateMachine idAllocationStateMachine = new ReplicatedIdAllocationStateMachine( me );
+        ReplicatedIdAllocationRequest idAllocationRequest = new ReplicatedIdAllocationRequest( me, someType, 0, 1024 );
+
+        // when
+        idAllocationStateMachine.onReplicated( idAllocationRequest );
+
+        // then
+        assertEquals( 1024, idAllocationStateMachine.getFirstNotAllocated( someType ) );
+        assertEquals( 0, idAllocationStateMachine.getFirstNotAllocated( someOtherType ) );
+    }
+
+    @Test
+    public void shouldUpdateHighestIdRangeForSelf()
+    {
+        // given
+        ReplicatedIdAllocationStateMachine idAllocationStateMachine = new ReplicatedIdAllocationStateMachine( me );
+        ReplicatedIdAllocationRequest idAllocationRequest = new ReplicatedIdAllocationRequest( me, someType, 0, 1024 );
+
+        // when
+        idAllocationStateMachine.onReplicated( idAllocationRequest );
+        IdRange highestIdRange = idAllocationStateMachine.getHighestIdRange( me, someType );
+
+        // then
+        assertEquals( 0, highestIdRange.getRangeStart() );
+        assertEquals( 1024, highestIdRange.getRangeLength() );
+    }
+
+    @Test
+    public void severalDistinctRequestsShouldIncrementallyUpdate()
+    {
+        // given
+        ReplicatedIdAllocationStateMachine idAllocationStateMachine = new ReplicatedIdAllocationStateMachine( me );
+
+        // when
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( me, someType,    0, 1024 ) );
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( me, someType, 1024, 1024 ) );
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( me, someType, 2048, 1024 ) );
+
+        // then
+        assertEquals( 3072, idAllocationStateMachine.getFirstNotAllocated( someType ) );
+    }
+
+    @Test
+    public void severalEqualRequestsShouldOnlyUpdateOnce()
+    {
+        // given
+        ReplicatedIdAllocationStateMachine idAllocationStateMachine = new ReplicatedIdAllocationStateMachine( me );
+
+        // when
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( me, someType, 0, 1024 ) );
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( me, someType, 0, 1024 ) );
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( me, someType, 0, 1024 ) );
+
+        // then
+        assertEquals( 1024, idAllocationStateMachine.getFirstNotAllocated( someType ) );
+    }
+
+    @Test
+    public void outOfOrderRequestShouldBeIgnored()
+    {
+        // given
+        ReplicatedIdAllocationStateMachine idAllocationStateMachine = new ReplicatedIdAllocationStateMachine( me );
+
+        // when
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( me, someType,    0, 1024 ) );
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( me, someType, 2048, 1024 ) ); // should be ignored - not adjacent to previous
+
+        // then
+        assertEquals( 1024, idAllocationStateMachine.getFirstNotAllocated( someType ) );
+    }
+
+    @Test
+    public void requestLosingRaceShouldBeIgnored()
+    {
+        // given
+        ReplicatedIdAllocationStateMachine idAllocationStateMachine = new ReplicatedIdAllocationStateMachine( me );
+
+        // when
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( someoneElse, someType, 0, 1024 ) );
+        idAllocationStateMachine.onReplicated( new ReplicatedIdAllocationRequest( me, someType, 0, 1024 ) ); // should be ignored - someone else took it first
+
+        IdRange highestIdRange = idAllocationStateMachine.getHighestIdRange( me, someType );
+
+        // then
+        assertEquals( null, highestIdRange );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdGeneratorTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdGeneratorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import org.junit.Before;
+
+import org.junit.Test;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.ha.id.IdAllocation;
+import org.neo4j.kernel.impl.store.IdGeneratorContractTest;
+import org.neo4j.kernel.impl.store.id.IdGenerator;
+import org.neo4j.kernel.impl.store.id.IdRange;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
+{
+    private ReplicatedIdRangeAcquirer rangeAcquirer = mock( ReplicatedIdRangeAcquirer.class );
+
+    @Before
+    public void stubAcquirer()
+    {
+        when( rangeAcquirer.acquireIds( IdType.NODE ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 0, 1024 ), -1, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 1024, 1024 ), 1023, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 2048, 1024 ), 2047, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 3072, 1024 ), 3071, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 4096, 1024 ), 4095, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 5120, 1024 ), 5119, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 6144, 1024 ), 6143, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 7168, 1024 ), 7167, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 8192, 1024 ), 8191, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 9216, 1024 ), 9215, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], -1, 0 ), 9216 + 1024, 0 ) );
+    }
+
+    @Override
+    protected IdGenerator createIdGenerator( int grabSize )
+    {
+        return openIdGenerator( grabSize );
+    }
+
+    @Override
+    protected IdGenerator openIdGenerator( int grabSize )
+    {
+        return openIdGenerator( 0, grabSize );
+    }
+
+    protected IdGenerator openIdGenerator( long highId, int grabSize )
+    {
+        return new ReplicatedIdGenerator( IdType.NODE, highId, rangeAcquirer, NullLogProvider.getInstance() );
+    }
+
+    @Test
+    public void shouldNotStepBeyondAllocationBoundaryWithBurnedId() throws Exception
+    {
+        ReplicatedIdRangeAcquirer rangeAcquirer = mock( ReplicatedIdRangeAcquirer.class );
+        when( rangeAcquirer.acquireIds( IdType.NODE ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 0, 1024 ), -1, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], -1, 0 ), 1024, 0 ) );
+
+        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( IdType.NODE, 1, rangeAcquirer, NullLogProvider
+                .getInstance() );
+
+        Set<Long> idsGenerated = new HashSet<>();
+
+        long nextId;
+        while( ( nextId = idGenerator.nextId() ) != -1)
+        {
+            idsGenerated.add( nextId );
+        }
+
+        long minId = Collections.min( idsGenerated );
+        long maxId = Collections.max( idsGenerated );
+
+        assertEquals( 1, minId );
+        assertEquals( 1023, maxId );
+    }
+
+    @Test
+    public void shouldNotStepBeyondAllocationBoundaryWithoutBurnedId() throws Exception
+    {
+        ReplicatedIdRangeAcquirer rangeAcquirer = mock( ReplicatedIdRangeAcquirer.class );
+        when( rangeAcquirer.acquireIds( IdType.NODE ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], 0, 1024 ), -1, 0 ) )
+                .thenReturn( new IdAllocation( new IdRange( new long[0], -1, 0 ), 1024, 0 ) );
+
+        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( IdType.NODE, 0, rangeAcquirer, NullLogProvider
+                .getInstance() );
+
+        Set<Long> idsGenerated = new HashSet<>();
+
+        long nextId;
+        while( ( nextId = idGenerator.nextId() ) != -1)
+        {
+            idsGenerated.add( nextId );
+        }
+
+        long minId = Collections.min( idsGenerated );
+        long maxId = Collections.max( idsGenerated );
+
+        assertEquals( 0, minId );
+        assertEquals( 1023, maxId );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdRangeAcquirerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdRangeAcquirerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.id;
+
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.replication.StubReplicator;
+import org.neo4j.kernel.IdType;
+import org.neo4j.logging.NullLogProvider;
+
+public class ReplicatedIdRangeAcquirerTest
+{
+    private final CoreMember one = new CoreMember( address( "a:1" ), address( "a:2" ) );
+    private final CoreMember two = new CoreMember( address( "b:1" ), address( "b:2" ) );
+    private final StubReplicator replicator = new StubReplicator();
+
+    @Test
+    public void consecutiveAllocationsFromSeparateIdGeneratorsForSameIdTypeShouldNotDuplicateWhenInitialIdIsZero()
+            throws Exception
+    {
+        consecutiveAllocationFromSeparateIdGeneratosForSameIdTypeShouldNotDuplicateForGivenInitialHighId( 0 );
+    }
+
+    @Test
+    public void consecutiveAllocationsFromSeparateIdGeneratorsForSameIdTypeShouldNotDuplicateWhenInitialIdIsNotZero()
+            throws Exception
+    {
+        consecutiveAllocationFromSeparateIdGeneratosForSameIdTypeShouldNotDuplicateForGivenInitialHighId( 1 );
+
+    }
+
+    private void consecutiveAllocationFromSeparateIdGeneratosForSameIdTypeShouldNotDuplicateForGivenInitialHighId(
+            long initialHighId ) throws Exception
+    {
+        Set<Long> idAllocations = new HashSet<>();
+        int idRangeLength = 8;
+
+        ReplicatedIdGenerator generatorOne = createForMemberWithInitialIdAndRangeLength( one, initialHighId,
+                idRangeLength );
+        ReplicatedIdGenerator generatorTwo = createForMemberWithInitialIdAndRangeLength( two, initialHighId,
+                idRangeLength );
+
+        // First iteration is bootstrapping the set, so we do it outside the loop to avoid an if check in there
+        long newId = generatorOne.nextId();
+        idAllocations.add( newId );
+
+        for ( int i = 1; i < idRangeLength - initialHighId; i++ )
+        {
+            newId = generatorOne.nextId();
+            boolean wasNew = idAllocations.add( newId );
+            assertTrue( "Id " + newId + " has already been returned", wasNew );
+            assertTrue( "Detected gap in id generation, missing " + (newId - 1), idAllocations.contains( newId - 1 ) );
+        }
+
+        for ( int i = 0; i < idRangeLength; i++ )
+        {
+            newId = generatorTwo.nextId();
+            boolean wasNew = idAllocations.add( newId );
+            assertTrue( "Id " + newId + " has already been returned", wasNew );
+            assertTrue( "Detected gap in id generation, missing " + (newId - 1), idAllocations.contains( newId - 1 ) );
+        }
+    }
+
+    private ReplicatedIdGenerator createForMemberWithInitialIdAndRangeLength( CoreMember member, long initialHighId,
+                                                                              int idRangeLength )
+    {
+        ReplicatedIdAllocationStateMachine idAllocationStateMachine = new ReplicatedIdAllocationStateMachine( member );
+
+        replicator.subscribe( idAllocationStateMachine );
+
+        ReplicatedIdRangeAcquirer acquirer = new ReplicatedIdRangeAcquirer( replicator,
+                idAllocationStateMachine, idRangeLength, 1, member, NullLogProvider.getInstance() );
+
+        ReplicatedIdGenerator generator = new ReplicatedIdGenerator( IdType.ARRAY_BLOCK, initialHighId, acquirer,
+                NullLogProvider.getInstance() );
+
+        return generator;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/session/GlobalSessionTrackerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/session/GlobalSessionTrackerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.session;
+
+import java.util.UUID;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class GlobalSessionTrackerTest
+{
+    CoreMember coreA = new CoreMember( address( "core:1" ), address( "raft:1" ) );
+    CoreMember coreB = new CoreMember( address( "core:2" ), address( "raft:2" ) );
+
+    GlobalSession sessionA = new GlobalSession( UUID.randomUUID(), coreA );
+    GlobalSession sessionA2 = new GlobalSession( UUID.randomUUID(), coreA );
+
+    GlobalSession sessionB = new GlobalSession( UUID.randomUUID(), coreB );
+
+    @Test
+    public void firstValidSequenceNumberIsZero()
+    {
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 1, -1 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 2, 1 ) ) );
+    }
+
+    @Test
+    public void repeatedOperationsAreRejected()
+    {
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+    }
+
+    @Test
+    public void seriesOfOperationsAreAccepted()
+    {
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 1 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 2 ) ) );
+    }
+
+    @Test
+    public void gapsAreNotAllowed()
+    {
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 1 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 3 ) ) );
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 2 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 3 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 4 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 6 ) ) );
+    }
+
+    @Test
+    public void localSessionsAreIndependent()
+    {
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 1 ) ) );
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 1, 0 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 1, 0 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 1, 1 ) ) );
+    }
+
+    @Test
+    public void globalSessionsAreIndependent()
+    {
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionB, new LocalOperationId( 0, 0 ) ) );
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 1, 0 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionB, new LocalOperationId( 1, 0 ) ) );
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 2, 0 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 2, 0 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionB, new LocalOperationId( 2, 0 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 2, 0 ) ) );
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionB, new LocalOperationId( 2, 0 ) ) );
+    }
+
+    @Test
+    public void newGlobalSessionUnderSameOwnerResetsCorrespondingLocalSessionTracker()
+    {
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA, new LocalOperationId( 0, 1 ) ) );
+
+        assertFalse( sessionTracker.validateAndTrackOperation( sessionA2, new LocalOperationId( 0, 2 ) ) );
+
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA2, new LocalOperationId( 0, 0 ) ) );
+        assertTrue( sessionTracker.validateAndTrackOperation( sessionA2, new LocalOperationId( 0, 1 ) ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/session/LocalSessionPoolTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/session/LocalSessionPoolTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.session;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+import static org.junit.Assert.*;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class LocalSessionPoolTest
+{
+    CoreMember coreMember = new CoreMember( address( "core:1" ), address( "raft:1" ) );
+
+    @Test
+    public void poolsHaveUniqueGlobalIDs()
+    {
+        LocalSessionPool sessionPoolA = new LocalSessionPool( coreMember );
+        LocalSessionPool sessionPoolB = new LocalSessionPool( coreMember );
+
+        assertNotEquals( sessionPoolA.getGlobalSession(), sessionPoolB.getGlobalSession() );
+    }
+
+    @Test
+    public void poolGivesBackSameSessionAfterRelease()
+    {
+        LocalSessionPool sessionPool = new LocalSessionPool( coreMember );
+
+        OperationContext contextA = sessionPool.acquireSession();
+        sessionPool.releaseSession( contextA );
+
+        OperationContext contextB = sessionPool.acquireSession();
+        sessionPool.releaseSession( contextB );
+
+        assertEquals( contextA.localSession(), contextB.localSession() );
+    }
+
+    @Test
+    public void sessionAcquirementIncreasesOperationId()
+    {
+        LocalSessionPool sessionPool = new LocalSessionPool( coreMember );
+        OperationContext context;
+
+        context = sessionPool.acquireSession();
+        LocalOperationId operationA = context.localOperationId();
+        sessionPool.releaseSession( context );
+
+        context = sessionPool.acquireSession();
+        LocalOperationId operationB = context.localOperationId();
+        sessionPool.releaseSession( context );
+
+        assertEquals( operationB.sequenceNumber(), operationA.sequenceNumber() + 1 );
+    }
+
+    @Test
+    public void poolHasIndependentSessions()
+    {
+        LocalSessionPool sessionPool = new LocalSessionPool( coreMember );
+
+        OperationContext contextA = sessionPool.acquireSession();
+        OperationContext contextB = sessionPool.acquireSession();
+
+        assertNotEquals( contextA.localSession(), contextB.localSession() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipperTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipperTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.shipping;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.neo4j.coreedge.raft.LeaderContext;
+import org.neo4j.coreedge.raft.OutboundMessageCollector;
+import org.neo4j.coreedge.raft.RaftMessages.AppendEntries;
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.ReplicatedString;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.helpers.Clock;
+import org.neo4j.helpers.collection.IteratorUtil;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RaftLogShipperTest
+{
+    OutboundMessageCollector outbound;
+    RaftLog raftLog;
+    Clock clock;
+    RaftTestMember leader;
+    RaftTestMember follower;
+    long leaderTerm;
+    long leaderCommit;
+    long retryTimeMillis;
+
+    RaftLogShipper<RaftTestMember> logShipper;
+
+    RaftLogEntry entry0 = new RaftLogEntry( 0, ReplicatedInteger.valueOf( 1000 ) );
+    RaftLogEntry entry1 = new RaftLogEntry( 0, ReplicatedString.valueOf( "kedha" ) );
+    RaftLogEntry entry2 = new RaftLogEntry( 0, ReplicatedInteger.valueOf( 2000 ) );
+    RaftLogEntry entry3 = new RaftLogEntry( 0, ReplicatedString.valueOf( "chupchick" ) );
+
+    @Before
+    public void setup()
+    {
+        // defaults
+        outbound = new OutboundMessageCollector();
+        raftLog = new InMemoryRaftLog();
+        clock = Clock.SYSTEM_CLOCK;
+        leader = new RaftTestMember( 0 );
+        follower = new RaftTestMember( 1 );
+        leaderTerm = 0;
+        leaderCommit = 0;
+        retryTimeMillis = 100000;
+    }
+
+    @After
+    public void teardown()
+    {
+        if ( logShipper != null )
+        {
+            logShipper.stop();
+            logShipper = null;
+        }
+    }
+
+    public void startLogShipper()
+    {
+        logShipper = new RaftLogShipper<>( outbound, NullLogProvider.getInstance(), raftLog,
+                clock, leader, follower, leaderTerm, leaderCommit, retryTimeMillis );
+        logShipper.start();
+    }
+
+    @Test
+    public void shouldSendLastEntryOnStart() throws Throwable
+    {
+        // given
+        raftLog.append( entry0 );
+        raftLog.append( entry1 );
+
+        // when
+        startLogShipper();
+
+        // then
+        assertTrue( outbound.hasEntriesTo( follower, entry1 ) );
+    }
+
+    @Test
+    public void shouldSendPreviousEntryOnMismatch() throws Throwable
+    {
+        // given
+        raftLog.append( entry0 );
+        raftLog.append( entry1 );
+        startLogShipper();
+
+        // when
+        outbound.clear();
+        logShipper.onMismatch( 0, new LeaderContext( 0, 0 ) );
+
+        // then
+        assertTrue( outbound.hasEntriesTo( follower, entry0 ) );
+    }
+
+    @Test
+    public void shouldKeepSendingFirstEntryAfterSeveralMismatches() throws Throwable
+    {
+        // given
+        raftLog.append( entry0 );
+        raftLog.append( entry1 );
+        startLogShipper();
+
+        logShipper.onMismatch( 0, new LeaderContext( 0, 0 ) );
+        logShipper.onMismatch( 0, new LeaderContext( 0, 0 ) );
+
+        // when
+        outbound.clear();
+        logShipper.onMismatch( 0, new LeaderContext( 0, 0 ) );
+
+        // then
+        assertTrue( outbound.hasEntriesTo( follower, entry0 ) );
+    }
+
+    @Test
+    public void shouldSendNextBatchAfterMatch() throws Throwable
+    {
+        // given
+        raftLog.append( entry0 );
+        raftLog.append( entry1 );
+        raftLog.append( entry2 );
+        raftLog.append( entry3 );
+        startLogShipper();
+
+        logShipper.onMismatch( 0, new LeaderContext( 0, 0 ) );
+
+        // when
+        outbound.clear();
+        logShipper.onMatch( 0, new LeaderContext( 0, 0 ) );
+
+        // then
+        assertTrue( outbound.hasEntriesTo( follower, entry1, entry2, entry3 ) );
+    }
+
+    @Test
+    public void shouldSendNewEntriesAfterMatchingLastEntry() throws Throwable
+    {
+        // given
+        raftLog.append( entry0 );
+        startLogShipper();
+
+        logShipper.onMatch( 0, new LeaderContext( 0, 0 ) );
+
+        // when
+        outbound.clear();
+
+        raftLog.append( entry1 );
+        logShipper.onNewEntry( 0, 0, entry1, new LeaderContext( 0, 0 ) );
+        raftLog.append( entry2 );
+        logShipper.onNewEntry( 1, 0, entry2, new LeaderContext( 0, 0 ) );
+
+        // then
+        assertTrue( outbound.hasEntriesTo( follower, entry1, entry2 ) );
+    }
+
+    @Test
+    public void shouldNotSendNewEntriesWhenNotMatched() throws Throwable
+    {
+        // given
+        raftLog.append( entry0 );
+        startLogShipper();
+
+        // when
+        outbound.clear();
+        logShipper.onNewEntry( 0, 0, entry1, new LeaderContext( 0, 0 ) );
+        logShipper.onNewEntry( 1, 0, entry2, new LeaderContext( 0, 0 ) );
+
+        // then
+        assertEquals( outbound.sentTo( follower ).size(), 0 );
+    }
+
+    @Test
+    public void shouldResendLastSentEntryOnFirstMismatch() throws Throwable
+    {
+        // given
+        raftLog.append( entry0 );
+        startLogShipper();
+        raftLog.append( entry1 );
+        raftLog.append( entry2 );
+
+        logShipper.onMatch( 0, new LeaderContext( 0, 0 ) );
+        logShipper.onNewEntry( 0, 0, entry1, new LeaderContext( 0, 0 ) );
+        logShipper.onNewEntry( 1, 0, entry2, new LeaderContext( 0, 0 ) );
+
+        // when
+        outbound.clear();
+        logShipper.onMismatch( 1, new LeaderContext( 0, 0 ) );
+
+        // then
+        assertTrue( outbound.hasEntriesTo( follower, entry2 ) );
+    }
+
+    @Test
+    public void shouldSendAllEntriesAndCatchupCompletely() throws Throwable
+    {
+        // given
+        final int ENTRY_COUNT = RaftLogShipper.MAX_BATCH_SIZE * 10;
+        Collection<RaftLogEntry> entries = new ArrayList<>();
+        for ( int i = 0; i < ENTRY_COUNT; i++ )
+        {
+            entries.add( new RaftLogEntry( 0, ReplicatedInteger.valueOf( i ) ) );
+        }
+
+        for ( RaftLogEntry entry : entries )
+        {
+            raftLog.append( entry );
+        }
+
+        // then
+        startLogShipper();
+
+        // back-tracking stage
+        RaftLogEntry firstEntry = new RaftLogEntry( 0, ReplicatedInteger.valueOf( 0 ) );
+        while ( !outbound.hasEntriesTo( follower, firstEntry ) )
+        {
+            logShipper.onMismatch( -1, new LeaderContext( 0, 0 ) );
+        }
+
+        // catchup stage
+        long matchIndex;
+
+        do
+        {
+            AppendEntries.Request last = (AppendEntries.Request) IteratorUtil.last( outbound.sentTo( follower ) );
+            matchIndex = last.prevLogIndex() + last.entries().length;
+
+            outbound.clear();
+            logShipper.onMatch( matchIndex, new LeaderContext( 0, 0 ) );
+        }
+        while ( outbound.sentTo( follower ).size() > 0 );
+
+        assertEquals( ENTRY_COUNT-1, matchIndex );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenHolderTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenHolderTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.token;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import org.neo4j.coreedge.raft.replication.token.ReplicatedLabelTokenHolder;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedTokenHolder;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedTokenRequest;
+import org.neo4j.coreedge.raft.replication.token.TokenType;
+import org.neo4j.coreedge.raft.replication.token.ReplicatedTokenRequestSerializer;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
+import org.neo4j.kernel.impl.core.Token;
+import org.neo4j.kernel.impl.store.LabelTokenStore;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.id.IdGenerator;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.util.Dependencies;
+
+import static java.util.Collections.singletonList;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReplicatedTokenHolderTest
+{
+    final int EXPECTED_TOKEN_ID = 1;
+    final int INJECTED_TOKEN_ID = 1024;
+
+    Dependencies dependencies = mock( Dependencies.class );
+    Collection<Command> expectedCommands;
+    Collection<Command> injectedCommands;
+
+    @Before
+    public void setup()
+    {
+        {
+            expectedCommands = new ArrayList<>();
+            Command.LabelTokenCommand labelTokenCommand = new Command.LabelTokenCommand();
+            labelTokenCommand.init( new LabelTokenRecord( EXPECTED_TOKEN_ID ) );
+            expectedCommands.add( labelTokenCommand );
+        }
+
+        {
+            injectedCommands = new ArrayList<>();
+            Command.LabelTokenCommand labelTokenCommand = new Command.LabelTokenCommand();
+            labelTokenCommand.init( new LabelTokenRecord( INJECTED_TOKEN_ID ) );
+            injectedCommands.add( labelTokenCommand );
+        }
+
+        NeoStores neoStore = mock( NeoStores.class );
+        LabelTokenStore labelTokenStore = mock( LabelTokenStore.class );
+        when (neoStore.getLabelTokenStore()).thenReturn( labelTokenStore );
+        when(labelTokenStore.allocateNameRecords( Matchers.<byte[]>any() )).thenReturn( singletonList( new DynamicRecord( 1l ) ) );
+        when( dependencies.resolveDependency( NeoStores.class ) ).thenReturn( neoStore );
+        when( dependencies.resolveDependency( TransactionRepresentationCommitProcess.class ) ).thenReturn( mock( TransactionRepresentationCommitProcess.class ) );
+    }
+
+    @Test
+    public void shouldCreateTokenId() throws Exception
+    {
+        // given
+        IdGeneratorFactory idGeneratorFactory = mock( IdGeneratorFactory.class );
+        IdGenerator idGenerator = mock( IdGenerator.class );
+        when( idGenerator.nextId() ).thenReturn( 1L );
+
+        when( idGeneratorFactory.get( any( IdType.class ) ) ).thenReturn( idGenerator );
+
+        Replicator replicator = new StubReplicator();
+        when( dependencies.resolveDependency( TransactionRepresentationCommitProcess.class ) )
+                .thenReturn( mock( TransactionRepresentationCommitProcess.class ) );
+
+        ReplicatedTokenHolder<Token,LabelTokenRecord> tokenHolder = new ReplicatedLabelTokenHolder( replicator,
+                idGeneratorFactory, dependencies );
+
+        tokenHolder.start();
+
+        // when
+        int tokenId = tokenHolder.getOrCreateId( "Person" );
+
+        // then
+        assertEquals( EXPECTED_TOKEN_ID, tokenId );
+    }
+
+    @Test
+    public void shouldGetExistingTokenIdFromAgesAgo() throws Exception
+    {
+        // given
+        IdGeneratorFactory idGeneratorFactory = mock( IdGeneratorFactory.class );
+        IdGenerator idGenerator = mock( IdGenerator.class );
+        when( idGenerator.nextId() ).thenReturn( 1024L );
+
+        when( idGeneratorFactory.get( any( IdType.class ) ) ).thenReturn( idGenerator );
+
+        Replicator replicator = new StubReplicator();
+
+        ReplicatedTokenHolder<Token,LabelTokenRecord> tokenHolder = new ReplicatedLabelTokenHolder( replicator,
+                idGeneratorFactory, dependencies );
+
+        tokenHolder.start();
+        tokenHolder.onReplicated( new ReplicatedTokenRequest( TokenType.LABEL, "Person", ReplicatedTokenRequestSerializer.createCommandBytes( expectedCommands ) ) );
+
+        // when
+        int tokenId = tokenHolder.getOrCreateId( "Person" );
+
+        // then
+        assertEquals( EXPECTED_TOKEN_ID, tokenId );
+    }
+
+    @Test
+    public void shouldStoreAndReturnASingleTokenForTwoConcurrentRequests() throws Exception
+    {
+        // given
+        IdGeneratorFactory idGeneratorFactory = mock( IdGeneratorFactory.class );
+        IdGenerator idGenerator = mock( IdGenerator.class );
+        when( idGenerator.nextId() ).thenReturn( 1L );
+
+        when( idGeneratorFactory.get( any( IdType.class ) ) ).thenReturn( idGenerator );
+
+        RaceConditionSimulatingReplicator replicator = new RaceConditionSimulatingReplicator();
+
+        ReplicatedTokenHolder<Token,LabelTokenRecord> tokenHolder = new ReplicatedLabelTokenHolder( replicator,
+                idGeneratorFactory, dependencies );
+
+        tokenHolder.start();
+        replicator.injectLabelTokenBeforeOtherOneReplicates( new ReplicatedTokenRequest( TokenType.LABEL, "Person",
+                ReplicatedTokenRequestSerializer.createCommandBytes( injectedCommands ) ) );
+
+        // when
+        int tokenId = tokenHolder.getOrCreateId( "Person" );
+
+        // then
+        assertEquals( INJECTED_TOKEN_ID, tokenId );
+
+    }
+
+    @Test
+    public void shouldStoreAndReturnASingleTokenForTwoDifferentConcurrentRequests() throws Exception
+    {
+        // given
+        IdGeneratorFactory idGeneratorFactory = mock( IdGeneratorFactory.class );
+        IdGenerator idGenerator = mock( IdGenerator.class );
+        when( idGenerator.nextId() ).thenReturn( 1L );
+
+        when( idGeneratorFactory.get( any( IdType.class ) ) ).thenReturn( idGenerator );
+
+        RaceConditionSimulatingReplicator replicator = new RaceConditionSimulatingReplicator();
+
+        ReplicatedTokenHolder<Token,LabelTokenRecord> tokenHolder = new ReplicatedLabelTokenHolder( replicator,
+                idGeneratorFactory, dependencies );
+
+        tokenHolder.start();
+        replicator.injectLabelTokenBeforeOtherOneReplicates( new ReplicatedTokenRequest( TokenType.LABEL, "Dog",
+                ReplicatedTokenRequestSerializer.createCommandBytes( injectedCommands ) ) );
+
+        // when
+        int tokenId = tokenHolder.getOrCreateId( "Person" );
+
+        // then
+        assertEquals( EXPECTED_TOKEN_ID, tokenId );
+
+    }
+
+    static class RaceConditionSimulatingReplicator implements Replicator
+    {
+        private final Collection<ReplicatedContentListener> listeners = new HashSet<>();
+        private ReplicatedTokenRequest otherToken;
+
+        public void injectLabelTokenBeforeOtherOneReplicates( ReplicatedTokenRequest token )
+        {
+            this.otherToken = token;
+        }
+
+        @Override
+        public void replicate( final ReplicatedContent content ) throws ReplicationFailedException
+        {
+            for ( ReplicatedContentListener listener : listeners )
+            {
+                if ( otherToken != null )
+                {
+                    listener.onReplicated( otherToken );
+                }
+                listener.onReplicated( content );
+            }
+        }
+
+        @Override
+        public void subscribe( ReplicatedContentListener listener )
+        {
+            this.listeners.add( listener );
+        }
+
+        @Override
+        public void unsubscribe( ReplicatedContentListener listener )
+        {
+            this.listeners.remove( listener );
+        }
+    }
+
+    static class StubReplicator implements Replicator
+    {
+        private final Collection<ReplicatedContentListener> listeners = new HashSet<>();
+
+        @Override
+        public void replicate( final ReplicatedContent content ) throws ReplicationFailedException
+        {
+            for ( ReplicatedContentListener listener : listeners )
+            {
+                listener.onReplicated( content );
+            }
+        }
+
+        @Override
+        public void subscribe( ReplicatedContentListener listener )
+        {
+            this.listeners.add( listener );
+        }
+
+        @Override
+        public void unsubscribe( ReplicatedContentListener listener )
+        {
+            this.listeners.remove( listener );
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/ReplayableCommitProcessTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/ReplayableCommitProcessTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import static org.neo4j.kernel.impl.api.TransactionApplicationMode.EXTERNAL;
+import static org.neo4j.kernel.impl.transaction.tracing.CommitEvent.NULL;
+
+public class ReplayableCommitProcessTest
+{
+    @Test
+    public void shouldCommitTransactions() throws Exception
+    {
+        // given
+        TransactionRepresentation newTx1 = mock( TransactionRepresentation.class );
+        TransactionRepresentation newTx2 = mock( TransactionRepresentation.class );
+        TransactionRepresentation newTx3 = mock( TransactionRepresentation.class );
+
+        StubLocalDatabase localDatabase = new StubLocalDatabase( 1 );
+        final ReplayableCommitProcess txListener = new ReplayableCommitProcess(
+                localDatabase, localDatabase );
+
+        // when
+        txListener.commit( newTx1, new LockGroup(), NULL, EXTERNAL );
+        txListener.commit( newTx2, new LockGroup(), NULL, EXTERNAL );
+        txListener.commit( newTx3, new LockGroup(), NULL, EXTERNAL );
+
+        // then
+        verify( localDatabase.commitProcess, times( 3 ) ).commit( any( TransactionRepresentation.class ),
+                any( LockGroup.class ), any( CommitEvent.class ), any( TransactionApplicationMode.class ) );
+    }
+
+    @Test
+    public void shouldNotCommitTransactionsThatAreAlreadyCommittedLocally() throws Exception
+    {
+        // given
+        TransactionRepresentation alreadyCommittedTx1 = mock( TransactionRepresentation.class );
+        TransactionRepresentation alreadyCommittedTx2 = mock( TransactionRepresentation.class );
+        TransactionRepresentation newTx = mock( TransactionRepresentation.class );
+
+        StubLocalDatabase localDatabase = new StubLocalDatabase( 3 );
+        final ReplayableCommitProcess txListener = new ReplayableCommitProcess(
+                localDatabase, localDatabase );
+
+        // when
+        txListener.commit( alreadyCommittedTx1, new LockGroup(), NULL, EXTERNAL );
+        txListener.commit( alreadyCommittedTx2, new LockGroup(), NULL, EXTERNAL );
+        txListener.commit( newTx, new LockGroup(), NULL, EXTERNAL );
+
+        // then
+        verify( localDatabase.commitProcess, times( 1 ) ).commit( eq( newTx ), any( LockGroup.class ),
+                any( CommitEvent.class ), any( TransactionApplicationMode.class ) );
+        verifyNoMoreInteractions( localDatabase.commitProcess );
+    }
+
+    private static class StubLocalDatabase implements TransactionCounter, TransactionCommitProcess
+    {
+        long lastCommittedTransactionId;
+        TransactionCommitProcess commitProcess = mock( TransactionCommitProcess.class );
+
+        public StubLocalDatabase( long lastCommittedTransactionId )
+        {
+            this.lastCommittedTransactionId = lastCommittedTransactionId;
+        }
+
+        @Override
+        public long lastCommittedTransactionId()
+        {
+            return lastCommittedTransactionId;
+        }
+
+        @Override
+        public long commit( TransactionRepresentation representation, LockGroup locks, CommitEvent commitEvent,
+                            TransactionApplicationMode mode ) throws TransactionFailureException
+        {
+            lastCommittedTransactionId++;
+            return commitProcess.commit( representation, locks, commitEvent, mode );
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionCommitProcessTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionCommitProcessTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.coreedge.raft.replication.session.LocalSessionPool;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+import static org.neo4j.kernel.impl.api.TransactionApplicationMode.INTERNAL;
+import static org.neo4j.kernel.impl.transaction.tracing.CommitEvent.NULL;
+
+@SuppressWarnings("unchecked")
+public class ReplicatedTransactionCommitProcessTest
+{
+    CoreMember coreMember = new CoreMember( address( "core:1" ), address( "raft:1" ) );
+
+    @Test
+    public void shouldReplicateOnlyOnceIfFirstAttemptSuccessful() throws Exception
+    {
+        // given
+        Replicator replicator = mock( Replicator.class );
+        ReplicatedTransactionStateMachine transactionStateMachine = mock( ReplicatedTransactionStateMachine.class );
+        Future future = mock( Future.class );
+        when( future.get( anyInt(), any( TimeUnit.class ) ) ).thenReturn( 23l );
+        when( transactionStateMachine.getFutureTxId( any( LocalOperationId.class ) ) ).thenReturn( future );
+
+        // when
+        new ReplicatedTransactionCommitProcess( replicator, new LocalSessionPool( coreMember ), transactionStateMachine )
+                .commit( tx(), new LockGroup(), NULL, INTERNAL );
+
+        // then
+        verify( replicator, times( 1 ) ).replicate( any( ReplicatedTransaction.class ) );
+    }
+
+    @Test
+    public void shouldRetryReplicationIfFirstAttemptTimesOut() throws Exception
+    {
+        // given
+        Replicator replicator = mock( Replicator.class );
+        ReplicatedTransactionStateMachine transactionStateMachine = mock( ReplicatedTransactionStateMachine.class );
+        Future future = mock( Future.class );
+        when( transactionStateMachine.getFutureTxId( any( LocalOperationId.class ) ) ).thenReturn( future );
+        when( future.get( anyInt(), any( TimeUnit.class ) ) ).thenThrow( TimeoutException.class ).thenReturn( 23l );
+
+        // when
+        new ReplicatedTransactionCommitProcess( replicator, new LocalSessionPool( coreMember ), transactionStateMachine )
+                .commit( tx(), new LockGroup(), NULL, INTERNAL );
+
+        // then
+        verify( replicator, times( 2 ) ).replicate( any( ReplicatedTransaction.class ) );
+    }
+
+    private TransactionRepresentation tx()
+    {
+        TransactionRepresentation tx = mock( TransactionRepresentation.class );
+        when( tx.additionalHeader() ).thenReturn( new byte[]{} );
+        return tx;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachineTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachineTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.locks.CoreServiceAssignment;
+import org.neo4j.coreedge.raft.replication.session.GlobalSession;
+import org.neo4j.coreedge.raft.replication.session.GlobalSessionTracker;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.kernel.impl.api.TransactionApplicationMode;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import static org.mockito.Mockito.when;
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+import static org.neo4j.coreedge.raft.locks.CoreServiceRegistry.ServiceType.LOCK_MANAGER;
+
+public class ReplicatedTransactionStateMachineTest
+{
+    CoreMember coreMember = new CoreMember( address( "core:1" ), address( "raft:1" ) );
+    GlobalSession globalSession = new GlobalSession( UUID.randomUUID(), coreMember );
+
+    @Test
+    public void shouldCommitTransaction() throws Exception
+    {
+        // given
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+        LocalOperationId localOperationId = new LocalOperationId( 0, 0 );
+
+        ReplicatedTransaction tx = ReplicatedTransactionFactory.createImmutableReplicatedTransaction(
+                mock( PhysicalTransactionRepresentation.class ), globalSession, localOperationId );
+
+        TransactionCommitProcess localCommitProcess = mock( TransactionCommitProcess.class );
+
+        final ReplicatedTransactionStateMachine listener = new ReplicatedTransactionStateMachine(
+                localCommitProcess, sessionTracker, globalSession );
+
+        // when
+        listener.onReplicated( tx );
+
+        // then
+        verify( localCommitProcess, times( 1 ) ).commit( any( TransactionRepresentation.class ),
+                any( LockGroup.class ), any( CommitEvent.class ), any(
+                        TransactionApplicationMode.class ) );
+    }
+
+    @Test
+    public void shouldOnlyCommitSameTransactionOnce() throws Exception
+    {
+        // given
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+        LocalOperationId localOperationId = new LocalOperationId( 0, 0 );
+
+        ReplicatedTransaction tx = ReplicatedTransactionFactory.createImmutableReplicatedTransaction(
+                mock( PhysicalTransactionRepresentation.class ), globalSession, localOperationId );
+
+        TransactionCommitProcess localCommitProcess = mock( TransactionCommitProcess.class );
+        ReplicatedTransactionStateMachine listener = new ReplicatedTransactionStateMachine( localCommitProcess,
+                sessionTracker, globalSession );
+
+        // when
+        listener.onReplicated( tx );
+        listener.onReplicated( tx );
+
+        // then
+        verify( localCommitProcess ).commit( any( TransactionRepresentation.class ), any( LockGroup.class ),
+                any( CommitEvent.class ), eq( TransactionApplicationMode.EXTERNAL ) );
+    }
+
+    @Test
+    public void shouldRejectTransactionCommittedUnderOldAssignmentOfLockManager() throws Exception
+    {
+        // given
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+        LocalOperationId localOperationIdBefore = new LocalOperationId( 0, 0 );
+        LocalOperationId localOperationIdAfter = new LocalOperationId( 0, 1 );
+
+        CoreMember newLockManager = new CoreMember( address( "new:1" ), address( "new:2" ) );
+
+        PhysicalTransactionRepresentation tx = new PhysicalTransactionRepresentation( Collections.emptyList() );
+        tx.setHeader( null, 0, 0, 0, 3, 0, 0 );
+        ReplicatedTransaction txBefore = ReplicatedTransactionFactory.createImmutableReplicatedTransaction(
+                tx, globalSession, localOperationIdBefore
+        );
+        PhysicalTransactionRepresentation after = mock( PhysicalTransactionRepresentation.class );
+        when( after.getLatestCommittedTxWhenStarted() ).thenReturn( 3L );
+        ReplicatedTransaction txAfter = ReplicatedTransactionFactory.createImmutableReplicatedTransaction(
+                after, globalSession, localOperationIdAfter
+        );
+
+        TransactionCommitProcess localCommitProcess = mock( TransactionCommitProcess.class );
+        when( localCommitProcess.commit( any( TransactionRepresentation.class ), any( LockGroup.class ),
+                any( CommitEvent.class ), any( TransactionApplicationMode.class ) ) )
+                .thenReturn( 4L );
+        ReplicatedTransactionStateMachine listener = new ReplicatedTransactionStateMachine( localCommitProcess,
+                sessionTracker, globalSession );
+
+        // when
+        listener.onReplicated( txBefore ); // Just to get the Id
+        listener.onReplicated( new CoreServiceAssignment( LOCK_MANAGER, newLockManager, UUID.randomUUID() ) );
+        listener.onReplicated( txAfter );
+
+        // then
+        verify( localCommitProcess ).commit( eq( tx ), any( LockGroup.class ), any( CommitEvent.class ), eq( TransactionApplicationMode.EXTERNAL ) );
+        verifyNoMoreInteractions( localCommitProcess );
+    }
+
+
+    @Test
+    public void shouldFailFutureForTransactionCommittedUnderWrongLockManager() throws Exception
+    {
+        // given
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+        LocalOperationId localOperationIdBefore = new LocalOperationId( 0, 0 );
+        LocalOperationId localOperationIdAfter = new LocalOperationId( 0, 1 );
+
+        CoreMember newLockManager = new CoreMember( address( "new:1" ), address( "new:2" ) );
+
+        ReplicatedTransaction txBefore = ReplicatedTransactionFactory.createImmutableReplicatedTransaction(
+                 mock( PhysicalTransactionRepresentation.class ), globalSession, localOperationIdBefore
+        );
+        PhysicalTransactionRepresentation after = mock( PhysicalTransactionRepresentation.class );
+        when( after.getLatestCommittedTxWhenStarted() ).thenReturn( 3L );
+        ReplicatedTransaction txAfter = ReplicatedTransactionFactory.createImmutableReplicatedTransaction(
+                after, globalSession, localOperationIdAfter
+        );
+
+        TransactionCommitProcess localCommitProcess = mock( TransactionCommitProcess.class );
+        when( localCommitProcess.commit( any( TransactionRepresentation.class ), any( LockGroup.class ),
+                any( CommitEvent.class ), any( TransactionApplicationMode.class ) ) )
+                .thenReturn( 4L );
+        ReplicatedTransactionStateMachine listener = new ReplicatedTransactionStateMachine( localCommitProcess,
+                sessionTracker, globalSession );
+
+        Future<Long> future = listener.getFutureTxId( localOperationIdAfter );
+
+        // when
+        listener.onReplicated( txBefore ); // Just to get the Id
+        listener.onReplicated( new CoreServiceAssignment( LOCK_MANAGER, newLockManager, UUID.randomUUID() ) );
+        listener.onReplicated( txAfter );
+
+        // then
+        try
+        {
+            future.get(1, TimeUnit.SECONDS);
+            fail( "Should have thrown exception" );
+        }
+        catch ( ExecutionException e )
+        {
+            assertThat( e.getCause().getMessage(), containsString( "different leader" ) );
+        }
+    }
+
+    @Test
+    public void shouldCommitTransactionWhichDoesNotNeedLockManager() throws Exception
+    {
+        // given
+        GlobalSessionTracker sessionTracker = new GlobalSessionTracker();
+        LocalOperationId localOperationId = new LocalOperationId( 0, 0 );
+
+        CoreMember lockManager = new CoreMember( address( "old:1" ), address( "old:2" ) );
+
+        ReplicatedTransaction tx = ReplicatedTransactionFactory.createImmutableReplicatedTransaction(
+                mock( PhysicalTransactionRepresentation.class ), globalSession, localOperationId );
+
+        TransactionCommitProcess localCommitProcess = mock( TransactionCommitProcess.class );
+        final ReplicatedTransactionStateMachine listener = new ReplicatedTransactionStateMachine(
+                localCommitProcess, sessionTracker, globalSession );
+
+        // when
+        listener.onReplicated( new CoreServiceAssignment( LOCK_MANAGER, lockManager, UUID.randomUUID() ) );
+        listener.onReplicated( tx );
+
+        // then
+        verify( localCommitProcess, times( 1 ) ).commit( any( TransactionRepresentation.class ),
+                any( LockGroup.class ), any( CommitEvent.class ), any(
+                        TransactionApplicationMode.class ) );
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/CandidateTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/CandidateTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import java.util.UUID;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.net.Inbound;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.RaftState;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import static org.neo4j.coreedge.raft.MessageUtils.messageFor;
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesRequest;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.voteRequest;
+import static org.neo4j.coreedge.raft.roles.Role.CANDIDATE;
+import static org.neo4j.coreedge.raft.roles.Role.FOLLOWER;
+import static org.neo4j.coreedge.raft.state.RaftStateBuilder.raftState;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CandidateTest
+{
+    private RaftTestMember myself = member( 0 );
+
+    /* A few members that we use at will in tests. */
+    private RaftTestMember member1 = member( 1 );
+    private RaftTestMember member2 = member( 2 );
+
+    private RaftLog raftLog = new InMemoryRaftLog();
+
+    @Mock
+    private Inbound inbound;
+
+    private LogProvider logProvider = NullLogProvider.getInstance();
+    public static final int HIGHEST_TERM = 99;
+
+    @Test
+    public void candidateShouldUpdateTermToCurrentMessageAndBecomeFollower() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState().build();
+
+        Candidate candidate = new Candidate();
+
+        // when
+        Outcome outcome = candidate.handle( voteRequest().from( member1 ).term( HIGHEST_TERM ).lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertEquals( FOLLOWER, outcome.newRole );
+        assertEquals( HIGHEST_TERM, outcome.newTerm );
+    }
+
+    @Test
+    public void candidateShouldBecomeFollowerIfReceivesMessageWithNewerTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .build();
+
+        Candidate candidate = new Candidate();
+
+        // when
+        RaftMessages.Vote.Request<RaftTestMember> message = voteRequest()
+                .from( member1 )
+                .term( state.term() + 1 )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build();
+        Outcome<RaftTestMember> outcome = candidate.handle( message, state, log() );
+
+        // then
+        assertEquals( message, messageFor( outcome,  myself ) );
+        assertEquals( FOLLOWER, outcome.newRole );
+    }
+
+    @Test
+    public void candidateShouldRejectAnyMessageWithOldTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState().build();
+
+        Candidate candidate = new Candidate();
+
+        // when
+        Outcome<RaftTestMember> outcome = candidate.handle( voteRequest().from( member1 ).term( state.term() - 1 ).lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertFalse( ((RaftMessages.Vote.Response) messageFor( outcome, member1 )).voteGranted() );
+        assertEquals( CANDIDATE, outcome.newRole );
+    }
+
+    @Test
+    public void candidateShouldBecomeFollowerOnReceiptOfAppendEntriesFromLeaderWithHigherTerm() throws Exception
+    {
+        candidateShouldBecomeFollowerOnReceiptOfAppendEntriesFromLeaderWithTerm( 2 );
+    }
+
+    @Test
+    public void candidateShouldBecomeFollowerOnReceiptOfAppendEntriesFromLeaderWithSameTerm() throws Exception
+    {
+        candidateShouldBecomeFollowerOnReceiptOfAppendEntriesFromLeaderWithTerm( 1 );
+    }
+
+    private void candidateShouldBecomeFollowerOnReceiptOfAppendEntriesFromLeaderWithTerm( int term ) throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( 1 )
+                .build();
+
+        Candidate candidate = new Candidate();
+
+        // when
+        RaftMessages.AppendEntries.Request<RaftTestMember> message = appendEntriesRequest()
+                .from( member1 )
+                .leader( member1 )
+                .leaderTerm( term )
+                .leaderCommit( 1 )
+                .correlationId( UUID.randomUUID() )
+                .prevLogIndex( 0 )
+                .prevLogTerm( term - 1 ).build();
+        Outcome<RaftTestMember> outcome = candidate.handle( message, state, log() );
+
+        // then
+        assertEquals( message, messageFor( outcome,  myself ) );
+        assertEquals( FOLLOWER, outcome.newRole );
+    }
+
+    private Log log()
+    {
+        return logProvider.getLog( getClass() );
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/ElectionTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/ElectionTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.coreedge.raft.ControlledTimeoutService;
+import org.neo4j.coreedge.raft.RaftInstanceBuilder;
+import org.neo4j.coreedge.raft.membership.RaftTestGroup;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.RaftInstance;
+import org.neo4j.coreedge.server.RaftTestMemberSetBuilder;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.net.Inbound;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.voteRequest;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.voteResponse;
+import static org.neo4j.coreedge.raft.roles.Role.CANDIDATE;
+import static org.neo4j.coreedge.raft.roles.Role.LEADER;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ElectionTest
+{
+    private RaftTestMember myself = member( 0 );
+
+    /* A few members that we use at will in tests. */
+    private RaftTestMember member1 = member( 1 );
+    private RaftTestMember member2 = member( 2 );
+
+    private RaftLog raftLog = new InMemoryRaftLog();
+
+    @Mock
+    private Inbound inbound;
+
+    private LogProvider logProvider = NullLogProvider.getInstance();
+
+    @Test
+    public void candidateShouldWinElectionAndBecomeLeader() throws Exception
+    {
+        // given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+
+        Outbound<RaftTestMember> outbound = mock( Outbound.class );
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .outbound( outbound )
+                .timeoutService( timeouts )
+                .build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) );
+
+        timeouts.invokeTimeout( RaftInstance.Timeouts.ELECTION );
+
+        // when
+        raft.handle( voteResponse().from( member1 ).term( 1 ).grant().build() );
+        raft.handle( voteResponse().from( member2 ).term( 1 ).grant().build() );
+
+        // then
+        assertEquals( 1, raft.term() );
+        assertEquals( LEADER, raft.currentRole() );
+
+        verify( outbound ).send( eq( member1 ), isA( RaftMessages.AppendEntries.Request.class ) );
+        verify( outbound ).send( eq( member2 ), isA( RaftMessages.AppendEntries.Request.class ) );
+    }
+
+    @Test
+    public void candidateShouldLoseElectionAndRemainCandidate() throws Exception
+    {
+        // Note the etcd implementation seems to diverge from the paper here, since the paper suggests that it should
+        // remain as a candidate
+
+        // given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+
+        Outbound<RaftTestMember> outbound = mock( Outbound.class );
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .outbound( outbound )
+                .timeoutService( timeouts )
+                .build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) );
+
+        timeouts.invokeTimeout( RaftInstance.Timeouts.ELECTION );
+
+        // when
+        raft.handle( voteResponse().from( member1 ).term( 1 ).deny().build() );
+        raft.handle( voteResponse().from( member2 ).term( 1 ).deny().build() );
+
+        // then
+        assertEquals( 1, raft.term() );
+        assertEquals( CANDIDATE, raft.currentRole() );
+
+        verify( outbound, never() ).send( eq( member1 ), isA( RaftMessages.AppendEntries.Request.class ) );
+        verify( outbound, never() ).send( eq( member2 ), isA( RaftMessages.AppendEntries.Request.class ) );
+    }
+
+    @Test
+    public void candidateShouldVoteForTheSameCandidateInTheSameTerm() throws Exception
+    {
+        // given
+        ControlledTimeoutService timeouts = new ControlledTimeoutService();
+
+        Outbound<RaftTestMember> outbound = mock( Outbound.class );
+
+        RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
+                .outbound( outbound )
+                .timeoutService( timeouts )
+                .build();
+
+        raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) );
+
+        // when
+        raft.handle( voteRequest().from( member1 ).candidate( member1 ).term( 1 ).build() );
+        raft.handle( voteRequest().from( member1 ).candidate( member1 ).term( 1 ).build() );
+
+        // then
+        verify( outbound, times( 2 ) ).send( member1, voteResponse().term( 1 ).grant().build() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/FollowerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/FollowerTest.java
@@ -1,0 +1,657 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.ReplicatedString;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.RaftMessages.Message;
+import org.neo4j.coreedge.raft.RaftMessages.Timeout.Election;
+import org.neo4j.coreedge.raft.RaftMessages.Vote;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.net.Inbound;
+import org.neo4j.coreedge.raft.outcome.CommitCommand;
+import org.neo4j.coreedge.raft.outcome.LogCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.RaftState;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.coreedge.raft.MessageUtils.messageFor;
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesRequest;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.heartbeat;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.voteRequest;
+import static org.neo4j.coreedge.raft.RaftMessages.AppendEntries;
+import static org.neo4j.coreedge.raft.roles.Role.CANDIDATE;
+import static org.neo4j.coreedge.raft.roles.Role.FOLLOWER;
+import static org.neo4j.coreedge.raft.state.RaftStateBuilder.raftState;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+import java.util.Iterator;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class FollowerTest
+{
+    private RaftTestMember myself = member( 0 );
+
+    /* A few members that we use at will in tests. */
+    private RaftTestMember member1 = member( 1 );
+    private RaftTestMember member2 = member( 2 );
+
+    @Mock
+    private Inbound inbound;
+
+    private LogProvider logProvider = NullLogProvider.getInstance();
+
+    private static final int HIGHEST_TERM = 99;
+
+    @Test
+    public void followerShouldUpdateTermToCurrentMessage() throws Exception
+    {
+        // Given
+        RaftState<RaftTestMember> state = raftState().build();
+
+
+        Follower follower = new Follower();
+
+        // When
+        Outcome<RaftTestMember> outcome = follower.handle( voteRequest().from( member1 ).term( HIGHEST_TERM )
+                .lastLogIndex( 0 ).lastLogTerm( -1 )
+                .build(), state, log() );
+
+        // Then
+        assertEquals( HIGHEST_TERM, outcome.newTerm );
+    }
+
+    @Test
+    public void shouldVoteOnceOnlyPerTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        Follower follower = new Follower();
+
+        // when
+        Outcome<RaftTestMember> outcome1 = follower.handle( voteRequest().from( member1 ).term( 1 ).build(), state,
+                log() );
+        state.update( outcome1 );
+        Outcome<RaftTestMember> outcome2 = follower.handle( voteRequest().from( member2 ).term( 1 ).build(), state,
+                log() );
+
+        // then
+        assertEquals( new Vote.Response<>( myself, 1, true ), messageFor( outcome1, member1 ) );
+        assertEquals( new Vote.Response<>( myself, 1, false ), messageFor( outcome2,  member2 ) );
+
+    }
+
+    @Test
+    public void followersShouldRejectAnyMessageWithOldTermAndStayAFollower() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .votingMembers( asSet( myself, member1, member2 ) )
+
+                .build();
+
+        Follower follower = new Follower();
+
+        // when
+        Outcome<RaftTestMember> outcome = follower.handle( voteRequest().from( member1 ).term( state.term() - 1 )
+                .lastLogIndex( 0 ).lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertEquals( new Vote.Response<>( myself, state.term(), false ), messageFor( outcome, member1 ) );
+        assertEquals( FOLLOWER, outcome.newRole );
+    }
+
+    @Test
+    public void followerShouldTransitToCandidateAndInstigateAnElectionAfterTimeout() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+
+        // when
+        Outcome<RaftTestMember> outcome = new Follower().handle( new Election<>( myself ), state,
+                log() );
+
+        state.update( outcome );
+
+        // then
+        assertEquals( CANDIDATE, outcome.newRole );
+
+        assertNotNull( messageFor( outcome, member1 ) );
+        assertNotNull( messageFor( outcome, member2 ) );
+    }
+
+    @Test
+    public void followerShouldVoteForOnlyOneCandidatePerElection() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState().build();
+
+        Follower follower = new Follower();
+
+        // when
+        Outcome<RaftTestMember> outcome1 = follower.handle( voteRequest().from( member1 ).term( state.term() )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+        state.update( outcome1 );
+        Outcome<RaftTestMember> outcome2 = follower.handle( voteRequest().from( member2 ).term( state.term() )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertThat( messageFor( outcome1,  member1 ), instanceOf( Vote.Response.class ) );
+        assertFalse( ((Vote.Response) messageFor( outcome2, member2 )).voteGranted() );
+    }
+
+    @Test
+    public void shouldBecomeCandidateOnReceivingElectionTimeoutMessage() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        Follower follower = new Follower();
+
+        // when
+        Outcome outcome = follower.handle( new Election<>( myself ), state, log() );
+
+        // then
+        assertEquals( CANDIDATE, outcome.newRole );
+    }
+
+    @Test
+    public void followerShouldRejectEntriesForWhichItDoesNotHavePrecedentInItsLog() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        Follower follower = new Follower();
+
+        // when
+        Outcome<RaftTestMember> outcome = follower.handle( new RaftMessages.AppendEntries.Request<>( myself, 99,
+                99, 0, new RaftLogEntry[] { new RaftLogEntry( 99, ContentGenerator.content() ) }, 99 ), state, log() );
+
+        // then
+        Message<RaftTestMember> response = messageFor( outcome,  myself );
+        assertThat( response, instanceOf( AppendEntries.Response.class ) );
+        assertFalse( ((AppendEntries.Response) response).success() );
+    }
+
+    @Test
+    public void followerShouldAcceptEntriesForWhichItHasPrecedentInItsLog() throws Exception
+    {
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .build();
+
+        Follower follower = new Follower();
+
+        state.update( follower.handle( new RaftMessages.AppendEntries.Request<>( myself, 0, -1, -1,
+                new RaftLogEntry[] { new RaftLogEntry( 0, ContentGenerator.content() ) }, 0 ), state, log() ) );
+
+        // when
+        Outcome<RaftTestMember> outcome = follower.handle( new RaftMessages.AppendEntries.Request<>( myself, 0,
+                0, 0, new RaftLogEntry[] { new RaftLogEntry( 0, ContentGenerator.content() ) }, 1 ), state, log() );
+
+        state.update( outcome );
+
+        // then
+        Message<RaftTestMember> response = messageFor( outcome, myself );
+        assertThat( response, instanceOf( AppendEntries.Response.class ) );
+        assertTrue( ((AppendEntries.Response) response).success() );
+    }
+
+
+    @Test
+    public void followerShouldOverwriteSomeAppendedEntriesOnReceiptOfConflictingCommittedEntries() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .build();
+
+        Follower follower = new Follower();
+
+        appendSomeEntriesToLog( state, follower, 9, 0 );
+
+        // when
+        Outcome<RaftTestMember> outcome = follower.handle( new AppendEntries.Request<>( myself, 1, -1, -1,
+                new RaftLogEntry[] { new RaftLogEntry( 1, new ReplicatedString( "commit this!" ) ) }, 0 ), state, log() );
+        state.update( outcome );
+
+        // then
+        assertEquals( 0, state.entryLog().commitIndex() );
+    }
+
+    @Test
+    public void followerWithEmptyLogShouldCommitEntriesWithHigherTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .build();
+
+        Follower follower = new Follower();
+
+        // when
+        Outcome<RaftTestMember> outcome = follower.handle( new AppendEntries.Request<>( myself, 1, -1, -1,
+                new RaftLogEntry[] { new RaftLogEntry( 1, new ReplicatedString( "commit this!" ) ) }, 0 ), state, log() );
+        state.update( outcome );
+
+        // then
+        assertEquals( 0, state.entryLog().commitIndex() );
+        assertEquals( 1, state.term() );
+    }
+
+    @Test
+    public void followerWithNonEmptyLogShouldOverwriteAppendedEntriesOnReceiptOfCommittedEntryWithHigherTerm()
+            throws Exception
+    {
+        // given
+        int term = 1;
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( term )
+                .build();
+
+        Follower follower = new Follower();
+
+        appendSomeEntriesToLog( state, follower, 9, term );
+
+        // when leader says it agrees with some of the existing log
+        Outcome<RaftTestMember> outcome = follower.handle( new AppendEntries.Request<>( member1, 2, 3, 1,
+                new RaftLogEntry[] { new RaftLogEntry( 2, new ReplicatedString( "commit this!" ) ) }, 4 ), state, log() );
+        state.update( outcome );
+
+        // then
+        assertEquals( 4, state.entryLog().commitIndex() );
+        assertEquals( 2, state.term() );
+    }
+    
+    @Test
+    public void followerReceivingHeartbeatIndicatingClusterIsAheadShouldElicitAppendResponse() throws Exception
+    {
+        // given
+        int term = 1;
+        int followerAppendIndex = 9;
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( term )
+                .build();
+
+        Follower follower = new Follower();
+        appendSomeEntriesToLog( state, follower, followerAppendIndex, term );
+
+        AppendEntries.Request<RaftTestMember> heartbeat = appendEntriesRequest().from( member1 )
+                .leader( member1 )
+                .leaderTerm( term )
+                .prevLogIndex( followerAppendIndex + 2 ) // leader has appended 2 ahead from this follower
+                .prevLogTerm( term ) // in the same term
+                .build(); // no entries, this is a heartbeat
+
+        Outcome<RaftTestMember> outcome = follower.handle( heartbeat, state, log() );
+
+        assertEquals( 1, outcome.outgoingMessages.size() );
+        Message<RaftTestMember> outgoing = outcome.outgoingMessages.iterator().next().message();
+        assertEquals( RaftMessages.Type.APPEND_ENTRIES_RESPONSE, outgoing.type() );
+        RaftMessages.AppendEntries.Response response = (AppendEntries.Response) outgoing;
+        assertFalse( response.success() );
+    }
+
+    @Test
+    public void heartbeatShouldNotResultInCommitIfReferringToFutureEntries() throws Exception
+    {
+        int term = 1;
+        int followerAppendIndex = 9;
+
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( term )
+                .build();
+
+
+        Follower follower = new Follower();
+        appendSomeEntriesToLog( state, follower, followerAppendIndex, term );
+
+        RaftMessages.Heartbeat<RaftTestMember> heartbeat = heartbeat().from( member1 )
+                .commitIndex( followerAppendIndex + 2 ) // The leader is talking about committing stuff we don't know about
+                .commitIndexTerm( term ) // And is in the same term
+                .leaderTerm( term + 2 )
+                .build();
+
+        Outcome<RaftTestMember> outcome = follower.handle( heartbeat, state, log() );
+
+        // Then there should be no actions taken against the log
+        assertFalse( outcome.logCommands.iterator().hasNext() );
+    }
+
+    @Test
+    public void heartbeatShouldNotResultInCommitIfHistoryMismatches() throws Exception
+    {
+        int term = 1;
+        int followerAppendIndex = 9;
+
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( term )
+                .build();
+
+
+        Follower follower = new Follower();
+        appendSomeEntriesToLog( state, follower, followerAppendIndex, term );
+
+        RaftMessages.Heartbeat<RaftTestMember> heartbeat = heartbeat().from( member1 )
+                .commitIndex( followerAppendIndex ) // The leader suggests that we commit stuff we have appended
+                .commitIndexTerm( term + 2 ) // but in a different term
+                .leaderTerm( term + 2 ) // And is in a term that is further in the future
+                .build();
+
+        Outcome<RaftTestMember> outcome = follower.handle( heartbeat, state, log() );
+
+        assertFalse( outcome.logCommands.iterator().hasNext() );
+    }
+
+    @Test
+    public void historyShouldResultInCommitIfHistoryMatches() throws Exception
+    {
+        int term = 1;
+        int followerAppendIndex = 9;
+
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( term )
+                .build();
+
+        Follower follower = new Follower();
+        appendSomeEntriesToLog( state, follower, followerAppendIndex, term );
+
+        RaftMessages.Heartbeat<RaftTestMember> heartbeat = heartbeat().from( member1 )
+                .commitIndex( followerAppendIndex - 1) // The leader suggests that we commit stuff we have appended
+                .commitIndexTerm( term ) // in the same term
+                .leaderTerm( term + 2 ) // with the leader in the future
+                .build();
+
+        Outcome<RaftTestMember> outcome = follower.handle( heartbeat, state, log() );
+
+        Iterator<LogCommand> iterator = outcome.logCommands.iterator();
+        assertTrue( iterator.hasNext() );
+        LogCommand logCommand = iterator.next();
+        assertFalse( iterator.hasNext() );
+        assertThat( logCommand, instanceOf( CommitCommand.class ) );
+        CommitCommand commit = (CommitCommand) logCommand;
+        CapturingRaftLog capture = new CapturingRaftLog();
+        commit.applyTo( capture );
+        assertEquals( followerAppendIndex - 1, capture.commitIndex() );
+    }
+
+    @Test
+    public void shouldAppendMultipleEntries() throws Exception
+    {
+        // given
+        int term = 1;
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( term )
+                .build();
+
+        Follower follower = new Follower();
+
+        RaftLogEntry[] entries = {
+                new RaftLogEntry( 1, new ReplicatedString( "commit this!" ) ),
+                new RaftLogEntry( 1, new ReplicatedString( "commit this as well!" ) ),
+                new RaftLogEntry( 1, new ReplicatedString( "commit this too!" ) )
+        };
+
+        Outcome<RaftTestMember> outcome = follower.handle(
+                new AppendEntries.Request<>( member1, 1, -1, -1, entries, -1 ), state, log() );
+        state.update( outcome );
+
+        // then
+        assertEquals( 2, state.entryLog().appendIndex() );
+    }
+
+    @Test
+    public void shouldTruncateIfTermDoesNotMatch() throws Exception
+    {
+        // given
+        int term = 1;
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( term )
+                .build();
+
+        Follower follower = new Follower();
+
+        state.update( follower.handle( new AppendEntries.Request<>( member1, 1, -1, -1,
+                new RaftLogEntry[] {
+                        new RaftLogEntry( 2, ContentGenerator.content() ),
+                },
+                -1 ), state, log() ) );
+
+
+        RaftLogEntry[] entries = {
+                new RaftLogEntry( 1, new ReplicatedString( "commit this!" ) ),
+        };
+
+        Outcome<RaftTestMember> outcome = follower.handle(
+                new AppendEntries.Request<>( member1, 1, -1, -1, entries, -1 ), state, log() );
+        state.update( outcome );
+
+        // then
+        assertEquals( 0, state.entryLog().appendIndex() );
+        assertEquals( 1, state.entryLog().readEntryTerm( 0 ) );
+    }
+
+    @Test
+    public void followerLearningAboutHigherCommitCausesValuesTobeAppliedToItsLog() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .build();
+
+        Follower follower = new Follower();
+
+        appendSomeEntriesToLog( state, follower, 3, 0 );
+
+        // when receiving AppEntries with high leader commit (3)
+        Outcome<RaftTestMember> outcome = follower.handle( new AppendEntries.Request<>( myself, 0, 2, 0,
+                new RaftLogEntry[] { new RaftLogEntry( 0, ContentGenerator.content() ) }, 3 ), state, log() );
+
+        state.update( outcome );
+
+        // then
+        assertEquals( 3, state.entryLog().commitIndex() );
+    }
+
+    @Test
+    public void shouldRenewElectionTimeoutOnReceiptOfHeartbeatInCurrentOrHigherTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term(0)
+                .build();
+
+        Follower follower = new Follower();
+
+        Outcome<RaftTestMember> outcome = follower.handle( new RaftMessages.Heartbeat<>( myself, 1, 1, 1 ),
+                state, log() );
+
+        // then
+        assertTrue( outcome.renewElectionTimeout );
+    }
+
+    @Test
+    public void shouldNotRenewElectionTimeoutOnReceiptOfHeartbeatInLowerTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( 2 )
+                .build();
+
+        Follower follower = new Follower();
+
+        Outcome<RaftTestMember> outcome = follower.handle( new RaftMessages.Heartbeat<>( myself, 1, 1, 1 ),
+                state, log() );
+
+        // then
+        assertFalse( outcome.renewElectionTimeout );
+    }
+
+    private void appendSomeEntriesToLog( RaftState raft, Follower follower, int numberOfEntriesToAppend, int
+            term ) throws RaftStorageException
+    {
+        for ( int i = 0; i < numberOfEntriesToAppend; i++ )
+        {
+            if ( i == 0 )
+            {
+                raft.update( follower.handle( new AppendEntries.Request<>( myself, term, i - 1, -1,
+                        new RaftLogEntry[] { new RaftLogEntry( term, ContentGenerator.content() ) }, -1 ), raft, log() ) );
+            }
+            else
+            {
+                raft.update( follower.handle( new AppendEntries.Request<>( myself, term, i - 1, term,
+                        new RaftLogEntry[]{new RaftLogEntry( term, ContentGenerator.content() )}, -1 ), raft, log() ) );
+            }
+        }
+    }
+
+    private static class ContentGenerator
+    {
+        private static int count = 0;
+
+        public static ReplicatedString content()
+        {
+            return new ReplicatedString( String.format( "content#%d", count++ ) );
+        }
+    }
+
+    private Log log()
+    {
+        return logProvider.getLog( getClass() );
+    }
+
+    private static final class CapturingRaftLog implements RaftLog
+    {
+
+        private long commitIndex;
+
+        @Override
+        public void replay() throws Throwable
+        {
+
+        }
+
+        @Override
+        public void registerListener( Listener consumer )
+        {
+
+        }
+
+        @Override
+        public long append( RaftLogEntry entry ) throws RaftStorageException
+        {
+            return 0;
+        }
+
+        @Override
+        public void truncate( long fromIndex ) throws RaftStorageException
+        {
+
+        }
+
+        @Override
+        public void commit( long commitIndex ) throws RaftStorageException
+        {
+            this.commitIndex = commitIndex;
+        }
+
+        @Override
+        public long appendIndex()
+        {
+            return 0;
+        }
+
+        @Override
+        public long commitIndex()
+        {
+            return commitIndex;
+        }
+
+        @Override
+        public RaftLogEntry readLogEntry( long logIndex ) throws RaftStorageException
+        {
+            return null;
+        }
+
+        @Override
+        public ReplicatedContent readEntryContent( long logIndex ) throws RaftStorageException
+        {
+            return null;
+        }
+
+        @Override
+        public long readEntryTerm( long logIndex ) throws RaftStorageException
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean entryExists( long logIndex )
+        {
+            return false;
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/LeaderTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/LeaderTest.java
@@ -1,0 +1,525 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.ReplicatedString;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.RaftMessages.AppendEntries;
+import org.neo4j.coreedge.raft.RaftMessages.Timeout.Heartbeat;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.outcome.ShipCommand;
+import org.neo4j.coreedge.raft.net.Inbound;
+import org.neo4j.coreedge.raft.net.Outbound;
+import org.neo4j.coreedge.raft.outcome.AppendLogEntry;
+import org.neo4j.coreedge.raft.outcome.CommitCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.FollowerState;
+import org.neo4j.coreedge.raft.state.FollowerStates;
+import org.neo4j.coreedge.raft.state.RaftState;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.coreedge.raft.MessageUtils.messageFor;
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesResponse;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.voteRequest;
+import static org.neo4j.coreedge.raft.roles.Role.FOLLOWER;
+import static org.neo4j.coreedge.raft.roles.Role.LEADER;
+import static org.neo4j.coreedge.raft.state.RaftStateBuilder.raftState;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+import static org.neo4j.helpers.collection.IteratorUtil.count;
+import static org.neo4j.helpers.collection.IteratorUtil.firstOrNull;
+import static org.neo4j.helpers.collection.IteratorUtil.single;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LeaderTest
+{
+    private RaftTestMember myself = member( 0 );
+
+    /* A few members that we use at will in tests. */
+    private RaftTestMember member1 = member( 1 );
+    private RaftTestMember member2 = member( 2 );
+
+    @Mock
+    private Inbound inbound;
+
+    @Mock
+    private Outbound outbound;
+
+    private LogProvider logProvider = NullLogProvider.getInstance();
+    private static final int HIGHEST_TERM = 99;
+
+    private static final ReplicatedString CONTENT = ReplicatedString.valueOf( "some-content-to-raft" );
+
+    @Test
+    public void leaderShouldUpdateTermToCurrentMessageAndBecomeFollower() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState().build();
+
+        Leader leader = new Leader();
+
+        // when
+        Outcome outcome = leader.handle( voteRequest().from( member1 ).term( HIGHEST_TERM ).lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertEquals( FOLLOWER, outcome.newRole );
+        assertEquals( HIGHEST_TERM, outcome.newTerm );
+    }
+
+    @Test
+    public void leaderShouldRejectVoteRequestWithNewerTermAndBecomeAFollower() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState().myself( myself ).build();
+
+        Leader leader = new Leader();
+
+        // when
+        RaftMessages.Vote.Request<RaftTestMember> message = voteRequest()
+                .from( member1 )
+                .term( state.term() + 1 )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 )
+                .build();
+        Outcome<RaftTestMember> outcome = leader.handle( message, state, log() );
+
+        // then
+        assertEquals( message, messageFor( outcome, myself ) );
+        assertEquals( FOLLOWER, outcome.newRole );
+        assertEquals( 0, count( outcome.logCommands ) );
+        assertEquals( state.term() + 1, outcome.newTerm );
+    }
+
+    @Test
+    public void leaderShouldNotRespondToSuccessResponseFromFollowerThatWillSoonUpToDateViaInFlightMessages()
+            throws Exception
+    {
+        // given
+        /*
+         * A leader who
+         * - has an append index of 100
+         * - knows about instance 2
+         * - assumes that instance 2 is at an index less than 100 -say 84 but it has already been sent up to 100
+         */
+        Leader leader = new Leader();
+        RaftTestMember instance2 = new RaftTestMember( 2 );
+        FollowerState instance2State = createArtificialFollowerState( 84 );
+
+        ReadableRaftState<RaftTestMember> state = mock( ReadableRaftState.class );
+
+        FollowerStates<RaftTestMember> followerState = new FollowerStates<>();
+        followerState = new FollowerStates<>( followerState, instance2, instance2State );
+
+        ReadableRaftLog logMock = mock( ReadableRaftLog.class );
+        when( logMock.appendIndex() ).thenReturn( 100l );
+
+        when( state.entryLog() ).thenReturn( logMock );
+        when( state.followerStates() ).thenReturn( followerState );
+        when( state.term() ).thenReturn( 4l ); // both leader and follower are in the same term
+
+        // when
+        // that leader is asked to handle a response from that follower that says that the follower is up to date
+        RaftMessages.AppendEntries.Response<RaftTestMember> response = appendEntriesResponse().success()
+                .matchIndex( 90 ).term( 4 ).from( instance2 ).build();
+
+        Outcome<RaftTestMember> outcome = leader.handle( response, state, mock( Log.class ) );
+
+        // then
+        // The leader should not be trying to send any messages to that instance
+        assertTrue( outcome.outgoingMessages.isEmpty() );
+        // And the follower state should be updated
+        FollowerStates<RaftTestMember> leadersViewOfFollowerStates = outcome.followerStates;
+        assertEquals( 90, leadersViewOfFollowerStates.get( instance2 ).getMatchIndex() );
+    }
+
+    @Test
+    public void leaderShouldNotRespondToSuccessResponseThatIndicatesUpToDateFollower() throws Exception
+    {
+        // given
+        /*
+         * A leader who
+         * - has an append index of 100
+         * - knows about instance 2
+         * - assumes that instance 2 is at an index less than 100 -say 84
+         */
+        Leader leader = new Leader();
+        RaftTestMember instance2 = new RaftTestMember( 2 );
+        FollowerState instance2State = createArtificialFollowerState( 84 );
+
+        ReadableRaftState<RaftTestMember> state = mock( ReadableRaftState.class );
+
+        FollowerStates<RaftTestMember> followerState = new FollowerStates<>();
+        followerState = new FollowerStates<>( followerState, instance2, instance2State );
+
+        ReadableRaftLog logMock = mock( ReadableRaftLog.class );
+        when( logMock.appendIndex() ).thenReturn( 100l );
+
+        when( state.entryLog() ).thenReturn( logMock );
+        when( state.followerStates() ).thenReturn( followerState );
+        when( state.term() ).thenReturn( 4l ); // both leader and follower are in the same term
+
+        // when
+        // that leader is asked to handle a response from that follower that says that the follower is up to date
+        RaftMessages.AppendEntries.Response<RaftTestMember> response = appendEntriesResponse().success()
+                .matchIndex( 100 ).term( 4 ).from( instance2 ).build();
+
+        Outcome<RaftTestMember> outcome = leader.handle( response, state, mock( Log.class ) );
+
+        // then
+        // The leader should not be trying to send any messages to that instance
+        assertTrue( outcome.outgoingMessages.isEmpty() );
+        // And the follower state should be updated
+        FollowerStates<RaftTestMember> updatedFollowerStates = outcome.followerStates;
+        assertEquals( 100, updatedFollowerStates.get( instance2 ).getMatchIndex() );
+    }
+
+    @Test
+    public void leaderShouldRespondToSuccessResponseThatIndicatesLaggingFollowerWithJustWhatItsMissing() throws
+            Exception
+    {
+        // given
+        /*
+         * A leader who
+         * - has an append index of 100
+         * - knows about instance 2
+         * - assumes that instance 2 is at an index less than 100 -say 50
+         */
+        Leader leader = new Leader();
+        RaftTestMember instance2 = new RaftTestMember( 2 );
+        FollowerState instance2State = createArtificialFollowerState( 50 );
+
+        ReadableRaftState<RaftTestMember> state = mock( ReadableRaftState.class );
+
+        FollowerStates<RaftTestMember> followerState = new FollowerStates<>();
+        followerState = new FollowerStates<>( followerState, instance2, instance2State );
+
+        ReadableRaftLog logMock = mock( ReadableRaftLog.class );
+        when( logMock.appendIndex() ).thenReturn( 100l );
+        when( logMock.commitIndex() ).thenReturn( 100l ); // assume that everything is committed, so we don't deal
+        // with commit requests in this test
+
+        when( state.entryLog() ).thenReturn( logMock );
+        when( state.followerStates() ).thenReturn( followerState );
+        when( state.term() ).thenReturn( 231l ); // both leader and follower are in the same term
+
+        // when that leader is asked to handle a response from that follower that says that the follower is still
+        // missing things
+        RaftMessages.AppendEntries.Response<RaftTestMember> response = appendEntriesResponse()
+                .success()
+                .matchIndex( 89 )
+                .term( 231 )
+                .from( instance2 ).build();
+
+        Outcome<RaftTestMember> outcome = leader.handle( response, state, mock( Log.class ) );
+
+        // then
+        int matchCount = 0;
+        for ( ShipCommand shipCommand : outcome.shipCommands )
+        {
+            if ( shipCommand instanceof ShipCommand.Match )
+            {
+                matchCount++;
+            }
+        }
+
+        assertThat( matchCount, greaterThan( 0 ) );
+    }
+
+    @Test
+    public void leaderShouldIgnoreSuccessResponseThatIndicatesLaggingWhileLocalStateIndicatesFollowerIsCaughtUp()
+            throws Exception
+    {
+        // given
+        /*
+         * A leader who
+         * - has an append index of 100
+         * - knows about instance 2
+         * - assumes that instance 2 is fully caught up
+         */
+        Leader leader = new Leader();
+        RaftTestMember instance2 = new RaftTestMember( 2 );
+        int i = 101;
+        int j = 100;
+        FollowerState instance2State = createArtificialFollowerState( j );
+
+        ReadableRaftState<RaftTestMember> state = mock( ReadableRaftState.class );
+
+        FollowerStates<RaftTestMember> followerState = new FollowerStates<>();
+        followerState = new FollowerStates<>( followerState, instance2, instance2State );
+
+        ReadableRaftLog logMock = mock( ReadableRaftLog.class );
+        when( logMock.appendIndex() ).thenReturn( 100l );
+        when( logMock.commitIndex() ).thenReturn( 100l ); // assume that everything is committed, so we don't deal
+        //  with commit requests in this test
+
+        when( state.entryLog() ).thenReturn( logMock );
+        when( state.followerStates() ).thenReturn( followerState );
+        when( state.term() ).thenReturn( 4l ); // both leader and follower are in the same term
+
+        // when that leader is asked to handle a response from that follower that says that the follower is still
+        // missing things
+        RaftMessages.AppendEntries.Response<RaftTestMember> response = appendEntriesResponse()
+                .success()
+                .matchIndex( 80 )
+                .term( 4 )
+                .from( instance2 ).build();
+
+        Outcome<RaftTestMember> outcome = leader.handle( response, state, mock( Log.class ) );
+
+        // then the leader should not send anything, since this is a delayed, out of order response to a previous append
+        // request
+        assertTrue( outcome.outgoingMessages.isEmpty() );
+        // The follower state should not be touched
+        FollowerStates<RaftTestMember> updatedFollowerStates = outcome.followerStates;
+        assertEquals( 100, updatedFollowerStates.get( instance2 ).getMatchIndex() );
+    }
+
+    private static FollowerState createArtificialFollowerState( long matchIndex )
+    {
+        return new FollowerState().onSuccessResponse( matchIndex );
+    }
+
+    // TODO: rethink this test, it does too much
+    @Test
+    public void leaderShouldSpawnMismatchCommandOnFailure() throws Exception
+    {
+        // given
+        /*
+         * A leader who
+         * - has an append index of 100
+         * - knows about instance 2
+         * - assumes that instance 2 is fully caught up
+         */
+        Leader leader = new Leader();
+        RaftTestMember instance2 = new RaftTestMember( 2 );
+        FollowerState instance2State = createArtificialFollowerState( 100 );
+
+        ReadableRaftState<RaftTestMember> state = mock( ReadableRaftState.class );
+
+        FollowerStates<RaftTestMember> followerState = new FollowerStates<>();
+        followerState = new FollowerStates<>( followerState, instance2, instance2State );
+
+        ReadableRaftLog logMock = mock( ReadableRaftLog.class );
+        when( logMock.appendIndex() ).thenReturn( 100l );
+        when( logMock.commitIndex() ).thenReturn( 100l ); // assume that everything is committed, so we don't deal
+        // with commit requests in this test
+
+        when( state.entryLog() ).thenReturn( logMock );
+        when( state.followerStates() ).thenReturn( followerState );
+        when( state.term() ).thenReturn( 4l ); // both leader and follower are in the same term
+
+        // when
+        // that leader is asked to handle a response from that follower that says that the follower is still missing
+        // things
+        RaftMessages.AppendEntries.Response<RaftTestMember> response = appendEntriesResponse()
+                .failure()
+                .matchIndex( -1 )
+                .term( 4 )
+                .from( instance2 ).build();
+
+        Outcome<RaftTestMember> outcome = leader.handle( response, state, mock( Log.class ) );
+
+        // then
+        int mismatchCount = 0;
+        for ( ShipCommand shipCommand : outcome.shipCommands )
+        {
+            if ( shipCommand instanceof ShipCommand.Mismatch )
+            {
+                mismatchCount++;
+            }
+        }
+
+        assertThat( mismatchCount, greaterThan( 0 ) );
+    }
+
+    @Test
+    public void leaderShouldRejectAppendEntriesResponseWithNewerTermAndBecomeAFollower() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState().myself( myself ).build();
+
+        Leader leader = new Leader();
+
+        // when
+        AppendEntries.Response<RaftTestMember> message = appendEntriesResponse()
+                .from( member1 )
+                .term( state.term() + 1 )
+                .build();
+        Outcome<RaftTestMember> outcome = leader.handle( message, state, log() );
+
+        // then
+        assertEquals( 0, count( outcome.outgoingMessages ) );
+        assertEquals( FOLLOWER, outcome.newRole );
+        assertEquals( 0, count( outcome.logCommands ) );
+        assertEquals( state.term() + 1, outcome.newTerm );
+    }
+
+    // TODO: test that shows we don't commit for previous terms
+
+    @Test
+    public void leaderShouldRejectAnyMessageWithOldTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState().build();
+
+        Leader leader = new Leader();
+
+        // when
+        RaftMessages.Vote.Request<RaftTestMember> message = voteRequest()
+                .from( member1 )
+                .term( state.term() - 1 )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 )
+                .build();
+        Outcome<RaftTestMember> outcome = leader.handle( message, state, log() );
+
+        // then
+        assertFalse( ((RaftMessages.Vote.Response<RaftTestMember>) messageFor( outcome, member1 ))
+                .voteGranted() );
+        assertEquals( LEADER, outcome.newRole );
+    }
+
+    @Test
+    public void leaderShouldSendHeartbeatsToAllClusterMembersOnReceiptOfHeartbeatTick() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        Leader leader = new Leader();
+
+        // when
+        Outcome<RaftTestMember> outcome = leader.handle( new Heartbeat<>( member1 ), state, log() );
+
+        // then
+        assertTrue( messageFor( outcome, member1 ) instanceof RaftMessages.Heartbeat );
+        assertTrue( messageFor( outcome, member2 ) instanceof RaftMessages.Heartbeat );
+    }
+
+    @Test
+    public void leaderShouldDecideToAppendToItsLogAndSendAppendEntriesMessageOnReceiptOfClientProposal()
+            throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        Leader leader = new Leader();
+
+        RaftMessages.NewEntry.Request<RaftTestMember> newEntryRequest = new RaftMessages.NewEntry.Request<>( member( 9 ), CONTENT );
+
+        // when
+        Outcome<RaftTestMember> outcome = leader.handle( newEntryRequest, state, log() );
+        //state.update( outcome );
+
+        // then
+        AppendLogEntry logCommand = (AppendLogEntry) single( outcome.logCommands );
+        assertEquals( 0, logCommand.index );
+        assertEquals( 0, logCommand.entry.term() );
+
+        ShipCommand.NewEntry shipCommand = (ShipCommand.NewEntry) single( outcome.shipCommands );
+
+        assertEquals( shipCommand, new ShipCommand.NewEntry( -1, -1, new RaftLogEntry( 0, CONTENT ) ) );
+    }
+
+    @Test
+    public void leaderShouldCommitOnMajorityResponse() throws Exception
+    {
+        // given
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        raftLog.append( new RaftLogEntry( 0, new ReplicatedString( "lalalala" ) ) );
+
+        RaftState<RaftTestMember> state = raftState().votingMembers( member1, member2 )
+                .term( 0 )
+                .lastLogIndexBeforeWeBecameLeader( -1 )
+                .leader( myself )
+                .leaderCommit( -1 )
+                .entryLog( raftLog )
+                .messagesSentToFollower( member1, raftLog.appendIndex() + 1 )
+                .messagesSentToFollower( member2, raftLog.appendIndex() + 1 )
+                .build();
+
+        Leader leader = new Leader();
+
+        // when a single instance responds (plus self == 2 out of 3 instances)
+        Outcome<RaftTestMember> outcome = leader.handle(
+                new RaftMessages.AppendEntries.Response<>( member1, 0, true, 0 ), state, log() );
+
+        // then
+        assertThat( firstOrNull( outcome.logCommands ), instanceOf( CommitCommand.class ) );
+        assertEquals( 0, outcome.leaderCommit );
+    }
+
+    @Test
+    public void leaderShouldCommitAllPreviouslyAppendedEntriesWhenCommittingLaterEntryInSameTerm() throws Exception
+    {
+        // given
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        raftLog.append( new RaftLogEntry( 0, new ReplicatedString( "first!" ) ) );
+        raftLog.append( new RaftLogEntry( 0, new ReplicatedString( "second" ) ) );
+        raftLog.append( new RaftLogEntry( 0, new ReplicatedString( "third" ) ) );
+
+        RaftState<RaftTestMember> state = raftState()
+                .votingMembers( myself, member1, member2 )
+                .term( 0 ).entryLog( raftLog )
+                .messagesSentToFollower( member1, raftLog.appendIndex() + 1 )
+                .messagesSentToFollower( member2, raftLog.appendIndex() + 1 )
+                .build();
+
+        Leader leader = new Leader();
+
+        // when
+        Outcome<RaftTestMember> outcome =
+                leader.handle( new AppendEntries.Response<>( member1, 0, true, 2 ), state, log() );
+
+        state.update( outcome );
+
+        // then
+        assertEquals( 2, raftLog.commitIndex() );
+    }
+
+    private Log log()
+    {
+        return logProvider.getLog( getClass() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/DurableTermStoreTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/DurableTermStoreTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.io.File;
+
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+public class DurableTermStoreTest extends TermStoreTest
+{
+    @Override
+    public TermStore createTermStore()
+    {
+        FileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        File directory = new File( "raft-log" );
+        fileSystem.mkdir( directory );
+        return new DurableTermStore( fileSystem, directory );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/DurableVoteStoreTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/DurableVoteStoreTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.io.File;
+
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+public class DurableVoteStoreTest extends VoteStoreTest
+{
+    @Override
+    public VoteStore<CoreMember> createVoteStore()
+    {
+        FileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        File directory = new File( "raft-log" );
+        fileSystem.mkdir( directory );
+        return new DurableVoteStore( fileSystem, directory );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/InMemoryTermStoreTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/InMemoryTermStoreTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+public class InMemoryTermStoreTest extends TermStoreTest
+{
+    @Override
+    public TermStore createTermStore()
+    {
+        return new InMemoryTermStore();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/InMemoryVoteStoreTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/InMemoryVoteStoreTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+public class InMemoryVoteStoreTest extends VoteStoreTest
+{
+    @Override public VoteStore<CoreMember> createVoteStore()
+    {
+        return new InMemoryVoteStore<>();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateBuilder.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.membership.RaftMembership;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.LogCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+
+import static java.util.Collections.emptySet;
+
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+public class RaftStateBuilder
+{
+    public static RaftStateBuilder raftState()
+    {
+        return new RaftStateBuilder();
+    }
+
+    public RaftTestMember myself;
+    public Set<RaftTestMember> votingMembers = emptySet();
+    public long term;
+    public RaftTestMember leader;
+    public long leaderCommit = -1;
+    public RaftTestMember votedFor;
+    private RaftLog entryLog = new InMemoryRaftLog();
+    public Set<RaftTestMember> votesForMe = emptySet();
+    public long lastLogIndexBeforeWeBecameLeader = -1;
+    private FollowerStates<RaftTestMember> followerStates = new FollowerStates<>();
+
+    public RaftStateBuilder myself( RaftTestMember myself )
+    {
+        this.myself = myself;
+        return this;
+    }
+
+    public RaftStateBuilder votingMembers( Set<RaftTestMember> currentMembers )
+    {
+        this.votingMembers = currentMembers;
+        return this;
+    }
+
+    public RaftStateBuilder term( long term )
+    {
+        this.term = term;
+        return this;
+    }
+
+    public RaftStateBuilder leader( RaftTestMember leader )
+    {
+        this.leader = leader;
+        return this;
+    }
+
+    public RaftStateBuilder leaderCommit( long leaderCommit )
+    {
+        this.leaderCommit = leaderCommit;
+        return this;
+    }
+
+    public RaftStateBuilder votedFor( RaftTestMember votedFor )
+    {
+        this.votedFor = votedFor;
+        return this;
+    }
+
+    public RaftStateBuilder entryLog( RaftLog entryLog )
+    {
+        this.entryLog = entryLog;
+        return this;
+    }
+
+    public RaftStateBuilder votesForMe( Set<RaftTestMember> votesForMe )
+    {
+        this.votesForMe = votesForMe;
+        return this;
+    }
+
+    public RaftStateBuilder lastLogIndexBeforeWeBecameLeader( long lastLogIndexBeforeWeBecameLeader )
+    {
+        this.lastLogIndexBeforeWeBecameLeader = lastLogIndexBeforeWeBecameLeader;
+        return this;
+    }
+
+    public RaftState<RaftTestMember> build() throws RaftStorageException
+    {
+        InMemoryTermStore termStore = new InMemoryTermStore();
+        InMemoryVoteStore<RaftTestMember> voteStore = new InMemoryVoteStore<>();
+        StubMembership membership = new StubMembership();
+
+        RaftState<RaftTestMember> state = new RaftState<>( myself, termStore, membership, entryLog, voteStore );
+
+        Collection<RaftMessages.Directed<RaftTestMember>> noMessages = Collections.emptyList();
+        List<LogCommand> noLogCommands = Collections.emptyList();
+
+        state.update( new Outcome<>( null, term, leader, leaderCommit, votedFor, votesForMe, lastLogIndexBeforeWeBecameLeader,
+                followerStates, false, noLogCommands, noMessages, Collections.emptySet() ) );
+        return state;
+    }
+
+    public RaftStateBuilder votingMembers( RaftTestMember... members )
+    {
+        return votingMembers( asSet( members ) );
+    }
+
+    public RaftStateBuilder messagesSentToFollower( RaftTestMember member, long nextIndex )
+    {
+        return this;
+    }
+
+    private class StubMembership implements RaftMembership<RaftTestMember>
+    {
+        @Override
+        public Set<RaftTestMember> votingMembers()
+        {
+            return votingMembers;
+        }
+
+        @Override
+        public Set<RaftTestMember> replicationMembers()
+        {
+            return votingMembers;
+        }
+
+        @Override
+        public void registerListener( Listener listener )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deregisterListener( Listener listener )
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.membership.RaftMembership;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.outcome.LogCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+
+import static java.util.Collections.emptySet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import static org.neo4j.coreedge.raft.roles.Role.CANDIDATE;
+import static org.neo4j.helpers.collection.IteratorUtil.asIterable;
+
+public class RaftStateTest
+{
+    @Test
+    public void shouldRemoveFollowerStateAfterBecomingLeader() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> raftState = new RaftState<>( new RaftTestMember( 0 ), mock( TermStore.class ),
+                new FakeMembership(), new InMemoryRaftLog(), new InMemoryVoteStore<>() );
+
+        raftState.update( new Outcome<>( CANDIDATE, 1, null, -1, null, new HashSet<>(), -1, initialFollowerStates(), true, emptyLogCommands(),
+                emptyOutgoingMessages(), Collections.emptySet() ) );
+
+        // when
+        raftState.update( new Outcome<>( CANDIDATE, 1, null, -1, null, new HashSet<>(), -1, new FollowerStates<>(), true, emptyLogCommands(),
+                emptyOutgoingMessages(), Collections.emptySet() ) );
+
+        // then
+        assertEquals( 0, raftState.followerStates().size() );
+    }
+
+    private Collection<RaftMessages.Directed<RaftTestMember>> emptyOutgoingMessages()
+    {
+        return new ArrayList<>();
+    }
+
+    private FollowerStates<RaftTestMember> initialFollowerStates()
+    {
+        return new FollowerStates<>( new FollowerStates<>(), new RaftTestMember( 1 ), new FollowerState() );
+    }
+
+    private Iterable<LogCommand> emptyLogCommands()
+    {
+        return asIterable( Collections.<LogCommand>emptyIterator() );
+    }
+
+    private class FakeMembership implements RaftMembership<RaftTestMember>
+    {
+        @Override
+        public Set<RaftTestMember> votingMembers()
+        {
+            return emptySet();
+        }
+
+        @Override
+        public Set<RaftTestMember> replicationMembers()
+        {
+            return emptySet();
+        }
+
+        @Override
+        public void registerListener( Listener listener )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deregisterListener( Listener listener )
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/TermStoreAdversarialTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/TermStoreAdversarialTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import org.neo4j.adversaries.ClassGuardedAdversary;
+import org.neo4j.adversaries.CountingAdversary;
+import org.neo4j.adversaries.fs.AdversarialFileSystemAbstraction;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.state.DurableTermStore;
+import org.neo4j.coreedge.raft.state.TermStore;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.graphdb.mockfs.SelectiveFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class TermStoreAdversarialTest
+{
+    public TermStore createTermStore( FileSystemAbstraction fileSystem )
+    {
+        File directory = new File( "raft-log" );
+        fileSystem.mkdir( directory );
+        return new DurableTermStore( fileSystem, directory );
+    }
+
+    @Test
+    public void shouldDiscardTermIfChannelFails() throws Exception
+    {
+        ClassGuardedAdversary adversary = new ClassGuardedAdversary( new CountingAdversary( 1, false ),
+                DurableTermStore.class.getName() );
+        adversary.disable();
+
+        EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+        FileSystemAbstraction fileSystem = new SelectiveFileSystemAbstraction(
+                new File( "raft-log/term.state" ), new AdversarialFileSystemAbstraction( adversary, fs ), fs );
+        TermStore log = createTermStore( fileSystem );
+
+        log.update( 21 );
+        adversary.enable();
+
+        try
+        {
+            log.update( 23 );
+            fail( "Should have thrown exception" );
+        }
+        catch ( RaftStorageException e )
+        {
+            // expected
+        }
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( log, fileSystem, new TermVerifier()
+        {
+            public void verifyTerm( TermStore termStore ) throws RaftStorageException
+            {
+                assertEquals( 21, termStore.currentTerm() );
+            }
+        } );
+    }
+
+    private void verifyCurrentLogAndNewLogLoadedFromFileSystem(
+            TermStore log,FileSystemAbstraction fileSystem, TermVerifier termVerifier ) throws RaftStorageException
+    {
+        termVerifier.verifyTerm( log );
+        termVerifier.verifyTerm( createTermStore( fileSystem ) );
+    }
+
+    private interface TermVerifier
+    {
+        void verifyTerm( TermStore termStore ) throws RaftStorageException;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/TermStoreDurabilityTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/TermStoreDurabilityTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.state.DurableTermStore;
+import org.neo4j.coreedge.raft.state.TermStore;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+
+import static org.junit.Assert.assertEquals;
+
+public class TermStoreDurabilityTest
+{
+    public TermStore createTermStore( EphemeralFileSystemAbstraction fileSystem )
+    {
+        File directory = new File( "raft-log" );
+        fileSystem.mkdir( directory );
+        return new DurableTermStore( fileSystem, directory );
+    }
+
+    @Test
+    public void shouldStoreTerm() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        TermStore termStore = createTermStore( fileSystem );
+
+        termStore.update( 23 );
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( termStore, fileSystem, new TermVerifier()
+        {
+            public void verifyTerm( TermStore termStore ) throws RaftStorageException
+            {
+                assertEquals( 23, termStore.currentTerm() );
+            }
+        } );
+    }
+
+    @Test
+    public void emptyFileShouldImplyZeroTerm() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        TermStore termStore = createTermStore( fileSystem );
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( termStore, fileSystem, new TermVerifier()
+        {
+            public void verifyTerm( TermStore termStore ) throws RaftStorageException
+            {
+                assertEquals( 0, termStore.currentTerm() );
+            }
+        } );
+    }
+
+    private void verifyCurrentLogAndNewLogLoadedFromFileSystem( TermStore termStore,
+                                                                EphemeralFileSystemAbstraction fileSystem,
+                                                                TermVerifier termVerifier ) throws RaftStorageException
+    {
+        termVerifier.verifyTerm( termStore );
+        termVerifier.verifyTerm( createTermStore( fileSystem ) );
+        fileSystem.crash();
+        termVerifier.verifyTerm( createTermStore( fileSystem ) );
+    }
+
+    private interface TermVerifier
+    {
+        void verifyTerm( TermStore termStore ) throws RaftStorageException;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/TermStoreTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/TermStoreTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public abstract class TermStoreTest
+{
+    public abstract TermStore createTermStore();
+
+    @Test
+    public void shouldStoreCurrentTerm() throws Exception
+    {
+        // given
+        TermStore termStore = createTermStore();
+
+        // when
+        termStore.update( 21 );
+
+        // then
+        assertEquals( 21, termStore.currentTerm() );
+    }
+
+    @Test
+    public void rejectLowerTerm() throws Exception
+    {
+        // given
+        TermStore termStore = createTermStore();
+        termStore.update( 21 );
+
+        // when
+        try
+        {
+            termStore.update( 20 );
+            fail( "Should have thrown exception" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // expected
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/VoteStoreAdversarialTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/VoteStoreAdversarialTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import org.neo4j.adversaries.ClassGuardedAdversary;
+import org.neo4j.adversaries.CountingAdversary;
+import org.neo4j.adversaries.fs.AdversarialFileSystemAbstraction;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.state.DurableVoteStore;
+import org.neo4j.coreedge.raft.state.VoteStore;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.graphdb.mockfs.SelectiveFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class VoteStoreAdversarialTest
+{
+    public VoteStore<CoreMember> createVoteStore( FileSystemAbstraction fileSystem )
+    {
+        File directory = new File( "raft-log" );
+        fileSystem.mkdir( directory );
+        return new DurableVoteStore( fileSystem, directory );
+    }
+
+    @Test
+    public void shouldDiscardVoteIfChannelFails() throws Exception
+    {
+        ClassGuardedAdversary adversary = new ClassGuardedAdversary( new CountingAdversary( 1, false ),
+                DurableVoteStore.class.getName() );
+        adversary.disable();
+
+        EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+        FileSystemAbstraction fileSystem = new SelectiveFileSystemAbstraction(
+                new File( "raft-log/vote.state" ), new AdversarialFileSystemAbstraction( adversary, fs ), fs );
+        VoteStore<CoreMember> store = createVoteStore( fileSystem );
+
+        final CoreMember member1 = new CoreMember( address( "host1:1001" ), address( "host1:2001" ) );
+        final CoreMember member2 = new CoreMember( address( "host2:1001" ), address( "host2:2001" ) );
+
+        store.update( member1 );
+        adversary.enable();
+
+        try
+        {
+            store.update( member2 );
+            fail( "Should have thrown exception" );
+        }
+        catch ( RaftStorageException e )
+        {
+            // expected
+        }
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( store, fileSystem,
+                store1 -> assertEquals( member1, store1.votedFor() ) );
+    }
+
+    private void verifyCurrentLogAndNewLogLoadedFromFileSystem(
+            VoteStore<CoreMember> store,FileSystemAbstraction fileSystem, VoteVerifier voteVerifier )
+            throws RaftStorageException
+    {
+        voteVerifier.verifyVote( store );
+        voteVerifier.verifyVote( createVoteStore( fileSystem ) );
+    }
+
+    private interface VoteVerifier
+    {
+        void verifyVote( VoteStore<CoreMember> store ) throws RaftStorageException;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/VoteStoreDurabilityTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/VoteStoreDurabilityTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.raft.state.DurableVoteStore;
+import org.neo4j.coreedge.raft.state.VoteStore;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class VoteStoreDurabilityTest
+{
+    public VoteStore<CoreMember> createVoteStore( EphemeralFileSystemAbstraction fileSystem )
+    {
+        File directory = new File( "raft-log" );
+        fileSystem.mkdir( directory );
+        return new DurableVoteStore( fileSystem, directory );
+    }
+
+    @Test
+    public void shouldStoreVote() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        VoteStore<CoreMember> voteStore = createVoteStore( fileSystem );
+
+        final CoreMember member = new CoreMember( address( "host1:1001" ), address( "host1:2001" ) );
+        voteStore.update( member );
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( voteStore, fileSystem,
+                voteStore1 -> assertEquals( member, voteStore1.votedFor() ) );
+    }
+
+    @Test
+    public void emptyFileShouldImplyNoVoteCast() throws Exception
+    {
+        EphemeralFileSystemAbstraction fileSystem = new EphemeralFileSystemAbstraction();
+        VoteStore<CoreMember> voteStore = createVoteStore( fileSystem );
+
+        verifyCurrentLogAndNewLogLoadedFromFileSystem( voteStore, fileSystem,
+                voteStore1 -> assertNull( voteStore1.votedFor() ) );
+    }
+
+    private void verifyCurrentLogAndNewLogLoadedFromFileSystem( VoteStore<CoreMember> voteStore,
+                                                                EphemeralFileSystemAbstraction fileSystem,
+                                                                VoteVerifier voteVerifier ) throws RaftStorageException
+    {
+        voteVerifier.verifyVote( voteStore );
+        voteVerifier.verifyVote( createVoteStore( fileSystem ) );
+        fileSystem.crash();
+        voteVerifier.verifyVote( createVoteStore( fileSystem ) );
+    }
+
+    private interface VoteVerifier
+    {
+        void verifyVote( VoteStore<CoreMember> voteStore ) throws RaftStorageException;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/VoteStoreTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/VoteStoreTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.CoreMember;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public abstract class VoteStoreTest
+{
+    public abstract VoteStore<CoreMember> createVoteStore();
+
+    @Test
+    public void shouldStoreVote() throws Exception
+    {
+        // given
+        VoteStore<CoreMember> voteStore = createVoteStore();
+        CoreMember member = new CoreMember( address( "host1:1001" ), address( "host1:2001" ) );
+
+        // when
+        voteStore.update( member );
+
+        // then
+        assertEquals( member, voteStore.votedFor() );
+    }
+
+    @Test
+    public void shouldStartWithNoVote() throws Exception
+    {
+        // given
+        VoteStore<CoreMember> voteStore = createVoteStore();
+
+        // then
+        assertNull( voteStore.votedFor() );
+    }
+
+    @Test
+    public void shouldUpdateVote() throws Exception
+    {
+        // given
+        VoteStore<CoreMember> voteStore = createVoteStore();
+        CoreMember member1 = new CoreMember( address( "host1:1001" ), address( "host1:2001" ) );
+        CoreMember member2 = new CoreMember( address( "host2:1001" ), address( "host2:2001" ) );
+
+        // when
+        voteStore.update( member1 );
+        voteStore.update( member2 );
+
+        // then
+        assertEquals( member2, voteStore.votedFor() );
+    }
+
+    @Test
+    public void shouldClearVote() throws Exception
+    {
+        // given
+        VoteStore<CoreMember> voteStore = createVoteStore();
+        CoreMember member = new CoreMember( address( "host1:1001" ), address( "host1:2001" ) );
+        voteStore.update( member );
+
+        // when
+        voteStore.update( null );
+
+        // then
+        assertNull( voteStore.votedFor() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ClusterSafetyViolations.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ClusterSafetyViolations.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.RaftMessageHandler;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.roles.Leader;
+import org.neo4j.coreedge.raft.roles.Role;
+
+public class ClusterSafetyViolations
+{
+    public static List<Violation> violations( ClusterState state ) throws RaftStorageException
+    {
+        List<Violation> invariantsViolated = new ArrayList<>();
+
+        if ( multipleLeadersInSameTerm( state ) )
+        {
+            invariantsViolated.add( Violation.MULTIPLE_LEADERS );
+        }
+
+        if ( inconsistentCommittedLogEntries( state ) )
+        {
+            invariantsViolated.add( Violation.DIVERGED_LOG );
+        }
+
+        return invariantsViolated;
+    }
+
+    public static boolean inconsistentCommittedLogEntries( ClusterState state ) throws RaftStorageException
+    {
+        int index = 0;
+        boolean moreLog = true;
+        while ( moreLog )
+        {
+            moreLog = false;
+            RaftLogEntry clusterLogEntry = null;
+            for ( ComparableRaftState memberState : state.states.values() )
+            {
+                if ( index <= memberState.entryLog().commitIndex() )
+                {
+                    RaftLogEntry memberLogEntry = memberState.entryLog().readLogEntry( index );
+                    if ( clusterLogEntry == null )
+                    {
+                        clusterLogEntry = memberLogEntry;
+                    }
+                    else
+                    {
+                        if ( !clusterLogEntry.equals( memberLogEntry ) )
+                        {
+                            return true;
+                        }
+                    }
+                }
+                if ( index < memberState.entryLog().commitIndex() )
+                {
+                    moreLog = true;
+                }
+            }
+            index++;
+        }
+        return false;
+    }
+
+    public static boolean multipleLeadersInSameTerm( ClusterState state )
+    {
+        Set<Long> termThatHaveALeader = new HashSet<>();
+        for ( Map.Entry<RaftTestMember, Role> entry : state.roles.entrySet() )
+        {
+            RaftMessageHandler role = entry.getValue().role;
+            if ( role instanceof Leader )
+            {
+                long term = state.states.get( entry.getKey() ).term();
+                if ( termThatHaveALeader.contains( term ) )
+                {
+                    return true;
+                }
+                else
+                {
+                    termThatHaveALeader.add( term );
+                }
+            }
+        }
+        return false;
+    }
+
+    public enum Violation
+    {
+        DIVERGED_LOG, MULTIPLE_LEADERS
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ClusterSafetyViolationsTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ClusterSafetyViolationsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.roles.Role;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.coreedge.raft.ReplicatedInteger.valueOf;
+import static org.neo4j.coreedge.raft.state.explorer.ClusterSafetyViolations.inconsistentCommittedLogEntries;
+import static org.neo4j.coreedge.raft.state.explorer.ClusterSafetyViolations.multipleLeadersInSameTerm;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+public class ClusterSafetyViolationsTest
+{
+    @Test
+    public void shouldRecogniseInconsistentCommittedContent() throws Exception
+    {
+        // given
+        ClusterState clusterState = new ClusterState( asSet( member( 0 ), member( 1 ) ) );
+
+        clusterState.states.get( member( 0 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 1 ) ) );
+        clusterState.states.get( member( 1 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 1 ) ) );
+
+        clusterState.states.get( member( 0 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 2 ) ) );
+        clusterState.states.get( member( 1 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 3 ) ) );
+
+        clusterState.states.get( member( 0 ) ).entryLog.commit( 0 );
+        clusterState.states.get( member( 1 ) ).entryLog.commit( 0 );
+
+        // then
+        assertFalse( inconsistentCommittedLogEntries( clusterState ) );
+
+        // when
+        clusterState.states.get( member( 0 ) ).entryLog.commit( 1 );
+        clusterState.states.get( member( 1 ) ).entryLog.commit( 1 );
+
+        // then
+        assertTrue( inconsistentCommittedLogEntries( clusterState ) );
+    }
+
+    @Test
+    public void shouldRecogniseInconsistentTerm() throws Exception
+    {
+        // given
+        ClusterState clusterState = new ClusterState( asSet( member( 0 ), member( 1 ) ) );
+
+        clusterState.states.get( member( 0 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 1 ) ) );
+        clusterState.states.get( member( 1 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 1 ) ) );
+
+        clusterState.states.get( member( 0 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 2 ) ) );
+        clusterState.states.get( member( 1 ) ).entryLog.append( new RaftLogEntry( 2, valueOf( 2 ) ) );
+
+        clusterState.states.get( member( 0 ) ).entryLog.commit( 0 );
+        clusterState.states.get( member( 1 ) ).entryLog.commit( 0 );
+
+        // then
+        assertFalse( inconsistentCommittedLogEntries( clusterState ) );
+
+        // when
+        clusterState.states.get( member( 0 ) ).entryLog.commit( 1 );
+        clusterState.states.get( member( 1 ) ).entryLog.commit( 1 );
+
+        // then
+        assertTrue( inconsistentCommittedLogEntries( clusterState ) );
+    }
+
+    @Test
+    public void shouldRecogniseSomeMembersBeingInconsistent() throws Exception
+    {
+        // given
+        ClusterState clusterState = new ClusterState( asSet( member( 0 ), member( 1 ), member(2) ) );
+
+        clusterState.states.get( member( 0 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 1 ) ) );
+        clusterState.states.get( member( 1 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 1 ) ) );
+        clusterState.states.get( member( 2 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 1 ) ) );
+
+        clusterState.states.get( member( 0 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 2 ) ) );
+        clusterState.states.get( member( 1 ) ).entryLog.append( new RaftLogEntry( 1, valueOf( 2 ) ) );
+        clusterState.states.get( member( 2 ) ).entryLog.append( new RaftLogEntry( 2, valueOf( 2 ) ) );
+
+        clusterState.states.get( member( 0 ) ).entryLog.commit( 0 );
+        clusterState.states.get( member( 1 ) ).entryLog.commit( 0 );
+        clusterState.states.get( member( 2 ) ).entryLog.commit( 0 );
+
+        // then
+        assertFalse( inconsistentCommittedLogEntries( clusterState ) );
+
+        // when
+        clusterState.states.get( member( 0 ) ).entryLog.commit( 1 );
+        clusterState.states.get( member( 1 ) ).entryLog.commit( 1 );
+
+        // then
+        assertFalse( inconsistentCommittedLogEntries( clusterState ) );
+
+        // when
+        clusterState.states.get( member( 2 ) ).entryLog.commit( 1 );
+
+        // then
+        assertTrue( inconsistentCommittedLogEntries( clusterState ) );
+    }
+
+    @Test
+    public void shouldRecogniseTwoLeadersInTheSameTerm() throws Exception
+    {
+        // given
+        ClusterState clusterState = new ClusterState( asSet( member( 0 ), member( 1 ), member(2) ) );
+
+        // when
+        clusterState.states.get( member( 0 ) ).term = 21;
+        clusterState.states.get( member( 1 ) ).term = 21;
+        clusterState.states.get( member( 2 ) ).term = 21;
+
+        clusterState.roles.put( member( 0 ), Role.LEADER );
+        clusterState.roles.put( member( 1 ), Role.LEADER );
+        clusterState.roles.put( member( 2 ), Role.FOLLOWER );
+
+        // then
+        assertTrue( multipleLeadersInSameTerm( clusterState ) );
+    }
+
+    @Test
+    public void shouldRecogniseTwoLeadersInDifferentTerms() throws Exception
+    {
+        // given
+        ClusterState clusterState = new ClusterState( asSet( member( 0 ), member( 1 ), member(2) ) );
+
+        // when
+        clusterState.states.get( member( 0 ) ).term = 21;
+        clusterState.states.get( member( 1 ) ).term = 22;
+        clusterState.states.get( member( 2 ) ).term = 21;
+
+        clusterState.roles.put( member( 0 ), Role.LEADER );
+        clusterState.roles.put( member( 1 ), Role.LEADER );
+        clusterState.roles.put( member( 2 ), Role.FOLLOWER );
+
+        // then
+        assertFalse( multipleLeadersInSameTerm( clusterState ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ClusterState.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ClusterState.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.coreedge.raft.state.RaftState;
+
+import static org.neo4j.coreedge.raft.state.RaftStateBuilder.raftState;
+
+public class ClusterState
+{
+    public final Map<RaftTestMember, Role> roles;
+    public final Map<RaftTestMember, ComparableRaftState> states;
+    public final Map<RaftTestMember, Queue<RaftMessages.Message<RaftTestMember>>> queues;
+
+    public ClusterState( Set<RaftTestMember> members ) throws RaftStorageException
+    {
+        this.roles = new HashMap<>();
+        this.states = new HashMap<>();
+        this.queues = new HashMap<>();
+
+        for ( RaftTestMember member : members )
+        {
+            roles.put( member, Role.FOLLOWER );
+            RaftState<RaftTestMember> memberState = raftState().myself( member ).votingMembers( members ).build();
+            states.put( member, new ComparableRaftState( memberState ) );
+            queues.put( member, new LinkedList<RaftMessages.Message<RaftTestMember>>() );
+        }
+    }
+
+    public ClusterState( ClusterState original )
+    {
+        this.roles = new HashMap<>( original.roles );
+        this.states = new HashMap<>( original.states );
+        this.queues = new HashMap<>( original.queues );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        ClusterState that = (ClusterState) o;
+        return Objects.equals( roles, that.roles ) &&
+                Objects.equals( states, that.states ) &&
+                Objects.equals( queues, that.queues );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( roles, states, queues );
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        for ( RaftTestMember member : roles.keySet() )
+        {
+            builder.append( member ).append( " : " ).append( roles.get( member ) ).append( "\n" );
+            builder.append( "  state: " ).append( states.get( member ) ).append( "\n" );
+            builder.append( "  queue: " ).append( queues.get( member ) ).append( "\n" );
+        }
+        return builder.toString();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ComparableRaftLog.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ComparableRaftLog.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer;
+
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+
+public class ComparableRaftLog extends InMemoryRaftLog
+{
+    public ComparableRaftLog( ReadableRaftLog raftLog ) throws RaftStorageException
+    {
+        for ( int i = 0; i < raftLog.appendIndex(); i++ )
+        {
+            append( raftLog.readLogEntry( i ) );
+        }
+        commit( raftLog.commitIndex() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ComparableRaftState.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ComparableRaftState.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.outcome.LogCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.FollowerStates;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+
+import static java.lang.String.format;
+
+public class ComparableRaftState implements ReadableRaftState<RaftTestMember>
+{
+    protected final RaftTestMember myself;
+    protected final Set<RaftTestMember> votingMembers;
+    protected final Set<RaftTestMember> replicationMembers;
+    protected long term = 0;
+    protected RaftTestMember leader;
+    private long leaderCommit = -1;
+    protected RaftTestMember votedFor = null;
+    protected Set<RaftTestMember> votesForMe = new HashSet<>();
+    protected long lastLogIndexBeforeWeBecameLeader = -1;
+    protected FollowerStates<RaftTestMember> followerStates = new FollowerStates<>();
+    protected final RaftLog entryLog;
+
+    public ComparableRaftState( RaftTestMember myself,
+                                Set<RaftTestMember> votingMembers,
+                                Set<RaftTestMember> replicationMembers,
+                                RaftLog entryLog )
+    {
+        this.myself = myself;
+        this.votingMembers = votingMembers;
+        this.replicationMembers = replicationMembers;
+        this.entryLog = entryLog;
+    }
+
+    public ComparableRaftState( ReadableRaftState<RaftTestMember> original ) throws RaftStorageException
+    {
+        this( original.myself(), original.votingMembers(), original.replicationMembers(), new ComparableRaftLog( original.entryLog() ) );
+    }
+
+    @Override
+    public RaftTestMember myself()
+    {
+        return myself;
+    }
+
+    @Override
+    public Set<RaftTestMember> votingMembers()
+    {
+        return votingMembers;
+    }
+
+    @Override
+    public Set<RaftTestMember> replicationMembers()
+    {
+        return replicationMembers;
+    }
+
+    @Override
+    public long term()
+    {
+        return term;
+    }
+
+    @Override
+    public RaftTestMember leader()
+    {
+        return leader;
+    }
+
+    @Override
+    public long leaderCommit()
+    {
+        return 0;
+    }
+
+    @Override
+    public RaftTestMember votedFor()
+    {
+        return votedFor;
+    }
+
+    @Override
+    public Set<RaftTestMember> votesForMe()
+    {
+        return votesForMe;
+    }
+
+    @Override
+    public long lastLogIndexBeforeWeBecameLeader()
+    {
+        return lastLogIndexBeforeWeBecameLeader;
+    }
+
+    @Override
+    public FollowerStates<RaftTestMember> followerStates()
+    {
+        return followerStates;
+    }
+
+    @Override
+    public ReadableRaftLog entryLog()
+    {
+        return entryLog;
+    }
+
+    public void update( Outcome<RaftTestMember> outcome ) throws RaftStorageException
+    {
+        term = outcome.newTerm;
+        votedFor = outcome.votedFor;
+        leader = outcome.leader;
+        votesForMe = outcome.votesForMe;
+        lastLogIndexBeforeWeBecameLeader = outcome.lastLogIndexBeforeWeBecameLeader;
+        followerStates= outcome.followerStates;
+
+        for ( LogCommand logCommand : outcome.logCommands )
+        {
+            logCommand.applyTo( entryLog );
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "state{myself=%s, term=%s, leader=%s, leaderCommit=%d, appended=%d, committed=%d, " +
+                        "votedFor=%s, votesForMe=%s, lastLogIndexBeforeWeBecameLeader=%d, followerStates=%s}",
+                myself, term, leader, leaderCommit,
+                entryLog.appendIndex(), entryLog.commitIndex(), votedFor, votesForMe,
+                lastLogIndexBeforeWeBecameLeader, followerStates );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        ComparableRaftState that = (ComparableRaftState) o;
+        return Objects.equals( term, that.term ) &&
+                Objects.equals( lastLogIndexBeforeWeBecameLeader, that.lastLogIndexBeforeWeBecameLeader ) &&
+                Objects.equals( myself, that.myself ) &&
+                Objects.equals( votingMembers, that.votingMembers ) &&
+                Objects.equals( leader, that.leader ) &&
+                Objects.equals( leaderCommit, that.leaderCommit ) &&
+                Objects.equals( entryLog, that.entryLog ) &&
+                Objects.equals( votedFor, that.votedFor ) &&
+                Objects.equals( votesForMe, that.votesForMe ) &&
+                Objects.equals( followerStates, that.followerStates );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( myself, votingMembers, term, leader, entryLog, votedFor, votesForMe, lastLogIndexBeforeWeBecameLeader, followerStates );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ComparableRaftStateTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ComparableRaftStateTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+public class ComparableRaftStateTest
+{
+    @Test
+    public void twoIdenticalStatesShouldBeEqual() throws Exception
+    {
+        // given
+        ComparableRaftState state1 = new ComparableRaftState( member( 0 ),
+                asSet( member( 0 ), member( 1 ), member( 2 ) ),
+                asSet( member( 0 ), member( 1 ), member( 2 ) ),
+                new InMemoryRaftLog() );
+
+        ComparableRaftState state2 = new ComparableRaftState( member( 0 ),
+                asSet( member( 0 ), member( 1 ), member( 2 ) ),
+                asSet( member( 0 ), member( 1 ), member( 2 ) ),
+                new InMemoryRaftLog() );
+
+        // then
+        assertEquals(state1, state2);
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/Action.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/Action.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer.action;
+
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.state.explorer.ClusterState;
+
+public interface Action
+{
+    ClusterState advance( ClusterState clusterState ) throws RaftStorageException;
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/DropMessage.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/DropMessage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer.action;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.state.explorer.ClusterState;
+
+public class DropMessage implements Action
+{
+    private final RaftTestMember member;
+
+    public DropMessage( RaftTestMember member )
+    {
+        this.member = member;
+    }
+
+    @Override
+    public ClusterState advance( ClusterState previous )
+    {
+        ClusterState newClusterState = new ClusterState( previous );
+        Queue<RaftMessages.Message<RaftTestMember>> inboundQueue = new LinkedList<>( previous.queues.get( member ) );
+        RaftMessages.Message<RaftTestMember> message = inboundQueue.poll();
+        if ( message == null )
+        {
+            return previous;
+        }
+
+        newClusterState.queues.put( member, inboundQueue );
+        return newClusterState;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/ElectionTimeout.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/ElectionTimeout.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer.action;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.state.explorer.ClusterState;
+
+public class ElectionTimeout implements Action
+{
+    private final RaftTestMember member;
+
+    public ElectionTimeout( RaftTestMember member )
+    {
+        this.member = member;
+    }
+
+    @Override
+    public ClusterState advance( ClusterState previous ) throws RaftStorageException
+    {
+        ClusterState newClusterState = new ClusterState( previous );
+        Queue<RaftMessages.Message<RaftTestMember>> newQueue = new LinkedList<>( previous.queues.get( member ) );
+        newQueue.offer( new RaftMessages.Timeout.Election<>( member ) );
+        newClusterState.queues.put( member, newQueue );
+        return newClusterState;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/HeartbeatTimeout.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/HeartbeatTimeout.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer.action;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.state.explorer.ClusterState;
+
+public class HeartbeatTimeout implements Action
+{
+    private final RaftTestMember member;
+
+    public HeartbeatTimeout( RaftTestMember member )
+    {
+        this.member = member;
+    }
+
+    @Override
+    public ClusterState advance( ClusterState previous ) throws RaftStorageException
+    {
+        ClusterState newClusterState = new ClusterState( previous );
+        Queue<RaftMessages.Message<RaftTestMember>> newQueue = new LinkedList<>( previous.queues.get( member ) );
+        newQueue.offer( new RaftMessages.Timeout.Heartbeat<>( member ) );
+        newClusterState.queues.put( member, newQueue );
+        return newClusterState;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/NewEntry.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/NewEntry.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer.action;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.ReplicatedString;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.state.explorer.ClusterState;
+
+public class NewEntry implements Action
+{
+    private final RaftTestMember member;
+
+    public NewEntry( RaftTestMember member )
+    {
+        this.member = member;
+    }
+
+    @Override
+    public ClusterState advance( ClusterState previous ) throws RaftStorageException
+    {
+        ClusterState newClusterState = new ClusterState( previous );
+        Queue<RaftMessages.Message<RaftTestMember>> newQueue = new LinkedList<>( previous.queues.get( member ) );
+        newQueue.offer( new RaftMessages.NewEntry.Request<RaftTestMember>( member, new ReplicatedString(
+                "content" ) ) );
+        newClusterState.queues.put( member, newQueue );
+        return newClusterState;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/OutOfOrderDelivery.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/OutOfOrderDelivery.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer.action;
+
+import java.util.LinkedList;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.state.explorer.ClusterState;
+
+public class OutOfOrderDelivery implements Action
+{
+    private final RaftTestMember member;
+
+    public OutOfOrderDelivery( RaftTestMember member )
+    {
+        this.member = member;
+    }
+
+    @Override
+    public ClusterState advance( ClusterState previous )
+    {
+        ClusterState newClusterState = new ClusterState( previous );
+        LinkedList<RaftMessages.Message<RaftTestMember>> inboundQueue = new LinkedList<>( previous.queues.get( member ) );
+        if ( inboundQueue.size() < 2 )
+        {
+            return previous;
+        }
+        RaftMessages.Message<RaftTestMember> message = inboundQueue.poll();
+        inboundQueue.add( 1, message );
+
+        newClusterState.queues.put( member, inboundQueue );
+        return newClusterState;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/OutOfOrderDeliveryTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/OutOfOrderDeliveryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer.action;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.RaftMessages.Timeout.Election;
+import org.neo4j.coreedge.raft.RaftMessages.Timeout.Heartbeat;
+import org.neo4j.coreedge.raft.state.explorer.ClusterState;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
+
+public class OutOfOrderDeliveryTest
+{
+    @Test
+    public void shouldReOrder() throws Exception
+    {
+        // given
+        ClusterState clusterState = new ClusterState( asSet( member( 0 ) ) );
+        clusterState.queues.get( member( 0 ) ).add( new Election<>( member( 0 ) ) );
+        clusterState.queues.get( member( 0 ) ).add( new Heartbeat<>( member( 0 ) ) );
+
+        // when
+        ClusterState reOrdered = new OutOfOrderDelivery( member( 0 ) ).advance( clusterState );
+
+        // then
+        assertEquals( new Heartbeat<>( member( 0 ) ), reOrdered.queues.get( member( 0 ) ).poll() );
+        assertEquals( new Election<>( member( 0 ) ), reOrdered.queues.get( member( 0 ) ).poll() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/ProcessMessage.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/ProcessMessage.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state.explorer.action;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.explorer.ClusterState;
+import org.neo4j.coreedge.raft.state.explorer.ComparableRaftState;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLog;
+
+public class ProcessMessage implements Action
+{
+    private final RaftTestMember member;
+    private Log log = NullLog.getInstance();
+
+    public ProcessMessage( RaftTestMember member )
+    {
+        this.member = member;
+    }
+
+    @Override
+    public ClusterState advance( ClusterState previous ) throws RaftStorageException
+    {
+        ClusterState newClusterState = new ClusterState( previous );
+        Queue<RaftMessages.Message<RaftTestMember>> inboundQueue = new LinkedList<>( previous.queues.get( member ) );
+        RaftMessages.Message<RaftTestMember> message = inboundQueue.poll();
+        if ( message == null )
+        {
+            return previous;
+        }
+        ComparableRaftState memberState = previous.states.get( member );
+        ComparableRaftState newMemberState = new ComparableRaftState( memberState );
+        Outcome<RaftTestMember> outcome = previous.roles.get( member ).role.handle( message, memberState, log );
+        newMemberState.update( outcome );
+
+        for ( RaftMessages.Directed<RaftTestMember> outgoingMessage : outcome.outgoingMessages )
+        {
+            LinkedList<RaftMessages.Message<RaftTestMember>> outboundQueue =
+                    new LinkedList<>( newClusterState.queues.get( outgoingMessage.to() ) );
+            outboundQueue.add( outgoingMessage.message() );
+            newClusterState.queues.put( outgoingMessage.to(), outboundQueue );
+        }
+
+        newClusterState.roles.put( member, outcome.newRole );
+        newClusterState.states.put( member, newMemberState );
+        newClusterState.queues.put( member, inboundQueue );
+        return newClusterState;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterFormationIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterFormationIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.coreedge.discovery.Cluster;
+import org.neo4j.coreedge.discovery.EdgeServerConnectionException;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.test.TargetDirectory;
+
+import static java.util.Arrays.asList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ClusterFormationIT
+{
+    @Rule
+    public final TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    private Cluster cluster;
+
+    @After
+    public void shutdown()
+    {
+        if ( cluster != null )
+        {
+            cluster.shutdown();
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToAddAndRemoveEdgeServers() throws Exception
+    {
+        // given
+        cluster = Cluster.start( dir.directory(), 3, 3);
+
+        // when
+        cluster.removeEdgeServerWithServerId( 0 );
+        cluster.addEdgeServerWithFileLocation( 0 );
+
+        // then
+        assertEquals( 3, cluster.numberOfEdgeServers() );
+
+        // when
+        cluster.removeEdgeServerWithServerId( 0 );
+        cluster.addEdgeServerWithFileLocation( 3 );
+
+        // then
+        assertEquals( 3, cluster.numberOfEdgeServers() );
+    }
+
+    @Test
+    public void shouldBeAbleToAddAndRemoveCoreServers() throws Exception
+    {
+        // given
+        cluster = Cluster.start( dir.directory(), 3, 0);
+
+        // when
+        cluster.removeCoreServerWithServerId( 0 );
+        cluster.addCoreServerWithServerId( 0, 3 );
+
+        // then
+        assertEquals( 3, cluster.numberOfCoreServers() );
+
+        // when
+        cluster.removeCoreServerWithServerId( 1 );
+
+        // then
+        assertEquals( 2, cluster.numberOfCoreServers() );
+
+        // when
+        cluster.addCoreServerWithServerId( 4, 3 );
+
+        // then
+        assertEquals( 3, cluster.numberOfCoreServers() );
+    }
+
+    @Test
+    public void shouldBeAbleToRestartTheCluster() throws Exception
+    {
+        // when
+        cluster = Cluster.start( dir.directory(), 3, 0);
+
+        // then
+        assertEquals( 3, cluster.numberOfCoreServers() );
+
+        // when
+        cluster.shutdown();
+        cluster = Cluster.start( dir.directory(), 3, 0 );
+
+        // then
+        assertEquals( 3, cluster.numberOfCoreServers() );
+
+        // when
+        cluster.removeCoreServerWithServerId( 1 );
+        cluster.addCoreServerWithServerId( 3, 3 );
+        cluster.shutdown();
+        cluster = Cluster.start( dir.directory(), 3, 0 );
+
+        assertEquals( 3, cluster.numberOfCoreServers() );
+    }
+
+    @Test
+    public void shouldThrowFriendlyExceptionIfEdgeServerCannotConnectToACoreCluster() throws Exception
+    {
+        // given
+        cluster = Cluster.start( dir.directory(), 0, 0 ); // deliberately using Hazelcast for simplicity
+
+        // when
+        try
+        {
+            cluster.startEdgeServer( 99, asList( AdvertisedSocketAddress.address( "localhost:5001" ) ) );
+        }
+        catch ( RuntimeException e )
+        {
+            assertTrue( e.getCause().getCause() instanceof EdgeServerConnectionException );
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterShutdownIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ClusterShutdownIT.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.coreedge.discovery.Cluster;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TargetDirectory;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import static junit.framework.TestCase.fail;
+
+@Ignore
+public class ClusterShutdownIT
+{
+    @Rule
+    public final TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void shouldShutdownEvenThoughWaitingForLock() throws Exception
+    {
+        final int clusterSize = 3;
+
+        // We test a reasonable set of permutations.
+        int shutdownOrders[][] = {{0, 1, 2}, {1, 2, 0}, {2, 0, 1}};
+
+        for ( int victimId = 0; victimId < clusterSize; victimId++ )
+        {
+            for ( int[] shutdownOrder : shutdownOrders )
+            {
+                shouldShutdownEvenThoughWaitingForLock0( clusterSize, victimId, shutdownOrder );
+            }
+        }
+    }
+
+    private void shouldShutdownEvenThoughWaitingForLock0( int clusterSize, int victimId, int[] shutdownOrder ) throws Exception
+    {
+        final int LONG_TIME = 60_000;
+        final int LONGER_TIME = 2 * LONG_TIME;
+        final int NUMBER_OF_LOCK_ACQUIRERS = 2;
+
+        final ExecutorService txExecutor = Executors.newCachedThreadPool(); // Blocking transactions are executed in parallel, not on the main thread.
+        final ExecutorService shutdownExecutor = Executors.newFixedThreadPool( 1 ); // Shutdowns are executed serially, not on the main thread.
+
+        final File dbDir = dir.directory();
+
+        // given - a cluster
+        final Cluster cluster = Cluster.start( dbDir, clusterSize, 0 );
+
+        try
+        {
+            // when - blocking on lock acquiring
+            final AtomicReference<Node> someNode = new AtomicReference<>();
+            final GraphDatabaseService victimDB = cluster.getCoreServerById( victimId );
+
+            try ( Transaction tx = victimDB.beginTx() )
+            {
+                someNode.set( victimDB.createNode() );
+                tx.success();
+            }
+
+            final AtomicInteger numberOfInstancesReady = new AtomicInteger();
+            for ( int i = 0; i < NUMBER_OF_LOCK_ACQUIRERS; i++ )
+            {
+                txExecutor.execute( new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        try ( Transaction tx = victimDB.beginTx() )
+                        {
+                            numberOfInstancesReady.incrementAndGet();
+
+                            tx.acquireWriteLock( someNode.get() );
+                            Thread.sleep( LONGER_TIME );
+
+                            tx.success();
+                        }
+                        catch( Exception e )
+                        {
+                            /* Since we are shutting down, a plethora of possible exceptions are expected. */
+                        }
+                    }
+                } );
+            }
+
+            while ( numberOfInstancesReady.get() < NUMBER_OF_LOCK_ACQUIRERS )
+            {
+                Thread.sleep( 100 );
+            }
+
+            final CountDownLatch shutdownLatch = new CountDownLatch( clusterSize );
+
+            // then - shutdown in any order should still be possible
+            for ( final Integer id : shutdownOrder )
+            {
+                shutdownExecutor.execute( new Runnable()
+                {
+                    @Override
+                    public void run()
+                    {
+                        cluster.getCoreServerById( id ).shutdown();
+                        shutdownLatch.countDown();
+                    }
+                } );
+            }
+
+            if ( !shutdownLatch.await( LONG_TIME, MILLISECONDS ) )
+            {
+                fail( "Cluster didn't shut down in a timely fashion." );
+            }
+        }
+        finally
+        {
+            txExecutor.shutdownNow();
+            shutdownExecutor.shutdownNow();
+
+            cluster.shutdown();
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ConcurrentLockingIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/ConcurrentLockingIT.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.coreedge.discovery.Cluster;
+import org.neo4j.coreedge.server.core.CoreGraphDatabase;
+import org.neo4j.coreedge.raft.NoLeaderTimeoutException;
+import org.neo4j.function.Supplier;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.tooling.GlobalGraphOperations;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.helpers.collection.Iterables.count;
+import static org.neo4j.test.Assert.assertEventually;
+
+@Ignore("Currently we only support writing on the leader")
+public class ConcurrentLockingIT
+{
+    @Rule
+    public final TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    private Cluster cluster;
+
+    @After
+    public void shutdown()
+    {
+        if ( cluster != null )
+        {
+            cluster.shutdown();
+        }
+    }
+
+    @Test
+    public void shouldConcurrentlyLock() throws Exception
+    {
+        final int coreServerCount = 5;
+        final int workersPerCorServer = 5;
+        final long nodeCount = 10;
+        final long durationMillis = 20_000;
+
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, coreServerCount, 0);
+
+        ExecutorService executor = Executors.newFixedThreadPool( coreServerCount * workersPerCorServer );
+
+        createNodes( nodeCount );
+
+        ArrayList<Callable<Long>> workerThreads = new ArrayList<>();
+
+        // when
+        for ( final CoreGraphDatabase coreDB : cluster.coreServers() )
+        {
+            for ( int i = 0; i < workersPerCorServer; i++ )
+            {
+                Callable<Long> workedThread = new Callable<Long>()
+                {
+                    ThreadLocalRandom tlr = ThreadLocalRandom.current();
+                    long count = 0;
+
+                    @Override
+                    public Long call() throws Exception
+                    {
+                        try
+                        {
+                            long endTime = System.currentTimeMillis() + durationMillis;
+
+                            while ( System.currentTimeMillis() <= endTime )
+                            {
+                                try ( Transaction tx = coreDB.beginTx() )
+                                {
+                                    for ( int i = 0; i < nodeCount; i++ )
+                                    {
+                                        Node node = coreDB.getNodeById( i );
+
+                                        if ( tlr.nextBoolean() )
+                                        {
+                                            tx.acquireReadLock( node );
+                                            count++;
+                                        }
+                                        else
+                                        {
+                                            tx.acquireWriteLock( node );
+                                            count++;
+                                        }
+                                    }
+
+                                    tx.success();
+                                }
+                                catch ( RuntimeException e )
+                                {
+                                    e.printStackTrace();
+                                    LockSupport.parkNanos( 250_000_000 );
+                                }
+                            }
+                        }
+                        catch ( Exception e )
+                        {
+                            e.printStackTrace();
+                        }
+
+                        return count;
+                    }
+                };
+
+                workerThreads.add( workedThread );
+            }
+        }
+
+        List<Future<Long>> futures = executor.invokeAll( workerThreads );
+        for ( Future<Long> future : futures )
+        {
+            assertThat( future.get(), greaterThan( 0L ) );
+        }
+        executor.shutdownNow();
+        executor.awaitTermination( durationMillis + 5_000, TimeUnit.MILLISECONDS );
+    }
+
+    public void createNodes( long nodeCount ) throws NoLeaderTimeoutException
+    {
+        GraphDatabaseService coreServer = cluster.findLeader( 5000 );
+        try ( Transaction tx = coreServer.beginTx() )
+        {
+            for ( int i = 0; i < nodeCount; i++ )
+            {
+                coreServer.createNode();
+                tx.success();
+            }
+        }
+
+        for ( final CoreGraphDatabase db : cluster.coreServers() )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                Supplier<Long> actualNodeCount = () -> count( GlobalGraphOperations.at( db ).getAllNodes() );
+
+                assertEventually( "nodes to appear", actualNodeCount, is( nodeCount ), 10, SECONDS );
+                tx.success();
+            }
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreEdgeRolesIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreEdgeRolesIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.neo4j.coreedge.discovery.Cluster;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.test.TargetDirectory;
+
+public class CoreEdgeRolesIT
+{
+    public final
+    @Rule
+    TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    @Rule
+    public ExpectedException exceptionMatcher = ExpectedException.none();
+
+    private Cluster cluster;
+
+    @After
+    public void shutdown()
+    {
+        if ( cluster != null )
+        {
+            cluster.shutdown();
+        }
+    }
+
+    @Test
+    public void edgeServersShouldRefuseWrites() throws Exception
+    {
+        // given
+        cluster = Cluster.start( dir.directory(), 3, 1);
+        GraphDatabaseService db = cluster.findAnEdgeServer();
+        Transaction tx = db.beginTx();
+        db.createNode();
+
+        // then
+        exceptionMatcher.expect( TransactionFailureException.class );
+
+        // when
+        tx.success();
+        tx.close();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreServerReplicationIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/CoreServerReplicationIT.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import java.io.File;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.coreedge.discovery.Cluster;
+import org.neo4j.coreedge.server.CoreEdgeClusterSettings;
+import org.neo4j.coreedge.server.core.CoreGraphDatabase;
+import org.neo4j.function.Supplier;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.tooling.GlobalGraphOperations;
+
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.cluster.ClusterSettings.server_id;
+import static org.neo4j.graphdb.DynamicLabel.label;
+import static org.neo4j.graphdb.DynamicRelationshipType.withName;
+import static org.neo4j.helpers.collection.Iterables.count;
+import static org.neo4j.helpers.collection.IteratorUtil.asList;
+import static org.neo4j.test.Assert.assertEventually;
+
+public class CoreServerReplicationIT
+{
+    @Rule
+    public final TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    private Cluster cluster;
+
+    @After
+    public void shutdown()
+    {
+        if ( cluster != null )
+        {
+            cluster.shutdown();
+        }
+    }
+
+    @Test
+    public void shouldReplicateTransactionToCoreServers() throws Exception
+    {
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 3, 0 );
+
+        // when
+        GraphDatabaseService coreDB = cluster.findLeader( 5000 );
+
+        try ( Transaction tx = coreDB.beginTx() )
+        {
+            Node node = coreDB.createNode( label( "boo" ) );
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        }
+
+        // then
+        for ( final CoreGraphDatabase db : cluster.coreServers() )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                Supplier<Long> nodeCount = () -> count( GlobalGraphOperations.at( db ).getAllNodes() );
+
+                Config config = db.getDependencyResolver().resolveDependency( Config.class );
+
+                assertEventually( "node to appear on core server " + config.get( CoreEdgeClusterSettings.raft_advertised_address ), nodeCount,
+                        greaterThan( 0L ), 15, SECONDS );
+
+                for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+                {
+                    assertEquals( "baz_bat", node.getProperty( "foobar" ) );
+                }
+
+                tx.success();
+            }
+        }
+    }
+
+    @Test
+    public void shouldReplicateTransactionToCoreServersAddedAfterInitialStartUp() throws Exception
+    {
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 3, 0 );
+
+        cluster.addCoreServerWithServerId( 3, 4 );
+
+        // when
+        GraphDatabaseService coreDB = cluster.findLeader( 5000 );
+
+        try ( Transaction tx = coreDB.beginTx() )
+        {
+            Node node = coreDB.createNode();
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        }
+
+        cluster.addCoreServerWithServerId( 4, 5 );
+
+        coreDB = cluster.findLeader( 5000 );
+
+        try ( Transaction tx = coreDB.beginTx() )
+        {
+            Node node = coreDB.createNode();
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        }
+
+        // then
+        for ( final CoreGraphDatabase db : cluster.coreServers() )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                Supplier<Long> nodeCount = () -> count( GlobalGraphOperations.at( db ).getAllNodes() );
+
+                Config config = db.getDependencyResolver().resolveDependency( Config.class );
+
+                assertEventually( "node to appear on core server " + config.get( HaSettings.ha_server ), nodeCount,
+                        equalTo( 2L ), 3, SECONDS );
+
+                for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+                {
+                    assertEquals( "baz_bat", node.getProperty( "foobar" ) );
+                }
+
+                tx.success();
+            }
+        }
+    }
+
+    @Test
+    public void shouldReplicateTransactionAfterOneOriginalServerRemovedFromCluster() throws Exception
+    {
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 3, 0 );
+        CoreGraphDatabase leader = cluster.findLeader( 5000 );
+        try ( Transaction tx = leader.beginTx() )
+        {
+            Node node = leader.createNode();
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        }
+
+        cluster.removeCoreServer( leader );
+        final GraphDatabaseService newLeader = cluster.findLeader( 5000 );
+        Supplier<Boolean> creationSuccess = () -> {
+            try ( Transaction tx = newLeader.beginTx() )
+            {
+                Node node = newLeader.createNode();
+                node.setProperty( "foobar", "baz_bat" );
+                tx.success();
+                return true;
+
+            }
+            catch ( Exception e )
+            {
+                // ignore temporary failures
+            }
+            return false;
+        };
+
+        assertEventually( "node could be created after server removed", creationSuccess, is( true ), 1, MINUTES );
+
+        // then
+        for ( final CoreGraphDatabase db : cluster.coreServers() )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                Supplier<Long> nodeCount = () -> count( GlobalGraphOperations.at( db ).getAllNodes() );
+
+                Config config = db.getDependencyResolver().resolveDependency( Config.class );
+
+                assertEventually( "node to appear on core server " + config.get( HaSettings.ha_server ), nodeCount,
+                        equalTo( 2L ), 1, MINUTES );
+
+                for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+                {
+                    assertEquals( "baz_bat", node.getProperty( "foobar" ) );
+                }
+
+                tx.success();
+            }
+        }
+    }
+
+    @Test
+    public void shouldReplicateToCoreServersAddedAfterInitialTransactions() throws Exception
+    {
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 3, 0 );
+
+        // when
+        for ( int i = 0; i < 15; i++ )
+        {
+            CoreGraphDatabase leader = cluster.findLeader( 5000 );
+
+            try ( Transaction tx = leader.beginTx() )
+            {
+                Node node = leader.createNode();
+                node.setProperty( "foobar", "baz_bat" );
+                tx.success();
+            }
+        }
+
+        cluster.addCoreServerWithServerId( 3, 4 );
+        cluster.addCoreServerWithServerId( 4, 5 );
+
+        // then
+        for ( final CoreGraphDatabase db : cluster.coreServers() )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                Supplier<Long> nodeCount = () -> count( GlobalGraphOperations.at( db ).getAllNodes() );
+
+                Config config = db.getDependencyResolver().resolveDependency( Config.class );
+
+                assertEventually( "node to appear on core server " + config.get( CoreEdgeClusterSettings
+                                .raft_listen_address ), nodeCount,
+                        is( 15L ), 1, MINUTES );
+
+                for ( Node node : GlobalGraphOperations.at( db ).getAllNodes() )
+                {
+                    DependencyResolver dependencyResolver = db.getDependencyResolver();
+                    InstanceId id = dependencyResolver.resolveDependency( Config.class ).get( server_id );
+                    assertEquals( "Assertion fails on server: " + id, "baz_bat", node.getProperty( "foobar" ) );
+                }
+
+                tx.success();
+            }
+        }
+    }
+
+    @Test
+    @Ignore("Currently we only support writing on the leader")
+    public void shouldReplicateTransactionFromAnyCoreServer() throws Exception
+    {
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 3, 0 );
+
+        // when
+        Set<CoreGraphDatabase> coreServers = cluster.coreServers();
+
+        ExecutorService executor = Executors.newFixedThreadPool( coreServers.size() );
+        try
+        {
+            for ( final CoreGraphDatabase coreServer : coreServers )
+            {
+                executor.submit( () -> {
+                    try ( Transaction tx = coreServer.beginTx() )
+                    {
+                        coreServer.createNode();
+                        tx.success();
+                    }
+                } );
+            }
+        }
+        finally
+        {
+            executor.shutdown();
+            if ( !executor.awaitTermination( 1, TimeUnit.MINUTES ) )
+            {
+                fail( "Initial transactions not finished within reasonable time." );
+            }
+        }
+
+        for ( final CoreGraphDatabase db : coreServers )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                Supplier<Long> nodeCount = () -> count( GlobalGraphOperations.at( db ).getAllNodes() );
+
+                Config config = db.getDependencyResolver().resolveDependency( Config.class );
+                assertEventually( "node to appear on core server " +
+                        config.get( CoreEdgeClusterSettings.transaction_listen_address ), nodeCount,
+                        is( (long) coreServers.size() ), 1, MINUTES );
+                tx.success();
+            }
+        }
+    }
+
+    @Test
+    @Ignore("Currently we only support writing on the leader")
+    public void shouldAtomicallyCreatePropertyTokenAcrossCluster() throws Exception
+    {
+        // given
+        final int NUMBER_OF_SERVERS = 3;
+        final int NODES_PER_SERVER = 2;
+
+        final File dbDir = dir.directory();
+
+        cluster = Cluster.start( dbDir, NUMBER_OF_SERVERS, 0 );
+        Set<CoreGraphDatabase> coreServers = cluster.coreServers();
+
+        // when
+        ExecutorService executor = Executors.newFixedThreadPool( NUMBER_OF_SERVERS );
+        try
+        {
+            for ( final CoreGraphDatabase coreServer : coreServers )
+            {
+                executor.submit( () -> {
+                    boolean success = false;
+                    while ( !success )
+                    {
+                        try
+                        {
+                            try ( Transaction tx = coreServer.beginTx() )
+                            {
+                                Node node1 = coreServer.createNode( label( "label1" ) );
+                                node1.setProperty( "key1", "value1" );
+                                Node node2 = coreServer.createNode( label( "label2" ) );
+                                node2.setProperty( "key2", "value2" );
+
+                                node1.createRelationshipTo( node2, withName( "relType1" ) );
+                                tx.success();
+                            }
+                            success = true;
+                        }
+                        catch ( Exception e )
+                        {
+                            e.printStackTrace();
+                        }
+                    }
+                } );
+            }
+        }
+        finally
+        {
+            executor.shutdown();
+            if ( !executor.awaitTermination( 1, TimeUnit.MINUTES ) )
+            {
+                fail( "Initial transactions not finished within reasonable time." );
+            }
+        }
+
+        // then
+        for ( final CoreGraphDatabase db : cluster.coreServers() )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                assertEventually( "Node count", () -> count( db.getAllNodes() ),
+                        is( (long) NUMBER_OF_SERVERS * NODES_PER_SERVER ), 1, MINUTES );
+
+                ResourceIterator<Node> nodes = db.findNodes( label( "label1" ) );
+                while ( nodes.hasNext() )
+                {
+                    Node node = nodes.next();
+                    assertEquals( "value1", node.getProperty( "key1" ) );
+                    Iterable<Label> labels = node.getSingleRelationship( withName( "relType1" ), Direction.OUTGOING )
+                            .getEndNode().getLabels();
+                    assertEquals( singletonList( label( "label2" ) ), asList( labels ) );
+                }
+
+                tx.success();
+            }
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/EdgeServerReplicationIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/EdgeServerReplicationIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import java.io.File;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.coreedge.discovery.Cluster;
+import org.neo4j.coreedge.server.edge.EdgeGraphDatabase;
+import org.neo4j.function.Supplier;
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.tooling.GlobalGraphOperations;
+
+import static java.io.File.pathSeparator;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.test.Assert.assertEventually;
+
+public class EdgeServerReplicationIT
+{
+    @Rule
+    public final TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    private Cluster cluster;
+
+    @After
+    public void shutdown()
+    {
+        if ( cluster != null )
+        {
+            cluster.shutdown();
+        }
+    }
+
+    @Test
+    public void shouldNotBeAbleToWriteToEdge() throws Exception
+    {
+        // given
+        cluster = Cluster.start( dir.directory(), 3, 1);
+
+        GraphDatabaseService edgeDB = cluster.findAnEdgeServer();
+
+        // when (write should fail)
+        boolean transactionFailed = false;
+        try ( Transaction tx = edgeDB.beginTx() )
+        {
+            Node node = edgeDB.createNode();
+            node.setProperty( "foobar", "baz_bat" );
+            node.addLabel( DynamicLabel.label( "Foo" ) );
+            tx.success();
+        }
+        catch ( TransactionFailureException e )
+        {
+            // expected
+            transactionFailed = true;
+        }
+
+        assertTrue( transactionFailed );
+    }
+
+    @Test
+    public void allServersBecomeAvailable() throws Exception
+    {
+        // given
+        cluster = Cluster.start( dir.directory(), 3, 1);
+
+        // then
+        for ( final EdgeGraphDatabase edgeGraphDatabase : cluster.edgeServers() )
+        {
+            Supplier<Boolean> availability = () -> edgeGraphDatabase.isAvailable( 0 );
+            assertEventually( "edge server becomes available", availability, is( true ), 10, SECONDS );
+        }
+    }
+
+    @Test
+    public void shouldEventuallyPullTransactionDownToAllEdgeServers() throws Exception
+    {
+        // given
+        cluster = Cluster.start( dir.directory(), 3, 0);
+        int nodesBeforeEdgeServerStarts = 1;
+
+        // when
+        GraphDatabaseService coreDB = cluster.findLeader( 5000 );
+        try ( Transaction tx = coreDB.beginTx() )
+        {
+            for ( int i = 0; i < nodesBeforeEdgeServerStarts; i++ )
+            {
+                Node node = coreDB.createNode();
+                node.setProperty( "foobar", "baz_bat" );
+            }
+            tx.success();
+        }
+
+        cluster.addEdgeServerWithFileLocation( 0 );
+
+        // when
+        try ( Transaction tx = coreDB.beginTx() )
+        {
+            Node node = coreDB.createNode();
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        }
+
+        // then
+        Set<EdgeGraphDatabase> edgeGraphDatabases = cluster.edgeServers();
+        for ( final GraphDatabaseService edgeDB : edgeGraphDatabases )
+        {
+            try ( Transaction tx = edgeDB.beginTx() )
+            {
+                Supplier<Long> nodeCount = () -> Iterables.count( GlobalGraphOperations.at( edgeDB ).getAllNodes() );
+                assertEventually( "node to appear on edge server", nodeCount, is( nodesBeforeEdgeServerStarts + 1l ),
+                        2, MINUTES );
+
+                for ( Node node : GlobalGraphOperations.at( edgeDB ).getAllNodes() )
+                {
+                    assertEquals( "baz_bat", node.getProperty( "foobar" ) );
+                }
+
+                tx.success();
+            }
+        }
+    }
+
+    @Test
+    public void shouldShutdownRatherThanPullUpdatesFromCoreServerWithDifferentStoreIfServerHasData() throws Exception
+    {
+
+        File edgeDatabaseStoreFileLocation = createExistingEdgeStore( dir.directory().getAbsolutePath() +
+                pathSeparator + "edgeStore" );
+
+        cluster = Cluster.start( dir.directory(), 3, 0);
+
+        GraphDatabaseService coreDB = this.cluster.findLeader( 5000 );
+
+        try ( Transaction tx = coreDB.beginTx() )
+        {
+            for ( int i = 0; i < 10; i++ )
+            {
+                Node node = coreDB.createNode();
+                node.setProperty( "foobar", "baz_bat" );
+            }
+            tx.success();
+        }
+
+        try
+        {
+            cluster.addEdgeServerWithFileLocation( edgeDatabaseStoreFileLocation );
+            fail();
+        }
+        catch ( Throwable required )
+        {
+            // Lifecycle should throw exception, server should not start.
+        }
+    }
+
+    private File createExistingEdgeStore( String path )
+    {
+        File dir = new File( path );
+        dir.mkdirs();
+
+        GraphDatabaseService db = new TestGraphDatabaseFactory()
+                .newEmbeddedDatabase( Cluster.edgeSeverStoreDirectory( dir, 1966 ) );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+
+        db.shutdown();
+
+        return dir;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/HazelcastClientLifeCycleIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/HazelcastClientLifeCycleIT.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.coreedge.discovery.Cluster;
+import org.neo4j.coreedge.server.CoreEdgeClusterSettings;
+import org.neo4j.coreedge.server.core.CoreGraphDatabase;
+import org.neo4j.coreedge.server.ListenSocketAddress;
+import org.neo4j.coreedge.discovery.EdgeServerConnectionException;
+import org.neo4j.coreedge.discovery.HazelcastClientLifecycle;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.coreedge.discovery.Cluster.start;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
+public class HazelcastClientLifeCycleIT
+{
+    public final
+    @Rule
+    TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    @Rule
+    public ExpectedException exceptionMatcher = ExpectedException.none();
+
+    private Cluster cluster;
+
+    @After
+    public void shutdown()
+    {
+        if ( cluster != null )
+        {
+            cluster.shutdown();
+        }
+    }
+
+    @Test
+    public void shouldConnectToCoreClusterAsLongAsOneInitialHostIsAvailable() throws Throwable
+    {
+        // given
+        cluster = start( dir.directory(), 2, 0 );
+
+        // when
+
+        ListenSocketAddress goodHostnamePort = hostnamePort( cluster.coreServers().iterator().next() );
+        InetSocketAddress address = goodHostnamePort.socketAddress();
+        String badHost = "localhost:9999";
+        String goodHost = address.getHostString() + ":" + address.getPort();
+
+        HazelcastClientLifecycle client = new HazelcastClientLifecycle( getConfig( badHost + "," + goodHost )
+        );
+
+        client.start();
+
+        // then
+        assertEquals( 2, client.currentTopology().getNumberOfCoreServers() );
+
+        client.stop();
+    }
+
+    private ListenSocketAddress hostnamePort( CoreGraphDatabase aCoreServer )
+    {
+        return aCoreServer.getDependencyResolver()
+                .resolveDependency( Config.class ).get( CoreEdgeClusterSettings.cluster_listen_address );
+    }
+
+    @Test
+    public void shouldThrowAnExceptionIfUnableToConnectToCoreCluster() throws Throwable
+    {
+        // when
+        String badHost = "localhost:9999";
+        HazelcastClientLifecycle client = new HazelcastClientLifecycle( getConfig( badHost ) );
+
+        // then
+        exceptionMatcher.expect( EdgeServerConnectionException.class );
+
+        client.start();
+        client.stop();
+    }
+
+
+    private Config getConfig( String initialHosts )
+    {
+        Map<String, String> params = stringMap();
+        params.put( "org.neo4j.server.database.mode", "CORE_EDGE" );
+        params.put( ClusterSettings.cluster_name.name(), Cluster.CLUSTER_NAME );
+        params.put( ClusterSettings.server_id.name(), String.valueOf( 99 ) );
+        params.put( CoreEdgeClusterSettings.initial_core_cluster_members.name(), initialHosts );
+        return new Config( params );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/RecoveryIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/RecoveryIT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.consistency.ConsistencyCheckService;
+import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.coreedge.discovery.Cluster;
+import org.neo4j.coreedge.server.core.CoreGraphDatabase;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.progress.ProgressMonitorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.FormattedLogProvider;
+import org.neo4j.test.TargetDirectory;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.graphdb.DynamicLabel.label;
+
+@Ignore("in progress")
+public class RecoveryIT
+{
+    @Rule
+    public final TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    private Cluster cluster;
+
+    @After
+    public void shutdown()
+    {
+        if ( cluster != null )
+        {
+            cluster.shutdown();
+        }
+    }
+
+    @Test
+    public void shouldBeConsistentAfterShutdown() throws Exception
+    {
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 3, 0 );
+
+        HashSet<File> storeDirs = new HashSet<>();
+
+        for ( int i = 0; i < cluster.numberOfCoreServers(); i++ )
+        {
+            CoreGraphDatabase theDb = cluster.getCoreServerById( i );
+
+            try ( Transaction tx = theDb.beginTx() )
+            {
+                Node node = theDb.createNode( label( "demo" ) );
+                node.setProperty( "server", i );
+                tx.success();
+            }
+
+            storeDirs.add( new File( theDb.getStoreDir() ) );
+        }
+
+        // when
+        cluster.shutdown();
+
+        // then
+        for ( File storeDir : storeDirs )
+        {
+            isConsistent( storeDir );
+        }
+    }
+
+    @Test
+    public void singleServerWithinClusterShouldBeConsistentAfterRestart() throws Exception
+    {
+        // given
+        int clusterSize = 3;
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, clusterSize, 0 );
+
+        ArrayList<String> storeDirs = new ArrayList<>();
+
+        for ( int i = 0; i < clusterSize; i++ )
+        {
+            CoreGraphDatabase theDb = cluster.getCoreServerById( i );
+
+            try ( Transaction tx = theDb.beginTx() )
+            {
+                Node node = theDb.createNode( label( "first-round" ) );
+                node.setProperty( "server", i );
+                tx.success();
+            }
+
+            storeDirs.add( theDb.getStoreDir() );
+        }
+
+        // when
+        for ( int i = 0; i < clusterSize; i++ )
+        {
+            cluster.removeCoreServerWithServerId( i );
+            fireSomeLoadAtTheCluster( cluster );
+            cluster.addCoreServerWithServerId( i, clusterSize );
+        }
+
+        cluster.shutdown();
+
+        // then
+        for ( int i = 0; i < clusterSize; i++ )
+        {
+            assertTrue( isConsistent( storeDirs.get( i ) ) );
+        }
+    }
+
+    private boolean isConsistent( File storeDir ) throws IOException
+    {
+        return isConsistent( storeDir.getCanonicalPath() );
+    }
+
+    private boolean isConsistent( String storeDir ) throws IOException
+    {
+        ConsistencyCheckService.Result result;
+
+        try
+        {
+            result = new ConsistencyCheckService().runFullConsistencyCheck( new File( storeDir ), new Config(),
+                    ProgressMonitorFactory.NONE, FormattedLogProvider.toOutputStream( System.err ), true );
+        }
+        catch ( ConsistencyCheckIncompleteException e )
+        {
+            throw new RuntimeException( e );
+        }
+
+        return result.isSuccessful();
+    }
+
+    private void fireSomeLoadAtTheCluster( Cluster cluster )
+    {
+        for ( CoreGraphDatabase theDb : cluster.coreServers() )
+        {
+            boolean tryAgain;
+            do
+            {
+                tryAgain = false;
+                try ( Transaction tx = theDb.beginTx() )
+                {
+                    Node node = theDb.createNode( label( "second-round" ) );
+                    node.setProperty( "server", "val" );
+                    tx.success();
+                }
+                catch ( Throwable t )
+                {
+                    tryAgain = true;
+                    parkNanos( MILLISECONDS.toNanos( 100 ) );
+                }
+            } while ( tryAgain );
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/RestartIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/RestartIT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios;
+
+import java.io.File;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.coreedge.discovery.Cluster;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.legacy.consistency.ConsistencyCheckService;
+import org.neo4j.coreedge.server.core.CoreGraphDatabase;
+import org.neo4j.coreedge.server.edge.EdgeGraphDatabase;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.progress.ProgressMonitorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.FormattedLogProvider;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.graphdb.DynamicLabel.label;
+
+public class RestartIT
+{
+    @Rule
+    public final TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    private Cluster cluster;
+
+    @After
+    public void shutdown()
+    {
+        if ( cluster != null )
+        {
+            cluster.shutdown();
+        }
+    }
+
+    @Test
+    public void restartFirstServer() throws Exception
+    {
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 3, 0);
+
+        // when
+        cluster.removeCoreServerWithServerId( 0 );
+        cluster.addCoreServerWithServerId( 0, 3 );
+
+        // then
+        cluster.shutdown();
+    }
+
+    @Test
+    public void restartSecondServer() throws Exception
+    {
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 3, 0);
+
+        // when
+        cluster.removeCoreServerWithServerId( 1 );
+        cluster.addCoreServerWithServerId( 1, 3 );
+
+        // then
+        cluster.shutdown();
+    }
+
+    @Test
+    public void restartWhileDoingTransactions() throws Exception
+    {
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 3, 0);
+
+        // when
+        final GraphDatabaseService coreDB = cluster.getCoreServerById( 0 );
+
+        ExecutorService executor = Executors.newCachedThreadPool();
+
+        final AtomicBoolean done = new AtomicBoolean( false );
+        executor.execute( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                while( !done.get() )
+                {
+                    try ( Transaction tx = coreDB.beginTx() )
+                    {
+                        Node node = coreDB.createNode( label( "boo" ) );
+                        node.setProperty( "foobar", "baz_bat" );
+                        tx.success();
+                    }
+                }
+            }
+        } );
+        Thread.sleep( 500 );
+
+        cluster.removeCoreServerWithServerId( 1 );
+        cluster.addCoreServerWithServerId( 1, 3 );
+        Thread.sleep( 500 );
+
+        // then
+        done.set( true );
+        executor.shutdown();
+        cluster.shutdown();
+    }
+
+    @Test
+    public void edgeTest() throws Exception
+    {
+        // given
+        File dbDir = dir.directory();
+        cluster = Cluster.start( dbDir, 2, 1);
+
+        // when
+        final GraphDatabaseService coreDB = cluster.findLeader( 5000 );
+
+        try ( Transaction tx = coreDB.beginTx() )
+        {
+            Node node = coreDB.createNode( label( "boo" ) );
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        }
+
+        cluster.addCoreServerWithServerId( 2, 3 );
+        cluster.shutdown();
+
+        for ( CoreGraphDatabase core : cluster.coreServers() )
+        {
+            ConsistencyCheckService.Result result = new ConsistencyCheckService().runFullConsistencyCheck(
+                    new File( core.getStoreDir() ), new Config(), ProgressMonitorFactory.NONE,
+                    FormattedLogProvider.toOutputStream( System.out ), new DefaultFileSystemAbstraction() );
+
+            assertTrue( "Inconsistent: " + core, result.isSuccessful() );
+        }
+
+        for ( EdgeGraphDatabase edge : cluster.edgeServers() )
+        {
+            ConsistencyCheckService.Result result = new ConsistencyCheckService().runFullConsistencyCheck(
+                    new File( edge.getStoreDir() ), new Config(), ProgressMonitorFactory.NONE,
+                    FormattedLogProvider.toOutputStream( System.out ), new DefaultFileSystemAbstraction() );
+
+            assertTrue( "Inconsistent: " + edge, result.isSuccessful() );
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/explorer/StateExplorerIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/scenarios/explorer/StateExplorerIT.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.scenarios.explorer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.state.explorer.ClusterSafetyViolations;
+import org.neo4j.coreedge.raft.state.explorer.ClusterState;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.raft.state.explorer.action.Action;
+import org.neo4j.coreedge.raft.state.explorer.action.DropMessage;
+import org.neo4j.coreedge.raft.state.explorer.action.ElectionTimeout;
+import org.neo4j.coreedge.raft.state.explorer.action.HeartbeatTimeout;
+import org.neo4j.coreedge.raft.state.explorer.action.NewEntry;
+import org.neo4j.coreedge.raft.state.explorer.action.ProcessMessage;
+import org.neo4j.coreedge.raft.state.explorer.action.OutOfOrderDelivery;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+
+public class StateExplorerIT
+{
+    @Test
+    public void shouldExploreAllTheStates() throws Exception
+    {
+        int clusterSize = 3;
+        Set<RaftTestMember> members = new HashSet<>();
+        for ( int i = 0; i < clusterSize; i++ )
+        {
+            members.add( member( i ) );
+        }
+
+        ClusterState initialState = new ClusterState( members );
+
+        List<Action> actions = new ArrayList<>();
+        for ( RaftTestMember member : members )
+        {
+            actions.add( new ProcessMessage( member ) );
+            actions.add( new NewEntry( member ) );
+            actions.add( new HeartbeatTimeout( member ) );
+            actions.add( new ElectionTimeout( member ) );
+            actions.add( new DropMessage( member ) );
+            actions.add( new OutOfOrderDelivery( member ) );
+        }
+
+        Set<ClusterState> exploredStates = new HashSet<>();
+        Set<ClusterState> statesToBeExplored = new HashSet<>();
+
+        statesToBeExplored.add( initialState );
+
+        int explorationDepth = 7;
+        for ( int i = 0; i < explorationDepth; i++ )
+        {
+            Set<ClusterState> newStates = new HashSet<>();
+            int counter = 0;
+            for ( ClusterState clusterState : statesToBeExplored )
+            {
+                if (counter++ % 1000 == 0) System.out.print( "." );
+                exploredStates.add( clusterState );
+                for ( Action action : actions )
+                {
+                    ClusterState nextClusterState = action.advance( clusterState );
+                    if ( !exploredStates.contains( nextClusterState ) )
+                    {
+                        newStates.add( nextClusterState );
+                    }
+                }
+            }
+            statesToBeExplored = newStates;
+            System.out.printf( "\nexplored %d states, planning to explore %d states%n",
+                    exploredStates.size(), statesToBeExplored.size() );
+        }
+
+        for ( ClusterState exploredState : exploredStates )
+        {
+            List<ClusterSafetyViolations.Violation> invariantsViolated = ClusterSafetyViolations.violations(
+                    exploredState );
+            assertThat( invariantsViolated, empty() );
+        }
+
+        System.out.println( "exploredStates = " + exploredStates.size() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/AdvertisedSocketAddressEncodeDecodeTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/AdvertisedSocketAddressEncodeDecodeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.AdvertisedSocketAddressDecoder;
+import org.neo4j.coreedge.server.AdvertisedSocketAddressEncoder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
+
+public class AdvertisedSocketAddressEncodeDecodeTest
+{
+    @Test
+    public void shouldEncodeAndDecodeHostnamePort()
+    {
+        ByteBuf buffer = Unpooled.buffer();
+
+        // given
+        AdvertisedSocketAddress sent = address( "test-hostname:1234" );
+
+        // when
+        new AdvertisedSocketAddressEncoder().encode( sent, buffer );
+
+        // then
+        AdvertisedSocketAddress received = new AdvertisedSocketAddressDecoder().decode( buffer );
+        assertNotSame( sent, received );
+        assertEquals( sent, received );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/ChannelKeepAliveTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/ChannelKeepAliveTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.ExpiryScheduler;
+import org.neo4j.coreedge.server.Expiration;
+import org.neo4j.coreedge.server.SenderService;
+import org.neo4j.helpers.FakeClock;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.OnDemandJobScheduler;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static junit.framework.TestCase.assertEquals;
+import static org.neo4j.coreedge.PortsForIntegrationTesting.findFreeAddress;
+
+public class ChannelKeepAliveTest
+{
+    /** Server that sends "Hello, World!" on connect. */
+    private Channel bootstrapHelloServer( InetSocketAddress serverAddress ) throws IOException
+    {
+        ServerBootstrap bootstrap = new ServerBootstrap()
+                .group( new NioEventLoopGroup() )
+                .channel( NioServerSocketChannel.class )
+                .localAddress( new InetSocketAddress( serverAddress.getPort() ) )
+                .childHandler( new ChannelInitializer<SocketChannel>()
+                {
+                    @Override
+                    protected void initChannel( SocketChannel ch ) throws Exception
+                    {
+                        ChannelPipeline pipeline = ch.pipeline();
+                        pipeline.addLast( new LengthFieldPrepender( 4 ) );
+
+                        ByteBuf buffer = ch.alloc().buffer();
+                        String message = "Hello, World!";
+                        buffer.writeInt( message.getBytes().length );
+                        buffer.writeBytes( message.getBytes() );
+                        ch.write( buffer );
+                        ch.flush();
+                    }
+                } );
+
+        return bootstrap.bind().syncUninterruptibly().channel();
+    }
+
+    /** Client that just discards read data. */
+    private ChannelInitializer<SocketChannel> discardClientInitializer()
+    {
+        ChannelInitializer<SocketChannel> channelInitializer = new ChannelInitializer<SocketChannel>()
+        {
+            @Override
+            protected void initChannel( SocketChannel channel ) throws Exception
+            {
+                final SimpleChannelInboundHandler<ByteBuf> clientHandler = new SimpleChannelInboundHandler<ByteBuf>()
+                {
+                    @Override
+                    protected void channelRead0( ChannelHandlerContext ctx, ByteBuf msg ) throws Exception
+                    {
+                        int size = msg.readInt();
+                        byte[] bytes = new byte[size];
+                        msg.readBytes( bytes );
+                    }
+                };
+
+                ChannelPipeline pipeline = channel.pipeline();
+                pipeline.addLast( new LengthFieldBasedFrameDecoder( Integer.MAX_VALUE, 0, 4, 0, 4 ) );
+                pipeline.addLast( clientHandler );
+            }
+        };
+
+        return channelInitializer;
+    }
+
+    @Test
+    public void shouldReapChannelOnlyAfterItHasExpired() throws Throwable
+    {
+        // given
+        InetSocketAddress serverAddress = findFreeAddress();
+        Channel serverChannel = bootstrapHelloServer( serverAddress );
+
+        final FakeClock fakeClock = new FakeClock();
+
+        OnDemandJobScheduler onDemandJobScheduler = new OnDemandJobScheduler();
+        SenderService senderService = new SenderService( new ExpiryScheduler( onDemandJobScheduler ),
+                new Expiration( fakeClock, 2, MINUTES ), discardClientInitializer(), NullLogProvider.getInstance() );
+
+        senderService.start();
+        senderService.send( new AdvertisedSocketAddress( serverAddress ), "GO!" );
+
+        // when
+        fakeClock.forward( 1, TimeUnit.MINUTES ); // 1 minutes total < 2 minutes expiry time
+        onDemandJobScheduler.runJob();
+
+        //then
+        assertEquals( 1, senderService.activeChannelCount() );
+
+        // when
+        fakeClock.forward( 2, TimeUnit.MINUTES ); // (1+2) minutes total > 2 minutes expiry time
+        onDemandJobScheduler.runJob();
+
+        //then
+        assertEquals( 0, senderService.activeChannelCount() );
+
+        senderService.stop();
+        serverChannel.close();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/RaftTestMember.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/RaftTestMember.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+public class RaftTestMember implements Comparable<RaftTestMember>
+{
+    public static RaftTestMember member( long id )
+    {
+        return new RaftTestMember( id );
+    }
+
+    private final long id;
+
+    public RaftTestMember( long id )
+    {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        RaftTestMember member = (RaftTestMember) o;
+
+        return id == member.id;
+
+    }
+
+    public long getId()
+    {
+        return id;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (int) (id ^ (id >>> 32));
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "M{id=%d}", id );
+    }
+
+    @Override
+    public int compareTo( RaftTestMember other )
+    {
+        return new Long( this.id ).compareTo( other.getId() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/RaftTestMemberSetBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/RaftTestMemberSetBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.coreedge.raft.membership.RaftGroup;
+import org.neo4j.coreedge.raft.membership.RaftTestGroup;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+
+public class RaftTestMemberSetBuilder implements RaftGroup.Builder<RaftTestMember>
+{
+    public static RaftTestMemberSetBuilder INSTANCE = new RaftTestMemberSetBuilder();
+
+    private RaftTestMemberSetBuilder()
+    {
+    }
+
+    @Override
+    public RaftGroup<RaftTestMember> build( Set<RaftTestMember> members )
+    {
+        return new RaftTestGroup( members );
+    }
+
+    public static RaftGroup<RaftTestMember> memberSet( int... ids )
+    {
+        HashSet<RaftTestMember> members = new HashSet<>();
+        for ( int id : ids )
+        {
+            members.add( member( id ) );
+        }
+        return new RaftTestGroup( members );
+    }
+}

--- a/enterprise/enterprise-performance-tests/LICENSES.txt
+++ b/enterprise/enterprise-performance-tests/LICENSES.txt
@@ -7,9 +7,11 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Jackson
   Lucene Core
   Metrics Core
+  Netty/All-in-One
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/enterprise-performance-tests/NOTICE.txt
+++ b/enterprise/enterprise-performance-tests/NOTICE.txt
@@ -29,9 +29,11 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Jackson
   Lucene Core
   Metrics Core
+  Netty/All-in-One
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/IdRangeIterator.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/IdRangeIterator.java
@@ -27,11 +27,11 @@ import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG
 
 public class IdRangeIterator
 {
-    static IdRangeIterator EMPTY_ID_RANGE_ITERATOR =
+    public static IdRangeIterator EMPTY_ID_RANGE_ITERATOR =
             new IdRangeIterator( new IdRange( EMPTY_LONG_ARRAY, 0, 0 ) )
             {
                 @Override
-                long next()
+                public long next()
                 {
                     return VALUE_REPRESENTING_NULL;
                 }
@@ -50,7 +50,7 @@ public class IdRangeIterator
         this.length = idRange.getRangeLength();
     }
 
-    long next()
+    public long next()
     {
         try
         {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockResult.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/LockResult.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.ha.lock;
 
+import java.util.Objects;
+
 public class LockResult
 {
     private final LockStatus status;
@@ -50,5 +52,27 @@ public class LockResult
     public String toString()
     {
         return "LockResult[" + status + ", " + message + "]";
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        LockResult that = (LockResult) o;
+        return Objects.equals( status, that.status ) &&
+                Objects.equals( message, that.message );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( status, message );
     }
 }

--- a/enterprise/neo4j-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-enterprise/LICENSES.txt
@@ -7,8 +7,10 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Lucene Core
   Metrics Core
+  Netty/All-in-One
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -29,8 +29,10 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Lucene Core
   Metrics Core
+  Netty/All-in-One
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/neo4j-enterprise/pom.xml
+++ b/enterprise/neo4j-enterprise/pom.xml
@@ -59,6 +59,11 @@
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-core-edge</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
       <artifactId>neo4j-metrics</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -14,6 +14,7 @@ Apache Software License, Version 2.0
   Data Mapper for Jackson
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Jackson
   JAX-RS provider for JSON content type
   Jetty :: Http Utility

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -36,6 +36,7 @@ Apache Software License, Version 2.0
   Data Mapper for Jackson
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Jackson
   JAX-RS provider for JSON content type
   Jetty :: Http Utility

--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -35,6 +35,7 @@
     <module>backup</module>
     <module>kernel</module>
     <module>ha</module>
+    <module>core-edge</module>
     <module>metrics</module>
     <module>neo4j-enterprise</module>
     <module>server-enterprise</module>

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -14,6 +14,7 @@ Apache Software License, Version 2.0
   Data Mapper for Jackson
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Jackson
   JAX-RS provider for JSON content type
   Jetty :: Http Utility

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -36,6 +36,7 @@ Apache Software License, Version 2.0
   Data Mapper for Jackson
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Jackson
   JAX-RS provider for JSON content type
   Jetty :: Http Utility

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/webadmin/rest/CoreDatabaseAvailabilityDiscoveryRepresentation.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/webadmin/rest/CoreDatabaseAvailabilityDiscoveryRepresentation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.webadmin.rest;
+
+import org.neo4j.server.rest.repr.MappingRepresentation;
+import org.neo4j.server.rest.repr.MappingSerializer;
+
+public class CoreDatabaseAvailabilityDiscoveryRepresentation extends MappingRepresentation
+{
+    private static final String WRITABLE_KEY = "writable";
+    private static final String DISCOVERY_REPRESENTATION_TYPE = "discovery";
+
+    private final String basePath;
+    private final String isWritableUri;
+
+    public CoreDatabaseAvailabilityDiscoveryRepresentation( String basePath, String isWritableUri )
+    {
+        super( DISCOVERY_REPRESENTATION_TYPE );
+        this.basePath = basePath;
+        this.isWritableUri = isWritableUri;
+    }
+
+    @Override
+    protected void serialize( MappingSerializer serializer )
+    {
+        serializer.putUri( WRITABLE_KEY, basePath + isWritableUri );
+    }
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/webadmin/rest/CoreDatabaseAvailabilityService.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/webadmin/rest/CoreDatabaseAvailabilityService.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.webadmin.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import org.neo4j.coreedge.server.core.CoreGraphDatabase;
+import org.neo4j.coreedge.raft.roles.Role;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.server.rest.management.AdvertisableService;
+import org.neo4j.server.rest.repr.BadInputException;
+import org.neo4j.server.rest.repr.OutputFormat;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.status;
+
+@Path(CoreDatabaseAvailabilityService.BASE_PATH)
+public class CoreDatabaseAvailabilityService implements AdvertisableService
+{
+    public static final String BASE_PATH = "server/core";
+    public static final String IS_WRITABLE_PATH = "/writable";
+    public static final String IS_AVAILABLE_PATH = "/available";
+
+    private final OutputFormat output;
+    private final CoreGraphDatabase coreDatabase;
+
+    public CoreDatabaseAvailabilityService( @Context OutputFormat output, @Context GraphDatabaseService db )
+    {
+        this.output = output;
+        if ( db instanceof CoreGraphDatabase )
+        {
+            this.coreDatabase = (CoreGraphDatabase) db;
+        }
+        else
+        {
+            this.coreDatabase = null;
+        }
+    }
+
+    @GET
+    public Response discover() throws BadInputException
+    {
+        if ( coreDatabase == null )
+        {
+            return status( FORBIDDEN ).build();
+        }
+
+        String isSlaveUri = IS_WRITABLE_PATH;
+
+        return output.ok( new CoreDatabaseAvailabilityDiscoveryRepresentation( BASE_PATH, isSlaveUri ) );
+    }
+
+    @GET
+    @Path(IS_WRITABLE_PATH)
+    public Response isWritable() throws BadInputException
+    {
+        if ( coreDatabase == null )
+        {
+            return status( FORBIDDEN ).build();
+        }
+
+        if ( coreDatabase.getRole() == Role.LEADER )
+        {
+            return positiveResponse();
+        }
+
+        return negativeResponse();
+    }
+
+    @GET
+    @Path( IS_AVAILABLE_PATH )
+    public Response isAvailable()
+    {
+        if ( coreDatabase == null )
+        {
+            return status( FORBIDDEN ).build();
+        }
+
+        return positiveResponse();
+    }
+
+    private Response negativeResponse()
+    {
+        return plainTextResponse( NOT_FOUND, "false" );
+    }
+
+    private Response positiveResponse()
+    {
+        return plainTextResponse( OK, "true" );
+    }
+
+    private Response plainTextResponse( Response.Status status, String entityBody )
+    {
+        return status( status ).type( TEXT_PLAIN_TYPE ).entity( entityBody ).build();
+    }
+
+    @Override
+    public String getName()
+    {
+        return "core";
+    }
+
+    @Override
+    public String getServerPath()
+    {
+        return BASE_PATH;
+    }
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/webadmin/rest/DatabaseRoleInfoServerModule.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/webadmin/rest/DatabaseRoleInfoServerModule.java
@@ -31,13 +31,13 @@ import org.neo4j.server.web.WebServer;
 
 import static java.util.Arrays.asList;
 
-public class MasterInfoServerModule implements ServerModule
+public class DatabaseRoleInfoServerModule implements ServerModule
 {
     private final WebServer server;
     private final Config config;
     private final Log log;
 
-    public MasterInfoServerModule( WebServer server, Config config, LogProvider logProvider )
+    public DatabaseRoleInfoServerModule( WebServer server, Config config, LogProvider logProvider )
     {
         this.server = server;
         this.config = config;
@@ -62,7 +62,7 @@ public class MasterInfoServerModule implements ServerModule
 
     private List<String> getClassNames()
     {
-        return asList( MasterInfoService.class.getName() );
+        return asList( MasterInfoService.class.getName(), CoreDatabaseAvailabilityService.class.getName() );
     }
 
     private URI managementApiUri()

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
@@ -16,6 +16,7 @@ Apache Software License, Version 2.0
   ExplorerCanvas
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Jackson
   JAX-RS provider for JSON content type
   Jetty :: Http Utility

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -38,6 +38,7 @@ Apache Software License, Version 2.0
   ExplorerCanvas
   Ganglia Integration for Metrics
   Graphite Integration for Metrics
+  hazelcast-all
   Jackson
   JAX-RS provider for JSON content type
   Jetty :: Http Utility

--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,12 @@
       </build>
     </profile>
     <profile>
+      <id>core-edge-tests-only</id>
+      <properties>
+        <test-phase>none</test-phase>
+      </properties>
+    </profile>
+    <profile>
       <id>java8-set-javadoc-doclint</id>
       <activation>
         <jdk>[1.8,)</jdk>


### PR DESCRIPTION
## catchup

 Store copy and transaction pulling, similar to the way slaves catch up with
 master in the traditional HA setup.
## discovery

Uses Hazelcast to discover an initial cluster topology both for Core and Edge
instances. This discovery layer is used to prompt RAFT cluster changes in Core as
instances leave and join, and used as a topology manager for Edge instances.
## raft

An implementation of a distributed log kept consistent by RAFT. While there
are several packages in here, the key ones are:
- log - where the log implementations for the RAFT protocol are kept
- replication - machinery for replicating entries in the raft log
- membership - where RAFT group membership is maintained (see above for
  initial setup)
## server

 The server package is where all the code is brought together. It also provides
 some shared infrastructure for sending messages, dealing with settings etc.
