### PR TITLE
3.0 Support REMOVE property in cost planner

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -73,7 +73,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
 
   test("create a single node with properties") {
     val result = updateWithBothPlanners("create (n {prop: 'foo'}) return n.prop as p")
-    assertStats(result, nodesCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1)
     // then
     result.toList should equal(List(Map("p" -> "foo")))
   }
@@ -85,7 +85,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("create node using null properties should just ignore those properties") {
     // when
     val result = updateWithBothPlanners("create (n {id: 12, property: null}) return n.id as id")
-    assertStats(result, nodesCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1)
 
     // then
    result.toList should equal(List(Map("id" -> 12)))
@@ -94,7 +94,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("create relationship using null properties should just ignore those properties") {
     // when
     val result = updateWithBothPlanners("create ()-[r:X {id: 12, property: null}]->() return r.id")
-    assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 1)
 
     // then
     result.toList should equal(List(Map("r.id" -> 12)))
@@ -128,7 +128,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("create relationship with property") {
     val result = updateWithBothPlanners("CREATE (a)-[r:R {prop: 42}]->(b)")
 
-    assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 1)
   }
 
   test("creates relationship in correct direction") {
@@ -733,7 +733,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
 
     val result = updateWithBothPlanners(query)
 
-    assertStats(result, nodesCreated = 171, relationshipsCreated = 253, propertiesSet = 564, labelsAdded = 171)
+    assertStats(result, nodesCreated = 171, relationshipsCreated = 253, propertiesWritten = 564, labelsAdded = 171)
 
   }
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateUniqueAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateUniqueAcceptanceTest.scala
@@ -67,8 +67,8 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineFunSuite with QueryStati
     val res2 = execute(query, "param" -> nodeProps2)
 
     //then
