### PR TITLE
Make default dbms dir relative to db location for tests.

### DIFF
--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
@@ -39,7 +39,7 @@ public interface TestServerBuilder
      * When the returned controls are {@link ServerControls#close() closed}, the temporary directory the server used
      * will be removed as well.
      */
-    public ServerControls newServer();
+    ServerControls newServer();
 
     /**
      * Configure the Neo4j instance. Configuration here can be both configuration aimed at the server as well as the
@@ -49,12 +49,12 @@ public interface TestServerBuilder
      * @param value the config value
      * @return this builder instance
      */
-    public TestServerBuilder withConfig( Setting<?> key, String value );
+    TestServerBuilder withConfig( Setting<?> key, String value );
 
     /**
      * @see #withConfig(org.neo4j.graphdb.config.Setting, String)
      */
-    public TestServerBuilder withConfig( String key, String value );
+    TestServerBuilder withConfig( String key, String value );
 
     /**
      * Shortcut for configuring the server to use an unmanaged extension. Please refer to the Neo4j Manual on how to
@@ -64,7 +64,7 @@ public interface TestServerBuilder
      * @param extension the extension class.
      * @return this builder instance
      */
-    public TestServerBuilder withExtension( String mountPath, Class<?> extension );
+    TestServerBuilder withExtension( String mountPath, Class<?> extension );
 
     /**
      * Shortcut for configuring the server to find and mount all unmanaged extensions in the given package.
@@ -73,7 +73,7 @@ public interface TestServerBuilder
      * @param packageName a java package with extension classes.
      * @return this builder instance
      */
-    public TestServerBuilder withExtension( String mountPath, String packageName );
+    TestServerBuilder withExtension( String mountPath, String packageName );
 
     /**
      * Data fixtures to inject upon server start. This can be either a file with a plain-text cypher query
@@ -81,14 +81,14 @@ public interface TestServerBuilder
      * @param cypherFileOrDirectory file with cypher statement, or directory containing ".cyp"-suffixed files.
      * @return this builder instance
      */
-    public TestServerBuilder withFixture( File cypherFileOrDirectory );
+    TestServerBuilder withFixture( File cypherFileOrDirectory );
 
     /**
      * Data fixture to inject upon server start. This should be a valid Cypher statement.
      * @param fixtureStatement a cypher statement
      * @return this builder instance
      */
-    public TestServerBuilder withFixture( String fixtureStatement );
+    TestServerBuilder withFixture( String fixtureStatement );
 
     /**
      * Data fixture to inject upon server start. This should be a user implemented fixture function
@@ -96,12 +96,12 @@ public interface TestServerBuilder
      * @param fixtureFunction a fixture function
      * @return this builder instance
      */
-    public TestServerBuilder withFixture( Function<GraphDatabaseService, Void> fixtureFunction );
+    TestServerBuilder withFixture( Function<GraphDatabaseService, Void> fixtureFunction );
 
     /**
      * Pre-populate the server with a database copied from the specified directory
      * @param sourceDirectory
      * @return this builder instance
      */
-    public TestServerBuilder copyFrom( File sourceDirectory );
+    TestServerBuilder copyFrom( File sourceDirectory );
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
@@ -41,10 +41,10 @@ import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.server.AbstractNeoServer;
 import org.neo4j.server.configuration.ServerSettings;
+import org.neo4j.server.web.ServerInternalSettings;
 
 import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
 import static org.neo4j.server.configuration.ConfigurationBuilder.ConfiguratorWrappingConfigurationBuilder.toStringForThirdPartyPackageProperty;
-import static org.neo4j.server.configuration.Configurator.DATABASE_LOCATION_PROPERTY_KEY;
 import static org.neo4j.server.configuration.Configurator.WEBSERVER_PORT_PROPERTY_KEY;
 import static org.neo4j.test.Digests.md5Hex;
 
@@ -177,7 +177,8 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
     private TestServerBuilder setDirectory( File dir )
     {
         this.serverFolder = dir;
-        config.put( DATABASE_LOCATION_PROPERTY_KEY, serverFolder.getAbsolutePath() );
+        config.put( ServerInternalSettings.neo4j_base_dir.name(), serverFolder.getAbsolutePath() );
+        config.put( ServerInternalSettings.legacy_db_location.name(), serverFolder.getAbsolutePath() );
         return this;
     }
 

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTest.java
@@ -229,7 +229,21 @@ public class InProcessBuilderTest
             assertTrue( cause instanceof IOException);
             assertTrue( cause.getMessage().contains( "exists but is not a directory" ));
         }
