### PR TITLE
Stricter constructor for ClassGuardedAdversary

### DIFF
--- a/community/io/src/test/java/org/neo4j/adversaries/ClassGuardedAdversary.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/ClassGuardedAdversary.java
@@ -19,9 +19,10 @@
  */
 package org.neo4j.adversaries;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toSet;
 
 /**
  * An adversary that delegates failure injection only when invoked through certain classes.
@@ -32,11 +33,10 @@ public class ClassGuardedAdversary implements Adversary
     private final Set<String> victimClasses;
     private volatile boolean enabled;
 
-    public ClassGuardedAdversary( Adversary delegate, String... victimClassNames )
+    public ClassGuardedAdversary( Adversary delegate, Class<?>... victimClasses )
     {
         this.delegate = delegate;
-        victimClasses = new HashSet<String>();
-        Collections.addAll( victimClasses, victimClassNames );
+        this.victimClasses = Stream.of( victimClasses ).map( Class::getName ).collect( toSet() );
         enabled = true;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
@@ -45,6 +45,7 @@ import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.PlatformModule;
+import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
@@ -71,7 +72,7 @@ public class PartialTransactionFailureIT
     {
         final ClassGuardedAdversary adversary = new ClassGuardedAdversary(
                 new CountingAdversary( 1, false ),
-                "org.neo4j.kernel.impl.nioneo.xa.Command$RelationshipCommand" );
+                Command.RelationshipCommand.class );
         adversary.disable();
 
         File storeDir = dir.graphDbDir();

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogAdversarialTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogAdversarialTest.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.coreedge.raft.log;
 
-import java.io.File;
-
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.adversaries.ClassGuardedAdversary;
 import org.neo4j.adversaries.CountingAdversary;
@@ -97,7 +97,7 @@ public class RaftLogAdversarialTest
     public void shouldDiscardEntryIfEntryChannelFails() throws Exception
     {
         ClassGuardedAdversary adversary = new ClassGuardedAdversary( new CountingAdversary( 1, false ),
-                NaiveDurableRaftLog.class.getName() );
+                NaiveDurableRaftLog.class );
         adversary.disable();
 
         EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
@@ -132,7 +132,7 @@ public class RaftLogAdversarialTest
     public void shouldDiscardEntryIfContentChannelFails() throws Exception
     {
         ClassGuardedAdversary adversary = new ClassGuardedAdversary( new CountingAdversary( 1, false ),
-                NaiveDurableRaftLog.class.getName() );
+                NaiveDurableRaftLog.class );
         adversary.disable();
 
         EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/TermStoreAdversarialTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/TermStoreAdversarialTest.java
@@ -19,16 +19,14 @@
  */
 package org.neo4j.coreedge.raft.state;
 
-import java.io.File;
-
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.adversaries.ClassGuardedAdversary;
 import org.neo4j.adversaries.CountingAdversary;
 import org.neo4j.adversaries.fs.AdversarialFileSystemAbstraction;
 import org.neo4j.coreedge.raft.log.RaftStorageException;
-import org.neo4j.coreedge.raft.state.DurableTermStore;
-import org.neo4j.coreedge.raft.state.TermStore;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.graphdb.mockfs.SelectiveFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -49,7 +47,7 @@ public class TermStoreAdversarialTest
     public void shouldDiscardTermIfChannelFails() throws Exception
     {
         ClassGuardedAdversary adversary = new ClassGuardedAdversary( new CountingAdversary( 1, false ),
-                DurableTermStore.class.getName() );
+                DurableTermStore.class );
         adversary.disable();
 
         EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/VoteStoreAdversarialTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/VoteStoreAdversarialTest.java
@@ -19,24 +19,21 @@
  */
 package org.neo4j.coreedge.raft.state;
 
-import java.io.File;
-
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.adversaries.ClassGuardedAdversary;
 import org.neo4j.adversaries.CountingAdversary;
 import org.neo4j.adversaries.fs.AdversarialFileSystemAbstraction;
 import org.neo4j.coreedge.raft.log.RaftStorageException;
 import org.neo4j.coreedge.server.CoreMember;
-import org.neo4j.coreedge.raft.state.DurableVoteStore;
-import org.neo4j.coreedge.raft.state.VoteStore;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.graphdb.mockfs.SelectiveFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.coreedge.server.AdvertisedSocketAddress.address;
 
 public class VoteStoreAdversarialTest
@@ -52,7 +49,7 @@ public class VoteStoreAdversarialTest
     public void shouldDiscardVoteIfChannelFails() throws Exception
     {
         ClassGuardedAdversary adversary = new ClassGuardedAdversary( new CountingAdversary( 1, false ),
-                DurableVoteStore.class.getName() );
+                DurableVoteStore.class );
         adversary.disable();
 
         EphemeralFileSystemAbstraction fs = new EphemeralFileSystemAbstraction();


### PR DESCRIPTION
`ClassGuardedAdversary` is an `Adversary` that does fault injection only when specified classes are present in the stacktrace. It accepts vararg of class names as a constructor parameter. This is a bit problematic because class names could be given as strings and get stale. This happened in `PartialTransactionFailureIT` which referenced a non-existing class from the 'org.neo4j.kernel.impl.nioneo.xa' package.

This commit changes the constructor of `ClassGuardedAdversary` to take vararg of `Class` objects.
