### PR TITLE
Add type in the response for RUN

### DIFF
--- a/community/bolt/src/docs/dev/examples.asciidoc
+++ b/community/bolt/src/docs/dev/examples.asciidoc
@@ -28,10 +28,10 @@ Client: RUN "RETURN 1 AS num" {}
   00 13 b2 10  8f 52 45 54  55 52 4e 20  31 20 41 53
   20 6e 75 6d  a0 00 00
 
-Server: SUCCESS { "fields": ["num"] }
+Server: SUCCESS { "fields": ["num"], "type": "r" }
 
-  00 0f b1 70  a1 86 66 69  65 6c 64 73  91 83 6e 75
-  6d 00 00
+  00 16 b1 70  a2 86 66 69  65 6c 64 73  91 83 6e 75
+  6d 84 74 79  70 65 81 72  00 00
 
 Client: PULL_ALL
 
@@ -90,10 +90,10 @@ Client: PULL_ALL
   00 02 B0 3F  00 00
 
 # Server responses
-Server: SUCCESS { "fields": ["num"] }
+Server: SUCCESS { "fields": ["num"], "type": "r" }
 
-  00 0f b1 70  a1 86 66 69  65 6c 64 73  91 83 6e 75
-  6d 00 00
+  00 16 b1 70  a2 86 66 69  65 6c 64 73  91 83 6e 75
+  6d 84 74 79  70 65 81 72  00 00
 
 Server: RECORD [1]
 
@@ -103,10 +103,10 @@ Server: SUCCESS { "type": "r" }
 
   00 0A B1 70  A1 84 74 79  70 65 81 72  00 00
 
-Server: SUCCESS { "fields": ["num"] }
+Server: SUCCESS { "fields": ["num"], "type": "r" }
 
-  00 0f b1 70  a1 86 66 69  65 6c 64 73  91 83 6e 75
-  6d 00 00
+  00 16 b1 70  a2 86 66 69  65 6c 64 73  91 83 6e 75
+  6d 84 74 79  70 65 81 72  00 00
 
 Server: RECORD [1]
 
@@ -192,10 +192,10 @@ Client: RUN "RETURN 1 AS num" {}
   00 13 b2 10  8f 52 45 54  55 52 4e 20  31 20 41 53
   20 6e 75 6d  a0 00 00
 
-Server: SUCCESS { "fields": ["num"] }
+Server: SUCCESS { "fields": ["num"], "type": "r" }
 
-  00 0f b1 70  a1 86 66 69  65 6c 64 73  91 83 6e 75
-  6d 00 00
+ 00 16 B1 70  A2 86 66 69  65 6C 64 73  91 83 6E 75
+ 6D 84 74 79  70 65 81 72  00 00
 ----
 
 === Accessing basic result metadata
@@ -225,10 +225,10 @@ Client: RUN "RETURN 1 AS num" {}
   00 13 B2 10  8F 52 45 54  55 52 4E 20  31 20 41 53
   20 6E 75 6D  A0 00 00
 
-Server: SUCCESS { "fields": ["num"] }
+Server: SUCCESS { "fields": ["num"], "type": "r" }
 
-  00 0f b1 70  A1 86 66 69  65 6C 64 73  91 83 6E 75
-  6d 00 00
+  00 16 b1 70  a2 86 66 69  65 6c 64 73  91 83 6e 75
+  6d 84 74 79  70 65 81 72  00 00
 
 Client: PULL_ALL
 
@@ -250,9 +250,10 @@ Client: RUN "CREATE ()" {}
   00 0D B2 10  89 43 52 45  41 54 45 20  28 29 A0 00
   00
 
-Server: SUCCESS { "fields": [] }
+Server: SUCCESS { "fields": [], "type": "w" }
 
-  00 0B B1 70  A1 86 66 69  65 6C 64 73  90 00 00
+  00 12 B1 70  A2 86 66 69  65 6C 64 73  90 84 74 79
+  70 65 81 77  00 00
 
 Client: PULL_ALL
 
@@ -297,9 +298,10 @@ Client: RUN "EXPLAIN RETURN 1 AS num" {}
   00 1C B2 10  D0 17 45 58  50 4C 41 49  4E 20 52 45
   54 55 52 4E  20 31 20 41  53 20 6E 75  6D A0 00 00
 
-Server: SUCCESS { "fields": [] }
+Server: SUCCESS { "fields": [], "type": "r" }
 
-  00 0B B1 70  A1 86 66 69  65 6C 64 73  90 00 00
+  00 12 B1 70  A2 86 66 69  65 6C 64 73  90 84 74 79
+  70 65 81 72  00 00
 
 Client: PULL_ALL
 
@@ -359,10 +361,10 @@ Client: RUN "PROFILE RETURN 1 AS num" {}
   00 1C B2 10  D0 17 50 52  4F 46 49 4C  45 20 52 45
   54 55 52 4E  20 31 20 41  53 20 6E 75  6D A0 00 00
 
