### PR TITLE
This will use the embedded jgit instead of whatever git happens to be…

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -134,7 +134,7 @@ the relevant Commercial Agreement.
         <configuration>
           <dotGitDirectory>${git.directory}</dotGitDirectory>
           <failOnNoGitDirectory>false</failOnNoGitDirectory>
-          <useNativeGit>true</useNativeGit>
+          <useNativeGit>false</useNativeGit>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
… available in your environment.

"As rule of thumb - stay on jgit (keep this false) until you notice performance problems."
