### PR TITLE
Fix inner variables in create relationship pattern

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/CreateRelationship.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/CreateRelationship.scala
@@ -90,7 +90,9 @@ extends UpdateAction
     Iterator(context)
   }
 
-  def identifiers = Seq(key-> CTRelationship)
+  def identifiers = Seq(key-> CTRelationship) ++
+    from.introducedIdentifier.map(n => n -> CTNode) ++
+    to.introducedIdentifier.map(n => n -> CTNode)
 
   override def symbolTableDependencies: Set[String] = {
       val a = props.flatMap(_._2.symbolTableDependencies).toSet

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ForeachAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ForeachAcceptanceTest.scala
@@ -51,4 +51,24 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite {
     // then
     result shouldBe empty
   }
+
+  test("foreach should let you use inner variables from create relationship patterns") {
+    // given
+    val query = """FOREACH (x in [1] |
+                  |CREATE (e:Event)-[i:IN]->(p:Place)
+                  |SET e.foo='e_bar'
+                  |SET i.foo='i_bar'
+                  |SET p.foo='p_bar')
+                  |WITH 0 as dummy
+                  |MATCH (e:Event)-[i:IN]->(p:Place)
+                  |RETURN e.foo, i.foo, p.foo""".stripMargin
+
+    // when
+    val result = execute(query).toList
+
+    // then
+    result.head.get("e.foo") should equal(Some("e_bar"))
+    result.head.get("i.foo") should equal(Some("i_bar"))
+    result.head.get("p.foo") should equal(Some("p_bar"))
+  }
 }


### PR DESCRIPTION
We should be able to use variables introduced by create relationship patterns
as inner variables inside a FOREACH.
