### PR TITLE
Fix deadlock in timeout service + minor cleanups.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/DelayedRenewableTimeoutService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/DelayedRenewableTimeoutService.java
@@ -33,6 +33,8 @@ import org.neo4j.helpers.Clock;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
 
 import static java.lang.System.nanoTime;
 
@@ -57,18 +59,15 @@ public class DelayedRenewableTimeoutService extends LifecycleAdapter implements 
     private final SortedSet<ScheduledRenewableTimeout> timeouts = new TreeSet<>();
     private final Queue<ScheduledRenewableTimeout> pendingRenewals = new ConcurrentLinkedDeque<>();
     private final Clock clock;
+    private final Log log;
     private final Random random;
     private final JobScheduler scheduler;
     private JobScheduler.JobHandle jobHandle;
 
-    public DelayedRenewableTimeoutService()
-    {
-        this( Clock.SYSTEM_CLOCK );
-    }
-
-    public DelayedRenewableTimeoutService( Clock clock )
+    public DelayedRenewableTimeoutService( Clock clock, LogProvider logProvider )
     {
         this.clock = clock;
+        this.log = logProvider.getLog( getClass() );
         this.random = new Random( nanoTime() );
         this.scheduler = new Neo4jJobScheduler();
     }
@@ -117,7 +116,7 @@ public class DelayedRenewableTimeoutService extends LifecycleAdapter implements 
     }
 
     @Override
-    public void run()
+    public synchronized void run()
     {
         try
         {
@@ -141,7 +140,6 @@ public class DelayedRenewableTimeoutService extends LifecycleAdapter implements 
                     if ( timeout.shouldTrigger( now ) )
                     {
                         triggered.add( timeout );
-                        timeout.trigger();
                     }
                     else
                     {
@@ -150,13 +148,21 @@ public class DelayedRenewableTimeoutService extends LifecycleAdapter implements 
                         break;
                     }
                 }
+            }
 
+            for ( ScheduledRenewableTimeout timeout : triggered )
+            {
+                timeout.trigger();
+            }
+
+            synchronized ( timeouts )
+            {
                 timeouts.removeAll( triggered );
             }
         }
         catch ( Throwable e )
         {
-            e.printStackTrace();
+            log.error( "Error handling timeouts", e );
         }
     }
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
@@ -36,7 +36,6 @@ import org.neo4j.helpers.Clock;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
-
 public class RaftInstanceBuilder<MEMBER>
 {
     private final MEMBER member;
@@ -47,7 +46,7 @@ public class RaftInstanceBuilder<MEMBER>
     private TermStore termStore = new InMemoryTermStore();
     private VoteStore<MEMBER> voteStore = new InMemoryVoteStore<>();
     private RaftLog raftLog = new InMemoryRaftLog();
-    private RenewableTimeoutService renewableTimeoutService = new DelayedRenewableTimeoutService();
+    private RenewableTimeoutService renewableTimeoutService = new DelayedRenewableTimeoutService( Clock.SYSTEM_CLOCK, NullLogProvider.getInstance() );
 
     private Inbound inbound = handler -> {};
     private Outbound<MEMBER> outbound = ( advertisedSocketAddress, messages ) -> {};

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipper.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipper.java
@@ -85,6 +85,7 @@ public class RaftLogShipper<MEMBER>
     }
 
     private final Outbound<MEMBER> outbound;
+    private final LogProvider logProvider;
     private final Log log;
     private final ReadableRaftLog raftLog;
     private final Clock clock;
@@ -114,6 +115,7 @@ public class RaftLogShipper<MEMBER>
         this.outbound = outbound;
         this.catchupBatchSize = catchupBatchSize;
         this.maxAllowedShippingLag = maxAllowedShippingLag;
+        this.logProvider = logProvider;
         this.log = logProvider.getLog( getClass() );
         this.raftLog = raftLog;
         this.clock = clock;
@@ -134,7 +136,7 @@ public class RaftLogShipper<MEMBER>
 
         try
         {
-            timeoutService = new DelayedRenewableTimeoutService();
+            timeoutService = new DelayedRenewableTimeoutService( clock, logProvider );
             timeoutService.init();
             timeoutService.start();
         }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -168,7 +168,7 @@ public class EnterpriseCoreEditionModule
         ListenSocketAddress raftListenAddress = config.get( CoreEdgeClusterSettings.raft_listen_address );
         RaftServer<CoreMember> raftServer = new RaftServer<>( marshall, raftListenAddress, logProvider );
 
