### PR TITLE
Core-edge: Exclude store_lock when deleting store.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFiles.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/storecopy/StoreFiles.java
@@ -38,7 +38,8 @@ public class StoreFiles
                     name.startsWith( "metrics" ) ||
                             name.startsWith( "raft-messages." ) ||
                             name.startsWith( "messages." ) ||
-                            name.startsWith( "raft-logs" )
+                            name.startsWith( "raft-logs" ) ||
+                            name.startsWith( "store_lock" )
             );
         }
     };


### PR DESCRIPTION
Store lock is not part of the store files. It has its own lifecycle.
