### PR TITLE
Introducing clock for RaftInstance

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
@@ -81,7 +81,13 @@ public class RaftInstanceBuilder<MEMBER>
 
         return new RaftInstance<>( member, termStore, voteStore, raftLog, electionTimeout, heartbeatInterval,
                 renewableTimeoutService, inbound, outbound, leaderWaitTimeout, logProvider, membershipManager, logShipping,
-                raftStorageExceptionHandler );
+                raftStorageExceptionHandler, clock );
+    }
+
+    public RaftInstanceBuilder<MEMBER> leaderWaitTimeout( long leaderWaitTimeout )
+    {
+        this.leaderWaitTimeout = leaderWaitTimeout;
+        return this;
     }
 
     public RaftInstanceBuilder<MEMBER> timeoutService( RenewableTimeoutService renewableTimeoutService )
@@ -111,6 +117,12 @@ public class RaftInstanceBuilder<MEMBER>
     public RaftInstanceBuilder<MEMBER> raftStorageExceptionHandler( RaftStorageExceptionHandler raftStorageExceptionHandler)
     {
         this.raftStorageExceptionHandler = raftStorageExceptionHandler;
+        return this;
+    }
+
+    public RaftInstanceBuilder<MEMBER> clock(Clock clock)
+    {
+        this.clock = clock;
         return this;
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -371,7 +371,7 @@ public class EnterpriseCoreEditionModule
                 myself, termStore, voteStore, raftLog, electionTimeout, heartbeatInterval,
                 raftTimeoutService, loggingRaftInbound,
                 new RaftOutbound( outbound ), leaderWaitTimeout, logProvider,
-                raftMembershipManager, logShipping, raftStorageExceptionHandler );
+                raftMembershipManager, logShipping, raftStorageExceptionHandler, Clock.SYSTEM_CLOCK );
 
         life.add( new RaftDiscoveryServiceConnector( discoveryService, raftInstance ) );
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.coreedge.raft;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,6 +34,9 @@ import org.neo4j.coreedge.raft.replication.ReplicatedContent;
 import org.neo4j.coreedge.server.RaftTestMember;
 import org.neo4j.coreedge.server.RaftTestMemberSetBuilder;
 import org.neo4j.coreedge.server.core.RaftStorageExceptionHandler;
+import org.neo4j.helpers.Clock;
+import org.neo4j.helpers.FakeClock;
+import org.neo4j.helpers.TickingClock;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -323,8 +328,12 @@ public class RaftInstanceTest
     {
         // Given
         ControlledRenewableTimeoutService timeouts = new ControlledRenewableTimeoutService();
+
+        int leaderWaitTimeout = 10000;
+        Clock clock = new TickingClock(0, leaderWaitTimeout + 1, TimeUnit.MILLISECONDS);
+
         RaftInstance<RaftTestMember> raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
-                .timeoutService( timeouts ).build();
+                .timeoutService( timeouts ).clock( clock ).leaderWaitTimeout( leaderWaitTimeout ).build();
 
         raft.bootstrapWithInitialMembers( new RaftTestGroup( asSet( myself, member1, member2 ) ) ); // @logIndex=0
 


### PR DESCRIPTION
- This saves us 10s on the getLeader timeout test