-        final DelayedRenewableTimeoutService raftTimeoutService = new DelayedRenewableTimeoutService();
+        final DelayedRenewableTimeoutService raftTimeoutService = new DelayedRenewableTimeoutService( Clock.SYSTEM_CLOCK, logProvider );
 
         File raftLogsDirectory = createRaftLogsDirectory( platformModule.storeDir, fileSystem );
         NaiveDurableRaftLog raftLog = new NaiveDurableRaftLog( fileSystem, raftLogsDirectory,

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/DelayedRenewableTimeoutServiceTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/DelayedRenewableTimeoutServiceTest.java
@@ -19,17 +19,22 @@
  */
 package org.neo4j.coreedge.raft;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.helpers.Clock;
 import org.neo4j.helpers.FakeClock;
 import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.logging.NullLogProvider;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 public class DelayedRenewableTimeoutServiceTest
@@ -61,7 +66,7 @@ public class DelayedRenewableTimeoutServiceTest
         // given
         final AtomicLong timeoutCount = new AtomicLong();
 
-        DelayedRenewableTimeoutService timeoutService = new DelayedRenewableTimeoutService();
+        DelayedRenewableTimeoutService timeoutService = new DelayedRenewableTimeoutService( Clock.SYSTEM_CLOCK, NullLogProvider.getInstance() );
 
         timeoutService.create( Timeouts.FOOBAR, 1000, 0, new RenewableTimeoutService.TimeoutHandler()
         {
@@ -90,7 +95,7 @@ public class DelayedRenewableTimeoutServiceTest
         // given
         final AtomicLong timeoutCount = new AtomicLong();
 
-        DelayedRenewableTimeoutService timeoutService = new DelayedRenewableTimeoutService();
+        DelayedRenewableTimeoutService timeoutService = new DelayedRenewableTimeoutService( Clock.SYSTEM_CLOCK, NullLogProvider.getInstance() );
 
         RenewableTimeoutService.RenewableTimeout timeout = timeoutService.create( Timeouts.FOOBAR, 1000, 0, new RenewableTimeoutService.TimeoutHandler()
         {
@@ -120,7 +125,7 @@ public class DelayedRenewableTimeoutServiceTest
 
         FakeClock clock = new FakeClock();
 
-        DelayedRenewableTimeoutService timeoutService = new DelayedRenewableTimeoutService( clock );
+        DelayedRenewableTimeoutService timeoutService = new DelayedRenewableTimeoutService( clock, NullLogProvider.getInstance() );
 
         RenewableTimeoutService.RenewableTimeout timeout = timeoutService.create( Timeouts.FOOBAR, 1000, 0, t -> timeoutCount
                 .incrementAndGet() );
@@ -141,5 +146,54 @@ public class DelayedRenewableTimeoutServiceTest
         Thread.sleep( 5 );
 
         assertThat( timeoutCount.get(), equalTo( 1L ) );
+    }
+
+    @Test
+    public void shouldNotDeadLockWhenCancellingDuringExpiryHandling() throws Throwable
+    {
+        // given: a timeout handler that blocks on a latch
+        final CountDownLatch latch = new CountDownLatch( 1 );
+
+        FakeClock clock = new FakeClock();
+        DelayedRenewableTimeoutService timeoutService = new DelayedRenewableTimeoutService( clock, NullLogProvider.getInstance() );
+
+        int TIMEOUT_MS = 1000;
+        RenewableTimeoutService.RenewableTimeout timeout = timeoutService.create( Timeouts.FOOBAR, TIMEOUT_MS, 0, handler -> {
+            try
+            {
+                latch.await( 10_000, TimeUnit.MILLISECONDS );
+            }
+            catch ( InterruptedException e )
+            {
+                Thread.interrupted();
+            }
+        } );
+
+        life.add( timeoutService );
+
+        clock.forward( TIMEOUT_MS, MILLISECONDS );
+        Thread.sleep( 5 ); // to make sure the scheduled thread has checked time elapsed
+
+        // given: another thread that wants to cancel the timeout while the handler is in progress
+        Thread cancelThread = new Thread()
+        {
+            @Override
+            public void run()
+            {
+                timeout.cancel(); // this would previously deadlock, because the timeout service was stuck handling the handler callback
+            }
+        };
+
+        // when: we cancel the timeout, then it should not deadlock, and the latch be immediately released
+        cancelThread.start();
+        // so the following join should finish immediately and the cancelThread should be dead
+        cancelThread.join( 5_000 );
+        assertFalse( cancelThread.isAlive() );
+
+        // cleanup
+        latch.countDown();
+        cancelThread.interrupt();
+        timeoutService.stop();
+        timeoutService.shutdown();
     }
 }


### PR DESCRIPTION
The deadlock could occur when the timeout cancel operation was called
from a client inside the same monitor that the timeout expiry would be
handled under. So there was the possibility of a circular wait graph.

Both the timeout expiry and the cancelling operation were locking
the internal collection of timeouts during processing, which is unnecessary.
The deadlock loop is broken by not locking the timeouts collection when
processing the triggered timeouts.

This commit also cleans up some logging and dependency injection.
