### PR TITLE
Store logIndex in transaction header for tokens

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/LogIndexTxHeaderEncoding.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/LogIndexTxHeaderEncoding.java
@@ -38,6 +38,11 @@ public class LogIndexTxHeaderEncoding
 
     public static long decodeLogIndexFromTxHeader( byte[] bytes )
     {
+        if ( bytes.length < Long.BYTES )
+        {
+            throw new IllegalArgumentException( "Unable to decode RAFT log index from transaction header" );
+        }
+
         long logIndex = 0;
         for ( int i = 0; i < Long.BYTES; i++ )
         {

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/LogIndexTxHeaderEncodingTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/LogIndexTxHeaderEncodingTest.java
@@ -35,4 +35,21 @@ public class LogIndexTxHeaderEncodingTest
         byte[] bytes = encodeLogIndexAsTxHeader( index );
         assertEquals( index, decodeLogIndexFromTxHeader( bytes ) );
     }
+
+    @Test
+    public void shouldThrowExceptionForAnEmptyByteArray() throws Exception
+    {
+        // given
+        try
+        {
+            // when
+            decodeLogIndexFromTxHeader( new byte[0] );
+            fail( "Should have thrown an exception because there's no way to decode this " );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // expected
+            assertEquals( "Unable to decode RAFT log index from transaction header", e.getMessage() );
+        }
+    }
 }


### PR DESCRIPTION
- If the last thing you have in the log is a token the
  store wouldn't be able to recover. With this change
  we will be able to.
