### PR TITLE
Set store high id in `end` instead of `apply` in HighIdTransactionApplier

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommandApplierFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CommandApplierFacade.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.impl.index.IndexCommand.CreateCommand;
 import org.neo4j.kernel.impl.index.IndexCommand.DeleteCommand;
 import org.neo4j.kernel.impl.index.IndexCommand.RemoveCommand;
 import org.neo4j.kernel.impl.index.IndexDefineCommand;
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.command.Command.LabelTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.NeoStoreCommand;
@@ -52,11 +53,11 @@ public class CommandApplierFacade implements CommandHandler, Visitor<Command,IOE
     }
 
     @Override
-    public void begin( TransactionToApply tx ) throws IOException
+    public void begin( TransactionToApply tx, LockGroup locks ) throws IOException
     {
         for ( CommandHandler handler : handlers )
         {
-            handler.begin( tx );
+            handler.begin( tx, locks );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsStoreApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsStoreApplier.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api;
 
 import java.io.IOException;
 
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.command.CommandHandler;
@@ -38,7 +39,7 @@ public class CountsStoreApplier extends CommandHandler.Adapter
     }
 
     @Override
-    public void begin( TransactionToApply transaction ) throws IOException
+    public void begin( TransactionToApply transaction, LockGroup locks ) throws IOException
     {
         countsTracker.apply( transaction.transactionId() ).map(
                 ( CountsTracker.Updater updater ) -> this.countsUpdater = updater );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LegacyIndexApplier.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.impl.index.IndexCommand.RemoveCommand;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.index.IndexDefineCommand;
 import org.neo4j.kernel.impl.index.IndexEntityType;
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.command.CommandHandler;
 import org.neo4j.kernel.impl.util.IdOrderingQueue;
 
@@ -131,7 +132,7 @@ public class LegacyIndexApplier extends CommandHandler.Adapter
     }
 
     @Override
-    public void begin( TransactionToApply transaction ) throws IOException
+    public void begin( TransactionToApply transaction, LockGroup locks ) throws IOException
     {
         if ( transaction.commitment().hasLegacyIndexChanges() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcess.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
+import org.neo4j.kernel.impl.transaction.tracing.StoreApplyEvent;
 
 import static org.neo4j.kernel.api.exceptions.Status.Transaction.CouldNotCommit;
 import static org.neo4j.kernel.api.exceptions.Status.Transaction.CouldNotWriteToLog;
@@ -131,7 +132,7 @@ public class TransactionRepresentationCommitProcess implements TransactionCommit
     private void applyToStore( TransactionToApply batch, CommitEvent commitEvent, TransactionApplicationMode mode )
             throws TransactionFailureException
     {
-        try
+        try ( StoreApplyEvent storeApplyEvent = commitEvent.beginStoreApply() )
         {
             storageEngine.apply( batch, mode );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodePropertyCommandsExtractor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodePropertyCommandsExtractor.java
@@ -28,6 +28,7 @@ import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.impl.api.TransactionToApply;
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
@@ -51,7 +52,7 @@ public class NodePropertyCommandsExtractor
     }
 
     @Override
-    public void begin( TransactionToApply transaction )
+    public void begin( TransactionToApply transaction, LockGroup locks )
     {
         nodeCommandsById.clear();
         propertyCommandsByNodeIds.clear();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RecoveryIndexingUpdatesValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/RecoveryIndexingUpdatesValidator.java
@@ -27,6 +27,7 @@ import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.TransactionToApply;
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 
 /**
@@ -61,7 +62,7 @@ public class RecoveryIndexingUpdatesValidator implements IndexUpdatesValidator, 
     public ValidatedIndexUpdates validate( TransactionRepresentation transaction ) throws IOException
     {
         // Extract updates...
-        extractor.begin( new TransactionToApply( transaction ) );
+        extractor.begin( new TransactionToApply( transaction ), new LockGroup() );
         transaction.accept( extractor );
 
         // and add them to the updates already existing in this batch.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CommandHandler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/CommandHandler.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.impl.index.IndexCommand.CreateCommand;
 import org.neo4j.kernel.impl.index.IndexCommand.DeleteCommand;
 import org.neo4j.kernel.impl.index.IndexCommand.RemoveCommand;
 import org.neo4j.kernel.impl.index.IndexDefineCommand;
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.command.Command.LabelTokenCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.NeoStoreCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
@@ -71,7 +72,7 @@ public interface CommandHandler extends AutoCloseable
     /**
      * Called before each transaction in this batch.
      */
-    void begin( TransactionToApply transaction ) throws IOException;
+    void begin( TransactionToApply transaction, LockGroup locks ) throws IOException;
 
     /**
      * Called after each transaction in this batch.
@@ -131,7 +132,7 @@ public interface CommandHandler extends AutoCloseable
     class Adapter implements CommandHandler
     {
         @Override
-        public void begin( TransactionToApply transaction ) throws IOException
+        public void begin( TransactionToApply transaction, LockGroup locks ) throws IOException
         {
         }
 
@@ -264,9 +265,9 @@ public interface CommandHandler extends AutoCloseable
         }
 
         @Override
-        public void begin( TransactionToApply transaction ) throws IOException
+        public void begin( TransactionToApply transaction, LockGroup locks ) throws IOException
         {
-            delegate.begin( transaction );
+            delegate.begin( transaction, locks );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplier.java
@@ -135,9 +135,9 @@ public class HighIdTransactionApplier extends CommandHandler.Delegator
     }
 
     @Override
-    public void apply()
+    public void end() throws Exception
     {
-        super.apply();
+        super.end();
         // Notifies the stores about the recovered ids and will bump those high ids atomically if
         // they surpass the current high ids
         for ( Map.Entry<CommonAbstractStore,HighId> highId : highIds.entrySet() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexTransactionApplier.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.impl.api.TransactionToApply;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.ValidatedIndexUpdates;
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.store.NodeLabels;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -65,7 +66,7 @@ public class IndexTransactionApplier extends CommandHandler.Adapter
     }
 
     @Override
-    public void begin( TransactionToApply transaction ) throws IOException
+    public void begin( TransactionToApply transaction, LockGroup locks ) throws IOException
     {
         indexUpdates = transaction.validatedIndexUpdates();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplier.java
@@ -46,22 +46,22 @@ public class NeoStoreTransactionApplier extends CommandHandler.Adapter
     // Ideally we don't want any cache access in here, but it is how it is. At least we try to minimize use of it
     private final CacheAccessBackDoor cacheAccess;
     private final LockService lockService;
-    private final LockGroup lockGroup;
+    private LockGroup lockGroup;
     private long transactionId;
 
     public NeoStoreTransactionApplier( NeoStores store, CacheAccessBackDoor cacheAccess,
-            LockService lockService, LockGroup lockGroup )
+            LockService lockService )
     {
         this.neoStores = store;
         this.cacheAccess = cacheAccess;
         this.lockService = lockService;
-        this.lockGroup = lockGroup;
     }
 
     @Override
-    public void begin( TransactionToApply transaction ) throws IOException
+    public void begin( TransactionToApply transaction, LockGroup locks ) throws IOException
     {
         transactionId = transaction.transactionId();
+        lockGroup = locks;
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsStoreApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/CountsStoreApplierTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.util.function.Optionals;
@@ -46,7 +47,7 @@ public class CountsStoreApplierTest
         final CountsStoreApplier applier = new CountsStoreApplier( tracker, TransactionApplicationMode.INTERNAL );
 
         // WHEN
-        applier.begin( new TransactionToApply( null, 2L ) );
+        applier.begin( new TransactionToApply( null, 2L ), new LockGroup() );
         applier.visitNodeCountsCommand( addNodeCommand() );
         applier.apply();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LegacyIndexApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LegacyIndexApplierTest.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.impl.index.IndexCommand.AddNodeCommand;
 import org.neo4j.kernel.impl.index.IndexCommand.AddRelationshipCommand;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.index.IndexDefineCommand;
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.transaction.command.CommandHandler;
 import org.neo4j.kernel.impl.transaction.log.FakeCommitment;
 import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
@@ -117,7 +118,7 @@ public class LegacyIndexApplierTest
                     FakeCommitment commitment = new FakeCommitment( txId, mock( TransactionIdStore.class ) );
                     commitment.setHasLegacyIndexChanges( true );
                     txToApply.commitment( commitment, txId );
-                    applier.begin( txToApply );
+                    applier.begin( txToApply, new LockGroup() );
                     applier.end();
                     applier.apply();
                     // Make sure threads are unordered

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/CommandHandlerContract.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/CommandHandlerContract.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.command;
+
+import org.neo4j.kernel.impl.api.CommandApplierFacade;
+import org.neo4j.kernel.impl.api.TransactionToApply;
+import org.neo4j.kernel.impl.locking.LockGroup;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+
+/**
+ * Serves as executor of transactions, i.e. the visit... methods and will invoke the other lifecycle methods
+ * like {@link CommandHandler#begin(TransactionToApply, LockGroup)}, {@link CommandHandler#end()} a.s.o correctly.
+ */
+public class CommandHandlerContract
+{
+    @FunctionalInterface
+    public interface ApplyFunction
+    {
+        boolean apply( CommandHandler applier, TransactionRepresentation tx ) throws Exception;
+    }
+
+    public static boolean apply( CommandHandler applier, TransactionToApply... transactions )
+            throws Exception
+    {
+        return apply( new CommandApplierFacade( applier ), transactions );
+    }
+
+    public static boolean apply( CommandApplierFacade applier, TransactionToApply... transactions )
+            throws Exception
+    {
+        return apply( applier, (handler,tx) -> {
+            tx.accept( applier );
+            return false;
+        }, transactions );
+    }
+
+    public static boolean apply( CommandHandler applier, ApplyFunction function, TransactionToApply... transactions )
+            throws Exception
+    {
+        boolean result = true;
+        for ( TransactionToApply tx : transactions )
+        {
+            applier.begin( tx, new LockGroup() );
+            try
+            {
+                result &= function.apply( applier, tx.transactionRepresentation() );
+            }
+            finally
+            {
+                applier.end();
+            }
+        }
+        if ( !(applier instanceof CommandApplierFacade) )
+        {
+            // This is really odd... the whole apply/close bit. CommandApplierFacade is apparently
+            // owning the call of apply itself. We'll just have to figure out why this is and then
+            // merge apply/close. We can't have it like this.
+            applier.apply();
+        }
+        applier.close();
+        return result;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplierTest.java
@@ -23,13 +23,14 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.kernel.impl.api.TransactionToApply;
+import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.PropertyType;
 import org.neo4j.test.NeoStoresRule;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.mockito.Mockito.mock;
+
 import static org.neo4j.kernel.impl.transaction.command.CommandHandler.EMPTY;
 
 public class HighIdTransactionApplierTest
@@ -44,7 +45,7 @@ public class HighIdTransactionApplierTest
         NeoStores neoStores = neoStoresRule.open();
         HighIdTransactionApplier tracker = new HighIdTransactionApplier( EMPTY, neoStores );
 
-        tracker.begin( mock( TransactionToApply.class ) );
+        tracker.begin( mock( TransactionToApply.class ), new LockGroup() );
         // WHEN
         // Nodes
         tracker.visitNodeCommand( Commands.createNode( 10, 2, 3 ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/HighIdTransactionApplierTest.java
@@ -22,12 +22,14 @@ package org.neo4j.kernel.impl.transaction.command;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.kernel.impl.api.TransactionToApply;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.PropertyType;
 import org.neo4j.test.NeoStoresRule;
 
 import static org.junit.Assert.assertEquals;
 
+import static org.mockito.Mockito.mock;
 import static org.neo4j.kernel.impl.transaction.command.CommandHandler.EMPTY;
 
 public class HighIdTransactionApplierTest
@@ -42,6 +44,7 @@ public class HighIdTransactionApplierTest
         NeoStores neoStores = neoStoresRule.open();
         HighIdTransactionApplier tracker = new HighIdTransactionApplier( EMPTY, neoStores );
 
+        tracker.begin( mock( TransactionToApply.class ) );
         // WHEN
         // Nodes
         tracker.visitNodeCommand( Commands.createNode( 10, 2, 3 ) );
@@ -74,6 +77,8 @@ public class HighIdTransactionApplierTest
         // Properties
         tracker.visitPropertyCommand( Commands.createProperty( 10, PropertyType.STRING, 0, 6, 7 ) );
         tracker.visitPropertyCommand( Commands.createProperty( 20, PropertyType.ARRAY, 1, 8, 9 ) );
+
+        tracker.end();
 
         tracker.apply();
         tracker.close();


### PR DESCRIPTION
Problem was that the se high id was set in `apply` (which is now
called at the end of a tx application batch) and the data applied
wasn't effectively available to transactions applied in the same
batch. E.g., populating an index (created in the same batch) would
have missed all the new nodes added by transactions preciding it in
the batch.
