### PR TITLE
Support shortestPath fallback on node-node case

### DIFF
--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
@@ -153,7 +153,7 @@ public class ShortestPath implements PathFinder<Path>
         lastMetadata = new Metadata();
         if ( start.equals( end ) )
         {
-            return Collections.singletonList( PathImpl.singular( start ) );
+            return filterPaths(Collections.singletonList( PathImpl.singular( start ) ));
         }
         Hits hits = new Hits();
         Collection<Long> sharedVisitedRels = new HashSet<Long>();


### PR DESCRIPTION
The shortestPath algorithm returns directly when the start and end node are the same. However, this is not checked for predicate compliance like all other return cases, and leads to unexpected results, where predicates are not considered in this case. This commit adds that check and verifies that with predicates, the cypher fallback will be enacted even for same start and end nodes.
