### PR TITLE
Bump BouncyCastle version and add it to Bolt

### DIFF
--- a/community/bolt/LICENSES.txt
+++ b/community/bolt/LICENSES.txt
@@ -292,4 +292,36 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+------------------------------------------------------------------------------
+Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
+  Bouncy Castle Provider
+------------------------------------------------------------------------------
+
+Please note: our license is an adaptation of the MIT X11 License and should be
+read as such.
+
+LICENSE
+
+Copyright (c) 2000 - 2011 The Legion Of The Bouncy Castle
+(http://www.bouncycastle.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 

--- a/community/bolt/NOTICE.txt
+++ b/community/bolt/NOTICE.txt
@@ -44,3 +44,7 @@ BSD License
   ASM Core
   Scala Compiler
 
+Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
+  Bouncy Castle Provider
+

--- a/community/bolt/pom.xml
+++ b/community/bolt/pom.xml
@@ -97,6 +97,14 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+
+    <!-- This dependency is needed for Netty to be able to generate
+    self signed certificate on a JDK without sun.security.* package -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-client</artifactId>

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -223,6 +223,8 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
+    <!-- This dependency is needed for Netty to be able to generate
+    self signed certificate on a JDK without sun.security.* package -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <licensing.phase>compile</licensing.phase>
     <lucene.version>5.3.1</lucene.version>
     <logback-classic.version>1.1.2</logback-classic.version>
-    <bouncycastle.version>1.52</bouncycastle.version>
+    <bouncycastle.version>1.53</bouncycastle.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
     <hsqldb.version>2.3.2</hsqldb.version>
     <test.runner.jvm.settings>-Xmx1G -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true</test.runner.jvm.settings>

--- a/tools/LICENSES.txt
+++ b/tools/LICENSES.txt
@@ -297,6 +297,38 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ------------------------------------------------------------------------------
+Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
+  Bouncy Castle Provider
+------------------------------------------------------------------------------
+
+Please note: our license is an adaptation of the MIT X11 License and should be
+read as such.
+
+LICENSE
+
+Copyright (c) 2000 - 2011 The Legion Of The Bouncy Castle
+(http://www.bouncycastle.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+------------------------------------------------------------------------------
 GNU Lesser General Public License, Version 2.1
   FindBugs-Annotations
 ------------------------------------------------------------------------------

--- a/tools/NOTICE.txt
+++ b/tools/NOTICE.txt
@@ -47,6 +47,10 @@ BSD License
   ASM Core
   Scala Compiler
 
+Bouncy Castle License
+  Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs
+  Bouncy Castle Provider
+
 GNU Lesser General Public License, Version 2.1
   FindBugs-Annotations
 


### PR DESCRIPTION
Latest release is 1.53 and it has some potentially valuable fixes for JDK 1.8. For more details see https://www.bouncycastle.org/releasenotes.html section '2.1.1 Version' release 1.53.

BouncyCastle is used by Netty for self-signed certificate generation. It is a fallback path if proprietary package `sun.security.x509 provided by OpenJDK is not in the classpath. In particular, IBM JDK does not include this package.
