### PR TITLE
Fix windows problems with locked lucene resources

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -525,6 +525,7 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
                     e, true );
             try
             {
+                life.shutdown();
                 // Close the neostore, so that locks are released properly
                 storageEngine.neoStores().close();
             }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
@@ -554,7 +554,7 @@ public class LuceneDataSource extends LifecycleAdapter
             if ( config.get( IndexManager.PROVIDER ).equals( LuceneIndexImplementation.SERVICE_NAME ) )
             {
                 IndexIdentifier identifier = new IndexIdentifier( IndexEntityType.Node, name );
-                getIndexSearcher( identifier );
+                getIndexSearcher( identifier ).close();
             }
         }
         for ( String name : indexStore.getNames( Relationship.class ) )
@@ -563,7 +563,7 @@ public class LuceneDataSource extends LifecycleAdapter
             if ( config.get( IndexManager.PROVIDER ).equals( LuceneIndexImplementation.SERVICE_NAME ) )
             {
                 IndexIdentifier identifier = new IndexIdentifier( IndexEntityType.Relationship, name );
-                getIndexSearcher( identifier );
+                getIndexSearcher( identifier ).close();
             }
         }
     }


### PR DESCRIPTION
Release index searchers obtained during backup
Shutdown nested neostore dataSource life in case if there was a problem during startup to release all obtained resources.
