### PR TITLE
Move FOREACH to its own card; fix typos and style

### DIFF
--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AggregationTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AggregationTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.docgen.RefcardTest
 class AggregationTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Aggregation"
-  val css = "general c3-3 c4-3 c5-4 c6-6"
+  val css = "general c3-3 c4-4 c5-4 c6-6"
   override val linkId = "query-aggregation"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -57,7 +57,7 @@ class AggregationTest extends RefcardTest with QueryStatisticsTestSupport {
 
   def text = """
 ###assertion=returns-one
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
 RETURN NODES(path),
 
@@ -67,9 +67,9 @@ count(*)
 The number of matching rows.
 
 ###assertion=returns-one
-MATCH path=(identifier)-->(m)
+MATCH path = (identifier)-->(m)
 WHERE id(identifier) = %A% AND id(m) = %B%
-RETURN NODES(path),
+RETURN nodes(path),
 
 count(identifier)
 ###
@@ -77,9 +77,9 @@ count(identifier)
 The number of non-++NULL++ values.
 
 ###assertion=returns-one
-MATCH path=(identifier)-->(m)
+MATCH path = (identifier)-->(m)
 WHERE id(identifier) = %A% AND id(m) = %B%
-RETURN NODES(path),
+RETURN nodes(path),
 
 count(DISTINCT identifier)
 ###
@@ -102,7 +102,7 @@ RETURN
 
 sum(n.property)
 
-,avg(n.property),min(n.property),max(n.property)
+,avg(n.property), min(n.property), max(n.property)
 ###
 
 Sum numerical values. Similar functions are +avg+, +min+, +max+.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CaseTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CaseTest.scala
@@ -27,7 +27,7 @@ class CaseTest extends RefcardTest with QueryStatisticsTestSupport {
   def graphDescription = List(
     "A KNOWS B")
   val title = "CASE"
-  val css = "general c2-1 c3-3 c4-2 c5-3 c6-1"
+  val css = "general c2-1 c3-3 c4-2 c5-5 c6-4"
   override val linkId = "cypher-expressions"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -51,8 +51,8 @@ MATCH n
 RETURN
 
 CASE n.eyes
- WHEN 'blue' THEN 1
- WHEN 'brown' THEN 2
+ WHEN "blue" THEN 1
+ WHEN "brown" THEN 2
  ELSE 3
 END
 
@@ -67,7 +67,7 @@ MATCH n
 RETURN
 
 CASE
- WHEN n.eyes = 'blue' THEN 1
+ WHEN n.eyes = "blue" THEN 1
  WHEN n.age < 40 THEN 2
  ELSE 3
 END

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionExpressionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionExpressionsTest.scala
@@ -23,10 +23,10 @@ import org.neo4j.cypher.QueryStatisticsTestSupport
 import org.neo4j.cypher.docgen.RefcardTest
 import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionResult
 
-class CollectionFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
+class CollectionExpressionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A:Person KNOWS B:Person", "B KNOWS C:Person", "C KNOWS ROOT")
-  val title = "Collection Functions"
-  val css = "general c3-3 c4-3 c5-4 c6-6"
+  val title = "Collection Expressions"
+  val css = "general c3-2 c4-4 c5-2 c6-6"
   override val linkId = "query-function"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -81,9 +81,9 @@ of the collection. +tail+ returns all but the first element.
 All return `NULL` for an empty collection.
 
 ###assertion=returns-one parameters=value
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
-WITH nodes(path) as coll
+WITH nodes(path) AS coll
 RETURN
 
 [x IN coll WHERE x.prop <> {value} | x.prop]
@@ -92,18 +92,18 @@ RETURN
 Combination of filter and extract in a concise notation.
 
 ###assertion=returns-one
-MATCH n WHERE id(n) = %A%
-WITH [n] as coll
+MATCH (n) WHERE id(n) = %A%
+WITH [n] AS coll
 RETURN
 
 extract(x IN coll | x.prop)
 ###
 
-A collection of the value of the expression for each element in the orignal collection.
+A collection of the value of the expression for each element in the original collection.
 
 ###assertion=returns-one parameters=value
-MATCH n WHERE id(n) = %A%
-WITH [n] as coll
+MATCH (n) WHERE id(n) = %A%
+WITH [n] AS coll
 RETURN
 
 filter(x IN coll WHERE x.prop <> {value})
@@ -112,22 +112,13 @@ filter(x IN coll WHERE x.prop <> {value})
 A filtered collection of the elements where the predicate is `TRUE`.
 
 ###assertion=returns-one
-MATCH n WHERE id(n) = %A%
-WITH [n] as coll
+MATCH (n) WHERE id(n) = %A%
+WITH [n] AS coll
 RETURN
 
 reduce(s = "", x IN coll | s + x.prop)
 ###
 
 Evaluate expression for each element in the collection, accumulate the results.
-
-###assertion=foreach
-WITH ["Alice","Bob","Charlie"] AS coll
-
-FOREACH (value IN coll |
- CREATE (:Person {name:value}))
-###
-
-Execute a mutating operation for each element in a collection.
              """
 }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionPredicatesTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionPredicatesTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class CollectionPredicatesTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Collection Predicates"
