### PR TITLE
Add CamelCase support to Cypher.

### DIFF
--- a/community/cypher/compatibility-suite/src/test/resources/cypher/ReturnAcceptance.feature
+++ b/community/cypher/compatibility-suite/src/test/resources/cypher/ReturnAcceptance.feature
@@ -198,3 +198,36 @@ Feature: ReturnAcceptanceTest
       | [({foo: 3})] |
       | []           |
       | []           |
+
+  Scenario: lower should transform string to lowercase
+    Given using: cineast
+    When running: Match (a:Movie) WHERE a.title contains 'Window' RETURN lower(a.title) as title
+    Then result:
+      | title |
+      | hitchhiker: windows |
+      | rear window |
+      | rear window |
+      | secret window |
+      | the woman in the window |
+
+  Scenario: upper should transform string to uppercase
+    Given using: cineast
+    When running: Match (a:Movie) WHERE a.title contains 'Window' RETURN upper(a.title) as title
+    Then result:
+      | title |
+      | HITCHHIKER: WINDOWS |
+      | REAR WINDOW |
+      | REAR WINDOW |
+      | SECRET WINDOW |
+      | THE WOMAN IN THE WINDOW |
+
+  Scenario: camelCast should transform string to camel case
+    Given using: cineast
+    When running: Match (a:Movie) WHERE a.title contains 'Window' RETURN camelCase(lower(a.title)) as title
+    Then result:
+      | title |
+      | Hitchhiker: Windows |
+      | Rear Window |
+      | Rear Window |
+      | Secret Window |
+      | The Woman In The Window |

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/ExpressionConverters.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/convert/commands/ExpressionConverters.scala
@@ -52,6 +52,7 @@ object ExpressionConverters {
           commandexpressions.Distinct(command, inner)
         else
           command
+      case CamelCase => commandexpressions.CamelCaseFunction(toCommandExpression(invocation.arguments.head))
       case Ceil => commandexpressions.CeilFunction(toCommandExpression(invocation.arguments.head))
       case Coalesce => commandexpressions.CoalesceFunction(toCommandExpression(invocation.arguments): _*)
       case Collect =>

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/StringFunctionsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/commands/expressions/StringFunctionsTest.scala
@@ -95,6 +95,19 @@ class StringFunctionsTest extends CypherFunSuite {
     intercept[CypherTypeException](lower(1024) should equal(expectedNull))
   }
 
+  test("camelCaseTests") {
+    def camelCase(x: Any) = CamelCaseFunction(Literal(x))(ExecutionContext.empty)(QueryStateHelper.empty)
+
+    camelCase("test") should equal("Test")
+    camelCase("TEST") should equal("Test")
+    camelCase("a STRING with multiple words and 3 numbers and '2' signs") should equal("A String With Multiple Words And 3 Numbers And '2' Signs")
+    camelCase("""leave strings in 'SINGLE' or "doUBle" quotes untouched""") should equal("""Leave Strings In 'SINGLE' Or "doUBle" Quotes Untouched""")
+    intercept[CypherTypeException](camelCase(1024) should equal(expectedNull))
+    camelCase("") should equal("")
+    camelCase(" ") should equal("")
+    camelCase(null) should be(null.asInstanceOf[String])
+  }
+
   test("upperTests") {
     def upper(x: Any) = UpperFunction(Literal(x))(ExecutionContext.empty)(QueryStateHelper.empty)
 

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Function.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/Function.scala
@@ -30,6 +30,7 @@ object Function {
     functions.Atan,
     functions.Atan2,
     functions.Avg,
+    functions.CamelCase,
     functions.Ceil,
     functions.Coalesce,
     functions.Collect,

--- a/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/functions/CamelCase.scala
+++ b/community/cypher/frontend-2.3/src/main/scala/org/neo4j/cypher/internal/frontend/v2_3/ast/functions/CamelCase.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.frontend.v2_3.ast.functions
+
+import org.neo4j.cypher.internal.frontend.v2_3.ast.{Function, SimpleTypedFunction}
+import org.neo4j.cypher.internal.frontend.v2_3.symbols._
+
+case object CamelCase extends Function with SimpleTypedFunction {
+  def name = "camelCase"
+
+  val signatures = Vector(
+    Signature(argumentTypes = Vector(CTString), outputType = CTString)
+  )
+}


### PR DESCRIPTION
Extended Cypher by adding a 'camelCase' String Function which changes each word in a string so the word starts with a capital char and all others to lower case. Words with non-abc-characters, like quotes and numbers, are left as-is.
E.g. "some STRING with 'wORds' in quotes" becomes "Some String With 'wORds' In Quotes"

These changes were made on top of 2.3 branch.
I also got chances ready for 3.0 branch but not made a PR yet awaiting this PR.