-    assertStats(res1, nodesCreated = 1, relationshipsCreated = 1, propertiesSet = 1, labelsAdded = 1)
-    assertStats(res2, nodesCreated = 0, relationshipsCreated = 0, propertiesSet = 0, labelsAdded = 0)
+    assertStats(res1, nodesCreated = 1, relationshipsCreated = 1, propertiesWritten = 1, labelsAdded = 1)
+    assertStats(res2, nodesCreated = 0, relationshipsCreated = 0, propertiesWritten = 0, labelsAdded = 0)
   }
 
   test("create_new_node_with_labels_on_the_left") {
@@ -139,7 +139,7 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineFunSuite with QueryStati
     val result = execute("match (a) where id(a) = 0 create unique (a)-[r:X]->({p}) return r", "p" -> nodeProps)
     val createdRel = result.columnAs[Relationship]("r").toList.head
 
-    assertStats(result, relationshipsCreated = 1, nodesCreated = 1, propertiesSet = 1)
+    assertStats(result, relationshipsCreated = 1, nodesCreated = 1, propertiesWritten = 1)
 
     val r = graph.inTx(a.getRelationships.asScala.head)
 
@@ -157,7 +157,7 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineFunSuite with QueryStati
     val result = execute("match (a) where id(a) = 0 create unique path=(a)-[:X]->({p}) return last(nodes(path))", "p" -> nodeProps)
     val endNode = result.columnAs[Node]("last(nodes(path))").toList.head
 
-    assertStats(result, relationshipsCreated = 1, nodesCreated = 1, propertiesSet = 1)
+    assertStats(result, relationshipsCreated = 1, nodesCreated = 1, propertiesWritten = 1)
     graph.inTx {
       endNode.getProperty("name") should equal("Lasse")
     }
@@ -170,7 +170,7 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineFunSuite with QueryStati
 
     val result = execute("match (n) where id(n) = 0 create unique (n)-[:REL]->(a {props1})-[:LER]->(b {props2}) return a,b", "props1"->props1, "props2"->props2)
 
-    assertStats(result, relationshipsCreated = 2, nodesCreated = 2, propertiesSet = 4)
+    assertStats(result, relationshipsCreated = 2, nodesCreated = 2, propertiesWritten = 4)
     val resultMap = result.toList.head
 
     graph.inTx {
@@ -189,7 +189,7 @@ class CreateUniqueAcceptanceTest extends ExecutionEngineFunSuite with QueryStati
 
     val result = execute("match (n) where id(n) = 0 create unique p=(n)-[:REL]->({props1})-[:LER]->({props2}) return p", "props1"->props1, "props2"->props2)
 
-    assertStats(result, relationshipsCreated = 2, nodesCreated = 2, propertiesSet = 4)
+    assertStats(result, relationshipsCreated = 2, nodesCreated = 2, propertiesWritten = 4)
     val path = result.toList.head("p").asInstanceOf[Path]
 
     val lasse = path.endNode()
@@ -385,7 +385,7 @@ FOREACH(name in ['a','b','c'] |
 return book
 """)
 
-    assertStats(result, nodesCreated = 2, relationshipsCreated = 4, propertiesSet = 1)
+    assertStats(result, nodesCreated = 2, relationshipsCreated = 4, propertiesWritten = 1)
 
     val book = result.toList.head("book").asInstanceOf[Node]
 
@@ -417,7 +417,7 @@ FOREACH(name in ['a','b','c'] |
 )
 """)
 
-    assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesWritten = 1)
 
     graph.inTx {
       val bookTags = tagRoot.getRelationships.asScala.map(_.getOtherNode(tagRoot)).map(_.getProperty("name")).toSet
@@ -438,7 +438,7 @@ CREATE UNIQUE
   (b)-[:X]->(x)
 RETURN x""")
 
-    assertStats(result, nodesCreated = 2, relationshipsCreated = 3, propertiesSet = 1)
+    assertStats(result, nodesCreated = 2, relationshipsCreated = 3, propertiesWritten = 1)
   }
 
   test("should_not_create_unnamed_parts_unnecessarily") {
@@ -466,7 +466,7 @@ CREATE UNIQUE
   (b)-[:X]->(x)-[:X]->(z {foo:'buzz'})
 RETURN x""")
 
-    assertStats(result, nodesCreated = 2, relationshipsCreated = 4, propertiesSet = 2)
+    assertStats(result, nodesCreated = 2, relationshipsCreated = 4, propertiesWritten = 2)
   }
 
   test("should_work_well_inside_foreach") {
@@ -521,7 +521,7 @@ RETURN value;""")
              v1
      */
 
-    assertStats(result, nodesCreated = 4, relationshipsCreated = 4, propertiesSet = 6)
+    assertStats(result, nodesCreated = 4, relationshipsCreated = 4, propertiesWritten = 6)
 
     val result2 = execute("""match (root) where id(root) = 0
 CREATE (value { year:2012, month:5, day:12 })
@@ -529,7 +529,7 @@ WITH root,value
 CREATE UNIQUE (root)-[:X]->(year {value:value.year})-[:X]->(month {value:value.month})-[:X]->(day {value:value.day})-[:X]->(value)
 RETURN value;""")
 
-    assertStats(result2, nodesCreated = 2, relationshipsCreated = 2, propertiesSet = 4)
+    assertStats(result2, nodesCreated = 2, relationshipsCreated = 2, propertiesWritten = 4)
 
     /*
              root

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -51,7 +51,7 @@ class LoadCsvAcceptanceTest
 
     for (url <- urls) {
       val result = execute(s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
-      assertStats(result, nodesCreated = 3, propertiesSet = 3)
+      assertStats(result, nodesCreated = 3, propertiesWritten = 3)
     }
   }
 
@@ -65,7 +65,7 @@ class LoadCsvAcceptanceTest
     for (url <- urls) {
       val result =
         execute(s"LOAD CSV FROM '$url' AS line CREATE (a {number: line[0]}) RETURN a.number")
-      assertStats(result, nodesCreated = 3, propertiesSet = 3)
+      assertStats(result, nodesCreated = 3, propertiesWritten = 3)
 
       result.columnAs[Long]("a.number").toList === List("")
     }
@@ -80,7 +80,7 @@ class LoadCsvAcceptanceTest
     })
     for (url <- urls) {
       val result = execute(s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
-      assertStats(result, nodesCreated = 3, propertiesSet = 3)
+      assertStats(result, nodesCreated = 3, propertiesWritten = 3)
     }
   }
 
@@ -97,7 +97,7 @@ class LoadCsvAcceptanceTest
         s"LOAD CSV WITH HEADERS FROM '$url' AS line CREATE (a {id: line.id, name: line.name}) RETURN a.name"
       )
 
-      assertStats(result, nodesCreated = 3, propertiesSet = 6)
+      assertStats(result, nodesCreated = 3, propertiesWritten = 6)
     }
   }
 
@@ -255,7 +255,7 @@ class LoadCsvAcceptanceTest
     ).cypherEscape
 
     val result = execute(s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
-    assertStats(result, nodesCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1)
   }
 
   test("should be able to open relative paths with dotdot") {
@@ -265,7 +265,7 @@ class LoadCsvAcceptanceTest
     ).cypherEscape
 
     val result = execute(s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
-    assertStats(result, nodesCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1)
   }
 
   test("should handle null keys in maps as result value") {
@@ -444,7 +444,7 @@ class LoadCsvAcceptanceTest
     createNode(Map("prop" -> second))
 
     val result = execute(s"MATCH (n) WITH n, '$first' as prefix  LOAD CSV FROM prefix + n.prop AS line CREATE (a {name: line[0]}) RETURN a.name")
-    assertStats(result, nodesCreated = 3, propertiesSet = 3)
+    assertStats(result, nodesCreated = 3, propertiesWritten = 3)
   }
 
   private def ensureNoIllegalCharsInWindowsFilePath(filename: String) = {

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
@@ -59,7 +59,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val result = updateWithBothPlanners("merge (a:Label) on create set a.prop = 42 return a.prop")
 
     result.toList should equal(List(Map("a.prop" -> 42)))
-    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
   }
 
   test("merge node with label when it exists") {
@@ -97,7 +97,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     // Then
     result.toList should equal(List(Map("a.prop" -> 43)))
-    assertStats(result, nodesCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1)
   }
 
   test("merge node with prop and label") {
@@ -134,13 +134,13 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     // Then
     result.toList should equal(List(Map("a.prop" -> 11)))
-    assertStats(result, nodesCreated = 1, propertiesSet = 1, labelsAdded = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
   }
 
   test("multiple merges after each other") {
     1 to 100 foreach { prop =>
       val result = updateWithBothPlanners(s"merge (a:Label {prop: $prop}) return a.prop")
-      assertStats(result, nodesCreated = 1, propertiesSet = 1, labelsAdded = 1)
+      assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
     }
   }
 
@@ -177,7 +177,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     // Then
     result.toList should equal(List(Map("a.prop" -> 42)))
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
   }
 
   test("merge node should match properties given ad map") {
@@ -200,7 +200,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val result = updateWithBothPlanners("merge (a:Label {prop:42}) return a.prop")
 
     // Then
-    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
     val props = result.columnAs[Node]("a.prop").toList
     props should equal(List(42))
   }
@@ -424,7 +424,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val result = executeWithRulePlanner("foreach(x in [1,2,3] | merge ({property: x}))")
 
     // then
-    assertStats(result, nodesCreated = 3, propertiesSet = 3)
+    assertStats(result, nodesCreated = 3, propertiesWritten = 3)
   }
 
   test("unrelated nodes with same property should not clash") {
@@ -446,7 +446,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val result = updateWithBothPlanners("MERGE (person:Person {name:'Lasse'}) RETURN person.name")
 
     // then does not throw
-    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
   }
 
   test("works with index and constraint") {
@@ -458,7 +458,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val result = updateWithBothPlanners("MERGE (person:Person {name:'Lasse', id:42}) RETURN person.name")
 
     // then does not throw
-    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesSet = 2)
+    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 2)
   }
 
   test("works with indexed and unindexed property") {
@@ -469,7 +469,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val result = updateWithBothPlanners("MERGE (person:Person {name:'Lasse', id:42}) RETURN person.name")
 
     // then does not throw
-    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesSet = 2)
+    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 2)
   }
 
   test("works with two indexed properties") {
@@ -481,7 +481,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val result = updateWithBothPlanners("MERGE (person:Person {name:'Lasse', id:42}) RETURN person.name")
 
     // then does not throw
-    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesSet = 2)
+    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 2)
   }
 
   test("works with property repeated in literal map in set") {
@@ -493,7 +493,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     // then - does not throw
     result.toList should equal(List(Map("person.ssn" -> 42)))
-    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesSet = 3)
+    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 3)
   }
 
   test("works with property in map that gets set") {
@@ -506,7 +506,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     // then - does not throw
     result.toList should equal(List(Map("person.ssn" -> 42)))
-    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesSet = 3)
+    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 3)
   }
 
   test("should work when finding multiple elements") {
@@ -520,7 +520,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     val result = updateWithBothPlanners(query)
 
-    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
   }
 
   test("should be able to merge using property from match") {
@@ -535,7 +535,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     val result = updateWithBothPlanners(query)
 
-    assertStats(result, nodesCreated = 3, propertiesSet = 3, labelsAdded = 3)
+    assertStats(result, nodesCreated = 3, propertiesWritten = 3, labelsAdded = 3)
   }
 
   test("should be able to merge using property from match with index") {
@@ -552,7 +552,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     val result = updateWithBothPlanners(query)
 
-    assertStats(result, nodesCreated = 3, propertiesSet = 3, labelsAdded = 3)
+    assertStats(result, nodesCreated = 3, propertiesWritten = 3, labelsAdded = 3)
   }
 
   test("should be able to use properties from match in ON CREATE") {
@@ -563,7 +563,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     val result = updateWithBothPlanners(query)
 
-    assertStats(result, nodesCreated = 1, propertiesSet = 1, labelsAdded = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
   }
 
   test("should be able to use properties from match in ON MATCH") {
@@ -573,7 +573,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val query = "MATCH (person:Person) MERGE (city: City) ON MATCH SET city.name = person.bornIn RETURN person.bornIn"
 
     val result = updateWithBothPlanners(query)
-    assertStats(result, nodesCreated = 1, propertiesSet = 1, labelsAdded = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
   }
 
   test("should be able to use properties from match in ON MATCH and ON CREATE") {
@@ -583,7 +583,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val query = "MATCH (person:Person) MERGE (city: City) ON MATCH SET city.name = person.bornIn ON CREATE SET city.name = person.bornIn RETURN person.bornIn"
 
     val result = updateWithBothPlanners(query)
-    assertStats(result, nodesCreated = 1, propertiesSet = 2, labelsAdded = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 2, labelsAdded = 1)
     executeWithAllPlanners("MATCH (n:City) WHERE NOT exists(n.name) RETURN n").toList shouldBe empty
   }
 
@@ -638,7 +638,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val result = executeWithRulePlanner("CREATE (a) FOREACH(x in [1,2,3] | MERGE (a)-[:X]->({id: x})) RETURN a")
 
     // then
-    assertStats(result, nodesCreated = 4, relationshipsCreated = 3, propertiesSet = 3)
+    assertStats(result, nodesCreated = 4, relationshipsCreated = 3, propertiesWritten = 3)
   }
 
   test("merge_should_see_variables_introduced_by_update_actions") {
@@ -663,7 +663,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     val result = updateWithBothPlanners("merge (test:L:B {prop : 42}) return labels(test) as labels")
 
-    assertStats(result, nodesCreated = 1, propertiesSet = 1, labelsAdded = 2)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 2)
     result.toList should equal(List(Map("labels" -> List("L", "B"))))
   }
 
@@ -673,7 +673,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     val result = updateWithBothPlanners("merge (test:L:B {prop : 42}) return labels(test) as labels")
 
-    assertStats(result, nodesCreated = 1, propertiesSet = 1, labelsAdded = 2)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 2)
     result.toList should equal(List(Map("labels" -> List("L", "B"))))
   }
 
@@ -696,6 +696,6 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     val result = updateWithBothPlanners(query)
 
-    assertStats(result, nodesCreated = 2, labelsAdded = 2, relationshipsCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 2, labelsAdded = 2, relationshipsCreated = 1, propertiesWritten = 1)
   }
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/NullAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/NullAcceptanceTest.scala
@@ -39,7 +39,7 @@ class NullAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
     // Given empty database
 
     // When
-    val result = executeWithRulePlanner("optional match (a:DoesNotExist) remove a.prop return a")
+    val result = updateWithBothPlanners("optional match (a:DoesNotExist) remove a.prop return a")
 
     // Then doesn't throw
     result.toList

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
@@ -32,7 +32,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val result = updateWithBothPlanners("MATCH (n) SET n.property = null RETURN count(*)")
 
     // then
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     node should not(haveProperty("property"))
   }
 
@@ -44,7 +44,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val result = updateWithBothPlanners("MATCH ()-[r]->() SET r.property = null RETURN count(*)")
 
     // then
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     relationship should not(haveProperty("property"))
   }
 
@@ -56,7 +56,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val result = updateWithBothPlanners("match (n) where n.name = 'Andres' set n.name = 'Michael'")
 
     // then
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     a should haveProperty("name").withValue("Michael")
   }
 
@@ -68,7 +68,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val result = updateWithBothPlanners("match (n) where n.name = 'Andres' set n.name = n.name + ' was here' return count(*)")
 
     // then
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     a should haveProperty("name").withValue("Andres was here")
   }
 
@@ -80,7 +80,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val result = updateWithBothPlanners("match (n) where n.name = 'Michael' set n.name = null return n.age")
 
     // then
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     n should not(haveProperty("name"))
   }
 
@@ -167,7 +167,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val result = updateWithBothPlanners("MATCH (n {foo:'A'}) SET n += {bar:'B'} RETURN count(*)")
 
     // then
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     a should haveProperty("foo").withValue("A")
     a should haveProperty("bar").withValue("B")
   }
@@ -180,7 +180,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val result = updateWithBothPlanners("MATCH (n {foo:'A'}) SET n += {foo:null} RETURN count(*)")
 
     // then
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     a should not(haveProperty("foo"))
     a should haveProperty("bar").withValue("B")
   }
@@ -210,7 +210,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     // when
     val result = updateWithBothPlanners("MATCH (n {foo:'A'}) SET n = {foo:'B', baz:'C'} RETURN count(*)")
 
-    assertStats(result, propertiesSet = 3)
+    assertStats(result, propertiesWritten = 3)
     // then
     a should not(haveProperty("bar"))
     a should haveProperty("foo").withValue("B")

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
@@ -281,9 +281,6 @@ object ClauseConverters {
     }
   }
 
-  private implicit def returnItemsToIdName(s: Seq[ReturnItem]): Set[IdName] =
-    s.map(item => IdName(item.name)).toSet
-
   private def addWithToLogicalPlanInput(builder: PlannerQueryBuilder,
                                         clause: With): PlannerQueryBuilder = clause match {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/ClauseConverters.scala
@@ -381,7 +381,7 @@ object ClauseConverters {
         ))
 
       case (builder, other) =>
-        throw new CantHandleQueryException(s"REMOVE $other not supported in cost planner yet")
+        throw new InternalException(s"REMOVE $other not supported in cost planner yet")
     }
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ExecuteUpdateCommandsPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ExecuteUpdateCommandsPipe.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.executionplan.Effects._
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.CollectionSupport
 import org.neo4j.cypher.internal.compiler.v3_0.mutation._
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
-import org.neo4j.cypher.internal.frontend.v3_0.{CypherTypeException, InternalException, ParameterWrongTypeException, SyntaxException}
+import org.neo4j.cypher.internal.frontend.v3_0.{CypherTypeException, InternalException, SyntaxException}
 import org.neo4j.graphdb.NotInTransactionException
 
 import scala.collection.mutable

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/MutatingStatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/MutatingStatementConvertersTest.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.ast.convert.plannerQuery
+
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{SimplePatternLength, PatternRelationship, IdName}
+import org.neo4j.cypher.internal.compiler.v3_0.planner._
+import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection.OUTGOING
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{Null, SignedDecimalIntegerLiteral, PropertyKeyName}
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+
+class MutatingStatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSupport {
+
+  test("setting a node property: MATCH (n) SET n.prop = 42 RETURN n") {
+    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) SET n.prop = 42 RETURN n")
+    query.horizon should equal(RegularQueryProjection(
+      projections = Map("n" -> varFor("n"))
+    ))
+
+    query.queryGraph.patternNodes should equal(Set(IdName("n")))
+    query.updateGraph.mutatingPatterns should equal(List(
+      SetNodePropertyPattern(IdName("n"), PropertyKeyName("prop")(pos), SignedDecimalIntegerLiteral("42")(pos))
+    ))
+  }
+
+  test("removing a node property should look like setting a property to null") {
+    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) REMOVE n.prop RETURN n")
+    query.horizon should equal(RegularQueryProjection(
+      projections = Map("n" -> varFor("n"))
+    ))
+
+    query.queryGraph.patternNodes should equal(Set(IdName("n")))
+    query.updateGraph.mutatingPatterns should equal(List(
+      SetNodePropertyPattern(IdName("n"), PropertyKeyName("prop")(pos), Null()(pos))
+    ))
+  }
+
+  test("setting a relationship property: MATCH (a)-[r]->(b) SET r.prop = 42 RETURN r") {
+    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a)-[r]->(b) SET r.prop = 42 RETURN r")
+    query.horizon should equal(RegularQueryProjection(
+      projections = Map("r" -> varFor("r"))
+    ))
+
+    query.queryGraph.patternRelationships should equal(Set(
+      PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), OUTGOING, List(), SimplePatternLength)
+    ))
+    query.updateGraph.mutatingPatterns should equal(List(
+      SetRelationshipPropertyPattern(IdName("r"), PropertyKeyName("prop")(pos), SignedDecimalIntegerLiteral("42")(pos))
+    ))
+  }
+
+  test("removing a relationship property should look like setting a property to null") {
+    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a)-[r]->(b) REMOVE r.prop RETURN r")
+    query.horizon should equal(RegularQueryProjection(
+      projections = Map("r" -> varFor("r"))
+    ))
+
+    query.queryGraph.patternRelationships should equal(Set(
+      PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), OUTGOING, List(), SimplePatternLength)
+    ))
+    query.updateGraph.mutatingPatterns should equal(List(
+      SetRelationshipPropertyPattern(IdName("r"), PropertyKeyName("prop")(pos), Null()(pos))
+    ))
+  }
+
+}

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/MutatingStatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/MutatingStatementConvertersTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 class MutatingStatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("setting a node property: MATCH (n) SET n.prop = 42 RETURN n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) SET n.prop = 42 RETURN n")
+    val query = buildPlannerQuery("MATCH (n) SET n.prop = 42 RETURN n")
     query.horizon should equal(RegularQueryProjection(
       projections = Map("n" -> varFor("n"))
     ))
@@ -40,7 +40,7 @@ class MutatingStatementConvertersTest extends CypherFunSuite with LogicalPlannin
   }
 
   test("removing a node property should look like setting a property to null") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) REMOVE n.prop RETURN n")
+    val query = buildPlannerQuery("MATCH (n) REMOVE n.prop RETURN n")
     query.horizon should equal(RegularQueryProjection(
       projections = Map("n" -> varFor("n"))
     ))
@@ -52,7 +52,7 @@ class MutatingStatementConvertersTest extends CypherFunSuite with LogicalPlannin
   }
 
   test("setting a relationship property: MATCH (a)-[r]->(b) SET r.prop = 42 RETURN r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a)-[r]->(b) SET r.prop = 42 RETURN r")
+    val query = buildPlannerQuery("MATCH (a)-[r]->(b) SET r.prop = 42 RETURN r")
     query.horizon should equal(RegularQueryProjection(
       projections = Map("r" -> varFor("r"))
     ))
@@ -66,7 +66,7 @@ class MutatingStatementConvertersTest extends CypherFunSuite with LogicalPlannin
   }
 
   test("removing a relationship property should look like setting a property to null") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a)-[r]->(b) REMOVE r.prop RETURN r")
+    val query = buildPlannerQuery("MATCH (a)-[r]->(b) REMOVE r.prop RETURN r")
     query.horizon should equal(RegularQueryProjection(
       projections = Map("r" -> varFor("r"))
     ))

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -44,12 +44,12 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   val nProp: Expression = Property( Variable( "n" ) _, PropertyKeyName( "prop" ) _ ) _
 
   test("RETURN 42") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("RETURN 42")
+    val query = buildPlannerQuery("RETURN 42")
     query.horizon should equal(RegularQueryProjection(Map("42" -> SignedDecimalIntegerLiteral("42")_)))
   }
 
   test("RETURN 42, 'foo'") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("RETURN 42, 'foo'")
+    val query = buildPlannerQuery("RETURN 42, 'foo'")
     query.horizon should equal(RegularQueryProjection(Map(
       "42" -> SignedDecimalIntegerLiteral("42")_,
       "'foo'" -> StringLiteral("foo")_
@@ -57,7 +57,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (n) return n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (n) return n")
+    val query = buildPlannerQuery("match (n) return n")
     query.horizon should equal(RegularQueryProjection(Map(
       "n" -> nIdent
     )))
@@ -66,7 +66,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (n) WHERE n:A:B RETURN n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) WHERE n:A:B RETURN n")
+    val query = buildPlannerQuery("MATCH (n) WHERE n:A:B RETURN n")
     query.horizon should equal(RegularQueryProjection(Map(
       "n" -> nIdent
     )))
@@ -80,7 +80,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (n) where n:X OR n:Y return n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (n) where n:X OR n:Y return n")
+    val query = buildPlannerQuery("match (n) where n:X OR n:Y return n")
     query.horizon should equal(RegularQueryProjection(Map(
       "n" -> nIdent
     )))
@@ -96,7 +96,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (n) WHERE n:X OR (n:A AND n:B) RETURN n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) WHERE n:X OR (n:A AND n:B) RETURN n")
+    val query = buildPlannerQuery("MATCH (n) WHERE n:X OR (n:A AND n:B) RETURN n")
     query.horizon should equal(RegularQueryProjection(Map(
       "n" -> nIdent
     )))
@@ -116,7 +116,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (n) WHERE id(n) = 42 RETURN n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) WHERE id(n) = 42 RETURN n")
+    val query = buildPlannerQuery("MATCH (n) WHERE id(n) = 42 RETURN n")
     query.horizon should equal(RegularQueryProjection(Map(
       "n" -> nIdent
     )))
@@ -132,7 +132,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (n) WHERE id(n) IN [42, 43] RETURN n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) WHERE id(n) IN [42, 43] RETURN n")
+    val query = buildPlannerQuery("MATCH (n) WHERE id(n) IN [42, 43] RETURN n")
     query.horizon should equal(RegularQueryProjection(Map(
       "n" -> nIdent
     )))
@@ -148,7 +148,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (n) WHERE n:A AND id(n) = 42 RETURN n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) WHERE n:A AND id(n) = 42 RETURN n")
+    val query = buildPlannerQuery("MATCH (n) WHERE n:A AND id(n) = 42 RETURN n")
     query.horizon should equal(RegularQueryProjection(Map(
       "n" -> nIdent
     )))
@@ -165,7 +165,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (p) = (a) return p") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match p = (a) return p")
+    val query = buildPlannerQuery("match p = (a) return p")
     query.queryGraph.patternRelationships should equal(Set())
     query.queryGraph.patternNodes should equal(Set[IdName]("a"))
     query.queryGraph.selections should equal(Selections(Set.empty))
@@ -175,7 +175,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match p = (a)-[r]->(b) return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match p = (a)-[r]->(b) return a,r")
+    val query = buildPlannerQuery("match p = (a)-[r]->(b) return a,r")
     query.queryGraph.patternRelationships should equal(Set(patternRel))
     query.queryGraph.patternNodes should equal(Set[IdName]("a", "b"))
     query.queryGraph.selections should equal(Selections(Set.empty))
@@ -186,7 +186,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)-[r]->(b)-[r2]->(c) return a,r,b, c") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)-[r]->(b)-[r2]->(c) return a,r,b")
+    val query = buildPlannerQuery("match (a)-[r]->(b)-[r2]->(c) return a,r,b")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), OUTGOING, Seq.empty, SimplePatternLength),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("c")), OUTGOING, Seq.empty, SimplePatternLength)))
@@ -201,7 +201,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)-[r]->(b)-[r2]->(a) return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)-[r]->(b)-[r2]->(a) return a,r")
+    val query = buildPlannerQuery("match (a)-[r]->(b)-[r2]->(a) return a,r")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), OUTGOING, Seq.empty, SimplePatternLength),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("a")), OUTGOING, Seq.empty, SimplePatternLength)))
@@ -215,7 +215,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)<-[r]-(b)-[r2]-(c) return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)<-[r]-(b)-[r2]-(c) return a,r")
+    val query = buildPlannerQuery("match (a)<-[r]-(b)-[r2]-(c) return a,r")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), INCOMING, Seq.empty, SimplePatternLength),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("c")), BOTH, Seq.empty, SimplePatternLength)))
@@ -229,7 +229,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)<-[r]-(b), (b)-[r2]-(c) return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)<-[r]-(b), (b)-[r2]-(c) return a,r")
+    val query = buildPlannerQuery("match (a)<-[r]-(b), (b)-[r2]-(c) return a,r")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), INCOMING, Seq.empty, SimplePatternLength),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("c")), BOTH, Seq.empty, SimplePatternLength)))
@@ -243,7 +243,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a), (n)-[r:Type]-(c) where b:A return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a), (n)-[r:Type]-(c) where n:A return a,r")
+    val query = buildPlannerQuery("match (a), (n)-[r:Type]-(c) where n:A return a,r")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("n"), IdName("c")), BOTH, Seq(relType("Type")), SimplePatternLength)))
     query.queryGraph.patternNodes should equal(Set(IdName("a"), IdName("n"), IdName("c")))
@@ -257,7 +257,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)-[r:Type|Foo]-(b) return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)-[r:Type|Foo]-(b) return a,r")
+    val query = buildPlannerQuery("match (a)-[r:Type|Foo]-(b) return a,r")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), BOTH, Seq(relType("Type"), relType("Foo")), SimplePatternLength)))
     query.queryGraph.patternNodes should equal(Set(IdName("a"), IdName("b")))
@@ -269,7 +269,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)-[r:Type*]-(b) return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)-[r:Type*]-(b) return a,r")
+    val query = buildPlannerQuery("match (a)-[r:Type*]-(b) return a,r")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), BOTH, Seq(relType("Type")), VarPatternLength(1, None))))
     query.queryGraph.patternNodes should equal(Set(IdName("a"), IdName("b")))
@@ -281,7 +281,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)-[r1:CONTAINS*0..1]->(b)-[r2:FRIEND*0..1]->(c) return a,b,c") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)-[r1:CONTAINS*0..1]->(b)-[r2:FRIEND*0..1]->(c) return a,b,c")
+    val query = buildPlannerQuery("match (a)-[r1:CONTAINS*0..1]->(b)-[r2:FRIEND*0..1]->(c) return a,b,c")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r1"), (IdName("a"), IdName("b")), OUTGOING, Seq(relType("CONTAINS")), VarPatternLength(0, Some(1))),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("c")), OUTGOING, Seq(relType("FRIEND")), VarPatternLength(0, Some(1)))))
@@ -295,7 +295,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)-[r:Type*3..]-(b) return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)-[r:Type*3..]-(b) return a,r")
+    val query = buildPlannerQuery("match (a)-[r:Type*3..]-(b) return a,r")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), BOTH, Seq(relType("Type")), VarPatternLength(3, None))))
     query.queryGraph.patternNodes should equal(Set(IdName("a"), IdName("b")))
@@ -307,7 +307,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)-[r:Type*5]-(b) return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)-[r:Type*5]-(b) return a,r")
+    val query = buildPlannerQuery("match (a)-[r:Type*5]-(b) return a,r")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), BOTH, Seq(relType("Type")), VarPatternLength.fixed(5))))
     query.queryGraph.patternNodes should equal(Set(IdName("a"), IdName("b")))
@@ -319,7 +319,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a)<-[r*]-(b)-[r2*]-(c) return a,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a)<-[r*]-(b)-[r2*]-(c) return a,r")
+    val query = buildPlannerQuery("match (a)<-[r*]-(b)-[r2*]-(c) return a,r")
     query.queryGraph.patternRelationships should equal(Set(
       PatternRelationship(IdName("r"), (IdName("a"), IdName("b")), INCOMING, Seq.empty, VarPatternLength(1, None)),
       PatternRelationship(IdName("r2"), (IdName("b"), IdName("c")), BOTH, Seq.empty, VarPatternLength(1, None))))
@@ -339,7 +339,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("optional match (a) return a") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("optional match (a) return a")
+    val query = buildPlannerQuery("optional match (a) return a")
     query.queryGraph.patternRelationships should equal(Set())
     query.queryGraph.patternNodes should equal(Set())
     query.queryGraph.selections should equal(Selections(Set.empty))
@@ -359,7 +359,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("optional match (a)-[r]->(b) return a,b,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("optional match (a)-[r]->(b) return a,b,r")
+    val query = buildPlannerQuery("optional match (a)-[r]->(b) return a,b,r")
     query.queryGraph.patternRelationships should equal(Set())
     query.queryGraph.patternNodes should equal(Set())
     query.queryGraph.selections should equal(Selections(Set.empty))
@@ -384,7 +384,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a) optional match (a)-[r]->(b) return a,b,r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a) optional match (a)-[r]->(b) return a,b,r")
+    val query = buildPlannerQuery("match (a) optional match (a)-[r]->(b) return a,b,r")
     query.queryGraph.patternNodes should equal(Set(IdName("a")))
     query.queryGraph.patternRelationships should equal(Set())
     query.queryGraph.selections should equal(Selections(Set.empty))
@@ -408,7 +408,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
 
   test("match (a) where (a)-->() return a") {
     // Given
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a) where (a)-->() return a")
+    val query = buildPlannerQuery("match (a) where (a)-->() return a")
 
     // Then inner pattern query graph
     val relName = "  UNNAMED20"
@@ -426,7 +426,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (n) return n.prop order by n.prop2 DESC") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (n) return n.prop order by n.prop2 DESC")
+    val query = buildPlannerQuery("match (n) return n.prop order by n.prop2 DESC")
     val result = query.toString
 
     val expectation =
@@ -436,21 +436,21 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (a) WITH 1 as b RETURN b") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a) WITH 1 as b RETURN b")
+    val query = buildPlannerQuery("MATCH (a) WITH 1 as b RETURN b")
     query.queryGraph.patternNodes should equal(Set(IdName("a")))
     query.horizon should equal(RegularQueryProjection(Map("b" -> SignedDecimalIntegerLiteral("1")_)))
     query.tail should equal(Some(PlannerQuery(QueryGraph(Set.empty, Set.empty, Set(IdName("b"))), UpdateGraph.empty, RegularQueryProjection(Map("b" -> Variable("b") _)))))
   }
 
   test("WITH 1 as b RETURN b") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("WITH 1 as b RETURN b")
+    val query = buildPlannerQuery("WITH 1 as b RETURN b")
 
     query.horizon should equal(RegularQueryProjection(Map("b" -> SignedDecimalIntegerLiteral("1")_)))
     query.tail should equal(Some(PlannerQuery(QueryGraph(Set.empty, Set.empty, Set(IdName("b"))), UpdateGraph.empty, RegularQueryProjection(Map("b" -> Variable("b") _)))))
   }
 
   test("MATCH (a) WITH a WHERE TRUE RETURN a") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a) WITH a WHERE TRUE RETURN a")
+    val query = buildPlannerQuery("MATCH (a) WITH a WHERE TRUE RETURN a")
     val result = query.toString
 
     val expectation =
@@ -460,7 +460,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
 
   test("match (a) where a.prop = 42 OR (a)-->() return a") {
     // Given
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a) where a.prop = 42 OR (a)-->() return a")
+    val query = buildPlannerQuery("match (a) where a.prop = 42 OR (a)-->() return a")
 
     // Then inner pattern query graph
     val relName = "  UNNAMED35"
@@ -483,7 +483,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
 
   test("match (a) where (a)-->() OR a.prop = 42 return a") {
     // Given
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a) where (a)-->() OR a.prop = 42 return a")
+    val query = buildPlannerQuery("match (a) where (a)-->() OR a.prop = 42 return a")
 
     // Then inner pattern query graph
     val relName = "  UNNAMED20"
@@ -506,7 +506,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
 
   test("match (a) where a.prop2 = 21 OR (a)-->() OR a.prop = 42 return a") {
     // Given
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a) where a.prop2 = 21 OR (a)-->() OR a.prop = 42 return a")
+    val query = buildPlannerQuery("match (a) where a.prop2 = 21 OR (a)-->() OR a.prop = 42 return a")
 
     // Then inner pattern query graph
     val relName = "  UNNAMED36"
@@ -534,7 +534,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
 
   test("match (n) return n limit 10") {
     // Given
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (n) return n limit 10")
+    val query = buildPlannerQuery("match (n) return n limit 10")
 
     // Then inner pattern query graph
     query.queryGraph.selections should equal(Selections())
@@ -550,7 +550,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
 
   test("match (n) return n skip 10") {
     // Given
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (n) return n skip 10")
+    val query = buildPlannerQuery("match (n) return n skip 10")
 
     // Then inner pattern query graph
     query.queryGraph.selections should equal(Selections())
@@ -565,14 +565,14 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (a) with * return a") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (a) with * return a")
+    val query = buildPlannerQuery("match (a) with * return a")
     query.queryGraph.patternNodes should equal(Set(IdName("a")))
     query.horizon should equal(RegularQueryProjection(Map[String, Expression]("a" -> Variable("a")_)))
     query.tail should equal(None)
   }
 
   test("MATCH (a) WITH a LIMIT 1 MATCH (a)-[r]->(b) RETURN a, b") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a) WITH a LIMIT 1 MATCH (a)-[r]->(b) RETURN a, b")
+    val query = buildPlannerQuery("MATCH (a) WITH a LIMIT 1 MATCH (a)-[r]->(b) RETURN a, b")
     query.queryGraph should equal(
       QueryGraph
         .empty
@@ -598,7 +598,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("optional match (a:Foo) with a match (a)-[r]->(b) return a") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("optional match (a:Foo) with a match (a)-[r]->(b) return a")
+    val query = buildPlannerQuery("optional match (a:Foo) with a match (a)-[r]->(b) return a")
 
     query.queryGraph should equal(
       QueryGraph
@@ -621,7 +621,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (a:Start) WITH a.prop AS property LIMIT 1 MATCH (b) WHERE id(b) = property RETURN b") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a:Start) WITH a.prop AS property LIMIT 1 MATCH (b) WHERE id(b) = property RETURN b")
+    val query = buildPlannerQuery("MATCH (a:Start) WITH a.prop AS property LIMIT 1 MATCH (b) WHERE id(b) = property RETURN b")
     query.tail should not be empty
     query.queryGraph.selections.predicates should equal(Set(
       Predicate(Set(IdName("a")), HasLabels(Variable("a")_, Seq(LabelName("Start")(null)))_)
@@ -651,7 +651,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (a:Start) WITH a.prop AS property MATCH (b) WHERE id(b) = property RETURN b") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a:Start) WITH a.prop AS property MATCH (b) WHERE id(b) = property RETURN b")
+    val query = buildPlannerQuery("MATCH (a:Start) WITH a.prop AS property MATCH (b) WHERE id(b) = property RETURN b")
     query.queryGraph.patternNodes should equal(Set(IdName("a")))
     query.queryGraph.selections.predicates should equal(Set(
       Predicate(Set(IdName("a")), HasLabels(Variable("a") _, Seq(LabelName("Start")(null))) _)
@@ -674,7 +674,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (a:Start) WITH a.prop AS property, count(*) AS count MATCH (b) WHERE id(b) = property RETURN b") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (a:Start) WITH a.prop AS property, count(*) AS count MATCH (b) WHERE id(b) = property RETURN b")
+    val query = buildPlannerQuery("MATCH (a:Start) WITH a.prop AS property, count(*) AS count MATCH (b) WHERE id(b) = property RETURN b")
     query.tail should not be empty
     query.queryGraph.selections.predicates should equal(Set(
       Predicate(Set(IdName("a")), HasLabels(Variable("a")_, Seq(LabelName("Start")(null)))_)
@@ -702,7 +702,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (n) RETURN count(*)") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) RETURN count(*)")
+    val query = buildPlannerQuery("MATCH (n) RETURN count(*)")
 
     query.horizon match {
       case AggregatingQueryProjection(groupingKeys, aggregationExpression, QueryShuffle(sorting, limit, skip)) =>
@@ -722,7 +722,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (n) RETURN n.prop, count(*)") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n) RETURN n.prop, count(*)")
+    val query = buildPlannerQuery("MATCH (n) RETURN n.prop, count(*)")
 
     query.horizon match {
       case AggregatingQueryProjection(groupingKeys, aggregationExpression, QueryShuffle(sorting, limit, skip)) =>
@@ -742,13 +742,13 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (n:Awesome {prop: 42}) USING INDEX n:Awesome(prop) RETURN n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (n:Awesome {prop: 42}) USING INDEX n:Awesome(prop) RETURN n")
+    val query = buildPlannerQuery("MATCH (n:Awesome {prop: 42}) USING INDEX n:Awesome(prop) RETURN n")
 
     query.queryGraph.hints should equal(Set[Hint](UsingIndexHint(varFor("n"), LabelName("Awesome")_, PropertyKeyName("prop")(pos))_))
   }
 
   test("MATCH shortestPath((a)-[r]->(b)) RETURN r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH shortestPath((a)-[r]->(b)) RETURN r")
+    val query = buildPlannerQuery("MATCH shortestPath((a)-[r]->(b)) RETURN r")
 
     query.queryGraph.patternNodes should equal(Set(IdName("a"), IdName("b")))
     query.queryGraph.shortestPathPatterns should equal(Set(
@@ -758,7 +758,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH allShortestPaths((a)-[r]->(b)) RETURN r") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH allShortestPaths((a)-[r]->(b)) RETURN r")
+    val query = buildPlannerQuery("MATCH allShortestPaths((a)-[r]->(b)) RETURN r")
 
     query.queryGraph.patternNodes should equal(Set(IdName("a"), IdName("b")))
     query.queryGraph.shortestPathPatterns should equal(Set(
@@ -768,7 +768,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH p = shortestPath((a)-[r]->(b)) RETURN p") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH p = shortestPath((a)-[r]->(b)) RETURN p")
+    val query = buildPlannerQuery("MATCH p = shortestPath((a)-[r]->(b)) RETURN p")
 
     query.queryGraph.patternNodes should equal(Set(IdName("a"), IdName("b")))
     query.queryGraph.shortestPathPatterns should equal(Set(
@@ -777,40 +777,8 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
     query.tail should be(empty)
   }
 
-  test("RETURN 1 as x UNION RETURN 2 as x") {
-    val query = buildPlannerQuery("RETURN 1 as x UNION RETURN 2 as x")
-    query.distinct should equal(true)
-    query.queries should have size 2
-
-    val q1 = query.queries.head
-    q1.queryGraph.patternNodes shouldBe empty
-    q1.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("1")(pos))))
-
-    val q2 = query.queries.last
-    q2.queryGraph.patternNodes shouldBe empty
-    q2.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("2")(pos))))
-  }
-
-  test("RETURN 1 as x UNION ALL RETURN 2 as x UNION ALL RETURN 3 as x") {
-    val query = buildPlannerQuery("RETURN 1 as x UNION ALL RETURN 2 as x UNION ALL RETURN 3 as x")
-    query.distinct should equal(false)
-    query.queries should have size 3
-
-    val q1 = query.queries.head
-    q1.queryGraph.patternNodes shouldBe empty
-    q1.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("1")(pos))))
-
-    val q2 = query.queries.tail.head
-    q2.queryGraph.patternNodes shouldBe empty
-    q2.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("2")(pos))))
-
-    val q3 = query.queries.last
-    q3.queryGraph.patternNodes shouldBe empty
-    q3.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("3")(pos))))
-  }
-
   test("match (n) return distinct n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (n) return distinct n")
+    val query = buildPlannerQuery("match (n) return distinct n")
     query.horizon should equal(AggregatingQueryProjection(
       groupingKeys = Map("n" -> varFor("n")),
       aggregationExpressions = Map.empty
@@ -820,7 +788,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (n) with distinct n.prop as x return x") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (n) with distinct n.prop as x return x")
+    val query = buildPlannerQuery("match (n) with distinct n.prop as x return x")
     query.horizon should equal(AggregatingQueryProjection(
       groupingKeys = Map("x" -> nProp),
       aggregationExpressions = Map.empty
@@ -830,7 +798,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("match (n) with distinct * return n") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("match (n) with distinct * return n")
+    val query = buildPlannerQuery("match (n) with distinct * return n")
     query.horizon should equal(AggregatingQueryProjection(
       groupingKeys = Map("n" -> varFor("n")),
       aggregationExpressions = Map.empty
@@ -840,7 +808,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("WITH DISTINCT 1 as b RETURN b") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("WITH DISTINCT 1 as b RETURN b")
+    val query = buildPlannerQuery("WITH DISTINCT 1 as b RETURN b")
 
     query.horizon should equal(AggregatingQueryProjection(
       groupingKeys = Map("b" -> SignedDecimalIntegerLiteral("1") _),
@@ -851,7 +819,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (owner) WITH owner, COUNT(*) AS collected WHERE (owner)--() RETURN owner") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("MATCH (owner) WITH owner, COUNT(*) AS collected WHERE (owner)--() RETURN owner")
+    val query = buildPlannerQuery("MATCH (owner) WITH owner, COUNT(*) AS collected WHERE (owner)--() RETURN owner")
     val result = query.toString
 
     val expectation =
@@ -861,7 +829,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("Funny query from boostingRecommendations") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery(
+    val query = buildPlannerQuery(
       """MATCH (origin)-[r1:KNOWS|WORKS_AT]-(c)-[r2:KNOWS|WORKS_AT]-(candidate)
         |WHERE origin.name = "Clark Kent"
         |AND type(r1)=type(r2) AND NOT (origin)-[:KNOWS]-(candidate)
@@ -879,7 +847,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (owner) WITH owner, COUNT(*) AS xyz WITH owner, xyz > 0 as collection WHERE (owner)--() RETURN owner") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery(
+    val query = buildPlannerQuery(
       """MATCH (owner)
         |WITH owner, COUNT(*) AS xyz
         |WITH owner, xyz > 0 as collection
@@ -894,7 +862,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("UNWIND [1,2,3] AS x RETURN x") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("UNWIND [1,2,3] AS x RETURN x")
+    val query = buildPlannerQuery("UNWIND [1,2,3] AS x RETURN x")
 
     val one = SignedDecimalIntegerLiteral("1")(pos)
     val two = SignedDecimalIntegerLiteral("2")(pos)
@@ -911,7 +879,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("WITH [1,2,3] as xes, 2 as y UNWIND xes AS x RETURN x, y") {
-    val UnionQuery(query :: Nil, _, _) = buildPlannerQuery("WITH [1,2,3] as xes, 2 as y UNWIND xes AS x RETURN x, y")
+    val query = buildPlannerQuery("WITH [1,2,3] as xes, 2 as y UNWIND xes AS x RETURN x, y")
 
     val one = SignedDecimalIntegerLiteral("1")(pos)
     val two = SignedDecimalIntegerLiteral("2")(pos)
@@ -940,8 +908,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   val collection = Collection(Seq(one, two, three))(pos)
 
   test("UNWIND [1,2,3] AS x MATCH (n) WHERE n.prop = x RETURN n") {
-    val UnionQuery(query :: Nil, _, _) =
-      buildPlannerQuery("UNWIND [1,2,3] AS x MATCH (n) WHERE n.prop = x RETURN n")
+    val query = buildPlannerQuery("UNWIND [1,2,3] AS x MATCH (n) WHERE n.prop = x RETURN n")
 
     query.horizon should equal(UnwindProjection(
       IdName("x"), collection
@@ -958,8 +925,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (n) UNWIND n.prop as x RETURN x") {
-    val UnionQuery(query :: Nil, _, _) =
-      buildPlannerQuery("MATCH (n) UNWIND n.prop as x RETURN x")
+    val query = buildPlannerQuery("MATCH (n) UNWIND n.prop as x RETURN x")
 
     query.queryGraph.patternNodes should equal(Set(IdName("n")))
 
@@ -974,8 +940,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (row) WITH collect(row) AS rows UNWIND rows AS node RETURN node") {
-    val UnionQuery(query :: Nil, _, _) =
-      buildPlannerQuery("MATCH (row) WITH collect(row) AS rows UNWIND rows AS node RETURN node")
+    val query = buildPlannerQuery("MATCH (row) WITH collect(row) AS rows UNWIND rows AS node RETURN node")
 
     query.queryGraph.patternNodes should equal(Set(IdName("row")))
 
@@ -1007,13 +972,11 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("MATCH (a:X)-[r1]->(b) OPTIONAL MATCH (b)-[r2]->(c:Y) RETURN b") {
-    val UnionQuery(query :: Nil, _, _) =
-      buildPlannerQuery("MATCH (a:X)-[r1]->(b) OPTIONAL MATCH (b)-[r2]->(c:Y) RETURN b")
+    val query = buildPlannerQuery("MATCH (a:X)-[r1]->(b) OPTIONAL MATCH (b)-[r2]->(c:Y) RETURN b")
   }
 
   test("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a1)<-[r]-(b2) RETURN a1, r, b2") {
-    val UnionQuery(query :: Nil, _, _) =
-      buildPlannerQuery("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a1)<-[r]-(b2) RETURN a1, r, b2")
+    val query = buildPlannerQuery("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a1)<-[r]-(b2) RETURN a1, r, b2")
 
     val result = query.toString
 
@@ -1025,8 +988,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
 
   // scalastyle:off
   test("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a2)<-[r]-(b2) WHERE a1 = a2 RETURN a1, r, b2, a2") {
-    val UnionQuery(query :: Nil, _, _) =
-      buildPlannerQuery("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a2)<-[r]-(b2) WHERE a1 = a2 RETURN a1, r, b2, a2")
+    val query = buildPlannerQuery("MATCH (a1)-[r]->(b1) WITH r, a1 LIMIT 1 OPTIONAL MATCH (a2)<-[r]-(b2) WHERE a1 = a2 RETURN a1, r, b2, a2")
 
     val result = query.toString
 
@@ -1038,8 +1000,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   // scalastyle:on
 
   test("MATCH (a:A) OPTIONAL MATCH (a)-->(b:B) OPTIONAL MATCH (a)-->(c:C) WITH coalesce(b, c) as x MATCH (x)-->(d) RETURN d") {
-    val UnionQuery(query :: Nil, _, _) =
-      buildPlannerQuery("MATCH (a:A) OPTIONAL MATCH (a)-->(b:B) OPTIONAL MATCH (a)-->(c:C) WITH coalesce(b, c) as x MATCH (x)-->(d) RETURN d")
+    val query = buildPlannerQuery("MATCH (a:A) OPTIONAL MATCH (a)-->(b:B) OPTIONAL MATCH (a)-->(c:C) WITH coalesce(b, c) as x MATCH (x)-->(d) RETURN d")
 
     query.queryGraph.patternNodes should equal(Set(IdName("a")))
     query.queryGraph.patternRelationships should equal(Set.empty)
@@ -1066,8 +1027,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("START n=node:nodes(name = \"A\") RETURN n") {
-    val UnionQuery(query :: Nil, _, _) =
-      buildPlannerQuery("START n=node:nodes(name = \"A\") RETURN n")
+    val query = buildPlannerQuery("START n=node:nodes(name = \"A\") RETURN n")
 
     val hint: LegacyIndexHint = NodeByIdentifiedIndex(varFor("n"), "nodes", "name", StringLiteral("A")_)_
 
@@ -1076,8 +1036,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   }
 
   test("START n=node:nodes(\"name:A\") RETURN n") {
-    val UnionQuery(query :: Nil, _, _) =
-      buildPlannerQuery("START n=node:nodes(\"name:A\") RETURN n")
+    val query = buildPlannerQuery("START n=node:nodes(\"name:A\") RETURN n")
 
     val hint: LegacyIndexHint = NodeByIndexQuery(varFor("n"), "nodes", StringLiteral("name:A")_)_
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/UnionStatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/UnionStatementConvertersTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.ast.convert.plannerQuery
+
+import org.neo4j.cypher.internal.compiler.v3_0.planner.{RegularQueryProjection, LogicalPlanningTestSupport}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.SignedDecimalIntegerLiteral
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+
+class UnionStatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSupport {
+
+  test("RETURN 1 as x UNION RETURN 2 as x") {
+    val query = buildPlannerUnionQuery("RETURN 1 as x UNION RETURN 2 as x")
+    query.distinct should equal(true)
+    query.queries should have size 2
+
+    val q1 = query.queries.head
+    q1.queryGraph.patternNodes shouldBe empty
+    q1.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("1")(pos))))
+
+    val q2 = query.queries.last
+    q2.queryGraph.patternNodes shouldBe empty
+    q2.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("2")(pos))))
+  }
+
+  test("RETURN 1 as x UNION ALL RETURN 2 as x UNION ALL RETURN 3 as x") {
+    val query = buildPlannerUnionQuery("RETURN 1 as x UNION ALL RETURN 2 as x UNION ALL RETURN 3 as x")
+    query.distinct should equal(false)
+    query.queries should have size 3
+
+    val q1 = query.queries.head
+    q1.queryGraph.patternNodes shouldBe empty
+    q1.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("1")(pos))))
+
+    val q2 = query.queries.tail.head
+    q2.queryGraph.patternNodes shouldBe empty
+    q2.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("2")(pos))))
+
+    val q3 = query.queries.last
+    q3.queryGraph.patternNodes shouldBe empty
+    q3.horizon should equal(RegularQueryProjection(Map("x" -> SignedDecimalIntegerLiteral("3")(pos))))
+  }
+
+}

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -188,6 +188,10 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
   }
 
   def buildPlannerQuery(query: String) = {
+    buildPlannerUnionQuery(query).queries.head
+  }
+
+  def buildPlannerUnionQuery(query: String) = {
     val parsedStatement = parser.parse(query.replace("\r\n", "\n"))
     val mkException = new SyntaxExceptionCreator(query, Some(pos))
     val cleanedStatement: Statement = parsedStatement.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
@@ -60,7 +60,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val result = updateWithBothPlanners(query)
     result.columnAs[Int]("count").next should equal(2)
-    assertStats(result, relationshipsCreated = 2, propertiesSet = 2)
+    assertStats(result, relationshipsCreated = 2, propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -72,7 +72,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val result = updateWithBothPlanners(query)
     result.columnAs[Int]("count").next should equal(2)
-    assertStats(result, relationshipsCreated = 2, propertiesSet = 2)
+    assertStats(result, relationshipsCreated = 2, propertiesWritten = 2)
     assertNumberOfEagerness(query, 1)
   }
 
@@ -113,7 +113,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
         |RETURN b2.deleted
       """.stripMargin
 
-    assertStats(updateWithBothPlanners(query), nodesCreated = 1, nodesDeleted = 2, propertiesSet = 1, labelsAdded = 1)
+    assertStats(updateWithBothPlanners(query), nodesCreated = 1, nodesDeleted = 2, propertiesWritten = 1, labelsAdded = 1)
     assertNumberOfEagerness(query, 1)
   }
 
@@ -264,7 +264,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val result = updateWithBothPlanners(query)
     result should use("RepeatableRead", "Eager")
-    assertStats(result, nodesCreated = 10, propertiesSet = 10)
+    assertStats(result, nodesCreated = 10, propertiesWritten = 10)
     assertNumberOfEagerness(query, 2)
   }
 
