### PR TITLE
Removed KTI pooling

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/LegacyIndexTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/LegacyIndexTransactionState.java
@@ -34,8 +34,6 @@ import org.neo4j.kernel.impl.transaction.state.RecordState;
  */
 public interface LegacyIndexTransactionState extends RecordState
 {
-    void clear();
-
     LegacyIndex nodeChanges( String indexName ) throws LegacyIndexNotFoundKernelException;
 
     LegacyIndex relationshipChanges( String indexName ) throws LegacyIndexNotFoundKernelException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingLegacyIndexTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingLegacyIndexTransactionState.java
@@ -42,20 +42,6 @@ public class CachingLegacyIndexTransactionState implements LegacyIndexTransactio
     }
 
     @Override
-    public void clear()
-    {
-        txState.clear();
-        if ( nodeLegacyIndexChanges != null && !nodeLegacyIndexChanges.isEmpty() )
-        {
-            nodeLegacyIndexChanges.clear();
-        }
-        if ( relationshipLegacyIndexChanges != null && !relationshipLegacyIndexChanges.isEmpty() )
-        {
-            relationshipLegacyIndexChanges.clear();
-        }
-    }
-
-    @Override
     public LegacyIndex nodeChanges( String indexName ) throws LegacyIndexNotFoundKernelException
     {
         if ( nodeLegacyIndexChanges == null )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
@@ -32,7 +32,6 @@ import org.neo4j.register.Register.DoubleLongRegister;
 import org.neo4j.register.Registers;
 
 import static java.util.Objects.requireNonNull;
-
 import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
 import static org.neo4j.kernel.api.ReadOperations.ANY_RELATIONSHIP_TYPE;
 import static org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory.indexSampleKey;
@@ -140,17 +139,6 @@ public class CountsRecordState implements CountsAccessor, RecordState, CountsAcc
     public boolean hasChanges()
     {
         return !counts.isEmpty();
-    }
-
-    /**
-     * Set this counter up to a pristine state, as if it had just been initialized.
-     */
-    public void clear()
-    {
-        if ( !counts.isEmpty() )
-        {
-            counts.clear();
-        }
     }
 
     public static final class Difference

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LegacyIndexTransactionStateImpl.java
@@ -241,23 +241,4 @@ public class LegacyIndexTransactionStateImpl implements LegacyIndexTransactionSt
     {
         return defineCommand != null;
     }
-
-    /** Set this data structure to it's initial state, allowing it to be re-used as if it had just been new'ed up. */
-    @Override
-    public void clear()
-    {
-        if ( !transactions.isEmpty() )
-        {
-            transactions.clear();
-        }
-        defineCommand = null;
-        if ( !nodeCommands.isEmpty() )
-        {
-            nodeCommands.clear();
-        }
-        if ( !relationshipCommands.isEmpty() )
-        {
-            relationshipCommands.clear();
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipChangesForNode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipChangesForNode.java
@@ -25,10 +25,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
-import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.helpers.collection.PrefetchingIterator;
@@ -135,7 +133,6 @@ public class RelationshipChangesForNode
     private Map<Integer /* Type */, Set<Long /* Id */>> outgoing;
     private Map<Integer /* Type */, Set<Long /* Id */>> incoming;
     private Map<Integer /* Type */, Set<Long /* Id */>> loops;
-    private PrimitiveIntSet typesChanged;
 
     private int totalOutgoing = 0;
     private int totalIncoming = 0;
@@ -150,7 +147,6 @@ public class RelationshipChangesForNode
     public void addRelationship( long relId, int typeId, Direction direction )
     {
         Map<Integer, Set<Long>> relTypeToRelsMap = getTypeToRelMapForDirection( direction );
-        typeChanged( typeId );
         Set<Long> rels = relTypeToRelsMap.get( typeId );
         if ( rels == null )
         {
@@ -174,19 +170,9 @@ public class RelationshipChangesForNode
         }
     }
 
-    private void typeChanged( int type )
-    {
-        if ( typesChanged == null )
-        {
-            typesChanged = Primitive.intSet();
-        }
-        typesChanged.add( type );
-    }
-
     public boolean removeRelationship( long relId, int typeId, Direction direction )
     {
         Map<Integer, Set<Long>> relTypeToRelsMap = getTypeToRelMapForDirection( direction );
-        typeChanged( typeId );
         Set<Long> rels = relTypeToRelsMap.get( typeId );
         if ( rels != null )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -19,16 +19,17 @@
  */
 package org.neo4j.kernel.api;
 
-import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.Clock;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
+import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.StatementOperationParts;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionHooks;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
+import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.storageengine.StorageEngine;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
@@ -46,17 +47,22 @@ public class KernelTransactionFactory
         TransactionHeaderInformationFactory headerInformationFactory = mock( TransactionHeaderInformationFactory.class );
         when( headerInformationFactory.create() ).thenReturn( headerInformation );
 
+        long lastTransactionIdWhenStarted = 0;
+
         StorageEngine storageEngine = mock( StorageEngine.class );
         when( storageEngine.neoStores() ).thenReturn( mock( NeoStores.class ) );
+        when( storageEngine.storeReadLayer() ).thenReturn( mock( StoreReadLayer.class ) );
+
         return new KernelTransactionImplementation( mock( StatementOperationParts.class ),
                 mock( SchemaWriteGuard.class ),
                 null, new TransactionHooks(),
                 mock( ConstraintIndexCreator.class ), headerInformationFactory,
                 mock( TransactionRepresentationCommitProcess.class ), mock( TransactionMonitor.class ),
                 mock( LegacyIndexTransactionState.class ),
-                mock(Pool.class),
+                mock( KernelTransactions.class ),
                 Clock.SYSTEM_CLOCK,
                 TransactionTracer.NULL,
-                storageEngine );
+                storageEngine,
+                lastTransactionIdWhenStarted );
     }
 }


### PR DESCRIPTION
Currently `KernelTransactionImplementation`s are pooled and reused. This is done with `MarshlandPool` that has `ThreadLocal`s backed by some other pool. So each thread that executed transactions has a KTI in it's thread local storage and reuses it.

Such reuse of KTI instance with their internal state has caused quite some issues because restoring KTIs to the pristine state before putting them back to the pool is tricky.

This commit removed pooling of KTIs. So whenever new transaction is started new KTI object is created.

Reasons:
- biggest reason to pool KTIs is transaction state but it is completely reinitialized when KTI is taken from the pool
- recent storage engine API refactoring made KTI state even smaller making even less things added to the pool
- code simplification
- removed need to reinitialize KTI state

Tested:
- microbenchmarks via Core API show 30% degradation for tiny read transactions (read couple nodes by id without labels and properties, etc.) and no degradation for read/write transactions of reasonable size
- microbenchmarks via Core API show same heap usage and GC
- benchmarking read/write Cypher queries show no performance degradation
- small LDBC read/write queries shows no performance degradation on a machine with 32 hardware threads
- long running soak test shows no throughput degradation, no excessive heap usage and GC activity