+    }
 
+    @Test
+    public void shouldPutServerFilesInTempDir() throws Throwable
+    {
+        // Given
+        File workingDirectory = new File( "." );
+        String[] originalFilesInWorkingDir = workingDirectory.list();
+
+        // When I start a server in an explicit test directory
+        try(ServerControls firstServer = newInProcessBuilder( testDir.directory() ).newServer())
+        {
+            // Then no files in the my regular working directory should change
+            assertThat( workingDirectory.list(), equalTo( originalFilesInWorkingDir ));
+        }
     }
 
     private void assertDBConfig( ServerControls server, String expected, String key ) throws JsonParseException

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -27,10 +27,10 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.ConfigurationMigrator;
 import org.neo4j.kernel.configuration.Internal;
 import org.neo4j.kernel.configuration.Migrator;
+import org.neo4j.kernel.configuration.Settings;
 
 import static org.neo4j.kernel.configuration.Settings.ANY;
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
@@ -44,11 +44,13 @@ import static org.neo4j.kernel.configuration.Settings.PATH;
 import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.kernel.configuration.Settings.basePath;
 import static org.neo4j.kernel.configuration.Settings.illegalValueMessage;
 import static org.neo4j.kernel.configuration.Settings.matches;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.port;
 import static org.neo4j.kernel.configuration.Settings.setting;
+import static org.neo4j.server.web.ServerInternalSettings.neo4j_base_dir;
 
 @Description("Settings used by the server configuration")
 public interface ServerSettings
@@ -141,24 +143,22 @@ public interface ServerSettings
     Setting<Integer> webserver_https_port = setting( "org.neo4j.server.webserver.https.port", INTEGER, "7473", port );
 
     @Description( "Path to the X.509 public certificate to be used by Neo4j for TLS connections" )
-    Setting<File> tls_certificate_file = setting(
-            "dbms.security.tls_certificate_file", PATH, "neo4j-home/ssl/snakeoil.cert" );
+    Setting<File> tls_certificate_file = setting( "dbms.security.tls_certificate_file", PATH, "conf/ssl/snakeoil.cert", basePath( neo4j_base_dir ) );
 
     @Description( "Path to the X.509 private key to be used by Neo4j for TLS connections" )
-    Setting<File> tls_key_file = setting(
-            "dbms.security.tls_key_file", PATH, "neo4j-home/ssl/snakeoil.key" );
+    Setting<File> tls_key_file = setting( "dbms.security.tls_key_file", PATH, "conf/ssl/snakeoil.key", basePath( neo4j_base_dir ) );
 
     @Deprecated
     @Description( "Path to the SSL certificate used for HTTPS connections. This is deprecated, please use " +
                   "'dbms.security.tls_certificate_file' instead." )
     Setting<File> webserver_https_cert_path = setting(
-            "org.neo4j.server.webserver.https.cert.location", PATH, "neo4j-home/ssl/snakeoil.cert" );
+            "org.neo4j.server.webserver.https.cert.location", PATH, "conf/ssl/snakeoil.cert", basePath( neo4j_base_dir ) );
 
     @Deprecated
     @Description( "Path to the SSL key used for HTTPS connections. This is deprecated, please use " +
                   "'dbms.security.tls_key_file'" )
     Setting<File> webserver_https_key_path = setting(
-            "org.neo4j.server.webserver.https.key.location", PATH, "neo4j-home/ssl/snakeoil.key" );
+            "org.neo4j.server.webserver.https.key.location", PATH, "conf/ssl/snakeoil.key", basePath( neo4j_base_dir ) );
 
 
     @Description( "Enable HTTP request logging." )

--- a/community/server/src/main/java/org/neo4j/server/web/ServerInternalSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/web/ServerInternalSettings.java
@@ -32,6 +32,7 @@ import static org.neo4j.kernel.configuration.Settings.NORMALIZED_RELATIVE_URI;
 import static org.neo4j.kernel.configuration.Settings.PATH;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
 import static org.neo4j.kernel.configuration.Settings.URI;
+import static org.neo4j.kernel.configuration.Settings.basePath;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
@@ -60,6 +61,13 @@ public class ServerInternalSettings
             "org.neo4j.server.webserver.statistics", BOOLEAN, FALSE );
 
     // paths
