### PR TITLE
Ability to import > 2.4 billion nodes in import tool

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/MemoryUsageStatsProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/MemoryUsageStatsProvider.java
@@ -33,9 +33,9 @@ import static org.neo4j.helpers.Format.bytes;
  */
 public class MemoryUsageStatsProvider extends GenericStatsProvider implements Stat
 {
-    private final MemoryStatsVisitor.Home[] users;
+    private final MemoryStatsVisitor.Visitable[] users;
 
-    public MemoryUsageStatsProvider( MemoryStatsVisitor.Home... users )
+    public MemoryUsageStatsProvider( MemoryStatsVisitor.Visitable... users )
     {
         this.users = users;
         add( Keys.memory_usage, this );
@@ -51,7 +51,7 @@ public class MemoryUsageStatsProvider extends GenericStatsProvider implements St
     public long asLong()
     {
         GatheringMemoryStatsVisitor visitor = new GatheringMemoryStatsVisitor();
-        for ( MemoryStatsVisitor.Home user : users )
+        for ( MemoryStatsVisitor.Visitable user : users )
         {
             user.acceptMemoryStatsVisitor( visitor );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
@@ -33,7 +33,7 @@ public class Utils
     {
         if ( value > Integer.MAX_VALUE )
         {
-            throw new ArithmeticException( getOverflowMessage( value, Integer.class ) );
+            throw new ArithmeticException( getOverflowMessage( value, Integer.TYPE ) );
         }
         return (int) value;
     }
@@ -42,7 +42,7 @@ public class Utils
     {
         if ( value > Short.MAX_VALUE )
         {
-            throw new ArithmeticException( getOverflowMessage( value, Short.class ) );
+            throw new ArithmeticException( getOverflowMessage( value, Short.TYPE ) );
         }
         return (short) value;
     }
@@ -51,7 +51,7 @@ public class Utils
     {
         if ( value > Byte.MAX_VALUE )
         {
-            throw new ArithmeticException( getOverflowMessage( value, Byte.class ) );
+            throw new ArithmeticException( getOverflowMessage( value, Byte.TYPE ) );
         }
         return (byte) value;
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
@@ -24,7 +24,7 @@ package org.neo4j.unsafe.impl.batchimport.cache;
  */
 public interface MemoryStatsVisitor
 {
-    interface Home
+    interface Visitable
     {
         void acceptMemoryStatsVisitor( MemoryStatsVisitor visitor );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCache.java
@@ -30,7 +30,7 @@ import static org.neo4j.kernel.impl.util.Bits.bitsFromLongs;
  * Caches labels for each node. Tries to keep memory as 8b (a long) per node. If a particular node has many labels
  * it will spill over into two or more longs in a separate array.
  */
-public class NodeLabelsCache implements MemoryStatsVisitor.Home
+public class NodeLabelsCache implements MemoryStatsVisitor.Visitable
 {
     public static class Client
     {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
@@ -27,7 +27,7 @@ import org.neo4j.graphdb.Direction;
  * Caches of parts of node store and relationship group store. A crucial part of batch import where
  * any random access must be covered by this cache. All I/O, both read and write must be sequential.
  */
-public class NodeRelationshipCache implements MemoryStatsVisitor.Home
+public class NodeRelationshipCache implements MemoryStatsVisitor.Visitable
 {
     private static final long EMPTY = -1;
 
@@ -181,7 +181,7 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Home
         }
     };
 
-    private static class RelGroupCache implements AutoCloseable, MemoryStatsVisitor.Home
+    private static class RelGroupCache implements AutoCloseable, MemoryStatsVisitor.Visitable
     {
         private static final int ENTRY_SIZE = 4;
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
@@ -24,7 +24,7 @@ package org.neo4j.unsafe.impl.batchimport.cache;
  *
  * @see NumberArrayFactory
  */
-public interface NumberArray extends MemoryStatsVisitor.Home, AutoCloseable
+public interface NumberArray extends MemoryStatsVisitor.Visitable, AutoCloseable
 {
     /**
      * @return length of the array, i.e. the capacity.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
@@ -31,7 +31,7 @@ import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
  * Maps node ids as specified by {@link InputNode#id()}, {@link InputRelationship#startNode()} and
  * {@link InputRelationship#endNode()} from an id of some unknown sort, coming directly from input, to actual node ids.
  */
-public interface IdMapper extends MemoryStatsVisitor.Home
+public interface IdMapper extends MemoryStatsVisitor.Visitable
 {
     /**
      * Maps an {@code inputId} to an actual node id.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
@@ -33,6 +33,7 @@ import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.EncodingIdMapper.NO_MONITOR;
+import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.TrackerFactories.dynamic;
 
 /**
  * Place to instantiate common {@link IdMapper} implementations.
@@ -94,7 +95,7 @@ public class IdMappers
      */
     public static IdMapper strings( NumberArrayFactory cacheFactory )
     {
-        return new EncodingIdMapper( cacheFactory, new StringEncoder(), Radix.STRING, NO_MONITOR );
+        return new EncodingIdMapper( cacheFactory, new StringEncoder(), Radix.STRING, NO_MONITOR, dynamic() );
     }
 
     /**
@@ -106,6 +107,6 @@ public class IdMappers
      */
     public static IdMapper longs( NumberArrayFactory cacheFactory )
     {
-        return new EncodingIdMapper( cacheFactory, new LongEncoder(), Radix.LONG, NO_MONITOR );
+        return new EncodingIdMapper( cacheFactory, new LongEncoder(), Radix.LONG, NO_MONITOR, dynamic() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArray;
+
+/**
+ * Base implementation of {@link Tracker} over a {@link NumberArray}.
+ *
+ * @param <ARRAY> type of {@link NumberArray} in this implementation.
+ */
+abstract class AbstractTracker<ARRAY extends NumberArray> implements Tracker
+{
+    static final int DEFAULT_VALUE = -1;
+
+    protected ARRAY array;
+
+    protected AbstractTracker( ARRAY array )
+    {
+        this.array = array;
+    }
+
+    @Override
+    public void acceptMemoryStatsVisitor( MemoryStatsVisitor visitor )
+    {
+        array.acceptMemoryStatsVisitor( visitor );
+    }
+
+    @Override
+    public void swap( long fromIndex, long toIndex, int count )
+    {
+        array.swap( fromIndex, toIndex, count );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -797,7 +797,7 @@ public class EncodingIdMapper implements IdMapper
         // TODO mention anything about the collisionValues data structure?
     }
 
-    private void nullSafeAcceptMemoryStatsVisitor( MemoryStatsVisitor visitor, MemoryStatsVisitor.Home mem )
+    private void nullSafeAcceptMemoryStatsVisitor( MemoryStatsVisitor visitor, MemoryStatsVisitor.Visitable mem )
     {
         if ( mem != null )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -28,6 +28,7 @@ import org.neo4j.function.Factory;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import org.neo4j.unsafe.impl.batchimport.Utils;
 import org.neo4j.unsafe.impl.batchimport.Utils.CompareType;
 import org.neo4j.unsafe.impl.batchimport.cache.IntArray;
 import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
@@ -51,12 +52,13 @@ import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.ParallelS
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.SourceInformation.encodeSourceInformation;
 
 /**
- * Maps arbitrary values to long ids. The values can be {@link #put(Object, long) added} in any order,
- * but {@link #needsPreparation() needs} {@link #prepare() preparation} in order to {@link #get(Object) get}
- * ids back later.
+ * Maps arbitrary values to long ids. The values can be {@link #put(Object, long, Group) added} in any order,
+ * but {@link #needsPreparation() needs} {@link #prepare(InputIterable, Collector, ProgressListener) preparation}
+ * in order to {@link #get(Object, Group) get} ids back later.
  *
- * In the {@link #prepare() preparation phase} the added entries are sorted according to a number representation
- * of each input value and {@link #get(Object)} does simple binary search to find the correct one.
+ * In the {@link #prepare(InputIterable, Collector, ProgressListener) preparation phase} the added entries are
+ * sorted according to a number representation of each input value and {@link #get(Object, Group)} does simple
+ * binary search to find the correct one.
  *
  * The implementation is space-efficient, much more so than using, say, a {@link HashMap}.
  *
@@ -88,8 +90,7 @@ public class EncodingIdMapper implements IdMapper
     public interface Monitor
     {
         /**
-         * Number of eIds that have been marked as collisions.
-         * @param count
+         * @param count Number of eIds that have been marked as collisions.
          */
         void numberOfCollisions( int count );
     }
@@ -115,6 +116,7 @@ public class EncodingIdMapper implements IdMapper
     private static final long GAP_VALUE = 0;
 
     private final NumberArrayFactory cacheFactory;
+    private final TrackerFactory trackerFactory;
     // Encoded values added in #put, in the order in which they are put. Indexes in the array are the actual node ids,
     // values are the encoded versions of the input ids.
     private LongArray dataCache;
@@ -125,7 +127,7 @@ public class EncodingIdMapper implements IdMapper
     // they end up sorted. Again, dataCache remains unchanged, only the ordering information is kept here.
     // Each index in trackerCache points to a dataCache index, where the value in dataCache contains the
     // encoded input id, used to match against the input id that is looked up during binary search.
-    private IntArray trackerCache;
+    private Tracker trackerCache;
     private final Encoder encoder;
     private final Radix radix;
     private final int processorsForSorting;
@@ -136,7 +138,7 @@ public class EncodingIdMapper implements IdMapper
     // These 3 caches below are needed only during duplicate input id detection, but referenced here so
     // that the memory visitor can see them when they are active.
     private LongArray collisionSourceDataCache;
-    private IntArray collisionTrackerCache;
+    private Tracker collisionTrackerCache;
 
     private boolean readyForUse;
     private long[][] sortBuckets;
@@ -147,17 +149,19 @@ public class EncodingIdMapper implements IdMapper
     private final Factory<Radix> radixFactory;
 
     public EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Factory<Radix> radixFactory,
-            Monitor monitor )
+            Monitor monitor, TrackerFactory trackerFactory )
     {
-        this( cacheFactory, encoder, radixFactory, monitor, DEFAULT_CACHE_CHUNK_SIZE,
+        this( cacheFactory, encoder, radixFactory, monitor, trackerFactory, DEFAULT_CACHE_CHUNK_SIZE,
                 Runtime.getRuntime().availableProcessors() - 1, DEFAULT );
     }
 
     public EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Factory<Radix> radixFactory,
-            Monitor monitor, int chunkSize, int processorsForSorting, Comparator comparator )
+            Monitor monitor, TrackerFactory trackerFactory, int chunkSize, int processorsForSorting,
+            Comparator comparator )
     {
         this.monitor = monitor;
         this.cacheFactory = cacheFactory;
+        this.trackerFactory = trackerFactory;
         this.comparator = comparator;
         this.processorsForSorting = max( processorsForSorting, 1 );
         this.dataCache = cacheFactory.newDynamicLongArray( chunkSize, GAP_VALUE );
@@ -263,7 +267,7 @@ public class EncodingIdMapper implements IdMapper
     {
         endPreviousGroup();
         dataCache = dataCache.fixate();
-        trackerCache = cacheFactory.newIntArray( highestSetIndex+1, -1 );
+        trackerCache = trackerFactory.create( cacheFactory, highestSetIndex+1 );
 
         try
         {
@@ -363,8 +367,8 @@ public class EncodingIdMapper implements IdMapper
             int batch = (int) min( max-i, 10_000 );
             for ( int j = 0; j < batch; j++, i++ )
             {
-                int dataIndexA = trackerCache.get( i );
-                int dataIndexB = trackerCache.get( i+1 );
+                long dataIndexA = trackerCache.get( i );
+                long dataIndexB = trackerCache.get( i+1 );
                 if ( dataIndexA == -1 || dataIndexB == -1 )
                 {
                     sameGroupDetector.reset();
@@ -386,7 +390,7 @@ public class EncodingIdMapper implements IdMapper
                             radixOf( eIdA ) + ":" + radixOf( eIdB ) );
                 case EQ:
                     // Here we have two equal encoded values. First let's check if they are in the same id space.
-                    int collision = sameGroupDetector.collisionWithinSameGroup(
+                    long collision = sameGroupDetector.collisionWithinSameGroup(
                             dataIndexA, groupOf( dataIndexA ).id(),
                             dataIndexB, groupOf( dataIndexB ).id() );
 
@@ -428,7 +432,7 @@ public class EncodingIdMapper implements IdMapper
     /**
      * @return {@code true} if marked as collision in this call, {@code false} if it was already marked as collision.
      */
-    private boolean markAsCollision( int dataIndex )
+    private boolean markAsCollision( long dataIndex )
     {
         long eId = dataCache.get( dataIndex );
         boolean isAlreadyMarked = isCollision( eId );
@@ -450,7 +454,7 @@ public class EncodingIdMapper implements IdMapper
         List<String> sourceDescriptions = new ArrayList<>();
         String lastSourceDescription = null;
         collisionSourceDataCache = cacheFactory.newLongArray( numberOfCollisions, -1 );
-        collisionTrackerCache = cacheFactory.newIntArray( numberOfCollisions, -1 );
+        collisionTrackerCache = trackerFactory.create( cacheFactory, numberOfCollisions );
         for ( long i = 0; ids.hasNext(); )
         {
             long j = 0;
@@ -559,7 +563,7 @@ public class EncodingIdMapper implements IdMapper
             long j = 0;
             for ( ; j < 10_000 && i < numberOfCollisions; j++, i++ )
             {
-                int collisionIndex = collisionTrackerCache.get( i );
+                long collisionIndex = collisionTrackerCache.get( i );
                 long dataIndex = collisionNodeIdCache.get( collisionIndex );
                 long eid = dataCache.get( dataIndex );
                 long sourceInformation = collisionSourceDataCache.get( collisionIndex );
@@ -574,7 +578,10 @@ public class EncodingIdMapper implements IdMapper
                 }
 
                 // Potential duplicate
-                Object inputId = collisionValues.get( collisionIndex );
+                // We cast the collision index to an int here. This means that we can't support > int-range
+                // number of collisions. But that's probably alright since the data structures and
+                // actual collisions values for all these collisions wouldn't fit in a heap anyway.
+                Object inputId = collisionValues.get( Utils.safeCastLongToInt( collisionIndex ) );
                 int detectorIndex = detector.add( inputId, sourceInformation );
                 if ( detectorIndex != -1 )
                 {   // Duplicate
@@ -647,7 +654,7 @@ public class EncodingIdMapper implements IdMapper
         while ( low <= high )
         {
             long mid = low + (high - low)/2;//(low + high) / 2;
-            int dataIndex = trackerCache.get( mid );
+            long dataIndex = trackerCache.get( mid );
             if ( dataIndex == -1 )
             {
                 return -1;
@@ -731,7 +738,7 @@ public class EncodingIdMapper implements IdMapper
         long lowestFound = -1; // lowest data index means "first put"
         for ( long index = fromIndex; index <= toIndex; index++ )
         {
-            int dataIndex = trackerCache.get( index );
+            long dataIndex = trackerCache.get( index );
             IdGroup group = groupOf( dataIndex );
             if ( groupId == group.id() )
             {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.unsafe.impl.batchimport.Utils;
+import org.neo4j.unsafe.impl.batchimport.cache.IntArray;
+
+/**
+ * {@link Tracker} capable of keeping {@code int} range values, using {@link IntArray}.
+ * Will fail in {@link #set(long, long)} with {@link ArithmeticException} if trying to put a too big value.
+ */
+public class IntTracker extends AbstractTracker<IntArray>
+{
+    public IntTracker( IntArray array )
+    {
+        super( array );
+    }
+
+    @Override
+    public long get( long index )
+    {
+        return array.get( index );
+    }
+
+    /**
+     * @throws ArithmeticException if value is bigger than {@link Integer#MAX_VALUE}.
+     */
+    @Override
+    public void set( long index, long value )
+    {
+        array.set( index, Utils.safeCastLongToInt( value ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongTracker.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
+
+/**
+ * {@link Tracker} capable of keeping {@code long} range values, using {@link LongArray}.
+ */
+public class LongTracker extends AbstractTracker<LongArray>
+{
+    public LongTracker( LongArray array )
+    {
+        super( array );
+    }
+
+    @Override
+    public long get( long index )
+    {
+        return array.get( index );
+    }
+
+    @Override
+    public void set( long index, long value )
+    {
+        array.set( index, value );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/SameGroupDetector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/SameGroupDetector.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 class SameGroupDetector
 {
     // Alternating data index, group id
-    private int[] seen = new int[100]; // grows on demand
+    private long[] seen = new long[100]; // grows on demand
     private int cursor;
 
     /**
@@ -36,7 +36,7 @@ class SameGroupDetector
      * supplied data index and group id. In the case of <strong>not</strong> {@code -1} both {@code dataIndexB}
      * and the returned data index should be marked as collisions.
      */
-    int collisionWithinSameGroup( int dataIndexA, int groupIdA, int dataIndexB, int groupIdB )
+    long collisionWithinSameGroup( long dataIndexA, int groupIdA, long dataIndexB, int groupIdB )
     {
         // The first call, add both the entries. For consecutive calls for this same collision stretch
         // only add and compare the second. The reason it's done in here instead of having a method signature
@@ -47,11 +47,11 @@ class SameGroupDetector
             add( dataIndexA, groupIdA );
         }
 
-        int collision = -1;
+        long collision = -1;
         for ( int i = 0; i < cursor; i++ )
         {
-            int dataIndexAtCursor = seen[i++];
-            int groupIdAtCursor = seen[i];
+            long dataIndexAtCursor = seen[i++];
+            long groupIdAtCursor = seen[i];
             if ( groupIdAtCursor == groupIdB )
             {
                 collision = dataIndexAtCursor;
@@ -64,7 +64,7 @@ class SameGroupDetector
         return collision;
     }
 
-    private void add( int dataIndex, int groupId )
+    private void add( long dataIndex, int groupId )
     {
         if ( cursor == seen.length )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
@@ -39,7 +39,7 @@ import org.neo4j.unsafe.impl.batchimport.input.Group;
  * a smaller data structure for smaller datasets, for example those that fit inside {@code int} range.
  * That's why this abstraction exists so that the best suited implementation can be picked for every import.
  */
-public interface Tracker extends MemoryStatsVisitor.Home
+public interface Tracker extends MemoryStatsVisitor.Visitable
 {
     /**
      * @param index data index to get the value for.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.helpers.progress.ProgressListener;
+import org.neo4j.unsafe.impl.batchimport.InputIterable;
+import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
+import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
+import org.neo4j.unsafe.impl.batchimport.input.Group;
+
+/**
+ * {@link EncodingIdMapper} is an index where arbitrary ids, be it {@link String} or {@code long} or whatever
+ * can be added and mapped to an internal (node) {@code long} id. The order in which ids are added can be
+ * any order and so in the end when all ids have been added the index goes through a
+ * {@link IdMapper#prepare(InputIterable, Collector, ProgressListener) prepare phase} where these ids are sorted
+ * so that {@link IdMapper#get(Object, Group)} can execute efficiently later on.
+ * <p>
+ * In that sorting the ids aren't moved, but instead a {@link Tracker} created where these moves are recorded
+ * and the initial data (in order of insertion) is kept intact to be able to track {@link Group} belonging among
+ * other things. Since a tracker is instantiated after all ids have been added there's an opportunity to create
+ * a smaller data structure for smaller datasets, for example those that fit inside {@code int} range.
+ * That's why this abstraction exists so that the best suited implementation can be picked for every import.
+ */
+public interface Tracker extends MemoryStatsVisitor.Home
+{
+    /**
+     * @param index data index to get the value for.
+     * @return value previously {@link #set(long, long)}.
+     */
+    long get( long index );
+
+    /**
+     * Swaps values from {@code fromIndex} to {@code toIndex}, as many items as {@code count} specifies.
+     *
+     * @param fromIndex index to swap from.
+     * @param toIndex index to swap to.
+     * @param count number of items to swap.
+     */
+    void swap( long fromIndex, long toIndex, int count );
+
+    /**
+     * Sets {@code value} at the specified {@code index}.
+     *
+     * @param index data index to set value at.
+     * @param value value to set at that index.
+     */
+    void set( long index, long value );
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactories.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+
+import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.AbstractTracker.DEFAULT_VALUE;
+
+/**
+ * Common {@link TrackerFactory} implementations.
+ */
+public class TrackerFactories
+{
+    /**
+     * @return {@link TrackerFactory} creating different {@link Tracker} instances depending on size.
+     */
+    public static TrackerFactory dynamic()
+    {
+        return new TrackerFactory()
+        {
+            @Override
+            public Tracker create( NumberArrayFactory arrayFactory, long size )
+            {
+                return size > Integer.MAX_VALUE
+                        ? new LongTracker( arrayFactory.newLongArray( size, DEFAULT_VALUE ) )
+                        : new IntTracker( arrayFactory.newIntArray( size, DEFAULT_VALUE ) );
+            }
+        };
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+
+/**
+ * Factory for {@link Tracker} instances.
+ */
+public interface TrackerFactory
+{
+    /**
+     * @param arrayFactory {@link NumberArrayFactory} to use as backing data structure for the {@link Tracker}.
+     * @param size size of the tracker.
+     * @return {@link Tracker} capable of keeping track of {@code size} items.
+     */
+    Tracker create( NumberArrayFactory arrayFactory, long size );
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
@@ -65,7 +65,7 @@ public class UtilsTest
     public void failSafeCastLongToIntOnOverflow()
     {
         expectedException.expect( ArithmeticException.class );
-        expectedException.expectMessage( "Value 2147483648 is too big to be represented as java.lang.Integer" );
+        expectedException.expectMessage( "Value 2147483648 is too big to be represented as int" );
 
         Utils.safeCastLongToInt( Integer.MAX_VALUE + 1l );
     }
@@ -74,7 +74,7 @@ public class UtilsTest
     public void failSafeCastLongToShortOnOverflow()
     {
         expectedException.expect( ArithmeticException.class );
-        expectedException.expectMessage( "Value 32768 is too big to be represented as java.lang.Short" );
+        expectedException.expectMessage( "Value 32768 is too big to be represented as short" );
 
         Utils.safeCastLongToShort( Short.MAX_VALUE + 1l );
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
@@ -582,11 +582,6 @@ public class EncodingIdMapperTest
                 any( Object.class ), anyLong(), anyString(), anyString(), anyString() );
     }
 
-    private List<Object> ids( Object... ids )
-    {
-        return Arrays.asList( ids );
-    }
-
     private IdMapper mapper( Encoder encoder, Factory<Radix> radix, Monitor monitor )
     {
         return mapper( encoder, radix, monitor, ParallelSort.DEFAULT );
@@ -594,8 +589,20 @@ public class EncodingIdMapperTest
 
     private IdMapper mapper( Encoder encoder, Factory<Radix> radix, Monitor monitor, Comparator comparator )
     {
-        return new EncodingIdMapper( NumberArrayFactory.HEAP, encoder, radix, monitor, 1_000, processors, comparator );
+        return new EncodingIdMapper( NumberArrayFactory.HEAP, encoder, radix, monitor, RANDOM_TRACKER_FACTORY,
+                1_000, processors, comparator );
     }
+
+    private static final TrackerFactory RANDOM_TRACKER_FACTORY = new TrackerFactory()
+    {
+        @Override
+        public Tracker create( NumberArrayFactory arrayFactory, long size )
+        {
+            return System.currentTimeMillis() % 2 == 0
+                    ? new IntTracker( arrayFactory.newIntArray( size, AbstractTracker.DEFAULT_VALUE ) )
+                    : new LongTracker( arrayFactory.newLongArray( size, AbstractTracker.DEFAULT_VALUE ) );
+        }
+    };
 
     private class ValueGenerator implements InputIterable<Object>
     {

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongStack.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongStack.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.collection.primitive;
+
+import static java.util.Arrays.copyOf;
+
+/**
+ * Like a {@code Stack<Long>} but for primitive longs. Virtually GC free in that it has an {@code long[]}
+ * and merely moves a cursor where to {@link #push(long)} and {@link #poll()} values to and from.
+ * If many items goes in the stack the {@code long[]} will grow to accomodate all of them, but not shrink again.
+ */
+public class PrimitiveLongStack implements PrimitiveLongCollection
+{
+    private long[] array;
+    private int cursor = -1; // where the top most item lives
+
+    public PrimitiveLongStack( int initialSize )
+    {
+        this.array = new long[initialSize];
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return cursor == -1;
+    }
+
+    @Override
+    public void clear()
+    {
+        cursor = -1;
+    }
+
+    @Override
+    public int size()
+    {
+        return cursor+1;
+    }
+
+    @Override
+    public void close()
+    {   // Nothing to close
+    }
+
+    @Override
+    public PrimitiveLongIterator iterator()
+    {
+        throw new UnsupportedOperationException( "Please implement" );
+    }
+
+    @Override
+    public void visitKeys( PrimitiveLongVisitor visitor )
+    {
+        throw new UnsupportedOperationException( "Please implement" );
+    }
+
+    public void push( long value )
+    {
+        ensureCapacity();
+        array[++cursor] = value;
+    }
+
+    private void ensureCapacity()
+    {
+        if ( cursor == array.length-1 )
+        {
+            array = copyOf( array, array.length << 1 );
+        }
+    }
+
+    /**
+     * @return the top most item, or -1 if stack is empty
+     */
+    public long poll()
+    {
+        return cursor == -1 ? -1 : array[cursor--];
+    }
+}

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongStackTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveLongStackTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.collection.primitive;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class PrimitiveLongStackTest
+{
+    @Test
+    public void shouldPushAndPollSomeEntities() throws Exception
+    {
+        // GIVEN
+        PrimitiveLongStack stack = new PrimitiveLongStack( 6 );
+
+        // WHEN/THEN
+        assertTrue( stack.isEmpty() );
+        assertEquals( -1, stack.poll() );
+
+        stack.push( 123 );
+        assertFalse( stack.isEmpty() );
+
+        stack.push( 456 );
+        assertFalse( stack.isEmpty() );
+        assertEquals( 456, stack.poll() );
+
+        assertFalse( stack.isEmpty() );
+        assertEquals( 123, stack.poll() );
+
+        assertTrue( stack.isEmpty() );
+        assertEquals( -1, stack.poll() );
+    }
+
+    @Test
+    public void shouldGrowArray() throws Exception
+    {
+        // GIVEN
+        PrimitiveLongStack stack = new PrimitiveLongStack( 5 );
+
+        // WHEN
+        for ( int i = 0; i <= 7; i++ )
+        {
+            stack.push( i );
+        }
+
+        // THEN
+        for ( int i = 7; i >= 0; i-- )
+        {
+            assertFalse( stack.isEmpty() );
+            assertEquals( i, stack.poll() );
+        }
+        assertTrue( stack.isEmpty() );
+        assertEquals( -1, stack.poll() );
+    }
+
+    @Test
+    public void shouldStoreLongs() throws Exception
+    {
+        // GIVEN
+        PrimitiveLongStack stack = new PrimitiveLongStack( 5 );
+        long value1 = 10L * Integer.MAX_VALUE;
+        long value2 = 101L * Integer.MAX_VALUE;
+        stack.push( value1 );
+        stack.push( value2 );
+
+        // WHEN
+        long firstPolledValue = stack.poll();
+        long secondPolledValue = stack.poll();
+
+        // THEN
+        assertEquals( value2, firstPolledValue );
+        assertEquals( value1, secondPolledValue );
+        assertTrue( stack.isEmpty() );
+    }
+}


### PR DESCRIPTION
Previously there was a limit of how many nodes could be imported in one
import using the import tool. That limit came from the "tracker", the data
stucture used for sorting ids after all had been added, only being capable
of handling int-range values. This to save 4 bytes compared to using long
for that always.

As imports grow bigger this needs to change, so this commit introduces support
for this tracker being long-range, but doesn't penalize < 2.4 billion imports
because the type of data structure can be decided after all nodes have been
imported and at that time it knows how many there are ans so the long-range
data structure is only used for the imports exceeding that threshold.
