### PR TITLE
Make `Settings` utility class internal

### DIFF
--- a/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/ConsistencyCheckService.java
@@ -28,7 +28,7 @@ import java.util.Date;
 import org.neo4j.function.Supplier;
 import org.neo4j.function.Suppliers;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.index.lucene.LuceneLabelScanStoreBuilder;

--- a/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/ConsistencyCheckSettings.java
+++ b/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/ConsistencyCheckSettings.java
@@ -25,13 +25,13 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.legacy.consistency.checking.full.TaskExecutionOrder;
 
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.FALSE;
-import static org.neo4j.helpers.Settings.NO_DEFAULT;
-import static org.neo4j.helpers.Settings.PATH;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.options;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
+import static org.neo4j.kernel.configuration.Settings.PATH;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.options;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
  * Settings for consistency checker

--- a/community/consistency-check-legacy/src/test/java/org/neo4j/legacy/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check-legacy/src/test/java/org/neo4j/legacy/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -36,7 +36,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -36,7 +36,7 @@ import org.neo4j.consistency.statistics.VerboseStatistics;
 import org.neo4j.function.Supplier;
 import org.neo4j.function.Suppliers;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.index.lucene.LuceneLabelScanStoreBuilder;

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckSettings.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckSettings.java
@@ -24,12 +24,12 @@ import java.io.File;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.FALSE;
-import static org.neo4j.helpers.Settings.NO_DEFAULT;
-import static org.neo4j.helpers.Settings.PATH;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
+import static org.neo4j.kernel.configuration.Settings.PATH;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
  * Settings for consistency checker

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -39,7 +39,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;

--- a/community/embedded-examples/src/main/java/org/neo4j/examples/Neo4jShell.java
+++ b/community/embedded-examples/src/main/java/org/neo4j/examples/Neo4jShell.java
@@ -34,7 +34,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.index.Index;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.shell.ShellLobby;
 import org.neo4j.shell.ShellServer;
 import org.neo4j.shell.ShellSettings;

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -38,27 +38,27 @@ import org.neo4j.kernel.configuration.Title;
 import org.neo4j.kernel.impl.cache.MonitorGc;
 import org.neo4j.logging.Level;
 
-import static org.neo4j.helpers.Settings.ANY;
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.BYTES;
-import static org.neo4j.helpers.Settings.DEFAULT;
-import static org.neo4j.helpers.Settings.DOUBLE;
-import static org.neo4j.helpers.Settings.DURATION;
-import static org.neo4j.helpers.Settings.FALSE;
-import static org.neo4j.helpers.Settings.INTEGER;
-import static org.neo4j.helpers.Settings.LONG;
-import static org.neo4j.helpers.Settings.NO_DEFAULT;
-import static org.neo4j.helpers.Settings.PATH;
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.basePath;
-import static org.neo4j.helpers.Settings.illegalValueMessage;
-import static org.neo4j.helpers.Settings.list;
-import static org.neo4j.helpers.Settings.matches;
-import static org.neo4j.helpers.Settings.max;
-import static org.neo4j.helpers.Settings.min;
-import static org.neo4j.helpers.Settings.options;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.ANY;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.BYTES;
+import static org.neo4j.kernel.configuration.Settings.DEFAULT;
+import static org.neo4j.kernel.configuration.Settings.DOUBLE;
+import static org.neo4j.kernel.configuration.Settings.DURATION;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.kernel.configuration.Settings.INTEGER;
+import static org.neo4j.kernel.configuration.Settings.LONG;
+import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
+import static org.neo4j.kernel.configuration.Settings.PATH;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.basePath;
+import static org.neo4j.kernel.configuration.Settings.illegalValueMessage;
+import static org.neo4j.kernel.configuration.Settings.list;
+import static org.neo4j.kernel.configuration.Settings.matches;
+import static org.neo4j.kernel.configuration.Settings.max;
+import static org.neo4j.kernel.configuration.Settings.min;
+import static org.neo4j.kernel.configuration.Settings.options;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
  * Settings for Neo4j. Use this with {@link GraphDatabaseBuilder}.

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -179,9 +179,9 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.Logger;
 import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.setting;
 import static org.neo4j.helpers.collection.Iterables.toList;
 import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
 import static org.neo4j.kernel.impl.transaction.log.pruning.LogPruneStrategyFactory.fromConfigValue;

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
-import org.neo4j.helpers.Settings;
 
 import static java.util.regex.Pattern.quote;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.helpers;