+    /**
+     * Common base directory used for resolving relative config paths. By default, this is the processes working directory, but this setting can
+     * conveniently be overridden to point somewhere else, which can be very helpful for tests that don't want to create a bunch of Neo4j files
+     * in the current directory.
+     */
+    public static final Setting<File> neo4j_base_dir = setting("dbms.base_dir", PATH, "." );
+
     public static final Setting<URI> rest_api_path = setting( "org.neo4j.server.webadmin.data.uri",
             NORMALIZED_RELATIVE_URI, "/db/data" );
 
@@ -76,14 +84,15 @@ public class ServerInternalSettings
 
     public static final Setting<Long> startup_timeout = setting( "org.neo4j.server.startup_timeout", DURATION, "120s" );
 
-    public static final Setting<File> auth_store = setting("dbms.security.auth_store.location", PATH, "data/dbms/auth");
-
     public static final Setting<File> rrd_store = setting("org.neo4j.server.webadmin.rrdb.location", PATH, "data/rrd");
 
-    public static final Setting<File> legacy_db_location = setting( "org.neo4j.server.database.location", PATH, "data/graph.db" );
+    public static final Setting<File> legacy_db_location = setting( "org.neo4j.server.database.location", PATH, "data/graph.db", basePath( neo4j_base_dir ) );
 
     public static final Setting<File> legacy_db_config = setting( "org.neo4j.server.db.tuning.properties", PATH,
             separator + "etc" + separator + "neo" + separator + ServerInternalSettings.DB_TUNING_CONFIG_FILE_NAME);
+
+
+    public static final Setting<File> auth_store = setting("dbms.security.auth_store.location", PATH, "data/dbms/auth", basePath( neo4j_base_dir ));
 
     public static final Setting<Boolean> webadmin_enabled = setting( "dbms.webadmin.enabled", BOOLEAN, TRUE );
 

--- a/community/server/src/test/java/org/neo4j/server/configuration/ServerConfigFactoryTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ServerConfigFactoryTest.java
@@ -30,14 +30,13 @@ import java.util.List;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
-import org.neo4j.test.SuppressOutput;
 import org.neo4j.logging.NullLog;
+import org.neo4j.test.SuppressOutput;
 
 import static org.junit.Assert.assertEquals;
-import static org.neo4j.test.SuppressOutput.suppressAll;
-
 import static org.junit.Assert.assertNotNull;
 import static org.neo4j.server.configuration.ServerConfigFactory.loadConfig;
+import static org.neo4j.test.SuppressOutput.suppressAll;
 
 public class ServerConfigFactoryTest
 {
@@ -108,7 +107,6 @@ public class ServerConfigFactoryTest
         assertEquals( "/extension1", thirdpartyJaxRsPackages.get( 0 ).getMountPoint() );
         assertEquals( "/extension2", thirdpartyJaxRsPackages.get( 1 ).getMountPoint() );
         assertEquals( "/extension3", thirdpartyJaxRsPackages.get( 2 ).getMountPoint() );
-
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ServerSettingsTest.java
@@ -66,8 +66,8 @@ public class ServerSettingsTest
         config.setLogger( logging.getLog( "config" ) );
 
         // Then
-        assertEquals( "cert", config.get( ServerSettings.tls_certificate_file ).getPath() );
-        assertEquals( "key", config.get( ServerSettings.tls_key_file ).getPath() );
+        assertEquals( "./cert", config.get( ServerSettings.tls_certificate_file ).getPath() );
+        assertEquals( "./key", config.get( ServerSettings.tls_key_file ).getPath() );
         logging.assertContainsMessageContaining(
                 "The TLS certificate configuration you are using, 'org.neo4j.server.webserver.https.cert.location' " +
                 "is deprecated. Please use 'dbms.security.tls_certificate_file' instead." );

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -151,7 +151,7 @@ public class CommunityServerBuilder
         return this;
     }
 
-    private void createPropertiesFile( File temporaryConfigFile )
+    private void createPropertiesFile( File temporaryConfigFile ) throws IOException
     {
         Map<String, String> properties = MapUtil.stringMap(
                 Configurator.MANAGEMENT_PATH_PROPERTY_KEY, webAdminUri,
@@ -211,6 +211,7 @@ public class CommunityServerBuilder
             }
         }
 
