### PR TITLE
Enable the use of enterprise edition from `neo4j-shell -path ...`

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseFactory.java
@@ -197,4 +197,9 @@ public class GraphDatabaseFactory
         getCurrentState().setMonitors( monitors );
         return this;
     }
+
+    public String getEdition()
+    {
+        return "Community";
+    }
 }

--- a/community/shell/src/main/java/org/neo4j/shell/ShellLobby.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellLobby.java
@@ -28,6 +28,7 @@ import org.neo4j.shell.impl.SimpleAppServer;
 import org.neo4j.shell.impl.RemoteClient;
 import org.neo4j.shell.impl.RmiLocation;
 import org.neo4j.shell.impl.SameJvmClient;
+import org.neo4j.shell.impl.SystemOutput;
 
 /**
  * A convenience class for creating servers clients as well as finding remote
@@ -95,7 +96,24 @@ public abstract class ShellLobby
     public static ShellClient newClient( ShellServer server, Map<String, Serializable> initialSession,
                                          CtrlCHandler signalHandler ) throws ShellException
     {
-        return new SameJvmClient( initialSession, server, signalHandler );
+        return newClient( server, initialSession, new SystemOutput(), signalHandler );
+    }
+
+    /**
+     * Creates a client and "starts" it, i.e. grabs the console prompt.
+     * @param server the server (in the same JVM) which the client will
+     * communicate with.
+     * @param initialSession the initial session variables the shell will have,
+     * in addition to those provided by the server initially.
+     * @param output the output to write to.
+     * @param signalHandler the ctrl-c handler to use
+     * @throws ShellException if the execution fails
+     * @return the new shell client.
+     */
+    public static ShellClient newClient( ShellServer server, Map<String, Serializable> initialSession,
+                                         Output output, CtrlCHandler signalHandler ) throws ShellException
+    {
+        return new SameJvmClient( initialSession, server, output, signalHandler );
     }
 	
     /**

--- a/community/shell/src/main/java/org/neo4j/shell/StartClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/StartClient.java
@@ -35,7 +35,9 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.helpers.Args;
+import org.neo4j.kernel.Version;
 import org.neo4j.shell.impl.RmiLocation;
 import org.neo4j.shell.impl.ShellBootstrap;
 import org.neo4j.shell.impl.SimpleAppServer;
@@ -52,6 +54,11 @@ import static org.neo4j.kernel.impl.util.Charsets.UTF_8;
 public class StartClient
 {
     private AtomicBoolean hasBeenShutdown = new AtomicBoolean();
+
+    /**
+     * Prints the version and edition of neo4j and exits.
+     */
+    public static final String ARG_VERSION = "version";
 
     /**
      * The path to the local (this JVM) {@link GraphDatabaseService} to
@@ -109,12 +116,14 @@ public class StartClient
      */
     public static final String ARG_CONFIG = "config";
 
+    private final GraphDatabaseFactory factory;
     private final PrintStream out;
     private final PrintStream err;
 
     // Visible for testing
     StartClient( PrintStream out, PrintStream err )
     {
+        this.factory = loadEditionDatabaseFactory();
         this.out = out;
         this.err = err;
     }
@@ -141,6 +150,21 @@ public class StartClient
         }
     }
 
