### PR TITLE
Core-Edge: Make log shipping parameters configurable.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
@@ -58,6 +58,8 @@ public class RaftInstanceBuilder<MEMBER>
     private long leaderWaitTimeout = 10000;
     private long catchupTimeout = 30000;
     private long retryTimeMillis = electionTimeout/2;
+    private int catchupBatchSize = 64;
+    private int maxAllowedShippingLag = 256;
 
     public RaftInstanceBuilder( MEMBER member, int expectedClusterSize, RaftGroup.Builder<MEMBER> memberSetBuilder )
     {
@@ -70,7 +72,7 @@ public class RaftInstanceBuilder<MEMBER>
     {
         LocalReplicator<MEMBER,MEMBER> localReplicator = new LocalReplicator<>( member, member, outbound );
         RaftMembershipManager<MEMBER> membershipManager = new RaftMembershipManager<>( localReplicator, memberSetBuilder, raftLog, logProvider, expectedClusterSize, electionTimeout, clock, catchupTimeout );
-        RaftLogShippingManager<MEMBER> logShipping = new RaftLogShippingManager<>( outbound, logProvider, raftLog, clock, member, membershipManager, retryTimeMillis );
+        RaftLogShippingManager<MEMBER> logShipping = new RaftLogShippingManager<>( outbound, logProvider, raftLog, clock, member, membershipManager, retryTimeMillis, catchupBatchSize, maxAllowedShippingLag );
 
         return new RaftInstance<>( member, termStore, voteStore, raftLog, electionTimeout, heartbeatInterval,
                 timeoutService, inbound, outbound, leaderWaitTimeout, logProvider, membershipManager, logShipping );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipper.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipper.java
@@ -42,8 +42,6 @@ import static org.neo4j.coreedge.raft.TimeoutService.*;
 // TODO: Maximum bound on size of batch in bytes, not just entry count.
 
 // Production ready
-// TODO: Make configuration configurable (batch size, outstanding, retry time).
-
 // TODO: Replace sender service with something more appropriate. No need for queue and multiplex capability, in fact is it bad to have?
 //  TODO Should we drop messages to unconnected channels instead? Use UDP? Because we are not allowed to go below a certain cluster size (safety)
 //  TODO then leader will keep trying to replicate to gone members, thus queuing things up is hurtful.
@@ -86,9 +84,6 @@ public class RaftLogShipper<MEMBER>
         PIPELINE
     }
 
-    public static final int MAX_BATCH_SIZE = 16;
-    public static final int MAX_OUTSTANDING = 64;
-
     private final Outbound<MEMBER> outbound;
     private final Log log;
     private final ReadableRaftLog raftLog;
@@ -100,6 +95,8 @@ public class RaftLogShipper<MEMBER>
     private ScheduledTimeoutService timeoutService;
     private final TimeoutName timeoutName = () -> "RESEND";
     private final long retryTimeMillis;
+    private final int catchupBatchSize;
+    private final int maxAllowedShippingLag;
     private Timeout timeout;
 
     private long timeoutAbsoluteMillis;
@@ -112,9 +109,11 @@ public class RaftLogShipper<MEMBER>
     private Mode mode = Mode.MISMATCH;
 
     public RaftLogShipper( Outbound<MEMBER> outbound, LogProvider logProvider, ReadableRaftLog raftLog, Clock clock, MEMBER leader, MEMBER follower,
-                           long leaderTerm, long leaderCommit, long retryTimeMillis )
+                           long leaderTerm, long leaderCommit, long retryTimeMillis, int catchupBatchSize, int maxAllowedShippingLag )
     {
         this.outbound = outbound;
+        this.catchupBatchSize = catchupBatchSize;
+        this.maxAllowedShippingLag = maxAllowedShippingLag;
         this.log = logProvider.getLog( getClass() );
         this.raftLog = raftLog;
         this.clock = clock;
@@ -245,7 +244,7 @@ public class RaftLogShipper<MEMBER>
         case PIPELINE:
             while( lastSentIndex <= prevLogIndex )
             {
-                if ( prevLogIndex - matchIndex <= MAX_OUTSTANDING )
+                if ( prevLogIndex - matchIndex <= maxAllowedShippingLag )
                 {
                     sendNewEntry( prevLogIndex, prevLogTerm, newLogEntry, leaderContext ); // all sending functions update lastSentIndex
                 }
@@ -357,7 +356,7 @@ public class RaftLogShipper<MEMBER>
 
         if ( lastIndex > matchIndex )
         {
-            long endIndex = min( lastIndex, matchIndex + MAX_BATCH_SIZE );
+            long endIndex = min( lastIndex, matchIndex + catchupBatchSize );
 
             scheduleTimeout( retryTimeMillis );
             sendRange( matchIndex + 1, endIndex, leaderContext );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
@@ -83,6 +83,14 @@ public class CoreEdgeClusterSettings
     public static final Setting<Long> leader_wait_timeout =
             setting( "core_edge.leader_wait_timeout", DURATION, "30s" );
 
+    @Description( "The maximum batch size when catching up (in unit of entries)" )
+    public static final Setting<Integer> catchup_batch_size =
+            setting( "core_edge.catchup_batch_size", INTEGER, "64" );
+
+    @Description( "The maximum lag allowed before log shipping pauses (in unit of entries)" )
+    public static final Setting<Integer> log_shipping_max_lag  =
+            setting( "core_edge.log_shipping_max_lag", INTEGER, "256" );
+
     @Description( "Expected size of core cluster" )
     public static final Setting<Integer> expected_core_cluster_size =
             setting( "core_edge.expected_core_cluster_size", INTEGER, "3" );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -335,7 +335,8 @@ public class EnterpriseCoreEditionModule
                 logProvider, expectedClusterSize, electionTimeout, SYSTEM_CLOCK, config.get( CoreEdgeClusterSettings.join_catch_up_timeout ) );
 
         RaftLogShippingManager<CoreMember> logShipping = new RaftLogShippingManager<>( new RaftOutbound( outbound ), logProvider, raftLog,
-                SYSTEM_CLOCK, myself, raftMembershipManager, electionTimeout );
+                SYSTEM_CLOCK, myself, raftMembershipManager, electionTimeout, config.get( CoreEdgeClusterSettings.catchup_batch_size ),
+                config.get( CoreEdgeClusterSettings.log_shipping_max_lag ) );
 
         RaftInstance<CoreMember> raftInstance = new RaftInstance<>(
                 myself, termStore, voteStore, raftLog, electionTimeout, heartbeatInterval,

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipperTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipperTest.java
@@ -52,6 +52,8 @@ public class RaftLogShipperTest
     long leaderTerm;
     long leaderCommit;
     long retryTimeMillis;
+    int catchupBatchSize = 64;
+    int maxAllowedShippingLag = 256;
 
     RaftLogShipper<RaftTestMember> logShipper;
 
@@ -87,7 +89,8 @@ public class RaftLogShipperTest
     public void startLogShipper()
     {
         logShipper = new RaftLogShipper<>( outbound, NullLogProvider.getInstance(), raftLog,
-                clock, leader, follower, leaderTerm, leaderCommit, retryTimeMillis );
+                clock, leader, follower, leaderTerm, leaderCommit, retryTimeMillis,
+                catchupBatchSize, maxAllowedShippingLag );
         logShipper.start();
     }
 
@@ -222,7 +225,7 @@ public class RaftLogShipperTest
     public void shouldSendAllEntriesAndCatchupCompletely() throws Throwable
     {
         // given
-        final int ENTRY_COUNT = RaftLogShipper.MAX_BATCH_SIZE * 10;
+        final int ENTRY_COUNT = catchupBatchSize * 10;
         Collection<RaftLogEntry> entries = new ArrayList<>();
         for ( int i = 0; i < ENTRY_COUNT; i++ )
         {


### PR DESCRIPTION
Makes the maximum batch size and lag when shipping logs configurable.
Also changes the defaults to 64 in a batch, and maximum 256 in lag.
