### PR TITLE
Coordinate local lock managers via replicated lock.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/ReplicatedLockRequestSerializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/ReplicatedLockRequestSerializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.net;
+
+import io.netty.buffer.ByteBuf;
+
+import org.neo4j.coreedge.raft.membership.CoreMemberMarshal;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.server.core.ReplicatedLockRequest;
+
+public class ReplicatedLockRequestSerializer
+{
+    public static void serialize( ReplicatedLockRequest<CoreMember> content, ByteBuf buffer )
+    {
+        buffer.writeInt( content.requestedLockSessionId() );
+        CoreMemberMarshal.serialize( content.owner(), buffer );
+    }
+
+    public static ReplicatedLockRequest<CoreMember> deserialize( ByteBuf buffer )
+    {
+        int requestedLockSessionId = buffer.readInt();
+        CoreMember owner = CoreMemberMarshal.deserialize( buffer );
+
+        return new ReplicatedLockRequest<>( owner, requestedLockSessionId );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenHolder.java
@@ -89,7 +89,6 @@ public abstract class ReplicatedTokenHolder<TOKEN extends Token, RECORD extends 
         {
             throw new IllegalStateException( "lastCommittedIndex must be set before start." );
         }
-        tokenCache.clear();
         replicator.subscribe( this );
     }
 
@@ -102,8 +101,8 @@ public abstract class ReplicatedTokenHolder<TOKEN extends Token, RECORD extends 
     @Override
     public void setInitialTokens( List<TOKEN> tokens ) throws NonUniqueTokenException
     {
-        // TODO: There is no need to initialize tokens until we have implemented raft log compression.
-        // TODO: at the moment, we receive all token allocations since the beginning of time.
+        tokenCache.clear();
+        tokenCache.putAll( tokens );
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/CurrentReplicatedLockState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/CurrentReplicatedLockState.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.core;
+
+public interface CurrentReplicatedLockState
+{
+    LockSession currentLockSession();
+
+    interface LockSession
+    {
+        int id();
+
+        boolean isMine();
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/LeaderOnlyLockManager.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/LeaderOnlyLockManager.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.core;
+
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.coreedge.server.core.CurrentReplicatedLockState.LockSession;
+import org.neo4j.kernel.impl.locking.AcquireLockTimeoutException;
+import org.neo4j.kernel.impl.locking.LockClientAlreadyClosedException;
+import org.neo4j.kernel.impl.locking.Locks;
+
+/**
+ * Each member of the cluster uses its own {@link LeaderOnlyLockManager} which wraps a local {@link Locks}.
+ * To prevent conflict between the local {@link Locks}, before issuing any locks, each server must first obtain a
+ * replicated exclusive lock via {@link ReplicatedLockStateMachine}.
+ *
+ * Since replication is only allowed from the leader, this means that only the leader is able to obtain
+ * a replicated lock, and therefore only the leader can issue locks.
+ */
+public class LeaderOnlyLockManager<MEMBER> implements Locks
+{
+    public static final int LOCK_WAIT_TIME = 30000;
+
+    private final MEMBER myself;
+
+    private final Replicator replicator;
+    private final Locks local;
+    private final ReplicatedLockStateMachine replicatedLockStateMachine;
+
+    public LeaderOnlyLockManager( MEMBER myself, Replicator replicator, Locks local, ReplicatedLockStateMachine replicatedLockStateMachine )
+    {
+        this.myself = myself;
+        this.replicator = replicator;
+        this.local = local;
+        this.replicatedLockStateMachine = replicatedLockStateMachine;
+    }
+
+    @Override
+    public synchronized Client newClient()
+    {
+        return new LeaderOnlyLockClient( local.newClient(), replicatedLockStateMachine.currentLockSession() );
+    }
+
+    private void requestLock() throws InterruptedException
+    {
+        // TODO: Don't even try if we are not the leader.
+
+        try
+        {
+            replicator.replicate( new ReplicatedLockRequest<>( myself, replicatedLockStateMachine.nextId() ));
+        }
+        catch ( Replicator.ReplicationFailedException e )
+        {
+            throw new LockClientAlreadyClosedException( "Could not acquire lock session. Leader switch?" );
+        }
+
+        synchronized ( replicatedLockStateMachine )
+        {
+            replicatedLockStateMachine.wait( LOCK_WAIT_TIME );
+        }
+    }
+
+    @Override
+    public void accept( Visitor visitor )
+    {
+        local.accept( visitor );
+    }
+
+    @Override
+    public void close()
+    {
+        local.close();
+    }
+
+    private class LeaderOnlyLockClient implements Client
+    {
+        private final Client localLocks;
+        private LockSession lockSession;
+        boolean sessionStarted = false;
+
+        public LeaderOnlyLockClient( Client localLocks, LockSession lockSession )
+        {
+            this.localLocks = localLocks;
+            this.lockSession = lockSession;
+        }
+
+        private void ensureHoldingReplicatedLock()
+        {
+            if ( !sessionStarted )
+            {
+                if ( !lockSession.isMine() )
+                {
+                    try
+                    {
+                        requestLock();
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        throw new RuntimeException( "Interrupted " );
+                    }
+                }
+
+                lockSession = replicatedLockStateMachine.currentLockSession();
+
+                if( !lockSession.isMine() )
+                {
+                    throw new RuntimeException( "Did not manage to acquire valid lock session ID. " + lockSession );
+                }
+
+                sessionStarted = true;
+            }
+
+            if( !replicatedLockStateMachine.currentLockSession().isMine() )
+            {
+                throw new RuntimeException( "Local instance lost lock session." );
+            }
+        }
+
+        @Override
+        public void acquireShared( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException
+        {
+            localLocks.acquireShared( resourceType, resourceId );
+        }
+
+        @Override
+        public void acquireExclusive( ResourceType resourceType, long resourceId ) throws AcquireLockTimeoutException
+        {
+            ensureHoldingReplicatedLock();
+            localLocks.acquireExclusive( resourceType, resourceId );
+        }
+
+        @Override
+        public boolean tryExclusiveLock( ResourceType resourceType, long resourceId )
+        {
+            ensureHoldingReplicatedLock();
+            return localLocks.tryExclusiveLock( resourceType, resourceId );
+        }
+
+        @Override
+        public boolean trySharedLock( ResourceType resourceType, long resourceId )
+        {
+            return localLocks.trySharedLock( resourceType, resourceId );
+        }
+
+        @Override
+        public void releaseShared( ResourceType resourceType, long resourceId )
+        {
+            localLocks.releaseShared( resourceType, resourceId );
+        }
+
+        @Override
+        public void releaseExclusive( ResourceType resourceType, long resourceId )
+        {
+            localLocks.releaseExclusive( resourceType, resourceId );
+        }
+
+        @Override
+        public void releaseAll()
+        {
+            localLocks.releaseAll();
+        }
+
+        @Override
+        public void stop()
+        {
+            localLocks.stop();
+        }
+
+        @Override
+        public void close()
+        {
+            localLocks.close();
+        }
+
+        @Override
+        public int getLockSessionId()
+        {
+            return lockSession.id();
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/ReplicatedLockRequest.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/ReplicatedLockRequest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.core;
+
+import java.util.Objects;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+import static java.lang.String.format;
+
+public class ReplicatedLockRequest<MEMBER> implements ReplicatedContent
+{
+    final MEMBER owner;
+    final int requestedLockSessionId;
+
+    public ReplicatedLockRequest( MEMBER owner, int requestedLockSessionId )
+    {
+        this.owner = owner;
+        this.requestedLockSessionId = requestedLockSessionId;
+    }
+
+    public MEMBER owner()
+    {
+        return owner;
+    }
+
+    public int requestedLockSessionId()
+    {
+        return requestedLockSessionId;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+        ReplicatedLockRequest that = (ReplicatedLockRequest) o;
+        return requestedLockSessionId == that.requestedLockSessionId &&
+               Objects.equals( owner, that.owner );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( owner, requestedLockSessionId );
+    }
+
+    @Override
+    public String toString()
+    {
+        return format( "ReplicatedLockRequest{owner=%s, requestedLockSessionId=%d}", owner, requestedLockSessionId );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/ReplicatedLockStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/ReplicatedLockStateMachine.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.core;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+
+/**
+ * Listens for {@link ReplicatedLockRequest}. Keeps track of the current holder of the replicated exclusive lock,
+ * which is identified by a monotonically increasing session id, and an owning member.
+ */
+public class ReplicatedLockStateMachine<MEMBER>
+        implements Replicator.ReplicatedContentListener, CurrentReplicatedLockState
+{
+    private final MEMBER myself;
+    private LockSession currentLockSession = new LockSession( 0, null );
+
+    public ReplicatedLockStateMachine( MEMBER myself, Replicator replicator )
+    {
+        this.myself = myself;
+        replicator.subscribe( this );
+    }
+
+    @Override
+    public synchronized void onReplicated( ReplicatedContent content, long logIndex )
+    {
+        if ( content instanceof ReplicatedLockRequest )
+        {
+            ReplicatedLockRequest<MEMBER> lockRequest = (ReplicatedLockRequest<MEMBER>) content;
+            int requestedLockSessionId = lockRequest.requestedLockSessionId;
+
+            if ( requestedLockSessionId > currentLockSession.id() )
+            {
+                currentLockSession = new LockSession(requestedLockSessionId, lockRequest.owner());
+            }
+
+            notifyAll();
+        }
+    }
+
+    public int nextId()
+    {
+        return currentLockSession.id + 1;
+    }
+
+    @Override
+    public CurrentReplicatedLockState.LockSession currentLockSession()
+    {
+        return currentLockSession;
+    }
+
+    public final class LockSession implements CurrentReplicatedLockState.LockSession
+    {
+        private final int id;
+        private final MEMBER owner;
+
+        public LockSession( int id, MEMBER owner )
+        {
+            this.id = id;
+            this.owner = owner;
+        }
+
+        @Override
+        public int id()
+        {
+            return id;
+        }
+
+        @Override
+        public boolean isMine()
+        {
+            return myself.equals( owner );
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/core/ReplicatedLockStateMachineTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/server/core/ReplicatedLockStateMachineTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.server.core;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.replication.StubReplicator;
+import org.neo4j.coreedge.server.RaftTestMember;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+
+public class ReplicatedLockStateMachineTest
+{
+    @Test
+    public void shouldKeepTrackOfGlobalLockSession() throws Exception
+    {
+        // given
+        StubReplicator replicator = new StubReplicator();
+        CurrentReplicatedLockState stateMachine = new ReplicatedLockStateMachine<>( member( 0 ), replicator );
+
+        // when
+        replicator.replicate( new ReplicatedLockRequest<>( member( 1 ), 0 ) );
+        replicator.replicate( new ReplicatedLockRequest<>( member( 2 ), 1 ) );
+
+        // then
+        assertEquals( 1, stateMachine.currentLockSession().id() );
+
+        // when
+        replicator.replicate( new ReplicatedLockRequest<>( member( 3 ), 0 ) );
+
+        // then
+        assertEquals( 1, stateMachine.currentLockSession().id() );
+
+        // when
+        replicator.replicate( new ReplicatedLockRequest<>( member( 4 ), 2 ) );
+
+        // then
+        assertEquals( 2, stateMachine.currentLockSession().id() );
+    }
+
+    @Test
+    public void shouldKeepTrackOfLocalLockSession() throws Exception
+    {
+        // given
+        StubReplicator replicator = new StubReplicator();
+        RaftTestMember me = member( 0 );
+        CurrentReplicatedLockState stateMachine = new ReplicatedLockStateMachine<>( me, replicator );
+
+        // when
+        replicator.replicate( new ReplicatedLockRequest<>( member( 1 ), 0 ) );
+        replicator.replicate( new ReplicatedLockRequest<>( member( 2 ), 1 ) );
+
+        // then
+        assertFalse( stateMachine.currentLockSession().isMine() );
+
+        // when
+        replicator.replicate( new ReplicatedLockRequest<>( me, 0 ) );
+
+        // then
+        assertFalse( stateMachine.currentLockSession().isMine() );
+
+        // when
+        replicator.replicate( new ReplicatedLockRequest<>( me, 2 ) );
+
+        // then
+        assertTrue( stateMachine.currentLockSession().isMine() );
+        assertEquals( 2, stateMachine.currentLockSession().id() );
+
+        // when
+        replicator.replicate( new ReplicatedLockRequest<>( member( 1 ), 2 ) );
+
+        // then
+        assertTrue( stateMachine.currentLockSession().isMine() );
+        assertEquals( 2, stateMachine.currentLockSession().id() );
+
+        // when
+        replicator.replicate( new ReplicatedLockRequest<>( member( 1 ), 3 ) );
+
+        // then
+        assertFalse( stateMachine.currentLockSession().isMine() );
+        assertEquals( 3, stateMachine.currentLockSession().id() );
+    }
+
+    @Test
+    public void shouldIssueNextLockSessionId() throws Exception
+    {
+        // given
+        StubReplicator replicator = new StubReplicator();
+        ReplicatedLockStateMachine stateMachine = new ReplicatedLockStateMachine<>( member( 0 ), replicator );
+
+        // then
+        assertEquals(1, stateMachine.nextId());
+
+        // when
+        replicator.replicate( new ReplicatedLockRequest<>( member( 1 ), 3 ) );
+
+        // then
+        assertEquals( 4, stateMachine.nextId() );
+    }
+
+}


### PR DESCRIPTION
Each member of the cluster uses its own LeaderOnlyLockManager
which wraps a local Locks.

To prevent conflict between the local Locks, before issuing
any locks, each server must first obtain a replicated exclusive
lock via ReplicatedLockStateMachine.

Since replication is only allowed from the leader, this means
that only the leader is able to obtain a replicated lock, and
therefore only the leader can issue locks.