+    private static GraphDatabaseFactory loadEditionDatabaseFactory()
+    {
+        GraphDatabaseFactory factory;
+        try
+        {
+            factory = (GraphDatabaseFactory) Class.forName( "org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory" )
+                    .newInstance();
+        }
+        catch ( Exception e )
+        {
+            factory = new GraphDatabaseFactory();
+        }
+        return factory;
+    }
+
     // visible for testing
     void start( String[] arguments, CtrlCHandler signalHandler )
     {
@@ -156,8 +180,13 @@ public class StartClient
         String port = args.get( ARG_PORT, null );
         String name = args.get( ARG_NAME, null );
         String pid = args.get( ARG_PID, null );
+        boolean version = args.getBoolean( ARG_VERSION, false, true );
 
-        if ( (path != null && (port != null || name != null || host != null || pid != null))
+        if ( version )
+        {
+            out.printf( "Neo4j %s, version %s", factory.getEdition(), Version.getKernelVersion() );
+        }
+        else if ( (path != null && (port != null || name != null || host != null || pid != null))
              || (pid != null && host != null) )
         {
             err.println( "You have supplied both " +
@@ -279,7 +308,7 @@ public class StartClient
     protected GraphDatabaseShellServer getGraphDatabaseShellServer( String dbPath, boolean readOnly, String configFile )
             throws RemoteException
     {
-        return new GraphDatabaseShellServer( dbPath, readOnly, configFile );
+        return new GraphDatabaseShellServer( factory, dbPath, readOnly, configFile );
     }
 
     private void shutdownIfNecessary( ShellServer server )

--- a/community/shell/src/main/java/org/neo4j/shell/StartClient.java
+++ b/community/shell/src/main/java/org/neo4j/shell/StartClient.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.Version;
 import org.neo4j.shell.impl.RmiLocation;
 import org.neo4j.shell.impl.ShellBootstrap;
 import org.neo4j.shell.impl.SimpleAppServer;
+import org.neo4j.shell.impl.SystemOutput;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 
 import static org.neo4j.io.fs.FileUtils.newBufferedFileReader;
@@ -299,7 +300,8 @@ public class StartClient
         {
             out.println( "NOTE: Local Neo4j graph database service at '" + dbPath + "'" );
         }
-        ShellClient client = ShellLobby.newClient( server, getSessionVariablesFromArgs( args ), signalHandler );
+        ShellClient client = ShellLobby.newClient( server, getSessionVariablesFromArgs( args ),
+                new SystemOutput( out ), signalHandler );
         grabPromptOrJustExecuteCommand( client, args );
 
         shutdownIfNecessary( server );

--- a/community/shell/src/main/java/org/neo4j/shell/impl/SystemOutput.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/SystemOutput.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.shell.impl;
 
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.neo4j.shell.Output;
 
@@ -35,13 +35,14 @@ public class SystemOutput implements Output
 {
 	private PrintWriter out;
 
-    public SystemOutput() {
-        try {
-            out = new PrintWriter(new OutputStreamWriter(System.out,"UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            System.err.println("Unsupported encoding UTF-8, using "+Charset.defaultCharset()+", error: "+e.getMessage());
-            out = new PrintWriter(new OutputStreamWriter(System.out, Charset.defaultCharset()));
-        }
+    public SystemOutput()
+    {
+        this( System.out );
+    }
+
+    public SystemOutput( OutputStream out )
+    {
+        this.out = new PrintWriter( new OutputStreamWriter( out, StandardCharsets.UTF_8 ) );
     }
 
     public void print( Serializable object )

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
@@ -63,7 +63,14 @@ public class GraphDatabaseShellServer extends AbstractAppServer
     public GraphDatabaseShellServer( String path, boolean readOnly, String configFileOrNull )
             throws RemoteException
     {
-        this( instantiateGraphDb( path, readOnly, configFileOrNull ), readOnly );
+        this( instantiateGraphDb( new GraphDatabaseFactory(), path, readOnly, configFileOrNull ), readOnly );
+        this.graphDbCreatedHere = true;
+    }
+
+    public GraphDatabaseShellServer( GraphDatabaseFactory factory, String path, boolean readOnly, String configFileOrNull )
+            throws RemoteException
+    {
+        this( instantiateGraphDb(  factory, path, readOnly, configFileOrNull ), readOnly );
         this.graphDbCreatedHere = true;
     }
 
@@ -190,10 +197,10 @@ public class GraphDatabaseShellServer extends AbstractAppServer
         }
     }
 
-    private static GraphDatabaseAPI instantiateGraphDb( String path, boolean readOnly,
-                                                        String configFileOrNull )
+    private static GraphDatabaseAPI instantiateGraphDb( GraphDatabaseFactory factory, String path, boolean readOnly,
+            String configFileOrNull )
     {
-        GraphDatabaseBuilder builder = new GraphDatabaseFactory().
+        GraphDatabaseBuilder builder = factory.
                 newEmbeddedDatabaseBuilder( path ).
                 setConfig( GraphDatabaseSettings.read_only, Boolean.toString( readOnly ) );
         if ( configFileOrNull != null )

--- a/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
@@ -42,7 +42,9 @@ import org.neo4j.test.SuppressOutput;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyMap;
@@ -170,6 +172,25 @@ public class StartClientTest
 
         // verify
         verify( databaseShellServer ).shutdown();
+    }
+
+    @Test
+    public void shouldPrintVersionAndExit() throws Exception
+    {
+        // given
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        CtrlCHandler ctrlCHandler = mock( CtrlCHandler.class );
+        StartClient client = new StartClient(
+                new PrintStream( out ), new PrintStream( err ) );
+
+        // when
+        client.start( new String[]{"-version"}, ctrlCHandler );
+
+        // then
+        assertEquals( 0, err.size() );
+        String version = out.toString();
+        assertThat( version, startsWith( "Neo4j Community, version " ) );
     }
 
     private String runAndCaptureOutput( String[] arguments )

--- a/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
@@ -175,6 +175,25 @@ public class StartClientTest
     }
 
     @Test
+    public void shouldReportEditionThroughDbInfoApp() throws Exception
+    {
+        // given
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        CtrlCHandler ctrlCHandler = mock( CtrlCHandler.class );
+        StartClient client = new StartClient(
+                new PrintStream( out ), new PrintStream( err ) );
+
+        // when
+        client.start( new String[]{"-path", db.getGraphDatabaseAPI().getStoreDir(),
+                "-c", "dbinfo -g Configuration edition"}, ctrlCHandler );
+
+        // then
+        assertEquals( 0, err.size() );
+        assertThat( out.toString(), containsString( "\"edition\": \"Community\"" ) );
+    }
+
+    @Test
     public void shouldPrintVersionAndExit() throws Exception
     {
         // given

--- a/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/graphdb/factory/HighlyAvailableGraphDatabaseFactory.java
@@ -61,6 +61,12 @@ public class HighlyAvailableGraphDatabaseFactory extends GraphDatabaseFactory
         };
     }
 
+    @Override
+    public String getEdition()
+    {
+        return "Enterprise";
+    }
+
     /**
      * @deprecated By using
      *             {@link HighlyAvailableGraphDatabaseFactory#newEmbeddedDatabase(String)}

--- a/enterprise/kernel/pom.xml
+++ b/enterprise/kernel/pom.xml
@@ -145,6 +145,12 @@
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-jmx</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
       <artifactId>neo4j-io</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/enterprise/kernel/src/main/java/org/neo4j/graphdb/factory/EnterpriseGraphDatabaseFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/graphdb/factory/EnterpriseGraphDatabaseFactory.java
@@ -42,4 +42,10 @@ public class EnterpriseGraphDatabaseFactory extends GraphDatabaseFactory
             }
         };
     }
+
+    @Override
+    public String getEdition()
+    {
+        return "Enterprise";
+    }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/EnterpriseVersionTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/EnterpriseVersionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.shell;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class EnterpriseVersionTest
+{
+    @Test
+    public void shouldPrintVersionAndExit() throws Exception
+    {
+        // given
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        CtrlCHandler ctrlCHandler = mock( CtrlCHandler.class );
+        StartClient client = new StartClient( new PrintStream( out ), new PrintStream( err ) );
+
+        // when
+        client.start( new String[]{"-version"}, ctrlCHandler );
+
+        // then
+        assertEquals( 0, err.size() );
+        String version = out.toString();
+        assertThat( version, startsWith( "Neo4j Enterprise, version " ) );
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/shell/EnterpriseVersionTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/shell/EnterpriseVersionTest.java
@@ -22,15 +22,23 @@ package org.neo4j.shell;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
+import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.test.TargetDirectory;
+
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.neo4j.test.TargetDirectory.testDirForTest;
 
 public class EnterpriseVersionTest
 {
+    @Rule
+    public final TargetDirectory.TestDirectory dir = testDirForTest( EnterpriseVersionTest.class );
+
     @Test
     public void shouldPrintVersionAndExit() throws Exception
     {
@@ -47,5 +55,23 @@ public class EnterpriseVersionTest
         assertEquals( 0, err.size() );
         String version = out.toString();
         assertThat( version, startsWith( "Neo4j Enterprise, version " ) );
+    }
+
+    @Test
+    public void shouldReportEditionThroughDbInfoApp() throws Exception
+    {
+        // given
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        CtrlCHandler ctrlCHandler = mock( CtrlCHandler.class );
+        StartClient client = new StartClient( new PrintStream( out ), new PrintStream( err ) );
+
+        // when
+        client.start( new String[]{"-path", dir.absolutePath(),
+                "-c", "dbinfo -g Configuration edition"}, ctrlCHandler );
+
+        // then
+        assertEquals( 0, err.size() );
+        assertThat( out.toString(), containsString( "\"edition\": \"Enterprise\"" ) );
     }
 }


### PR DESCRIPTION
The shell (when used as `neo4j-shell -path ...`) always used a community `GraphDatabaseFactory` for starting the database, this meant that it would be unable to open a database that made use of Property Existence Constraints.

This pull request also adds the ability to tell:
1. which version and edition of Neo4j the shell command belongs to (`neo4j-shell -version`), and
2. which edition of Neo4j is running for the database the shell is connected to (through the `dbinfo` command)
