### PR TITLE
Compiled plans - dependency cleanup

### DIFF
--- a/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
@@ -191,6 +191,23 @@ public abstract class Expression extends ExpressionTemplate
         };
     }
 
+    public static Expression cast( Class<?> type, Expression expression )
+    {
+        return cast( typeReference( type ), expression );
+    }
+
+    public static Expression cast( final TypeReference type, Expression expression )
+    {
+        return new Expression()
+        {
+            @Override
+            public void accept( ExpressionVisitor visitor )
+            {
+                visitor.cast( type, expression );
+            }
+        };
+    }
+
     public static Expression newInstance( Class<?> type )
     {
         return newInstance( typeReference( type ) );

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionTemplate.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionTemplate.java
@@ -163,6 +163,30 @@ public abstract class ExpressionTemplate
         };
     }
 
+    public static ExpressionTemplate cast( Class<?> clazz, ExpressionTemplate expression )
+    {
+        return new ExpressionTemplate()
+        {
+            @Override
+            protected void templateAccept( CodeBlock method, ExpressionVisitor visitor )
+            {
+                visitor.cast( typeReference( clazz ), expression.materialize( method ) );
+            }
+        };
+    }
+
+    public static ExpressionTemplate cast( TypeReference type, ExpressionTemplate expression )
+    {
+        return new ExpressionTemplate()
+        {
+            @Override
+            protected void templateAccept( CodeBlock method, ExpressionVisitor visitor )
+            {
+                visitor.cast( type, expression.materialize( method ) );
+            }
+        };
+    }
+
     abstract void templateAccept( CodeBlock method, ExpressionVisitor visitor );
 
     private static Expression[] tryMaterialize( ExpressionTemplate[] templates )

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionToString.java
@@ -182,4 +182,14 @@ class ExpressionToString implements ExpressionVisitor
         rhs.accept( this );
         result.append( ")" );
     }
+
+    @Override
+    public void cast( TypeReference type, Expression expression )
+    {
+        result.append( "cast{type=" );
+        type.writeTo( result );
+        result.append( ", expression=" );
+        expression.accept( this );
+        result.append( "}" );
+    }
 }

--- a/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/ExpressionVisitor.java
@@ -51,4 +51,6 @@ public interface ExpressionVisitor
     void gt( Expression lhs, Expression rhs );
 
     void sub( Expression lhs, Expression rhs );
+
+    void cast( TypeReference type, Expression expression );
 }

--- a/community/codegen/src/main/java/org/neo4j/codegen/source/MethodWriter.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/source/MethodWriter.java
@@ -412,4 +412,12 @@ class MethodWriter implements MethodEmitter, ExpressionVisitor
         append( " - " );
         rhs.accept( this );
     }
