### PR TITLE
Don't apply transactions that have already been committed

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EnterpriseEdgeEditionModule.java
@@ -149,8 +149,11 @@ public class EnterpriseEdgeEditionModule extends EditionModule
                 channelInitializer ) );
         channelInitializer.setOwner( edgeToCoreClient );
 
+        Supplier<TransactionIdStore> transactionIdStoreSupplier =
+                () -> platformModule.dependencies.resolveDependency( TransactionIdStore.class ) ;
+
         ApplyPulledTransactions applyPulledTransactions =
-                new ApplyPulledTransactions( logProvider, transactionApplierSupplier );
+                new ApplyPulledTransactions( logProvider, transactionApplierSupplier, transactionIdStoreSupplier );
 
         TxPollingClient txPollingClient = life.add(
                 new TxPollingClient( platformModule.jobScheduler, config.get( HaSettings.pull_interval ),


### PR DESCRIPTION
- A TX Pull response could contain transactions that
  have already been applied on an edge server. We shouldn't
  apply those again.