@@ -308,7 +308,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val query = "MATCH (:L {id: 0}) CREATE (:L {id:0})"
 
-    assertStats(updateWithBothPlanners(query), nodesCreated = 1, labelsAdded = 1,  propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), nodesCreated = 1, labelsAdded = 1,  propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -326,7 +326,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode("prop1" -> 42, "prop2" -> 42)
     val query = "MATCH (a {prop1: 42}), (n {prop2: 42}) CREATE ({prop3: 42})"
 
-    assertStats(updateWithBothPlanners(query), nodesCreated = 4, propertiesSet = 4)
+    assertStats(updateWithBothPlanners(query), nodesCreated = 4, propertiesWritten = 4)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -335,7 +335,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode("prop1" -> 42, "prop2" -> 42)
     val query = "MATCH (a {prop1: 42}), (n {prop2: 42}) CREATE ({prop1: 42, prop2: 42})"
 
-    assertStats(updateWithBothPlanners(query), nodesCreated = 4, propertiesSet = 8)
+    assertStats(updateWithBothPlanners(query), nodesCreated = 4, propertiesWritten = 8)
     assertNumberOfEagerness(query, 1)
   }
 
@@ -344,7 +344,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode()
     val query = "MATCH (a), (b) CREATE (a)-[r:KNOWS]->(b) SET r = { key: 42 }"
 
