### PR TITLE
Cypher will never produce a NaN

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/NaNAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/NaNAcceptanceTest.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.{SyntaxException, ExecutionEngineFunSuite, NewPlannerTestSupport}
+
+class NaNAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  test("square root of negative number should not produce nan") {
+    val query = "WITH sqrt(-1) AS shouldBeNull RETURN shouldBeNull"
+
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("shouldBeNull" -> null)))
+  }
+
+  test("log of negative number should not produce nan") {
+    val query = "WITH log(-1) AS shouldBeNull RETURN shouldBeNull"
+
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("shouldBeNull" -> null)))
+  }
+
+  test("log10 of negative number should not produce nan") {
+    val query = "WITH log10(-1) AS shouldBeNull RETURN shouldBeNull"
+
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("shouldBeNull" -> null)))
+  }
+
+  test("asin() outside of [-1, 1] should not produce nan") {
+    val query = "WITH asin(2) AS shouldBeNull RETURN shouldBeNull"
+
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("shouldBeNull" -> null)))
+  }
+
+  test("acos() outside of [-1, 1] should not produce nan") {
+    val query = "WITH acos(2) AS shouldBeNull RETURN shouldBeNull"
+
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("shouldBeNull" -> null)))
+  }
+
+  test("0 over 0 should not produce nan") {
+    val query = s"WITH 0.0 / 0.0 AS shouldBeNull RETURN shouldBeNull"
+
+    a [org.neo4j.cypher.ArithmeticException] should be thrownBy executeWithAllPlanners(query)
+  }
+
+  test("any other number over 0 should produce a too large number") {
+    val query = s"WITH 10.0 / 0.0 AS inf RETURN inf"
+
+    a [SyntaxException] should be thrownBy executeWithAllPlanners(query)
+  }
+
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/foldConstants.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/foldConstants.scala
@@ -74,6 +74,8 @@ case object foldConstants extends Rewriter {
     case e@Divide(lhs: SignedIntegerLiteral, rhs: DecimalDoubleLiteral) =>
       DecimalDoubleLiteral((lhs.value / rhs.value).toString)(e.position)
     case e@Divide(lhs: DecimalDoubleLiteral, rhs: DecimalDoubleLiteral) =>
+      // standard 0.0 / 0.0 produces Double.NaN
+      if (lhs.value == 0.0 && rhs.value == 0.0) throw new ArithmeticException("/ by zero")
       DecimalDoubleLiteral((lhs.value / rhs.value).toString)(e.position)
 
     case e@Modulo(lhs: SignedIntegerLiteral, rhs: SignedIntegerLiteral) =>

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/MathFunction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/MathFunction.scala
@@ -35,10 +35,15 @@ abstract class MathFunction(arg: Expression) extends Expression with NumericHelp
   def symbolTableDependencies = arg.symbolTableDependencies
 }
 
-abstract class NullSafeMathFunction(arg: Expression) extends MathFunction(arg) {
+abstract class NullAndNaNSafeMathFunction(arg: Expression) extends MathFunction(arg) {
   override def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = {
     val value = arg(ctx)
-    if (null == value) null else apply(asDouble(value))
+    if (value == null || java.lang.Double.isNaN(asDouble(value))) null
+    else {
+      val result = apply(asDouble(value))
+      if (java.lang.Double.isNaN(result)) null
+      else result
+    }
   }
 
   def apply(value: Double): Double
@@ -63,13 +68,13 @@ trait NumericHelper {
   }
 }
 
-case class AbsFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class AbsFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double): Double = Math.abs(value)
 
   def rewrite(f: (Expression) => Expression) = f(AbsFunction(argument.rewrite(f)))
 }
 
-case class AcosFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class AcosFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double): Double = Math.acos(value)
 
   def rewrite(f: (Expression) => Expression) = f(AcosFunction(argument.rewrite(f)))
@@ -77,7 +82,7 @@ case class AcosFunction(argument: Expression) extends NullSafeMathFunction(argum
   override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class AsinFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class AsinFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double): Double = Math.asin(value)
 
   def rewrite(f: (Expression) => Expression) = f(AsinFunction(argument.rewrite(f)))
@@ -85,7 +90,7 @@ case class AsinFunction(argument: Expression) extends NullSafeMathFunction(argum
   override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class AtanFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class AtanFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double): Double = Math.atan(value)
 
   def rewrite(f: (Expression) => Expression) = f(AtanFunction(argument.rewrite(f)))
