### PR TITLE
Cleanup of package dependencies in Cypher

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LazyLabel.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/LazyLabel.scala
@@ -19,33 +19,33 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.pipes
 
+import org.neo4j.cypher.internal.compiler.v3_0.spi.TokenContext
 import org.neo4j.cypher.internal.frontend.v3_0.ast.LabelName
-import org.neo4j.cypher.internal.compiler.v3_0.spi.{TokenContext, QueryContext}
-import org.neo4j.cypher.internal.frontend.v3_0.{SemanticTable, LabelId}
+import org.neo4j.cypher.internal.frontend.v3_0.{LabelId, SemanticTable}
 
-case class LazyLabel(name:String) {
-  private var id : Option[LabelId] = None
+case class LazyLabel(name: String) {
+  private var id: Option[LabelId] = None
 
   def id(context: TokenContext): Option[LabelId] = id match {
     case None => {
       id = context.getOptLabelId(name).map(LabelId)
       id
     }
-    case x    => x
+    case x => x
   }
 
   // yuck! this is only used by tests...
-  def id(table:SemanticTable):Option[LabelId] = id match {
+  def id(table: SemanticTable): Option[LabelId] = id match {
     case None => {
       id = table.resolvedLabelIds.get(name)
       id
     }
-    case x    => x
+    case x => x
   }
 }
 
 object LazyLabel {
-  def apply(name: LabelName)(implicit table:SemanticTable): LazyLabel = {
+  def apply(name: LabelName)(implicit table: SemanticTable): LazyLabel = {
     val label = new LazyLabel(name.name)
     label.id = name.id
     label

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -176,13 +176,13 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
       AllNodesScanPipe(id)()
 
     case NodeCountFromCountStore(IdName(id), label, _) =>
-      NodeCountFromCountStorePipe(id, label)()
+      NodeCountFromCountStorePipe(id, label.map(LazyLabel.apply))()
 
     case RelationshipCountFromCountStore(IdName(id), startLabel, typeNames, endLabel, bothDirections, _) =>
-      RelationshipCountFromCountStorePipe(id, startLabel, typeNames, endLabel, bothDirections)()
+      RelationshipCountFromCountStorePipe(id, startLabel.map(LazyLabel.apply), typeNames, endLabel.map(LazyLabel.apply), bothDirections)()
 
     case NodeByLabelScan(IdName(id), label, _) =>
-      NodeByLabelScanPipe(id, label)()
+      NodeByLabelScanPipe(id, LazyLabel(label))()
 
     case NodeByIdSeek(IdName(id), nodeIdExpr, _) =>
       NodeByIdSeekPipe(id, nodeIdExpr.asCommandSeekArgs)()
@@ -297,16 +297,16 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
       ProduceResultsPipe(source, columns)()
 
     case CreateNode(_, idName, labels, props) =>
-      CreateNodePipe(source, idName.name, labels, props.map(toCommandExpression))()
+      CreateNodePipe(source, idName.name, labels.map(LazyLabel.apply), props.map(toCommandExpression))()
 
     case MergeCreateNode(_, idName, labels, props) =>
-      MergeCreateNodePipe(source, idName.name, labels, props.map(toCommandExpression))()
+      MergeCreateNodePipe(source, idName.name, labels.map(LazyLabel.apply), props.map(toCommandExpression))()
 
     case CreateRelationship(_, idName, startNode, typ, endNode, props) =>
       CreateRelationshipPipe(source, idName.name, startNode.name, typ, endNode.name, props.map(toCommandExpression))()
 
     case SetLabels(_, IdName(name), labels) =>
-     SetPipe(source, SetLabelsOperation(name, labels))()
+     SetPipe(source, SetLabelsOperation(name, labels.map(LazyLabel.apply)))()
 
     case SetNodeProperty(_, IdName(name), propertyKey, expression) =>
       SetPipe(source, SetNodePropertyOperation(name, LazyPropertyKey(propertyKey),
@@ -325,7 +325,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
         SetRelationshipPropertyFromMapOperation(name, toCommandExpression(expression), removeOtherProps))()
 
     case RemoveLabels(_, IdName(name), labels) =>
-      RemoveLabelsPipe(source, name, labels)()
+      RemoveLabelsPipe(source, name, labels.map(LazyLabel.apply))()
 
     case DeleteNode(_, expression) =>
       DeleteNodePipe(source, toCommandExpression(expression))()

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/SortDescription.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/SortDescription.scala
@@ -17,17 +17,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
+package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.SortDescription
-import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.IdName
 
-case class Sort(left: LogicalPlan, sortItems: Seq[SortDescription])
-               (val solved: PlannerQuery with CardinalityEstimation)
-  extends LogicalPlan with LogicalPlanWithoutExpressions with EagerLogicalPlan  {
-
-  val lhs = Some(left)
-  val rhs = None
-
-  def availableSymbols = left.availableSymbols
+sealed trait SortDescription {
+  def id: IdName
 }
+
+case class Ascending(id: IdName) extends SortDescription
+
+case class Descending(id: IdName) extends SortDescription

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPQueryGraphSolver.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPQueryGraphSolver.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.expandSolverStep.{planSinglePatternSide, planSingleProjectEndpoints}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.solveOptionalMatches.OptionalSolver
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.{applyOptional, outerHashJoin, planShortestPaths}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.{leafPlanOptions, applyOptional, outerHashJoin, planShortestPaths}
 import org.neo4j.cypher.internal.frontend.v3_0.InternalException
 
 import scala.annotation.tailrec
@@ -53,7 +53,7 @@ object IDPQueryGraphSolver {
  */
 case class IDPQueryGraphSolver(monitor: IDPQueryGraphSolverMonitor,
                                maxTableSize: Int = 256,
-                               leafPlanFinder: LogicalLeafPlan.Finder = leafPlanOptions,
+                               leafPlanFinder: LeafPlanFinder = leafPlanOptions,
                                solvers: Seq[QueryGraph => IDPSolverStep[PatternRelationship, LogicalPlan, LogicalPlanningContext]] = Seq(joinSolverStep(_), expandSolverStep(_)),
                                optionalSolvers: Seq[OptionalSolver] = Seq(applyOptional, outerHashJoin))
   extends QueryGraphSolver with PatternExpressionSolving {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/package.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/package.scala
@@ -19,6 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner
 
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
+
 package object logical {
   type Selector[P] = Iterable[P] => Option[P]
+  type LeafPlanFinder = LogicalPlanningFunction2[QueryPlannerConfiguration, QueryGraph, Set[LogicalPlan]]
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/CreateNode.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/CreateNode.scala
@@ -20,11 +20,10 @@
 
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
-import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{Expression, LabelName}
 
-case class CreateNode(source: LogicalPlan, idName: IdName, labels: Seq[LazyLabel], properties: Option[Expression])
+case class CreateNode(source: LogicalPlan, idName: IdName, labels: Seq[LabelName], properties: Option[Expression])
                            (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalPlan with LogicalPlanWithoutExpressions {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LogicalPlan.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LogicalPlan.scala
@@ -21,8 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
 import java.lang.reflect.Method
 
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{LogicalPlanningFunction2, QueryPlannerConfiguration}
-import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery, QueryGraph}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
 import org.neo4j.cypher.internal.frontend.v3_0.Foldable._
 import org.neo4j.cypher.internal.frontend.v3_0.Rewritable._
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{Expression, Variable}
@@ -135,10 +134,6 @@ abstract class LogicalLeafPlan extends LogicalPlan with LazyLogicalPlan {
 
 abstract class NodeLogicalLeafPlan extends LogicalLeafPlan {
   def idName: IdName
-}
-
-object LogicalLeafPlan {
-  type Finder = LogicalPlanningFunction2[QueryPlannerConfiguration, QueryGraph, Set[LogicalPlan]]
 }
 
 final case class IdName(name: String) extends PageDocFormatting // with ToPrettyString[IdName] {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/MergeCreateNode.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/MergeCreateNode.scala
@@ -20,11 +20,10 @@
 
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
-import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{Expression, LabelName}
 
-case class MergeCreateNode(source: LogicalPlan, idName: IdName, labels: Seq[LazyLabel], properties: Option[Expression])
+case class MergeCreateNode(source: LogicalPlan, idName: IdName, labels: Seq[LabelName], properties: Option[Expression])
                           (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalPlan with LogicalPlanWithoutExpressions {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/NodeByLabelScan.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/NodeByLabelScan.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.LabelName
 
-case class NodeByLabelScan(idName: IdName, label: LazyLabel, argumentIds: Set[IdName])
+case class NodeByLabelScan(idName: IdName, label: LabelName, argumentIds: Set[IdName])
                           (val solved: PlannerQuery with CardinalityEstimation)
   extends NodeLogicalLeafPlan with LogicalPlanWithoutExpressions {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/NodeCountFromCountStore.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/NodeCountFromCountStore.scala
@@ -19,11 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
-import org.neo4j.cypher.internal.compiler.v3_0.planner.{PlannerQuery, CardinalityEstimation}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.LabelName
 
 
-case class NodeCountFromCountStore(idName: IdName, labelName: Option[LazyLabel], argumentIds: Set[IdName])
+case class NodeCountFromCountStore(idName: IdName, labelName: Option[LabelName], argumentIds: Set[IdName])
                                     (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalLeafPlan with LogicalPlanWithoutExpressions {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/RelationshipCountFromCountStore.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/RelationshipCountFromCountStore.scala
@@ -19,12 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.{LazyTypes, LazyLabel}
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyTypes
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.LabelName
 
-case class RelationshipCountFromCountStore(idName: IdName, startLabel: Option[LazyLabel],
-                                             typeNames: LazyTypes, endLabel: Option[LazyLabel], bothDirections: Boolean,
-                                             argumentIds: Set[IdName])
+case class RelationshipCountFromCountStore(idName: IdName, startLabel: Option[LabelName],
+                                           typeNames: LazyTypes, endLabel: Option[LabelName], bothDirections: Boolean,
+                                           argumentIds: Set[IdName])
                                             (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalLeafPlan with LogicalPlanWithoutExpressions {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/RemoveLabels.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/RemoveLabels.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.LabelName
 
-case class RemoveLabels(source: LogicalPlan, idName: IdName, labelNames: Seq[LazyLabel])
+case class RemoveLabels(source: LogicalPlan, idName: IdName, labelNames: Seq[LabelName])
                     (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalPlan with LogicalPlanWithoutExpressions {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/SetLabels.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/SetLabels.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.LabelName
 
-case class SetLabels(source: LogicalPlan, idName: IdName, labelNames: Seq[LazyLabel])
+case class SetLabels(source: LogicalPlan, idName: IdName, labelNames: Seq[LabelName])
                     (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalPlan with LogicalPlanWithoutExpressions {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
@@ -21,9 +21,9 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
 import org.neo4j.cypher.internal.compiler.v3_0.commands.QueryExpression
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.CollectionSupport
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.{LazyType, LazyTypes, SortDescription}
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.{LazyType, LazyTypes}
 import org.neo4j.cypher.internal.compiler.v3_0.planner._
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.LogicalPlanningContext
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{SortDescription, LogicalPlanningContext}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics.CardinalityModel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{Limit => LimitPlan, Skip => SkipPlan, _}
 import org.neo4j.cypher.internal.frontend.v3_0.ast._

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlanner.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.{LazyLabel, LazyTypes}
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyTypes
 import org.neo4j.cypher.internal.compiler.v3_0.planner._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.LogicalPlanningContext
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
@@ -51,7 +51,7 @@ case object countStorePlanner {
                     case PatternRelationship(relId, (startNodeId, endNodeId), direction, types, SimplePatternLength)
                       if relId.name == countName && noWrongPredicates(Set(startNodeId, endNodeId), selections) =>
 
-                      def planRelAggr(fromLabel: Option[LazyLabel], toLabel: Option[LazyLabel], bothDirections: Boolean = false) =
+                      def planRelAggr(fromLabel: Option[LabelName], toLabel: Option[LabelName], bothDirections: Boolean = false) =
                         Some(context.logicalPlanProducer.planCountStoreRelationshipAggregation(query, IdName(aggregationIdent), fromLabel, LazyTypes(types.map(_.name)), toLabel, bothDirections, argumentIds)(context))
 
                       (findLabel(startNodeId, selections), direction, findLabel(endNodeId, selections)) match {
@@ -86,7 +86,7 @@ case object countStorePlanner {
     labelPredicates.size <= 1 && other.isEmpty
   }
 
-  def findLabel(nodeId: IdName, selections: Selections): Option[LazyLabel] = selections.predicates.collectFirst {
-    case Predicate(nIds, h: HasLabels) if nIds == Set(nodeId) && h.labels.size == 1 => LazyLabel(h.labels.head.name)
+  def findLabel(nodeId: IdName, selections: Selections): Option[LabelName] = selections.predicates.collectFirst {
+    case Predicate(nIds, h: HasLabels) if nIds == Set(nodeId) && h.labels.size == 1 => h.labels.head
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/labelScanLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/labelScanLeafPlanner.scala
@@ -19,10 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{Variable, UsingScanHint}
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{LeafPlanner, LogicalPlanningContext}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{UsingScanHint, Variable}
 
 object labelScanLeafPlanner extends LeafPlanner {
   def apply(qg: QueryGraph)(implicit context: LogicalPlanningContext) = {
@@ -37,7 +36,7 @@ object labelScanLeafPlanner extends LeafPlanner {
         case hint@UsingScanHint(Variable(`identName`), `labelName`) => hint
       }
 
-      context.logicalPlanProducer.planNodeByLabelScan(idName, LazyLabel(labelName), Seq(labelPredicate), hint, qg.argumentIds)
+      context.logicalPlanProducer.planNodeByLabelScan(idName, labelName, Seq(labelPredicate), hint, qg.argumentIds)
     }
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/leafPlanOptions.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/leafPlanOptions.scala
@@ -17,13 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
-
+package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
 import org.neo4j.cypher.internal.compiler.v3_0.planner.QueryGraph
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{LogicalLeafPlan, LogicalPlan}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{LeafPlanFinder, LogicalPlanningContext, QueryPlannerConfiguration}
 
-object leafPlanOptions extends LogicalLeafPlan.Finder {
+object leafPlanOptions extends LeafPlanFinder {
 
   def apply(config: QueryPlannerConfiguration, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Set[LogicalPlan] = {
     val queryPlannerKit = config.toKit()

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/selectHasLabelWithJoin.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/selectHasLabelWithJoin.scala
@@ -19,19 +19,17 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{HasLabels, Variable}
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.QueryGraph
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{IdName, LogicalPlan}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{CandidateGenerator, LogicalPlanningContext}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{HasLabels, Variable}
 
 case object selectHasLabelWithJoin extends CandidateGenerator[LogicalPlan] {
 
   def apply(plan: LogicalPlan, queryGraph: QueryGraph)(implicit context: LogicalPlanningContext): Seq[LogicalPlan] =
     queryGraph.selections.unsolvedPredicates(plan).collect {
       case s@HasLabels(id: Variable, Seq(labelName)) =>
-        val labelScan = context.logicalPlanProducer.planNodeByLabelScan(IdName(id.name), LazyLabel(labelName)(context.semanticTable), Seq(s), None, Set.empty)
+        val labelScan = context.logicalPlanProducer.planNodeByLabelScan(IdName(id.name), labelName, Seq(s), None, Set.empty)
         context.logicalPlanProducer.planNodeHashJoin(Set(IdName(id.name)), plan, labelScan, Set.empty)
     }
-
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/sortSkipAndLimit.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/sortSkipAndLimit.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.{Ascending, Descending, SortDescription}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{PlannerQuery, QueryProjection}
@@ -54,8 +53,8 @@ object sortSkipAndLimit extends PlanTransformer[PlannerQuery] {
   }
 
   private def sortDescription(in: ast.SortItem): SortDescription = in match {
-    case ast.AscSortItem(ast.Variable(key)) => Ascending(key)
-    case ast.DescSortItem(ast.Variable(key)) => Descending(key)
+    case ast.AscSortItem(ast.Variable(key)) => Ascending(IdName(key))
+    case ast.DescSortItem(ast.Variable(key)) => Descending(IdName(key))
     case _ => throw new InternalException("Sort items expected to only use single variable expression")
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
@@ -227,9 +227,6 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
   class fromDbStructure(dbStructure: Visitable[DbStructureVisitor])
     extends DelegatingLogicalPlanningConfiguration(DbStructureLogicalPlanningConfiguration(dbStructure))
 
-  implicit def lazyLabel(label: String)(implicit plan: SemanticPlan): LazyLabel =
-    LazyLabel(LabelName(label)(_))(plan.semanticTable)
-
   implicit def propertyKeyId(label: String)(implicit plan: SemanticPlan): PropertyKeyId =
     plan.semanticTable.resolvedPropertyKeyNames(label)
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilderAcceptanceTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilderAcceptanceTest.scala
@@ -69,7 +69,7 @@ class PipeExecutionPlanBuilderAcceptanceTest extends CypherFunSuite with Logical
   }
 
   test("simple label scan query") {
-    val logicalPlan = NodeByLabelScan(IdName("n"), LazyLabel("Foo"), Set.empty)_
+    val logicalPlan = NodeByLabelScan(IdName("n"), lblName("Foo"), Set.empty)_
     val pipeInfo = build(logicalPlan)
 
     pipeInfo should not be 'updating

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/CardinalityCostModelTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/CardinalityCostModelTest.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
@@ -45,9 +44,9 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
 
   test("should introduce increase cost when estimating an eager operator and lazyness is preferred") {
     val plan = NodeHashJoin(Set("a"),
-      NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solvedWithEstimation(10.0)),
+      NodeByLabelScan("a", lblName("A"), Set.empty)(solvedWithEstimation(10.0)),
       Expand(
-        NodeByLabelScan("b", LazyLabel("B"), Set.empty)(solvedWithEstimation(5.0)),
+        NodeByLabelScan("b", lblName("B"), Set.empty)(solvedWithEstimation(5.0)),
         "b", SemanticDirection.OUTGOING, Seq.empty, "a", "r", ExpandAll)(solvedWithEstimation(15.0))
     )(solvedWithEstimation(10.0))
 
@@ -65,7 +64,7 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
         Seq(HasLabels(varFor("a2"), Seq(LabelName("A")(pos)))(pos)),
         Expand(
           Expand(
-            NodeByLabelScan("a1", LazyLabel("A"), Set.empty)(solvedWithEstimation(10.0)),
+            NodeByLabelScan("a1", lblName("A"), Set.empty)(solvedWithEstimation(10.0)),
             "a1", SemanticDirection.OUTGOING, Seq.empty, "b", "r1", ExpandAll
           )(solvedWithEstimation(50.0)),
           "b", SemanticDirection.INCOMING, Seq.empty, "a2", "r2", ExpandAll
@@ -76,11 +75,11 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
     val eagerPlan = Projection(
       NodeHashJoin(Set("b"),
         Expand(
-          NodeByLabelScan("a1", LazyLabel("A"), Set.empty)(solvedWithEstimation(10.0)),
+          NodeByLabelScan("a1", lblName("A"), Set.empty)(solvedWithEstimation(10.0)),
           "a1", SemanticDirection.OUTGOING, Seq.empty, "b", "r1", ExpandAll
         )(solvedWithEstimation(50.0)),
         Expand(
-          NodeByLabelScan("a2", LazyLabel("A"), Set.empty)(solvedWithEstimation(10.0)),
+          NodeByLabelScan("a2", lblName("A"), Set.empty)(solvedWithEstimation(10.0)),
           "a2", SemanticDirection.OUTGOING, Seq.empty, "b", "r2", ExpandAll
         )(solvedWithEstimation(50.0))
       )(solvedWithEstimation(250.0)), Map("b" -> varFor("b"))

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/CartesianProductPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/CartesianProductPlanningIntegrationTest.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.BeLikeMatcher._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{LogicalPlanningTestSupport2, PlannerQuery}
@@ -61,10 +60,10 @@ class CartesianProductPlanningIntegrationTest extends CypherFunSuite with Logica
 
     plan.plan should equal(
       CartesianProduct(
-        NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solved),
+        NodeByLabelScan("a", lblName("A"), Set.empty)(solved),
         CartesianProduct(
-          NodeByLabelScan("c", LazyLabel("C"), Set.empty)(solved),
-          NodeByLabelScan("b", LazyLabel("B"), Set.empty)(solved)
+          NodeByLabelScan("c", lblName("C"), Set.empty)(solved),
+          NodeByLabelScan("b", lblName("B"), Set.empty)(solved)
         )(solved)
       )(solved)
     )
@@ -83,8 +82,8 @@ class CartesianProductPlanningIntegrationTest extends CypherFunSuite with Logica
 
     plan.plan should equal(
       CartesianProduct(
-        NodeByLabelScan("b", LazyLabel("B"), Set.empty)(solved),
-        NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solved)
+        NodeByLabelScan("b", lblName("B"), Set.empty)(solved),
+        NodeByLabelScan("a", lblName("A"), Set.empty)(solved)
       )(solved)
     )
   }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/CreateNodePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/CreateNodePlanningIntegrationTest.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
@@ -67,7 +66,7 @@ class CreateNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlann
   test("should plan create with labels") {
     planFor("CREATE (a:A:B)").plan should equal(
       EmptyResult(
-        CreateNode(SingleRow()(solved), IdName("a"), Seq(LazyLabel("A"), LazyLabel("B")), None)(solved))(solved)
+        CreateNode(SingleRow()(solved), IdName("a"), Seq(lblName("A"), lblName("B")), None)(solved))(solved)
     )
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/FindShortestPathsPlanningIntegrationTest.scala
@@ -80,10 +80,10 @@ class FindShortestPathsPlanningIntegrationTest extends CypherFunSuite with Logic
           NodeHashJoin(
             Set(IdName("b")),
             Expand(
-              NodeByLabelScan(IdName("a"), LazyLabel("X"), Set.empty)(solved),
+              NodeByLabelScan(IdName("a"), lblName("X"), Set.empty)(solved),
               IdName("a"), SemanticDirection.INCOMING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved),
             Expand(
-              NodeByLabelScan(IdName("c"), LazyLabel("X"), Set.empty)(solved),
+              NodeByLabelScan(IdName("c"), lblName("X"), Set.empty)(solved),
               IdName("c"), SemanticDirection.INCOMING, Seq.empty, IdName("b"), IdName("r2"), ExpandAll)(solved)
           )(solved)
         )(solved),

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LeafPlanningIntegrationTest.scala
@@ -219,7 +219,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         case _ => Double.MaxValue
       }
     } planFor "MATCH (n:Awesome) RETURN n").plan should equal(
-      NodeByLabelScan("n", LazyLabel("Awesome"), Set.empty)(solved)
+      NodeByLabelScan("n", lblName("Awesome"), Set.empty)(solved)
     )
   }
 
@@ -235,7 +235,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     } planFor "MATCH (n:Awesome) RETURN n"
 
     plan.plan should equal(
-      NodeByLabelScan("n", lazyLabel("Awesome"), Set.empty)(solved)
+      NodeByLabelScan("n", lblName("Awesome"), Set.empty)(solved)
     )
   }
 
@@ -421,7 +421,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     plan.plan should equal(
       Selection(
         Seq(HasLabels(varFor("n"), Seq(LabelName("Foo")_))_, HasLabels(varFor("n"), Seq(LabelName("Baz")_))_),
-        NodeByLabelScan("n", LazyLabel("Bar"), Set.empty)(solved)
+        NodeByLabelScan("n", lblName("Bar"), Set.empty)(solved)
       )(solved)
     )
   }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlan2PlanDescriptionTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlan2PlanDescriptionTest.scala
@@ -20,14 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v3_0.commands.ManyQueryExpression
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
-import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.{LabelName, _}
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.{EstimatedRows, ExpandExpression, Index, KeyNames, LabelName}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
-import org.neo4j.cypher.internal.frontend.v3_0.ast._
+import org.neo4j.cypher.internal.frontend.v3_0._
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{LabelName => AstLabelName, _}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.frontend.v3_0.{InputPosition, LabelId, PropertyKeyId, SemanticDirection}
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 class LogicalPlan2PlanDescriptionTest extends CypherFunSuite with TableDrivenPropertyChecks {
@@ -54,7 +53,7 @@ class LogicalPlan2PlanDescriptionTest extends CypherFunSuite with TableDrivenPro
       , AllNodesScan(IdName("b"), Set.empty)(42) ->
         PlanDescriptionImpl(id, "AllNodesScan", NoChildren, Seq(EstimatedRows(42)), Set("b"))
 
-      , NodeByLabelScan(IdName("node"), LazyLabel("X"), Set.empty)(33) ->
+      , NodeByLabelScan(IdName("node"), AstLabelName("X")(DummyPosition(0)), Set.empty)(33) ->
         PlanDescriptionImpl(id, "NodeByLabelScan", NoChildren, Seq(LabelName("X"), EstimatedRows(33)), Set("node"))
 
       , NodeByIdSeek(IdName("node"), ManySeekableArgs(Collection(Seq(SignedDecimalIntegerLiteral("1")(pos)))(pos)), Set.empty)(333) ->

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/MergeNodePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/MergeNodePlanningIntegrationTest.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{Collection, In, MapExpression, Property, PropertyKeyName, SignedDecimalIntegerLiteral, Variable}
@@ -44,9 +43,9 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
 
   test("should plan single merge node from a label scan") {
 
-    val labelScan = NodeByLabelScan(aId, LazyLabel("X"), Set.empty)(solved)
+    val labelScan = NodeByLabelScan(aId, lblName("X"), Set.empty)(solved)
     val optional = Optional(labelScan)(solved)
-    val onCreate = MergeCreateNode(SingleRow()(solved), aId, Seq(LazyLabel("X")), None)(solved)
+    val onCreate = MergeCreateNode(SingleRow()(solved), aId, Seq(lblName("X")), None)(solved)
 
     val mergeNode = AntiConditionalApply(optional, onCreate, aId)(solved)
     val emptyResult = EmptyResult(mergeNode)(solved)
@@ -136,7 +135,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
     val allNodesScan = AllNodesScan(aId, Set.empty)(solved)
     val optional = Optional(allNodesScan)(solved)
     val setLabels = SetLabels(SingleRow()(solved),
-      aId, Seq(LazyLabel("L")))(solved)
+      aId, Seq(lblName("L")))(solved)
     val onMatch = ConditionalApply(optional, setLabels, aId)(solved)
 
     val createAndOnCreate = SetNodeProperty(MergeCreateNode(SingleRow()(solved), aId, Seq.empty, None)(solved), aId, PropertyKeyName("prop")(pos), SignedDecimalIntegerLiteral("1")(pos))(solved)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/NamedPathProjectionPlanningIntegrationTest.scala
@@ -31,7 +31,7 @@ class NamedPathProjectionPlanningIntegrationTest extends CypherFunSuite with Log
   test("should build plans containing outgoing path projections") {
     planFor("MATCH p = (a:X)-[r]->(b) RETURN p").plan should equal(
       Projection(
-        Expand( NodeByLabelScan("a",  LazyLabel("X"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved),
+        Expand( NodeByLabelScan("a",  lblName("X"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved),
         expressions = Map(
           "p" -> PathExpression(NodePathStep(Variable("a")_,SingleRelationshipPathStep(Variable("r")_, SemanticDirection.OUTGOING, NilPathStep)))_
         )
@@ -51,7 +51,7 @@ class NamedPathProjectionPlanningIntegrationTest extends CypherFunSuite with Log
           varFor("a")
         ) _),
         Projection(
-          Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved),
+          Expand(NodeByLabelScan("a", lblName("X"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved),
           expressions = Map("a" -> varFor("a"), "b" -> varFor("b"), "p" -> pathExpr, "r" -> varFor("r")))(solved)
       )(solved)
     )
@@ -75,7 +75,7 @@ class NamedPathProjectionPlanningIntegrationTest extends CypherFunSuite with Log
           ) _
         ),
         Projection(
-          Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved),
+          Expand(NodeByLabelScan("a", lblName("X"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved),
           expressions = Map("a" -> varFor("a"), "b" -> varFor("b"), "p" -> pathExpr, "r" -> varFor("r"))
         )(solved)
       )(solved)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/NodeHashJoinPlanningIntegrationTest.scala
@@ -49,10 +49,10 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
         NodeHashJoin(
           Set(IdName("b")),
           Expand(
-            NodeByLabelScan(IdName("a"), LazyLabel("X"), Set.empty)(solved),
+            NodeByLabelScan(IdName("a"), lblName("X"), Set.empty)(solved),
             IdName("a"), SemanticDirection.INCOMING, Seq.empty, IdName("b"), IdName("r1"))(solved),
           Expand(
-            NodeByLabelScan(IdName("c"), LazyLabel("X"), Set.empty)(solved),
+            NodeByLabelScan(IdName("c"), lblName("X"), Set.empty)(solved),
             IdName("c"), SemanticDirection.INCOMING, Seq.empty, IdName("b"), IdName("r2"))(solved)
         )(solved)
       )(solved)
@@ -86,10 +86,10 @@ class NodeHashJoinPlanningIntegrationTest extends CypherFunSuite with LogicalPla
         NodeHashJoin(
           Set(IdName("b")),
           Expand(
-            NodeByLabelScan(IdName("a"), LazyLabel("A"), Set.empty)(solved),
+            NodeByLabelScan(IdName("a"), lblName("A"), Set.empty)(solved),
             IdName("a"), SemanticDirection.OUTGOING, Seq(RelTypeName("X") _), IdName("b"), IdName("r1"), ExpandAll)(solved),
           Expand(
-            NodeByLabelScan(IdName("c"), LazyLabel("C"), Set.empty)(solved),
+            NodeByLabelScan(IdName("c"), lblName("C"), Set.empty)(solved),
             IdName("c"), SemanticDirection.INCOMING, Seq(RelTypeName("X") _), IdName("b"), IdName("r2"), ExpandAll)(solved)
         )(solved)
       )(solved)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -41,8 +41,8 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       }
     } planFor "MATCH (a:X)-[r1]->(b) OPTIONAL MATCH (b)-[r2]->(c:Y) RETURN b").plan should equal(
         OuterHashJoin(Set("b"),
-          Expand(NodeByLabelScan("a", LazyLabel("X"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq(), "b", "r1")(solved),
-          Expand(NodeByLabelScan("c", LazyLabel("Y"), Set.empty)(solved), "c", SemanticDirection.INCOMING, Seq(), "b", "r2")(solved)
+          Expand(NodeByLabelScan("a", lblName("X"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq(), "b", "r1")(solved),
+          Expand(NodeByLabelScan("c", lblName("Y"), Set.empty)(solved), "c", SemanticDirection.INCOMING, Seq(), "b", "r2")(solved)
         )(solved)
     )
   }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/UnionPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/UnionPlanningIntegrationTest.scala
@@ -19,10 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{Variable, LabelName}
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
+import org.neo4j.cypher.internal.frontend.v3_0.ast.Variable
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
 class UnionPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
@@ -38,11 +37,11 @@ class UnionPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTe
       ProduceResult(Seq("a"),
         Union(
           Projection(
-            NodeByLabelScan("  a@7", LazyLabel(LabelName("A") _), Set.empty)(solved),
+            NodeByLabelScan("  a@7", lblName("A"), Set.empty)(solved),
             Map("a" -> Variable("  a@7") _)
           )(solved),
           Projection(
-            NodeByLabelScan("  a@43", LazyLabel(LabelName("B") _), Set.empty)(solved),
+            NodeByLabelScan("  a@43", lblName("B"), Set.empty)(solved),
             Map("a" -> Variable("  a@43") _)
           )(solved)
         )(solved)
@@ -62,11 +61,11 @@ class UnionPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTe
         Aggregation(
           left = Union(
             Projection(
-              NodeByLabelScan("  a@7", LazyLabel(LabelName("A") _), Set.empty)(solved),
+              NodeByLabelScan("  a@7", lblName("A"), Set.empty)(solved),
               Map("a" -> Variable("  a@7") _)
             )(solved),
             Projection(
-              NodeByLabelScan("  a@39", LazyLabel(LabelName("B") _), Set.empty)(solved),
+              NodeByLabelScan("  a@39", lblName("B"), Set.empty)(solved),
               Map("a" -> Variable("  a@39") _)
             )(solved)
           )(solved),

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPQueryGraphSolverTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPQueryGraphSolverTest.scala
@@ -111,7 +111,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
 
       val plan = queryGraphSolver.plan(cfg.qg)
       plan should equal(
-        Expand(NodeByLabelScan("b", LazyLabel("B"), Set.empty)(solved), "b", SemanticDirection.INCOMING, Seq.empty, "a", "r")(solved)
+        Expand(NodeByLabelScan("b", lblName("B"), Set.empty)(solved), "b", SemanticDirection.INCOMING, Seq.empty, "a", "r")(solved)
       )
 
       verify(monitor).initTableFor(cfg.qg, 0)
@@ -149,7 +149,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
       plan should equal(
         Selection(Seq(labelBPredicate),
           Expand(
-            NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved)
+            NodeByLabelScan("a", lblName("A"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved)
         )(solved))
 
       verify(monitor).initTableFor(cfg.qg, 0)
@@ -192,9 +192,9 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
       plan should equal(
         NodeHashJoin(Set("c"),
           Expand(
-            NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "c", "r1")(solved),
+            NodeByLabelScan("a", lblName("A"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "c", "r1")(solved),
           Expand(
-            NodeByLabelScan("b", LazyLabel("B"), Set.empty)(solved), "b", SemanticDirection.INCOMING, Seq.empty, "c", "r2")(solved)
+            NodeByLabelScan("b", lblName("B"), Set.empty)(solved), "b", SemanticDirection.INCOMING, Seq.empty, "c", "r2")(solved)
         )(solved))
 
       verify(monitor).initTableFor(cfg.qg, 0)
@@ -242,9 +242,9 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
         Selection(Seq(cfg.predicate),
           NodeHashJoin(Set("c"),
             Expand(
-              NodeByLabelScan("a", LazyLabel("A"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "c", "r1")(solved),
+              NodeByLabelScan("a", lblName("A"), Set.empty)(solved), "a", SemanticDirection.OUTGOING, Seq.empty, "c", "r1")(solved),
             Expand(
-              NodeByLabelScan("b", LazyLabel("B"), Set.empty)(solved), "b", SemanticDirection.INCOMING, Seq.empty, "c", "r2")(solved)
+              NodeByLabelScan("b", lblName("B"), Set.empty)(solved), "b", SemanticDirection.INCOMING, Seq.empty, "c", "r2")(solved)
           )(solved)
         )(solved)
       )

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LabelScanLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LabelScanLeafPlannerTest.scala
@@ -65,7 +65,7 @@ class LabelScanLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
 
     // then
     resultPlans should equal(Seq(
-      NodeByLabelScan(idName, LazyLabel("Awesome"), Set.empty)(solved))
+      NodeByLabelScan(idName, lblName("Awesome"), Set.empty)(solved))
     )
   }
 
@@ -98,6 +98,6 @@ class LabelScanLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSu
 
     // then
     resultPlans should equal(
-      Seq(NodeByLabelScan(idName, LazyLabel(LabelName("Awesome")_), Set.empty)(solved)))
+      Seq(NodeByLabelScan(idName, lblName("Awesome"), Set.empty)(solved)))
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/SortSkipAndLimitTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/SortSkipAndLimitTest.scala
@@ -19,10 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.{Ascending, SortDescription}
 import org.neo4j.cypher.internal.compiler.v3_0.planner._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Cardinality, LogicalPlanningContext}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Ascending, SortDescription, Cardinality, LogicalPlanningContext}
 import org.neo4j.cypher.internal.frontend.v3_0.ast
 import org.neo4j.cypher.internal.frontend.v3_0.ast.{AscSortItem, PatternExpression}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/TriadicSelectionFinderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/TriadicSelectionFinderTest.scala
@@ -19,13 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.QueryGraphProducer
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{LogicalPlanningTestSupport, QueryGraph}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
-import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection.{OUTGOING, INCOMING}
+import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection.{INCOMING, OUTGOING}
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
@@ -223,7 +222,7 @@ class TriadicSelectionFinderTest extends CypherFunSuite with LogicalPlanningTest
   private def produceTriadicTestCase(aLabel: String = "X",
                                      r1Types: Seq[String] = Seq.empty, r1Direction: SemanticDirection = OUTGOING, bLabels: Seq[String] = Seq.empty,
                                      r2Types: Seq[String] = Seq.empty, r2Direction: SemanticDirection = OUTGOING, cLabels: Seq[String] = Seq.empty): (Expand, Selection) = {
-    val lblScan = NodeByLabelScan(IdName("a"), LazyLabel(aLabel), Set.empty)(solved)
+    val lblScan = NodeByLabelScan(IdName("a"), lblName(aLabel), Set.empty)(solved)
     val expand1 = Expand(lblScan, IdName("a"), OUTGOING, r1Types.map(RelTypeName(_)(pos)), IdName("b"), IdName("r1"), ExpandAll)(solved)
     val expand2 = Expand(expand1, IdName("b"), r2Direction, r2Types.map(RelTypeName(_)(pos)), IdName("c"), IdName("r2"), ExpandAll)(solved)
     val relationshipUniqueness = Not(Equals(Variable("r1")(pos), Variable("r2")(pos))(pos))(pos)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGeneratorTest.scala
@@ -27,7 +27,6 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.cypher.internal.compatibility.EntityAccessorWrapper3_0
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlanBuilder.tracer
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InternalExecutionResult
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyLabel
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.{CostBasedPlannerName, NormalMode, TaskCloser}
@@ -72,7 +71,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("label scan") {// MATCH (a:T1) RETURN a
     //given
-    val plan = ProduceResult(List("a"), NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved))
+    val plan = ProduceResult(List("a"), NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved))
 
     //when
     val compiled = compileAndExecute(plan)
@@ -135,8 +134,8 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("cartesian product of two label scans") {
     //given
-    val lhs = NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved)
-    val rhs = NodeByLabelScan(IdName("b"), LazyLabel("T2"), Set.empty)(solved)
+    val lhs = NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved)
+    val rhs = NodeByLabelScan(IdName("b"), lblName("T2"), Set.empty)(solved)
     val join = CartesianProduct(lhs, rhs)(solved)
     val plan = ProduceResult(List("a", "b"), join)
 
@@ -180,7 +179,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
     //given
     val plan = ProduceResult(List("a", "b"),
         Expand(
-          NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), IdName("a"),
+          NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved), IdName("a"),
           SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved))
 
     //when
@@ -240,7 +239,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   //given
   val plan = ProduceResult(List("a", "b"),
                 Expand(
-                  NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), IdName("a"),
+                  NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved), IdName("a"),
                   SemanticDirection.INCOMING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved))
 
     //when
@@ -256,7 +255,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   //given
   val plan = ProduceResult(List("a", "b"),
                              OptionalExpand(
-                               NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), IdName("a"),
+                               NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved), IdName("a"),
                                SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll,
                                Seq(HasLabels(varFor("b"), Seq(LabelName("T1")(pos)))(pos)))(solved))
 
@@ -276,7 +275,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   //given
   val plan = ProduceResult(List("a", "b"),
       Expand(
-        NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), IdName("a"), SemanticDirection.BOTH,
+        NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved), IdName("a"), SemanticDirection.BOTH,
         Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved))
 
     //when
@@ -294,7 +293,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("expand into on top of expand all") {
     //given
-    val scanT1 = NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved)
+    val scanT1 = NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved)
     val expandAll = Expand(
       scanT1, IdName("a"), SemanticDirection.OUTGOING,
       Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
@@ -320,7 +319,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("optional expand into on top of expand all") {
     //given
-    val scanT1 = NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved)
+    val scanT1 = NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved)
     val expandAll = Expand(
       scanT1, IdName("a"), SemanticDirection.OUTGOING,
       Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
@@ -346,7 +345,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("expand into on top of expand all with relationship types") {
     //given
-    val scanT2 = NodeByLabelScan(IdName("a"), LazyLabel("T2"), Set.empty)(solved)
+    val scanT2 = NodeByLabelScan(IdName("a"), lblName("T2"), Set.empty)(solved)
     val expandAll = Expand(
       scanT2, IdName("a"), SemanticDirection.OUTGOING,
       Seq(RelTypeName("R2")(pos)), IdName("b"), IdName("r1"), ExpandAll)(solved)
@@ -371,7 +370,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("optional expand into on top of expand all with relationship types") {
     //given
-    val scanT2 = NodeByLabelScan(IdName("a"), LazyLabel("T2"), Set.empty)(solved)
+    val scanT2 = NodeByLabelScan(IdName("a"), lblName("T2"), Set.empty)(solved)
     val expandAll = Expand(
       scanT2, IdName("a"), SemanticDirection.OUTGOING,
       Seq(RelTypeName("R2")(pos)), IdName("b"), IdName("r1"), ExpandAll)(solved)
@@ -397,7 +396,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("expand into on top of expand all with a loop") {
     //given
-    val scanT3 = NodeByLabelScan(IdName("a"), LazyLabel("T3"), Set.empty)(solved)
+    val scanT3 = NodeByLabelScan(IdName("a"), lblName("T3"), Set.empty)(solved)
     val expandAll = Expand(
       scanT3, IdName("a"), SemanticDirection.OUTGOING,
       Seq(RelTypeName("R3")(pos)), IdName("b"), IdName("r1"), ExpandAll)(solved)
@@ -422,7 +421,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
   test("optional expand into on top of expand all with a loop") {
     //given
-    val scanT3 = NodeByLabelScan(IdName("a"), LazyLabel("T3"), Set.empty)(solved)
+    val scanT3 = NodeByLabelScan(IdName("a"), lblName("T3"), Set.empty)(solved)
     val expandAll = Expand(
       scanT3, IdName("a"), SemanticDirection.OUTGOING,
       Seq(RelTypeName("R3")(pos)), IdName("b"), IdName("r1"), ExpandAll)(solved)
@@ -482,9 +481,9 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
     // MATCH (a:T1)-[r1]->(b)<-[r2]-(c:T2) RETURN b
 
     //given
-    val lhs = Expand(NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved), IdName("a"),
+    val lhs = Expand(NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved), IdName("a"),
       SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
-    val rhs = Expand(NodeByLabelScan(IdName("c"), LazyLabel("T2"), Set.empty)(solved), IdName("c"),
+    val rhs = Expand(NodeByLabelScan(IdName("c"), lblName("T2"), Set.empty)(solved), IdName("c"),
       SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r2"), ExpandAll)(solved)
     val join = NodeHashJoin(Set(IdName("b")), lhs, rhs)(solved)
     val plan = ProduceResult(List("a", "b", "c"), join)
@@ -505,9 +504,9 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   test("hash join on top of hash join") {
 
     //given
-    val scan1 = NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved)
-    val scan2 = NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved)
-    val scan3 = NodeByLabelScan(IdName("a"), LazyLabel("T1"), Set.empty)(solved)
+    val scan1 = NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved)
+    val scan2 = NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved)
+    val scan3 = NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved)
     val join1 = NodeHashJoin(Set(IdName("a")), scan1, scan2)(solved)
     val join2 = NodeHashJoin(Set(IdName("a")), scan3, join1)(solved)
     val projection = Projection(join2, Map("a" -> varFor("a")))(solved)

--- a/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/AstConstructionTestSupport.scala
+++ b/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/AstConstructionTestSupport.scala
@@ -29,8 +29,10 @@ trait AstConstructionTestSupport extends CypherTestSupport {
 
   def varFor(name: String): Variable = Variable(name)(pos)
 
+  def lblName(s: String) = LabelName(s)(pos)
+
   def hasLabels(v: String, label: String) =
-    HasLabels(varFor(v), Seq(LabelName(label)(pos)))(pos)
+    HasLabels(varFor(v), Seq(lblName(label)))(pos)
 
   def prop(variable: String, propKey: String) = Property(varFor(variable), PropertyKeyName(propKey)(pos))(pos)
 


### PR DESCRIPTION
In preparation for more modular code, move out runtime types from 
logical planning.
