### PR TITLE
Don't show a file limit warning on OS X when running `neo4j console`

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -264,6 +264,7 @@ startit() {
 
 console() {
 
+  detectos
   checkstatus
   checklimits
 


### PR DESCRIPTION
We generally don't want to detect and warn about file limits on OS X because `ulimit -n` reports an incorrect value.
The problem was that `console` did not detect the operating system before checking for limits, so it ended up showing the file limits warning on OS X.

This fixes #159