-    assertStats(updateWithBothPlanners(query), relationshipsCreated = 4, propertiesSet = 4)
+    assertStats(updateWithBothPlanners(query), relationshipsCreated = 4, propertiesWritten = 4)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -701,7 +701,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
   test("create directional relationship with property, match and delete relationship and nodes within same transaction should be eager and work") {
     val query = "CREATE ()-[:T {prop: 3}]->() WITH * MATCH (a)-[r {prop : 3}]->(b) DELETE r, a, b"
 
-    assertStats(updateWithBothPlanners(query), nodesCreated = 2, relationshipsCreated = 1, propertiesSet = 1, nodesDeleted = 2, relationshipsDeleted = 1)
+    assertStats(updateWithBothPlanners(query), nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 1, nodesDeleted = 2, relationshipsDeleted = 1)
     assertNumberOfEagerness(query, 1)
   }
 
@@ -836,7 +836,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val result = updateWithBothPlanners(query)
     result.toList should equal(List(Map("c" -> 36)))
-    assertStats(result, propertiesSet = 36)
+    assertStats(result, propertiesWritten = 36)
 
     assertNumberOfEagerness(query, 1)
   }
@@ -849,7 +849,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val result = updateWithBothPlanners(query)
     result.toList should equal(List(Map("c" -> 36)))
