### PR TITLE
Provide proper error message for invalid CREATE

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/commands/PatternConverters.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/commands/PatternConverters.scala
@@ -26,6 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.{expressions => commande
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.UnNamedNameGenerator
 import org.neo4j.cypher.internal.frontend.v3_0.{SemanticDirection, SyntaxException, ast}
 import org.neo4j.helpers.ThisShouldNotHappenError
+import org.neo4j.cypher.internal.frontend.v3_0.InternalException
 
 object PatternConverters {
   implicit class PatternConverter(val pattern: ast.Pattern) extends AnyVal {
@@ -273,10 +274,10 @@ object PatternConverters {
         // Direction.{OUTGOING|BOTH}
         case _                  => (fromEnd, toEnd)
       }
-      val typeName = relationship.types match {
-        case Seq(i) => i.name
-        case _ => throw new SyntaxException(s"A single relationship type must be specified for CREATE (${relationship.position})")
-      }
+      //Semantic checking enforces types.size == 1
+      val typeName = relationship.types.headOption.map(_.name).getOrElse(
+        throw new InternalException("Expected single relationship type"))
+
       mutation.CreateRelationship(relationship.legacyName, from, to, typeName, legacyProperties)
     }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
@@ -159,11 +159,16 @@ object ClauseConverters {
       val leftIdName = IdName.fromVariable(leftNode.variable.get)
       val rightIdName = IdName.fromVariable(rightNode.variable.get)
 
+
+      //Semantic checking enforces types.size == 1
+      val relType = rel.types.headOption.getOrElse(
+        throw new InternalException("Expected single relationship type"))
+
       (Vector(
         CreateNodePattern(leftIdName, leftNode.labels, leftNode.properties),
         CreateNodePattern(rightIdName, rightNode.labels, rightNode.properties)
       ), Vector(CreateRelationshipPattern(IdName.fromVariable(rel.variable.get),
-        leftIdName, rel.types.head, rightIdName, rel.properties, rel.direction)))
+        leftIdName, relType, rightIdName, rel.properties, rel.direction)))
 
     //CREATE ()->[:R]->()-[:R]->...->()
     case RelationshipChain(left, rel, rightNode) =>

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -615,6 +615,15 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
       "HAS is no longer supported in Cypher, please use EXISTS instead (line 1, column 17 (offset: 16))")
   )
 
+  test("give a nice error message when creating a pattern with no relationship type") {
+    executeAndEnsureError("CREATE ()-->()", "A single relationship type must be specified for CREATE (line 1, column 10 (offset: 9))")
+  }
+
+  test("give a nice error message when trying to create multiple relationship types") {
+    executeAndEnsureError("CREATE ()-[:A|:B]->()",
+      "A single relationship type must be specified for CREATE (line 1, column 10 (offset: 9))")
+  }
+
   def executeAndEnsureError(query: String, expected: String, params: (String,Any)*) {
     import org.neo4j.cypher.internal.frontend.v3_0.helpers.StringHelper._
     import scala.collection.JavaConverters._


### PR DESCRIPTION
When creating a relationship without a type or when trying to create
a relationship with multiple types there should be a proper error message
just as in the rule planner.
