### PR TITLE
Bolt rejects nodes, rels, paths as parameters

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -211,6 +211,7 @@ public class Neo4jPack
                 }
             }
         }
+
         // TODO: combine these
         public void packProperties( PropertyContainer entity ) throws IOException
         {
@@ -223,7 +224,6 @@ public class Neo4jPack
             }
         }
     }
-
 
     public static class Unpacker extends PackStream.Unpacker
     {
@@ -265,25 +265,25 @@ public class Neo4jPack
                     char signature = unpackStructSignature();
                     switch ( signature )
                     {
-                        case NODE:
-                        {
-                            return ValueNode.unpackFields( this );
-                        }
-                        case RELATIONSHIP:
-                        {
-                            return ValueRelationship.unpackFields( this );
-                        }
-                        case UNBOUND_RELATIONSHIP:
-                        {
-                            return ValueUnboundRelationship.unpackFields( this );
-                        }
-                        case PATH:
-                        {
-                            return pathUnpacker.unpackFields( this );
-                        }
-                        default:
-                            throw new BoltIOException( Status.Request.InvalidFormat,
-                                    "Unknown struct type: " + Integer.toHexString(signature) );
+                    case NODE:
+                    {
+                        throw new BoltIOException( Status.Request.Invalid, "Nodes cannot be unpacked." );
+                    }
+                    case RELATIONSHIP:
+                    {
+                        throw new BoltIOException( Status.Request.Invalid, "Relationships cannot be unpacked." );
+                    }
+                    case UNBOUND_RELATIONSHIP:
+                    {
+                        throw new BoltIOException( Status.Request.Invalid, "Relationships cannot be unpacked." );
+                    }
+                    case PATH:
+                    {
+                        throw new BoltIOException( Status.Request.Invalid, "Paths cannot be unpacked." );
+                    }
+                    default:
+                        throw new BoltIOException( Status.Request.InvalidFormat,
+                                "Unknown struct type: " + Integer.toHexString( signature ) );
                     }
                 }
                 case END_OF_STREAM:

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/PackStreamMessageFormatV1.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/PackStreamMessageFormatV1.java
@@ -163,7 +163,7 @@ public class PackStreamMessageFormatV1 implements MessageFormat
 
             packer.pack( "message" );
             packer.pack( message );
-            
+
             onMessageComplete.onMessageComplete();
         }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/CypherAdapterStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/CypherAdapterStream.java
