### PR TITLE
[core-edge] Include last appended in AppendResponse.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessages.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessages.java
@@ -299,13 +299,15 @@ public interface RaftMessages
             private long term;
             private boolean success;
             private long matchIndex;
+            private long appendIndex;
 
-            public Response( MEMBER from, long term, boolean success, long matchIndex )
+            public Response( MEMBER from, long term, boolean success, long matchIndex, long appendIndex )
             {
                 super( from, Type.APPEND_ENTRIES_RESPONSE );
                 this.term = term;
                 this.success = success;
                 this.matchIndex = matchIndex;
+                this.appendIndex = appendIndex;
             }
 
             public long term()
@@ -313,46 +315,48 @@ public interface RaftMessages
                 return term;
             }
 
+            public boolean success()
+            {
+                return success;
+            }
+
             public long matchIndex()
             {
                 return matchIndex;
+            }
+
+            public long appendIndex()
+            {
+                return appendIndex;
             }
 
             @Override
             public boolean equals( Object o )
             {
                 if ( this == o )
-                {
-                    return true;
-                }
+                { return true; }
                 if ( o == null || getClass() != o.getClass() )
-                {
-                    return false;
-                }
-
+                { return false; }
+                if ( !super.equals( o ) )
+                { return false; }
                 Response<?> response = (Response<?>) o;
-
-                return term == response.term && success == response.success;
+                return term == response.term &&
+                       success == response.success &&
+                       matchIndex == response.matchIndex &&
+                       appendIndex == response.appendIndex;
             }
 
             @Override
             public int hashCode()
             {
-                int result = (int) (term ^ (term >>> 32));
-                result = 31 * result + (success ? 1 : 0);
-                return result;
+                return Objects.hash( super.hashCode(), term, success, matchIndex, appendIndex );
             }
 
             @Override
             public String toString()
             {
-                return format( "AppendEntries.Response from %s {term=%d, success=%s, matchIndex=%d}",
-                        super.from(), term, success, matchIndex );
-            }
-
-            public boolean success()
-            {
-                return success;
+                return String.format( "Response{term=%d, success=%s, matchIndex=%d, appendIndex=%d}",
+                        term, success, matchIndex, appendIndex );
             }
         }
     }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageDecoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageDecoder.java
@@ -99,8 +99,6 @@ public class RaftMessageDecoder extends MessageToMessageDecoder<ByteBuf>
                 entries[i] = new RaftLogEntry( entryTerm, content );
             }
 
-            // TODO: This currently needs to be last, because tx-content doesn't know its length and will just read
-            // to exhaustion.
             list.add( new RaftMessages.AppendEntries.Request<>( from, term, prevLogIndex, prevLogTerm,
                     entries, leaderCommit ) );
         }
@@ -109,8 +107,9 @@ public class RaftMessageDecoder extends MessageToMessageDecoder<ByteBuf>
             long term = buffer.readLong();
             boolean success = buffer.readBoolean();
             long matchIndex = buffer.readLong();
+            long appendIndex = buffer.readLong();
 
