### PR TITLE
Make SlaveTransactionCommitProcess turn ComExceptions into TransientTransactionFailureExceptions

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberChangeEvent.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberChangeEvent.java
@@ -25,7 +25,7 @@ import org.neo4j.cluster.InstanceId;
 
 /**
  * This event represents a change in the cluster members internal state. The possible states
- * are enumerated in ClusterMemberState.
+ * are enumerated in {@link HighAvailabilityMemberState}.
  */
 public class HighAvailabilityMemberChangeEvent
 {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberState.java
@@ -52,7 +52,6 @@ public enum HighAvailabilityMemberState
                 public HighAvailabilityMemberState masterIsAvailable( HighAvailabilityMemberContext context,
                                                                       InstanceId masterId, URI masterHaURI )
                 {
-//                    assert context.getAvailableMaster() == null;
                     if ( masterId.equals( context.getMyId() ) )
                     {
                         throw new RuntimeException( "Received a MasterIsAvailable event for my InstanceId while in" +

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ClusterTransactionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ClusterTransactionIT.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.ha;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -26,6 +27,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
@@ -34,28 +36,34 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleListener;
 import org.neo4j.kernel.lifecycle.LifecycleStatus;
 import org.neo4j.test.ha.ClusterRule;
+import org.neo4j.tooling.GlobalGraphOperations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.helpers.Exceptions.contains;
 import static org.neo4j.kernel.impl.ha.ClusterManager.fromXml;
 
-public class ClusterTransactionTest
+public class ClusterTransactionIT
 {
     @Rule
     public final ClusterRule clusterRule = new ClusterRule( getClass() );
 
+    private ClusterManager.ManagedCluster cluster;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        cluster = clusterRule.provider( fromXml( getClass().getResource( "/threeinstances.xml" ).toURI() ) )
+                             .config( HaSettings.ha_server, ":6001-6005" )
+                             .config( HaSettings.tx_push_factor, "2" ).startCluster();
+
+        cluster.await( ClusterManager.allSeesAllAsAvailable() );
+    }
+
     @Test
     public void givenClusterWhenShutdownMasterThenCannotStartTransactionOnSlave() throws Throwable
     {
-
-        final ClusterManager.ManagedCluster cluster =
-                clusterRule.provider( fromXml( getClass().getResource( "/threeinstances.xml" ).toURI() ) )
-                        .config( HaSettings.ha_server, ":6001-6005" )
-                        .config( HaSettings.tx_push_factor, "2" ).startCluster();
-
-        cluster.await( ClusterManager.allSeesAllAsAvailable() );
-
         final HighlyAvailableGraphDatabase master = cluster.getMaster();
         final HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
 
@@ -106,5 +114,51 @@ public class ClusterTransactionTest
 
         // Then
         assertThat( result.get(), equalTo( true ) );
+    }
+
+    @Test
+    public void slaveMustConnectLockManagerToNewMasterAfterTwoOtherClusterMembersRoleSwitch() throws Throwable
+    {
+        final HighlyAvailableGraphDatabase initialMaster = cluster.getMaster();
+        HighlyAvailableGraphDatabase firstSlave = cluster.getAnySlave();
+        HighlyAvailableGraphDatabase secondSlave = cluster.getAnySlave( firstSlave );
+
+        // Run a transaction on the slaves, to make sure that a master connection has been initialised in all
+        // internal pools.
+        try ( Transaction tx = firstSlave.beginTx() )
+        {
+            firstSlave.createNode();
+            tx.success();
+        }
+        try ( Transaction tx = secondSlave.beginTx() )
+        {
+            secondSlave.createNode();
+            tx.success();
+        }
+        cluster.sync();
+
+        ClusterManager.RepairKit failedMaster = cluster.fail( initialMaster );
+        cluster.await( ClusterManager.masterAvailable( initialMaster ) );
+        failedMaster.repair();
+        cluster.await( ClusterManager.masterAvailable( initialMaster ) );
+        cluster.await( ClusterManager.allSeesAllAsAvailable() );
+
+        // The cluster has now switched the master role to one of the slaves.
+        // The slave that didn't switch, should still have done the work to reestablish the connection to the new
+        // master.
+        HighlyAvailableGraphDatabase slave = cluster.getAnySlave( initialMaster );
+        try ( Transaction tx = slave.beginTx() )
+        {
+            slave.createNode();
+            tx.success();
+        }
+
+        // We assert that the transaction above does not throw any exceptions, and that we have now created 3 nodes.
+        HighlyAvailableGraphDatabase master = cluster.getMaster();
+        try ( Transaction tx = master.beginTx() )
+        {
+            GlobalGraphOperations gops = GlobalGraphOperations.at( master );
+            assertThat( IteratorUtil.count( gops.getAllNodes() ), is( 3 ) );
+        }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/UniqueConstraintHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/UniqueConstraintHaIT.java
@@ -19,14 +19,15 @@
  */
 package org.neo4j.kernel.api;
 
-import java.io.File;
-
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.graphdb.InvalidTransactionTypeException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.TransientTransactionFailureException;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.kernel.TopLevelTransaction;
 import org.neo4j.kernel.ha.HaSettings;
@@ -37,13 +38,11 @@ import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterRule;
 
 import static java.util.Arrays.asList;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.Iterables.single;
@@ -174,7 +173,7 @@ public class UniqueConstraintHaIT
             slaveTx.finish();
             fail( "Expected this commit to fail :(" );
         }
-        catch( TransactionFailureException e )
+        catch( TransactionFailureException | TransientTransactionFailureException e )
         {
             assertThat(e.getCause().getCause(), instanceOf( org.neo4j.kernel.api.exceptions.TransactionFailureException.class ));
         }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTokenCreatorTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTokenCreatorTest.java
@@ -23,17 +23,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
 import java.util.Arrays;
 
 import org.neo4j.com.ComException;
 import org.neo4j.com.RequestContext;
-import org.neo4j.com.ResourceReleaser;
 import org.neo4j.com.Response;
 import org.neo4j.graphdb.TransientTransactionFailureException;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
-import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.test.ConstantRequestContextFactory;
+import org.neo4j.test.IntegerResponse;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -101,32 +100,6 @@ public class SlaveTokenCreatorTest
         );
     }
 
-    private static class IntegerResponse extends Response<Integer>
-    {
-
-        public IntegerResponse( Integer response )
-        {
-            super( response, StoreId.DEFAULT, new ResourceReleaser()
-            {
-                @Override
-                public void release()
-                {
-                }
-            } );
-        }
-
-        @Override
-        public void accept( Handler handler ) throws IOException
-        {
-        }
-
-        @Override
-        public boolean hasTransactionsToBeApplied()
-        {
-            return false;
-        }
-    }
-
     private SlaveTokenCreatorFixture fixture;
     private Master master;
     private RequestContext requestContext;
@@ -140,14 +113,7 @@ public class SlaveTokenCreatorTest
         master = mock( Master.class );
         requestContext = new RequestContext( 1, 2, 3, 4, 5 );
         this.name = "Poke";
-        requestContextFactory = new RequestContextFactory( 0, null )
-        {
-            @Override
-            public RequestContext newRequestContext( long epoch, int machineId, int eventIdentifier )
-            {
-                return requestContext;
-            }
-        };
+        requestContextFactory = new ConstantRequestContextFactory( requestContext );
         tokenCreator = fixture.build( master, requestContextFactory );
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcessTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveTransactionCommitProcessTest.java
@@ -19,49 +19,103 @@
  */
 package org.neo4j.kernel.ha;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.com.ComException;
 import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
+import org.neo4j.graphdb.TransientTransactionFailureException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.api.TransactionApplicationMode;
 import org.neo4j.kernel.impl.locking.LockGroup;
-import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
-import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+import org.neo4j.test.ConstantRequestContextFactory;
+import org.neo4j.test.LongResponse;
 
-import static org.mockito.Matchers.any;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SlaveTransactionCommitProcessTest
 {
+    private AtomicInteger lastSeenEventIdentifier;
+    private Master master;
+    private RequestContext requestContext;
+    private RequestContextFactory reqFactory;
+    private Response<Long> response;
+    private PhysicalTransactionRepresentation tx;
+    private SlaveTransactionCommitProcess commitProcess;
+
+    @Before
+    public void setUp()
+    {
+        lastSeenEventIdentifier = new AtomicInteger( -1 );
+        master = mock( Master.class );
+        requestContext = new RequestContext( 10, 11, 12, 13, 14 );
+        reqFactory = new ConstantRequestContextFactory( requestContext )
+        {
+            @Override
+            public RequestContext newRequestContext( int eventIdentifier )
+            {
+                lastSeenEventIdentifier.set( eventIdentifier );
+                return super.newRequestContext( eventIdentifier );
+            }
+        };
+        response = new LongResponse( 42L );
+        tx = new PhysicalTransactionRepresentation(
+                Collections.<Command>emptyList() );
+        tx.setHeader( new byte[]{}, 1, 1, 1, 1, 1, 1337 );
+
+        commitProcess = new SlaveTransactionCommitProcess( master, reqFactory );
+    }
+
     @Test
     public void shouldForwardLockIdentifierToMaster() throws Exception
     {
         // Given
-        Master master = mock( Master.class );
-        RequestContextFactory reqFactory = mock( RequestContextFactory.class );
-
-        Response<Long> response = mock(Response.class);
-        when(response.response()).thenReturn( 1l );
-
-        when(master.commit( any( RequestContext.class), any( TransactionRepresentation.class) )).thenReturn( response );
-
-        SlaveTransactionCommitProcess process = new SlaveTransactionCommitProcess( master, reqFactory );
-        PhysicalTransactionRepresentation tx = new PhysicalTransactionRepresentation(
-                Collections.<Command>emptyList() );
-        tx.setHeader(new byte[]{}, 1, 1, 1, 1, 1, 1337);
+        when( master.commit( requestContext, tx ) ).thenReturn( response );
 
         // When
-        process.commit(tx , new LockGroup(), CommitEvent.NULL, TransactionApplicationMode.INTERNAL );
+        commitProcess.commit( tx , new LockGroup(), CommitEvent.NULL, TransactionApplicationMode.INTERNAL );
 
         // Then
-        verify( reqFactory ).newRequestContext( 1337 );
+        assertThat( lastSeenEventIdentifier.get(), is( 1337 ) );
+    }
+
+    @Test( expected = TransientTransactionFailureException.class )
+    public void mustTranslateComExceptionsToTransientTransactionFailures() throws Exception
+    {
+        when( master.commit( requestContext, tx ) ).thenThrow( new ComException() );
+
+        commitProcess.commit( tx , new LockGroup(), CommitEvent.NULL, TransactionApplicationMode.INTERNAL );
+        // Then we assert that the right exception is thrown
+    }
+
+    @Test
+    public void mustTranslateIOExceptionsToKernelTransactionFailures() throws Exception
+    {
+        when( master.commit( requestContext, tx ) ).thenThrow( new IOException() );
+
+        try
+        {
+            commitProcess.commit( tx , new LockGroup(), CommitEvent.NULL, TransactionApplicationMode.INTERNAL );
+            fail( "commit should have thrown" );
+        }
+        catch ( TransactionFailureException e )
+        {
+            assertThat( e.status(), is( (Status) Status.Transaction.CouldNotCommit ) );
+        }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UniqueConstraintStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UniqueConstraintStressIT.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.kernel.ha;
 
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
 import org.neo4j.com.ComException;
 import org.neo4j.graphdb.ConstraintViolationException;
@@ -37,6 +37,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.TransientTransactionFailureException;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.test.OtherThreadExecutor;
@@ -47,7 +48,6 @@ import org.neo4j.test.ha.ClusterRule;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.helpers.collection.IteratorUtil.loop;
 
 /**
@@ -371,7 +371,7 @@ public class UniqueConstraintStressIT
                         }
                     }
                 }
-                catch ( TransactionFailureException e )
+                catch ( TransactionFailureException | TransientTransactionFailureException e )
                 {
                     // Swallowed on purpose, we except it to fail sometimes due to either
                     //  - constraint violation on master
@@ -380,11 +380,6 @@ public class UniqueConstraintStressIT
                 catch ( ConstraintViolationException e )
                 {
                     // Constraint violation detected on slave while building transaction
-                }
-                catch ( ComException e )
-                {
-                    // Happens sometimes, cause:
-                    // - The lock session requested to start is already in use. Please retry your request in a few seconds.
                 }
                 return i;
             }

--- a/enterprise/ha/src/test/java/org/neo4j/test/ConstantRequestContextFactory.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ConstantRequestContextFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import org.neo4j.com.RequestContext;
+import org.neo4j.kernel.ha.com.RequestContextFactory;
+
+public class ConstantRequestContextFactory extends RequestContextFactory
+{
+    private final RequestContext requestContext;
+
+    public ConstantRequestContextFactory( RequestContext requestContext )
+    {
+        super( 0, null );
+        this.requestContext = requestContext;
+    }
+
+    @Override
+    public RequestContext newRequestContext( long epoch, int machineId, int eventIdentifier )
+    {
+        return requestContext;
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/test/IntegerResponse.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/IntegerResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.io.IOException;
+
+import org.neo4j.com.ResourceReleaser;
+import org.neo4j.com.Response;
+import org.neo4j.kernel.impl.store.StoreId;
+
+public class IntegerResponse extends Response<Integer>
+{
+    public IntegerResponse( Integer response )
+    {
+        super( response, StoreId.DEFAULT, new ResourceReleaser()
+        {
+            @Override
+            public void release()
+            {
+            }
+        } );
+    }
+
+    @Override
+    public void accept( Handler handler ) throws IOException
+    {
+    }
+
+    @Override
+    public boolean hasTransactionsToBeApplied()
+    {
+        return false;
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/test/LongResponse.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/LongResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import java.io.IOException;
+
+import org.neo4j.com.ResourceReleaser;
+import org.neo4j.com.Response;
+import org.neo4j.kernel.impl.store.StoreId;
+
+public class LongResponse extends Response<Long>
+{
+    public LongResponse( Long response )
+    {
+        super( response, StoreId.DEFAULT, new ResourceReleaser()
+        {
+            @Override
+            public void release()
+            {
+            }
+        } );
+    }
+
+    @Override
+    public void accept( Handler handler ) throws IOException
+    {
+    }
+
+    @Override
+    public boolean hasTransactionsToBeApplied()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
After this, it should not be possible for naked `ComExceptions` to bubble out to user-land.

As usual, this requires care when merging forward, because package names have changed, etc.

How about it, @davidegrohmann ? :)