@@ -61,14 +61,9 @@ public class CypherAdapterStream implements RecordStream
     @Override
     public void accept( final Visitor visitor ) throws Exception
     {
-        delegate.accept( new Result.ResultVisitor<Exception>()
-        {
-            @Override
-            public boolean visit( Result.ResultRow row ) throws Exception
-            {
-                visitor.visit( currentRecord.reset( row ) );
-                return true;
-            }
+        delegate.accept( row -> {
+            visitor.visit( currentRecord.reset( row ) );
+            return true;
         } );
 
         QueryExecutionType qt = delegate.getQueryExecutionType();

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
@@ -25,9 +25,7 @@ import java.util.UUID;
 import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.runtime.spi.RecordStream;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.logging.LogService;
@@ -53,7 +51,7 @@ public class SessionStateMachine implements Session, SessionState
         /**
          * Before the session has been initialized.
          */
-        UNITIALIZED
+        UNINITIALIZED
                 {
                     @Override
                     public State init( SessionStateMachine ctx, String clientName )
@@ -424,7 +422,7 @@ public class SessionStateMachine implements Session, SessionState
     };
 
     /** The current session state */
-    private State state = State.UNITIALIZED;
+    private State state = State.UNINITIALIZED;
 
     /** The current pending result, if present */
     private RecordStream currentResult;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
@@ -31,9 +31,7 @@ import java.util.Map;
 import org.neo4j.bolt.v1.packstream.PackedInputArray;
 import org.neo4j.bolt.v1.packstream.PackedOutputArray;
 import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
-import org.neo4j.graphdb.Relationship;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -41,7 +39,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.bolt.v1.messaging.example.Nodes.ALICE;
 import static org.neo4j.bolt.v1.messaging.example.Paths.ALL_PATHS;
 import static org.neo4j.bolt.v1.messaging.example.Relationships.ALICE_KNOWS_BOB;
-import static org.neo4j.bolt.v1.messaging.example.Support.labels;
 
 public class Neo4jPackTest
 {
@@ -127,55 +124,32 @@ public class Neo4jPackTest
     }
 
     @Test
-    public void shouldBeAbleToPackAndUnpackNode() throws IOException
+    public void shouldNotBeAbleToUnpackNode() throws IOException
     {
-        // Given
-        Object unpacked = unpacked( packed( ALICE ) );
-
-        // Then
-        assertThat( unpacked, instanceOf( Node.class ) );
-        Node unpackedNode = (Node) unpacked;
-        assertThat( unpackedNode.getId(), equalTo( ALICE.getId() ) );
-        assertThat( labels( unpackedNode ), equalTo( labels( ALICE ) ) );
-        assertThat( unpackedNode.getAllProperties(), equalTo( ALICE.getAllProperties() ) );
+        // Expect
+        exception.expect( BoltIOException.class );
+        // When
+        unpacked( packed( ALICE ) );
     }
 
     @Test
-    public void shouldBeAbleToPackAndUnpackRelationship() throws IOException
+    public void shouldNotBeAbleToUnpackRelationship() throws IOException
     {
-        // Given
-        Object unpacked = unpacked( packed( ALICE_KNOWS_BOB ) );
-
-        // Then
-        assertThat( unpacked, instanceOf( Relationship.class ) );
-        Relationship unpackedRelationship = (Relationship) unpacked;
-        assertThat( unpackedRelationship.getId(), equalTo( ALICE_KNOWS_BOB.getId() ) );
-        assertThat( unpackedRelationship.getStartNode().getId(),
-                equalTo( ALICE_KNOWS_BOB.getStartNode().getId() ) );
-        assertThat( unpackedRelationship.getEndNode().getId(),
-                equalTo( ALICE_KNOWS_BOB.getEndNode().getId() ) );
-        assertThat( unpackedRelationship.getType().name(),
-                equalTo( ALICE_KNOWS_BOB.getType().name() ) );
-        assertThat( unpackedRelationship.getAllProperties(),
-                equalTo( ALICE_KNOWS_BOB.getAllProperties() ) );
+        // Expect
+        exception.expect( BoltIOException.class );
+        // When
+        unpacked( packed( ALICE_KNOWS_BOB ) );
     }
 
     @Test
-    public void shouldBeAbleToPackAndUnpackPaths() throws IOException
+    public void shouldNotBeAbleToUnpackPaths() throws IOException
     {
         for ( Path path : ALL_PATHS )
         {
-            System.out.println(path);
-
-            // Given
-            Object unpacked = unpacked( packed( path ) );
-
-            // Then
-            assertThat( unpacked, instanceOf( Path.class ) );
-            Path unpackedPath = (Path) unpacked;
-            assertThat( unpackedPath, equalTo( path ) );
-
+            // Expect
+            exception.expect( BoltIOException.class );
+            // When
+            unpacked( packed( path ) );
         }
     }
-
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionIT.java
@@ -42,7 +42,6 @@ import org.neo4j.kernel.api.exceptions.Status;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.failedWith;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.streamContaining;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.success;
@@ -65,7 +64,7 @@ public class SessionIT
         session.init( "TestClient/1.0", null, null );
 
         // When
-        session.run( "", Collections.<String,Object>emptyMap(), null, responses );
+        session.run( "", EMPTY_PARAMS, null, responses );
 
         // Then
         assertThat( responses.next(), failedWith( Status.Statement.InvalidSyntax ) );
@@ -79,7 +78,7 @@ public class SessionIT
         session.init( "TestClient/1.0", null, null );
 
         // When
-        session.run( "CREATE (n {k:'k'}) RETURN n.k", Collections.<String,Object>emptyMap(), null, responses );
+        session.run( "CREATE (n {k:'k'}) RETURN n.k", EMPTY_PARAMS, null, responses );
 
         // Then
         assertThat( responses.next(), success() );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineTest.java
@@ -64,7 +64,7 @@ public class SessionStateMachineTest
     public void initialStateShouldBeUninitalized()
     {
         // When & Then
-        assertThat( machine.state(), CoreMatchers.equalTo( SessionStateMachine.State.UNITIALIZED ) );
+        assertThat( machine.state(), CoreMatchers.equalTo( SessionStateMachine.State.UNINITIALIZED ) );
     }
 
     @Test


### PR DESCRIPTION
When encountering a node, relationship or path as parameter Bolt now throws an exception.