-    assertStats(result, propertiesSet = 36)
+    assertStats(result, propertiesWritten = 36)
 
     assertNumberOfEagerness(query, 0)
   }
@@ -862,7 +862,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val result = updateWithBothPlanners(query)
     result.toList should equal(List(Map("c" -> 36)))
-    assertStats(result, propertiesSet = 0)
+    assertStats(result, propertiesWritten = 0)
 
     assertNumberOfEagerness(query, 1)
   }
@@ -875,7 +875,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val result = updateWithBothPlanners(query)
     result.toList should equal(List(Map("c" -> 36)))
-    assertStats(result, propertiesSet = 0)
+    assertStats(result, propertiesWritten = 0)
 
     assertNumberOfEagerness(query, 1)
   }
@@ -888,7 +888,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val result = updateWithBothPlanners(query, "map" -> Map("id" -> 0))
     result.toList should equal(List(Map("c" -> 36)))
-    assertStats(result, propertiesSet = 36)
+    assertStats(result, propertiesWritten = 36)
 
     assertNumberOfEagerness(query, 1)
   }
@@ -917,7 +917,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     relate(a, b, "KNOWS")
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a.prop = 42"
-    assertStats(executeWithRulePlanner(query), propertiesSet = 1)
+    assertStats(executeWithRulePlanner(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1010,7 +1010,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
   test("should not be eager when merging on two different labels") {
     val query = "MERGE(:L1) MERGE(p:L2) ON CREATE SET p.name = 'Blaine'"
 
-    assertStats(updateWithBothPlanners(query), nodesCreated = 2, propertiesSet = 1, labelsAdded = 2)
+    assertStats(updateWithBothPlanners(query), nodesCreated = 2, propertiesWritten = 1, labelsAdded = 2)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1045,7 +1045,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode()
     val query = "MERGE() MERGE(p: Person) ON CREATE SET p.name = 'Blaine'"
 
-    assertStats(updateWithBothPlanners(query), nodesCreated = 1, labelsAdded = 1, propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1077,7 +1077,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node {prop:5}) SET n.value = 10 RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1176,7 +1176,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode()
     val query = "MATCH (n) SET n.prop = 5 RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1184,7 +1184,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode(Map("prop" -> 20))
     val query = "MATCH (n { prop: 20 }) SET n.prop = 10 RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1192,7 +1192,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createLabeledNode("Node")
     val query = "MATCH (n:Node) SET n.prop = 10 RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1217,7 +1217,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val query = "MATCH (a), (b :Book {isbn : '123'}) SET a.isbn = '456' RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 1)
   }
 
@@ -1226,7 +1226,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode(Map("id" -> 0))
     val query = "MATCH (a),(b {id: 0}) SET a.id = 0 RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 2)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 2)
     assertNumberOfEagerness(query, 1)
   }
 
