### PR TITLE
Only use predicate locks when updating

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.{ExecutionEngineFunSuite, HintException, IndexHintException, NewPlannerTestSupport, SyntaxException}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
 
 class UniqueIndexAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
@@ -102,5 +102,48 @@ class UniqueIndexAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
 
     //THEN
     result.toList should equal (List(Map("n" -> jake)))
+  }
+
+  test("should not use unique index for read only query") {
+    //GIVEN
+    val andres = createLabeledNode(Map("name" -> "Andres"), "Person")
+    val jake = createLabeledNode(Map("name" -> "Jacob"), "Person")
+    relate(andres, createNode())
+    relate(jake, createNode())
+
+    graph.createConstraint("Person", "name")
+
+    //WHEN
+    val result = executeWithAllPlannersAndRuntimes("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN {coll} RETURN n","coll"->List("Jacob"))
+
+    //THEN
+    result should use("NodeIndexSeek")
+    result shouldNot use("NodeUniqueIndexSeek")
+  }
+
+  test("should use unique index for merge queries") {
+    //GIVEN
+    createLabeledNode(Map("name" -> "Andres"), "Person")
+    graph.createConstraint("Person", "name")
+
+    //WHEN
+    val result = updateWithBothPlanners("MERGE (n:Person {name: 'Andres'}) RETURN n.name")
+
+    //THEN
+    result shouldNot use("NodeIndexSeek")
+    result should use("NodeUniqueIndexSeek")
+  }
+
+  test("should use unique index for mixed read write queries") {
+    //GIVEN
+    createLabeledNode(Map("name" -> "Andres"), "Person")
+    graph.createConstraint("Person", "name")
+
+    //WHEN
+    val result = updateWithBothPlanners("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN {coll} SET n:Foo RETURN n.name","coll"->List("Jacob"))
+
+    //THEN
+    result shouldNot use("NodeIndexSeek")
+    result should use("NodeUniqueIndexSeek")
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/IndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/IndexSeekLeafPlanner.scala
@@ -134,7 +134,24 @@ object uniqueIndexSeekLeafPlanner extends AbstractIndexSeekLeafPlanner {
     context.planContext.getUniqueIndexRule(label, property)
 }
 
-object indexSeekLeafPlanner extends AbstractIndexSeekLeafPlanner {
+object allIndexSeekLeafPlanner extends AbstractIndexSeekLeafPlanner {
+  protected def constructPlan(idName: IdName,
+                              label: LabelToken,
+                              propertyKey: PropertyKeyToken,
+                              valueExpr: QueryExpression[Expression],
+                              hint: Option[UsingIndexHint],
+                              argumentIds: Set[IdName])
+                             (implicit context: LogicalPlanningContext): (Seq[Expression]) => LogicalPlan =
+    (predicates: Seq[Expression]) =>
+      context.logicalPlanProducer.planNodeIndexSeek(idName, label, propertyKey, valueExpr, predicates, hint, argumentIds)
+
+  protected def findIndexesFor(label: String, property: String)(implicit context: LogicalPlanningContext): Option[IndexDescriptor] = {
+    context.planContext.getIndexRule(label, property)
+  }
+}
+
+//only looks at non-unique indexes
+object nonUniqueindexSeekLeafPlanner extends AbstractIndexSeekLeafPlanner {
   protected def constructPlan(idName: IdName,
                               label: LabelToken,
                               propertyKey: PropertyKeyToken,

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningConfiguration.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningConfiguration.scala
@@ -19,12 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner
 
-import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Cost, _}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.GraphStatistics
-import org.neo4j.cypher.internal.frontend.v3_0.{SemanticTable, PropertyKeyId, LabelId}
+import org.neo4j.cypher.internal.frontend.v3_0.{LabelId, PropertyKeyId, SemanticTable}
 
 trait LogicalPlanningConfiguration {
   def updateSemanticTableWithTokens(in: SemanticTable): SemanticTable
@@ -36,6 +35,7 @@ trait LogicalPlanningConfiguration {
   def labelCardinality: Map[String, Cardinality]
   def knownLabels: Set[String]
   def qg: QueryGraph
+  def queryPlannerConfiguration: QueryPlannerConfiguration
 
   protected def mapCardinality(pf: PartialFunction[PlannerQuery, Double]): PartialFunction[PlannerQuery, Cardinality] = pf.andThen(Cardinality.apply)
 }
@@ -51,6 +51,7 @@ class DelegatingLogicalPlanningConfiguration(val parent: LogicalPlanningConfigur
   override def labelCardinality = parent.labelCardinality
   override def knownLabels = parent.knownLabels
   override def qg = parent.qg
+  override def queryPlannerConfiguration = parent.queryPlannerConfiguration
 }
 
 trait LogicalPlanningConfigurationAdHocSemanticTable {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -22,8 +22,6 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0._
-import org.neo4j.cypher.internal.compiler.v3_0.ast
-import org.neo4j.cypher.internal.compiler.v3_0.parser
 import org.neo4j.cypher.internal.compiler.v3_0.planner.execution.PipeExecutionBuilderContext
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
@@ -33,10 +31,10 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.rewriter.Lo
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, PlanContext}
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
+import org.neo4j.cypher.internal.frontend.v3_0._
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, CypherTestSupport}
-import org.neo4j.cypher.internal.frontend.v3_0._
 import org.neo4j.helpers.Clock
 
 import scala.collection.mutable
@@ -123,7 +121,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
                                       useErrorsOverWarnings: Boolean = false): LogicalPlanningContext =
     LogicalPlanningContext(planContext, LogicalPlanProducer(metrics.cardinality), metrics, semanticTable,
       strategy, QueryGraphSolverInput(Map.empty, cardinality, strictness),
-      notificationLogger = notificationLogger, useErrorsOverWarnings = useErrorsOverWarnings, config = QueryPlannerConfiguration.default)
+      notificationLogger = notificationLogger, useErrorsOverWarnings = useErrorsOverWarnings, config = QueryPlannerConfiguration.readOnly)
 
   def newMockedStatistics = mock[GraphStatistics]
   def hardcodedStatistics = HardcodedGraphStatistics

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
@@ -172,7 +172,10 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
           val unionQuery = toUnionQuery(ast, semanticTable)
           val metrics = metricsFactory.newMetrics(planContext.statistics)
           val logicalPlanProducer = LogicalPlanProducer(metrics.cardinality)
-          val context = LogicalPlanningContext(planContext, logicalPlanProducer, metrics, newTable, queryGraphSolver, QueryGraphSolverInput.empty)
+          val context = LogicalPlanningContext(planContext, logicalPlanProducer,
+            metrics, newTable, queryGraphSolver, QueryGraphSolverInput.empty,
+            devNullLogger, useErrorsOverWarnings = false,
+            config.queryPlannerConfiguration)
           val plannerQuery = unionQuery.queries.head
           val resultPlan = planner.internalPlan(plannerQuery)(context)
           SemanticPlan(resultPlan.endoRewrite(unnestApply), newTable)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/RealLogicalPlanningConfiguration.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/RealLogicalPlanningConfiguration.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner
 import org.neo4j.cypher.internal.compiler.v3_0.HardcodedGraphStatistics
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics.{QueryGraphCardinalityModel, QueryGraphSolverInput}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{CardinalityCostModel, Cost, Metrics, StatisticsBackedCardinalityModel}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{CardinalityCostModel, Cost, Metrics, QueryPlannerConfiguration, StatisticsBackedCardinalityModel}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.GraphStatistics
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticTable
 
@@ -48,6 +48,6 @@ case class RealLogicalPlanningConfiguration()
   override def uniqueIndexes = Set.empty
   override def labelCardinality = Map.empty
   override def knownLabels = Set.empty
-
   override def qg: QueryGraph = ???
+  override def queryPlannerConfiguration = QueryPlannerConfiguration.default
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/StubbedLogicalPlanningConfiguration.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/StubbedLogicalPlanningConfiguration.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{Expression, HasLabels}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics.{CardinalityModel, QueryGraphCardinalityModel, QueryGraphSolverInput}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{IdName, LogicalPlan}
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Cardinality, Cost, Selectivity}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Cardinality, Cost, QueryPlannerConfiguration, Selectivity}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.GraphStatistics
-import org.neo4j.cypher.internal.frontend.v3_0.{SemanticTable, LabelId}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{Expression, HasLabels}
+import org.neo4j.cypher.internal.frontend.v3_0.{LabelId, SemanticTable}
 
 class StubbedLogicalPlanningConfiguration(parent: LogicalPlanningConfiguration)
   extends LogicalPlanningConfiguration with LogicalPlanningConfigurationAdHocSemanticTable {
@@ -41,6 +41,7 @@ class StubbedLogicalPlanningConfiguration(parent: LogicalPlanningConfiguration)
 
   var indexes: Set[(String, String)] = Set.empty
   var uniqueIndexes: Set[(String, String)] = Set.empty
+  var queryPlannerConfiguration = QueryPlannerConfiguration.default
 
   def indexOn(label: String, property: String) {
     indexes = indexes + (label -> property)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/IndexLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/IndexLeafPlannerTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 import org.neo4j.cypher.internal.compiler.v3_0.commands.SingleQueryExpression
 import org.neo4j.cypher.internal.compiler.v3_0.planner.BeLikeMatcher._
 import org.neo4j.cypher.internal.compiler.v3_0.planner._
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.{indexSeekLeafPlanner, mergeUniqueIndexSeekLeafPlanner, uniqueIndexSeekLeafPlanner}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.{allIndexSeekLeafPlanner, mergeUniqueIndexSeekLeafPlanner, uniqueIndexSeekLeafPlanner}
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
@@ -43,7 +43,7 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
       qg = queryGraph(inCollectionValue, hasLabels)
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans shouldBe empty
@@ -70,7 +70,7 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
       indexOn("Awesome", "prop")
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans should beLike {
@@ -90,7 +90,7 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
       val x = cfg.x
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans should beLike {
@@ -107,7 +107,7 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
       indexOn("Awesome", "prop")
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans shouldBe empty
@@ -140,7 +140,7 @@ class IndexLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSuppor
       indexOn("Awesome", "prop")
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans should beLike {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/IndexSeekLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/IndexSeekLeafPlannerTest.scala
@@ -19,11 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.SingleQueryExpression
 import org.neo4j.cypher.internal.compiler.v3_0.planner.BeLikeMatcher._
 import org.neo4j.cypher.internal.compiler.v3_0.planner._
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.{indexSeekLeafPlanner, uniqueIndexSeekLeafPlanner}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.{allIndexSeekLeafPlanner, nonUniqueindexSeekLeafPlanner, uniqueIndexSeekLeafPlanner}
+import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
 import scala.language.reflectiveCalls
@@ -43,7 +43,7 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
       qg = queryGraph(inCollectionValue, hasLabels)
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans shouldBe empty
@@ -57,7 +57,7 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
       uniqueIndexOn("Awesome", "prop")
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = nonUniqueindexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans shouldBe empty
@@ -83,7 +83,7 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
       indexOn("Awesome", "prop")
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans should beLike {
@@ -102,7 +102,7 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
       val x = cfg.x
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans should beLike {
@@ -119,7 +119,7 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
       indexOn("Awesome", "prop")
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans shouldBe empty
@@ -151,7 +151,7 @@ class IndexSeekLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
       indexOn("Awesome", "prop")
     }.withLogicalPlanningContext { (cfg, ctx) =>
       // when
-      val resultPlans = indexSeekLeafPlanner(cfg.qg)(ctx)
+      val resultPlans = allIndexSeekLeafPlanner(cfg.qg)(ctx)
 
       // then
       resultPlans should beLike {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.{IndexSeekByRange, UniqueIndexSeekByRange}
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.IndexSeekByRange
 
 /**
  * These tests are testing the actual index implementation, thus they should all check the actual result.
@@ -170,7 +170,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     result should (use(IndexSeekByRange.name) and evaluateTo(List(Map("a" -> a1), Map("a" -> a2))))
   }
 
-  test("should plan a UniqueIndexSeek when constraint exists") {
+  test("should plan an IndexSeek when constraint exists") {
 
     graph.inTx {
       (1 to 100).foreach { _ =>
@@ -189,7 +189,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
 
     val result = executeWithAllPlanners("MATCH (a:Address) WHERE a.prop STARTS WITH 'www' RETURN a")
 
-    result should (use(UniqueIndexSeekByRange.name) and evaluateTo(List(Map("a" -> a1), Map("a" -> a2))))
+    result should (use(IndexSeekByRange.name) and evaluateTo(List(Map("a" -> a1), Map("a" -> a2))))
   }
 
   test("should be able to plan index seek for numerical less than") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -361,7 +361,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
 
     //THEN
     assertDbHits(7)(result)("Projection")
-    assertDbHits(1)(result)("NodeUniqueIndexSeek")
+    assertDbHits(2)(result)("NodeIndexSeek")
    }
 
   test("should show expand without types in a simple form") {


### PR DESCRIPTION
Read-only queries hitting a unique index need not be using predicate locks.
Code is now changed so that read-only queries treat unique indexes and _normal_
indexes equivalently, whereas updating query still use the locking method.