-  val css = "general c2-2 c3-3 c4-2 c5-2 c6-5"
+  val css = "general c2-2 c3-3 c4-4 c5-5 c6-5"
   override val linkId = "query-predicates"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -47,9 +47,9 @@ class CollectionPredicatesTest extends RefcardTest with QueryStatisticsTestSuppo
 
   def text = """
 ###assertion=returns-one
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
-WITH nodes(path) as coll, n, m
+WITH nodes(path) AS coll, n, m
 WHERE
 
 all(x IN coll WHERE exists(x.property))
@@ -59,38 +59,38 @@ RETURN n,m###
 Returns `true` if the predicate is `TRUE` for all elements of the collection.
 
 ###assertion=returns-one
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
-WITH nodes(path) as coll, n, m
+WITH nodes(path) AS coll, n, m
 WHERE
 
 any(x IN coll WHERE exists(x.property))
 
-RETURN n,m###
+RETURN n, m###
 
 Returns `true` if the predicate is `TRUE` for at least one element of the collection.
 
 ###assertion=returns-none
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
-WITH nodes(path) as coll, n, m
+WITH nodes(path) AS coll, n, m
 WHERE
 
 none(x IN coll WHERE exists(x.property))
 
-RETURN n,m###
+RETURN n, m###
 
 Returns `TRUE` if the predicate is `FALSE` for all elements of the collection.
 
 ###assertion=returns-none
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
-WITH nodes(path) as coll, n, m
+WITH nodes(path) AS coll, n, m
 WHERE
 
 single(x IN coll WHERE exists(x.property))
 
-RETURN n,m###
+RETURN n, m###
 
 Returns `TRUE` if the predicate is `TRUE` for exactly one element in the collection.
              """

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CollectionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class CollectionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A KNOWS B")
   val title = "Collections"
-  val css = "general c2-2 c3-1 c4-3 c5-2 c6-4"
+  val css = "general c2-2 c3-2 c4-3 c5-2 c6-4"
   override val linkId = "syntax-collections"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -52,9 +52,9 @@ class CollectionsTest extends RefcardTest with QueryStatisticsTestSupport {
       case "parameters=coll" =>
         Map("coll" -> List(1, 2, 3))
       case "parameters=range" =>
-        Map("first_num" -> 1, "last_num" -> 10, "step" -> 2)
+        Map("firstNum" -> 1, "lastNum" -> 10, "step" -> 2)
       case "parameters=subscript" =>
-        Map("start_idx" -> 1, "end_idx" -> -1, "idx" -> 0)
+        Map("startIdx" -> 1, "endIdx" -> -1, "idx" -> 0)
       case "" =>
         Map()
     }
@@ -67,7 +67,7 @@ class CollectionsTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=returns-one
 RETURN
 
-['a','b','c'] AS coll
+["a", "b", "c"] AS coll
 
 ###
 
@@ -85,7 +85,7 @@ Collections can be passed in as parameters.
 ###assertion=returns-one parameters=range
 RETURN
 
-range({first_num},{last_num},{step}) AS coll
+range({firstNum}, {lastNum}, {step}) AS coll
 
 ###
 
@@ -113,11 +113,11 @@ RETURN matchedNode.coll[0] AS value,
 Properties can be arrays/collections of strings, numbers or booleans.
 
 ###assertion=returns-one parameters=subscript
-WITH [1,2,3] as coll
+WITH [1, 2, 3] AS coll
 RETURN
 
 coll[{idx}] AS value,
-coll[{start_idx}..{end_idx}] AS slice
+coll[{startIdx}..{endIdx}] AS slice
 
 ###
 
@@ -130,7 +130,7 @@ Out of range elements are ignored.
 //
 
 UNWIND {names} AS name
-MATCH (n {name:name})
+MATCH (n {name: name})
 RETURN avg(n.age)
 
 ###

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ConstraintTest.scala
@@ -27,7 +27,7 @@ import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
 class ConstraintTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A:Person KNOWS B:Person")
   val title = "CONSTRAINT"
-  val css = "write c2-2 c4-4 c5-5 c6-4"
+  val css = "write c2-2 c4-4 c5-5 c6-3"
   override val linkId = "query-constraints"
 
   override protected def newTestGraphDatabaseFactory() = new TestEnterpriseGraphDatabaseFactory()

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class CreateTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT LINK A", "A LINK B", "B LINK C", "C LINK ROOT")
   val title = "CREATE"
-  val css = "write c4-4 c5-5 c6-3"
+  val css = "write c4-3 c5-4 c6-1"
   override val linkId = "query-create"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateUniqueTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateUniqueTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class CreateUniqueTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT LINK A", "A LINK B", "B LINK C", "C LINK ROOT")
   val title = "CREATE UNIQUE"
-  val css = "col carddeprecation c2-1 c3-3 c4-4 c5-4 c6-6"
+  val css = "col carddeprecation c2-1 c3-3 c4-4 c5-5 c6-6"
   override val linkId = "query-create-unique"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DeleteTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/DeleteTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class DeleteTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT LINK A:Person", "A LINK B", "B LINK C", "C LINK ROOT")
   val title = "DELETE"
