### PR TITLE
Fixed command aggregation for legacy indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionStateImpl.java
@@ -162,10 +162,10 @@ public class LegacyIndexTransactionStateImpl implements LegacyIndexTransactionSt
         }
         else if ( command.getEntityType() == IndexEntityType.Relationship.id() )
         {
-            commands = nodeCommands.get( indexName );
+            commands = relationshipCommands.get( indexName );
             if ( commands == null )
             {
-                nodeCommands.put( indexName, commands = new ArrayList<>() );
+                relationshipCommands.put( indexName, commands = new ArrayList<>() );
             }
         }
         else

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexCommand.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexCommand.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.index;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.kernel.impl.transaction.command.Command;
@@ -205,22 +206,28 @@ public abstract class IndexCommand extends Command
         }
 
         @Override
-        public int hashCode()
+        public boolean equals( Object o )
         {
-            int result = (int) (startNode ^ (startNode >>> 32));
-            result = 31 * result + (int) (endNode ^ (endNode >>> 32));
-            return result;
-        }
-
-        @Override
-        public boolean equals( Object obj )
-        {
-            if ( !super.equals( obj ) )
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
             {
                 return false;
             }
-            AddRelationshipCommand other = (AddRelationshipCommand) obj;
-            return startNode == other.startNode && endNode == other.endNode;
+            if ( !super.equals( o ) )
+            {
+                return false;
+            }
+            AddRelationshipCommand that = (AddRelationshipCommand) o;
+            return startNode == that.startNode && endNode == that.endNode;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash( super.hashCode(), startNode, endNode );
         }
 
         @Override
@@ -297,15 +304,28 @@ public abstract class IndexCommand extends Command
         }
 
         @Override
-        public int hashCode()
+        public boolean equals( Object o )
         {
-            return config != null ? config.hashCode() : 0;
+            if ( this == o )
+            {
+                return true;
+            }
+            if ( o == null || getClass() != o.getClass() )
+            {
+                return false;
+            }
+            if ( !super.equals( o ) )
+            {
+                return false;
+            }
+            CreateCommand that = (CreateCommand) o;
+            return Objects.equals( config, that.config );
         }
 
         @Override
-        public boolean equals( Object obj )
+        public int hashCode()
         {
-            return super.equals( obj ) && config.equals( ((CreateCommand)obj).config );
+            return Objects.hash( super.hashCode(), config );
         }
 
         @Override
@@ -323,20 +343,34 @@ public abstract class IndexCommand extends Command
     }
 
     @Override
-    public boolean equals( Object obj )
+    public boolean equals( Object o )
     {
-        IndexCommand other = (IndexCommand) obj;
-        boolean equals = getCommandType() == other.getCommandType() &&
-                entityType == other.entityType &&
-                indexNameId == other.indexNameId &&
-                keyId == other.keyId &&
-                getValueType() == other.getValueType();
-        if ( !equals )
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
         {
             return false;
         }
+        if ( !super.equals( o ) )
+        {
+            return false;
+        }
+        IndexCommand that = (IndexCommand) o;
+        return commandType == that.commandType &&
+               indexNameId == that.indexNameId &&
+               entityType == that.entityType &&
+               entityId == that.entityId &&
+               keyId == that.keyId &&
+               valueType == that.valueType &&
+               Objects.equals( value, that.value );
+    }
 
-        return value == null ? other.value == null : value.equals( other.value );
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( super.hashCode(), commandType, indexNameId, entityType, entityId, keyId, valueType, value );
     }
 
     public byte getCommandType()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexDefineCommand.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexDefineCommand.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.index;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.collection.primitive.Primitive;
@@ -31,7 +32,6 @@ import org.neo4j.kernel.impl.transaction.command.CommandRecordVisitor;
 import org.neo4j.kernel.impl.transaction.command.NeoCommandHandler;
 
 import static java.lang.String.format;
