### PR TITLE
Fix server tests based on the browser static content

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/NeoServerDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerDocIT.java
@@ -19,32 +19,21 @@
  */
 package org.neo4j.server;
 
-import org.junit.Before;
 import org.junit.Test;
 
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
-import org.neo4j.server.helpers.FunctionalTestHelper;
 import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
-import org.neo4j.server.rest.JaxRsResponse;
-import org.neo4j.server.rest.RestRequest;
+import org.neo4j.test.server.HTTP;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public class NeoServerDocIT extends AbstractRestFunctionalTestBase
 {
-    private FunctionalTestHelper functionalTestHelper;
-
-    @Before
-    public void setUp()
-    {
-        functionalTestHelper = new FunctionalTestHelper( server() );
-    }
-
     @Test
     public void whenServerIsStartedItshouldStartASingleDatabase() throws Exception
     {
@@ -57,18 +46,8 @@ public class NeoServerDocIT extends AbstractRestFunctionalTestBase
         assertFalse( server().baseUri()
                 .toString()
                 .contains( "browser" ) );
-        JaxRsResponse response = RestRequest.req().get( server().baseUri().toString(), MediaType.TEXT_HTML_TYPE );
-        assertThat( response.getStatus(), is( 200 ) );
-        assertThat( response.getEntity(), containsString( "Neo4j" ) );
+
+        HTTP.Response res = HTTP.withHeaders( HttpHeaders.ACCEPT, MediaType.TEXT_HTML ).GET( server().baseUri().toString() );
+        assertThat( res.header( "Location" ), containsString( "browser") );
     }
-
-    @Test
-    public void serverShouldProvideAWelcomePage() throws Exception
-    {
-        JaxRsResponse response = RestRequest.req().get( functionalTestHelper.browserUri() );
-
-        assertThat( response.getStatus(), is( 200 ) );
-        assertThat( response.getHeaders().getFirst( "Content-Type" ), containsString( "html" ) );
-    }
-
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationDocIT.java
@@ -203,7 +203,6 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
         assertAuthorizationRequired( "POST", "db/data/transaction/commit", RawPayload.quotedJson(
                 "{'statements':[{'statement':'MATCH (n) RETURN n'}]}" ), 200 );
 
-        assertEquals(200, HTTP.GET( server.baseUri().resolve( "browser" ).toString() ).status());
         assertEquals(200, HTTP.GET( server.baseUri().resolve( "" ).toString() ).status() );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationWhitelistIT.java
+++ b/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationWhitelistIT.java
@@ -22,6 +22,8 @@ package org.neo4j.server.security.auth;
 import org.junit.After;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.helpers.CommunityServerBuilder;
@@ -30,6 +32,7 @@ import org.neo4j.test.server.HTTP;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 public class AuthorizationWhitelistIT extends ExclusiveServerTestBase
 {
@@ -39,6 +42,7 @@ public class AuthorizationWhitelistIT extends ExclusiveServerTestBase
     public void shouldWhitelistBrowser() throws Exception
     {
         // Given
+        assumeTrue( browserIsLoaded() );
         server = CommunityServerBuilder.server().withProperty( ServerSettings.auth_enabled.name(), "true" ).build();
 
         // When
@@ -73,7 +77,7 @@ public class AuthorizationWhitelistIT extends ExclusiveServerTestBase
         server.start();
 
         // Then I should get a unauthorized response for access to the DB
-        HTTP.Response response = HTTP.GET( server.baseUri().resolve( "db/data" ).toString() );
+        HTTP.Response response = HTTP.GET(HTTP.GET( server.baseUri().resolve( "db/data" ).toString()).location() );
         assertThat( response.status(), equalTo( 401 ) );
     }
 
@@ -81,5 +85,12 @@ public class AuthorizationWhitelistIT extends ExclusiveServerTestBase
     public void cleanup()
     {
         if ( server != null ) { server.stop(); }
+    }
+
+    private boolean browserIsLoaded() throws IOException
+    {
+        // In some automatic builds, the Neo4j browser is not built, and it is subsequently not present for these
+        // tests. So - only run these tests if the browser artifact is on the classpath
+        return getClass().getClassLoader().getResource( "browser" ) != null;
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
+++ b/community/server/src/test/java/org/neo4j/server/web/TestJetty9WebServer.java
@@ -137,8 +137,8 @@ public class TestJetty9WebServer extends ExclusiveServerTestBase
         server.start();
 
         // When
-        HTTP.Response okResource = HTTP.GET( server.baseUri().resolve( "/browser/content/help/create.html" ).toString() );
-        HTTP.Response illegalResource = HTTP.GET( server.baseUri().resolve( "/browser/content/help/" ).toString() );
+        HTTP.Response okResource = HTTP.GET( server.baseUri().resolve( "/webadmin/index.html" ).toString() );
+        HTTP.Response illegalResource = HTTP.GET( server.baseUri().resolve( "/webadmin/css/" ).toString() );
 
         // Then
         // Depends on specific resources exposed by the browser module; if this test starts to fail,

--- a/community/server/src/test/java/org/neo4j/test/server/HTTP.java
+++ b/community/server/src/test/java/org/neo4j/test/server/HTTP.java
@@ -22,6 +22,8 @@ package org.neo4j.test.server;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
 import org.codehaus.jackson.JsonNode;
 
 import java.net.URI;
@@ -51,7 +53,12 @@ public class HTTP
 {
 
     private static final Builder BUILDER = new Builder().withHeaders( "Accept", "application/json" );
-    private static final Client CLIENT = new Client();
+    private static final Client CLIENT;
+    static {
+        DefaultClientConfig defaultClientConfig = new DefaultClientConfig();
+        defaultClientConfig.getProperties().put( ClientConfig.PROPERTY_FOLLOW_REDIRECTS, Boolean.FALSE );
+        CLIENT = Client.create( defaultClientConfig );
+    }
 
     public static Builder withHeaders( Map<String, String> headers )
     {

--- a/manual/neo4j-harness-enterprise-test/src/test/java/org/neo4j/harness/enterprise/doc/ExtensionTestingDocTest.java
+++ b/manual/neo4j-harness-enterprise-test/src/test/java/org/neo4j/harness/enterprise/doc/ExtensionTestingDocTest.java
@@ -71,7 +71,8 @@ public class ExtensionTestingDocTest
                 .newServer() )
         {
             // When
-            HTTP.Response response = HTTP.GET( server.httpURI().resolve( "myExtension" ).toString() );
+            HTTP.Response response = HTTP.GET(
+                    HTTP.GET( server.httpURI().resolve( "myExtension" ).toString() ).location() );
 
             // Then
             assertEquals( 200, response.status() );

--- a/manual/neo4j-harness-test/src/test/java/org/neo4j/harness/doc/ExtensionTestingDocTest.java
+++ b/manual/neo4j-harness-test/src/test/java/org/neo4j/harness/doc/ExtensionTestingDocTest.java
@@ -73,7 +73,8 @@ public class ExtensionTestingDocTest
                 .newServer() )
         {
             // When
-            HTTP.Response response = HTTP.GET( server.httpURI().resolve( "myExtension" ).toString() );
+            HTTP.Response response = HTTP.GET(
+                    HTTP.GET( server.httpURI().resolve( "myExtension" ).toString() ).location() );
 
             // Then
             assertEquals( 200, response.status() );


### PR DESCRIPTION
Some tets were failing in CI since we not always build the browser,
this change will make sure that no tests in server are based on the
browser excpet one that now it is guarded by an assumption.