-  val css = "write c2-2 c4-4 c5-5 c6-3"
+  val css = "write c2-2 c4-3 c5-4 c6-2"
   override val linkId = "query-delete"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/FunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/FunctionsTest.scala
@@ -80,11 +80,11 @@ timestamp()###
 Milliseconds since midnight, January 1, 1970 UTC.
 
 ###assertion=returns-one
-MATCH (n)-[node_or_relationship]->(m)
+MATCH (n)-[nodeOrRelationship]->(m)
 WHERE id(n) = %A% AND id(m) = %B%
 RETURN
 
-id(node_or_relationship)###
+id(nodeOrRelationship)###
 
 The internal id of the relationship or node.
 
@@ -93,14 +93,14 @@ RETURN
 
 toInt({expr})###
 
-Converts the given input in an integer if possible; otherwise it returns +NULL+.
+Converts the given input into an integer if possible; otherwise it returns +NULL+.
 
 ###assertion=toFloat parameters=toFloat
 RETURN
 
 toFloat({expr})###
 
-Converts the given input in a floating point number if possible; otherwise it returns +NULL+.
+Converts the given input into a floating point number if possible; otherwise it returns +NULL+.
 
 ###assertion=returns-one parameters=map
 RETURN

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ImportTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ImportTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class ImportTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List()
   val title = "Import"
-  val css = "write c2-1 c4-4 c5-4 c6-3"
+  val css = "write c2-1 c4-4 c5-5 c6-3"
   override val linkId = "cypherdoc-importing-csv-files-with-cypher"
 
   implicit var csvFilesDir: File = createDir(dir, "csv")
@@ -93,7 +93,8 @@ Load CSV data which has headers.
 ###assertion=created
 //
 
-LOAD CSV FROM '%ARTIST_WITH_FIELD_DELIMITER%'
+LOAD CSV FROM
+'%ARTIST_WITH_FIELD_DELIMITER%'
 AS line FIELDTERMINATOR ';'
 CREATE (:Artist {name: line[1], year: toInt(line[2])})
 ###

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.docgen.RefcardTest
 class LabelsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A:Person KNOWS ROOT")
   val title = "Labels"
-  val css = "general c2-1 c3-2 c4-2 c5-3 c6-2"
+  val css = "general c2-1 c3-2 c4-1 c5-3 c6-3"
   override val linkId = "cypherdoc-labels-constraints-and-indexes"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -66,7 +66,7 @@ class LabelsTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=create parameters=bname
 //
 
-CREATE (n:Person {name:{value}})
+CREATE (n:Person {name: {value}})
 
 DELETE n
 RETURN n###
@@ -76,7 +76,7 @@ Create a node with label and property.
 ###assertion=create parameters=bname
 //
 
-MERGE (n:Person {name:{value}})
+MERGE (n:Person {name: {value}})
 
 DELETE n
 RETURN n###
@@ -99,7 +99,7 @@ MATCH (n:Person)
 
 RETURN n###
 
-Matches nodes labeled as `Person`.
+Matches nodes labeled `Person`.
 
 ###assertion=related parameters=aname
 //

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MapsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MapsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class MapsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A KNOWS B")
   val title = "Maps"
-  val css = "general c2-2 c3-3 c4-3 c5-2 c6-5"
+  val css = "general c2-2 c3-3 c4-2 c5-2 c6-4"
   override val linkId = "syntax-collections"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -64,8 +64,8 @@ class MapsTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=returns-one
 RETURN
 
-{name:'Alice', age:38,
- address:{city:'London', residential:true}}
+{name: "Alice", age: 38,
+ address: {city: 'London', residential: true}}
 
 ###
 
@@ -76,7 +76,7 @@ Nested maps and collections are supported.
 //
 
 MERGE (p:Person {name: {map}.name})
-ON CREATE SET p={map}
+ON CREATE SET p = {map}
 
 RETURN p
 ###
@@ -94,7 +94,7 @@ RETURN matchedNode
 Nodes and relationships are returned as maps of their data.
 
 ###assertion=returns-one
