### PR TITLE
Accepts raw ascii code as delimiter in import tool

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/DelimiterConverter.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/DelimiterConverter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tooling;
+
+import org.neo4j.function.Function;
+import org.neo4j.kernel.impl.util.Converters;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
+
+/**
+ * Converts a delimiter configuration into a character used as delimiter. Configuration can be normal characters
+ * as well as examples like: '\t', '\123', "TAB" and more.
+ */
+class DelimiterConverter implements Function<String,Character>
+{
+    private final Function<String,Character> fallback = Converters.toCharacter();
+
+    @Override
+    public Character apply( String value ) throws RuntimeException
+    {
+        // Parse "raw" ASCII character style characters:
+        // - \123 --> character with id 123
+        // - \t   --> tab character
+        if ( value.startsWith( "\\" ) && value.length() > 1 )
+        {
+            String raw = value.substring( 1 );
+            try
+            {
+                return (char) Integer.parseInt( raw );
+            }
+            catch ( NumberFormatException e )
+            {
+                if ( raw.equals( "t" ) )
+                {
+                    return Configuration.TABS.delimiter();
+                }
+                throw new IllegalArgumentException( "Invalid delimiter character '" + value + "'" );
+            }
+        }
+        // hard coded TAB --> tab character
+        else if ( value.equals( "TAB" ) )
+        {
+            return Configuration.TABS.delimiter();
+        }
+        // default to just returning the configured character
+        return fallback.apply( value );
+    }
+}

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -682,20 +682,7 @@ public class ImportTool
         }
     };
 
-    private static final Function<String,Character> DELIMITER_CONVERTER = new Function<String,Character>()
-    {
-        private final Function<String,Character> fallback = Converters.toCharacter();
-
-        @Override
-        public Character apply( String value ) throws RuntimeException
-        {
-            if ( value.equals( "TAB" ) )
-            {
-                return '\t';
-            }
-            return fallback.apply( value );
-        }
-    };
+    private static final Function<String,Character> DELIMITER_CONVERTER = new DelimiterConverter();
 
     private static final Function2<Args,String,Collection<Option<File[]>>> INPUT_FILES_EXTRACTOR =
             new Function2<Args,String,Collection<Option<File[]>>>()

