### PR TITLE
Disable all the metrics by default

### DIFF
--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -53,7 +53,7 @@ public class MetricsSettings
     @Description( "The default enablement value for all the supported metrics. Set this to `false` to turn off all " +
                   "metrics by default. The individual settings can then be used to selectively re-enable specific " +
                   "metrics." )
-    public static Setting<Boolean> metricsEnabled = setting( "metrics.enabled", Settings.BOOLEAN, Settings.TRUE );
+    public static Setting<Boolean> metricsEnabled = setting( "metrics.enabled", Settings.BOOLEAN, Settings.FALSE );
 
     @Description( "The default enablement value for all Neo4j specific support metrics. Set this to `false` to turn " +
                   "off all Neo4j specific metrics by default. The individual `metrics.neo4j.*` metrics can then be " +

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
@@ -35,7 +35,6 @@ import java.util.UUID;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.test.TargetDirectory;
@@ -60,10 +59,10 @@ public class MetricsKernelExtensionFactoryIT
     @Before
     public void setup() throws IOException
     {
-        String dbPath = folder.directory( "data" ).getAbsolutePath();
+        File dbPath = folder.directory( "data" );
         outputFile = folder.file( "metrics.csv" );
         db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( dbPath ).
-                setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE ).
+                setConfig( MetricsSettings.neoEnabled, Settings.TRUE ).
                 setConfig( csvEnabled, Settings.TRUE ).
                 setConfig( csvFile, single.name() ).
                 setConfig( csvPath, outputFile.getAbsolutePath() ).newGraphDatabase();


### PR DESCRIPTION
The default configuration is sub-optimal since the metrics are enabled
by default and hence collecting all the data, but there are no
reporters (e.g., CSV, Ganglia, Graphite) enabled by default hence we
basically collect data that will never been read.  This change will
disable everything in the metrics extension in order to solve this
problem.
