### PR TITLE
Introduce grouped configuration.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigValues.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigValues.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.configuration;
+
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.helpers.Function;
+import org.neo4j.helpers.Pair;
+
+import static java.util.stream.Collectors.toList;
+import static org.neo4j.helpers.Pair.pair;
+
+public class ConfigValues implements Function<String, String>
+{
+    private final Map<String, String> raw;
+
+    public ConfigValues( Map<String,String> raw )
+    {
+        this.raw = raw;
+    }
+
+    @Override
+    public String apply( String s )
+    {
+        return raw.get( s );
+    }
+
+    public List<Pair<String, String>> rawConfiguration()
+    {
+        return raw.entrySet().stream()
+                .map( e -> pair(e.getKey(), e.getValue()) )
+                .collect( toList() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.configuration;
+
+import org.neo4j.graphdb.config.Setting;
+
+public interface ConfigView
+{
+    <T> T get( Setting<T> setting );
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,11 +39,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.neo4j.helpers.Settings.BOOLEAN;
+import static org.neo4j.helpers.Settings.INTEGER;
+import static org.neo4j.helpers.Settings.NO_DEFAULT;
 import static org.neo4j.helpers.Settings.STRING;
 import static org.neo4j.helpers.Settings.setting;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
-public class TestConfig
+public class ConfigTest
 {
 
     public static class MyMigratingSettings
@@ -206,4 +209,34 @@ public class TestConfig
         assertThat( config.get( setting("non-overlapping", STRING, "") ), equalTo( "huzzah" ) );
         assertThat( config.get( setting("unrelated", STRING, "") ), equalTo( "hello" ) );
     }
+
+    @Test
+    public void shouldProvideViewOfGroups() throws Throwable
+    {
+        // Given
+        Config config = new Config( stringMap(
+                "myusers.0.name", "Bob",
+                "myusers.0.age", "81",
+                "myusers.1.name", "Greta",
+                "myusers.1.age", "82" ) );
+
+        Setting<String> name = setting( "name", STRING, NO_DEFAULT );
+        Setting<Integer> age = setting( "age", INTEGER, NO_DEFAULT );
+
+        // When
+        List<ConfigView> views = config.view( Config.groups( "myusers" ) );
+
+        // Then
+        assertThat( views.size(), equalTo( 2 ));
+
+        ConfigView bob = views.get( 0 );
+        assertThat( bob.get( name ), equalTo( "Bob" ) );
+        assertThat( bob.get( age ), equalTo( 81 ) );
+
+        ConfigView greta = views.get( 1 );
+        assertThat( greta.get( name ), equalTo( "Greta" ) );
+        assertThat( greta.get( age ), equalTo( 82 ) );
+
+    }
+
 }


### PR DESCRIPTION
This allows configuration options like:

```
dbms.books.0.name=Lord of the Rings
dbms.books.0.author=Unknown
dbms.books.1.name=Dr Who
dbms.books.1.author=Spielberg, Steven
```

This commit does not contain the user-facing java API part of this, but it
will simply be a way to help build these setting strings, like:

```
setConfig( books(0, book_name ), "Lordi" )
```

Eg. it ends up existing only once we use this API, which we will do for
Bolt in upcoming commits.