--- a/community/import-tool/src/test/java/org/neo4j/tooling/DelimiterConverterTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/DelimiterConverterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tooling;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class DelimiterConverterTest
+{
+    private final DelimiterConverter converter = new DelimiterConverter();
+
+    @Test
+    public void shouldConvertCharacter() throws Exception
+    {
+        // GIVEN
+        String candidates = "abcdefghijklmnopqrstuvwxyzåäö\"'^`\\"; // to name a few
+
+        // THEN
+        for ( int i = 0; i < candidates.length(); i++ )
+        {
+            char expected = candidates.charAt( i );
+            assertCorrectConversion( expected, String.valueOf( expected ) );
+        }
+    }
+
+    @Test
+    public void shouldConvertRawAscii() throws Exception
+    {
+        for ( char expected = 0; expected < Character.MAX_VALUE; expected++ )
+        {
+            assertCorrectConversion( expected, "\\" + (int)expected );
+        }
+    }
+
+    @Test
+    public void shouldConvertEscaped_t_AsTab() throws Exception
+    {
+        // GIVEN
+        char expected = '\t';
+
+        // THEN
+        assertCorrectConversion( expected, "\\t" );
+    }
+
+    @Test
+    public void shouldConvertSpelledOut_TAB_AsTab() throws Exception
+    {
+        // GIVEN
+        char expected = '\t';
+
+        // THEN
+        assertCorrectConversion( expected, "TAB" );
+    }
+
+    @Test
+    public void shouldNotAcceptRandomEscapedStrings() throws Exception
+    {
+        try
+        {
+            converter.apply( "\\bogus" );
+            fail( "Should fail" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // Good
+        }
+    }
+
+    @Test
+    public void shouldNotAcceptStrings() throws Exception
+    {
+        try
+        {
+            converter.apply( "bogus" );
+            fail( "Should fail" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // Good
+        }
+    }
+
+    private void assertCorrectConversion( char expected, String material )
+    {
+        // WHEN
+        char converted = converter.apply( material );
+
+        // THEN
+        assertEquals( expected, converted );
+    }
+}

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.neo4j.csv.reader.IllegalMultilineFieldException;
@@ -75,6 +76,7 @@ import static org.neo4j.helpers.ArrayUtil.join;
 import static org.neo4j.helpers.Exceptions.contains;
 import static org.neo4j.helpers.Exceptions.withMessage;
 import static org.neo4j.helpers.collection.Iterables.filter;
+import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.count;
 import static org.neo4j.helpers.collection.IteratorUtil.single;
 import static org.neo4j.helpers.collection.IteratorUtil.singleOrNull;
@@ -83,7 +85,6 @@ import static org.neo4j.tooling.ImportTool.MULTI_FILE_DELIMITER;
 
 public class ImportToolTest
 {
-
     private static final int RELATIONSHIP_COUNT = 10_000;
     private static final int NODE_COUNT = 100;
 
@@ -847,6 +848,83 @@ public class ImportToolTest
         finally
         {
             System.setErr( prevErr );
+        }
+    }
+
+    @Test
+    public void shouldAcceptRawAsciiCharacterCodeAsQuoteConfiguration() throws Exception
+    {
+        // GIVEN
+        char weirdDelimiter = 1; // not '1', just the character represented with code 1, which seems to be SOH
+        String name1 = weirdDelimiter + "Weird" + weirdDelimiter;
+        String name2 = "Start " + weirdDelimiter + "middle thing" + weirdDelimiter + " end!";
+        File data = data(
+                ":ID,name",
+                "1," + name1,
+                "2," + name2 );
+
+        // WHEN
+        importTool(
+                "--into", dbRule.getStoreDirAbsolutePath(),
+                "--nodes", data.getAbsolutePath(),
+                "--quote", String.valueOf( weirdDelimiter ) );
+
+        // THEN
+        Set<String> names = asSet( "Weird", name2 );
+        GraphDatabaseService db = dbRule.getGraphDatabaseAPI();
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( Node node : at( db ).getAllNodes() )
+            {
+                String name = (String) node.getProperty( "name" );
+                assertTrue( "Didn't expect node with name '" + name + "'", names.remove( name ) );
+            }
+            assertTrue( names.isEmpty() );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldAcceptSpecialTabCharacterAsDelimiterConfiguration() throws Exception
+    {
+        // GIVEN
+        List<String> nodeIds = nodeIds();
+        Configuration config = Configuration.TABS;
+
+        // WHEN
+        importTool(
+                "--into", dbRule.getStoreDirAbsolutePath(),
+                "--delimiter", "\\t",
+                "--array-delimiter", String.valueOf( config.arrayDelimiter() ),
+                "--nodes", nodeData( true, config, nodeIds, alwaysTrue() ).getAbsolutePath(),
+                "--relationships", relationshipData( true, config, nodeIds, alwaysTrue(), true ).getAbsolutePath() );
+
+        // THEN
+        verifyData();
+    }
+
+    @Test
+    public void shouldReportBadDelimiterConfiguration() throws Exception
+    {
+        // GIVEN
+        List<String> nodeIds = nodeIds();
+        Configuration config = Configuration.TABS;
+
+        // WHEN
+        try
+        {
+            importTool(
+                    "--into", dbRule.getStoreDirAbsolutePath(),
+                    "--delimiter", "\\bogus",
+                    "--array-delimiter", String.valueOf( config.arrayDelimiter() ),
+                    "--nodes", nodeData( true, config, nodeIds, alwaysTrue() ).getAbsolutePath(),
+                    "--relationships", relationshipData( true, config, nodeIds, alwaysTrue(), true ).getAbsolutePath() );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // THEN
+            assertThat( e.getMessage(), containsString( "bogus" ) );
         }
     }
 


### PR DESCRIPTION
to accomodate for use cases where delimiter is a very specific character
or even if there are no quote characters at all, where \0 can be used.