@@ -1241,7 +1241,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode()
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}) SET b.id = 1 RETURN count(*)"
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1249,14 +1249,14 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode(Map("prop" -> "Fooo"))
     val query = "MATCH (n) WHERE n.prop =~ 'Foo*' SET n.prop = 'bar' RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
   test("matching property using REPLACE and writing should be eager") {
     createNode(Map("prop" -> "baz"))
     val query = "MATCH (n) WHERE replace(n.prop, 'foo', 'bar') = 'baz' SET n.prop = 'qux' RETURN count(*)"
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1264,7 +1264,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode(Map("prop" -> "aafooaaa"))
     val query = "MATCH (n) WHERE substring(n.prop, 2, 3) = 'foo' SET n.prop = 'bar' RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1272,7 +1272,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode(Map("prop" -> "fooaaa"))
     val query = "MATCH (n) WHERE left(n.prop, 3) = 'foo' SET n.prop = 'bar' RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1280,7 +1280,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode(Map("prop" -> "aaafoo"))
     val query = "MATCH (n) WHERE right(n.prop, 3) = 'foo' SET n.prop = 'bar' RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1288,7 +1288,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     createNode(Map("prop" -> "foo,bar"))
     val query = "MATCH (n) WHERE split(n.prop, ',') = ['foo', 'bar'] SET n.prop = 'baz,qux' RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1296,7 +1296,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     relate(createNode(Map("prop" -> 5)),createNode())
     val query = "MATCH (n {prop : 5})-[r]-() SET r.prop = 6 RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 1)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1304,7 +1304,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     relate(createNode(Map("prop" -> 5)),createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m.prop = 5 RETURN count(*)"
     val result = updateWithBothPlanners(query)
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
 
     assertNumberOfEagerness(query, 1)
@@ -1315,7 +1315,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     val query = "MATCH ()-[r {prop : 3}]-() SET r.prop = 6 RETURN count(*) AS c"
 
     val result = updateWithBothPlanners(query)
-    assertStats(result, propertiesSet = 2)
+    assertStats(result, propertiesWritten = 2)
     result.toList should equal(List(Map("c" -> 2)))
 
     assertNumberOfEagerness(query, 1)
@@ -1325,7 +1325,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     relate(createNode(), createNode(), "prop1" -> 3)
     val query = "MATCH ()-[r {prop1 : 3}]-() SET r.prop2 = 6"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 2)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1333,7 +1333,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     relate(createNode(), createNode(), "prop" -> 3)
     val query = "MATCH (n)-[r {prop : 3}]-() SET n.prop = 6 RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 2)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1343,7 +1343,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop) SET r.prop = 'foo' RETURN count(*)"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 2)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1353,7 +1353,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop1) SET r.prop2 = 'foo'"
 
-    assertStats(updateWithBothPlanners(query), propertiesSet = 2)
+    assertStats(updateWithBothPlanners(query), propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1365,7 +1365,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o {prop:42}) SET n.prop = 42 RETURN count(*)"
 
     val result = updateWithBothPlanners(query)
-    assertStats(result, propertiesSet = 8, nodesCreated = 4)
+    assertStats(result, propertiesWritten = 8, nodesCreated = 4)
     assertNumberOfEagerness(query, 1)
   }
 
@@ -1377,7 +1377,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o {prop:42}) SET n.prop2 = 42 RETURN count(*)"
 
     val result = updateWithBothPlanners(query)
-    assertStats(result, propertiesSet = 8, nodesCreated = 4)
+    assertStats(result, propertiesWritten = 8, nodesCreated = 4)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -1385,7 +1385,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     relate(createNode(Map("prop" -> 5)),createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop: 5} RETURN count(*)"
     val result = updateWithBothPlanners(query)
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
 
     assertNumberOfEagerness(query, 1)
@@ -1395,7 +1395,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     relate(createNode(Map("prop" -> 5)),createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop2: 5} RETURN count(*)"
     val result = updateWithBothPlanners(query)
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
 
     assertNumberOfEagerness(query, 0)
@@ -1405,7 +1405,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     relate(createNode(Map("prop" -> 5)),createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {props} RETURN count(*)"
     val result = updateWithBothPlanners(query, "props" -> Map("prop" -> 5))
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
 
     assertNumberOfEagerness(query, 1)
@@ -1415,7 +1415,7 @@ class EagerizationAcceptanceTest extends ExecutionEngineFunSuite with TableDrive
     relate(createNode(Map("prop" -> 5)),createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop2: 5} RETURN count(*)"
     val result = updateWithBothPlanners(query)
-    assertStats(result, propertiesSet = 1)
+    assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
 
     assertNumberOfEagerness(query, 0)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -863,7 +863,7 @@ order by a.COL1""")
                                CREATE (actor)-[:ACTED_IN]->(movie)""")
 
     // then
-    assertStats(result, nodesCreated = 1, propertiesSet = 1, labelsAdded = 1, relationshipsCreated = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1, relationshipsCreated = 1)
   }
 
   test("should iterate all node id sets from start during matching") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/MutatingIntegrationTest.scala
@@ -45,7 +45,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with Assertions wi
 
     val result = updateWithBothPlanners("create (a {name : 'Andres'}) return a.name")
 
-    assertStats(result, nodesCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1)
     graph.inTx {
       graph.getAllNodes.asScala should have size before + 1
     }
@@ -58,7 +58,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with Assertions wi
 
     val result = updateWithBothPlanners("match (a) where id(a) = 0 with a create (b {age : a.age * 2}) return b.age")
 
-    assertStats(result, nodesCreated = 1, propertiesSet = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1)
 
     result.toList should equal(List(Map("b.age" -> 30)))
   }
@@ -74,7 +74,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with Assertions wi
 
     assertStats(result,
       nodesCreated = 1,
-      propertiesSet = 1
+      propertiesWritten = 1
     )
   }
 
@@ -140,7 +140,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with Assertions wi
 
     val result = updateWithBothPlanners("MATCH (n) with collect(n.name) as names create (m {name : names}) RETURN m.name")
     assertStats(result,
-      propertiesSet = 1,
+      propertiesWritten = 1,
       nodesCreated = 1
     )
 
@@ -150,7 +150,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with Assertions wi
   test("set a property to an empty collection") {
     val result = updateWithBothPlanners("create (n {x : []}) return n.x")
     assertStats(result,
-      propertiesSet = 1,
+      propertiesWritten = 1,
       nodesCreated = 1
     )
     result.toComparableResult should equal (List(Map("n.x" -> List.empty)))
@@ -201,7 +201,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with Assertions wi
 
     assertStats(result,
       nodesCreated = 3,
-      propertiesSet = 6
+      propertiesWritten = 6
     )
   }
 
@@ -304,7 +304,7 @@ return distinct center""")
     val q = "create (a{param}) return a.arrayProp"
     val result =  executeScalar[Array[String]](q, "param" -> map)
 
-    assertStats(updateWithBothPlanners(q, "param"->map), nodesCreated = 1, propertiesSet = 1)
+    assertStats(updateWithBothPlanners(q, "param"->map), nodesCreated = 1, propertiesWritten = 1)
     result.toList should equal(List("foo","bar"))
   }
 
@@ -400,7 +400,7 @@ return distinct center""")
   test("create two rels in one command should work") {
     val result = updateWithBothPlanners("create (a{name:'a'})-[:test]->(b), (a)-[:test2]->(c)")
 
-    assertStats(result, nodesCreated = 3, relationshipsCreated = 2, propertiesSet = 1)
+    assertStats(result, nodesCreated = 3, relationshipsCreated = 2, propertiesWritten = 1)
   }
 
   test("cant set properties after node is already created") {
@@ -444,7 +444,7 @@ return distinct center""")
                  MATCH (center)-[r]->()
                  DELETE center,r""")
 
-    assertStats(result, nodesCreated = 7, propertiesSet = 7, relationshipsCreated = 21, nodesDeleted = 1, relationshipsDeleted = 6)
+    assertStats(result, nodesCreated = 7, propertiesWritten = 7, relationshipsCreated = 21, nodesDeleted = 1, relationshipsDeleted = 6)
   }
 
   test("for each applied to null should never execute") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
