### PR TITLE
Removed usages of sun.misc.BASE64[Encoder,Decoder]

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
@@ -19,42 +19,19 @@
  */
 package org.neo4j.kernel.api.index;
 
-import sun.misc.BASE64Encoder;
-
-import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Array;
+import java.util.Base64;
 
 import org.neo4j.helpers.UTF8;
 
-public class ArrayEncoder
+public final class ArrayEncoder
 {
-    private static final BASE64Encoder base64Encoder = new BASE64Encoder()
+    private static final Base64.Encoder base64Encoder = Base64.getEncoder();
+
+    private ArrayEncoder()
     {
-        @Override
-        protected void encodeBufferPrefix( OutputStream out ) throws IOException
-        {
-            // don't initialize the non-thread-safe state and make sure we don't add any buffer prefix
-        }
-
-        @Override
-        protected void encodeBufferSuffix( OutputStream outputStream ) throws IOException
-        {
-            // make sure we don't add any buffer suffix
-        }
-
-        @Override
-        protected void encodeLinePrefix( OutputStream outputStream, int i ) throws IOException
-        {
-            // make sure we don't add any line prefix
-        }
-
-        @Override
-        protected void encodeLineSuffix( OutputStream out ) throws IOException
-        {
-            // don't use the non-thread-safe state and make sure we don't add any line suffix
-        }
-    };
+        throw new AssertionError( "Not for instantiation!" );
+    }
 
     public static String encode( Object array )
     {
@@ -83,7 +60,7 @@ public class ArrayEncoder
             {
                 type = "L";
                 String str = o.toString();
-                builder.append( base64Encoder.encode( UTF8.encode( str ) ) );
+                builder.append( base64Encoder.encodeToString( UTF8.encode( str ) ) );
             }
             builder.append( "|" );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/ArrayEncoderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/ArrayEncoderTest.java
@@ -19,20 +19,19 @@
  */
 package org.neo4j.kernel.api.index;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.junit.Rule;
-import org.junit.Test;
 
 import org.neo4j.function.Function;
 import org.neo4j.helpers.ArrayUtil;
 import org.neo4j.test.ThreadingRule;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -40,7 +39,6 @@ public class ArrayEncoderTest
 {
     @Rule
     public final ThreadingRule threads = new ThreadingRule();
-
 
     private static final Character[] base64chars = new Character[]{
             'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U',

--- a/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
+++ b/community/kernel/src/test/java/org/neo4j/test/subprocess/SubProcess.java
@@ -43,6 +43,7 @@ import java.rmi.server.RemoteObject;
 import java.rmi.server.UnicastRemoteObject;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -540,14 +541,14 @@ public abstract class SubProcess<T, P> implements Serializable
         {
             throw new RuntimeException( "Broken implementation!", e );
         }
-        return new sun.misc.BASE64Encoder().encode( os.toByteArray() );
+        return Base64.getEncoder().encodeToString( os.toByteArray() );
     }
 
     @SuppressWarnings( "restriction" )
     private static DispatcherTrap deserialize( String data ) throws Exception
     {
         return (DispatcherTrap) new ObjectInputStream( new ByteArrayInputStream(
-                new sun.misc.BASE64Decoder().decodeBuffer( data ) ) ).readObject();
+                Base64.getDecoder().decode( data ) ) ).readObject();
     }
 
     private interface Dispatcher extends Remote

--- a/community/shell/src/main/java/org/neo4j/shell/impl/ShellBootstrap.java
+++ b/community/shell/src/main/java/org/neo4j/shell/impl/ShellBootstrap.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.rmi.RemoteException;
+import java.util.Base64;
 
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.configuration.Config;
@@ -68,7 +69,7 @@ public class ShellBootstrap implements Serializable
         {
             throw new RuntimeException( "Broken implementation!", e );
         }
-        return new sun.misc.BASE64Encoder().encode( os.toByteArray() );
+        return Base64.getEncoder().encodeToString( os.toByteArray() );
     }
 
     @SuppressWarnings("boxing")

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/PaxosClusterMemberEvents.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/member/paxos/PaxosClusterMemberEvents.java
@@ -25,11 +25,10 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import sun.misc.BASE64Encoder;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.member.ClusterMemberEvents;
@@ -397,9 +396,8 @@ public class PaxosClusterMemberEvents implements ClusterMemberEvents, Lifecycle
             }
             catch ( Throwable t )
             {
-
                 log.error( String.format( "Could not handle cluster member available message: %s (%d)",
-                        new BASE64Encoder().encode( payload.getBuf() ), payload.getLen() ), t );
+                        Base64.getEncoder().encodeToString( payload.getBuf() ), payload.getLen() ), t );
             }
         }
     }


### PR DESCRIPTION
Those are JDK internal classes and not part of the public API.
Used `java.util.Base64` instead.