+package org.neo4j.kernel.configuration;
 
 import java.io.File;
 import java.net.URI;
@@ -30,9 +30,13 @@ import java.util.regex.Pattern;
 
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.helpers.Function;
+import org.neo4j.helpers.Function2;
+import org.neo4j.helpers.Functions;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.helpers.TimeUtil;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.kernel.configuration.Config;
 
 /**
  * Create settings for configurations in Neo4j. See {@link org.neo4j.graphdb.factory.GraphDatabaseSettings} for example.
@@ -47,13 +51,10 @@ import org.neo4j.kernel.configuration.Config;
  * which means that you don't want any default value at all, and MANDATORY, which means that the user has to specify a value
  * for this setting. Not providing a mandatory value for a setting leads to an IllegalArgumentException.
  *
- * @deprecated this class is deprecated and will be moved to internal packages in the next major release
+ * If a setting does not have a provided value, and no default, then
  */
-@Deprecated
-public final class Settings
+public class Settings
 {
-    // NOTE: Do not use this class, use org.neo4j.kernel.configuration.Settings instead
-
     private static final String MATCHES_PATTERN_MESSAGE = "matches the pattern `%s`";
 
     private interface SettingHelper<T>
@@ -67,19 +68,19 @@ public final class Settings
     // Set default value to this if user HAS to set a value
     @SuppressWarnings("RedundantStringConstructorCall")
     // It's an explicitly allocated string so identity equality checks work
-    @Deprecated public static final String MANDATORY = org.neo4j.kernel.configuration.Settings.MANDATORY;
-    @Deprecated public static final String NO_DEFAULT = null;
-    @Deprecated public static final String EMPTY = "";
+    public static final String MANDATORY = new String( "mandatory" );
+    public static final String NO_DEFAULT = null;
+    public static final String EMPTY = "";
 
-    @Deprecated public static final String TRUE = "true";
-    @Deprecated public static final String FALSE = "false";
+    public static final String TRUE = "true";
+    public static final String FALSE = "false";
 
-    @Deprecated public static final String DEFAULT = "default";
+    public static final String DEFAULT = "default";
 
-    @Deprecated public static final String SEPARATOR = ",";
+    public static final String SEPARATOR = ",";
 
-    @Deprecated public static final String DURATION_FORMAT = "\\d+(ms|s|m)";
-    @Deprecated public static final String SIZE_FORMAT = "\\d+[kmgKMG]?";
+    public static final String DURATION_FORMAT = "\\d+(ms|s|m)";
+    public static final String SIZE_FORMAT = "\\d+[kmgKMG]?";
 
     private static final String DURATION_UNITS = DURATION_FORMAT.substring(
             DURATION_FORMAT.indexOf( '(' ) + 1, DURATION_FORMAT.indexOf( ')' ) )
@@ -91,9 +92,8 @@ public final class Settings
             .replace( "[", "" )
             .replace( "]", "" );
 
-    @Deprecated public static final String ANY = ".+";
+    public static final String ANY = ".+";
 
-    @Deprecated
     @SuppressWarnings("unchecked")
     public static <T> Setting<T> setting( final String name, final Function<String, T> parser,
                                           final String defaultValue )
@@ -101,7 +101,6 @@ public final class Settings
         return setting( name, parser, defaultValue, (Setting<T>) null );
     }
 
-    @Deprecated
     public static <T> Setting<T> setting( final String name, final Function<String, T> parser,
                                           final String defaultValue,
                                           final Function2<T, Function<String, String>, T>... valueConverters )
@@ -109,7 +108,6 @@ public final class Settings
         return setting( name, parser, defaultValue, null, valueConverters );
     }
 
-    @Deprecated
     @SuppressWarnings("unchecked")
     public static <T> Setting<T> setting( final String name, final Function<String, T> parser,
                                           final Setting<T> inheritedSetting )
