### PR TITLE
Add an echo " done" and newline to stdout on stop

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/utils
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/utils
@@ -252,6 +252,7 @@ stopit() {
 
       x=$[$x+1]
     done
+    echo " done"
     [ -e "$PID_FILE" ] && rm  "$PID_FILE"
   fi
 }


### PR DESCRIPTION
Fixes #5919: As per previous functionality, which was broken by commit b15b487cae2c41b2356af30aa201b00388a882f3.