-Server: SUCCESS { "fields": ["num"] }
+Server: SUCCESS { "fields": ["num"], "type": "r" }
 
-  00 0f b1 70  a1 86 66 69  65 6c 64 73  91 83 6e 75
-  6d 00 00
+  00 16 b1 70  a2 86 66 69  65 6c 64 73  91 83 6e 75
+  6d 84 74 79  70 65 81 72  00 00
 
 Client: PULL_ALL
 
@@ -438,7 +440,7 @@ Server: SUCCESS {
 ----
 === Accessing notifications
 When Neo4j executes a statement it may include notifications for the user.
-These notifications can be warnings about problematic statements or other valuable information for a client. 
+These notifications can be warnings about problematic statements or other valuable information for a client.
 Unlike failures or errors, notifications do not affect the execution of a statement.
 
 .Notifications
@@ -463,9 +465,10 @@ Client: RUN "EXPLAIN MATCH (n), (m) RETURN n, m" {}
   54 43 48 20  28 6E 29 2C  20 28 6D 29  20 52 45 54
   55 52 4E 20  6E 2C 20 6D  A0 00 00
 
-Server: SUCCESS { "fields": [] }
+Server: SUCCESS { "fields": [], "type": "r" }
 
-  00 0B B1 70  A1 86 66 69  65 6C 64 73  90 00 00
+  00 12 B1 70  A2 86 66 69  65 6C 64 73  90 84 74 79
+  70 65 81 72  00 00
 
 Client: PULL_ALL
 

--- a/community/bolt/src/docs/dev/messaging.asciidoc
+++ b/community/bolt/src/docs/dev/messaging.asciidoc
@@ -120,9 +120,10 @@ If successful, the subsequent response will consist of a single `SUCCESS` messag
 A successful job will always produce a result stream which must then be explicitly consumed (via `PULL_ALL` or `DISCARD_ALL`), even if empty.
 
 Depending on the statement you are executing, additional metadata may be returned in both the `SUCCESS` message from the `RUN`, as well as in the final `SUCCESS` after the stream has been consumed.
-It is up to the statement you are running to determine what meta data to return.
-Notably, most queries will contain a 'fields' metadata section in the `SUCCESS` message for the `RUN` statement, which lists the result record field names.
-We list further examples of meta data in the <<bolt-examples,examples section>>.
+It is up to the statement you are running to determine what metadata to return.
+Notably, all queries will contain a `fields` and a `type` metadata section in the `SUCCESS` message for the `RUN` statement.
+The `fields` section lists the result record field names and `type` describes the type of query; `r` (`read`), `w` (`write`), or `rw` (`read/write`).
+We list further examples of metadata in the <<bolt-examples,examples section>>.
 
 In the case where a previous result stream has not yet been fully consumed, an attempt to `RUN` a new job will trigger a `FAILURE` response.
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/RunCallback.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/RunCallback.java
@@ -38,6 +38,10 @@ public class RunCallback extends MessageProcessingCallback<StatementMetadata>
     public void result( StatementMetadata result, Void none ) throws Exception
     {
         successMetadata.put( "fields", result.fieldNames() );
+        if ( !result.queryType().isEmpty() )
+        {
+            successMetadata.put( "type", result.queryType() );
+        }
     }
 
     @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/StatementMetadata.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/StatementMetadata.java
@@ -26,4 +26,5 @@ package org.neo4j.bolt.v1.runtime;
 public interface StatementMetadata
 {
     String[] fieldNames();
+    String queryType();
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/CypherAdapterStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/CypherAdapterStream.java
@@ -37,6 +37,7 @@ public class CypherAdapterStream implements RecordStream
 {
     private final Result delegate;
     private final String[] fieldNames;
+    private final String queryType;
     private CypherAdapterRecord currentRecord;
 
     public CypherAdapterStream( Result delegate )
@@ -44,6 +45,7 @@ public class CypherAdapterStream implements RecordStream
         this.delegate = delegate;
         this.fieldNames = delegate.columns().toArray( new String[delegate.columns().size()] );
         this.currentRecord = new CypherAdapterRecord( fieldNames );
+        this.queryType = queryTypeCode( delegate.getQueryExecutionType().queryType() );
     }
 
     @Override
@@ -56,6 +58,12 @@ public class CypherAdapterStream implements RecordStream
     public String[] fieldNames()
     {
         return fieldNames;
+    }
+
+    @Override
+    public String queryType()
+    {
+        return queryType;
     }
 
     @Override
@@ -72,7 +80,7 @@ public class CypherAdapterStream implements RecordStream
         } );
 
         QueryExecutionType qt = delegate.getQueryExecutionType();
