### PR TITLE
Print transaction in CheckTxLogs.

### DIFF
--- a/tools/src/main/java/org/neo4j/tools/txlog/CommittedRecords.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/CommittedRecords.java
@@ -38,7 +38,7 @@ import org.neo4j.tools.txlog.checktypes.CheckType;
 class CommittedRecords<R extends Abstract64BitRecord>
 {
     private final CheckType<?,R> checkType;
-    private final Map<Long,LogRecord<R>> recordsById;
+    private final Map<Long,RecordInfo<R>> recordsById;
 
     CommittedRecords( CheckType<?,R> check )
     {
@@ -46,18 +46,12 @@ class CommittedRecords<R extends Abstract64BitRecord>
         this.recordsById = new HashMap<>();
     }
 
-    public boolean isValid( R record )
+    public void put( R record, long logVersion, long txId )
     {
-        LogRecord<R> current = recordsById.get( record.getId() );
-        return current == null || checkType.equal( record, current.record() );
+        recordsById.put( record.getId(), new RecordInfo<>( record, logVersion, txId ) );
     }
 
-    public void put( R record, long logVersion )
-    {
-        recordsById.put( record.getId(), new LogRecord<>( record, logVersion ) );
-    }
-
-    public LogRecord<R> get( long id )
+    public RecordInfo<R> get( long id )
     {
         return recordsById.get( id );
     }

--- a/tools/src/main/java/org/neo4j/tools/txlog/InconsistenciesHandler.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/InconsistenciesHandler.java
@@ -25,10 +25,9 @@ package org.neo4j.tools.txlog;
 interface InconsistenciesHandler
 {
     /**
-     * Processes found inconsistency.
-     *
+     * For reporting of inconsistencies found between before and after state of commands.
      * @param committed the record seen previously during transaction log scan and considered valid
      * @param current the record met during transaction log scan and considered inconsistent with committed
      */
-    void handle( LogRecord<?> committed, LogRecord<?> current );
+    void reportInconsistentCommand( RecordInfo<?> committed, RecordInfo<?> current );
 }

--- a/tools/src/main/java/org/neo4j/tools/txlog/PrintingInconsistenciesHandler.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/PrintingInconsistenciesHandler.java
@@ -40,9 +40,11 @@ class PrintingInconsistenciesHandler implements InconsistenciesHandler
     }
 
     @Override
-    public void handle( LogRecord<?> committed, LogRecord<?> current )
+    public void reportInconsistentCommand( RecordInfo<?> committed, RecordInfo<?> current )
     {
-        System.out.println( "Before state: " + committed + " is inconsistent with after state: " + current );
+        System.out.println( "+" + committed );
+        System.out.println( "-" + current );
+
         seenInconsistencies++;
         if ( seenInconsistencies >= inconsistenciesToPrint )
         {

--- a/tools/src/main/java/org/neo4j/tools/txlog/RecordInfo.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/RecordInfo.java
@@ -29,15 +29,17 @@ import org.neo4j.kernel.impl.store.record.PropertyRecord;
  *
  * @param <R> the type of the record
  */
-public class LogRecord<R extends Abstract64BitRecord>
+public class RecordInfo<R extends Abstract64BitRecord>
 {
     private final R record;
     private final long logVersion;
+    private final long txId;
 
-    public LogRecord( R record, long logVersion )
+    public RecordInfo( R record, long logVersion, long txId )
     {
         this.record = record;
         this.logVersion = logVersion;
+        this.txId = txId;
     }
 
     public R record()
@@ -45,9 +47,14 @@ public class LogRecord<R extends Abstract64BitRecord>
         return record;
     }
 
+    public long txId()
+    {
+        return txId;
+    }
+
     @Override
     public String toString()
     {
-        return record + " from log #" + logVersion;
+        return String.format( "%s (log:%d txId:%d)", record, logVersion, txId );
     }
 }


### PR DESCRIPTION
The transaction in which reported inconsistencies were introduced
is now printed together with a count.

Also fixes before/after confusion in the printed report.