@@ -117,7 +115,6 @@ public final class Settings
         return setting( name, parser, null, inheritedSetting );
     }
 
-    @Deprecated
     public static <T> Setting<T> setting( final String name, final Function<String, T> parser,
                                           final String defaultValue,
                                           final Setting<T> inheritedSetting, final Function2<T, Function<String,
@@ -191,7 +188,6 @@ public final class Settings
         };
     }
 
-    @Deprecated
     public static final Function<String, Integer> INTEGER = new Function<String, Integer>()
     {
         @Override
@@ -214,7 +210,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, Long> LONG = new Function<String, Long>()
     {
         @Override
@@ -237,7 +232,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, Boolean> BOOLEAN = new Function<String, Boolean>()
     {
         @Override
@@ -264,7 +258,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, Float> FLOAT = new Function<String, Float>()
     {
         @Override
@@ -287,7 +280,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, Double> DOUBLE = new Function<String, Double>()
     {
         @Override
@@ -310,7 +302,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, String> STRING = new Function<String, String>()
     {
         @Override
@@ -326,7 +317,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, List<String>> STRING_LIST = new Function<String, List<String>>()
     {
         @Override
@@ -350,8 +340,7 @@ public final class Settings
         }
     };
 
-    @Deprecated
-    public static final Function<String, HostnamePort> HOSTNAME_PORT = new Function<String, HostnamePort>()
+    public static final Function<String,HostnamePort> HOSTNAME_PORT = new Function<String, HostnamePort>()
     {
         @Override
         public HostnamePort apply( String value )
@@ -366,7 +355,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, Long> DURATION = new Function<String, Long>()
     {
         @Override
@@ -382,7 +370,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, Long> BYTES = new Function<String, Long>()
     {
         @Override
@@ -419,7 +406,7 @@ public final class Settings
             catch ( NumberFormatException e )
             {
                 throw new IllegalArgumentException( String.format( "%s is not a valid size, must be e.g. 10, 5K, 1M, " +
-                                                                   "11G", value ) );
+                        "11G", value ) );
             }
         }
 
@@ -430,7 +417,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, URI> URI =
             new Function<String, URI>()
             {
@@ -454,7 +440,6 @@ public final class Settings
                 }
             };
 
-    @Deprecated
     public static final Function<String, URI> NORMALIZED_RELATIVE_URI = new Function<String, URI>()
     {
         @Override
@@ -483,7 +468,6 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static final Function<String, File> PATH = new Function<String, File>()
     {
         @Override
@@ -503,7 +487,7 @@ public final class Settings
 
     /**
      * For values expressed with a unit such as {@code 100M}.
-     *
+     * 
      * <ul>
      *   <li>100M<br>   ==&gt; 100 * 1024 * 1024</li>
      *   <li>37261<br>  ==&gt; 37261</li>
@@ -512,7 +496,6 @@ public final class Settings
      *   <li>10k<br>    ==&gt; 10 * 1024</li>
      * </ul>
      */
-    @Deprecated
     public static final Function<String, Long> LONG_WITH_OPTIONAL_UNIT = new Function<String, Long>()
     {
         @Override
@@ -522,19 +505,16 @@ public final class Settings
         }
     };
 
-    @Deprecated
     public static <T extends Enum> Function<String, T> options( final Class<T> enumClass )
     {
         return options( EnumSet.allOf( enumClass ) );
     }
 
-    @Deprecated
     public static <T> Function<String, T> options( T... optionValues )
     {
         return Settings.<T>options( Iterables.<T,T>iterable( optionValues ) );
     }
 
-    @Deprecated
     public static <T> Function<String, T> options( final Iterable<T> optionValues )
     {
         return new Function<String, T>()
@@ -569,7 +549,6 @@ public final class Settings
         };
     }
 
-    @Deprecated
     public static <T> Function<String, List<T>> list( final String separator, final Function<String, T> itemParser )
     {
         return new Function<String, List<T>>()
@@ -598,7 +577,6 @@ public final class Settings
     }
 
     // Modifiers
-    @Deprecated
     public static Function2<String, Function<String, String>, String> matches( final String regex )
     {
         final Pattern pattern = Pattern.compile( regex );
@@ -624,7 +602,6 @@ public final class Settings
         };
     }
 
-    @Deprecated
     public static <T extends Comparable<T>> Function2<T, Function<String, String>, T> min( final T min )
     {
         return new Function2<T, Function<String, String>, T>()
@@ -647,7 +624,6 @@ public final class Settings
         };
     }
 
-    @Deprecated
     public static <T extends Comparable<T>> Function2<T, Function<String, String>, T> max( final T max )
     {
         return new Function2<T, Function<String, String>, T>()
@@ -670,7 +646,6 @@ public final class Settings
         };
     }
 
-    @Deprecated
     public static <T extends Comparable<T>> Function2<T, Function<String, String>, T> range( final T min, final T max )
     {
         return new Function2<T, Function<String, String>, T>()
@@ -689,11 +664,9 @@ public final class Settings
         };
     }
 