@@ -51,23 +51,23 @@ trait QueryStatisticsTestSupport {
   }
 
   def assertStats(
-    result: InternalExecutionResult,
-    nodesCreated: Int = 0,
-    relationshipsCreated: Int = 0,
-    propertiesSet: Int = 0,
-    nodesDeleted: Int = 0,
-    relationshipsDeleted: Int = 0,
-    labelsAdded: Int = 0,
-    labelsRemoved: Int = 0,
-    indexesAdded: Int = 0,
-    indexesRemoved: Int = 0,
-    constraintsAdded: Int = 0,
-    constraintsRemoved: Int = 0
+                   result: InternalExecutionResult,
+                   nodesCreated: Int = 0,
+                   relationshipsCreated: Int = 0,
+                   propertiesWritten: Int = 0,
+                   nodesDeleted: Int = 0,
+                   relationshipsDeleted: Int = 0,
+                   labelsAdded: Int = 0,
+                   labelsRemoved: Int = 0,
+                   indexesAdded: Int = 0,
+                   indexesRemoved: Int = 0,
+                   constraintsAdded: Int = 0,
+                   constraintsRemoved: Int = 0
   ) = {
     assertStatsResult(
       nodesCreated,
       relationshipsCreated,
-      propertiesSet,
+      propertiesWritten,
       nodesDeleted,
       relationshipsDeleted,
       labelsAdded,
@@ -80,29 +80,29 @@ trait QueryStatisticsTestSupport {
   }
 
   // This api is more in line with scala test assertions which prefer the expectation before the actual
-  def assertStatsResult(
-    nodesCreated: Int = 0,
-    relationshipsCreated: Int = 0,
-    propertiesSet: Int = 0,
-    nodesDeleted: Int = 0,
-    relationshipsDeleted: Int = 0,
-    labelsAdded: Int = 0,
-    labelsRemoved: Int = 0,
-    indexesAdded: Int = 0,
-    indexesRemoved: Int = 0,
-    constraintsAdded: Int = 0,
-    constraintsRemoved: Int = 0
-  ): QueryStatisticsAssertions = QueryStatistics(
-    nodesCreated,
-    relationshipsCreated,
-    propertiesSet,
-    nodesDeleted,
-    relationshipsDeleted,
-    labelsAdded,
-    labelsRemoved,
-    indexesAdded,
-    indexesRemoved,
-    constraintsAdded,
-    constraintsRemoved
-  )
+  def assertStatsResult(nodesCreated: Int = 0,
+                        relationshipsCreated: Int = 0,
+                        propertiesWritten: Int = 0,
+                        nodesDeleted: Int = 0,
+                        relationshipsDeleted: Int = 0,
+                        labelsAdded: Int = 0,
+                        labelsRemoved: Int = 0,
+                        indexesAdded: Int = 0,
+                        indexesRemoved: Int = 0,
+                        constraintsAdded: Int = 0,
+                        constraintsRemoved: Int = 0
+                       ): QueryStatisticsAssertions =
+    QueryStatistics(
+      nodesCreated,
+      relationshipsCreated,
+      propertiesWritten,
+      nodesDeleted,
+      relationshipsDeleted,
+      labelsAdded,
+      labelsRemoved,
+      indexesAdded,
+      indexesRemoved,
+      constraintsAdded,
+      constraintsRemoved
+    )
 }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
@@ -70,7 +70,7 @@ class CreateTest extends DocumentingTestBase with QueryStatisticsTestSupport wit
       text = "When creating a new node with labels, you can add properties at the same time.",
       queryText = "create (n:Person {name : 'Andres', title : 'Developer'})",
       optionalResultExplanation = "Nothing is returned from this query.",
-      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesSet = 2, labelsAdded = 1))
+      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesWritten = 2, labelsAdded = 1))
   }
 
   @Test def create_single_node_and_return_it() {
@@ -129,7 +129,7 @@ will be created. """,
       queryText = "create p = (andres {name:'Andres'})-[:WORKS_AT]->(neo)<-[:WORKS_AT]-(michael {name:'Michael'}) return p",
       optionalResultExplanation = "This query creates three nodes and two relationships in one go, assigns it to a path variable, " +
         "and returns it.",
-      assertions = (p) => assertStats(p, nodesCreated = 3, relationshipsCreated = 2, propertiesSet = 2))
+      assertions = (p) => assertStats(p, nodesCreated = 3, relationshipsCreated = 2, propertiesWritten = 2))
   }
 
   @Test def create_relationship_with_properties() {
@@ -159,7 +159,7 @@ In this case we add a +Person+ label to the node as well.
       parameters = Map("props" -> Map("name" -> "Andres", "position" -> "Developer")),
       queryText = "create (n:Person {props}) return n",
       optionalResultExplanation = "",
-      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesSet = 2, labelsAdded = 1))
+      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesWritten = 2, labelsAdded = 1))
   }
 
   @Test def create_multiple_nodes_from_maps() {
@@ -171,6 +171,6 @@ In this case we add a +Person+ label to the node as well.
         Map("name" -> "Michael", "position" -> "Developer"))),
       queryText = "UNWIND {props} as map CREATE (n) SET n = map",
       optionalResultExplanation = "",
-      assertions = (p) => assertStats(p, nodesCreated = 2, propertiesSet = 4))
+      assertions = (p) => assertStats(p, nodesCreated = 2, propertiesWritten = 4))
   }
 }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateUniqueTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateUniqueTest.scala
@@ -26,9 +26,9 @@ import org.neo4j.visualization.graphviz.AsciiDocSimpleStyle
 
 class CreateUniqueTest extends DocumentingTestBase with QueryStatisticsTestSupport with SoftReset {
 
-  override protected def getGraphvizStyle: GraphStyle = 
+  override protected def getGraphvizStyle: GraphStyle =
     AsciiDocSimpleStyle.withAutomaticRelationshipTypeColors()
-  
+
   override def graphDescription = List(
     "root X A",
     "root X B",
@@ -65,7 +65,7 @@ class CreateUniqueTest extends DocumentingTestBase with QueryStatisticsTestSuppo
       queryText = "match (root {name: 'root'}) create unique (root)-[:X]-(leaf {name:'D'} ) return leaf",
       optionalResultExplanation = "No node connected with the root node has the name +D+, and so a new node is created to " +
         "match the pattern.",
-      assertions = (p) => assertStats(p, relationshipsCreated = 1, nodesCreated = 1, propertiesSet = 1))
+      assertions = (p) => assertStats(p, relationshipsCreated = 1, nodesCreated = 1, propertiesWritten = 1))
   }
 
   @Test def create_relationship_with_values() {
@@ -76,7 +76,7 @@ class CreateUniqueTest extends DocumentingTestBase with QueryStatisticsTestSuppo
       optionalResultExplanation = "In this example, we want the relationship to have a value, and since no such relationship can be found," +
         " a new node and relationship are created. Note that since we are not interested in the created node, we don't " +
         "name it.",
-      assertions = (p) => assertStats(p, relationshipsCreated = 1, nodesCreated = 1, propertiesSet = 1))
+      assertions = (p) => assertStats(p, relationshipsCreated = 1, nodesCreated = 1, propertiesWritten = 1))
   }
 
   @Test def commad_separated_pattern() {

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentationTestBaseTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentationTestBaseTest.scala
@@ -81,7 +81,7 @@ Use `UNWIND` to create multiple nodes from a parameter.
       ,
       queryText = "unwind {props} as properties create (n) set n = properties return n",
       optionalResultExplanation = "",
-      assertions = (p) => assertStats(p, nodesCreated = 2, propertiesSet = 4))
+      assertions = (p) => assertStats(p, nodesCreated = 2, propertiesWritten = 4))
 
     // ensure that the parameters are printed
     val resultSource = io.Source.fromFile("target/docs/dev/ql/internaltesting/create-multiple-nodes-with-parameters-for-properties.asciidoc", "utf-8")

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ForeachTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ForeachTest.scala
@@ -39,6 +39,6 @@ class ForeachTest extends DocumentingTestBase with QueryStatisticsTestSupport wi
       text = "This query will set the property `marked` to true on all nodes along a path.",
       queryText = "match p = (begin)-[*]->(end) where begin.name='A' and end.name='D' foreach(n in nodes(p) | set n.marked = true)",
       optionalResultExplanation = "Nothing is returned from this query, but four properties are set.",
-      assertions = (p) => { assertStats(p, propertiesSet = 4); assertEquals(p.toList.length, 0) })
+      assertions = (p) => { assertStats(p, propertiesWritten = 4); assertEquals(p.toList.length, 0) })
   }
 }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/LoadCSVTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/LoadCSVTest.scala
@@ -91,7 +91,7 @@ include::csv-files/artists.csv[]
         """
 A new node with the +Artist+ label is created for each row in the CSV file.
 In addition, two columns from the CSV file are set as properties on the nodes.""",
-      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesSet = 8, labelsAdded = 4))
+      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesWritten = 8, labelsAdded = 4))
   }
 
   @Test def should_import_data_from_a_csv_file_with_headers() {
@@ -110,7 +110,7 @@ include::csv-files/artists-with-headers.csv[]
       optionalResultExplanation = """
 This time, the file starts with a single row containing column names.
 Indicate this using +WITH HEADERS+ and you can access specific fields by their corresponding column name.""",
-      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesSet = 8, labelsAdded = 4))
+      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesWritten = 8, labelsAdded = 4))
   }
 
   @Test def should_import_data_from_a_csv_file_with_custom_field_terminator() {
@@ -129,7 +129,7 @@ include::csv-files/artists-fieldterminator.csv[]
       queryText = s"LOAD CSV FROM '%ARTIST_WITH_FIELD_DELIMITER%' AS line FIELDTERMINATOR ';' CREATE (:Artist {name: line[1], year: toInt(line[2])})",
       optionalResultExplanation =
         "As values in this file are separated by a semicolon, a custom +FIELDTERMINATOR+ is specified in the +LOAD CSV+ clause.",
-      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesSet = 8, labelsAdded = 4))
+      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesWritten = 8, labelsAdded = 4))
   }
 
   @Test def should_import_data_from_a_csv_file_with_periodic_commit() {
@@ -144,7 +144,7 @@ For more information, see <<query-periodic-commit>>.
 """,
       queryText = s"USING PERIODIC COMMIT LOAD CSV FROM '%ARTIST%' AS line CREATE (:Artist {name: line[1], year: toInt(line[2])})",
       optionalResultExplanation = "",
-      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesSet = 8, labelsAdded = 4))
+      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesWritten = 8, labelsAdded = 4))
   }
 
   @Test def should_import_data_from_a_csv_file_with_periodic_commit_after_500_rows() {
@@ -153,7 +153,7 @@ For more information, see <<query-periodic-commit>>.
       text = """You can set the number of rows as in the example, where it is set to 500 rows.""",
       queryText = s"USING PERIODIC COMMIT 500 LOAD CSV FROM '%ARTIST%' AS line CREATE (:Artist {name: line[1], year: toInt(line[2])})",
       optionalResultExplanation = "",
-      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesSet = 8, labelsAdded = 4))
+      assertions = (p) => assertStats(p, nodesCreated = 4, propertiesWritten = 8, labelsAdded = 4))
   }
 
   @Test def should_import_data_from_a_csv_file_which_uses_the_escape_char() {

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MergeTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MergeTest.scala
@@ -71,7 +71,7 @@ class MergeTest extends DocumentingTestBase with QueryStatisticsTestSupport with
       queryText = "merge (charlie {name:'Charlie Sheen', age:10})\nreturn charlie",
       optionalResultExplanation = "A new node with the name 'Charlie Sheen' will be created since not all properties " +
         "matched the existing 'Charlie Sheen' node.",
-      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesSet = 2)
+      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesWritten = 2)
     )
   }
 
@@ -81,7 +81,7 @@ class MergeTest extends DocumentingTestBase with QueryStatisticsTestSupport with
       text = "Merging a single node with both label and property matching an existing node.",
       queryText = "merge (michael:Person {name:'Michael Douglas'})\nreturn michael.name, michael.bornIn",
       optionalResultExplanation = "'Michael Douglas' will be matched and the _name_ and  _bornIn_ properties returned.",
-      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesSet = 0)
+      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesWritten = 0)
     )
   }
 
@@ -98,7 +98,7 @@ though the +MATCH+ clause results in three bound nodes having the value 'New Yor
 the 'bornIn' property, only a single 'New York' node (i.e. a +City+ node with a name
 of 'New York') is created. As the 'New York' node is not matched for the first bound
 node, it is created. However, the newly-created 'New York' node is matched and bound for the second and third bound nodes.""",
-      assertions = (p) => assertStats(p, nodesCreated = 3, propertiesSet = 3, labelsAdded = 3)
+      assertions = (p) => assertStats(p, nodesCreated = 3, propertiesWritten = 3, labelsAdded = 3)
     )
   }
 
@@ -110,7 +110,7 @@ node, it is created. However, the newly-created 'New York' node is matched and b
 on create set keanu.created = timestamp()
 return keanu.name, keanu.created""",
       optionalResultExplanation = "The query creates the 'keanu' node and sets a timestamp on creation time.",
-      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesSet = 2, labelsAdded = 1)
+      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesWritten = 2, labelsAdded = 1)
     )
   }
 
@@ -120,7 +120,7 @@ return keanu.name, keanu.created""",
       text = "Merging nodes and setting properties on found nodes.",
       queryText = "merge (person:Person) on match set person.found = true return person.name, person.found",
       optionalResultExplanation = "The query finds all the +Person+ nodes, sets a property on them, and returns them.",
-      assertions = (p) => assertStats(p, propertiesSet = 5)
+      assertions = (p) => assertStats(p, propertiesWritten = 5)
     )
   }
 
@@ -135,7 +135,7 @@ on match set keanu.lastSeen = timestamp()
 return keanu.name, keanu.created, keanu.lastSeen""",
       optionalResultExplanation = "The query creates the 'keanu' node, and sets a timestamp on creation time. If 'keanu' had already existed, a " +
         "different property would have been set.",
-      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesSet = 2, labelsAdded = 1)
+      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesWritten = 2, labelsAdded = 1)
     )
   }
 
@@ -147,7 +147,7 @@ return keanu.name, keanu.created, keanu.lastSeen""",
                     |on match set person.found = true, person.lastAccessed = timestamp()
                     |return person.name, person.found, person.lastAccessed""".stripMargin,
       optionalResultExplanation = "",
-      assertions = (p) => assertStats(p, propertiesSet = 10)
+      assertions = (p) => assertStats(p, propertiesWritten = 10)
     )
   }
 
@@ -158,7 +158,7 @@ return keanu.name, keanu.created, keanu.lastSeen""",
       queryText = """merge (laurence:Person {name: 'Laurence Fishburne'}) return laurence.name""",
       optionalResultExplanation = "The query creates the 'laurence' node. If 'laurence' had already existed, +MERGE+ would " +
         "just match the existing node.",
-      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesSet = 1, labelsAdded = 1)
+      assertions = (p) => assertStats(p, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
     )
   }
 
@@ -168,7 +168,7 @@ return keanu.name, keanu.created, keanu.lastSeen""",
       text = "Merge using unique constraints matches an existing node.",
       queryText = """merge (oliver:Person {name:'Oliver Stone'}) return oliver.name, oliver.bornIn""",
       optionalResultExplanation = "The 'oliver' node already exists, so +MERGE+ just matches it.",
-      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesSet = 0, labelsAdded = 0)
+      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesWritten = 0, labelsAdded = 0)
     )
   }
 
@@ -203,7 +203,7 @@ For more information on parameters, see <<cypher-parameters>>.""",
       parameters = Map("param" -> Map("name" -> "Keanu Reeves", "role" -> "Neo")),
       queryText = "merge (person:Person {name:{param}.name, role:{param}.role}) return person.name, person.role",
       optionalResultExplanation = "",
-      assertions = p => assertStats(p, nodesCreated = 1, propertiesSet = 2, labelsAdded = 1)
+      assertions = p => assertStats(p, nodesCreated = 1, propertiesWritten = 2, labelsAdded = 1)
     )
   }
 
@@ -233,7 +233,7 @@ return movie""",
       optionalResultExplanation = "In our example graph, 'Oliver Stone' and 'Rob Reiner' have never worked together. When we try to +MERGE+ a " +
         "movie between them, Neo4j will not use any of the existing movies already connected to either person. Instead, " +
         "a new 'movie' node is created.",
-      assertions = (p) => assertStats(p, relationshipsCreated = 2, nodesCreated = 1, propertiesSet = 0, labelsAdded = 1)
+      assertions = (p) => assertStats(p, relationshipsCreated = 2, nodesCreated = 1, propertiesWritten = 0, labelsAdded = 1)
     )
   }
 
@@ -267,7 +267,7 @@ return person.name, person.bornIn, city""".stripMargin,
         """This builds on the example from <<merge-merge-single-node-derived-from-an-existing-node-property>>. The second +MERGE+ creates a +BORN_IN+ relationship between each person and a city
 corresponding to the value of the person’s 'bornIn' property. 'Charlie Sheen', 'Rob Reiner' and 'Oliver Stone' all have
 a +BORN_IN+ relationship to the 'same' +City+ node ('New York').""",
-      assertions = (p) => assertStats(p, nodesCreated = 3, propertiesSet = 3, labelsAdded = 3, relationshipsCreated = 5)
+      assertions = (p) => assertStats(p, nodesCreated = 3, propertiesWritten = 3, labelsAdded = 3, relationshipsCreated = 5)
     )
   }
 
@@ -292,7 +292,7 @@ even though the 'name' property may be identical, these are two separate people.
 This is in contrast to the example shown above in <<merge-merge-on-a-relationship-between-two-existing-nodes>>,
 where we used the first +MERGE+ to bind the +City+ nodes to prevent them from being recreated (and thus duplicated) in the
 second +MERGE+.""",
