### PR TITLE
Fix count query failures on empty database

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeCountFromCountStorePipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeCountFromCountStorePipe.scala
@@ -32,14 +32,13 @@ case class NodeCountFromCountStorePipe(ident: String, label: Option[LazyLabel])(
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val baseContext = state.initialContext.getOrElse(ExecutionContext.empty)
-    val labelId: Int = label match {
+    val count = label match {
       case Some(lazyLabel) => lazyLabel.id(state.query) match {
-        case Some(idOfLabel) => idOfLabel
-        case _ => throw new IllegalArgumentException("Cannot find id for label: " + lazyLabel)
+        case Some(idOfLabel) => state.query.nodeCountByCountStore(idOfLabel)
+        case _ => 0
       }
-      case _ => NameId.WILDCARD
+      case _ => state.query.nodeCountByCountStore(NameId.WILDCARD)
     }
-    val count = state.query.nodeCountByCountStore(labelId)
     Seq(baseContext.newWith1(ident, count)).iterator
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeCountFromCountStorePipeTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NodeCountFromCountStorePipeTest.scala
@@ -41,7 +41,7 @@ class NodeCountFromCountStorePipeTest extends CypherFunSuite with AstConstructio
     pipe.createResults(queryState).map(_("count(n)")).toSet should equal(Set(42L))
   }
 
-  test("should throw an exception when the label id can not be resolved") {
+  test("should return zero if label is missing") {
     implicit val table = new SemanticTable()
 
     val pipe = NodeCountFromCountStorePipe("count(n)", Some(LazyLabel(LabelName("A") _)))()
@@ -51,7 +51,7 @@ class NodeCountFromCountStorePipeTest extends CypherFunSuite with AstConstructio
     when(mockedContext.getOptLabelId("A")).thenReturn(None)
     val queryState = QueryStateHelper.emptyWith(query = mockedContext)
 
-    a [IllegalArgumentException] should be thrownBy pipe.createResults(queryState)
+    pipe.createResults(queryState).map(_("count(n)")).toSet should equal(Set(0L))
   }
 
   test("should return a count for nodes without a label") {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/RelationshipCountFromCountStorePipeTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/RelationshipCountFromCountStorePipeTest.scala
@@ -79,7 +79,7 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
     pipe.createResults(queryState).map(_("count(r)")).toSet should equal(Set(80L))
   }
 
-  test("should throw an exception when the label id can not be resolved") {
+  test("should return zero if rel-type is missing") {
     implicit val table = new SemanticTable()
 
     val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Seq("X")), Some(LazyLabel(LabelName("A") _)), bothDirections = false)()
@@ -90,7 +90,7 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
     when(mockedContext.getOptLabelId("A")).thenReturn(None)
     val queryState = QueryStateHelper.emptyWith(query = mockedContext)
 
-    a [IllegalArgumentException] should be thrownBy pipe.createResults(queryState)
+    pipe.createResults(queryState).map(_("count(r)")).toSet should equal(Set(0L))
   }
 
 }


### PR DESCRIPTION
Queries with simple count() expressions that can use the optimization of looking
up the count from the count store, and that counts nodes/relationships with
labels/relationship types, would fail if the label/relationship type did not exist in
the database (in particular with an empty database).
Now those counts should return 0.