+        properties.put( ServerInternalSettings.neo4j_base_dir.name(), tmpDir() );
         properties.put( ServerSettings.auth_enabled.name(), "false" );
         properties.put( ServerInternalSettings.auth_store.name(), "neo4j-home/data/dbms/authorization" );
         properties.put( ServerInternalSettings.rrd_store.name(), "neo4j-home/data/rrd/" );
@@ -221,6 +222,16 @@ public class CommunityServerBuilder
         }
 
         ServerTestUtils.writePropertiesToFile( properties, temporaryConfigFile );
+    }
+
+    private String tmpDir() throws IOException
+    {
+        File file = File.createTempFile( "neo4j", "test" );
+        boolean delete = file.delete();
+        assert delete;
+        boolean mkdir = file.mkdir();
+        assert mkdir;
+        return file.getAbsolutePath();
     }
 
     public static final Map<String, String> good_tuning_file_properties =

--- a/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationDocIT.java
@@ -25,13 +25,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import javax.ws.rs.core.HttpHeaders;
 
-import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.configuration.ServerSettings;
@@ -39,6 +38,7 @@ import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.rest.RESTDocsGenerator;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
+import org.neo4j.server.web.ServerInternalSettings;
 import org.neo4j.test.TestData;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 import org.neo4j.test.server.HTTP;
@@ -52,6 +52,8 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
 {
     public @Rule TestData<RESTDocsGenerator> gen = TestData.producedThrough( RESTDocsGenerator.PRODUCER );
     private CommunityNeoServer server;
+
+    @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
     @Before
     public void setUp()
@@ -300,8 +302,8 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
 
     public void startServer( boolean authEnabled ) throws IOException
     {
-        FileUtils.deleteFile( new File( "neo4j-home/data/dbms/authorization" ) ); // TODO: Implement a common component for managing Neo4j file structure and use that here
         server = CommunityServerBuilder.server()
+                .withProperty( ServerInternalSettings.neo4j_base_dir.name(), tempDir.getRoot().getAbsolutePath() )
                 .withProperty( ServerSettings.auth_enabled.name(), Boolean.toString( authEnabled ) )
                 .build();
         server.start();

--- a/community/server/src/test/java/org/neo4j/server/rest/security/UsersDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/UsersDocIT.java
@@ -25,13 +25,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import javax.ws.rs.core.HttpHeaders;
 
-import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.configuration.ServerSettings;
@@ -39,6 +38,7 @@ import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.rest.RESTDocsGenerator;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
+import org.neo4j.server.web.ServerInternalSettings;
 import org.neo4j.test.TestData;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 import org.neo4j.test.server.HTTP;
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertThat;
 public class UsersDocIT extends ExclusiveServerTestBase
 {
     public @Rule TestData<RESTDocsGenerator> gen = TestData.producedThrough( RESTDocsGenerator.PRODUCER );
+    public @Rule TemporaryFolder tmpDir = new TemporaryFolder();
     private CommunityNeoServer server;
 
     @Before
@@ -152,9 +153,9 @@ public class UsersDocIT extends ExclusiveServerTestBase
 
     public void startServer(boolean authEnabled) throws IOException
     {
-        FileUtils.deleteFile( new File( "neo4j-home/data/dbms/authorization" ) ); // TODO: Implement a common component for managing Neo4j file structure and use that here
-        server = CommunityServerBuilder.server().withProperty( ServerSettings.auth_enabled.name(),
-                Boolean.toString( authEnabled ) ).build();
+        server = CommunityServerBuilder.server()
+                .withProperty( ServerSettings.auth_enabled.name(), Boolean.toString( authEnabled ) )
+                .withProperty( ServerInternalSettings.neo4j_base_dir.name(), tmpDir.getRoot().getAbsolutePath() ).build();
         server.start();
     }
 


### PR DESCRIPTION
For our production artifacts, we explicitly put the files that go under
`dbms` dir at their appropriate locations depending on platform.

However, for tests, there is a default directory (`data/dbms` and
`neo4j-home/dbms`) which is both obnoxious and inconsistent between
settings.

This introduces a base directory, relative to where the database directory
is. It does not change any production defaults, since those are specified
in the neo4j-server.properties file, but it means our tests and the
neo4j-harness module stops putting `neo4j-home` all over the place.
