### PR TITLE
Bugfix and test for broken KernelTransaction state...

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -242,14 +242,11 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     @Override
     public void markForTermination()
     {
-        if ( !terminated )
+        if ( !terminated && !closed )
         {
             failure = true;
             terminated = true;
-            if ( !closed )
-            {
-                transactionMonitor.transactionTerminated( hasTxStateWithChanges() );
-            }
+            transactionMonitor.transactionTerminated( hasTxStateWithChanges() );
         }
     }
 


### PR DESCRIPTION
...in case Transaction#terminate() was called after Transaction#close() call.

I believe, this was introduced in #5817.

1) Javadocs clearly state that 

```
Calling {@link #terminate()} on an already closed transaction has no effect.
```

2) The test attached in this PR demonstrates that on the next construction of the `Transaction` object, which is backed by the `KernelTransaction` on which the `close() => terminate()` sequence was called, the `terminated` flag is set to `true`, hence upon the very first check the transaction will fail.

At a first glance ignoring `terminate()` call on a closed transaction seemed like an adequate thing to do. In case that's not enough, you guys will at least know about the problem :)

@tinwelint, since you are the the author of #5817, I'd like to hear your opinion on this, please.