@@ -112,13 +117,13 @@ case class Atan2Function(y: Expression, x: Expression) extends Expression with N
   def symbolTableDependencies = x.symbolTableDependencies ++ y.symbolTableDependencies
 }
 
-case class CeilFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class CeilFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double) = math.ceil(value)
 
   def rewrite(f: (Expression) => Expression) = f(CeilFunction(argument.rewrite(f)))
 }
 
-case class CosFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class CosFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double): Double = math.cos(value)
 
   def rewrite(f: (Expression) => Expression) = f(CosFunction(argument.rewrite(f)))
@@ -126,7 +131,7 @@ case class CosFunction(argument: Expression) extends NullSafeMathFunction(argume
   override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class CotFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class CotFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double): Double = 1.0/math.tan(value)
 
   def rewrite(f: (Expression) => Expression) = f(CotFunction(argument.rewrite(f)))
@@ -134,7 +139,7 @@ case class CotFunction(argument: Expression) extends NullSafeMathFunction(argume
   override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class DegreesFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class DegreesFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double): Double = math.toDegrees(value)
 
   def rewrite(f: (Expression) => Expression) = f(DegreesFunction(argument.rewrite(f)))
@@ -154,7 +159,7 @@ case class EFunction() extends Expression() {
   def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class ExpFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class ExpFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double): Double = math.exp(value)
 
   def rewrite(f: (Expression) => Expression) = f(ExpFunction(argument.rewrite(f)))
@@ -162,13 +167,13 @@ case class ExpFunction(argument: Expression) extends NullSafeMathFunction(argume
   override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class FloorFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class FloorFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double) =  math.floor(value)
 
   def rewrite(f: (Expression) => Expression) = f(FloorFunction(argument.rewrite(f)))
 }
 
-case class LogFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class LogFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double) = math.log(value)
 
   def rewrite(f: (Expression) => Expression) = f(LogFunction(argument.rewrite(f)))
@@ -176,7 +181,7 @@ case class LogFunction(argument: Expression) extends NullSafeMathFunction(argume
   override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class Log10Function(argument: Expression) extends NullSafeMathFunction(argument) {
+case class Log10Function(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double) = math.log10(value)
 
   def rewrite(f: (Expression) => Expression) = f(Log10Function(argument.rewrite(f)))
@@ -196,7 +201,7 @@ case class PiFunction() extends Expression {
   def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class RadiansFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class RadiansFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double) = math.toRadians(value)
 
   def rewrite(f: (Expression) => Expression) = f(RadiansFunction(argument.rewrite(f)))
@@ -204,7 +209,7 @@ case class RadiansFunction(argument: Expression) extends NullSafeMathFunction(ar
   override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class SinFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class SinFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double) = math.sin(value)
 
   def rewrite(f: (Expression) => Expression) = f(SinFunction(argument.rewrite(f)))
@@ -212,7 +217,7 @@ case class SinFunction(argument: Expression) extends NullSafeMathFunction(argume
   override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class HaversinFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class HaversinFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double) = ( 1.0d - math.cos(value) ) / 2
 
   def rewrite(f: (Expression) => Expression) = f(HaversinFunction(argument.rewrite(f)))
@@ -220,7 +225,7 @@ case class HaversinFunction(argument: Expression) extends NullSafeMathFunction(a
   override def calculateType(symbols: SymbolTable) = CTFloat
 }
 
-case class TanFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class TanFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double) = math.tan(value)
 
   def rewrite(f: (Expression) => Expression) = f(TanFunction(argument.rewrite(f)))
@@ -269,20 +274,20 @@ case class RangeFunction(start: Expression, end: Expression, step: Expression) e
     step.symbolTableDependencies
 }
 
-case class SignFunction(argument: Expression) extends NullSafeMathFunction(argument) {
+case class SignFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
   def apply(value: Double) =  Math.signum(value)
 
   def rewrite(f: (Expression) => Expression) = f(SignFunction(argument.rewrite(f)))
 }
 
