### PR TITLE
Add info on creating GH issues.

### DIFF
--- a/CONTRIBUTING.asciidoc
+++ b/CONTRIBUTING.asciidoc
@@ -1,0 +1,14 @@
+== Issues
+
+*GitHub issues should only be used for bug reports and feature requests.*
+
+.How to get help
+* http://stackoverflow.com/questions/tagged/neo4j[Neo4j on StackOverflow]
+* http://support.neo4j.com[Customer Support Portal]
+* Head over to http://neo4j.com/developer/contribute/ for more tips!
+
+== Pull Requests
+
+To contribute, follow the instructions in http://neo4j.com/developer/contributing-code[Contributing Code] and make sure to  send in a http://neo4j.com/developer/cla[Contributors License Agreement]!
+
+For more information, see http://neo4j.com/developer/contribute/.


### PR DESCRIPTION
I noticed that a _/CONTRIBUTING.*_ file will make GitHub hint to that file when someone is about to open an issue:

![contribution-hint](https://cloud.githubusercontent.com/assets/1732305/11454406/22b0120e-962b-11e5-830f-cb762ba379b0.png)

Thought this might be a good opportunity to state how Neo4j uses GH issues.