-
 import static org.neo4j.collection.primitive.Primitive.intObjectMap;
 
 /**
@@ -142,25 +142,35 @@ public class IndexDefineCommand extends Command
         return id;
     }
 
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        if ( !super.equals( o ) )
+        {
+            return false;
+        }
+        IndexDefineCommand that = (IndexDefineCommand) o;
+        return nextIndexNameId.get() == that.nextIndexNameId.get() &&
+               nextKeyId.get() == that.nextKeyId.get() &&
+               Objects.equals( indexNameIdRange, that.indexNameIdRange ) &&
+               Objects.equals( keyIdRange, that.keyIdRange ) &&
+               Objects.equals( idToIndexName, that.idToIndexName ) &&
+               Objects.equals( idToKey, that.idToKey );
+    }
 
     @Override
     public int hashCode()
     {
-        int result = nextIndexNameId != null ? nextIndexNameId.hashCode() : 0;
-        result = 31 * result + (nextKeyId != null ? nextKeyId.hashCode() : 0);
-        result = 31 * result + (getIndexNameIdRange() != null ? getIndexNameIdRange().hashCode() : 0);
-        result = 31 * result + (getKeyIdRange() != null ? getKeyIdRange().hashCode() : 0);
-        result = 31 * result + (idToIndexName != null ? idToIndexName.hashCode() : 0);
-        result = 31 * result + (idToKey != null ? idToKey.hashCode() : 0);
-        return result;
-    }
-
-    @Override
-    public boolean equals( Object obj )
-    {
-        IndexDefineCommand other = (IndexDefineCommand) obj;
-        return getIndexNameIdRange().equals( other.getIndexNameIdRange() ) &&
-                getKeyIdRange().equals( other.getKeyIdRange() );
+        return Objects.hash( super.hashCode(), nextIndexNameId.get(), nextKeyId.get(), indexNameIdRange, keyIdRange,
+                idToIndexName, idToKey );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionStateImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionStateImplTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.state;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.function.Function;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.index.IndexImplementation;
+import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.kernel.impl.index.IndexCommand;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.index.IndexDefineCommand;
+import org.neo4j.kernel.impl.index.IndexEntityType;
+import org.neo4j.kernel.impl.transaction.command.Command;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LegacyIndexTransactionStateImplTest
+{
+    @Test
+    public void tracksNodeCommands()
+    {
+        LegacyIndexTransactionStateImpl state = newLegacyIndexTxState();
+
+        state.addNode( "index1", 1, "key1", "value1" );
+        state.removeNode( "index1", 1, "key2", "value2" );
+        state.addNode( "index1", 2, "key1", "value3" );
+        state.addNode( "index1", 3, "key2", "value4" );
+        state.removeNode( "index2", 4, "key1", "value5" );
+
+        IndexDefineCommand indexDefinedCommand = new IndexDefineCommand();
+        indexDefinedCommand.getOrAssignIndexNameId( "index1" );
+        indexDefinedCommand.getOrAssignIndexNameId( "index2" );
+        indexDefinedCommand.getOrAssignKeyId( "key1" );
+        indexDefinedCommand.getOrAssignKeyId( "key2" );
+
+        Set<Command> expectedCommands = new HashSet<>( Arrays.asList(
+                indexDefinedCommand,
+                addNode( 1, 1, 1, "value1" ),
+                removeNode( 1, 1, 2, "value2" ),
+                addNode( 1, 2, 1, "value3" ),
+                addNode( 1, 3, 2, "value4" ),
+                removeNode( 2, 4, 1, "value5" )
+        ) );
+        assertEquals( expectedCommands, extractCommands( state ) );
+    }
+
+    @Test
+    public void tracksRelationshipCommands()
+    {
+        LegacyIndexTransactionStateImpl state = newLegacyIndexTxState();
+
+        state.removeRelationship( "index1", 1, "key1", "value1" );
+        state.addRelationship( "index1", 1, "key2", "value2", 11, 11 );
+        state.removeRelationship( "index1", 2, "key1", "value3" );
+        state.addRelationship( "index1", 3, "key2", "value4", 22, 22 );
+        state.addRelationship( "index2", 4, "key1", "value5", 33, 33 );
+
+        IndexDefineCommand indexDefinedCommand = new IndexDefineCommand();
+        indexDefinedCommand.getOrAssignIndexNameId( "index1" );
+        indexDefinedCommand.getOrAssignIndexNameId( "index2" );
+        indexDefinedCommand.getOrAssignKeyId( "key1" );
+        indexDefinedCommand.getOrAssignKeyId( "key2" );
+
+        Set<Command> expectedCommands = new HashSet<>( Arrays.asList(
+                indexDefinedCommand,
+                removeRelationship( 1, 1, 1, "value1" ),
+                addRelationship( 1, 1, 2, "value2", 11, 11 ),
+                removeRelationship( 1, 2, 1, "value3" ),
+                addRelationship( 1, 3, 2, "value4", 22, 22 ),
+                addRelationship( 2, 4, 1, "value5", 33, 33 )
+        ) );
+        assertEquals( expectedCommands, extractCommands( state ) );
+    }
+
+    @Test
+    public void nodeIndexDeletionRemovesCommands()
+    {
+        LegacyIndexTransactionStateImpl state = newLegacyIndexTxState();
+
+        state.addNode( "index", 1, "key", "value1" );
+        state.addNode( "index", 2, "key", "value2" );
+        state.removeNode( "index", 3, "key", "value3" );
+
+        state.deleteIndex( IndexEntityType.Node, "index" );
+
+        IndexDefineCommand indexDefinedCommand = new IndexDefineCommand();
+        indexDefinedCommand.getOrAssignIndexNameId( "index" );
+        indexDefinedCommand.getOrAssignKeyId( "key" );
+
+        IndexCommand.DeleteCommand delete = new IndexCommand.DeleteCommand();
+        delete.init( 1, IndexEntityType.Node.id() );
+
+        Set<Command> expectedCommands = new HashSet<>( Arrays.asList( indexDefinedCommand, delete ) );
+        assertEquals( expectedCommands, extractCommands( state ) );
+    }
+
+    @Test
+    public void relationshipIndexDeletionRemovesCommands()
+    {
+        LegacyIndexTransactionStateImpl state = newLegacyIndexTxState();
+
+        state.removeRelationship( "index", 1, "key", "value1" );
+        state.addRelationship( "index", 2, "key", "value2", 11, 11 );
+        state.addRelationship( "index", 3, "key", "value3", 22, 22 );
+
+        state.deleteIndex( IndexEntityType.Relationship, "index" );
+
+        IndexDefineCommand indexDefinedCommand = new IndexDefineCommand();
+        indexDefinedCommand.getOrAssignIndexNameId( "index" );
+        indexDefinedCommand.getOrAssignKeyId( "key" );
+
+        IndexCommand.DeleteCommand delete = new IndexCommand.DeleteCommand();
+        delete.init( 1, IndexEntityType.Relationship.id() );
+
+        Set<Command> expectedCommands = new HashSet<>( Arrays.asList( indexDefinedCommand, delete ) );
+        assertEquals( expectedCommands, extractCommands( state ) );
+    }
+
+    @Test
+    public void removalOfNodeIndexDoesNotClearRelationshipCommandsForRelationshipIndexWithSameName()
+    {
+        LegacyIndexTransactionStateImpl state = newLegacyIndexTxState();
+
+        state.addNode( "index", 1, "key", "value" );
+        state.addRelationship( "index", 1, "key", "value", 11, 11 );
+        state.deleteIndex( IndexEntityType.Node, "index" );
+
+        IndexDefineCommand indexDefinedCommand = new IndexDefineCommand();
+        indexDefinedCommand.getOrAssignIndexNameId( "index" );
+        indexDefinedCommand.getOrAssignKeyId( "key" );
+
+        IndexCommand.DeleteCommand delete = new IndexCommand.DeleteCommand();
+        delete.init( 1, IndexEntityType.Node.id() );
+
+        Set<Command> expectedCommands = new HashSet<>( Arrays.asList(
+                indexDefinedCommand,
+                delete,
+                addRelationship( 1, 1, 1, "value", 11, 11 )
+        ) );
+        assertEquals( expectedCommands, extractCommands( state ) );
+    }
+
+    @Test
+    public void removalOfRelationshipIndexDoesNotClearNodeCommandsForNodeIndexWithSameName()
+    {
+        LegacyIndexTransactionStateImpl state = newLegacyIndexTxState();
+
+        state.addNode( "index", 1, "key", "value" );
+        state.addRelationship( "index", 1, "key", "value", 11, 11 );
+        state.deleteIndex( IndexEntityType.Relationship, "index" );
+
+        IndexDefineCommand indexDefinedCommand = new IndexDefineCommand();
+        indexDefinedCommand.getOrAssignIndexNameId( "index" );
+        indexDefinedCommand.getOrAssignKeyId( "key" );
+
+        IndexCommand.DeleteCommand delete = new IndexCommand.DeleteCommand();
+        delete.init( 1, IndexEntityType.Relationship.id() );
+
+        Set<Command> expectedCommands = new HashSet<>( Arrays.asList(
+                indexDefinedCommand,
+                delete,
+                addNode( 1, 1, 1, "value" )
+        ) );
+        assertEquals( expectedCommands, extractCommands( state ) );
+    }
+
+    private static Set<Command> extractCommands( LegacyIndexTransactionStateImpl state )
+    {
+        Set<Command> commands = new HashSet<>();
+        state.extractCommands( commands );
+        return commands;
+    }
+
+    private static Command addNode( int index, long id, int key, Object value )
+    {
+        IndexCommand.AddNodeCommand command = new IndexCommand.AddNodeCommand();
+        command.init( index, id, key, value );
+        return command;
+    }
+
+    private static Command addRelationship( int index, long id, int key, Object value, long startNode, long endNode )
+    {
+        IndexCommand.AddRelationshipCommand command = new IndexCommand.AddRelationshipCommand();
+        command.init( index, id, key, value, startNode, endNode );
+        return command;
+    }
+
+    private static Command removeNode( int index, long id, int key, Object value )
+    {
+        IndexCommand.RemoveCommand command = new IndexCommand.RemoveCommand();
+        command.init( index, IndexEntityType.Node.id(), id, key, value );
+        return command;
+    }
+
+    private static Command removeRelationship( int index, long id, int key, Object value )
+    {
+        IndexCommand.RemoveCommand command = new IndexCommand.RemoveCommand();
+        command.init( index, IndexEntityType.Relationship.id(), id, key, value );
+        return command;
+    }
+
+    private static LegacyIndexTransactionStateImpl newLegacyIndexTxState()
+    {
+        IndexConfigStore indexConfigStore = mock( IndexConfigStore.class );
+        when( indexConfigStore.get( eq( Node.class ), anyString() ) )
+                .thenReturn( singletonMap( IndexManager.PROVIDER, "test" ) );
+        when( indexConfigStore.get( eq( Relationship.class ), anyString() ) )
+                .thenReturn( singletonMap( IndexManager.PROVIDER, "test" ) );
+
+        Function<String,IndexImplementation> providerLookup = new Function<String,IndexImplementation>()
+        {
+            @Override
+            public IndexImplementation apply( String s ) throws RuntimeException
+            {
+                return mock( IndexImplementation.class );
+            }
+        };
+
+        return new LegacyIndexTransactionStateImpl( indexConfigStore, providerLookup );
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/index/LegacyIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/LegacyIndexTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.index.Index;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class LegacyIndexTest
+{
+    private static final RelationshipType TYPE = DynamicRelationshipType.withName( "TYPE" );
+
+    @Rule
+    public final DatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Test
+    public void removalOfNodeIndexDoesNotInfluenceRelationshipIndexWithSameName()
+    {
+        String indexName = "index";
+
+        createNodeLegacyIndexWithSingleNode( db, indexName );
+        createRelationshipLegacyIndexWithSingleRelationship( db, indexName );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship relationship = db.createNode().createRelationshipTo( db.createNode(), TYPE );
+            Index<Relationship> relationshipIndex = db.index().forRelationships( indexName );
+            relationshipIndex.add( relationship, "key", "otherValue" );
+
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            nodeIndex.delete();
+
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertFalse( db.index().existsForNodes( indexName ) );
+            Index<Relationship> relationshipIndex = db.index().forRelationships( indexName );
+            assertEquals( 2, sizeOf( relationshipIndex ) );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void removalOfRelationshipIndexDoesNotInfluenceNodeIndexWithSameName()
+    {
+        String indexName = "index";
+
+        createNodeLegacyIndexWithSingleNode( db, indexName );
+        createRelationshipLegacyIndexWithSingleRelationship( db, indexName );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            nodeIndex.add( node, "key", "otherValue" );
+
+            Index<Relationship> relationshipIndex = db.index().forRelationships( indexName );
+            relationshipIndex.delete();
+
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertFalse( db.index().existsForRelationships( indexName ) );
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            assertEquals( 2, sizeOf( nodeIndex ) );
+            tx.success();
+        }
+    }
+
+    private static void createNodeLegacyIndexWithSingleNode( GraphDatabaseService db, String indexName )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            nodeIndex.add( node, "key", System.currentTimeMillis() );
+            tx.success();
+        }
+    }
+
+    private static void createRelationshipLegacyIndexWithSingleRelationship( GraphDatabaseService db, String indexName )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship relationship = db.createNode().createRelationshipTo( db.createNode(), TYPE );
+            Index<Relationship> relationshipIndexIndex = db.index().forRelationships( indexName );
+            relationshipIndexIndex.add( relationship, "key", System.currentTimeMillis() );
+            tx.success();
+        }
+    }
+
+    private static int sizeOf( Index<?> index )
+    {
+        return index.query( "_id_:*" ).size();
+    }
+}


### PR DESCRIPTION
`LegacyIndexTransactionStateImpl` is responsible for tracking node/relationship additions and removals. It uses two separate maps for this. Each map has index name as a key and list of corresponding commands as a value. When index is dropped, corresponding list of commands is cleared.

However additions to relationship legacy index ended up in the map dedicated to node legacy index and removals from relationship legacy index cleared commands from the node map. In particular this was a problem for node and relationship indexes that had same name. It could lead to missing entries in the legacy index after transaction completed successfully.

This commit makes `LegacyIndexTransactionStateImpl` use relationship map for relationship commands. It also improves `equals`/`hashCode` methods for legacy index commands.
