### PR TITLE
Release lock client in KTI

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -32,12 +32,14 @@ import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.store.PersistenceCache;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
-import org.neo4j.kernel.impl.locking.NoOpClient;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.NoOpLocks;
 import org.neo4j.kernel.impl.store.NeoStore;
-import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreTransactionContext;
 import org.neo4j.kernel.impl.transaction.state.TransactionRecordState;
+import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -54,7 +56,8 @@ public class KernelTransactionFactory
                 mock( SchemaWriteGuard.class ), null, null,
                 null, mock( TransactionRecordState.class ),
                 mock( RecordStateForCacheAccessor.class ),
-                null, mock( NeoStore.class ), new NoOpClient(), new TransactionHooks(),
+                null, mock( NeoStore.class ), new NoOpLocks(),
+                new TransactionHooks(),
                 mock( ConstraintIndexCreator.class ), headerInformationFactory,
                 mock( TransactionRepresentationCommitProcess.class ), mock( TransactionMonitor.class ),
                 mock( PersistenceCache.class ),
@@ -62,6 +65,7 @@ public class KernelTransactionFactory
                 mock( LegacyIndexTransactionState.class ),
                 mock(Pool.class),
                 Clock.SYSTEM_CLOCK,
-                TransactionTracer.NULL );
+                TransactionTracer.NULL,
+                mock( NeoStoreTransactionContext.class ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/NoOpLocks.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/NoOpLocks.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.locking;
+
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public class NoOpLocks extends LifecycleAdapter implements Locks
+{
+    private boolean closed;
+
+    @Override
+    public void shutdown() throws Throwable
+    {
+        closed = true;
+    }
+
+    @Override
+    public Client newClient()
+    {
+        if ( closed )
+        {
+            throw new IllegalStateException();
+        }
+        return new NoOpClient();
+    }
+
+    @Override
+    public void accept( Visitor visitor )
+    {
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
@@ -84,19 +84,19 @@ public class TransactionThroughMasterSwitchStressIT
     {
         // Duration of this test. If the timeout is hit in the middle of a round, the round will be completed
         // and exit after that.
+        ManagedCluster cluster = clusterRule.startCluster();
         long duration = parseTimeMillis.apply( System.getProperty( getClass().getName() + ".duration", "30s" ) );
         long endTime = currentTimeMillis() + duration;
         while ( currentTimeMillis() < endTime )
         {
-            oneRound();
+            oneRound( cluster );
         }
     }
 
-    private void oneRound() throws Throwable
+    private void oneRound( ManagedCluster cluster ) throws Throwable
     {
         // GIVEN a cluster and a node
         final String key = "key";
-        ManagedCluster cluster = clusterRule.startCluster();
         final GraphDatabaseService master = cluster.getMaster();
         final long nodeId = createNode( master );
         cluster.sync();


### PR DESCRIPTION
`KernelTransactionImplementation` doesn't reference `Locks.Client` since those instances are hard wired to a specific `Locks` instance. Other similar references are always kept on the service level, like `CommitProcess`, where there's a proxy in between which switches when role switches.

This commit undos parts of https://github.com/neo4j/neo4j/pull/5817 because of the issue described in https://github.com/neo4j/neo4j/issues/5996 and because this solution where `Locks` is referenced conforms with other types of references and is a simpler fix to the original problem.

**NOTE:** merge of this PR to 3.0 should be a null-merge.
