### PR TITLE
LogicalPlans should not know about LazyType

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -305,7 +305,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
       MergeCreateNodePipe(source, idName.name, labels.map(LazyLabel.apply), props.map(toCommandExpression))()
 
     case CreateRelationship(_, idName, startNode, typ, endNode, props) =>
-      CreateRelationshipPipe(source, idName.name, startNode.name, typ, endNode.name, props.map(toCommandExpression))()
+      CreateRelationshipPipe(source, idName.name, startNode.name, LazyType(typ)(context.semanticTable), endNode.name, props.map(toCommandExpression))()
 
     case SetLabels(_, IdName(name), labels) =>
      SetPipe(source, SetLabelsOperation(name, labels.map(LazyLabel.apply)))()

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/CreateRelationship.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/CreateRelationship.scala
@@ -20,11 +20,10 @@
 
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.LazyType
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
-import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{Expression, RelTypeName}
 
-case class CreateRelationship(source: LogicalPlan, idName: IdName, startNode: IdName, typ: LazyType, endNode: IdName,
+case class CreateRelationship(source: LogicalPlan, idName: IdName, startNode: IdName, typ: RelTypeName, endNode: IdName,
                               properties: Option[Expression])
                            (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalPlan with LogicalPlanWithoutExpressions {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
@@ -471,7 +471,7 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends Colle
 
     val solved = inner.solved.amendUpdateGraph(_.addMutatingPatterns(pattern))
 
-    CreateRelationship(inner, pattern.relName, pattern.startNode, LazyType(pattern.relType)(context.semanticTable),
+    CreateRelationship(inner, pattern.relName, pattern.startNode, pattern.relType,
       pattern.endNode, pattern.properties)(solved)
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/CreateRelationshipPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/CreateRelationshipPlanningIntegrationTest.scala
@@ -34,7 +34,7 @@ class CreateRelationshipPlanningIntegrationTest extends CypherFunSuite with Logi
           CreateNode(
             CreateNode(SingleRow()(solved), IdName("a"), Seq.empty, None)(solved),
             IdName("b"), Seq.empty, None)(solved),
-          IdName("r"), IdName("a"), LazyType("R"), IdName("b"), None)(solved)
+          IdName("r"), IdName("a"), relType("R"), IdName("b"), None)(solved)
       )(solved)
     )
   }
@@ -52,9 +52,9 @@ class CreateRelationshipPlanningIntegrationTest extends CypherFunSuite with Logi
                     IdName("b"),Seq.empty,None)(solved),
                   IdName("c"),Seq.empty,None)(solved),
                 IdName("d"),Seq.empty,None)(solved),
-              IdName("r1"),IdName("a"),LazyType("R1"),IdName("b"),None)(solved),
-            IdName("r2"),IdName("c"),LazyType("R2"),IdName("b"),None)(solved),
-          IdName("r3"),IdName("c"),LazyType("R3"),IdName("d"),None)(solved)
+              IdName("r1"),IdName("a"),relType("R1"),IdName("b"),None)(solved),
+            IdName("r2"),IdName("c"),relType("R2"),IdName("b"),None)(solved),
+          IdName("r3"),IdName("c"),relType("R3"),IdName("d"),None)(solved)
       )(solved)
     )
   }
@@ -69,9 +69,11 @@ class CreateRelationshipPlanningIntegrationTest extends CypherFunSuite with Logi
                 CreateNode(SingleRow()(solved),IdName("a"),Seq.empty,None)(solved),
                 IdName("b"),Seq.empty,None)(solved),
               IdName("c"),Seq.empty,None)(solved),
-            IdName("r1"),IdName("b"),LazyType("R1"),IdName("a"),None)(solved),
-          IdName("r2"),IdName("c"),LazyType("R2"),IdName("b"),None)(solved)
+            IdName("r1"),IdName("b"),relType("R1"),IdName("a"),None)(solved),
+          IdName("r2"),IdName("c"),relType("R2"),IdName("b"),None)(solved)
       )(solved)
     )
   }
+
+  private def relType(name: String): RelTypeName = RelTypeName(name)(pos)
 }


### PR DESCRIPTION
`LazyType` is a runtime concern and should not be used by logical plans.
