### PR TITLE
Enable testing for Cypher hint errors with server

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
@@ -852,7 +852,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
                 "/node/\\d+/relationships/in/\\{-list\\|&\\|types\\}", hostname, scheme );
     }
 
-//    @Test
+    @Test
     public void correctStatusCodeWhenUsingHintWithoutAnyIndex() throws Exception
     {
         // begin and execute and commit

--- a/community/server/src/test/java/org/neo4j/test/server/ServerHolder.java
+++ b/community/server/src/test/java/org/neo4j/test/server/ServerHolder.java
@@ -22,12 +22,14 @@ package org.neo4j.test.server;
 import java.io.IOException;
 
 import org.neo4j.server.NeoServer;
+import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.helpers.ServerHelper;
 
 final class ServerHolder extends Thread
 {
     private static AssertionError allocation;
     private static NeoServer server;
+    private static CommunityServerBuilder builder;
 
     static synchronized NeoServer allocate() throws IOException
     {
@@ -52,9 +54,16 @@ final class ServerHolder extends Thread
         shutdown();
     }
 
+    static synchronized void setServerBuilderProperty( String key, String value )
+    {
+        initBuilder();
+        builder = builder.withProperty( key, value );
+    }
+
     private static NeoServer startServer() throws IOException
     {
-        NeoServer server = ServerHelper.createNonPersistentServer();
+        initBuilder();
+        NeoServer server = ServerHelper.createNonPersistentServer( builder );
         return server;
     }
 
@@ -67,7 +76,16 @@ final class ServerHolder extends Thread
         }
         finally
         {
+            builder = null;
             server = null;
+        }
+    }
+
+    private static void initBuilder()
+    {
+        if ( builder == null )
+        {
+            builder = CommunityServerBuilder.server();
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
+++ b/community/server/src/test/java/org/neo4j/test/server/SharedServerTestBase.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Callable;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.helpers.ServerHelper;
 import org.neo4j.test.SuppressOutput;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 
 import static org.neo4j.test.SuppressOutput.suppressAll;
 
@@ -56,6 +57,7 @@ public class SharedServerTestBase
                 @Override
                 public Void call() throws Exception
                 {
+                    ServerHolder.setServerBuilderProperty( GraphDatabaseSettings.cypher_hints_error.name(), "true" );
                     server = ServerHolder.allocate();
                     ServerHelper.cleanTheDatabase( server );
                     return null;


### PR DESCRIPTION
- Set dbms.cypher.hints.error to true for all tests based on SharedServerTestBase
- Re-enabled the test TransactionIt.correctStatusCodeWhenUsingHintWithoutAnyIndex