-        visitor.addMetadata( "type", queryTypeCode( qt.queryType() ) );
+        visitor.addMetadata( "type", queryType );
 
         if ( delegate.getQueryStatistics().containsUpdates() )
         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
@@ -396,6 +396,12 @@ public class SessionStateMachine implements Session, SessionState
         {
             return currentResult.fieldNames();
         }
+
+        @Override
+        public String queryType()
+        {
+            return currentResult.queryType();
+        }
     };
 
     /** The current session state */

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/RecordStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/spi/RecordStream.java
@@ -30,6 +30,10 @@ public interface RecordStream extends AutoCloseable
     /** Positional names for all fields in every record of this stream. */
     String[] fieldNames();
 
+    /** Query type one on r (read), w (write) or rw (read-write). */
+    String queryType();
+
+
     void accept( Visitor visitor ) throws Exception;
 
     @Override
@@ -48,6 +52,7 @@ public interface RecordStream extends AutoCloseable
     RecordStream EMPTY = new RecordStream()
     {
         private final String[] nothing = new String[0];
+        private final String emptySting = "";
 
         @Override
         public void close()
@@ -59,6 +64,12 @@ public interface RecordStream extends AutoCloseable
         public String[] fieldNames()
         {
             return nothing;
+        }
+
+        @Override
+        public String queryType()
+        {
+            return emptySting;
         }
 
         @Override

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/CypherStatementRunnerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/CypherStatementRunnerTest.java
@@ -21,6 +21,7 @@ package org.neo4j.bolt.v1.runtime.internal;
 
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.QueryExecutionType;
 import org.neo4j.graphdb.Result;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 
@@ -44,7 +45,10 @@ public class CypherStatementRunnerTest
     public void shouldCreateImplicitTxIfNoneExists() throws Exception
     {
         // Given
-        when( db.execute( anyString(), anyMap() ) ).thenReturn( mock( Result.class ) );
+        Result result = mock( Result.class );
+        when( result.getQueryExecutionType() )
+                .thenReturn( QueryExecutionType.profiled( QueryExecutionType.QueryType.READ_ONLY ) );
+        when( db.execute( anyString(), anyMap() ) ).thenReturn( result );
         when( engine.isPeriodicCommit( anyString() ) ).thenReturn( false );
         when( ctx.hasTransaction() ).thenReturn( false );
 
@@ -66,10 +70,12 @@ public class CypherStatementRunnerTest
     public void shouldNotCreateImplicitTxIfUsingPeriodicCommit() throws Exception
     {
         // Given
-        when( db.execute( anyString(), anyMap() ) ).thenReturn( mock( Result.class ) );
+        Result result = mock( Result.class );
+        when( result.getQueryExecutionType() )
+                .thenReturn( QueryExecutionType.profiled( QueryExecutionType.QueryType.READ_ONLY ) );
+        when( db.execute( anyString(), anyMap() ) ).thenReturn( result );
         when( engine.isPeriodicCommit( anyString() ) ).thenReturn( true );
         when( ctx.hasTransaction() ).thenReturn( false );
-
         CypherStatementRunner cypherRunner = new CypherStatementRunner( db, engine );
 
         // When

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/ConcurrentAccessIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/ConcurrentAccessIT.java
@@ -150,15 +150,15 @@ public class ConcurrentAccessIT
                 assertThat( client, eventuallyRecieves(
                         msgSuccess( map( "fields", asList() ) ),
                         msgSuccess(),
-                        msgSuccess( map( "fields", asList() ) ),
+                        msgSuccess( map( "fields", asList(), "type", "w" ) ),
                         msgSuccess(),
-                        msgSuccess( map( "fields", asList() ) ),
+                        msgSuccess( map( "fields", asList()) ),
                         msgSuccess()) );
 
                 // Verify no visible data
                 client.send( matchAll );
                 assertThat( client, eventuallyRecieves(
-                        msgSuccess( map( "fields", asList( "n" ) ) ),
+                        msgSuccess( map( "fields", asList( "n" ), "type", "r" ) ),
                         msgSuccess() ) );
 
             }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
@@ -125,7 +125,7 @@ public class TransportSessionIT
         assertThat( client, eventuallyRecieves( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyRecieves(
                 msgSuccess(),
-                msgSuccess( map( "fields", asList( "a", "a_squared" ) ) ),
+                msgSuccess( map( "fields", asList( "a", "a_squared" ), "type", "r") ),
                 msgRecord( eqRecord( equalTo( 1l ), equalTo( 1l ) ) ),
                 msgRecord( eqRecord( equalTo( 2l ), equalTo( 4l ) ) ),
                 msgRecord( eqRecord( equalTo( 3l ), equalTo( 9l ) ) ),


### PR DESCRIPTION
Instead of only return `type: [r,w,rw]` in response to
`PULL_ALL` also include it in the response of `RUN`.
