### PR TITLE
Retry replication until lock session changes.

### DIFF
--- a/community/storage-engine-api/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/storage-engine-api/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -109,6 +109,8 @@ public interface Status
         ReleaseLocksFailed( DatabaseError, "The transaction was unable to release one or more of its locks." ),
         AcquireLockTimeout( TransientError, "The transaction was unable to acquire a lock, for instance due to a " +
                 "timeout or the transaction thread being interrupted." ),
+        LockSessionInvalid( TransientError, "The lock session under which this transaction was started is no longer valid." ),
+
         DeadlockDetected( TransientError, "This transaction, and at least one more transaction, has acquired locks " +
         "in a way that it will wait indefinitely, and the database has aborted it. Retrying this transaction " +
         "will most likely be successful."),

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/OperationContext.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/OperationContext.java
@@ -48,4 +48,14 @@ public class OperationContext
     {
         return localSession;
     }
+
+
+    @Override
+    public String toString()
+    {
+        return "OperationContext{" +
+               "globalSession=" + globalSession +
+               ", localOperationId=" + localOperationId +
+               '}';
+    }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
@@ -95,11 +95,6 @@ public class CoreEdgeClusterSettings
     public static final Setting<Long> tx_replication_retry_interval =
             setting( "core_edge.tx_replication_retry_interval", DURATION, "1s" );
 
-    @Description("The maximum time for trying to replicate a transaction and receive a successful response. " +
-            "Note that the transaction might still have been committed in the cluster.")
-    public static final Setting<Long> tx_replication_timeout =
-            setting( "core_edge.tx_replication_timeout", DURATION, "30s" );
-
     @Description("Expected size of core cluster")
     public static final Setting<Integer> expected_core_cluster_size =
             setting( "core_edge.expected_core_cluster_size", INTEGER, "3" );


### PR DESCRIPTION
Previously we would give up after a maximum timeout which isn't
suitable under the leader-only lock management strategy (and probably
not under any other strategy either). Since the lock session change
now exists as a safe and natural abort marker, we use that instead.