-      assertions = (p) => assertStats(p, nodesCreated = 5, propertiesSet = 5, labelsAdded = 5, relationshipsCreated = 5)
+      assertions = (p) => assertStats(p, nodesCreated = 5, propertiesWritten = 5, labelsAdded = 5, relationshipsCreated = 5)
     )
   }
 }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SetTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SetTest.scala
@@ -98,7 +98,7 @@ Use a parameter to give the value of a property.
       parameters = Map("surname" -> "Taylor"),
       queryText = "match (n {name: 'Andres'}) set n.surname = {surname} return n",
       optionalResultExplanation = "The Andres node has got an surname added.",
-      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesSet = 1))
+      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesWritten = 1))
   }
 
   @Test def set_all_properties_using_a_parameter() {
@@ -110,7 +110,7 @@ This will replace all existing properties on the node with the new set provided 
       parameters = Map("props" -> Map("name" -> "Andres", "position" -> "Developer")),
       queryText = "match (n {name: 'Andres'}) set n = {props} return n",
       optionalResultExplanation = "The Andres node has had all it's properties replaced by the properties in the +props+ parameter.",
-      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesSet = 4))
+      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesWritten = 4))
   }
 
   @Test def set_multiple_properties_in_one_set_clause() {
@@ -119,7 +119,7 @@ This will replace all existing properties on the node with the new set provided 
       text = "If you want to set multiple properties in one go, simply separate them with a comma.",
       queryText = "match (n {name: 'Andres'}) set n.position = 'Developer', n.surname = 'Taylor'",
       optionalResultExplanation = "",
-      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesSet = 2))
+      assertions = (p) => assertStats(p, nodesCreated = 0, propertiesWritten = 2))
   }
 
   @Test def set_single_label_on_a_node() {

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/cookbook/PrettyGraphsTest.scala
@@ -97,11 +97,11 @@ class PrettyGraphsTest extends DocumentingTest with QueryStatisticsTestSupport {
   }
 
   private def assertWheelGraph = ResultAssertions { p =>
-    assertStats(p, nodesCreated = 7, relationshipsCreated = 12, propertiesSet = 6)
+    assertStats(p, nodesCreated = 7, relationshipsCreated = 12, propertiesWritten = 6)
   }
 
   private def assertCompleteGraph = ResultAssertions { p =>
-    assertStats(p, nodesCreated = 6, relationshipsCreated = 15, propertiesSet = 6, labelsAdded = 6)
+    assertStats(p, nodesCreated = 6, relationshipsCreated = 15, propertiesWritten = 6, labelsAdded = 6)
   }
 
   private def assertFriendshipGraph = ResultAssertions { p =>

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionFunctionsTest.scala
@@ -41,7 +41,7 @@ class CollectionFunctionsTest extends RefcardTest with QueryStatisticsTestSuppor
         assertStats(result, nodesCreated = 0)
         assert(result.toList.size === 0)
       case "foreach" =>
-        assertStats(result, nodesCreated = 3, labelsAdded = 3, propertiesSet = 3)
+        assertStats(result, nodesCreated = 3, labelsAdded = 3, propertiesWritten = 3)
         assert(result.toList.size === 0)
     }
   }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateTest.scala
@@ -32,19 +32,19 @@ class CreateTest extends RefcardTest with QueryStatisticsTestSupport {
   override def assert(name: String, result: InternalExecutionResult) {
     name match {
       case "create-node" =>
-        assertStats(result, nodesCreated = 1, propertiesSet = 1)
+        assertStats(result, nodesCreated = 1, propertiesWritten = 1)
         assert(result.toList.size === 1)
       case "create-node-from-map" =>
-        assertStats(result, nodesCreated = 1, propertiesSet = 1)
+        assertStats(result, nodesCreated = 1, propertiesWritten = 1)
         assert(result.toList.size === 1)
       case "create-nodes-from-maps" =>
-        assertStats(result, nodesCreated = 2, propertiesSet = 2)
+        assertStats(result, nodesCreated = 2, propertiesWritten = 2)
         assert(result.toList.size === 2)
       case "create-rel" =>
         assertStats(result, relationshipsCreated = 1)
         assert(result.dumpToString.contains("KNOWS"))
       case "create-rel-prop" =>
-        assertStats(result, relationshipsCreated = 1, propertiesSet = 1)
+        assertStats(result, relationshipsCreated = 1, propertiesWritten = 1)
         assert(result.toList.size === 1)
     }
   }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateUniqueTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateUniqueTest.scala
@@ -32,7 +32,7 @@ class CreateUniqueTest extends RefcardTest with QueryStatisticsTestSupport {
   override def assert(name: String, result: InternalExecutionResult) {
     name match {
       case "create" =>
-        assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesSet = 1)
+        assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesWritten = 1)
         assert(result.toList.size === 1)
     }
   }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ExampleTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ExampleTest.scala
@@ -36,7 +36,7 @@ class ExamplesTest extends RefcardTest with QueryStatisticsTestSupport {
         assertStats(result, nodesCreated = 0)
         assert(result.toList.size === 0)
       case "create" =>
-        assertStats(result, nodesCreated = 1, nodesDeleted = 1, propertiesSet = 3, labelsAdded = 1)
+        assertStats(result, nodesCreated = 1, nodesDeleted = 1, propertiesWritten = 3, labelsAdded = 1)
         assert(result.toList.size === 0)
     }
   }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ImportTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ImportTest.scala
@@ -65,7 +65,7 @@ class ImportTest extends RefcardTest with QueryStatisticsTestSupport {
   override def assert(name: String, result: InternalExecutionResult) {
     name match {
       case "created" =>
-        assertStats(result, nodesCreated = 4, labelsAdded = 4, propertiesSet = 8)
+        assertStats(result, nodesCreated = 4, labelsAdded = 4, propertiesWritten = 8)
     }
   }
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
@@ -38,10 +38,10 @@ class LabelsTest extends RefcardTest with QueryStatisticsTestSupport {
         assertStats(result, labelsAdded = 3)
         assert(result.toList.size === 1)
       case "create-rel" =>
-        assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesSet = 1, labelsAdded = 1)
+        assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesWritten = 1, labelsAdded = 1)
         assert(result.toList.size === 1)
       case "create" =>
-        assertStats(result, nodesCreated = 1, propertiesSet = 1, labelsAdded = 1, nodesDeleted = 1)
+        assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1, nodesDeleted = 1)
         assert(result.toList.size === 1)
       case "remove-label" =>
         assertStats(result, labelsRemoved = 1)

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MapsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MapsTest.scala
@@ -38,7 +38,7 @@ class MapsTest extends RefcardTest with QueryStatisticsTestSupport {
         assertStats(result, nodesCreated = 0)
         assert(result.toList.size === 1)
       case "returns-one-merge" =>
-        assertStats(result, nodesCreated = 1, propertiesSet = 3, labelsAdded = 1)
+        assertStats(result, nodesCreated = 1, propertiesWritten = 3, labelsAdded = 1)
         assert(result.toList.size === 1)
       case "returns-none" =>
         assertStats(result, nodesCreated = 0)

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MergeTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MergeTest.scala
@@ -32,13 +32,13 @@ class MergeTest extends RefcardTest with QueryStatisticsTestSupport {
   override def assert(name: String, result: InternalExecutionResult) {
     name match {
       case "merge" =>
-        assertStats(result, nodesCreated = 1, propertiesSet = 2, labelsAdded = 1)
+        assertStats(result, nodesCreated = 1, propertiesWritten = 2, labelsAdded = 1)
         assert(result.toList.size === 1)
       case "merge-rel" =>
         assertStats(result, relationshipsCreated = 1)
         assert(result.toList.size === 1)
       case "merge-sub" =>
-        assertStats(result, relationshipsCreated = 1, nodesCreated = 1, propertiesSet = 1, labelsAdded = 1)
+        assertStats(result, relationshipsCreated = 1, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
         assert(result.toList.size === 1)
     }
   }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PathFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PathFunctionsTest.scala
@@ -41,7 +41,7 @@ class PathFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
         assertStats(result, nodesCreated = 0)
         assert(result.toList.size === 0)
       case "friends" =>
-        assertStats(result, nodesCreated = 0, propertiesSet = 1)
+        assertStats(result, nodesCreated = 0, propertiesWritten = 1)
         assert(result.toList.size === 0)
     }
   }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
@@ -40,7 +40,7 @@ class PatternsTest extends RefcardTest with QueryStatisticsTestSupport {
       case "empty" =>
         assert(result.toList.size === 0)
       case "create" =>
-        assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesSet = 1)
+        assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesWritten = 1)
         assert(result.toList.size === 1)
     }
   }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RemoveTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RemoveTest.scala
@@ -35,7 +35,7 @@ class RemoveTest extends RefcardTest with QueryStatisticsTestSupport {
         assertStats(result, labelsRemoved = 1)
         assert(result.toList.size === 0)
       case "remove-prop" =>
-        assertStats(result, nodesCreated = 1, propertiesSet = 2)
+        assertStats(result, nodesCreated = 1, propertiesWritten = 2)
         assert(result.toList.size === 0)
     }
   }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ReturnTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ReturnTest.scala
@@ -32,13 +32,13 @@ class ReturnTest extends RefcardTest with QueryStatisticsTestSupport {
   override def assert(name: String, result: InternalExecutionResult) {
     name match {
       case "all-nodes" =>
-        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesSet = 0, relationshipsDeleted = 0)
+        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesWritten = 0, relationshipsDeleted = 0)
         assert(result.toList.size === 4)
       case "alias" =>
-        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesSet = 0, relationshipsDeleted = 0)
+        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesWritten = 0, relationshipsDeleted = 0)
         assert(result.dumpToString.contains("columnName"))
       case "unique" =>
-        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesSet = 0, relationshipsDeleted = 0)
+        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesWritten = 0, relationshipsDeleted = 0)
         assert(result.toList.size === 1)
       case "skip" =>
         assertStats(result, nodesDeleted = 0)

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SetTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SetTest.scala
@@ -32,13 +32,13 @@ class SetTest extends RefcardTest with QueryStatisticsTestSupport {
   override def assert(name: String, result: InternalExecutionResult) {
     name match {
       case "set" =>
-        assertStats(result, propertiesSet = 2)
+        assertStats(result, propertiesWritten = 2)
         assert(result.dumpToString().contains("a value"))
       case "set-label" =>
         assertStats(result, nodesCreated = 1, labelsAdded = 1)
         assert(result.dumpToString().contains("Person"))
       case "map" =>
-        assertStats(result, nodesCreated = 1, propertiesSet = 1)
+        assertStats(result, nodesCreated = 1, propertiesWritten = 1)
         assert(result.dumpToString().contains("a value"))
     }
   }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StartTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StartTest.scala
@@ -33,19 +33,19 @@ class StartTest extends RefcardTest with QueryStatisticsTestSupport {
   override def assert(name: String, result: InternalExecutionResult) {
     name match {
       case "create" =>
-        assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesSet = 0)
+        assertStats(result, nodesCreated = 1, relationshipsCreated = 1, propertiesWritten = 0)
         assert(result.toList.size === 1)
       case "all-nodes" =>
-        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesSet = 0, relationshipsDeleted = 0)
+        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesWritten = 0, relationshipsDeleted = 0)
         assert(result.toList.size === 4)
       case "single-node-by-id" =>
-        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesSet = 0, relationshipsDeleted = 0)
+        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesWritten = 0, relationshipsDeleted = 0)
         assert(result.toList.size === 1)
       case "multiple-nodes-by-id" =>
-        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesSet = 0, relationshipsDeleted = 0)
+        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesWritten = 0, relationshipsDeleted = 0)
         assert(result.toList.size === 2)
       case "multiple-start-nodes-by-id" =>
-        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesSet = 0, relationshipsDeleted = 0)
+        assertStats(result, nodesDeleted = 0, relationshipsCreated = 0, propertiesWritten = 0, relationshipsDeleted = 0)
         assert(result.toList.size === 1)
       case "index-match" =>
         assertStats(result)


### PR DESCRIPTION
Since SET n.prop = null is semantically equivalent to removing a property, we planned this as a rewrite to SetProperty in the ClauseConversion phase.