-    @Deprecated
     public static final Function2<Integer, Function<String, String>, Integer> port =
             illegalValueMessage( "must be a valid port number", range( 0, 65535 ) );
 
-    @Deprecated
     public static <T> Function2<T, Function<String, String>, T> illegalValueMessage( final String message,
                                                                                      final Function2<T,
                                                                                              Function<String,
@@ -721,7 +694,7 @@ public final class Settings
                 String description = message;
                 if ( valueFunction != null
                      && !String.format( MATCHES_PATTERN_MESSAGE, ANY ).equals(
-                        valueFunction.toString() ) )
+                             valueFunction.toString() ) )
                 {
                     description += " (" + valueFunction.toString() + ")";
                 }
@@ -730,7 +703,6 @@ public final class Settings
         };
     }
 
-    @Deprecated
     public static Function2<String, Function<String, String>, String> toLowerCase =
             new Function2<String, Function<String, String>, String>()
             {
@@ -741,7 +713,6 @@ public final class Settings
                 }
             };
 
-    @Deprecated
     public static Function2<URI, Function<String, String>, URI> normalize =
             new Function2<URI, Function<String, String>, URI>()
             {
@@ -758,7 +729,6 @@ public final class Settings
             };
 
     // Setting converters and constraints
-    @Deprecated
     public static Function2<File, Function<String, String>, File> basePath( final Setting<File> baseSetting )
     {
         return new Function2<File, Function<String, String>, File>()
@@ -779,7 +749,6 @@ public final class Settings
         };
     }
 
-    @Deprecated
     public static Function2<File, Function<String, String>, File> isFile =
             new Function2<File, Function<String, String>, File>()
             {
@@ -796,7 +765,6 @@ public final class Settings
                 }
             };
 
-    @Deprecated
     public static Function2<File, Function<String, String>, File> isDirectory =
             new Function2<File, Function<String, String>, File>()
             {
@@ -814,7 +782,6 @@ public final class Settings
             };
 
     // Setting helpers