-case class RoundFunction(expression: Expression) extends NullSafeMathFunction(expression) {
+case class RoundFunction(expression: Expression) extends NullAndNaNSafeMathFunction(expression) {
   def apply(value: Double) =  math.round(value)
 
   def rewrite(f: (Expression) => Expression) = f(RoundFunction(expression.rewrite(f)))
 }
 
-case class SqrtFunction(argument: Expression) extends NullSafeMathFunction(argument) {
-  def apply(value: Double) = Math.sqrt(value)
+case class SqrtFunction(argument: Expression) extends NullAndNaNSafeMathFunction(argument) {
+  def apply(value: Double) = math.sqrt(value)
 
   def rewrite(f: (Expression) => Expression) = f(SqrtFunction(argument.rewrite(f)))
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/ParameterExpression.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/ParameterExpression.scala
@@ -29,6 +29,7 @@ case class ParameterExpression(parameterName: String) extends Expression {
   def apply(ctx: ExecutionContext)(implicit state: QueryState) = state.getParam(parameterName) match {
     // this runtime check is necessary to enforce that Cypher never outputs a NaN
     case d: Double if java.lang.Double.isNaN(d) => null
+    case f: Float if java.lang.Double.isNaN(f) => null
     case other => other
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/ParameterExpression.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/ParameterExpression.scala
@@ -25,7 +25,12 @@ import pipes.QueryState
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 
 case class ParameterExpression(parameterName: String) extends Expression {
-  def apply(ctx: ExecutionContext)(implicit state: QueryState) = state.getParam(parameterName)
+
+  def apply(ctx: ExecutionContext)(implicit state: QueryState) = state.getParam(parameterName) match {
+    // this runtime check is necessary to enforce that Cypher never outputs a NaN
+    case d: Double if java.lang.Double.isNaN(d) => null
+    case other => other
+  }
 
   override def toString(): String = "{" + parameterName + "}"
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/Pow.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/Pow.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_0.commands.expressions
 
 case class Pow(a: Expression, b: Expression) extends Arithmetics(a, b) {
-  def calc(a: Number, b: Number) = math.pow(a.doubleValue(), b.doubleValue())
+  def calc(a: Number, b: Number) = makeNaNNull(math.pow(a.doubleValue(), b.doubleValue()))
 
   def rewrite(f: (Expression) => Expression) = f(Pow(a.rewrite(f), b.rewrite(f)))
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/TypeSafeMathSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/TypeSafeMathSupport.scala
@@ -31,6 +31,7 @@ trait TypeSafeMathSupport {
   protected def makeNaNNull(value: Any) = value match {
     case null => null
     case d: Double if java.lang.Double.isNaN(d) => null
+    case f: Float if java.lang.Double.isNaN(f) => null
     case other => other
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/TypeSafeMathSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/TypeSafeMathSupport.scala
@@ -22,7 +22,19 @@ package org.neo4j.cypher.internal.compiler.v3_0.helpers
 import org.neo4j.cypher.internal.frontend.v3_0.ArithmeticException
 
 trait TypeSafeMathSupport {
-  def plus(left: Any, right: Any): Any = {
+
+  def plus(left: Any, right: Any): Any = makeNaNNull(innerPlus(left, right))
+  def minus(left: Any, right: Any): Any = makeNaNNull(innerMinus(left, right))
+  def multiply(left: Any, right: Any): Any = makeNaNNull(innerMultiply(left, right))
+  def divide(left: Any, right: Any): Any = makeNaNNull(innerDivide(left, right))
+
+  protected def makeNaNNull(value: Any) = value match {
+    case null => null
+    case d: Double if java.lang.Double.isNaN(d) => null
+    case other => other
+  }
+
+  private def innerPlus(left: Any, right: Any): Any = {
 
     try {
       (left, right) match {
@@ -77,57 +89,7 @@ trait TypeSafeMathSupport {
     }
   }
 
-  def divide(left: Any, right: Any): Any = {
-    (left, right) match {
-      case (null, _) => null
-      case (_, null) => null
-
-      case (l: Byte, r: Byte)   => l / r
-      case (l: Byte, r: Double) => l / r
-      case (l: Byte, r: Float)  => l / r
-      case (l: Byte, r: Int)    => l / r
-      case (l: Byte, r: Long)   => l / r
-      case (l: Byte, r: Short)  => l / r
-
-      case (l: Double, r: Byte)   => l / r
-      case (l: Double, r: Double) => l / r
-      case (l: Double, r: Float)  => l / r
-      case (l: Double, r: Int)    => l / r
-      case (l: Double, r: Long)   => l / r
-      case (l: Double, r: Short)  => l / r
-
-      case (l: Float, r: Byte)   => l / r
-      case (l: Float, r: Double) => l / r
-      case (l: Float, r: Float)  => l / r
-      case (l: Float, r: Int)    => l / r
-      case (l: Float, r: Long)   => l / r
-      case (l: Float, r: Short)  => l / r
-
-      case (l: Int, r: Byte)   => l / r
-      case (l: Int, r: Double) => l / r
-      case (l: Int, r: Float)  => l / r
-      case (l: Int, r: Int)    => l / r
-      case (l: Int, r: Long)   => l / r
-      case (l: Int, r: Short)  => l / r
-
-      case (l: Long, r: Byte)   => l / r
-      case (l: Long, r: Double) => l / r
-      case (l: Long, r: Float)  => l / r
-      case (l: Long, r: Int)    => l / r
-      case (l: Long, r: Long)   => l / r
-      case (l: Long, r: Short)  => l / r
-
-      case (l: Short, r: Byte)   => l / r
-      case (l: Short, r: Double) => l / r
-      case (l: Short, r: Float)  => l / r
-      case (l: Short, r: Int)    => l / r
-      case (l: Short, r: Long)   => l / r
-      case (l: Short, r: Short)  => l / r
-
-    }
-  }
-
-  def minus(left: Any, right: Any): Any = {
+  private def innerMinus(left: Any, right: Any): Any = {
     try {
       (left, right) match {
         case (null, _) => null
@@ -182,7 +144,7 @@ trait TypeSafeMathSupport {
     }
   }
 
-  def multiply(left: Any, right: Any): Any = {
+  private def innerMultiply(left: Any, right: Any): Any = {
     try {
       (left, right) match {
         case (null, _) => null
@@ -234,6 +196,56 @@ trait TypeSafeMathSupport {
     } catch {
       case e: java.lang.ArithmeticException  =>
         throw new ArithmeticException(s"result of $left * $right cannot be represented as an integer")
+    }
+  }
+
+  private def innerDivide(left: Any, right: Any): Any = {
+    (left, right) match {
+      case (null, _) => null
+      case (_, null) => null
+
+      case (l: Byte, r: Byte)   => l / r
+      case (l: Byte, r: Double) => l / r
+      case (l: Byte, r: Float)  => l / r
+      case (l: Byte, r: Int)    => l / r
+      case (l: Byte, r: Long)   => l / r
+      case (l: Byte, r: Short)  => l / r
+
+      case (l: Double, r: Byte)   => l / r
+      case (l: Double, r: Double) => l / r
+      case (l: Double, r: Float)  => l / r
+      case (l: Double, r: Int)    => l / r
+      case (l: Double, r: Long)   => l / r
+      case (l: Double, r: Short)  => l / r
+
+      case (l: Float, r: Byte)   => l / r
+      case (l: Float, r: Double) => l / r
+      case (l: Float, r: Float)  => l / r
+      case (l: Float, r: Int)    => l / r
+      case (l: Float, r: Long)   => l / r
+      case (l: Float, r: Short)  => l / r
+
+      case (l: Int, r: Byte)   => l / r
+      case (l: Int, r: Double) => l / r
+      case (l: Int, r: Float)  => l / r
+      case (l: Int, r: Int)    => l / r
+      case (l: Int, r: Long)   => l / r
+      case (l: Int, r: Short)  => l / r
+
+      case (l: Long, r: Byte)   => l / r
+      case (l: Long, r: Double) => l / r
+      case (l: Long, r: Float)  => l / r
+      case (l: Long, r: Int)    => l / r
+      case (l: Long, r: Long)   => l / r
+      case (l: Long, r: Short)  => l / r
+
+      case (l: Short, r: Byte)   => l / r
+      case (l: Short, r: Double) => l / r
+      case (l: Short, r: Float)  => l / r
+      case (l: Short, r: Int)    => l / r
+      case (l: Short, r: Long)   => l / r
+      case (l: Short, r: Short)  => l / r
+
     }
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -311,13 +311,17 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       JavaConversionSupport.asScala(statement.readOperations().nodeGetPropertyKeys(id))
 
     def getProperty(id: Long, propertyKeyId: Int): Any = try {
-      statement.readOperations().nodeGetProperty(id, propertyKeyId)
+      statement.readOperations().nodeGetProperty(id, propertyKeyId) match {
+        case null => null
+        case d: java.lang.Double if java.lang.Double.isNaN(d) => null
+        case f: java.lang.Float if java.lang.Float.isNaN(f) => null
+        case other => other
+      }
     } catch {
       case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => null
     }
 
-    def hasProperty(id: Long, propertyKey: Int) =
-      statement.readOperations().nodeHasProperty(id, propertyKey)
+    def hasProperty(id: Long, propertyKey: Int) = getProperty(id, propertyKey) != null
 
     def removeProperty(id: Long, propertyKeyId: Int) {
       statement.dataWriteOperations().nodeRemoveProperty(id, propertyKeyId)
@@ -360,10 +364,14 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       asScala(statement.readOperations().relationshipGetPropertyKeys(id))
 
     def getProperty(id: Long, propertyKeyId: Int): Any =
-      statement.readOperations().relationshipGetProperty(id, propertyKeyId)
+      statement.readOperations().relationshipGetProperty(id, propertyKeyId) match {
+        case null => null
+        case d: java.lang.Double if java.lang.Double.isNaN(d) => null
+        case f: java.lang.Float if java.lang.Float.isNaN(f) => null
+        case other => other
+      }
 
-    def hasProperty(id: Long, propertyKey: Int) =
-      statement.readOperations().relationshipHasProperty(id, propertyKey)
+    def hasProperty(id: Long, propertyKey: Int) = getProperty(id, propertyKey) != null
 
     def removeProperty(id: Long, propertyKeyId: Int) {
       statement.dataWriteOperations().relationshipRemoveProperty(id, propertyKeyId)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -344,7 +344,6 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     createLabeledNode(Map("prop" -> 10.0), "Label")
     createLabeledNode(Map("prop" -> 100), "Label")
     createLabeledNode(Map("prop" -> Double.PositiveInfinity), "Label")
-    createLabeledNode(Map("prop" -> Double.NaN), "Label")
 
     // Non-matches
     createLabeledNode(Map("prop" -> Double.NegativeInfinity), "Label")
@@ -352,6 +351,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     createLabeledNode(Map("prop" -> 0), "Label")
     createLabeledNode(Map("prop" -> 5), "Label")
     createLabeledNode(Map("prop" -> 5.0), "Label")
+    createLabeledNode(Map("prop" -> Double.NaN), "Label")
 
     (1 to 400).foreach { _ =>
       createLabeledNode("Label")
@@ -361,14 +361,11 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     val query = "MATCH (n:Label) WHERE n.prop > 5 RETURN n.prop AS prop"
 
     // When
-    val result = executeWithAllPlannersReplaceNaNs(query)
+    val result = executeWithAllPlanners(query)
 
     // Then
     val values = result.columnAs[Number]("prop").toSeq
-    // TODO: this check should not be here, waiting for cypher to update NaN treatment behaviour
-    // values.exists(d => java.lang.Double.isNaN(d.doubleValue())) should be(right = true)
-    val saneValues = values.filter(d => !java.lang.Double.isNaN(d.doubleValue()))
-    saneValues should equal(Seq(10, 10.0, 100, Double.PositiveInfinity))
+    values should equal(Seq(10, 10.0, 100, Double.PositiveInfinity))
     result should use("NodeIndexSeekByRange")
   }
 
@@ -378,7 +375,6 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     createLabeledNode(Map("prop" -> 10.0), "Label")
     createLabeledNode(Map("prop" -> 100), "Label")
     createLabeledNode(Map("prop" -> Double.PositiveInfinity), "Label")
-    createLabeledNode(Map("prop" -> Double.NaN), "Label")
 
     // Non-matches
     createLabeledNode(Map("prop" -> Double.NegativeInfinity), "Label")
@@ -386,6 +382,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     createLabeledNode(Map("prop" -> 0), "Label")
     createLabeledNode(Map("prop" -> 5), "Label")
     createLabeledNode(Map("prop" -> 5.0), "Label")
+    createLabeledNode(Map("prop" -> Double.NaN), "Label")
 
     (1 to 400).foreach { _ =>
       createLabeledNode("Label")
@@ -395,14 +392,11 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     val query = "MATCH (n:Label) WHERE NOT n.prop <= 5 RETURN n.prop AS prop"
 
     // When
-    val result = executeWithAllPlannersReplaceNaNs(query)
+    val result = executeWithAllPlanners(query)
 
     // Then
     val values = result.columnAs[Number]("prop").toSeq
-    // TODO: this check should not be here, waiting for cypher to update NaN treatment behaviour
-    //values.exists(d => java.lang.Double.isNaN(d.doubleValue())) should be(right = true)
-    val saneValues = values.filter(d => !java.lang.Double.isNaN(d.doubleValue()))
-    saneValues should equal(Seq(10, 10.0, 100, Double.PositiveInfinity))
+    values should equal(Seq(10, 10.0, 100, Double.PositiveInfinity))
     result should use("NodeIndexSeekByRange")
   }
 
@@ -414,12 +408,12 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     createLabeledNode(Map("prop" -> 10.0), "Label")
     createLabeledNode(Map("prop" -> 100), "Label")
     createLabeledNode(Map("prop" -> Double.PositiveInfinity), "Label")
-    createLabeledNode(Map("prop" -> Double.NaN), "Label")
 
     // Non-matches
     createLabeledNode(Map("prop" -> Double.NegativeInfinity), "Label")
     createLabeledNode(Map("prop" -> -5), "Label")
     createLabeledNode(Map("prop" -> 0), "Label")
+    createLabeledNode(Map("prop" -> Double.NaN), "Label")
 
     (1 to 400).foreach { _ =>
       createLabeledNode("Label")
@@ -429,14 +423,11 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     val query = "MATCH (n:Label) WHERE n.prop >= 5 RETURN n.prop AS prop"
 
     // When
-    val result = executeWithAllPlannersReplaceNaNs(query)
+    val result = executeWithAllPlanners(query)
 
     // Then
     val values = result.columnAs[Number]("prop").toSeq
-    // TODO: this check should not be here, waiting for cypher to update NaN treatment behaviour
-    //values.exists(d => java.lang.Double.isNaN(d.doubleValue())) should be(right = true)
-    val saneValues = values.filter(d => !java.lang.Double.isNaN(d.doubleValue()))
-    saneValues should equal(Seq(5, 5.0, 10, 10.0, 100, Double.PositiveInfinity))
+    values should equal(Seq(5, 5.0, 10, 10.0, 100, Double.PositiveInfinity))
     result should use("NodeIndexSeekByRange")
   }
 
@@ -448,12 +439,12 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     createLabeledNode(Map("prop" -> 10.0), "Label")
     createLabeledNode(Map("prop" -> 100), "Label")
     createLabeledNode(Map("prop" -> Double.PositiveInfinity), "Label")
-    createLabeledNode(Map("prop" -> Double.NaN), "Label")
 
     // Non-matches
     createLabeledNode(Map("prop" -> Double.NegativeInfinity), "Label")
     createLabeledNode(Map("prop" -> -5), "Label")
     createLabeledNode(Map("prop" -> 0), "Label")
+    createLabeledNode(Map("prop" -> Double.NaN), "Label")
 
     (1 to 400).foreach { _ =>
       createLabeledNode("Label")
@@ -463,14 +454,11 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     val query = "MATCH (n:Label) WHERE NOT n.prop < 5 RETURN n.prop AS prop"
 
     // When
-    val result = executeWithAllPlannersReplaceNaNs(query)
+    val result = executeWithAllPlanners(query)
 
     // Then
     val values = result.columnAs[Number]("prop").toSeq
-    // TODO: this check should not be here, waiting for cypher to update NaN treatment behaviour
-    // values.exists(d => java.lang.Double.isNaN(d.doubleValue())) should be(right = true)
-    val saneValues = values.filter(d => !java.lang.Double.isNaN(d.doubleValue()))
-    saneValues should equal(Seq(5, 5.0, 10, 10.0, 100, Double.PositiveInfinity))
+    values should equal(Seq(5, 5.0, 10, 10.0, 100, Double.PositiveInfinity))
     result should use("NodeIndexSeekByRange")
   }
 


### PR DESCRIPTION
Cypher previously had undocumented support for `NaN`, the floating-point placeholder for calculations that are undefined (see http://stackoverflow.com/questions/2887131/when-can-java-produce-a-nan or similar resources for a background). This is unnecessary, as Cypher already has the `null` value for things that are undefined.
