### PR TITLE
Fix reading of props with different block sizes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -81,7 +81,8 @@ class StorePropertyPayloadCursor
     private final DynamicStringStore stringStore;
     private final DynamicArrayStore arrayStore;
 
-    private AbstractDynamicStore.DynamicRecordCursor recordCursor;
+    private AbstractDynamicStore.DynamicRecordCursor stringRecordCursor;
+    private AbstractDynamicStore.DynamicRecordCursor arrayRecordCursor;
     private ByteBuffer buffer = cachedBuffer;
 
     private final long[] data = new long[MAX_NUMBER_OF_PAYLOAD_LONG_ARRAY];
@@ -202,11 +203,15 @@ class StorePropertyPayloadCursor
         assertOfType( STRING );
         try
         {
-            readFromStore( stringStore );
+            if ( stringRecordCursor == null )
+            {
+                stringRecordCursor = stringStore.newDynamicRecordCursor();
+            }
+            readFromStore( stringStore, stringRecordCursor );
         }
         catch ( IOException e )
         {
-            throw new UnderlyingStorageException( e );
+            throw new UnderlyingStorageException( "Unable to read string value", e );
         }
         buffer.flip();
         return UTF8.decode( buffer.array(), 0, buffer.limit() );
@@ -224,11 +229,15 @@ class StorePropertyPayloadCursor
         assertOfType( ARRAY );
         try
         {
-            readFromStore( arrayStore );
+            if ( arrayRecordCursor == null )
+            {
+                arrayRecordCursor = arrayStore.newDynamicRecordCursor();
+            }
+            readFromStore( arrayStore, arrayRecordCursor );
         }
         catch ( IOException e )
         {
-            throw new UnderlyingStorageException( e );
+            throw new UnderlyingStorageException( "Unable to read array value", e );
         }
         buffer.flip();
         return readArrayFromBuffer( buffer );
@@ -247,23 +256,20 @@ class StorePropertyPayloadCursor
     private Bits valueAsBits()
     {
         Bits bits = Bits.bits( MAX_BYTES_IN_SHORT_STRING_OR_SHORT_ARRAY );
-        for ( int i = 0; i < currentBlocksUsed(); i++ )
+        int blocksUsed = currentBlocksUsed();
+        for ( int i = 0; i < blocksUsed; i++ )
         {
             bits.put( data[position + i] );
         }
         return bits;
     }
 
-    private void readFromStore( AbstractDynamicStore store ) throws IOException
+    private void readFromStore( AbstractDynamicStore store, AbstractDynamicStore.DynamicRecordCursor cursor )
+            throws IOException
     {
-        if ( recordCursor == null )
-        {
-            recordCursor = store.newDynamicRecordCursor();
-        }
-
         buffer.clear();
         long startBlockId = PropertyBlock.fetchLong( currentHeader() );
-        try ( GenericCursor<DynamicRecord> records = store.getRecordsCursor( startBlockId, true, recordCursor ) )
+        try ( GenericCursor<DynamicRecord> records = store.getRecordsCursor( startBlockId, true, cursor ) )
         {
             while ( records.next() )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/LargePropertiesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/LargePropertiesIT.java
@@ -19,44 +19,60 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
-import org.neo4j.test.DatabaseRule;
-import org.neo4j.test.GraphTransactionRule;
-import org.neo4j.test.ImpermanentDatabaseRule;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.test.EphemeralFileSystemRule;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class LargePropertiesIT
 {
-    @ClassRule
-    public static DatabaseRule db = new ImpermanentDatabaseRule();
-
     @Rule
-    public GraphTransactionRule tx = new GraphTransactionRule( db );
+    public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
 
-    private Node node;
-
-    @Before
-    public void createInitialNode()
-    {
-        node = db.getGraphDatabaseService().createNode();
-    }
-
-    @After
-    public void deleteInitialNode()
-    {
-        node.delete();
-    }
-    
     @Test
-    public void testLargeProperties()
+    public void readArrayAndStringPropertiesWithDifferentBlockSizes()
     {
-        byte[] bytes = new byte[10*1024*1024];
-        node.setProperty( "large_array", bytes );
-        node.setProperty( "large_string", new String( bytes ) );
+        String stringValue = RandomStringUtils.randomAlphanumeric( 10000 );
+        byte[] arrayValue = RandomStringUtils.randomAlphanumeric( 10000 ).getBytes();
+
+        GraphDatabaseService db = new TestGraphDatabaseFactory()
+                .setFileSystem( fs.get() )
+                .newImpermanentDatabaseBuilder()
+                .setConfig( GraphDatabaseSettings.string_block_size, "1024" )
+                .setConfig( GraphDatabaseSettings.array_block_size, "2048" )
+                .newGraphDatabase();
+        try
+        {
+            long nodeId;
+            try ( Transaction tx = db.beginTx() )
+            {
+                Node node = db.createNode();
+                nodeId = node.getId();
+                node.setProperty( "string", stringValue );
+                node.setProperty( "array", arrayValue );
+                tx.success();
+            }
+
+            try ( Transaction tx = db.beginTx() )
+            {
+                Node node = db.getNodeById( nodeId );
+                assertEquals( stringValue, node.getProperty( "string" ) );
+                assertArrayEquals( arrayValue, (byte[]) node.getProperty( "array" ) );
+                tx.success();
+            }
+        }
+        finally
+        {
+            db.shutdown();
+        }
     }
 }


### PR DESCRIPTION
Currently we have two dynamic stores for long property values - `DynamicStringStore` and `DynamicArrayStore`. They can have their block sizes configured separately via `string_block_size` and `array_block_size` internal properties. `StorePropertyCursor` and `StorePropertyPayloadCursor` are used to read actual property values. Payload cursor wraps a dynamic record cursor tries to reuse most of it's internal state.

Issue occurred because `StorePropertyPayloadCursor` tried to use same dynamic record cursor for reading from both dynamic string and array store, which can have different block size.

This commit makes property payload cursor use different cursors for dynamic string store and dynamic array store. It also restructures `StorePropertyPayloadCursorTest` because previously some basic tests were not executed as they were not inside an inner class.

Fixes #6133
