### PR TITLE
Add the option to trace ComExceptions

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/Client.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Client.java
@@ -108,12 +108,35 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         this.readTimeout = readTimeout;
         // ResourcePool no longer controls max concurrent channels. Use this value for the pool size
         this.maxUnusedChannels = maxConcurrentChannels;
-        this.comExceptionHandler = ComExceptionHandler.NO_OP;
+        this.comExceptionHandler = getNoOpComExceptionHandler();
         this.address = new InetSocketAddress( hostNameOrIp, port );
         this.protocol = createProtocol( chunkSize, protocolVersion.getApplicationProtocol() );
         this.responseUnpacker = responseUnpacker;
 
         msgLog.info( getClass().getSimpleName() + " communication channel created towards " + address );
+    }
+
+    private ComExceptionHandler getNoOpComExceptionHandler()
+    {
+        return new ComExceptionHandler()
+        {
+            @Override
+            public void handle( ComException exception )
+            {
+                if ( ComException.TRACE_HA_CONNECTIVITY )
+                {
+                    String noOpComExceptionHandler = "NoOpComExceptionHandler";
+                    //noinspection ThrowableResultOfMethodCallIgnored
+                    traceComException( exception, noOpComExceptionHandler );
+                }
+            }
+        };
+    }
+
+    private ComException traceComException( ComException exception, String tracePoint )
+    {
+        StringLogger log = this.msgLog;
+        return exception.traceComException( log, tracePoint );
     }
 
     protected Protocol createProtocol( int chunkSize, byte applicationProtocolVersion )
@@ -148,7 +171,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
 
                 String msg = Client.this.getClass().getSimpleName() + " could not connect to " + address;
                 msgLog.info( msg, true );
-                throw new ComException( msg, channelFuture.getCause() );
+                throw traceComException( new ComException( msg, channelFuture.getCause() ), "Client.start" );
             }
 
             @Override
@@ -197,7 +220,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
     {
         channelPool.close( true );
         bootstrap.releaseExternalResources();
-        comExceptionHandler = ComExceptionHandler.NO_OP;
+        comExceptionHandler = getNoOpComExceptionHandler();
         msgLog.info( toString() + " shutdown", true );
     }
 
@@ -249,7 +272,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
         {
             failure = e;
             comExceptionHandler.handle( e );
-            throw e;
+            throw traceComException( e, "Client.sendRequest" );
         }
         catch ( Throwable e )
         {
@@ -303,7 +326,9 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
             if ( result == null )
             {
                 msgLog.error( "Unable to acquire new channel for " + type );
-                throw new ComException( "Unable to acquire new channel for " + type );
+                throw traceComException(
+                        new ComException( "Unable to acquire new channel for " + type ),
+                        "Client.acquireChannelContext" );
             }
             return result;
         }
@@ -333,7 +358,7 @@ public abstract class Client<T> extends LifecycleAdapter implements ChannelPipel
 
     public void setComExceptionHandler( ComExceptionHandler handler )
     {
-        comExceptionHandler = (handler == null) ? ComExceptionHandler.NO_OP : handler;
+        comExceptionHandler = (handler == null) ? getNoOpComExceptionHandler() : handler;
     }
 
     protected byte getInternalProtocolVersion()

--- a/enterprise/com/src/main/java/org/neo4j/com/ComException.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ComException.java
@@ -19,8 +19,12 @@
  */
 package org.neo4j.com;
 
+import org.neo4j.kernel.impl.util.StringLogger;
+
 public class ComException extends RuntimeException
 {
+    public static final boolean TRACE_HA_CONNECTIVITY = Boolean.getBoolean( "org.neo4j.com.TRACE_HA_CONNECTIVITY" );
+
     public ComException()
     {
         super();
@@ -39,5 +43,16 @@ public class ComException extends RuntimeException
     public ComException( Throwable cause )
     {
         super( cause );
+    }
+
+    public ComException traceComException( StringLogger log, String tracePoint )
+    {
+        if ( TRACE_HA_CONNECTIVITY )
+        {
+            String msg = String.format( "ComException@%x trace from %s: %s",
+                    System.identityHashCode( this ), tracePoint, getMessage() );
+            log.debug( msg, this, true );
+        }
+        return this;
     }
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/ComExceptionHandler.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/ComExceptionHandler.java
@@ -21,13 +21,5 @@ package org.neo4j.com;
 
 public interface ComExceptionHandler
 {
-    static ComExceptionHandler NO_OP = new ComExceptionHandler()
-    {
-        @Override
-        public void handle( ComException exception )
-        {
-        }
-    };
-
     void handle( ComException exception );
 }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpacker.java
@@ -297,7 +297,8 @@ public class TransactionCommittingResponseUnpacker implements ResponseUnpacker, 
             }
             catch ( IllegalStateException e )
             {
-                throw new ComException( "Failed to pull updates", e );
+                throw new ComException( "Failed to pull updates", e )
+                        .traceComException( log, "BatchingResponseHandler.obligation" );
             }
             catch ( InterruptedException e )
             {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
@@ -80,6 +80,7 @@ public class MasterClientResolver implements MasterClientFactory, ComExceptionHa
     @Override
     public void handle( ComException exception )
     {
+        exception.traceComException( log, "MasterClientResolver.handle" );
         if ( exception instanceof IllegalProtocolVersionException )
         {
             log.info( "Handling " + exception + ", will pick new master client" );
@@ -94,6 +95,10 @@ public class MasterClientResolver implements MasterClientFactory, ComExceptionHa
             log.info( "Handling " + exception + ", will go to PENDING and ask for election" );
 
             invalidEpochHandler.handle();
+        }
+        else
+        {
+            log.debug( "Ignoring " + exception + "." );
         }
     }
 


### PR DESCRIPTION
This is enabled by turning on debug-level logging, and adding a `wrapper.java.additional=-Dorg.neo4j.com.TRACE_HA_CONNECTIVITY=true` to `neo4j-wrapper.conf`.

This is useful for debugging a particular class of connectivity errors, often seen as "MasterClient214 cannot connect" exceptions and log messages, that can somehow persist for a long time after the actual failure.

_NOTE:_ Packages and classes have moved around in 2.3 and/or 3.0, so one should be extra careful when merging this forward.