-            list.add( new RaftMessages.AppendEntries.Response<>( from, term, success, matchIndex ) );
+            list.add( new RaftMessages.AppendEntries.Response<>( from, term, success, matchIndex, appendIndex ) );
         }
         else if ( messageType.equals( NEW_ENTRY_REQUEST ) )
         {

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageEncoder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/codecs/RaftMessageEncoder.java
@@ -90,6 +90,7 @@ public class RaftMessageEncoder extends MessageToMessageEncoder<RaftMessages.Mes
             buf.writeLong( appendResponse.term() );
             buf.writeBoolean( appendResponse.success() );
             buf.writeLong( appendResponse.matchIndex() );
+            buf.writeLong( appendResponse.appendIndex() );
         }
         else if ( message instanceof RaftMessages.NewEntry.Request )
         {

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Candidate.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Candidate.java
@@ -62,8 +62,8 @@ public class Candidate implements RaftMessageHandler
                 if ( req.leaderTerm() < ctx.term() )
                 {
                     RaftMessages.AppendEntries.Response<MEMBER> appendResponse =
-                            new RaftMessages.AppendEntries.Response<>( ctx.myself(), ctx.term(), false, req
-                                    .prevLogIndex() );
+                            new RaftMessages.AppendEntries.Response<>( ctx.myself(), ctx.term(), false,
+                                    req.prevLogIndex(), ctx.entryLog().appendIndex() );
 
                     outcome.addOutgoingMessage( new RaftMessages.Directed<>( req.from(), appendResponse ) );
                     break;

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
@@ -102,8 +102,8 @@ public class Follower implements RaftMessageHandler
 
                 if ( req.leaderTerm() < ctx.term() )
                 {
-                    Response<MEMBER> appendResponse =
-                            new Response<>( ctx.myself(), ctx.term(), false, req.prevLogIndex() );
+                    Response<MEMBER> appendResponse = new Response<>(
+                            ctx.myself(), ctx.term(), false, -1, ctx.entryLog().appendIndex() );
 
                     outcome.addOutgoingMessage( new RaftMessages.Directed<>( req.from(), appendResponse ) );
                     break;
@@ -117,7 +117,9 @@ public class Follower implements RaftMessageHandler
                 if ( !logHistoryMatches( ctx, req.prevLogIndex(), req.prevLogTerm() ) )
                 {
                     assert req.prevLogIndex() > -1 && req.prevLogTerm() > -1;
-                    Response<MEMBER> appendResponse = new Response<>( ctx.myself(), req.leaderTerm(), false, -1 );
+                    Response<MEMBER> appendResponse = new Response<>(
+                            ctx.myself(), req.leaderTerm(), false, -1, ctx.entryLog().appendIndex() );
+
                     outcome.addOutgoingMessage( new RaftMessages.Directed<>( req.from(), appendResponse ) );
                     break;
                 }
@@ -152,7 +154,7 @@ public class Follower implements RaftMessageHandler
                 long endMatchIndex = req.prevLogIndex() + req.entries().length; // this is the index of the last incoming entry
                 if ( endMatchIndex >= 0 )
                 {
-                    Response<MEMBER> appendResponse = new Response<>( ctx.myself(), req.leaderTerm(), true, endMatchIndex );
+                    Response<MEMBER> appendResponse = new Response<>( ctx.myself(), req.leaderTerm(), true, endMatchIndex, endMatchIndex );
                     outcome.addOutgoingMessage( new RaftMessages.Directed<>( req.from(), appendResponse ) );
                 }
                 break;

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Leader.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Leader.java
@@ -94,7 +94,8 @@ public class Leader implements RaftMessageHandler
                 if ( req.leaderTerm() < ctx.term() )
                 {
                     RaftMessages.AppendEntries.Response<MEMBER> appendResponse =
-                            new RaftMessages.AppendEntries.Response<>( ctx.myself(), ctx.term(), false, req.prevLogIndex() );
+                            new RaftMessages.AppendEntries.Response<>(
+                                    ctx.myself(), ctx.term(), false, req.prevLogIndex(), ctx.entryLog().appendIndex() );
 
                     outcome.addOutgoingMessage( new RaftMessages.Directed<>( req.from(), appendResponse ) );
                     break;
@@ -170,7 +171,7 @@ public class Leader implements RaftMessageHandler
                 }
                 else // Response indicated failure. Must go back a log entry and retry - this is where catchup happens
                 {
-                    outcome.addShipCommand( new ShipCommand.Mismatch( ctx.entryLog().appendIndex(), res.from() ) ); // TODO: Fix remote last appended parameter.
+                    outcome.addShipCommand( new ShipCommand.Mismatch( res.appendIndex(), res.from() ) );
                 }
 
                 break;

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesMessageFlowTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesMessageFlowTest.java
@@ -76,7 +76,8 @@ public class AppendEntriesMessageFlowTest
                 .prevLogTerm( 0 ).leaderCommit( 0 ).build() );
 
         // then
-        verify( outbound ).send( same( otherMember ), eq( appendEntriesResponse().from( myself ).term( 0 ).failure()
+        verify( outbound ).send( same( otherMember ),
+                eq( appendEntriesResponse().from( myself ).term( 0 ).appendIndex( -1 ).matchIndex( -1 ).failure()
                 .build() ) );
     }
 
@@ -88,8 +89,8 @@ public class AppendEntriesMessageFlowTest
                 .prevLogTerm( -1 ).logEntry( new RaftLogEntry( 0, data ) ).leaderCommit( -1 ).build() );
 
         // then
-        verify( outbound ).send( same( otherMember ), eq( appendEntriesResponse().from( myself ).term( 0 ).success()
-                .build() ) );
+        verify( outbound ).send( same( otherMember ), eq( appendEntriesResponse().
+                appendIndex( 0 ).matchIndex( 0 ).from( myself ).term( 0 ).success().build() ) );
     }
 
     @Test
@@ -100,7 +101,8 @@ public class AppendEntriesMessageFlowTest
                 .prevLogTerm( -1 ).logEntry( new RaftLogEntry( 0, data ) ).build() );
 
         // then