-WITH {name:'Alice', age:38, children:['John','Max']} AS map
+WITH {name: "Alice", age: 38, children: ['John', 'Max']} AS map
 RETURN
 
 map.name, map.age, map.children[0]

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MatchTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MatchTest.scala
@@ -54,9 +54,9 @@ class MatchTest extends RefcardTest with QueryStatisticsTestSupport {
 //
 
 MATCH (n:Person)-[:KNOWS]->(m:Person)
-WHERE n.name="Alice"
+WHERE n.name = "Alice"
 
-RETURN n,m###
+RETURN n, m###
 
 Node patterns can contain labels and properties.
 
@@ -66,16 +66,16 @@ Node patterns can contain labels and properties.
 MATCH (n)-->(m)
 
 WHERE id(n) = %A% AND id(m) = %B%
-RETURN n,m###
+RETURN n, m###
 
 Any pattern can be used in `MATCH`.
 
 ###assertion=related
 //
 
-MATCH (n {name:'Alice'})-->(m)
+MATCH (n {name: "Alice"})-->(m)
 
-RETURN n,m###
+RETURN n, m###
 
 Patterns with node properties.
 
@@ -103,7 +103,7 @@ Optional pattern, ++NULL++s will be used for missing parts.
 MATCH (m:Person)
 USING SCAN m:Person
 
-WHERE m.name = 'Alice'
+WHERE m.name = "Alice"
 
 RETURN m###
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MathematicalFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MathematicalFunctionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class MathematicalFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A")
   val title = "Mathematical Functions"
-  val css = "general c2-1 c3-2 c4-1 c5-2 c6-5"
+  val css = "general c2-1 c3-3 c4-2 c5-3 c6-5"
   override val linkId = "query-functions-mathematical"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -72,7 +72,7 @@ RETURN
 
 round({expr})
 
-,floor({expr}),ceil({expr})
+, floor({expr}), ceil({expr})
 ###
 
 Round to the nearest integer, +ceil+ and +floor+ find the next integer up or down.
@@ -98,7 +98,7 @@ RETURN
 
 sin({expr})
 
-,cos({expr}),tan({expr}),cot({expr}),asin({expr}),acos({expr}),atan({expr}),atan2({expr},{expr}),haversin({expr})
+,cos({expr}), tan({expr}), cot({expr}), asin({expr}), acos({expr}), atan({expr}), atan2({expr}, {expr}), haversin({expr})
 ###
 
 Trigonometric functions, also `cos`, `tan`, `cot`, `asin`, `acos`, `atan`, `atan2`, `haversin`.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MergeTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MergeTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class MergeTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("A:Person KNOWS B:Person")
   val title = "MERGE"
-  val css = "write c4-4 c5-5 c6-3"
+  val css = "write c4-3 c5-4 c6-1"
   override val linkId = "query-merge"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -62,9 +62,9 @@ class MergeTest extends RefcardTest with QueryStatisticsTestSupport {
 //
 
 MERGE (n:Person {name: {value}})
-ON CREATE SET n.created=timestamp()
+ON CREATE SET n.created = timestamp()
 ON MATCH SET
-    n.counter= coalesce(n.counter, 0) + 1,
+    n.counter = coalesce(n.counter, 0) + 1,
     n.accessTime = timestamp()
 
 RETURN n###
@@ -90,7 +90,7 @@ MATCH (a:Person {name: {value1}})
 MERGE
   (a)-[r:KNOWS]->(b:Person {name: {value3}})
 
-RETURN r,b###
+RETURN r, b###
 
 +MERGE+ finds or creates subgraphs attached to the node.
 """

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PathFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PathFunctionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.docgen.RefcardTest
 class PathFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A:Person KNOWS B:Person", "B KNOWS C:Person", "C KNOWS ROOT")
   val title = "Path Functions"
-  val css = "general c3-3 c4-3 c5-4 c6-6"
+  val css = "general c3-3 c4-3 c5-2 c6-5"
   override val linkId = "query-functions-collection"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -63,7 +63,7 @@ class PathFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
 
   def text = """
 ###assertion=returns-one
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
 RETURN
 
@@ -73,7 +73,7 @@ length(path)
 The number of relationships in the path.
 
 ###assertion=returns-one
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
 RETURN
 
@@ -83,7 +83,7 @@ nodes(path)
 The nodes in the path as a collection.
 
 ###assertion=returns-one
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
 RETURN
 
@@ -93,20 +93,13 @@ relationships(path)
 The relationships in the path as a collection.
 
 ###assertion=returns-one
-MATCH path=(n)-->(m)
+MATCH path = (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
-RETURN extract(x IN nodes(path) | x.prop)
+RETURN
+
+extract(x IN nodes(path) | x.prop)
 ###
 
-Assign a path and process its nodes.
-
-###assertion=friends
-MATCH path = (begin) -[*]-> (end)
-WHERE id(begin) = %A% AND id(end) = %B%
-FOREACH
-  (n IN rels(path) | SET n.marked = TRUE)
-###
-
-Execute a mutating operation for each relationship of a path.
+Extract properties from the nodes in a path.
 """
 }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class PatternsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A:Person:Swedish KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Patterns"
-  val css = "general c2-2 c3-2 c6-2"
+  val css = "general c2-2 c3-2 c6-4"
   override val linkId = "introduction-pattern"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -64,23 +64,11 @@ class PatternsTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=related
 MATCH
 
-(n)-->(m)
-
-WHERE id(n) = %A% AND id(m) = %B%
-
-RETURN n,m###
-
-A relationship from `n` to `m` exists.
-
-###assertion=related
-MATCH
-
 (n:Person)
 
 RETURN n###
 
-Matches nodes with the label `Person`.
-
+Node with `Person` label.
 
 ###assertion=related
 MATCH
@@ -89,7 +77,7 @@ MATCH
 
 RETURN n###
 
-Matches nodes which have both `Person` and `Swedish` labels.
+Node with both `Person` and `Swedish` labels.
 
 ###assertion=related parameters=alice
 MATCH
@@ -98,16 +86,18 @@ MATCH
 
 RETURN n###
 
-Matches nodes with the declared properties.
+Node with the declared properties.
 
 ###assertion=related
 MATCH
 
-(n:Person)-->(m)
+(n)-->(m)
 
-RETURN n,m###
+WHERE id(n) = %A% AND id(m) = %B%
 
-Node `n` labeled `Person` has a relationship to `m`.
+RETURN n, m###
+
+Relationship from `n` to `m`.
 
 ###assertion=related
 MATCH
@@ -116,9 +106,18 @@ MATCH
 
 WHERE id(n) = %A% AND id(m) = %B%
 
-RETURN n,m###
+RETURN n, m###
 
-A relationship in any direction between `n` and `m`.
+Relationship in any direction between `n` and `m`.
+
+###assertion=related
+MATCH
+
+(n:Person)-->(m)
+
+RETURN n, m###
+
+Node `n` labeled `Person` with relationship to `m`.
 
 ###assertion=related
 MATCH
@@ -127,20 +126,20 @@ MATCH
 
 WHERE id(n) = %A% AND id(m) = %B%
 
-RETURN n,m###
+RETURN n, m###
 
-A relationship from `n` to `m` of type `KNOWS` exists.
+Relationship of type `KNOWS` from `n` to `m`.
 
 ###assertion=related
 MATCH
 
-(n)-[:KNOWS|LOVES]->(m)
+(n)-[:KNOWS|:LOVES]->(m)
 
 WHERE id(n) = %A% AND id(m) = %B%
 
-RETURN n,m###
+RETURN n, m###
 
-A relationship from `n` to `m` of type `KNOWS` or `LOVES` exists.
+Relationship of type `KNOWS` or of type `LOVES` from `n` to `m`.
 
 ###assertion=related
 MATCH
@@ -151,7 +150,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 
 RETURN r###
 
-Bind an identifier to the relationship.
+Bind the relationship to identifier `r`.
 
 ###assertion=related
 MATCH
@@ -160,9 +159,9 @@ MATCH
 
 WHERE id(n) = %A% AND id(m) = %B%
 
-RETURN n,m###
+RETURN n, m###
 
-Variable length paths.
+Variable length path of between 1 and 5 relationships from `n` to `m`.
 
 ###assertion=related
 MATCH
@@ -171,20 +170,20 @@ MATCH
 
 WHERE id(n) = %A% AND id(m) = %B%
 
-RETURN n,m###
+RETURN n, m###
 
-Any depth.
-See the performance tips.
+Veriable lenth path of any number of relationships from `n` to `m`.
+(Please see the performance tips.)
 
 ###assertion=create parameters=aname
-MATCH n WHERE id(n) = %A%
+MATCH (n) WHERE id(n) = %A%
 CREATE UNIQUE
 
 (n)-[:KNOWS]->(m {property: {value}})
 
 RETURN m###
 
-Match or set properties in `MATCH`, `CREATE`, `CREATE UNIQUE` or `MERGE` clauses.
+A relationship of type `KNOWS` from `n` to an `m` that has the declared property.
 
 ###assertion=empty
 MATCH p =
@@ -214,7 +213,7 @@ size((n)-->()-->())
 
 AS fof###
 
-Count the number of rows matching the pattern expression.
+Count the paths matching the pattern.
 """
 }
 /* confirm this, then add.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class PredicatesTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A:Person KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Predicates"
-  val css = "general c2-2 c3-3 c4-2 c5-1 c6-4"
+  val css = "general c2-2 c3-3 c4-1 c5-4 c6-6"
   override val linkId = "query-where"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -76,12 +76,12 @@ AND
 
 n.property <> {value}
 
-RETURN n,m###
+RETURN n, m###
 
 Use comparison operators.
 
 ###assertion=returns-three
-MATCH n
+MATCH (n)
 WHERE
 
 exists(n.property)
@@ -96,7 +96,7 @@ WHERE id(n) = %A% AND id(m) = %B% AND
 
 n.number >= 1 AND n.number <= 10
 
-RETURN n,m###
+RETURN n, m###
 
 Use boolean operators to combine predicates.
 
@@ -106,7 +106,7 @@ WHERE id(n) = %A% AND id(m) = %B% AND
 
 1 <= n.number <= 10
 
-RETURN n,m###
+RETURN n, m###
 
 Use chained operators to combine predicates.
 
@@ -128,12 +128,12 @@ WHERE
 
 identifier IS NULL
 
-RETURN n,m###
+RETURN n, m###
 
 Check if something is `NULL`.
 
 ###assertion=returns-one parameters=aname
-MATCH n
+MATCH (n)
 WHERE
 
 NOT exists(n.property) OR n.property = {value}
@@ -143,7 +143,7 @@ RETURN n###
 Either property does not exist or predicate is +TRUE+.
 
 ###assertion=returns-none parameters=aname
-MATCH n
+MATCH (n)
 WHERE
 
 n.property = {value}
@@ -153,7 +153,7 @@ RETURN n###
 Non-existing property returns `NULL`, which is not equal to anything.
 
 ###assertion=returns-none parameters=aname
-MATCH n
+MATCH (n)
 WHERE
 
 n["property"] = {value}
@@ -163,7 +163,7 @@ RETURN n###
 Properties may also be accessed using a dynamically computed property name.
 
 ###assertion=returns-two
-MATCH n
+MATCH (n)
 WHERE
 
 n.property STARTS WITH "Tob" OR
@@ -175,7 +175,7 @@ RETURN n###
 String matching.
 
 ###assertion=returns-one parameters=regex
-MATCH n
+MATCH (n)
 WHERE EXISTS(n.property) AND
 
 n.property =~ "Tob.*"
@@ -185,7 +185,7 @@ RETURN n###
 String regular expression matching.
 
 ###assertion=returns-four
-MATCH n, m
+MATCH (n), (m)
 WHERE
 
 (n)-[:KNOWS]->(m)
@@ -195,7 +195,7 @@ RETURN n###
 Make sure the pattern has at least one match.
 
 ###assertion=returns-none
-MATCH n, m
+MATCH (n), (m)
 WHERE id(n) = %A% AND id(m) = %B% AND
 
 NOT (n)-[:KNOWS]->(m)
@@ -205,7 +205,7 @@ RETURN n###
 Exclude matches to `(n)-[:KNOWS]->(m)` from the result.
 
 ###assertion=returns-one parameters=names
-MATCH n
+MATCH (n)
 WHERE exists(n.property) AND
 
 n.property IN [{value1}, {value2}]

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RelationshipFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RelationshipFunctionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class RelationshipFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "Relationship Functions"
-  val css = "general c2-2 c3-2 c4-2 c5-4 c6-6"
+  val css = "general c2-2 c3-2 c4-3 c5-1 c6-5"
   override val linkId = "query-functions-scalar"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RemoveTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/RemoveTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class RemoveTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT LINK A:Person", "A LINK B", "B LINK C", "C LINK ROOT")
   val title = "REMOVE"
-  val css = "write c2-2 c4-4 c5-5 c6-3"
+  val css = "write c2-2 c4-3 c5-4 c6-2"
   override val linkId = "query-remove"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ReturnTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ReturnTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class ReturnTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT LINK A", "A LINK B", "B LINK C", "C LINK ROOT")
   val title = "RETURN"
-  val css = "read c3-3 c4-3 c5-3 c6-2"
+  val css = "read c3-3 c4-2 c5-3 c6-2"
   override val linkId = "query-return"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -54,7 +54,7 @@ class ReturnTest extends RefcardTest with QueryStatisticsTestSupport {
   override def parameters(name: String): Map[String, Any] =
     name match {
       case "parameters=limits" =>
-        Map("limit_number" -> 2, "skip_number" -> 1)
+        Map("limitNumber" -> 2, "skipNumber" -> 1)
       case "" =>
         Map()
     }
@@ -68,14 +68,14 @@ class ReturnTest extends RefcardTest with QueryStatisticsTestSupport {
   def text = """
 ###assertion=all-nodes
 //
-MATCH n
+MATCH (n)
 
 RETURN *###
 
 Return the value of all identifiers.
 
 ### assertion=alias
-MATCH n
+MATCH (n)
 WHERE id(n) = 1
 
 RETURN n AS columnName###
@@ -83,7 +83,7 @@ RETURN n AS columnName###
 Use alias for result column name.
 
 ### assertion=unique
-MATCH n--x
+MATCH (n)--(x)
 WHERE id(x) in [%A%,%C%]
 AND n.name = "B"
 
@@ -93,7 +93,7 @@ Return unique rows.
 
 ###assertion=all-nodes
 //
-MATCH n
+MATCH (n)
 RETURN *
 
 ORDER BY n.property
@@ -103,7 +103,7 @@ Sort the result.
 
 ###assertion=all-nodes
 //
-MATCH n
+MATCH (n)
 RETURN *
 
 ORDER BY n.property DESC
@@ -113,36 +113,36 @@ Sort the result in descending order.
 
 ###assertion=skip parameters=limits
 //
-MATCH n
+MATCH (n)
 RETURN *
 
-SKIP {skip_number}
+SKIP {skipNumber}
 ###
 
 Skip a number of results.
 
 ###assertion=skiplimit parameters=limits
 //
-MATCH n
+MATCH (n)
 RETURN *
 
-LIMIT {limit_number}
+LIMIT {limitNumber}
 ###
 
 Limit the number of results.
 
 ###assertion=skiplimit parameters=limits
 //
-MATCH n
+MATCH (n)
 RETURN *
 
-SKIP {skip_number} LIMIT {limit_number}
+SKIP {skipNumber} LIMIT {limitNumber}
 ###
 
 Skip results at the top and limit the number of results.
 
 ###assertion=count
-MATCH n
+MATCH (n)
 
 RETURN count(*)
 ###

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SetTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SetTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class SetTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT LINK A")
   val title = "SET"
-  val css = "write c2-2 c4-4 c5-5 c6-3"
+  val css = "write c2-2 c4-3 c5-4 c6-2"
   override val linkId = "query-set"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -45,7 +45,7 @@ class SetTest extends RefcardTest with QueryStatisticsTestSupport {
 
   override def parameters(name: String): Map[String, Any] =
     name match {
-      case "parameters=set" => Map("value" -> "a value", "value2" -> "another value")
+      case "parameters=set" => Map("value1" -> "a value", "value2" -> "another value")
       case "parameters=map" => Map("map" -> Map("property" -> "a value"))
       case "" => Map()
     }
@@ -55,12 +55,12 @@ class SetTest extends RefcardTest with QueryStatisticsTestSupport {
 
   def text = """
 ###assertion=set parameters=set
-MATCH n WHERE id(n) = %A%
+MATCH (n) WHERE id(n) = %A%
 
-SET n.property = {value},
+SET n.property1 = {value1},
     n.property2 = {value2}
 
-RETURN n.property###
+RETURN n.property1###
 
 Update or create a property.
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StartTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StartTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class StartTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT LINK A", "A LINK B", "B LINK C", "C LINK ROOT")
   val title = "START"
-  val css = "col carddeprecation c2-1 c3-3 c4-4 c5-4 c6-6"
+  val css = "col carddeprecation c2-1 c3-3 c4-4 c5-5 c6-6"
   override def indexProps: List[String] = List("value", "name", "key")
   override val linkId = "query-start"
 
@@ -79,7 +79,7 @@ class StartTest extends RefcardTest with QueryStatisticsTestSupport {
 ### assertion=index-match parameters=index-match
 //
 
-START n=node:nodeIndexName(key={value})
+START n = node:nodeIndexName(key = {value})
 
 RETURN n###
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StringFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StringFunctionsTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class StringFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT KNOWS A", "A KNOWS B", "B KNOWS C", "C KNOWS ROOT")
   val title = "String Functions"
-  val css = "general c2-1 c3-2 c4-1 c5-3 c6-5"
+  val css = "general c2-1 c3-2 c4-3 c5-3 c6-5"
   override val linkId = "query-functions-string"
 
   override def assert(name: String, result: InternalExecutionResult) {
@@ -49,7 +49,7 @@ class StringFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
       case "parameters=replace" =>
         Map("original" -> "Hi", "search" -> "i", "replacement" -> "ello")
       case "parameters=sub" =>
-        Map("original" -> "String", "begin" -> 3, "substring_length" -> 2, "sub_length" -> 2)
+        Map("original" -> "String", "begin" -> 3, "subLength" -> 2)
       case "parameters=split" =>
         Map("original" -> "A,B,C", "delimiter" -> ",")
       case "" =>
@@ -83,17 +83,17 @@ All arguments are be expressions.
 ###assertion=returns-one parameters=sub
 RETURN
 
-substring({original}, {begin}, {sub_length})
+substring({original}, {begin}, {subLength})
 ###
 
 Get part of a string.
-The `sub_length` argument is optional.
+The `subLength` argument is optional.
 
 ###assertion=returns-one parameters=sub
 RETURN
 
-left({original}, {sub_length}),
-  right({original}, {sub_length})
+left({original}, {subLength}),
+  right({original}, {subLength})
 ###
 
 The first part of a string. The last part of the string.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/WhereTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/WhereTest.scala
@@ -52,10 +52,10 @@ class WhereTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=returns-one parameters=aname
 MATCH (n)-->(m)
 
-WHERE  n.property <> {value}
+WHERE n.property <> {value}
 
 AND id(n) = %A% AND id(m) = %B%
-RETURN n,m###
+RETURN n, m###
 
 Use a predicate to filter.
 Note that +WHERE+ is always part of a  +MATCH+, +OPTIONAL MATCH+, +WITH+ or +START+ clause.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/WithTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/WithTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.InternalExecutionRe
 class WithTest extends RefcardTest with QueryStatisticsTestSupport {
   val graphDescription = List("ROOT FRIEND A", "A FRIEND B", "B FRIEND C", "C FRIEND ROOT")
   val title = "WITH"
-  val css = "read c2-2 c3-3 c4-3 c5-3 c6-2"
+  val css = "read c2-2 c3-3 c4-2 c5-3 c6-2"
   override val linkId = "query-with"
 
   override def assert(name: String, result: InternalExecutionResult) {

--- a/manual/refcard/src/cypher-refcard.asciidoc
+++ b/manual/refcard/src/cypher-refcard.asciidoc
@@ -1,7 +1,9 @@
-= Neo4j Cypher Refcard {neo4j-version} =
+= Neo4j Cypher Refcard {neo4j-version}
 :sources: ../docs/neo4j-cypher-refcard-tests-docs-jar/dev/ql/refcard
+:docs-home: http://neo4j.com/docs
 
 *Cypher is the declarative query language for Neo4j, the world’s leading graph database.*
+
 
 Key principles and capabilities of Cypher are as follows:
 
@@ -18,11 +20,14 @@ or read the full Cypher documentation in the
 For live graph models using Cypher check out <a href="http://gist.neo4j.org" target="_blank">GraphGist</a>.</p></div>
 ++++
 
+The Cypher Refcard is also link:{docs-home}/pdf/neo4j-cypher-refcard-{neo4j-version}.pdf[available as PDF].
+
 Note: `{value}` denotes either literals, for ad hoc Cypher queries; or parameters, which is the best practice for applications.
 Neo4j properties can be strings, numbers, booleans or arrays thereof.
 Cypher also supports maps and collections.
 
-== Syntax ==
+
+== Syntax
 
 .Read Query Structure
 ["refcard", cardcss="read c2-2 c3-2 c4-2 c5-2"]
@@ -46,7 +51,7 @@ include::{sources}/with.asciidoc[]
 include::{sources}/union.asciidoc[]
 
 .Write-Only Query Structure
-["refcard", cardcss="write c2-2 c4-4 c5-5 c6-3"]
+["refcard", cardcss="write c2-2 c4-3 c5-4 c6-1"]
 ----
 (CREATE [UNIQUE] | MERGE)*
 [SET|DELETE|REMOVE|FOREACH]*
@@ -54,7 +59,7 @@ include::{sources}/union.asciidoc[]
 ----
 
 .Read-Write Query Structure
-["refcard", cardcss="write c2-2 c4-4 c5-5 c6-3"]
+["refcard", cardcss="write c2-2 c4-3 c5-4 c6-1"]
 ----
 [MATCH WHERE]
 [OPTIONAL MATCH WHERE]
@@ -74,6 +79,8 @@ include::{sources}/delete.asciidoc[]
 
 include::{sources}/remove.asciidoc[]
 
+include::{sources}/foreach.asciidoc[]
+
 include::{sources}/index.asciidoc[]
 
 include::{sources}/constraint.asciidoc[]
@@ -81,7 +88,7 @@ include::{sources}/constraint.asciidoc[]
 include::{sources}/import.asciidoc[]
 
 ++++
-<div class="col cardgeneral c3-2 c6-1"><div class="blk">
+<div class="col cardgeneral c3-1 c6-2"><div class="blk">
 ++++
 
 [options="header", cols=",m"]
@@ -101,7 +108,7 @@ include::{sources}/import.asciidoc[]
 ++++
 
 ++++
-<div class="col cardgeneral c3-2 c6-1"><div class="blk">
+<div class="col cardgeneral c3-1 c6-3"><div class="blk">
 ++++
 
 [options="header", cols="a"]
@@ -112,9 +119,9 @@ include::{sources}/import.asciidoc[]
 * +NULL+ is not equal to +NULL+.
   Not knowing two values does not imply that they are the same value.
   So the expression `NULL = NULL` yields +NULL+ and not +TRUE+.
-  To check if an expressoin is +NULL+, use +IS NULL+.
+  To check if an expression is +NULL+, use +IS NULL+.
 * Arithmetic expressions, comparisons and function calls (except +coalesce+) will return +NULL+ if any argument is +NULL+.
-* Missing elements like a property that doesn't exist or accessing elements that don't exist in a collection yields +NULL+.
+* An attempt to access a missing element in a collection or a property that doesn't exist yields +NULL+.
 * In +OPTIONAL MATCH+ clauses, ++NULL++s will be used for missing parts of the pattern.
 |===
 
@@ -140,7 +147,7 @@ include::{sources}/functions.asciidoc[]
 
 include::{sources}/path-functions.asciidoc[]
 
-include::{sources}/collection-functions.asciidoc[]
+include::{sources}/collection-expressions.asciidoc[]
 
 include::{sources}/mathematical-functions.asciidoc[]
 
@@ -156,7 +163,7 @@ include::{sources}/create-unique.asciidoc[]
 
 
 ++++
-<div class="col cardperformance c2-2 c3-3 c5-4 c6-6"><div class="blk">
+<div class="col cardperformance c2-2 c3-3 c4-4 c5-1 c6-6"><div class="blk">
 ++++
 
 [options="header", cols="a"]


### PR DESCRIPTION
FOREACH is a query clause, not a function:
- Create test and card for FOREACH.
- Move FOREACH examples from Collection Functions and Path Functions.
- Rename Collection Functions to Collection Expressions to reflect that
  not all of the remaining items are functions.

Fix typos, formatting and style:
- Fix a few typos and improve wording.
- Consistent use of " for string literals.
- Consistent camelCase for names of variables, properties and parameters.
  (NB: Variables are still called "identifiers" in 2.3.)
- Consistent camelCase for functions.
- Consistent spacing in
  - property maps
  - patterns
  - assignment and comparison
  - lists (items in a collection, expressions in a clause, etc.)
- Fix bug where uninterpolated strings make it into the output.
  (WHERE id(begin) = %A% AND id(end) = %B% etc.)
- Wrap all bare nodes in parentheses.
  (Since this will break in 3.0 we should not enforce the habit in 2.3)
- Capitalize AS.
- Break lines consistently in queries.
- Use colon for each relationship type when there are several ((n)-[:A|:B]->(m)).