-    @Deprecated
     private static Function<Function<String, String>, String> named( final String name )
     {
         return new Function<Function<String, String>, String>()
@@ -871,7 +838,6 @@ public final class Settings
     {
     }
 
-    @Deprecated
     public static class DefaultSetting<T> implements SettingHelper<T>
     {
         private final String name;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/MonitorGc.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/MonitorGc.java
@@ -24,8 +24,8 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.Log;
 
-import static org.neo4j.helpers.Settings.DURATION;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.DURATION;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 public class MonitorGc implements Lifecycle
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Exceptions;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
@@ -34,11 +34,11 @@ import org.neo4j.graphdb.security.URLAccessRule;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.Logger;
 
-import static org.neo4j.helpers.Settings.ANY;
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.illegalValueMessage;
-import static org.neo4j.helpers.Settings.matches;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.ANY;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.illegalValueMessage;
+import static org.neo4j.kernel.configuration.Settings.matches;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
  * This is the main factory for creating database instances. It delegates creation to three different modules

--- a/community/kernel/src/test/java/org/neo4j/helpers/FunctionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/FunctionsTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.neo4j.function.BiFunction;
 import org.neo4j.function.Function;
 import org.neo4j.function.Functions;
+import org.neo4j.kernel.configuration.Settings;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;

--- a/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/SettingsTest.java
@@ -36,21 +36,21 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import static org.neo4j.helpers.Functions.map;
-import static org.neo4j.helpers.Settings.DURATION;
-import static org.neo4j.helpers.Settings.INTEGER;
-import static org.neo4j.helpers.Settings.MANDATORY;
-import static org.neo4j.helpers.Settings.NORMALIZED_RELATIVE_URI;
-import static org.neo4j.helpers.Settings.NO_DEFAULT;
-import static org.neo4j.helpers.Settings.PATH;
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.basePath;
-import static org.neo4j.helpers.Settings.isFile;
-import static org.neo4j.helpers.Settings.list;
-import static org.neo4j.helpers.Settings.matches;
-import static org.neo4j.helpers.Settings.max;
-import static org.neo4j.helpers.Settings.min;
-import static org.neo4j.helpers.Settings.range;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.DURATION;
+import static org.neo4j.kernel.configuration.Settings.INTEGER;
+import static org.neo4j.kernel.configuration.Settings.MANDATORY;
+import static org.neo4j.kernel.configuration.Settings.NORMALIZED_RELATIVE_URI;
+import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
+import static org.neo4j.kernel.configuration.Settings.PATH;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.basePath;
+import static org.neo4j.kernel.configuration.Settings.isFile;
+import static org.neo4j.kernel.configuration.Settings.list;
+import static org.neo4j.kernel.configuration.Settings.matches;
+import static org.neo4j.kernel.configuration.Settings.max;
+import static org.neo4j.kernel.configuration.Settings.min;
+import static org.neo4j.kernel.configuration.Settings.range;
+import static org.neo4j.kernel.configuration.Settings.setting;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class SettingsTest

--- a/community/kernel/src/test/java/org/neo4j/kernel/DiagnosticsLoggingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/DiagnosticsLoggingTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.TestGraphDatabaseFactory;

--- a/community/kernel/src/test/java/org/neo4j/kernel/StoreLockerLifecycleAdapterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/StoreLockerLifecycleAdapterTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;

--- a/community/kernel/src/test/java/org/neo4j/kernel/TestGuard.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TestGuard.java
@@ -25,7 +25,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.guard.GuardOperationsCountException;
 import org.neo4j.kernel.guard.GuardTimeoutException;

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/SystemPropertiesConfigurationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/SystemPropertiesConfigurationTest.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.configuration;
 import org.junit.Test;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 
 import static org.junit.Assert.assertEquals;

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestConfig.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestConfig.java
@@ -29,7 +29,6 @@ import java.util.Set;
 
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
-import org.neo4j.helpers.Settings;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
@@ -37,9 +36,9 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.setting;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class TestConfig

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexSamplingCancellationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexSamplingCancellationTest.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.index_background_sampling_enabled;
-import static org.neo4j.helpers.Settings.FALSE;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
 import static org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode.TRIGGER_REBUILD_ALL;
 
 public class IndexSamplingCancellationTest

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
@@ -38,7 +38,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseAPI;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestExceptionTypeOnInvalidIds.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestExceptionTypeOnInvalidIds.java
@@ -36,7 +36,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.fail;
-import static org.neo4j.helpers.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
 
 public class TestExceptionTypeOnInvalidIds
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestReadOnlyNeo4j.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestReadOnlyNeo4j.java
@@ -31,7 +31,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.api.exceptions.ReadOnlyDbException;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.EphemeralFileSystemRule;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -40,7 +40,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreFactoryTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/UpgradeStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/UpgradeStoreIT.java
@@ -37,7 +37,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -40,7 +40,7 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
-import static org.neo4j.helpers.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
 import static org.neo4j.kernel.GraphDatabaseDependencies.newDependencies;
 import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.ephemeral;
 import static org.neo4j.test.GraphDatabaseServiceCleaner.cleanDatabaseContent;

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneCommandApplierTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/LuceneCommandApplierTest.java
@@ -26,7 +26,7 @@ import java.io.File;
 import java.util.Map;
 
 import org.neo4j.graphdb.Node;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.index.IndexCommand.AddNodeCommand;

--- a/community/server/src/main/java/org/neo4j/server/configuration/ConfigurationBuilder.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ConfigurationBuilder.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.Config;
 
 /**

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerConfigFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerConfigFactory.java
@@ -33,7 +33,7 @@ import org.neo4j.server.web.ServerInternalSettings;
 import org.neo4j.shell.ShellSettings;
 
 import static java.util.Arrays.asList;
-import static org.neo4j.helpers.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.server.web.ServerInternalSettings.legacy_db_config;
 

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -27,28 +27,28 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.ConfigurationMigrator;
 import org.neo4j.kernel.configuration.Internal;
 import org.neo4j.kernel.configuration.Migrator;
 
-import static org.neo4j.helpers.Settings.ANY;
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.DURATION;
-import static org.neo4j.helpers.Settings.EMPTY;
-import static org.neo4j.helpers.Settings.FALSE;
-import static org.neo4j.helpers.Settings.HOSTNAME_PORT;
-import static org.neo4j.helpers.Settings.INTEGER;
-import static org.neo4j.helpers.Settings.NO_DEFAULT;
-import static org.neo4j.helpers.Settings.PATH;
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.STRING_LIST;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.illegalValueMessage;
-import static org.neo4j.helpers.Settings.matches;
-import static org.neo4j.helpers.Settings.min;
-import static org.neo4j.helpers.Settings.port;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.ANY;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.DURATION;
+import static org.neo4j.kernel.configuration.Settings.EMPTY;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.kernel.configuration.Settings.HOSTNAME_PORT;
+import static org.neo4j.kernel.configuration.Settings.INTEGER;
+import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
+import static org.neo4j.kernel.configuration.Settings.PATH;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.illegalValueMessage;
+import static org.neo4j.kernel.configuration.Settings.matches;
+import static org.neo4j.kernel.configuration.Settings.min;
+import static org.neo4j.kernel.configuration.Settings.port;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 @Description("Settings used by the server configuration")
 public interface ServerSettings

--- a/community/server/src/main/java/org/neo4j/server/web/ServerInternalSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/web/ServerInternalSettings.java
@@ -25,14 +25,14 @@ import java.net.URI;
 import org.neo4j.graphdb.config.Setting;
 
 import static java.io.File.separator;
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.DURATION;
-import static org.neo4j.helpers.Settings.FALSE;
-import static org.neo4j.helpers.Settings.NORMALIZED_RELATIVE_URI;
-import static org.neo4j.helpers.Settings.PATH;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.URI;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.DURATION;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.kernel.configuration.Settings.NORMALIZED_RELATIVE_URI;
+import static org.neo4j.kernel.configuration.Settings.PATH;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.URI;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
  *

--- a/community/server/src/test/java/org/neo4j/server/WrappingNeoServerBootstrapperDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/WrappingNeoServerBootstrapperDocIT.java
@@ -31,7 +31,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.jmx.Primitives;
 import org.neo4j.jmx.impl.JmxKernelExtension;
 import org.neo4j.kernel.GraphDatabaseAPI;

--- a/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
@@ -38,7 +38,7 @@ import org.neo4j.logging.AssertableLogProvider;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.neo4j.helpers.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.server.configuration.ServerSettings.http_log_config_file;
 import static org.neo4j.server.configuration.ServerSettings.http_logging_enabled;

--- a/community/server/src/test/java/org/neo4j/server/integration/ServerConfigIT.java
+++ b/community/server/src/test/java/org/neo4j/server/integration/ServerConfigIT.java
@@ -26,7 +26,7 @@ import org.junit.rules.TemporaryFolder;
 
 import javax.management.ObjectName;
 
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.jmx.impl.ConfigurationBean;
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.configuration.ServerSettings;

--- a/community/server/src/test/java/org/neo4j/server/webadmin/rest/Neo4jShellConsoleSessionDocTest.java
+++ b/community/server/src/test/java/org/neo4j/server/webadmin/rest/Neo4jShellConsoleSessionDocTest.java
@@ -29,7 +29,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;

--- a/community/shell/src/main/java/org/neo4j/shell/ShellSettings.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellSettings.java
@@ -22,15 +22,15 @@ package org.neo4j.shell;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 
-import static org.neo4j.helpers.Settings.ANY;
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.FALSE;
-import static org.neo4j.helpers.Settings.INTEGER;
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.illegalValueMessage;
-import static org.neo4j.helpers.Settings.matches;
-import static org.neo4j.helpers.Settings.port;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.ANY;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.kernel.configuration.Settings.INTEGER;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.illegalValueMessage;
+import static org.neo4j.kernel.configuration.Settings.matches;
+import static org.neo4j.kernel.configuration.Settings.port;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
  * Settings for the shell extension

--- a/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ErrorsAndWarningsTest.java
@@ -31,7 +31,7 @@ import java.io.PrintStream;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.test.ImpermanentDatabaseRule;
 
 import static org.hamcrest.CoreMatchers.containsString;

--- a/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ShellDocTest.java
@@ -26,7 +26,7 @@ import java.io.PrintWriter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.shell.impl.CollectingOutput;

--- a/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
@@ -34,7 +34,7 @@ import java.rmi.RemoteException;
 
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.shell.impl.AbstractClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.ImpermanentDatabaseRule;

--- a/community/shell/src/test/java/org/neo4j/shell/StartDbWithShell.java
+++ b/community/shell/src/test/java/org/neo4j/shell/StartDbWithShell.java
@@ -22,7 +22,7 @@ package org.neo4j.shell;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 
 import static org.neo4j.helpers.SillyUtils.ignore;
 

--- a/community/shell/src/test/java/org/neo4j/shell/impl/TestShellServerExtension.java
+++ b/community/shell/src/test/java/org/neo4j/shell/impl/TestShellServerExtension.java
@@ -21,7 +21,7 @@ package org.neo4j.shell.impl;
 
 import java.util.Map;
 
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.extension.KernelExtensionFactoryContractTest;
 import org.neo4j.shell.ShellSettings;
 

--- a/community/udc/src/main/java/org/neo4j/ext/udc/UdcSettings.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/UdcSettings.java
@@ -23,19 +23,19 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.Internal;
 
-import static org.neo4j.helpers.Settings.ANY;
-import static org.neo4j.helpers.Settings.FALSE;
-import static org.neo4j.helpers.Settings.HOSTNAME_PORT;
-import static org.neo4j.helpers.Settings.INTEGER;
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.illegalValueMessage;
-import static org.neo4j.helpers.Settings.matches;
-import static org.neo4j.helpers.Settings.min;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.ANY;
+import static org.neo4j.kernel.configuration.Settings.FALSE;
+import static org.neo4j.kernel.configuration.Settings.HOSTNAME_PORT;
+import static org.neo4j.kernel.configuration.Settings.INTEGER;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.illegalValueMessage;
+import static org.neo4j.kernel.configuration.Settings.matches;
+import static org.neo4j.kernel.configuration.Settings.min;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 @Description( "Usage Data Collector configuration settings" )
 public class UdcSettings

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -42,7 +42,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.CancellationRequest;
 import org.neo4j.helpers.Service;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.FileSystemAbstraction;

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupSettings.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupSettings.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.backup;
 
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.HOSTNAME_PORT;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.HOSTNAME_PORT;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupEmbeddedIT.java
@@ -36,7 +36,7 @@ import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.EmbeddedDatabaseRule;
 import org.neo4j.test.ProcessStreamHandler;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/EmbeddedServer.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/EmbeddedServer.java
@@ -23,7 +23,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 
 public class EmbeddedServer implements ServerInterface
 {

--- a/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupTests.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupTests.java
@@ -33,7 +33,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestBackup.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestBackup.java
@@ -39,7 +39,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.StoreLockException;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestConfiguration.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestConfiguration.java
@@ -27,7 +27,7 @@ import java.io.File;
 import java.net.InetAddress;
 
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.fail;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestOnlineBackupExtension.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestOnlineBackupExtension.java
@@ -21,7 +21,7 @@ package org.neo4j.backup;
 
 import java.util.Map;
 
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.extension.KernelExtensionFactoryContractTest;
 
 public class TestOnlineBackupExtension extends KernelExtensionFactoryContractTest

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterSettings.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/ClusterSettings.java
@@ -25,17 +25,17 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.HostnamePort;
 
-import static org.neo4j.helpers.Settings.ANY;
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.DURATION;
-import static org.neo4j.helpers.Settings.HOSTNAME_PORT;
-import static org.neo4j.helpers.Settings.MANDATORY;
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.illegalValueMessage;
-import static org.neo4j.helpers.Settings.list;
-import static org.neo4j.helpers.Settings.matches;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.ANY;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.DURATION;
+import static org.neo4j.kernel.configuration.Settings.HOSTNAME_PORT;
+import static org.neo4j.kernel.configuration.Settings.MANDATORY;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.illegalValueMessage;
+import static org.neo4j.kernel.configuration.Settings.list;
+import static org.neo4j.kernel.configuration.Settings.matches;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 import org.neo4j.helpers.Function;
 

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/client/ClusterClientModule.java
@@ -60,7 +60,7 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.Factory;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.NamedThreadFactory;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.util.Dependencies;

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -31,7 +31,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.CancellationRequest;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
@@ -22,18 +22,18 @@ package org.neo4j.kernel.ha;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.ConfigurationMigrator;
 import org.neo4j.kernel.configuration.Migrator;
 
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.BYTES;
-import static org.neo4j.helpers.Settings.DURATION;
-import static org.neo4j.helpers.Settings.HOSTNAME_PORT;
-import static org.neo4j.helpers.Settings.INTEGER;
-import static org.neo4j.helpers.Settings.min;
-import static org.neo4j.helpers.Settings.options;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.BYTES;
+import static org.neo4j.kernel.configuration.Settings.DURATION;
+import static org.neo4j.kernel.configuration.Settings.HOSTNAME_PORT;
+import static org.neo4j.kernel.configuration.Settings.INTEGER;
+import static org.neo4j.kernel.configuration.Settings.min;
+import static org.neo4j.kernel.configuration.Settings.options;
+import static org.neo4j.kernel.configuration.Settings.setting;
 import static org.neo4j.kernel.ha.HaSettings.TxPushStrategy.fixed_descending;
 
 /**

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -65,7 +65,7 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;

--- a/enterprise/ha/src/test/java/jmx/HaBeanIT.java
+++ b/enterprise/ha/src/test/java/jmx/HaBeanIT.java
@@ -54,8 +54,8 @@ import static org.junit.Assert.fail;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.setting;
 import static org.neo4j.helpers.collection.Iterables.filter;
 import static org.neo4j.helpers.collection.Iterables.first;
 import static org.neo4j.kernel.impl.ha.ClusterManager.masterSeesMembers;

--- a/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.function.IntFunction;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.SuppressOutput;

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestSlaveOnlyCluster.java
@@ -31,7 +31,7 @@ import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.function.IntFunction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.ha.ClusterManager;

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ReadOnlySlaveTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ReadOnlySlaveTest.java
@@ -29,7 +29,7 @@ import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.api.exceptions.ReadOnlyDbException;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -24,10 +24,10 @@ import java.io.File;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.Obsoleted;
 
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
  * Settings for the Neo4j Enterprise metrics reporting.

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.test.TargetDirectory;
 

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
@@ -22,11 +22,11 @@ package org.neo4j.server.enterprise;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 
-import static org.neo4j.helpers.Settings.BOOLEAN;
-import static org.neo4j.helpers.Settings.DURATION;
-import static org.neo4j.helpers.Settings.STRING;
-import static org.neo4j.helpers.Settings.TRUE;
-import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
+import static org.neo4j.kernel.configuration.Settings.DURATION;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 @Description("Settings available in the Enterprise server")
 public interface EnterpriseServerSettings


### PR DESCRIPTION
Adding new configuration options to Neo4j is not a public API. This
commit deprecates the Settings public utility class in favor of an internal
equivalent class.

The old class does not inherit from the new one, since the intent of this
change (beyond cleaning up surface API) is to allow refactoring the
now-internal Settings class.