-        verify( outbound ).send( same( otherMember ), eq( appendEntriesResponse().from( myself ).term( 0 ).success()
+        verify( outbound ).send( same( otherMember ),
+                eq( appendEntriesResponse().from( myself ).term( 0 ).appendIndex( 0 ).matchIndex( 0 ).success()
                 .build() ) );
     }
 
@@ -136,10 +138,19 @@ public class AppendEntriesMessageFlowTest
 
         // then
         InOrder invocationOrder = inOrder( outbound );
-        invocationOrder.verify( outbound, times( 3 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
-                myself ).term( 0 ).success().build() ) );
-        invocationOrder.verify( outbound, times( 3 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
-                myself ).term( 1 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 0 ).appendIndex( 0 ).matchIndex( 0 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 0 ).appendIndex( 1 ).matchIndex( 1 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 0 ).appendIndex( 2 ).matchIndex( 2 ).success().build() ) );
+
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 1 ).appendIndex( 3 ).matchIndex( 3 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 1 ).appendIndex( 4 ).matchIndex( 4 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 1 ).appendIndex( 5 ).matchIndex( 5 ).success().build() ) );
     }
 
     @Test
@@ -159,9 +170,13 @@ public class AppendEntriesMessageFlowTest
 
         // then
         InOrder invocationOrder = inOrder( outbound );
-        invocationOrder.verify( outbound, times( 3 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
-                myself ).term( 0 ).success().build() ) );
         invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
-                myself ).term( 2 ).failure().build() ) );
+                myself ).term( 0 ).matchIndex( 0 ).appendIndex( 0 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 0 ).matchIndex( 1 ).appendIndex( 1 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 0 ).matchIndex( 2 ).appendIndex( 2 ).success().build() ) );
+        invocationOrder.verify( outbound, times( 1 ) ).send( same( otherMember ), eq( appendEntriesResponse().from(
+                myself ).term( 2 ).matchIndex( -1 ).appendIndex( 2 ).failure().build() ) );
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesResponseBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/AppendEntriesResponseBuilder.java
@@ -25,12 +25,13 @@ public class AppendEntriesResponseBuilder<MEMBER>
     private long term = -1;
     private MEMBER from = null;
     private long matchIndex = -1;
+    private long appendIndex = -1;
 
     public RaftMessages.AppendEntries.Response<MEMBER> build()
     {
         // a response of false should always have a match index of -1
         assert !( success == false && matchIndex != -1 );
-        return new RaftMessages.AppendEntries.Response<>( from, term, success, matchIndex );
+        return new RaftMessages.AppendEntries.Response<>( from, term, success, matchIndex, appendIndex );
     }
 
     public AppendEntriesResponseBuilder<MEMBER> from( MEMBER from )
@@ -48,6 +49,12 @@ public class AppendEntriesResponseBuilder<MEMBER>
     public AppendEntriesResponseBuilder<MEMBER> matchIndex( long matchIndex )
     {
         this.matchIndex = matchIndex;
+        return this;
+    }
+
+    public AppendEntriesResponseBuilder<MEMBER> appendIndex( long appendIndex )
+    {
+        this.appendIndex = appendIndex;
         return this;
     }
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/net/RaftMessageProcessingTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/net/RaftMessageProcessingTest.java
@@ -147,7 +147,7 @@ public class RaftMessageProcessingTest
         // given
         CoreMember member = new CoreMember( address( "host1:9000" ), address( "host1:9001" ) );
         RaftMessages.AppendEntries.Response response =
-                new RaftMessages.AppendEntries.Response<>( member, 1, false, -1 );
+                new RaftMessages.AppendEntries.Response<>( member, 1, false, -1, 0 );
 
         // when
         channel.writeOutbound( response );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/LeaderTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/LeaderTest.java
@@ -483,7 +483,7 @@ public class LeaderTest
 
         // when a single instance responds (plus self == 2 out of 3 instances)
         Outcome<RaftTestMember> outcome = leader.handle(
-                new RaftMessages.AppendEntries.Response<>( member1, 0, true, 0 ), state, log() );
+                new RaftMessages.AppendEntries.Response<>( member1, 0, true, 0, 0 ), state, log() );
 
         // then
         assertThat( firstOrNull( outcome.getLogCommands() ), instanceOf( CommitCommand.class ) );
@@ -510,7 +510,7 @@ public class LeaderTest
 
         // when
         Outcome<RaftTestMember> outcome =
-                leader.handle( new AppendEntries.Response<>( member1, 0, true, 2 ), state, log() );
+                leader.handle( new AppendEntries.Response<>( member1, 0, true, 2, 2 ), state, log() );
 
         state.update( outcome );
 


### PR DESCRIPTION
This is useful when a follower is way behind and needs to
tell the leader from where it should start searching for
a matching first item to catchup from.

This commit also fixes some missing equality in
AppendEntries.Response and tests that depended on
the missing behaviour.