+
+    @Override
+    public void cast( TypeReference type, Expression expression )
+    {
+        append( "(").append( type.name() ).append( ") " );
+        expression.accept( this );
+
+    }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/java/org/neo4j/cypher/internal/compiler/v3_0/executionplan/GeneratedQuery.java
+++ b/community/cypher/cypher-compiler-3.0/src/main/java/org/neo4j/cypher/internal/compiler/v3_0/executionplan/GeneratedQuery.java
@@ -25,13 +25,13 @@ import org.neo4j.cypher.internal.compiler.v3_0.ExecutionMode;
 import org.neo4j.cypher.internal.compiler.v3_0.TaskCloser;
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.QueryExecutionTracer;
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription;
-import org.neo4j.kernel.api.Statement;
+import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext;
 
 public interface GeneratedQuery
 {
     GeneratedQueryExecution execute(
             TaskCloser closer,
-            Statement statement,
+            QueryContext queryContext,
             EntityAccessor entityAccessor,
             ExecutionMode executionMode,
             Provider<InternalPlanDescription> description,

--- a/community/cypher/cypher-compiler-3.0/src/main/java/org/neo4j/cypher/internal/compiler/v3_0/executionplan/GeneratedQuery.java
+++ b/community/cypher/cypher-compiler-3.0/src/main/java/org/neo4j/cypher/internal/compiler/v3_0/executionplan/GeneratedQuery.java
@@ -32,7 +32,6 @@ public interface GeneratedQuery
     GeneratedQueryExecution execute(
             TaskCloser closer,
             QueryContext queryContext,
-            EntityAccessor entityAccessor,
             ExecutionMode executionMode,
             Provider<InternalPlanDescription> description,
             QueryExecutionTracer tracer,

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
@@ -37,7 +37,6 @@ import org.neo4j.cypher.internal.frontend.v3_0.notification.{InternalNotificatio
 import org.neo4j.cypher.internal.frontend.v3_0.{InternalException, InvalidArgumentException, SemanticTable}
 import org.neo4j.graphdb.QueryExecutionType.QueryType
 import org.neo4j.helpers.Clock
-import org.neo4j.kernel.api
 
 object RuntimeBuilder {
   def create(runtimeName: Option[RuntimeName], interpretedProducer: InterpretedPlanBuilder,
@@ -143,7 +142,7 @@ case class CompiledPlanBuilder(clock: Clock, structure:CodeStructure[GeneratedQu
 
         def isStale(lastTxId: () => Long, statistics: GraphStatistics) = fingerprint.isStale(lastTxId, statistics)
 
-        def run(queryContext: QueryContext, kernelStatement: api.Statement,
+        def run(queryContext: QueryContext,
                 executionMode: ExecutionMode, params: Map[String, Any]): InternalExecutionResult = {
           val taskCloser = new TaskCloser
           taskCloser.addTask(queryContext.close)
@@ -154,7 +153,7 @@ case class CompiledPlanBuilder(clock: Clock, structure:CodeStructure[GeneratedQu
               new ExplainExecutionResult(compiled.columns.toList,
                 compiled.planDescription, QueryType.READ_ONLY, preparedQuery.notificationLogger.notifications)
             } else
-              compiled.executionResultBuilder(kernelStatement, entityAccessor, executionMode, createTracer(executionMode), params, taskCloser)
+              compiled.executionResultBuilder(queryContext, entityAccessor, executionMode, createTracer(executionMode), params, taskCloser)
           } catch {
             case (t: Throwable) =>
               taskCloser.close(success = false)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
@@ -20,16 +20,24 @@
 package org.neo4j.cypher.internal.compiler.v3_0
 
 import org.neo4j.cypher.internal.compiler.v3_0.CompilationPhaseTracer.CompilationPhase._
+import org.neo4j.cypher.internal.compiler.v3_0.CompiledPlanBuilder.createTracer
+import org.neo4j.cypher.internal.compiler.v3_0.codegen.profiling.ProfilingTracer
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.{CodeGenerator, CodeStructure}
-import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{CompiledPlan, GeneratedQuery, NewRuntimeSuccessRateMonitor, PipeInfo}
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlanBuilder.DescriptionProvider
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InterpretedExecutionPlanBuilder.interpretedToExecutionPlan
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{EntityAccessor, ExecutionPlan, GeneratedQuery, InternalExecutionResult, NewRuntimeSuccessRateMonitor, PlanFingerprint, PlanFingerprintReference, Provider}
 import org.neo4j.cypher.internal.compiler.v3_0.helpers._
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments
 import org.neo4j.cypher.internal.compiler.v3_0.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.compiler.v3_0.planner.execution.{PipeExecutionBuilderContext, PipeExecutionPlanBuilder}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
-import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
-import org.neo4j.cypher.internal.frontend.v3_0.notification.RuntimeUnsupportedNotification
+import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, PlanContext, QueryContext}
+import org.neo4j.cypher.internal.frontend.v3_0.notification.{InternalNotification, RuntimeUnsupportedNotification}
 import org.neo4j.cypher.internal.frontend.v3_0.{InternalException, InvalidArgumentException, SemanticTable}
+import org.neo4j.graphdb.QueryExecutionType.QueryType
 import org.neo4j.helpers.Clock
+import org.neo4j.kernel.api
 
 object RuntimeBuilder {
   def create(runtimeName: Option[RuntimeName], interpretedProducer: InterpretedPlanBuilder,
@@ -44,14 +52,20 @@ trait RuntimeBuilder {
   def apply(logicalPlan: LogicalPlan, pipeBuildContext: PipeExecutionBuilderContext, planContext: PlanContext,
             tracer: CompilationPhaseTracer, semanticTable: SemanticTable,
             monitor: NewRuntimeSuccessRateMonitor, plannerName: PlannerName,
-            preparedQuery: PreparedQuery): Either[CompiledPlan, PipeInfo] = {
+            entityAccessor: EntityAccessor,
+            preparedQuery: PreparedQuery,
+            createFingerprintReference: Option[PlanFingerprint] => PlanFingerprintReference,
+            config: CypherCompilerConfiguration): ExecutionPlan = {
     try {
-      Left(compiledProducer(logicalPlan, semanticTable, planContext, monitor, tracer, plannerName))
+      compiledProducer(logicalPlan, semanticTable, planContext, monitor, tracer,
+        plannerName, entityAccessor, preparedQuery, createFingerprintReference)
     } catch {
       case e: CantCompileQueryException =>
         monitor.unableToHandlePlan(logicalPlan, e)
         fallback(preparedQuery)
-        Right(interpretedProducer(logicalPlan, pipeBuildContext, planContext, tracer))
+        val foo = interpretedProducer.apply(logicalPlan, pipeBuildContext, planContext, tracer, preparedQuery, createFingerprintReference, config)
+
+        foo
     }
   }
 
@@ -76,13 +90,15 @@ case class WarningFallbackRuntimeBuilder(interpretedProducer: InterpretedPlanBui
 }
 
 case class InterpretedRuntimeBuilder(interpretedProducer: InterpretedPlanBuilder) extends RuntimeBuilder {
-
   override def apply(logicalPlan: LogicalPlan, pipeBuildContext: PipeExecutionBuilderContext, planContext: PlanContext,
-                     tracer: CompilationPhaseTracer, semanticTable: SemanticTable,
-                     monitor: NewRuntimeSuccessRateMonitor, plannerName: PlannerName,
-                     preparedQuery: PreparedQuery): Either[CompiledPlan, PipeInfo] = {
-    Right(interpretedProducer.apply(logicalPlan, pipeBuildContext, planContext, tracer))
-  }
+            tracer: CompilationPhaseTracer, semanticTable: SemanticTable,
+            monitor: NewRuntimeSuccessRateMonitor, plannerName: PlannerName,
+            entityAccessor: EntityAccessor,
+            preparedQuery: PreparedQuery,
+            createFingerprintReference: Option[PlanFingerprint] => PlanFingerprintReference,
+            config: CypherCompilerConfiguration): ExecutionPlan =
+    interpretedProducer(logicalPlan, pipeBuildContext, planContext, tracer, preparedQuery, createFingerprintReference, config)
+
 
   override def compiledProducer = throw new InternalException("This should never be called")
 
@@ -100,9 +116,11 @@ case class ErrorReportingRuntimeBuilder(compiledProducer: CompiledPlanBuilder) e
 case class InterpretedPlanBuilder(clock: Clock, monitors: Monitors) {
 
   def apply(logicalPlan: LogicalPlan, pipeBuildContext: PipeExecutionBuilderContext,
-            planContext: PlanContext, tracer: CompilationPhaseTracer) =
+            planContext: PlanContext, tracer: CompilationPhaseTracer, preparedQuery: PreparedQuery,
+            createFingerprintReference: Option[PlanFingerprint] => PlanFingerprintReference,
+            config: CypherCompilerConfiguration) =
     closing(tracer.beginPhase(PIPE_BUILDING)) {
-      new PipeExecutionPlanBuilder(clock, monitors).build(logicalPlan)(pipeBuildContext, planContext)
+      interpretedToExecutionPlan(new PipeExecutionPlanBuilder(clock, monitors).build(logicalPlan)(pipeBuildContext, planContext), planContext, preparedQuery, createFingerprintReference, config)
     }
 }
 
@@ -112,10 +130,69 @@ case class CompiledPlanBuilder(clock: Clock, structure:CodeStructure[GeneratedQu
 
   def apply(logicalPlan: LogicalPlan, semanticTable: SemanticTable, planContext: PlanContext,
             monitor: NewRuntimeSuccessRateMonitor, tracer: CompilationPhaseTracer,
-            plannerName: PlannerName) = {
-    monitor.newPlanSeen(logicalPlan)
+            plannerName: PlannerName,
+            entityAccessor: EntityAccessor,
+            preparedQuery: PreparedQuery,
+            createFingerprintReference:Option[PlanFingerprint]=>PlanFingerprintReference): ExecutionPlan = {
+            monitor.newPlanSeen(logicalPlan)
     closing(tracer.beginPhase(CODE_GENERATION)) {
-      codeGen.generate(logicalPlan, planContext, clock, semanticTable, plannerName)
+      val compiled = codeGen.generate(logicalPlan, planContext, clock, semanticTable, plannerName)
+
+      new ExecutionPlan {
+        val fingerprint = createFingerprintReference(compiled.fingerprint)
+
+        def isStale(lastTxId: () => Long, statistics: GraphStatistics) = fingerprint.isStale(lastTxId, statistics)
+
+        def run(queryContext: QueryContext, kernelStatement: api.Statement,
+                executionMode: ExecutionMode, params: Map[String, Any]): InternalExecutionResult = {
+          val taskCloser = new TaskCloser
+          taskCloser.addTask(queryContext.close)
+          try {
+            if (executionMode == ExplainMode) {
+              //close all statements
+              taskCloser.close(success = true)
+              new ExplainExecutionResult(compiled.columns.toList,
+                compiled.planDescription, QueryType.READ_ONLY, preparedQuery.notificationLogger.notifications)
+            } else
+              compiled.executionResultBuilder(kernelStatement, entityAccessor, executionMode, createTracer(executionMode), params, taskCloser)
+          } catch {
+            case (t: Throwable) =>
+              taskCloser.close(success = false)
+              throw t
+          }
+        }
+
+        def plannerUsed: PlannerName = compiled.plannerUsed
+
+        def isPeriodicCommit: Boolean = compiled.periodicCommit.isDefined
+
+        def runtimeUsed = CompiledRuntimeName
+
+        override def notifications: Seq[InternalNotification] = Seq.empty
+      }
     }
+  }
+}
+
+object CompiledPlanBuilder {
+
+
+  def createTracer( mode: ExecutionMode ) : DescriptionProvider = mode match {
+    case ProfileMode =>
+      val tracer = new ProfilingTracer()
+      (description: InternalPlanDescription) => (new Provider[InternalPlanDescription] {
+
+        override def get(): InternalPlanDescription = description.map {
+          plan: InternalPlanDescription =>
+            val data = tracer.get(plan.id)
+            plan.
+              addArgument(Arguments.DbHits(data.dbHits())).
+              addArgument(Arguments.Rows(data.rows())).
+              addArgument(Arguments.Time(data.time()))
+        }
+      }, Some(tracer))
+    case _ => (description: InternalPlanDescription) => (new Provider[InternalPlanDescription] {
+      override def get(): InternalPlanDescription = description
+    }, None)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGenerator.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGenerator.scala
@@ -31,12 +31,11 @@ import org.neo4j.cypher.internal.compiler.v3_0.planDescription.{Id, InternalPlan
 import org.neo4j.cypher.internal.compiler.v3_0.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{LogicalPlan2PlanDescription, LogicalPlanIdentificationBuilder}
-import org.neo4j.cypher.internal.compiler.v3_0.spi.{InstrumentedGraphStatistics, PlanContext}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.{InstrumentedGraphStatistics, PlanContext, QueryContext}
 import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionMode, PlannerName, TaskCloser}
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticTable
 import org.neo4j.cypher.internal.frontend.v3_0.helpers.Eagerly
 import org.neo4j.helpers.Clock
-import org.neo4j.kernel.api.Statement
 
 class CodeGenerator(val structure: CodeStructure[GeneratedQuery]) {
 
@@ -68,13 +67,13 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery]) {
         }
 
         val builder = new RunnablePlan {
-          def apply(statement: Statement, entityAccessor: EntityAccessor, execMode: ExecutionMode,
+          def apply(queryContext: QueryContext, entityAccessor: EntityAccessor, execMode: ExecutionMode,
                     descriptionProvider: DescriptionProvider, params: Map[String, Any],
                     closer: TaskCloser): InternalExecutionResult = {
             val (provider, tracer) = descriptionProvider(description)
-            val execution: GeneratedQueryExecution = query.execute(closer, statement, entityAccessor, execMode,
+            val execution: GeneratedQueryExecution = query.execute(closer, queryContext, entityAccessor, execMode,
               provider, tracer.getOrElse(QueryExecutionTracer.NONE), asJavaHashMap(params))
-            new CompiledExecutionResult(closer, statement, execution, provider)
+            new CompiledExecutionResult(closer, queryContext, execution, provider)
           }
         }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGenerator.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGenerator.scala
@@ -67,11 +67,11 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery]) {
         }
 
         val builder = new RunnablePlan {
-          def apply(queryContext: QueryContext, entityAccessor: EntityAccessor, execMode: ExecutionMode,
+          def apply(queryContext: QueryContext, execMode: ExecutionMode,
                     descriptionProvider: DescriptionProvider, params: Map[String, Any],
                     closer: TaskCloser): InternalExecutionResult = {
             val (provider, tracer) = descriptionProvider(description)
-            val execution: GeneratedQueryExecution = query.execute(closer, queryContext, entityAccessor, execMode,
+            val execution: GeneratedQueryExecution = query.execute(closer, queryContext, execMode,
               provider, tracer.getOrElse(QueryExecutionTracer.NONE), asJavaHashMap(params))
             new CompiledExecutionResult(closer, queryContext, execution, provider)
           }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ErrorReportingExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ErrorReportingExecutablePlanBuilder.scala
@@ -25,9 +25,9 @@ import org.neo4j.cypher.internal.compiler.v3_0.{CompilationPhaseTracer, Prepared
 import org.neo4j.cypher.internal.frontend.v3_0.InvalidArgumentException
 
 case class ErrorReportingExecutablePlanBuilder(inner: ExecutablePlanBuilder) extends ExecutablePlanBuilder {
-  override def producePlan(inputQuery: PreparedQuery, planContext: PlanContext, tracer: CompilationPhaseTracer): Either[CompiledPlan, PipeInfo] =
+  override def producePlan(inputQuery: PreparedQuery, planContext: PlanContext, tracer: CompilationPhaseTracer, createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference): ExecutionPlan =
     try {
-      inner.producePlan(inputQuery, planContext, tracer)
+      inner.producePlan(inputQuery, planContext, tracer, createFingerprintReference)
     } catch {
       case e: CantHandleQueryException =>
         throw new InvalidArgumentException("The given query is not currently supported in the selected cost-based planner", e)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlan.scala
@@ -19,15 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 
-import org.neo4j.cypher.internal.compiler.v3_0.ExecutionMode
-import org.neo4j.cypher.internal.compiler.v3_0.{RuntimeName, PlannerName}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, QueryContext}
+import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionMode, PlannerName, RuntimeName}
 import org.neo4j.cypher.internal.frontend.v3_0.notification.InternalNotification
-import org.neo4j.kernel.api.Statement
 
 abstract class ExecutionPlan {
-  //TODO run should not have direct access to statement?
-  def run(queryContext: QueryContext, statement: Statement, planType: ExecutionMode, params: Map[String, Any]): InternalExecutionResult
+  def run(queryContext: QueryContext, planType: ExecutionMode, params: Map[String, Any]): InternalExecutionResult
   def isPeriodicCommit: Boolean
   def plannerUsed: PlannerName
   def isStale(lastTxId: () => Long, statistics: GraphStatistics): Boolean

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.QueryExecutionTracer
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.profiling.ProfilingTracer
 import org.neo4j.cypher.internal.compiler.v3_0.commands._
-import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlanBuilder.{DescriptionProvider, tracer}
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlanBuilder.DescriptionProvider
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders._
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
@@ -37,7 +37,6 @@ import org.neo4j.cypher.internal.frontend.v3_0.PeriodicCommitInOpenTransactionEx
 import org.neo4j.cypher.internal.frontend.v3_0.ast.Statement
 import org.neo4j.cypher.internal.frontend.v3_0.notification.InternalNotification
 import org.neo4j.graphdb.GraphDatabaseService
-import org.neo4j.graphdb.QueryExecutionType.QueryType
 import org.neo4j.helpers.Clock
 import org.neo4j.kernel.api.{Statement => KernelStatement}
 
@@ -91,75 +90,33 @@ object ExecutablePlanBuilder {
 }
 
 trait ExecutablePlanBuilder {
-  def producePlan(inputQuery: PreparedQuery, planContext: PlanContext, tracer: CompilationPhaseTracer = CompilationPhaseTracer.NO_TRACING): Either[CompiledPlan, PipeInfo]
+  def producePlan(inputQuery: PreparedQuery, planContext: PlanContext, tracer: CompilationPhaseTracer = CompilationPhaseTracer.NO_TRACING,
+                  createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference): ExecutionPlan
 }
 
 class ExecutionPlanBuilder(graph: GraphDatabaseService, entityAccessor: EntityAccessor,
-                           config: CypherCompilerConfiguration, clock: Clock, pipeBuilder: ExecutablePlanBuilder)
+                           clock: Clock,
+                           executionPlanBuilder: ExecutablePlanBuilder,
+                           createFingerprintReference: Option[PlanFingerprint] => PlanFingerprintReference)
   extends PatternGraphBuilder {
 
-  def build(planContext: PlanContext, inputQuery: PreparedQuery, tracer: CompilationPhaseTracer=CompilationPhaseTracer.NO_TRACING): ExecutionPlan = {
-    val executablePlan = pipeBuilder.producePlan(inputQuery, planContext, tracer)
-    executablePlan match {
-      case Left(compiledPlan) => buildCompiled(compiledPlan, planContext, inputQuery)
-      case Right(pipeInfo) => buildInterpreted(pipeInfo, planContext, inputQuery)
-    }
+  def build(planContext: PlanContext, inputQuery: PreparedQuery,
+            tracer: CompilationPhaseTracer = CompilationPhaseTracer.NO_TRACING): ExecutionPlan = {
+    executionPlanBuilder.producePlan(inputQuery, planContext, tracer, createFingerprintReference)
   }
+}
 
-  private def buildCompiled(compiledPlan: CompiledPlan, planContext: PlanContext, inputQuery: PreparedQuery) = {
-    new ExecutionPlan {
-      val fingerprint = PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, compiledPlan.fingerprint)
-
-      def isStale(lastCommittedTxId: () => Long, statistics: GraphStatistics) = fingerprint.isStale(lastCommittedTxId, statistics)
-
-      def run(queryContext: QueryContext, kernelStatement: KernelStatement,
-              executionMode: ExecutionMode, params: Map[String, Any]): InternalExecutionResult = {
-        val taskCloser = new TaskCloser
-        taskCloser.addTask(queryContext.close)
-        try {
-          if (executionMode == ExplainMode) {
-            //close all statements
-            taskCloser.close(success = true)
-            new ExplainExecutionResult(compiledPlan.columns.toList,
-              compiledPlan.planDescription, QueryType.READ_ONLY, inputQuery.notificationLogger.notifications)
-          } else
-            compiledPlan.executionResultBuilder(kernelStatement, entityAccessor, executionMode,
-              tracer(executionMode), params, taskCloser)
-        } catch {
-          case (t: Throwable) =>
-            taskCloser.close(success = false)
-            throw t
-        }
-      }
-
-      def plannerUsed: PlannerName = compiledPlan.plannerUsed
-
-      def isPeriodicCommit: Boolean = compiledPlan.periodicCommit.isDefined
-
-      def runtimeUsed = CompiledRuntimeName
-
-      def notifications = Seq.empty
-    }
-  }
-
-
-
-  private def checkForNotifications(pipe: Pipe, planContext: PlanContext): Seq[InternalNotification] = {
-    val notificationCheckers = Seq(checkForEagerLoadCsv,
-      CheckForLoadCsvAndMatchOnLargeLabel(planContext, config.nonIndexedLabelWarningThreshold))
-
-    notificationCheckers.flatMap(_(pipe))
-  }
-
-
-  private def buildInterpreted(pipeInfo: PipeInfo, planContext: PlanContext, inputQuery: PreparedQuery) = {
+object InterpretedExecutionPlanBuilder {
+  def interpretedToExecutionPlan(pipeInfo: PipeInfo, planContext: PlanContext, inputQuery: PreparedQuery,
+                                 createFingerprintReference:Option[PlanFingerprint]=>PlanFingerprintReference,
+                                 config: CypherCompilerConfiguration) = {
     val abstractQuery = inputQuery.abstractQuery
     val PipeInfo(pipe, updating, periodicCommitInfo, fp, planner) = pipeInfo
     val columns = getQueryResultColumns(abstractQuery, pipe.symbols)
     val resultBuilderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, columns)
     val func = getExecutionPlanFunction(periodicCommitInfo, abstractQuery.getQueryText, updating, resultBuilderFactory, inputQuery.notificationLogger)
     new ExecutionPlan {
-      private val fingerprint = PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, fp)
+      private val fingerprint = createFingerprintReference(fp)
 
       def run(queryContext: QueryContext, ignored: KernelStatement, planType: ExecutionMode, params: Map[String, Any]) =
         func(queryContext, planType, params)
@@ -170,9 +127,15 @@ class ExecutionPlanBuilder(graph: GraphDatabaseService, entityAccessor: EntityAc
 
       def runtimeUsed = InterpretedRuntimeName
 
-      def notifications = checkForNotifications(pipe, planContext)
+      def notifications = checkForNotifications(pipe, planContext, config)
     }
+  }
 
+  private def checkForNotifications(pipe: Pipe, planContext: PlanContext, config: CypherCompilerConfiguration): Seq[InternalNotification] = {
+    val notificationCheckers = Seq(checkForEagerLoadCsv,
+      CheckForLoadCsvAndMatchOnLargeLabel(planContext, config.nonIndexedLabelWarningThreshold))
+
+    notificationCheckers.flatMap(_(pipe))
   }
 
   private def getQueryResultColumns(q: AbstractQuery, currentSymbols: SymbolTable): List[String] = q match {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
@@ -42,7 +42,7 @@ import org.neo4j.kernel.api.{Statement => KernelStatement}
 
 
 trait RunnablePlan {
-  def apply(statement: KernelStatement,
+  def apply(queryContext: QueryContext,
             nodeManager: EntityAccessor,
             execMode: ExecutionMode,
             descriptionProvider: DescriptionProvider,
@@ -118,7 +118,7 @@ object InterpretedExecutionPlanBuilder {
     new ExecutionPlan {
       private val fingerprint = createFingerprintReference(fp)
 
-      def run(queryContext: QueryContext, ignored: KernelStatement, planType: ExecutionMode, params: Map[String, Any]) =
+      def run(queryContext: QueryContext, planType: ExecutionMode, params: Map[String, Any]) =
         func(queryContext, planType, params)
 
       def isPeriodicCommit = periodicCommitInfo.isDefined

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
@@ -43,7 +43,6 @@ import org.neo4j.kernel.api.{Statement => KernelStatement}
 
 trait RunnablePlan {
   def apply(queryContext: QueryContext,
-            nodeManager: EntityAccessor,
             execMode: ExecutionMode,
             descriptionProvider: DescriptionProvider,
             params: Map[String, Any],
@@ -94,7 +93,7 @@ trait ExecutablePlanBuilder {
                   createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference): ExecutionPlan
 }
 
-class ExecutionPlanBuilder(graph: GraphDatabaseService, entityAccessor: EntityAccessor,
+class ExecutionPlanBuilder(graph: GraphDatabaseService,
                            clock: Clock,
                            executionPlanBuilder: ExecutablePlanBuilder,
                            createFingerprintReference: Option[PlanFingerprint] => PlanFingerprintReference)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
@@ -24,6 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters.reattachAliasedExpr
 import org.neo4j.cypher.internal.compiler.v3_0.commands._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.groupInequalityPredicatesForLegacy
 import org.neo4j.cypher.internal.compiler.v3_0.commands.values.{KeyToken, TokenType}
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InterpretedExecutionPlanBuilder.interpretedToExecutionPlan
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders.prepare.KeyTokenResolver
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders.{DisconnectedShortestPathEndPointsBuilder, _}
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.Converge.iterateUntilConverged
@@ -37,12 +38,16 @@ trait ExecutionPlanInProgressRewriter {
   def rewrite(in: ExecutionPlanInProgress)(implicit context: PipeMonitor): ExecutionPlanInProgress
 }
 
-class LegacyExecutablePlanBuilder(monitors: Monitors, rewriterSequencer: (String) => RewriterStepSequencer, eagernessRewriter: Pipe => Pipe = addEagernessIfNecessary)
+class LegacyExecutablePlanBuilder(monitors: Monitors, config: CypherCompilerConfiguration, rewriterSequencer: (String) => RewriterStepSequencer, eagernessRewriter: Pipe => Pipe = addEagernessIfNecessary)
   extends PatternGraphBuilder with ExecutablePlanBuilder with GraphQueryBuilder {
 
   private implicit val pipeMonitor: PipeMonitor = monitors.newMonitor[PipeMonitor]()
 
-  override def producePlan(in: PreparedQuery, planContext: PlanContext, tracer: CompilationPhaseTracer) = {
+  override def producePlan(inputQuery: PreparedQuery, planContext: PlanContext, tracer: CompilationPhaseTracer = CompilationPhaseTracer.NO_TRACING,
+  createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference): ExecutionPlan =
+    interpretedToExecutionPlan(producePipe(inputQuery, planContext, tracer), planContext, inputQuery, createFingerprintReference, config)
+
+  def producePipe(in: PreparedQuery, planContext: PlanContext, tracer: CompilationPhaseTracer): PipeInfo = {
     val rewriter = rewriterSequencer("LegacyPipeBuilder")(reattachAliasedExpressions).rewriter
     val rewrite = in.rewrite(rewriter)
 
@@ -63,7 +68,7 @@ class LegacyExecutablePlanBuilder(monitors: Monitors, rewriterSequencer: (String
       case q: Union =>
         buildUnionQuery(q, planContext)
     }
-    Right(res)
+    res
   }
 
   private val unionBuilder = new UnionBuilder(this)
@@ -112,10 +117,9 @@ class LegacyExecutablePlanBuilder(monitors: Monitors, rewriterSequencer: (String
 
     psq.where.map(p => p.token) match {
       case None => psq
-      case Some(predicates) => {
+      case Some(predicates) =>
         val newWhere = groupInequalityPredicatesForLegacy(predicates).map(Unsolved(_)).toSeq
         psq.copy(where = newWhere)
-      }
     }
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/SilentFallbackPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/SilentFallbackPlanBuilder.scala
@@ -19,27 +19,28 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 
-import org.neo4j.cypher.internal.compiler.v3_0.{CompilationPhaseTracer, PreparedQuery}
-import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.CantHandleQueryException
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
+import org.neo4j.cypher.internal.compiler.v3_0.{CompilationPhaseTracer, PreparedQuery}
+import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.notification.PlannerUnsupportedNotification
 
 trait FallbackBuilder extends ExecutablePlanBuilder {
 
-  def producePlan(inputQuery: PreparedQuery, planContext: PlanContext,
-                  tracer: CompilationPhaseTracer): Either[CompiledPlan, PipeInfo] = {
+  override def producePlan(inputQuery: PreparedQuery, planContext: PlanContext,
+                  tracer: CompilationPhaseTracer,
+                  createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference): ExecutionPlan = {
     val queryText = inputQuery.queryText
     val statement = inputQuery.statement
     try {
       monitor.newQuerySeen(queryText, statement)
 
-      newBuilder.producePlan(inputQuery, planContext, tracer)
+      newBuilder.producePlan(inputQuery, planContext, tracer, createFingerprintReference)
     } catch {
       case e: CantHandleQueryException =>
         monitor.unableToHandleQuery(queryText, statement, e)
         warn(inputQuery)
-        oldBuilder.producePlan(inputQuery, planContext, tracer)
+        oldBuilder.producePlan(inputQuery, planContext, tracer, createFingerprintReference)
     }
   }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.conditions.containsNamedPathOnlyForShortestPath
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.plannerQuery.StatementConverters._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters._
-import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{ExecutablePlanBuilder, NewRuntimeSuccessRateMonitor}
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{EntityAccessor, ExecutablePlanBuilder, NewRuntimeSuccessRateMonitor, PlanFingerprint, PlanFingerprintReference}
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.closing
 import org.neo4j.cypher.internal.compiler.v3_0.planner.execution.PipeExecutionBuilderContext
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
@@ -33,7 +33,6 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.{ApplyRewriter, RewriterCondition, RewriterStep, RewriterStepSequencer}
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
-import org.neo4j.cypher.internal.frontend.v3_0.notification.{MissingLabelNotification, InternalNotification}
 import org.neo4j.cypher.internal.frontend.v3_0.{InternalException, Scope, SemanticTable}
 
 /* This class is responsible for taking a query from an AST object to a runnable object.  */
@@ -47,10 +46,11 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
                                           plannerName: CostBasedPlannerName,
                                           runtimeBuilder: RuntimeBuilder,
                                           updateStrategy: UpdateStrategy,
-                                          useErrorsOverWarnings: Boolean)
+                                          entityAccessor: EntityAccessor,
+                                          config: CypherCompilerConfiguration)
   extends ExecutablePlanBuilder {
 
-  def producePlan(inputQuery: PreparedQuery, planContext: PlanContext, tracer: CompilationPhaseTracer) = {
+  override def producePlan(inputQuery: PreparedQuery, planContext: PlanContext, tracer: CompilationPhaseTracer, createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference) = {
     val statement =
       CostBasedExecutablePlanBuilder.rewriteStatement(
         statement = inputQuery.statement,
@@ -71,7 +71,7 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
           produceLogicalPlan(ast, rewrittenSemanticTable)(planContext, inputQuery.notificationLogger)
         }
         runtimeBuilder(logicalPlan, pipeBuildContext, planContext, tracer, rewrittenSemanticTable, planBuilderMonitor,
-                      plannerName, inputQuery)
+                      plannerName, entityAccessor, inputQuery, createFingerprintReference, config)
       case x =>
         throw new CantHandleQueryException(x.toString())
     }
@@ -86,7 +86,7 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
     val logicalPlanProducer = LogicalPlanProducer(metrics.cardinality)
 
     val context = LogicalPlanningContext(planContext, logicalPlanProducer, metrics, semanticTable,
-      queryGraphSolver, notificationLogger = notificationLogger, useErrorsOverWarnings = useErrorsOverWarnings,
+      queryGraphSolver, notificationLogger = notificationLogger, useErrorsOverWarnings = config.useErrorsOverWarnings,
       config = QueryPlannerConfiguration.default.withUpdateStrategy(updateStrategy))
 
     val plan = queryPlanner.plan(unionQuery)(context)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.conditions.containsNamedPathOnlyForShortestPath
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.plannerQuery.StatementConverters._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters._
-import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{EntityAccessor, ExecutablePlanBuilder, NewRuntimeSuccessRateMonitor, PlanFingerprint, PlanFingerprintReference}
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{ExecutablePlanBuilder, NewRuntimeSuccessRateMonitor, PlanFingerprint, PlanFingerprintReference}
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.closing
 import org.neo4j.cypher.internal.compiler.v3_0.planner.execution.PipeExecutionBuilderContext
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
@@ -46,7 +46,6 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
                                           plannerName: CostBasedPlannerName,
                                           runtimeBuilder: RuntimeBuilder,
                                           updateStrategy: UpdateStrategy,
-                                          entityAccessor: EntityAccessor,
                                           config: CypherCompilerConfiguration)
   extends ExecutablePlanBuilder {
 
@@ -71,7 +70,7 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
           produceLogicalPlan(ast, rewrittenSemanticTable)(planContext, inputQuery.notificationLogger)
         }
         runtimeBuilder(logicalPlan, pipeBuildContext, planContext, tracer, rewrittenSemanticTable, planBuilderMonitor,
-                      plannerName, entityAccessor, inputQuery, createFingerprintReference, config)
+                      plannerName,  inputQuery, createFingerprintReference, config)
       case x =>
         throw new CantHandleQueryException(x.toString())
     }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedPipeBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedPipeBuilderFactory.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_0.planner
 
 import org.neo4j.cypher.internal.compiler.v3_0._
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.EntityAccessor
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.{IDPQueryGraphSolver, IDPQueryGraphSolverMonitor}
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
@@ -34,7 +35,8 @@ object CostBasedPipeBuilderFactory {
              tokenResolver: SimpleTokenResolver = new SimpleTokenResolver(),
              plannerName: Option[CostBasedPlannerName],
              runtimeBuilder: RuntimeBuilder,
-             useErrorsOverWarnings: Boolean,
+             entityAccessor: EntityAccessor,
+             config: CypherCompilerConfiguration,
              updateStrategy: Option[UpdateStrategy]
     ) = {
 
@@ -51,6 +53,7 @@ object CostBasedPipeBuilderFactory {
     CostBasedExecutablePlanBuilder(monitors, metricsFactory, tokenResolver, queryPlanner,
       createQueryGraphSolver(actualPlannerName), rewriterSequencer, semanticChecker, actualPlannerName, runtimeBuilder,
       actualUpdateStrategy,
-      useErrorsOverWarnings)
+      entityAccessor,
+      config)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedPipeBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedPipeBuilderFactory.scala
@@ -20,7 +20,6 @@
 package org.neo4j.cypher.internal.compiler.v3_0.planner
 
 import org.neo4j.cypher.internal.compiler.v3_0._
-import org.neo4j.cypher.internal.compiler.v3_0.executionplan.EntityAccessor
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.{IDPQueryGraphSolver, IDPQueryGraphSolverMonitor}
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
@@ -35,7 +34,6 @@ object CostBasedPipeBuilderFactory {
              tokenResolver: SimpleTokenResolver = new SimpleTokenResolver(),
              plannerName: Option[CostBasedPlannerName],
              runtimeBuilder: RuntimeBuilder,
-             entityAccessor: EntityAccessor,
              config: CypherCompilerConfiguration,
              updateStrategy: Option[UpdateStrategy]
     ) = {
@@ -53,7 +51,6 @@ object CostBasedPipeBuilderFactory {
     CostBasedExecutablePlanBuilder(monitors, metricsFactory, tokenResolver, queryPlanner,
       createQueryGraphSolver(actualPlannerName), rewriterSequencer, semanticChecker, actualPlannerName, runtimeBuilder,
       actualUpdateStrategy,
-      entityAccessor,
       config)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/profiler/Profiler.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/profiler/Profiler.scala
@@ -101,7 +101,7 @@ trait Counter {
   }
 }
 
-final class ProfilingQueryContext(val inner: QueryContext, val p: Pipe)
+final class ProfilingQueryContext(inner: QueryContext, val p: Pipe)
   extends DelegatingQueryContext(inner) with Counter {
   self =>
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
@@ -31,6 +31,14 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
   protected def singleDbHit[A](value: A): A = value
   protected def manyDbHits[A](value: Iterator[A]): Iterator[A] = value
 
+  type KernelStatement = inner.KernelStatement
+
+  type EntityAccessor = inner.EntityAccessor
+
+  override def statement: KernelStatement = inner.statement
+
+  override def entityAccessor: EntityAccessor = inner.entityAccessor
+
   def isOpen: Boolean = inner.isOpen
 
   def isTopLevelTx: Boolean = inner.isTopLevelTx
@@ -152,10 +160,6 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
   override def lockNodes(nodeIds: Long*): Unit = inner.lockNodes(nodeIds:_*)
 
   override def lockRelationships(relIds: Long*): Unit = inner.lockRelationships(relIds:_*)
-
-  type KernelStatement = inner.KernelStatement
-
-  override def statement: KernelStatement = inner.statement
 }
 
 class DelegatingOperations[T <: PropertyContainer](protected val inner: Operations[T]) extends Operations[T] {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
@@ -23,10 +23,10 @@ import java.net.URL
 
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
-import org.neo4j.graphdb.{Path, Relationship, PropertyContainer, Node}
+import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
-class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
+class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
 
   protected def singleDbHit[A](value: A): A = value
   protected def manyDbHits[A](value: Iterator[A]): Iterator[A] = value
@@ -152,6 +152,10 @@ class DelegatingQueryContext(inner: QueryContext) extends QueryContext {
   override def lockNodes(nodeIds: Long*): Unit = inner.lockNodes(nodeIds:_*)
 
   override def lockRelationships(relIds: Long*): Unit = inner.lockRelationships(relIds:_*)
+
+  type KernelStatement = inner.KernelStatement
+
+  override def statement: KernelStatement = inner.statement
 }
 
 class DelegatingOperations[T <: PropertyContainer](protected val inner: Operations[T]) extends Operations[T] {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
@@ -44,7 +44,11 @@ trait QueryContext extends TokenContext {
 
   type KernelStatement
 
+  type EntityAccessor
+
   def statement: KernelStatement
+
+  def entityAccessor: EntityAccessor
 
   def nodeOps: Operations[Node]
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
@@ -41,6 +41,11 @@ import org.neo4j.kernel.api.index.IndexDescriptor
  * the core layer, we can move that responsibility outside of the scope of cypher.
  */
 trait QueryContext extends TokenContext {
+
+  type KernelStatement
+
+  def statement: KernelStatement
+
   def nodeOps: Operations[Node]
 
   def relationshipOps: Operations[Relationship]

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -23,11 +23,12 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.plannerQuery.StatementConverters._
-import org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters.{namePatternPredicatePatternElements, normalizeWithClauses, normalizeReturnClauses}
+import org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters.{namePatternPredicatePatternElements, normalizeReturnClauses, normalizeWithClauses}
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.EntityAccessor
 import org.neo4j.cypher.internal.compiler.v3_0.planner.execution.PipeExecutionBuilderContext
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.{IDPQueryGraphSolverMonitor, IDPQueryGraphSolver}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.{IDPQueryGraphSolver, IDPQueryGraphSolverMonitor}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.rewriter.LogicalPlanRewriter
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.LogicalPlanProducer
@@ -166,9 +167,18 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
       plannerName = None,
       runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.SYSTEM_CLOCK, monitors)),
       semanticChecker = semanticChecker,
-      useErrorsOverWarnings = false,
-      updateStrategy = None)
+      updateStrategy = None,
+      entityAccessor = mock[EntityAccessor],
+      config = config)
   }
+
+  val config = CypherCompilerConfiguration(
+    queryCacheSize = 100,
+    statsDivergenceThreshold = 0.5,
+    queryPlanTTL = 1000,
+    useErrorsOverWarnings = false,
+    nonIndexedLabelWarningThreshold = 10000
+  )
 
   def produceLogicalPlan(queryText: String)(implicit planner: CostBasedExecutablePlanBuilder, planContext: PlanContext): LogicalPlan = {
     val parsedStatement = parser.parse(queryText)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -24,7 +24,6 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.plannerQuery.StatementConverters._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters.{namePatternPredicatePatternElements, normalizeReturnClauses, normalizeWithClauses}
-import org.neo4j.cypher.internal.compiler.v3_0.executionplan.EntityAccessor
 import org.neo4j.cypher.internal.compiler.v3_0.planner.execution.PipeExecutionBuilderContext
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical._
@@ -168,7 +167,6 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
       runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.SYSTEM_CLOCK, monitors)),
       semanticChecker = semanticChecker,
       updateStrategy = None,
-      entityAccessor = mock[EntityAccessor],
       config = config)
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -25,7 +25,7 @@ import java.util
 import org.neo4j.cypher._
 import org.neo4j.cypher.internal._
 import org.neo4j.cypher.internal.compiler.v3_0
-import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{ExecutionPlan => ExecutionPlan_v3_0, EntityAccessor, InternalExecutionResult}
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{EntityAccessor, ExecutionPlan => ExecutionPlan_v3_0, InternalExecutionResult}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.{Argument, InternalPlanDescription, PlanDescriptionArgumentSerializer}
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
@@ -36,9 +36,9 @@ import org.neo4j.cypher.internal.frontend.v3_0.{CypherException => InternalCyphe
 import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.spi.v3_0.{GeneratedQueryStructure, TransactionBoundGraphStatistics, TransactionBoundPlanContext, TransactionBoundQueryContext}
 import org.neo4j.cypher.javacompat.ProfilerStatistics
-import org.neo4j.graphdb.{InputPosition, QueryExecutionType, ResourceIterator, GraphDatabaseService, Node, Relationship}
 import org.neo4j.graphdb.Result.ResultVisitor
 import org.neo4j.graphdb.impl.notification.{NotificationCode, NotificationDetail}
+import org.neo4j.graphdb.{GraphDatabaseService, InputPosition, Node, QueryExecutionType, Relationship, ResourceIterator}
 import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.{KernelAPI, Statement}
@@ -198,7 +198,7 @@ trait CompatibilityFor3_0 {
         case CypherExecutionMode.normal => NormalModev3_0
       }
       exceptionHandlerFor3_0.runSafely {
-        ExecutionResultWrapperFor3_0(inner.run(queryContext(graph, txInfo), txInfo.statement, innerExecutionMode, params), inner.plannerUsed, inner.runtimeUsed)
+        ExecutionResultWrapperFor3_0(inner.run(queryContext(graph, txInfo), innerExecutionMode, params), inner.plannerUsed, inner.runtimeUsed)
       }
     }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/GeneratedQueryStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/GeneratedQueryStructure.scala
@@ -51,6 +51,7 @@ import org.neo4j.kernel.api.index.IndexDescriptor
 import org.neo4j.kernel.api.{ReadOperations, Statement, StatementTokenNameLookup, TokenNameLookup}
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.kernel.impl.api.{RelationshipDataExtractor, RelationshipVisitor}
+import org.neo4j.kernel.impl.core.NodeManager
 
 import scala.collection.mutable
 
@@ -71,7 +72,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
         closer = clazz.field(typeRef[TaskCloser], "closer"),
         statement = clazz.field(typeRef[Statement], "statement"),
         ro = clazz.field(typeRef[ReadOperations], "ro"),
-        entityAccessor = clazz.field(typeRef[EntityAccessor], "nodeManager"),
+        entityAccessor = clazz.field(typeRef[NodeManager], "nodeManager"),
         executionMode = clazz.field(typeRef[ExecutionMode], "executionMode"),
         description = clazz.field(typeRef[Provider[InternalPlanDescription]], "description"),
         tracer = clazz.field(typeRef[QueryExecutionTracer], "tracer"),
@@ -115,7 +116,6 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
       using(clazz.generateMethod(typeRef[GeneratedQueryExecution], "execute",
         param[TaskCloser]("closer"),
         param[QueryContext]("queryContext"),
-        param[EntityAccessor]("nodeManager"),
         param[ExecutionMode]("executionMode"),
         param[Provider[InternalPlanDescription]]("description"),
         param[QueryExecutionTracer]("tracer"),
@@ -130,7 +130,6 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
           typeRef[util.Map[String, Object]]),
           execute.load("closer"),
           execute.load("queryContext"),
-          execute.load("nodeManager"),
           execute.load("executionMode"),
           execute.load("description"),
           execute.load("tracer"),
@@ -848,7 +847,6 @@ private object Templates {
   val CONSTRUCTOR = MethodTemplate.constructor(
     param[TaskCloser]("closer"),
     param[QueryContext]("queryContext"),
-    param[EntityAccessor]("nodeManager"),
     param[ExecutionMode]("executionMode"),
     param[Provider[InternalPlanDescription]]("description"),
     param[QueryExecutionTracer]("tracer"),
@@ -863,7 +861,9 @@ private object Templates {
     put(self(), typeRef[Provider[InternalPlanDescription]], "description", load("description")).
     put(self(), typeRef[QueryExecutionTracer], "tracer", load("tracer")).
     put(self(), typeRef[util.Map[String, Object]], "params", load("params")).
-    put(self(), typeRef[EntityAccessor], "nodeManager", load("nodeManager")).
+    put(self(), typeRef[NodeManager], "nodeManager",
+      cast(typeRef[NodeManager],
+        invoke(load("queryContext"), method[QueryContext, NodeManager]("entityAccessor")))).
     build()
 
   val SET_SUCCESSFUL_CLOSEABLE = MethodTemplate.method(typeRef[Unit], "setSuccessfulCloseable",

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/GeneratedQueryStructure.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/GeneratedQueryStructure.scala
@@ -39,11 +39,12 @@ import org.neo4j.cypher.internal.compiler.v3_0.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_0.helpers._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.{Id, InternalPlanDescription}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.CantCompileQueryException
+import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionMode, TaskCloser}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols.CypherType
-import org.neo4j.cypher.internal.frontend.v3_0.{SemanticDirection, CypherExecutionException, ParameterNotFoundException, symbols}
-import org.neo4j.graphdb.{Relationship, Node, Direction}
+import org.neo4j.cypher.internal.frontend.v3_0.{CypherExecutionException, ParameterNotFoundException, SemanticDirection, symbols}
 import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
+import org.neo4j.graphdb.{Direction, Node, Relationship}
 import org.neo4j.helpers.collection.MapUtil
 import org.neo4j.kernel.api.exceptions.KernelException
 import org.neo4j.kernel.api.index.IndexDescriptor
@@ -68,6 +69,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
       // fields
       val fields = Fields(
         closer = clazz.field(typeRef[TaskCloser], "closer"),
+        statement = clazz.field(typeRef[Statement], "statement"),
         ro = clazz.field(typeRef[ReadOperations], "ro"),
         entityAccessor = clazz.field(typeRef[EntityAccessor], "nodeManager"),
         executionMode = clazz.field(typeRef[ExecutionMode], "executionMode"),
@@ -112,7 +114,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
     val query = using(generator.generateClass(packageName,className, typeRef[GeneratedQuery])) { clazz =>
       using(clazz.generateMethod(typeRef[GeneratedQueryExecution], "execute",
         param[TaskCloser]("closer"),
-        param[Statement]("statement"),
+        param[QueryContext]("queryContext"),
         param[EntityAccessor]("nodeManager"),
         param[ExecutionMode]("executionMode"),
         param[Provider[InternalPlanDescription]]("description"),
@@ -120,14 +122,14 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
         param[util.Map[String, Object]]("params"))) { execute =>
         execute.returns(Expression.invoke(Expression.newInstance(execution), MethodReference.constructorReference(execution,
           typeRef[TaskCloser],
-          typeRef[Statement],
+          typeRef[QueryContext],
           typeRef[EntityAccessor],
           typeRef[ExecutionMode],
           typeRef[Provider[InternalPlanDescription]],
           typeRef[QueryExecutionTracer],
           typeRef[util.Map[String, Object]]),
           execute.load("closer"),
-          execute.load("statement"),
+          execute.load("queryContext"),
           execute.load("nodeManager"),
           execute.load("executionMode"),
           execute.load("description"),
@@ -178,6 +180,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
 }
 
 private case class Fields(closer: FieldReference,
+                          statement: FieldReference,
                           ro: FieldReference,
                           entityAccessor: FieldReference,
                           executionMode: FieldReference,
@@ -844,14 +847,18 @@ private object Templates {
 
   val CONSTRUCTOR = MethodTemplate.constructor(
     param[TaskCloser]("closer"),
-    param[Statement]("statement"),
+    param[QueryContext]("queryContext"),
     param[EntityAccessor]("nodeManager"),
     param[ExecutionMode]("executionMode"),
     param[Provider[InternalPlanDescription]]("description"),
     param[QueryExecutionTracer]("tracer"),
+
     param[util.Map[String, Object]]("params")).
     put(self(), typeRef[TaskCloser], "closer", load("closer")).
-    put(self(), typeRef[ReadOperations], "ro", invoke(load("statement"), method[Statement, ReadOperations]("readOperations"))).
+    put(self(), typeRef[Statement], "statement",
+      cast(typeRef[Statement],
+        invoke(load("queryContext"), method[QueryContext, Statement]("statement")))).
+    put(self(), typeRef[ReadOperations], "ro", invoke(get(self(), typeRef[Statement], "statement"), method[Statement, ReadOperations]("readOperations"))).
     put(self(), typeRef[ExecutionMode], "executionMode", load("executionMode")).
     put(self(), typeRef[Provider[InternalPlanDescription]], "description", load("description")).
     put(self(), typeRef[QueryExecutionTracer], "tracer", load("tracer")).

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -41,7 +41,7 @@ import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, Relati
 import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, AlreadyIndexedException}
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
 import org.neo4j.kernel.impl.api.{KernelStatement => InternalKernelStatement}
-import org.neo4j.kernel.impl.core.{RelationshipProxy, ThreadToStatementContextBridge}
+import org.neo4j.kernel.impl.core.{NodeManager, RelationshipProxy, ThreadToStatementContextBridge}
 import org.neo4j.kernel.impl.locking.ResourceTypes
 import org.neo4j.kernel.security.URLAccessValidationError
 import org.neo4j.kernel.{GraphDatabaseAPI, Traversal, Uniqueness}
@@ -57,14 +57,17 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
 
   type KernelStatement = Statement
 
+  type EntityAccessor = NodeManager
+
   private var open = true
   private val txBridge = graph.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge])
-
   val nodeOps = new NodeOperations
   val relationshipOps = new RelationshipOperations
   val relationshipActions = graph.getDependencyResolver.resolveDependency(classOf[RelationshipProxy.RelationshipActions])
 
   override def statement = _statement
+
+  override def entityAccessor = graph.getDependencyResolver.resolveDependency(classOf[NodeManager])
 
   def isOpen = open
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -40,7 +40,7 @@ import org.neo4j.kernel.api._
 import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, AlreadyIndexedException}
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
-import org.neo4j.kernel.impl.api.KernelStatement
+import org.neo4j.kernel.impl.api.{KernelStatement => InternalKernelStatement}
 import org.neo4j.kernel.impl.core.{RelationshipProxy, ThreadToStatementContextBridge}
 import org.neo4j.kernel.impl.locking.ResourceTypes
 import org.neo4j.kernel.security.URLAccessValidationError
@@ -55,6 +55,8 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
                                          initialStatement: Statement)(implicit indexSearchMonitor: IndexSearchMonitor)
   extends TransactionBoundTokenContext(initialStatement) with QueryContext {
 
+  type KernelStatement = Statement
+
   private var open = true
   private val txBridge = graph.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge])
 
@@ -62,15 +64,17 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   val relationshipOps = new RelationshipOperations
   val relationshipActions = graph.getDependencyResolver.resolveDependency(classOf[RelationshipProxy.RelationshipActions])
 
+  override def statement = _statement
+
   def isOpen = open
 
   def setLabelsOnNode(node: Long, labelIds: Iterator[Int]): Int = labelIds.foldLeft(0) {
-    case (count, labelId) => if (statement.dataWriteOperations().nodeAddLabel(node, labelId)) count + 1 else count
+    case (count, labelId) => if (_statement.dataWriteOperations().nodeAddLabel(node, labelId)) count + 1 else count
   }
 
   def close(success: Boolean) {
     try {
-      statement.close()
+      _statement.close()
 
       if (success)
         tx.success()
@@ -114,40 +118,40 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     start.createRelationshipTo(end, withName(relType))
 
   def createRelationship(start: Long, end: Long, relType: Int) = {
-    val relId = statement.dataWriteOperations().relationshipCreate(relType, start, end)
+    val relId = _statement.dataWriteOperations().relationshipCreate(relType, start, end)
     relationshipOps.getById(relId)
   }
 
   def getOrCreateRelTypeId(relTypeName: String): Int =
-    statement.tokenWriteOperations().relationshipTypeGetOrCreateForName(relTypeName)
+    _statement.tokenWriteOperations().relationshipTypeGetOrCreateForName(relTypeName)
 
   def getLabelsForNode(node: Long) =
-    JavaConversionSupport.asScala(statement.readOperations().nodeGetLabels(node))
+    JavaConversionSupport.asScala(_statement.readOperations().nodeGetLabels(node))
 
   def getPropertiesForNode(node: Long) =
-    JavaConversionSupport.asScala(statement.readOperations().nodeGetPropertyKeys(node))
+    JavaConversionSupport.asScala(_statement.readOperations().nodeGetPropertyKeys(node))
 
   def getPropertiesForRelationship(relId: Long) =
-    JavaConversionSupport.asScala(statement.readOperations().relationshipGetPropertyKeys(relId))
+    JavaConversionSupport.asScala(_statement.readOperations().relationshipGetPropertyKeys(relId))
 
   override def isLabelSetOnNode(label: Int, node: Long) =
-    statement.readOperations().nodeHasLabel(node, label)
+    _statement.readOperations().nodeHasLabel(node, label)
 
   def getOrCreateLabelId(labelName: String) =
-    statement.tokenWriteOperations().labelGetOrCreateForName(labelName)
+    _statement.tokenWriteOperations().labelGetOrCreateForName(labelName)
 
   def getRelationshipsForIds(node: Node, dir: SemanticDirection, types: Option[Seq[Int]]): Iterator[Relationship] = types match {
     case None =>
-      val relationships = statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir))
+      val relationships = _statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir))
       new BeansAPIRelationshipIterator(relationships, relationshipActions)
     case Some(typeIds) =>
-      val relationships = statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeIds: _*)
+      val relationships = _statement.readOperations().nodeGetRelationships(node.getId, toGraphDb(dir), typeIds: _*)
       new BeansAPIRelationshipIterator(relationships, relationshipActions)
   }
 
   def indexSeek(index: IndexDescriptor, value: Any) = {
     indexSearchMonitor.indexSeek(index, value)
-    JavaConversionSupport.mapToScalaENFXSafe(statement.readOperations().nodesGetFromIndexSeek(index, value))(nodeOps.getById)
+    JavaConversionSupport.mapToScalaENFXSafe(_statement.readOperations().nodesGetFromIndexSeek(index, value))(nodeOps.getById)
   }
 
   def indexSeekByRange(index: IndexDescriptor, value: Any) = value match {
@@ -210,12 +214,12 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   }
 
   private def indexSeekByPrefixRange(index: IndexDescriptor, prefix: String): scala.Iterator[Node] = {
-    val indexedNodes = statement.readOperations().nodesGetFromIndexRangeSeekByPrefix(index, prefix)
+    val indexedNodes = _statement.readOperations().nodesGetFromIndexRangeSeekByPrefix(index, prefix)
     JavaConversionSupport.mapToScalaENFXSafe(indexedNodes)(nodeOps.getById)
   }
 
   private def indexSeekByNumericalRange(index: IndexDescriptor, range: InequalitySeekRange[Number]): scala.Iterator[Node] = {
-    val readOps = statement.readOperations()
+    val readOps = _statement.readOperations()
     val matchingNodes: PrimitiveLongIterator = (range match {
 
       case rangeLessThan: RangeLessThan[Number] =>
@@ -242,7 +246,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   }
 
   private def indexSeekByStringRange(index: IndexDescriptor, range: InequalitySeekRange[String]): scala.Iterator[Node] = {
-    val readOps = statement.readOperations()
+    val readOps = _statement.readOperations()
     val propertyKeyId = index.getPropertyKeyId
     val matchingNodes: PrimitiveLongIterator = range match {
 
@@ -271,59 +275,59 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   }
 
   def indexScan(index: IndexDescriptor) =
-    mapToScalaENFXSafe(statement.readOperations().nodesGetFromIndexScan(index))(nodeOps.getById)
+    mapToScalaENFXSafe(_statement.readOperations().nodesGetFromIndexScan(index))(nodeOps.getById)
 
   def lockingUniqueIndexSeek(index: IndexDescriptor, value: Any): Option[Node] = {
     indexSearchMonitor.lockingUniqueIndexSeek(index, value)
-    val nodeId = statement.readOperations().nodeGetFromUniqueIndexSeek(index, value)
+    val nodeId = _statement.readOperations().nodeGetFromUniqueIndexSeek(index, value)
     if (StatementConstants.NO_SUCH_NODE == nodeId) None else Some(nodeOps.getById(nodeId))
   }
 
   def removeLabelsFromNode(node: Long, labelIds: Iterator[Int]): Int = labelIds.foldLeft(0) {
     case (count, labelId) =>
-      if (statement.dataWriteOperations().nodeRemoveLabel(node, labelId)) count + 1 else count
+      if (_statement.dataWriteOperations().nodeRemoveLabel(node, labelId)) count + 1 else count
   }
 
   def getNodesByLabel(id: Int): Iterator[Node] =
-    JavaConversionSupport.mapToScalaENFXSafe(statement.readOperations().nodesGetForLabel(id))(nodeOps.getById)
+    JavaConversionSupport.mapToScalaENFXSafe(_statement.readOperations().nodesGetForLabel(id))(nodeOps.getById)
 
   def nodeGetDegree(node: Long, dir: SemanticDirection): Int =
-    statement.readOperations().nodeGetDegree(node, toGraphDb(dir))
+    _statement.readOperations().nodeGetDegree(node, toGraphDb(dir))
 
   def nodeGetDegree(node: Long, dir: SemanticDirection, relTypeId: Int): Int =
-    statement.readOperations().nodeGetDegree(node, toGraphDb(dir), relTypeId)
+    _statement.readOperations().nodeGetDegree(node, toGraphDb(dir), relTypeId)
 
-  override def nodeIsDense(node: Long): Boolean = statement.readOperations().nodeIsDense(node)
+  override def nodeIsDense(node: Long): Boolean = _statement.readOperations().nodeIsDense(node)
 
-  private def kernelStatement: KernelStatement =
+  private def kernelStatement: InternalKernelStatement =
     txBridge
       .getKernelTransactionBoundToThisThread(true)
       .acquireStatement()
-      .asInstanceOf[KernelStatement]
+      .asInstanceOf[InternalKernelStatement]
 
   class NodeOperations extends BaseOperations[Node] {
     def delete(obj: Node) {
-      statement.dataWriteOperations().nodeDelete(obj.getId)
+      _statement.dataWriteOperations().nodeDelete(obj.getId)
     }
 
     def propertyKeyIds(id: Long): Iterator[Int] =
-      JavaConversionSupport.asScala(statement.readOperations().nodeGetPropertyKeys(id))
+      JavaConversionSupport.asScala(_statement.readOperations().nodeGetPropertyKeys(id))
 
     def getProperty(id: Long, propertyKeyId: Int): Any = try {
-      statement.readOperations().nodeGetProperty(id, propertyKeyId)
+      _statement.readOperations().nodeGetProperty(id, propertyKeyId)
     } catch {
       case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => null
     }
 
     def hasProperty(id: Long, propertyKey: Int) =
-      statement.readOperations().nodeHasProperty(id, propertyKey)
+      _statement.readOperations().nodeHasProperty(id, propertyKey)
 
     def removeProperty(id: Long, propertyKeyId: Int) {
-      statement.dataWriteOperations().nodeRemoveProperty(id, propertyKeyId)
+      _statement.dataWriteOperations().nodeRemoveProperty(id, propertyKeyId)
     }
 
     def setProperty(id: Long, propertyKeyId: Int, value: Any) {
-      statement.dataWriteOperations().nodeSetProperty(id, properties.Property.property(propertyKeyId, value) )
+      _statement.dataWriteOperations().nodeSetProperty(id, properties.Property.property(propertyKeyId, value) )
     }
 
     def getById(id: Long) = try {
@@ -344,32 +348,32 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       kernelStatement.hasTxStateWithChanges && kernelStatement.txState().nodeIsDeletedInThisTx(n.getId)
 
     override def acquireExclusiveLock(obj: Long) =
-      statement.readOperations().acquireExclusive(ResourceTypes.NODE, obj)
+      _statement.readOperations().acquireExclusive(ResourceTypes.NODE, obj)
 
     override def releaseExclusiveLock(obj: Long) =
-      statement.readOperations().releaseExclusive(ResourceTypes.NODE, obj)
+      _statement.readOperations().releaseExclusive(ResourceTypes.NODE, obj)
   }
 
   class RelationshipOperations extends BaseOperations[Relationship] {
     def delete(obj: Relationship) {
-      statement.dataWriteOperations().relationshipDelete(obj.getId)
+      _statement.dataWriteOperations().relationshipDelete(obj.getId)
     }
 
     def propertyKeyIds(id: Long): Iterator[Int] =
-      asScala(statement.readOperations().relationshipGetPropertyKeys(id))
+      asScala(_statement.readOperations().relationshipGetPropertyKeys(id))
 
     def getProperty(id: Long, propertyKeyId: Int): Any =
-      statement.readOperations().relationshipGetProperty(id, propertyKeyId)
+      _statement.readOperations().relationshipGetProperty(id, propertyKeyId)
 
     def hasProperty(id: Long, propertyKey: Int) =
-      statement.readOperations().relationshipHasProperty(id, propertyKey)
+      _statement.readOperations().relationshipHasProperty(id, propertyKey)
 
     def removeProperty(id: Long, propertyKeyId: Int) {
-      statement.dataWriteOperations().relationshipRemoveProperty(id, propertyKeyId)
+      _statement.dataWriteOperations().relationshipRemoveProperty(id, propertyKeyId)
     }
 
     def setProperty(id: Long, propertyKeyId: Int, value: Any) {
-      statement.dataWriteOperations().relationshipSetProperty(id, properties.Property.property(propertyKeyId, value) )
+      _statement.dataWriteOperations().relationshipSetProperty(id, properties.Property.property(propertyKeyId, value) )
     }
 
     def getById(id: Long) = try {
@@ -390,14 +394,14 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       kernelStatement.hasTxStateWithChanges && kernelStatement.txState().relationshipIsDeletedInThisTx(r.getId)
 
     override def acquireExclusiveLock(obj: Long) =
-      statement.readOperations().acquireExclusive(ResourceTypes.RELATIONSHIP, obj)
+      _statement.readOperations().acquireExclusive(ResourceTypes.RELATIONSHIP, obj)
 
     override def releaseExclusiveLock(obj: Long) =
-      statement.readOperations().acquireExclusive(ResourceTypes.RELATIONSHIP, obj)
+      _statement.readOperations().acquireExclusive(ResourceTypes.RELATIONSHIP, obj)
   }
 
   def getOrCreatePropertyKeyId(propertyKey: String) =
-    statement.tokenWriteOperations().propertyKeyGetOrCreateForName(propertyKey)
+    _statement.tokenWriteOperations().propertyKeyGetOrCreateForName(propertyKey)
 
   abstract class BaseOperations[T <: PropertyContainer] extends Operations[T] {
     def primitiveLongIteratorToScalaIterator(primitiveIterator: PrimitiveLongIterator): Iterator[Long] =
@@ -412,53 +416,53 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     val javaCreator = new java.util.function.Function[K, V]() {
       def apply(key: K) = creator
     }
-    statement.readOperations().schemaStateGetOrCreate(key, javaCreator)
+    _statement.readOperations().schemaStateGetOrCreate(key, javaCreator)
   }
 
   def addIndexRule(labelId: Int, propertyKeyId: Int): IdempotentResult[IndexDescriptor] = try {
-    IdempotentResult(statement.schemaWriteOperations().indexCreate(labelId, propertyKeyId))
+    IdempotentResult(_statement.schemaWriteOperations().indexCreate(labelId, propertyKeyId))
   } catch {
     case _: AlreadyIndexedException =>
-      val indexDescriptor = statement.readOperations().indexesGetForLabelAndPropertyKey(labelId, propertyKeyId)
-      if(statement.readOperations().indexGetState(indexDescriptor) == InternalIndexState.FAILED)
+      val indexDescriptor = _statement.readOperations().indexesGetForLabelAndPropertyKey(labelId, propertyKeyId)
+      if(_statement.readOperations().indexGetState(indexDescriptor) == InternalIndexState.FAILED)
         throw new FailedIndexException(indexDescriptor.userDescription(tokenNameLookup))
      IdempotentResult(indexDescriptor, wasCreated = false)
   }
 
   def dropIndexRule(labelId: Int, propertyKeyId: Int) =
-    statement.schemaWriteOperations().indexDrop(new IndexDescriptor(labelId, propertyKeyId))
+    _statement.schemaWriteOperations().indexDrop(new IndexDescriptor(labelId, propertyKeyId))
 
   def createUniqueConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[UniquenessConstraint] = try {
-    IdempotentResult(statement.schemaWriteOperations().uniquePropertyConstraintCreate(labelId, propertyKeyId))
+    IdempotentResult(_statement.schemaWriteOperations().uniquePropertyConstraintCreate(labelId, propertyKeyId))
   } catch {
     case existing: AlreadyConstrainedException =>
       IdempotentResult(existing.constraint().asInstanceOf[UniquenessConstraint], wasCreated = false)
   }
 
   def dropUniqueConstraint(labelId: Int, propertyKeyId: Int) =
-    statement.schemaWriteOperations().constraintDrop(new UniquenessConstraint(labelId, propertyKeyId))
+    _statement.schemaWriteOperations().constraintDrop(new UniquenessConstraint(labelId, propertyKeyId))
 
   def createNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int): IdempotentResult[NodePropertyExistenceConstraint] =
     try {
-      IdempotentResult(statement.schemaWriteOperations().nodePropertyExistenceConstraintCreate(labelId, propertyKeyId))
+      IdempotentResult(_statement.schemaWriteOperations().nodePropertyExistenceConstraintCreate(labelId, propertyKeyId))
     } catch {
       case existing: AlreadyConstrainedException =>
         IdempotentResult(existing.constraint().asInstanceOf[NodePropertyExistenceConstraint], wasCreated = false)
     }
 
   def dropNodePropertyExistenceConstraint(labelId: Int, propertyKeyId: Int) =
-    statement.schemaWriteOperations().constraintDrop(new NodePropertyExistenceConstraint(labelId, propertyKeyId))
+    _statement.schemaWriteOperations().constraintDrop(new NodePropertyExistenceConstraint(labelId, propertyKeyId))
 
   def createRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int): IdempotentResult[RelationshipPropertyExistenceConstraint] =
     try {
-      IdempotentResult(statement.schemaWriteOperations().relationshipPropertyExistenceConstraintCreate(relTypeId, propertyKeyId))
+      IdempotentResult(_statement.schemaWriteOperations().relationshipPropertyExistenceConstraintCreate(relTypeId, propertyKeyId))
     } catch {
       case existing: AlreadyConstrainedException =>
         IdempotentResult(existing.constraint().asInstanceOf[RelationshipPropertyExistenceConstraint], wasCreated = false)
     }
 
   def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) =
-    statement.schemaWriteOperations().constraintDrop(new RelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
+    _statement.schemaWriteOperations().constraintDrop(new RelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
 
   override def getImportURL(url: URL): Either[String,URL] = graph match {
     case db: GraphDatabaseAPI =>
@@ -473,14 +477,14 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
 
   def relationshipEndNode(rel: Relationship) = rel.getEndNode
 
-  private val tokenNameLookup = new StatementTokenNameLookup(statement.readOperations())
+  private val tokenNameLookup = new StatementTokenNameLookup(_statement.readOperations())
 
   override def commitAndRestartTx() {
     tx.success()
     tx.close()
 
     tx = graph.beginTx()
-    statement = txBridge.get()
+    _statement = txBridge.get()
   }
 
   // Legacy dependency between kernel and compiler
@@ -514,18 +518,18 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   }
 
   def nodeCountByCountStore(labelId: Int): Long = {
-    statement.readOperations().countsForNode(labelId)
+    _statement.readOperations().countsForNode(labelId)
   }
 
   def relationshipCountByCountStore(startLabelId: Int, typeId: Int, endLabelId: Int): Long = {
-    statement.readOperations().countsForRelationship(startLabelId, typeId, endLabelId)
+    _statement.readOperations().countsForRelationship(startLabelId, typeId, endLabelId)
   }
 
   override def lockNodes(nodeIds: Long*) =
-    nodeIds.sorted.foreach(statement.readOperations().acquireExclusive(ResourceTypes.NODE, _))
+    nodeIds.sorted.foreach(_statement.readOperations().acquireExclusive(ResourceTypes.NODE, _))
 
   override def lockRelationships(relIds: Long*) =
-    relIds.sorted.foreach(statement.readOperations().acquireExclusive(ResourceTypes.RELATIONSHIP, _))
+    relIds.sorted.foreach(_statement.readOperations().acquireExclusive(ResourceTypes.RELATIONSHIP, _))
 }
 
 object TransactionBoundQueryContext {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundTokenContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundTokenContext.scala
@@ -24,49 +24,49 @@ import org.neo4j.kernel.api.Statement
 import org.neo4j.kernel.api.exceptions.{LabelNotFoundKernelException, PropertyKeyNotFoundException, RelationshipTypeNotFoundException}
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations
 
-abstract class TransactionBoundTokenContext(protected var statement: Statement) extends TokenContext {
+abstract class TransactionBoundTokenContext(protected var _statement: Statement) extends TokenContext {
   def getOptPropertyKeyId(propertyKeyName: String): Option[Int] = {
-    val propertyId: Int = statement.readOperations().propertyKeyGetForName(propertyKeyName)
+    val propertyId: Int = _statement.readOperations().propertyKeyGetForName(propertyKeyName)
     if (propertyId == KeyReadOperations.NO_SUCH_PROPERTY_KEY) None
     else Some(propertyId)
   }
 
   def getPropertyKeyId(propertyKeyName: String) = {
-    val propertyId: Int = statement.readOperations().propertyKeyGetForName(propertyKeyName)
+    val propertyId: Int = _statement.readOperations().propertyKeyGetForName(propertyKeyName)
     if (propertyId == KeyReadOperations.NO_SUCH_PROPERTY_KEY)
       throw new PropertyKeyNotFoundException("No such property.", null)
     propertyId
   }
 
-  def getPropertyKeyName(propertyKeyId: Int): String = statement.readOperations().propertyKeyGetName(propertyKeyId)
+  def getPropertyKeyName(propertyKeyId: Int): String = _statement.readOperations().propertyKeyGetName(propertyKeyId)
 
   def getLabelId(labelName: String): Int = {
-    val labelId: Int = statement.readOperations().labelGetForName(labelName)
+    val labelId: Int = _statement.readOperations().labelGetForName(labelName)
     if (labelId == KeyReadOperations.NO_SUCH_LABEL)
       throw new LabelNotFoundKernelException("No such label", null)
     labelId
   }
 
   def getOptLabelId(labelName: String): Option[Int] = {
-    val labelId: Int = statement.readOperations().labelGetForName(labelName)
+    val labelId: Int = _statement.readOperations().labelGetForName(labelName)
     if (labelId == KeyReadOperations.NO_SUCH_LABEL) None
     else Some(labelId)
   }
 
-  def getLabelName(labelId: Int): String = statement.readOperations().labelGetName(labelId)
+  def getLabelName(labelId: Int): String = _statement.readOperations().labelGetName(labelId)
 
   def getOptRelTypeId(relType: String): Option[Int] = {
-    val relTypeId: Int = statement.readOperations().relationshipTypeGetForName(relType)
+    val relTypeId: Int = _statement.readOperations().relationshipTypeGetForName(relType)
     if (relTypeId == KeyReadOperations.NO_SUCH_RELATIONSHIP_TYPE) None
     else Some(relTypeId)
   }
 
   def getRelTypeId(relType: String): Int = {
-    val relTypeId: Int = statement.readOperations().relationshipTypeGetForName(relType)
+    val relTypeId: Int = _statement.readOperations().relationshipTypeGetForName(relType)
     if (relTypeId == KeyReadOperations.NO_SUCH_RELATIONSHIP_TYPE)
       throw new RelationshipTypeNotFoundException("No such relationship.", null)
     relTypeId
   }
 
-  def getRelTypeName(id: Int): String = statement.readOperations().relationshipTypeGetName(id)
+  def getRelTypeName(id: Int): String = _statement.readOperations().relationshipTypeGetName(id)
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -105,7 +105,6 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
 
     CypherCompilerFactory.costBasedCompiler(
       graph,
-      new EntityAccessorWrapper3_0(nodeManager),
       CypherCompilerConfiguration(
         queryCacheSize = 128,
         statsDivergenceThreshold = 0.5,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher
 
-import org.neo4j.cypher.internal.compatibility.EntityAccessorWrapper3_0
 import org.neo4j.cypher.internal.compiler.v3_0.CypherCompilerConfiguration
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, CypherTestSupport}
@@ -29,7 +28,7 @@ import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundQueryContext.IndexSear
 import org.neo4j.graphdb._
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.kernel.api.{DataWriteOperations, KernelAPI}
-import org.neo4j.kernel.impl.core.{NodeManager, ThreadToStatementContextBridge}
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 import org.neo4j.kernel.{GraphDatabaseAPI, monitoring}
 import org.neo4j.test.TestGraphDatabaseFactory
 
@@ -236,6 +235,4 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
     useErrorsOverWarnings = false,
     nonIndexedLabelWarningThreshold = 10000
   )
-
-  def entityAccessor = new EntityAccessorWrapper3_0(graph.getDependencyResolver.resolveDependency(classOf[NodeManager]))
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -19,17 +19,19 @@
  */
 package org.neo4j.cypher
 
+import org.neo4j.cypher.internal.compatibility.EntityAccessorWrapper3_0
+import org.neo4j.cypher.internal.compiler.v3_0.CypherCompilerConfiguration
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.helpers.GraphIcing
 import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundPlanContext
+import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.graphdb._
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.kernel.api.{DataWriteOperations, KernelAPI}
-import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
+import org.neo4j.kernel.impl.core.{NodeManager, ThreadToStatementContextBridge}
 import org.neo4j.kernel.{GraphDatabaseAPI, monitoring}
 import org.neo4j.test.TestGraphDatabaseFactory
-import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundQueryContext.IndexSearchMonitor
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
@@ -226,4 +228,14 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
   def planContext: PlanContext = new TransactionBoundPlanContext(statement, graph)
 
   def indexSearchMonitor = kernelMonitors.newMonitor(classOf[IndexSearchMonitor])
+
+  val config = CypherCompilerConfiguration(
+    queryCacheSize = 100,
+    statsDivergenceThreshold = 0.5,
+    queryPlanTTL = 1000,
+    useErrorsOverWarnings = false,
+    nonIndexedLabelWarningThreshold = 10000
+  )
+
+  def entityAccessor = new EntityAccessorWrapper3_0(graph.getDependencyResolver.resolveDependency(classOf[NodeManager]))
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler
 
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.CypherCompiler.{CLOCK, DEFAULT_QUERY_PLAN_TTL, DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD}
-import org.neo4j.cypher.internal.compatibility.{EntityAccessorWrapper3_0, WrappedMonitors3_0}
+import org.neo4j.cypher.internal.compatibility.WrappedMonitors3_0
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v3_0.{CypherCompilerFactory, InfoLogger, _}
 import org.neo4j.cypher.internal.spi.v3_0.GeneratedQueryStructure
@@ -173,7 +173,6 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
 
     CypherCompilerFactory.costBasedCompiler(
       graph = graph,
-      new EntityAccessorWrapper3_0(nodeManager),
       CypherCompilerConfiguration(
         queryCacheSize = 1,
         statsDivergenceThreshold = DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
@@ -23,7 +23,7 @@ import java.io.{File, FileWriter}
 import java.text.NumberFormat
 import java.util.{Date, Locale}
 
-import org.neo4j.cypher.internal.compatibility.{EntityAccessorWrapper3_0, WrappedMonitors3_0}
+import org.neo4j.cypher.internal.compatibility.WrappedMonitors3_0
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_0.planner._
@@ -38,7 +38,6 @@ import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.factory.GraphDatabaseFactory
 import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseAPI
-import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.kernel.monitoring.{Monitors => KernelMonitors}
 
 import scala.xml.Elem
@@ -294,15 +293,13 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
       queryPlanner = queryPlanner,
       runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(clock, monitors), CompiledPlanBuilder(clock,GeneratedQueryStructure)),
       semanticChecker = checker,
-      entityAccessor = entityAccessor,
       config = config,
       updateStrategy = None
     )
     val pipeBuilder = new SilentFallbackPlanBuilder(new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer), planner,
                                                     planBuilderMonitor)
-    val nodeManager = graph.asInstanceOf[GraphDatabaseAPI].getDependencyResolver.resolveDependency(classOf[NodeManager])
     val execPlanBuilder =
-      new ExecutionPlanBuilder(graph, new EntityAccessorWrapper3_0(nodeManager), clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
+      new ExecutionPlanBuilder(graph, clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
     val planCacheFactory = () => new LRUCache[Statement, ExecutionPlan](100)
     val cacheHitMonitor = monitors.newMonitor[CypherCacheHitMonitor[Statement]](monitorTag)
     val cacheFlushMonitor =
@@ -319,9 +316,8 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val checker = new SemanticChecker
     val rewriter = new ASTRewriter(rewriterSequencer)
     val pipeBuilder = new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer)
-    val nodeManager = graph.asInstanceOf[GraphDatabaseAPI].getDependencyResolver.resolveDependency(classOf[NodeManager])
     val execPlanBuilder =
-      new ExecutionPlanBuilder(graph, new EntityAccessorWrapper3_0(nodeManager), clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
+      new ExecutionPlanBuilder(graph, clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
     val planCacheFactory = () => new LRUCache[Statement, ExecutionPlan](100)
     val cacheHitMonitor = monitors.newMonitor[CypherCacheHitMonitor[Statement]](monitorTag)
     val cacheFlushMonitor =

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
@@ -538,7 +538,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     db.withTx {
       tx =>
         val queryContext = new TransactionBoundQueryContext(db, tx, true, db.statement)(indexSearchMonitor)
-        val result = plan.run(queryContext, statement, ProfileMode, parameters)
+        val result = plan.run(queryContext, ProfileMode, parameters)
         (result.toList, result)
     }
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_0
 import java.util.concurrent.TimeUnit
 
 import org.neo4j.cypher.GraphDatabaseTestSupport
-import org.neo4j.cypher.internal.compatibility.{EntityAccessorWrapper3_0, StringInfoLogger3_0, WrappedMonitors3_0}
+import org.neo4j.cypher.internal.compatibility.{StringInfoLogger3_0, WrappedMonitors3_0}
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlan
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_0.ast.Statement
@@ -31,7 +31,6 @@ import org.neo4j.cypher.internal.spi.v3_0.GeneratedQueryStructure
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.helpers.{Clock, FrozenClock}
-import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.logging.AssertableLogProvider.inLog
 import org.neo4j.logging.{AssertableLogProvider, Log, NullLog}
 
@@ -40,11 +39,9 @@ import scala.collection.Map
 class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphDatabaseTestSupport {
   def createCompiler(queryCacheSize: Int = 128, statsDivergenceThreshold: Double = 0.5, queryPlanTTL: Long = 1000,
                      clock: Clock = Clock.SYSTEM_CLOCK, log: Log = NullLog.getInstance) = {
-    val nodeManager = graph.getDependencyResolver.resolveDependency(classOf[NodeManager])
-    val entityAccessor = new EntityAccessorWrapper3_0(nodeManager)
 
     CypherCompilerFactory.costBasedCompiler(
-      graph, entityAccessor,
+      graph,
       CypherCompilerConfiguration(
         queryCacheSize,
         statsDivergenceThreshold,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LabelActionTest.scala
@@ -187,4 +187,8 @@ class SnitchingQueryContext extends QueryContext {
   override def lockNodes(nodeIds: Long*): Unit = ???
 
   override def lockRelationships(relIds: Long*): Unit = ???
+
+  override type KernelStatement = this.type
+
+  override def statement: KernelStatement = ???
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LabelActionTest.scala
@@ -191,4 +191,8 @@ class SnitchingQueryContext extends QueryContext {
   override type KernelStatement = this.type
 
   override def statement: KernelStatement = ???
+
+  override type EntityAccessor = this.type
+
+  override def entityAccessor: EntityAccessor = ???
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
@@ -67,7 +67,7 @@ class RuleExecutablePlanBuilderTest
     plannerName = None,
     runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(Clock.SYSTEM_CLOCK, mock[Monitors]), CompiledPlanBuilder(Clock.SYSTEM_CLOCK,GeneratedQueryStructure)),
     semanticChecker = mock[SemanticChecker],
-    entityAccessor = entityAccessor,
+    entityAccessor = mock[EntityAccessor],
     updateStrategy = None,
     config = config
   )

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
@@ -55,6 +55,7 @@ class RuleExecutablePlanBuilderTest
   with Timed
   with MockitoSugar {
 
+
   val ast = mock[Statement]
   val rewriterSequencer = RewriterStepSequencer.newValidating _
   val queryPlanner = new DefaultQueryPlanner(LogicalPlanRewriter(rewriterSequencer))
@@ -66,8 +67,9 @@ class RuleExecutablePlanBuilderTest
     plannerName = None,
     runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(Clock.SYSTEM_CLOCK, mock[Monitors]), CompiledPlanBuilder(Clock.SYSTEM_CLOCK,GeneratedQueryStructure)),
     semanticChecker = mock[SemanticChecker],
-    useErrorsOverWarnings = false,
-    updateStrategy = None
+    entityAccessor = entityAccessor,
+    updateStrategy = None,
+    config = config
   )
 
   class FakePreparedQuery(q: AbstractQuery)
@@ -86,9 +88,9 @@ class RuleExecutablePlanBuilderTest
     val planContext = mock[PlanContext]
 
     val exception = intercept[ExecutionException](timeoutAfter(5) {
-      val pipeBuilder = new LegacyExecutablePlanBuilderWithCustomPlanBuilders(Seq(new BadBuilder), new WrappedMonitors3_0(kernelMonitors))
+      val pipeBuilder = new LegacyExecutablePlanBuilderWithCustomPlanBuilders(Seq(new BadBuilder), new WrappedMonitors3_0(kernelMonitors), config)
       val query = new FakePreparedQuery(q)
-      pipeBuilder.producePlan(query, planContext)
+      pipeBuilder.producePipe(query, planContext, CompilationPhaseTracer.NO_TRACING)
     })
 
     assertTrue("Execution plan builder didn't throw expected exception - was " + exception.getMessage,
@@ -108,14 +110,14 @@ class RuleExecutablePlanBuilderTest
         .updates(DeletePropertyAction(variable, PropertyKey("foo")))
         .returns(ReturnItem(Variable("x"), "x"))
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), RewriterStepSequencer.newValidating)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
       val queryContext = new TransactionBoundQueryContext(graph, tx, isTopLevelTx = true, statement)(indexSearchMonitor)
       val pkId = queryContext.getPropertyKeyId("foo")
       val parsedQ = new FakePreparedQuery(q)
 
       // when
 
-      val commands = pipeBuilder.producePlan(parsedQ, planContext).right.toOption.get.pipe.asInstanceOf[ExecuteUpdateCommandsPipe].commands
+      val commands = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe.asInstanceOf[ExecuteUpdateCommandsPipe].commands
 
       assertTrue("Property was not resolved", commands == Seq(DeletePropertyAction(variable, PropertyKey("foo", pkId))))
     } finally {
@@ -134,13 +136,13 @@ class RuleExecutablePlanBuilderTest
         .where(HasLabel(Variable("x"), Label("Person")))
         .returns(ReturnItem(Variable("x"), "x"))
 
-      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), RewriterStepSequencer.newValidating)
+      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
       val queryContext = new TransactionBoundQueryContext(graph, tx, isTopLevelTx = true, statement)(indexSearchMonitor)
       val labelId = queryContext.getLabelId("Person")
       val parsedQ = new FakePreparedQuery(q)
 
       // when
-      val predicate = execPlanBuilder.producePlan(parsedQ, planContext).right.toOption.get.pipe.asInstanceOf[FilterPipe].predicate
+      val predicate = execPlanBuilder.producePipe(parsedQ, planContext,CompilationPhaseTracer.NO_TRACING).pipe.asInstanceOf[FilterPipe].predicate
 
       assertTrue("Label was not resolved", predicate == HasLabel(Variable("x"), Label("Person", labelId)))
     } finally {
@@ -164,8 +166,8 @@ class RuleExecutablePlanBuilderTest
         .returns(AllVariables())
       val parsedQ = new FakePreparedQuery(q)
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), RewriterStepSequencer.newValidating)
-      val pipe = pipeBuilder.producePlan(parsedQ, planContext).right.toOption.get.pipe
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
+      val pipe = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
         classOf[EmptyResultPipe],
@@ -192,8 +194,8 @@ class RuleExecutablePlanBuilderTest
         .returns(AllVariables())
       val parsedQ = new FakePreparedQuery(q)
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), RewriterStepSequencer.newValidating)
-      val pipe = pipeBuilder.producePlan(parsedQ, planContext).right.toOption.get.pipe
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
+      val pipe = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
         classOf[EmptyResultPipe],
@@ -219,8 +221,8 @@ class RuleExecutablePlanBuilderTest
       val parsedQ = new FakePreparedQuery(q)
 
 
-      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), RewriterStepSequencer.newValidating)
-      val pipe = execPlanBuilder.producePlan(parsedQ, planContext).right.toOption.get.pipe
+      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
+      val pipe = execPlanBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
         classOf[EmptyResultPipe],
@@ -243,10 +245,10 @@ class RuleExecutablePlanBuilderTest
       )
       val parsedQ = new FakePreparedQuery(q)
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), RewriterStepSequencer.newValidating)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
 
       // when
-      val periodicCommit = pipeBuilder.producePlan(parsedQ, planContext).right.toOption.get.periodicCommit
+      val periodicCommit = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).periodicCommit
 
       assert(periodicCommit === Some(PeriodicCommitInfo(None)))
     } finally {
@@ -255,7 +257,7 @@ class RuleExecutablePlanBuilderTest
   }
 }
 
-class LegacyExecutablePlanBuilderWithCustomPlanBuilders(innerBuilders: Seq[PlanBuilder], monitors:Monitors) extends LegacyExecutablePlanBuilder(monitors, RewriterStepSequencer.newValidating) {
+class LegacyExecutablePlanBuilderWithCustomPlanBuilders(innerBuilders: Seq[PlanBuilder], monitors:Monitors, config: CypherCompilerConfiguration) extends LegacyExecutablePlanBuilder(monitors, config, RewriterStepSequencer.newValidating) {
   override val phases = new Phase { def myBuilders: Seq[PlanBuilder] = innerBuilders }
 }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
@@ -67,7 +67,6 @@ class RuleExecutablePlanBuilderTest
     plannerName = None,
     runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(Clock.SYSTEM_CLOCK, mock[Monitors]), CompiledPlanBuilder(Clock.SYSTEM_CLOCK,GeneratedQueryStructure)),
     semanticChecker = mock[SemanticChecker],
-    entityAccessor = mock[EntityAccessor],
     updateStrategy = None,
     config = config
   )

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGeneratorTest.scala
@@ -29,6 +29,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlanBuilde
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InternalExecutionResult
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.compiler.v3_0.{CostBasedPlannerName, NormalMode, TaskCloser}
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
@@ -847,10 +848,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   private def compileAndExecute(plan: LogicalPlan, params: Map[String, AnyRef] = Map.empty, taskCloser: TaskCloser = new TaskCloser) = {
     compile(plan).
 
-
-
-
-    executionResultBuilder(statement, new EntityAccessorWrapper3_0(nodeManager), NormalMode, tracer(NormalMode), params, taskCloser)
+    executionResultBuilder(queryContext, new EntityAccessorWrapper3_0(nodeManager), NormalMode, tracer(NormalMode), params, taskCloser)
   }
 
   /*
@@ -903,8 +901,10 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
     16L -> RelationshipData(hNode, iNode, 16L, 3),
     17L -> RelationshipData(iNode, hNode, 17L, 3))
 
+  val queryContext = mock[QueryContext]
   val ro = mock[ReadOperations]
   val statement = mock[org.neo4j.kernel.api.Statement]
+  when(queryContext.statement).thenReturn(statement.asInstanceOf[queryContext.KernelStatement])
   when(statement.readOperations()).thenReturn(ro)
   when(ro.nodesGetAll()).thenAnswer(new Answer[PrimitiveLongIterator] {
     override def answer(invocationOnMock: InvocationOnMock): PrimitiveLongIterator = primitiveIterator(allNodes.map(_.getId))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGeneratorTest.scala
@@ -24,7 +24,6 @@ import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.collection.primitive.PrimitiveLongIterator
-import org.neo4j.cypher.internal.compatibility.EntityAccessorWrapper3_0
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlanBuilder.tracer
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InternalExecutionResult
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport
@@ -848,7 +847,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   private def compileAndExecute(plan: LogicalPlan, params: Map[String, AnyRef] = Map.empty, taskCloser: TaskCloser = new TaskCloser) = {
     compile(plan).
 
-    executionResultBuilder(queryContext, new EntityAccessorWrapper3_0(nodeManager), NormalMode, tracer(NormalMode), params, taskCloser)
+    executionResultBuilder(queryContext, NormalMode, tracer(NormalMode), params, taskCloser)
   }
 
   /*
@@ -901,10 +900,25 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
     16L -> RelationshipData(hNode, iNode, 16L, 3),
     17L -> RelationshipData(iNode, hNode, 17L, 3))
 
+  val nodeManager = mock[NodeManager]
+  when(nodeManager.newNodeProxyById(anyLong())).thenAnswer(new Answer[Node]() {
+    override def answer(invocationOnMock: InvocationOnMock): NodeProxy = {
+      val id = invocationOnMock.getArguments.apply(0).asInstanceOf[Long].toInt
+      allNodes(id)
+    }
+  })
+  when(nodeManager.newRelationshipProxyById(anyLong())).thenAnswer(new Answer[Relationship]() {
+    override def answer(invocationOnMock: InvocationOnMock): RelationshipProxy = {
+      val id = invocationOnMock.getArguments.apply(0).asInstanceOf[Long].toInt
+      relMap(id).relationship
+    }
+  })
+
   val queryContext = mock[QueryContext]
   val ro = mock[ReadOperations]
   val statement = mock[org.neo4j.kernel.api.Statement]
   when(queryContext.statement).thenReturn(statement.asInstanceOf[queryContext.KernelStatement])
+  when(queryContext.entityAccessor).thenReturn(nodeManager.asInstanceOf[queryContext.EntityAccessor])
   when(statement.readOperations()).thenReturn(ro)
   when(ro.nodesGetAll()).thenAnswer(new Answer[PrimitiveLongIterator] {
     override def answer(invocationOnMock: InvocationOnMock): PrimitiveLongIterator = primitiveIterator(allNodes.map(_.getId))
@@ -967,20 +981,6 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
       }.head
       label.exists(l => nodesForLabel.contains(l) && nodesForLabel(l).exists(_.getId == nodeId)
       )
-    }
-  })
-
-  val nodeManager = mock[NodeManager]
-  when(nodeManager.newNodeProxyById(anyLong())).thenAnswer(new Answer[Node]() {
-    override def answer(invocationOnMock: InvocationOnMock): NodeProxy = {
-      val id = invocationOnMock.getArguments.apply(0).asInstanceOf[Long].toInt
-      allNodes(id)
-    }
-  })
-  when(nodeManager.newRelationshipProxyById(anyLong())).thenAnswer(new Answer[Relationship]() {
-    override def answer(invocationOnMock: InvocationOnMock): RelationshipProxy = {
-      val id = invocationOnMock.getArguments.apply(0).asInstanceOf[Long].toInt
-      relMap(id).relationship
     }
   })
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/ir/BuildProbeTableInstructionsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/ir/BuildProbeTableInstructionsTest.scala
@@ -27,8 +27,9 @@ import org.mockito.stubbing.Answer
 import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.{CodeGenContext, JoinTableMethod, Variable}
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.EntityAccessor
-import org.neo4j.cypher.internal.frontend.v3_0.{SemanticTable, symbols}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_0.{SemanticTable, symbols}
 import org.neo4j.graphdb.Node
 import org.neo4j.kernel.api.{ReadOperations, Statement}
 
@@ -42,12 +43,14 @@ class BuildProbeTableInstructionsTest extends CypherFunSuite with CodeGenSugar {
 
   private val entityAccessor = mock[EntityAccessor]
   private val statement = mock[Statement]
+  private val queryContext = mock[QueryContext]
   private val readOps = mock[ReadOperations]
   private val allNodeIds = mutable.ArrayBuffer[Long]()
 
   // used by instructions that generate probe tables
   private implicit val codeGenContext = new CodeGenContext(SemanticTable(), Map.empty)
 
+  when(queryContext.statement).thenReturn(statement.asInstanceOf[queryContext.KernelStatement])
   when(statement.readOperations()).thenReturn(readOps)
   when(readOps.nodesGetAll()).then(new Answer[PrimitiveLongIterator] {
     def answer(invocation: InvocationOnMock) = allNodeIdsIterator()
@@ -163,7 +166,7 @@ class BuildProbeTableInstructionsTest extends CypherFunSuite with CodeGenSugar {
   private def runTest(buildInstruction: BuildProbeTable, nodes: Set[Variable]): List[Map[String, Object]] = {
     val instructions = buildProbeTableWithTwoAllNodeScans(buildInstruction, nodes)
     val ids = instructions.flatMap(_.allOperatorIds.map(id => id -> null)).toMap
-    evaluate(instructions, statement, entityAccessor, Seq(resultRowKey), Map.empty[String, Object], ids)
+    evaluate(instructions, queryContext, entityAccessor, Seq(resultRowKey), Map.empty[String, Object], ids)
   }
 
   private def buildProbeTableWithTwoAllNodeScans(buildInstruction: BuildProbeTable, nodes: Set[Variable]): Seq[Instruction] = {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/ir/CodeGenSugar.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/ir/CodeGenSugar.scala
@@ -28,10 +28,11 @@ import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlanBuilde
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.{Id, InternalPlanDescription}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
-import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, PlanContext}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, PlanContext, QueryContext}
 import org.neo4j.cypher.internal.compiler.v3_0.{CostBasedPlannerName, ExecutionMode, NormalMode, TaskCloser}
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticTable
-import org.neo4j.cypher.internal.spi.v3_0.GeneratedQueryStructure
+import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundQueryContext.IndexSearchMonitor
+import org.neo4j.cypher.internal.spi.v3_0.{GeneratedQueryStructure, TransactionBoundQueryContext}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
 import org.neo4j.helpers.Clock
@@ -70,7 +71,8 @@ trait CodeGenSugar extends MockitoSugar {
       val statement = graphDb.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge]).get()
       val nodeManager =
         graphDb.asInstanceOf[GraphDatabaseAPI].getDependencyResolver.resolveDependency(classOf[NodeManager])
-      val result = plan.executionResultBuilder(statement, new EntityAccessorWrapper3_0(nodeManager), mode,
+      val queryContext = new TransactionBoundQueryContext(graphDb, tx, true, statement)(mock[IndexSearchMonitor])
+      val result = plan.executionResultBuilder(queryContext, new EntityAccessorWrapper3_0(nodeManager), mode,
         tracer(mode), params, taskCloser)
       tx.success()
       result.size
@@ -81,13 +83,13 @@ trait CodeGenSugar extends MockitoSugar {
   }
 
   def evaluate(instructions: Seq[Instruction],
-               stmt: Statement = mock[Statement],
+               qtx: QueryContext = mockQueryContext(),
                entityAccessor: EntityAccessor = null,
                columns: Seq[String] = Seq.empty,
                params: Map[String, AnyRef] = Map.empty,
                operatorIds: Map[String, Id] = Map.empty): List[Map[String, Object]] = {
     val clazz = compile(instructions, columns,  operatorIds)
-    val result = newInstance(clazz, statement = stmt, entityAccessor = entityAccessor, params = params)
+    val result = newInstance(clazz, queryContext = qtx, entityAccessor = entityAccessor, params = params)
     evaluate(result)
   }
 
@@ -113,19 +115,27 @@ trait CodeGenSugar extends MockitoSugar {
 
   def newInstance(clazz: GeneratedQuery,
                   taskCloser: TaskCloser = new TaskCloser,
-                  statement: Statement = mock[Statement],
+                  queryContext: QueryContext = mockQueryContext(),
                   graphdb: GraphDatabaseService = null,
                   entityAccessor: EntityAccessor = null,
                   executionMode: ExecutionMode = null,
                   provider: Provider[InternalPlanDescription] = null,
                   queryExecutionTracer: QueryExecutionTracer = QueryExecutionTracer.NONE,
                   params: Map[String, AnyRef] = Map.empty): InternalExecutionResult = {
-    val generated = clazz.execute(taskCloser, statement, entityAccessor,
+    val generated = clazz.execute(taskCloser, queryContext,  entityAccessor,
       executionMode, provider, queryExecutionTracer, JavaConversions.mapAsJavaMap(params))
-    new CompiledExecutionResult(taskCloser, statement, generated, provider)
+    new CompiledExecutionResult(taskCloser, queryContext, generated, provider)
   }
 
   def insertStatic(clazz: Class[GeneratedQueryExecution], mappings: (String, Id)*) = mappings.foreach {
     case (name, id) => setStaticField(clazz, name, id)
+  }
+
+  private def mockQueryContext() = {
+    val qc = mock[QueryContext]
+    val statement = mock[Statement]
+    when(qc.statement).thenReturn(statement.asInstanceOf[qc.KernelStatement])
+
+    qc
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/ir/CompiledProfilingTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/ir/CompiledProfilingTest.scala
@@ -31,6 +31,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.planDescription._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Cardinality, plans}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_0.ast.SignedDecimalIntegerLiteral
 import org.neo4j.cypher.internal.frontend.v3_0.symbols
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
@@ -53,6 +54,8 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
       Seq("n"), Map("OP1" -> id1, "OP2" -> id2, "X" -> new Id()))
 
     val statement = mock[Statement]
+    val queryContext = mock[QueryContext]
+    when(queryContext.statement).thenReturn(statement.asInstanceOf[queryContext.KernelStatement])
     val readOps = mock[ReadOperations]
     val entityAccessor = mock[EntityAccessor]
     when(entityAccessor.newNodeProxyById(anyLong())).thenReturn(mock[Node])
@@ -75,7 +78,7 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
 
     // when
     val tracer = new ProfilingTracer()
-    newInstance(compiled, statement = statement, entityAccessor = entityAccessor, provider = provider, queryExecutionTracer = tracer).size
+    newInstance(compiled, queryContext = queryContext, entityAccessor = entityAccessor, provider = provider, queryExecutionTracer = tracer).size
 
     // then
     tracer.dbHitsOf(id1) should equal(3)


### PR DESCRIPTION
- Refactor how executable plans are constructed, remove `Either[Interpreted, Compiled]` instead construct `ExecutionPlan` directly.
- Compiled plan are not explicitly dependent on kernel statements
- Provide direct access to `NodeManager` without wrapping it.
