### PR TITLE
Document transaction key in REST response

### DIFF
--- a/community/server/src/docs/dev/rest-api/transactional.asciidoc
+++ b/community/server/src/docs/dev/rest-api/transactional.asciidoc
@@ -24,6 +24,8 @@ There has also been improvements to the serialization format.
 * Cypher queries with +USING PERIODIC COMMIT+  (see <<query-periodic-commit>>) may only be executed when creating a new transaction and immediately committing it with a single HTTP request (see <<rest-api-begin-and-commit-a-transaction-in-one-request>> for how to do that).
 * The serialization format for Cypher results is mostly the same as the <<rest-api-cypher,Cypher endpoint>>.
 However, the format for raw entities is slightly less verbose and does not include hypermedia links.
+* Whenever a request fails the transaction will be rolled back.
+By checking the result for the presence/absence of the `transaction` key you can figure out if the transaction is still open.
 --
 
 [TIP]
@@ -52,6 +54,8 @@ include::include-query-statistics.asciidoc[]
 include::return-results-in-graph-format.asciidoc[]
 
 include::handling-errors.asciidoc[]
+
+include::handling-errors-in-an-open-transaction.asciidoc[]
 
 include::transactional-status-codes.asciidoc[]
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionDocTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionDocTest.java
@@ -38,6 +38,7 @@ import org.neo4j.test.server.HTTP;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assert.assertEquals;
@@ -92,6 +93,7 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
 
         // Then
         Map<String, Object> result = jsonToMap( response.entity() );
+        assertThat(result, hasKey( "transaction" ));
         assertNoErrors( result );
     }
 
@@ -321,6 +323,29 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
     }
 
     @Test
+    @Documented("Handling errors in an open transaction\n" +
+                "\n" +
+                "Whenever there is an error in a request the server will rollback the transaction.\n" +
+                  "By inspecting the response for the presence/absence of the `transaction` key you can tell if the " +
+                 "transaction is still open")
+    public void errors_in_open_transaction() throws JsonParseException
+    {
+        // Given
+        String location = POST( getDataUri() + "transaction" ).location();
+
+        // Document
+        ResponseEntity response = gen.get()
+                .noGraph()
+                .expectedStatus( 200 )
+                .payload( quotedJson( "{ 'statements': [ { 'statement': 'This is not a valid Cypher Statement.' } ] }" ) )
+                .post( location );
+
+        // Then
+        Map<String, Object> result = jsonToMap( response.entity() );
+        assertThat(result, not(hasKey( "transaction" )));
+    }
+
+    @Test
     @Documented( "Include query statistics\n" +
                  "\n" +
                  "By setting `includeStats` to `true` for a statement, query statistics will be returned for it." )
@@ -338,14 +363,14 @@ public class TransactionDocTest extends AbstractRestFunctionalTestBase
         Map<String,Object> entity = jsonToMap( response.entity() );
         assertNoErrors( entity );
         Map<String,Object> firstResult = ((List<Map<String,Object>>) entity.get( "results" )).get( 0 );
-        
+
         assertThat( firstResult, hasKey( "stats" ) );
         Map<String,Object> stats = (Map<String,Object>) firstResult.get( "stats" );
         assertThat( (Integer) stats.get( "nodes_created" ), equalTo( 1 ) );
     }
 
-    
-    
+
+
     private void assertNoErrors( Map<String, Object> response )
     {
         assertErrors( response );


### PR DESCRIPTION
The presence of the key `transaction` in the response is currently
being used by drivers to figure out if the transaction is still open.
This is undocumented and somewhat accidental behavior, this PR adds
docs and tests around the behavior of transactions using the REST API.
