### PR TITLE
Deprecate limit execution time in server

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -451,6 +451,8 @@ public abstract class GraphDatabaseSettings
     @Internal
     public static final Setting<String> forced_kernel_id = setting("forced_kernel_id", STRING, NO_DEFAULT, illegalValueMessage("has to be a valid kernel identifier", matches("[a-zA-Z0-9]*")));
 
+    @Deprecated
+    @Obsoleted( "Subsumed by transaction termination feature" )
     @Internal
     public static final Setting<Boolean> execution_guard_enabled = setting("execution_guard_enabled", BOOLEAN, FALSE );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/guard/Guard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/guard/Guard.java
@@ -23,6 +23,10 @@ import org.neo4j.logging.Log;
 
 import static java.lang.System.currentTimeMillis;
 
+/**
+ * Please use transaction termination feature instead.
+ */
+@Deprecated
 public class Guard
 {
     private final ThreadLocal<GuardInternal> threadLocal = new ThreadLocal<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/GuardingStatementOperations.java
@@ -38,6 +38,10 @@ import org.neo4j.kernel.impl.api.operations.EntityWriteOperations;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
 
+/**
+ * Please use transaction termination feature instead.
+ */
+@Deprecated
 public class GuardingStatementOperations implements
         EntityWriteOperations,
         EntityReadOperations

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -27,6 +27,7 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.HostnamePort;
+import org.neo4j.kernel.configuration.Obsoleted;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.configuration.ConfigurationMigrator;
 import org.neo4j.kernel.configuration.Internal;
@@ -81,6 +82,8 @@ public interface ServerSettings
     Setting<Integer> webserver_max_threads = setting( "org.neo4j.server.webserver.maxthreads",
             INTEGER, ""+Math.min(Runtime.getRuntime().availableProcessors(),500), min( 1 ) );
 
+    @Deprecated
+    @Obsoleted( "Subsumed by transaction termination. Moreover it was based on an internal experimental feature in the kernel." )
     @Description( "If execution time limiting is enabled in the database, this configures the maximum request execution time." )
     Setting<Long> webserver_limit_execution_time = setting(
             "org.neo4j.server.webserver.limit.executiontime", DURATION, NO_DEFAULT );

--- a/community/server/src/main/java/org/neo4j/server/guard/GuardingRequestFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/guard/GuardingRequestFilter.java
@@ -19,17 +19,26 @@
  */
 package org.neo4j.server.guard;
 
+import java.io.IOException;
+import java.util.Timer;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.neo4j.kernel.guard.Guard;
 import org.neo4j.kernel.guard.GuardException;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Timer;
-
 import static javax.servlet.http.HttpServletResponse.SC_REQUEST_TIMEOUT;
 
+/**
+ * Please use the transaction termination feature instead.
+ */
+@Deprecated
 public class GuardingRequestFilter implements Filter
 {
 


### PR DESCRIPTION
This feature is not needed anylonger since it has been subsumed by the
transaction termination feature.  Moreover, it was based on an
internal experimental kernel feature.
