### PR TITLE
Ensure enterprise neo4j-wrapper.conf is same as community.

### DIFF
--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j-wrapper.conf
@@ -45,6 +45,23 @@ wrapper.java.additional=-XX:+AlwaysPreTouch
 #wrapper.java.additional=-XX:+PrintPromotionFailure
 #wrapper.java.additional=-XX:+PrintTenuringDistribution
 
+# Remote JMX monitoring, uncomment and adjust the following lines as needed.
+# Also make sure to update the jmx.access and jmx.password files with appropriate permission roles and passwords,
+# the shipped configuration contains only a read only role called 'monitor' with password 'Neo4j'.
+# For more details, see: http://download.oracle.com/javase/7/docs/technotes/guides/management/agent.html
+# On Unix based systems the jmx.password file needs to be owned by the user that will run the server,
+# and have permissions set to 0600.
+# For details on setting these file permissions on Windows see:
+#     http://docs.oracle.com/javase/7/docs/technotes/guides/management/security-windows.html
+#wrapper.java.additional=-Dcom.sun.management.jmxremote.port=3637
+#wrapper.java.additional=-Dcom.sun.management.jmxremote.authenticate=true
+#wrapper.java.additional=-Dcom.sun.management.jmxremote.ssl=false
+#wrapper.java.additional=-Dcom.sun.management.jmxremote.password.file=conf/jmx.password
+#wrapper.java.additional=-Dcom.sun.management.jmxremote.access.file=conf/jmx.access
+
+# Some systems cannot discover host name automatically, and need this line configured:
+#wrapper.java.additional=-Djava.rmi.server.hostname=$THE_NEO4J_SERVER_HOSTNAME
+
 #********************************************************************
 # Wrapper settings
 #********************************************************************


### PR DESCRIPTION
This particular difference was that community version did not have commented out lines to enable JMX monitoring even though this feature is available in community edition.
