### PR TITLE
Fix bug with cost planner NodeIndexSeekByRange

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Sargable.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/plans/Sargable.scala
@@ -107,8 +107,9 @@ object AsStringRangeSeekable {
 
 object AsValueRangeSeekable {
   def unapply(v: Any): Option[InequalityRangeSeekable] = v match {
-    case inequalities@AndedPropertyInequalities(ident, prop, _) =>
-      Some(InequalityRangeSeekable(ident, prop.propertyKey, inequalities))
+    case inequalities@AndedPropertyInequalities(ident, prop, innerInequalities)
+      if innerInequalities.forall( _.rhs.dependencies.isEmpty ) =>
+        Some(InequalityRangeSeekable(ident, prop.propertyKey, inequalities))
     case _ =>
       None
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -1009,4 +1009,86 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Ne
     result should (use("SchemaIndex") and evaluateTo(List(Map("n.prop" -> 1), Map("n.prop" -> 5))))
   }
 
+  test("should not use index seek by range when rhs of > inequality depends on property") {
+    // Given
+    val size = createTestModelBigEnoughToConsiderPickingIndexSeek
+
+    // When
+    val query = "MATCH (a)-->(b:Label) WHERE b.prop > a.prop RETURN count(a) as c"
+    val result = executeWithAllPlanners(query)
+
+    println(result.executionPlanDescription())
+
+    // Then
+    result should evaluateTo(List(Map("c" -> size/2)))
+    result shouldNot use("NodeIndexSeekByRange")
+  }
+
+  test("should not use index seek by range when rhs of <= inequality depends on property") {
+    // Given
+    val size = createTestModelBigEnoughToConsiderPickingIndexSeek
+
+    // When
+    val query = "MATCH (a)-->(b:Label) WHERE b.prop <= a.prop RETURN count(a) as c"
+    val result = executeWithAllPlanners(query)
+
+    // Then
+    result should evaluateTo(List(Map("c" -> size/2)))
+    result shouldNot use("NodeIndexSeekByRange")
+  }
+
+  test("should not use index seek by range when rhs of >= inequality depends on same property") {
+    // Given
+    val size = createTestModelBigEnoughToConsiderPickingIndexSeek
+
+    // When
+    val query = "MATCH (a)-->(b:Label) WHERE b.prop >= b.prop RETURN count(a) as c"
+    val result = executeWithAllPlanners(query)
+
+    // Then
+    result should evaluateTo(List(Map("c" -> size)))
+    result shouldNot use("NodeIndexSeekByRange")
+  }
+
+  test("should use index seek by range with literal on the lhs of inequality") {
+    // Given
+    val size = createTestModelBigEnoughToConsiderPickingIndexSeek
+
+    // When
+    val query = s"MATCH (a)-->(b:Label) WHERE ${size/2} < b.prop RETURN count(a) as c"
+    val result = executeWithAllPlanners(query)
+
+    // Then
+    assert(size > 20)
+    result should use("NodeIndexSeekByRange")
+    result should evaluateTo(List(Map("c" -> (size/2))))
+  }
+
+  test("should use index seek by range with double inequalities") {
+    // Given
+    val size = createTestModelBigEnoughToConsiderPickingIndexSeek
+
+    // When
+    val query = s"MATCH (a)-->(b:Label) WHERE 10 < b.prop <= ${size - 10} RETURN count(a) as c"
+    val result = executeWithAllPlanners(query)
+
+    // Then
+    assert(size > 20)
+    result should use("NodeIndexSeekByRange")
+    result should evaluateTo(List(Map("c" -> (size - 20))))
+  }
+
+  private def createTestModelBigEnoughToConsiderPickingIndexSeek: Int = {
+    val size = 400
+
+    graph.createIndex("Label", "prop")
+
+    (1 to size).foreach { i =>
+      // Half of unlabeled nodes has prop = 0 (for even i:s prop = 0, for odd i:s prop = i)
+      val a = createNode(Map("prop" -> (i & 1) * i))
+      val b = createLabeledNode(Map("prop" -> i), "Label")
+      relate(a, b)
+    }
+    size
+  }
 }


### PR DESCRIPTION
The cost planner should not pick a NodeIndexSeekByRange as a leaf plan
if the right-hand-side of the range inequality has dependencies
