### PR TITLE
Retry logic for transactions that time out.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedLabelTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedLabelTokenHolder.java
@@ -34,9 +34,10 @@ import org.neo4j.storageengine.api.Token;
 
 public class ReplicatedLabelTokenHolder extends ReplicatedTokenHolder<Token,LabelTokenRecord> implements LabelTokenHolder
 {
-    public ReplicatedLabelTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies )
+    public ReplicatedLabelTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies,
+                                       long timeoutMillis)
     {
-        super( replicator, idGeneratorFactory, IdType.LABEL_TOKEN, dependencies, new Token.Factory(), TokenType.LABEL );
+        super( replicator, idGeneratorFactory, IdType.LABEL_TOKEN, dependencies, new Token.Factory(), TokenType.LABEL, timeoutMillis );
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedPropertyKeyTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedPropertyKeyTokenHolder.java
@@ -34,9 +34,9 @@ import org.neo4j.storageengine.api.Token;
 
 public class ReplicatedPropertyKeyTokenHolder extends ReplicatedTokenHolder<Token,PropertyKeyTokenRecord> implements PropertyKeyTokenHolder
 {
-    public ReplicatedPropertyKeyTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies )
+    public ReplicatedPropertyKeyTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies, long timeoutMillis )
     {
-        super( replicator, idGeneratorFactory, IdType.PROPERTY_KEY_TOKEN, dependencies, new Token.Factory(), TokenType.PROPERTY );
+        super( replicator, idGeneratorFactory, IdType.PROPERTY_KEY_TOKEN, dependencies, new Token.Factory(), TokenType.PROPERTY, timeoutMillis );
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedRelationshipTypeTokenHolder.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedRelationshipTypeTokenHolder.java
@@ -34,9 +34,9 @@ import org.neo4j.kernel.impl.util.Dependencies;
 
 public class ReplicatedRelationshipTypeTokenHolder extends ReplicatedTokenHolder<RelationshipTypeToken,RelationshipTypeTokenRecord> implements RelationshipTypeTokenHolder
 {
-    public ReplicatedRelationshipTypeTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies )
+    public ReplicatedRelationshipTypeTokenHolder( Replicator replicator, IdGeneratorFactory idGeneratorFactory, Dependencies dependencies, long timeoutMillis )
     {
-        super( replicator, idGeneratorFactory, IdType.RELATIONSHIP_TYPE_TOKEN, dependencies, new RelationshipTypeToken.Factory(), TokenType.RELATIONSHIP );
+        super( replicator, idGeneratorFactory, IdType.RELATIONSHIP_TYPE_TOKEN, dependencies, new RelationshipTypeToken.Factory(), TokenType.RELATIONSHIP, timeoutMillis );
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/TokenFutures.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/TokenFutures.java
@@ -39,7 +39,7 @@ public class TokenFutures
         CompletableFutureTokenId completableFutureTokenId = new CompletableFutureTokenId()
         {
             @Override
-            public void close() throws Exception
+            public void close()
             {
                 disposeFuture( key, this );
             }
@@ -121,7 +121,7 @@ public class TokenFutures
 
     public interface FutureTokenId extends java.lang.AutoCloseable, Future<Integer>
     {
+        @Override
+        void close();
     }
-
-
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/CommittingTransaction.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/CommittingTransaction.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+
+public interface CommittingTransaction extends AutoCloseable
+{
+    long waitUntilCommitted( long timeout, TimeUnit unit ) throws InterruptedException, TimeoutException,
+            TransactionFailureException;
+
+    void notifySuccessfullyCommitted( long txId );
+
+    void notifyCommitFailed( TransactionFailureException e );
+
+    @Override
+    void close();
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/CommittingTransactions.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/CommittingTransactions.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+
+public interface CommittingTransactions
+{
+    CommittingTransaction register( LocalOperationId localOperationId );
+
+    CommittingTransaction retrieve( LocalOperationId localOperationId );
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/CommittingTransactionsRegistry.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/CommittingTransactionsRegistry.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+
+public class CommittingTransactionsRegistry implements CommittingTransactions
+{
+    private final Map<LocalOperationId, CommittingTransactionFuture> outstanding = new ConcurrentHashMap<>();
+
+    @Override
+    public CommittingTransaction register( LocalOperationId localOperationId )
+    {
+        final CommittingTransactionFuture future = new CommittingTransactionFuture( localOperationId );
+        outstanding.put( localOperationId, future );
+        return future;
+    }
+
+    @Override
+    public CommittingTransaction retrieve( LocalOperationId localOperationId )
+    {
+        return outstanding.remove( localOperationId );
+    }
+
+    public class CommittingTransactionFuture implements CommittingTransaction
+    {
+        private final LocalOperationId localOperationId;
+        private final CompletableFuture<Long> future = new CompletableFuture<>();
+
+        CommittingTransactionFuture( LocalOperationId localOperationId )
+        {
+            this.localOperationId = localOperationId;
+        }
+
+        @Override
+        public void close()
+        {
+            outstanding.remove( localOperationId );
+        }
+
+        @Override
+        public long waitUntilCommitted( long timeout, TimeUnit unit )
+                throws TransactionFailureException, TimeoutException, InterruptedException
+        {
+            try
+            {
+                return future.get( timeout, unit );
+            }
+            catch ( ExecutionException e )
+            {
+                throw (TransactionFailureException) e.getCause();
+            }
+        }
+
+        @Override
+        public void notifySuccessfullyCommitted( long txId )
+        {
+            future.complete( txId );
+        }
+
+        @Override
+        public void notifyCommitFailed( TransactionFailureException e )
+        {
+            future.completeExceptionally( e );
+        }
+    }
+
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachine.java
@@ -20,20 +20,16 @@
 package org.neo4j.coreedge.raft.replication.tx;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
 
 import org.neo4j.coreedge.raft.replication.ReplicatedContent;
 import org.neo4j.coreedge.raft.replication.Replicator;
 import org.neo4j.coreedge.raft.replication.session.GlobalSession;
 import org.neo4j.coreedge.raft.replication.session.GlobalSessionTracker;
-import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
 import org.neo4j.coreedge.server.core.CurrentReplicatedLockState;
 import org.neo4j.graphdb.TransientFailureException;
 import org.neo4j.graphdb.TransientTransactionFailureException;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionToApply;
@@ -42,6 +38,7 @@ import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 
 import static org.neo4j.coreedge.raft.replication.tx.LogIndexTxHeaderEncoding.encodeLogIndexAsTxHeader;
+import static org.neo4j.kernel.api.exceptions.Status.Transaction.LockSessionInvalid;
 
 public class ReplicatedTransactionStateMachine implements Replicator.ReplicatedContentListener
 {
@@ -49,24 +46,19 @@ public class ReplicatedTransactionStateMachine implements Replicator.ReplicatedC
     private final GlobalSession myGlobalSession;
     private final CurrentReplicatedLockState currentReplicatedLockState;
     private final TransactionCommitProcess commitProcess;
-    private final Map<LocalOperationId, FutureTxId> outstanding = new ConcurrentHashMap<>();
+    private final CommittingTransactions transactionFutures;
     private long lastCommittedIndex = -1;
 
     public ReplicatedTransactionStateMachine( TransactionCommitProcess commitProcess,
                                               GlobalSession myGlobalSession,
-                                              CurrentReplicatedLockState currentReplicatedLockState )
+                                              CurrentReplicatedLockState currentReplicatedLockState,
+                                              CommittingTransactions transactionFutures )
     {
         this.commitProcess = commitProcess;
         this.myGlobalSession = myGlobalSession;
         this.currentReplicatedLockState = currentReplicatedLockState;
+        this.transactionFutures = transactionFutures;
         this.sessionTracker = new GlobalSessionTracker();
-    }
-
-    public Future<Long> getFutureTxId( LocalOperationId localOperationId )
-    {
-        final FutureTxId future = new FutureTxId( localOperationId );
-        outstanding.put( localOperationId, future );
-        return future;
     }
 
     @Override
@@ -86,38 +78,46 @@ public class ReplicatedTransactionStateMachine implements Replicator.ReplicatedC
             return;
         }
 
+        TransactionRepresentation tx;
         try
         {
             byte[] extraHeader = encodeLogIndexAsTxHeader( logIndex );
-            TransactionRepresentation tx = ReplicatedTransactionFactory.extractTransactionRepresentation(
+            tx = ReplicatedTransactionFactory.extractTransactionRepresentation(
                     replicatedTx, extraHeader );
-
-            // A missing future means the transaction does not belong to this instance
-            Optional<CompletableFuture<Long>> future = replicatedTx.globalSession().equals( myGlobalSession ) ?
-                    Optional.ofNullable( outstanding.remove( replicatedTx.localOperationId() ) ) :
-                    Optional.<CompletableFuture<Long>>empty();
-
-            if ( currentReplicatedLockState.currentLockSession().id() != tx.getLockSessionId() )
-            {
-                future.ifPresent( txFuture -> txFuture.completeExceptionally( new TransientTransactionFailureException(
-                        "Attempt to commit transaction that was started on a different leader. " +
-                                "Please retry the transaction." ) ) );
-                return;
-            }
-
-            try
-            {
-               long txId = commitProcess.commit( new TransactionToApply( tx ), CommitEvent.NULL,
-                        TransactionApplicationMode.EXTERNAL );
-                future.ifPresent( txFuture -> txFuture.complete( txId ) );
-            }
-            catch ( TransientFailureException e )
-            {
-                future.ifPresent( txFuture -> txFuture.completeExceptionally( e ) );
-            }
         }
-        catch ( TransactionFailureException | IOException e )
+        catch ( IOException e )
         {
+            throw new IllegalStateException( "Failed to locally commit a transaction that has already been " +
+                    "committed to the RAFT log. This server cannot process later transactions and needs to be " +
+                    "restarted once the underlying cause has been addressed.", e );
+        }
+
+        // A missing future means the transaction does not belong to this instance
+        Optional<CommittingTransaction> future = replicatedTx.globalSession().equals( myGlobalSession ) ?
+                Optional.ofNullable( transactionFutures.retrieve( replicatedTx.localOperationId() ) ) :
+                Optional.<CommittingTransaction>empty();
+
+        int currentLockSessionId = currentReplicatedLockState.currentLockSession().id();
+        int txLockSessionId = tx.getLockSessionId();
+        if ( currentLockSessionId != txLockSessionId )
+        {
+            future.ifPresent( txFuture -> txFuture.notifyCommitFailed( new TransactionFailureException( LockSessionInvalid,
+                    "The lock session in the cluster has changed: " +
+                            "[current lock session id:%d, tx lock session id:%d]",
+                    currentLockSessionId, txLockSessionId ) ) );
+            return;
+        }
+
+        try
+        {
+           long txId = commitProcess.commit( new TransactionToApply( tx ), CommitEvent.NULL,
+                   TransactionApplicationMode.EXTERNAL );
+
+            future.ifPresent( txFuture -> txFuture.notifySuccessfullyCommitted( txId ) );
+        }
+        catch ( TransactionFailureException e )
+        {
+            future.ifPresent( txFuture -> txFuture.notifyCommitFailed( e ) );
             throw new IllegalStateException( "Failed to locally commit a transaction that has already been " +
                     "committed to the RAFT log. This server cannot process later transactions and needs to be " +
                     "restarted once the underlying cause has been addressed.", e );
@@ -128,26 +128,4 @@ public class ReplicatedTransactionStateMachine implements Replicator.ReplicatedC
     {
         this.lastCommittedIndex = lastCommittedIndex;
     }
-
-    private class FutureTxId extends CompletableFuture<Long>
-    {
-        private final LocalOperationId localOperationId;
-
-        FutureTxId( LocalOperationId localOperationId )
-        {
-            this.localOperationId = localOperationId;
-        }
-
-        @Override
-        public boolean cancel( boolean mayInterruptIfRunning )
-        {
-            if ( !super.cancel( mayInterruptIfRunning ) )
-            {
-                return false;
-            }
-            outstanding.remove( localOperationId );
-            return true;
-        }
-    }
-
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
@@ -94,6 +94,10 @@ public class CoreEdgeClusterSettings
     public static final Setting<Long> tx_replication_retry_interval =
             setting( "core_edge.tx_replication_retry_interval", DURATION, "1s" );
 
+    @Description("Time out for a token to be replicated")
+    public static final Setting<Long> token_creation_timeout =
+            setting( "core_edge.token_creation_timeout", DURATION, "1s" );
+
     @Description("Expected size of core cluster")
     public static final Setting<Integer> expected_core_cluster_size =
             setting( "core_edge.expected_core_cluster_size", INTEGER, "3" );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -246,12 +246,13 @@ public class EnterpriseCoreEditionModule
 
         this.idGeneratorFactory = dependencies.satisfyDependency( replicatedIdGeneratorFactory );
 
-        ReplicatedRelationshipTypeTokenHolder relationshipTypeTokenHolder =
-                new ReplicatedRelationshipTypeTokenHolder( replicator, this.idGeneratorFactory, dependencies );
-        ReplicatedPropertyKeyTokenHolder propertyKeyTokenHolder =
-                new ReplicatedPropertyKeyTokenHolder( replicator, this.idGeneratorFactory, dependencies );
-        ReplicatedLabelTokenHolder labelTokenHolder =
-                new ReplicatedLabelTokenHolder( replicator, this.idGeneratorFactory, dependencies );
+        Long tokenCreationTimeout = config.get( CoreEdgeClusterSettings.token_creation_timeout );
+        ReplicatedRelationshipTypeTokenHolder relationshipTypeTokenHolder = new ReplicatedRelationshipTypeTokenHolder(
+                replicator, this.idGeneratorFactory, dependencies, tokenCreationTimeout );
+        ReplicatedPropertyKeyTokenHolder propertyKeyTokenHolder = new ReplicatedPropertyKeyTokenHolder(
+                replicator, this.idGeneratorFactory, dependencies, tokenCreationTimeout );
+        ReplicatedLabelTokenHolder labelTokenHolder = new ReplicatedLabelTokenHolder(
+                replicator, this.idGeneratorFactory, dependencies, tokenCreationTimeout );
 
         LifeSupport tokenLife = new LifeSupport();
         this.relationshipTypeTokenHolder = tokenLife.add( relationshipTypeTokenHolder );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/CommitProcessStateMachineCollaborationTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/CommitProcessStateMachineCollaborationTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.replication.Replicator;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.coreedge.raft.replication.session.LocalSessionPool;
+import org.neo4j.coreedge.server.AdvertisedSocketAddress;
+import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.coreedge.server.core.CurrentReplicatedLockState;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionToApply;
+import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.neo4j.kernel.impl.transaction.tracing.CommitEvent.NULL;
+import static org.neo4j.storageengine.api.TransactionApplicationMode.INTERNAL;
+
+public class CommitProcessStateMachineCollaborationTest
+{
+    @Test
+    public void shouldAlwaysCompleteFutureEvenIfReplicationHappensAtUnfortunateMoment() throws Exception
+    {
+        // given
+        final int numberOfTimesToTimeout = 1;
+        AtomicInteger timeoutCounter = new AtomicInteger( numberOfTimesToTimeout );
+
+        CoreMember coreMember = new CoreMember( new AdvertisedSocketAddress( "core:1" ),
+                new AdvertisedSocketAddress( "raft:1" ) );
+
+        TriggeredReplicator replicator = new TriggeredReplicator();
+        StubCommittingTransactionsRegistry txFutures = new StubCommittingTransactionsRegistry( replicator, timeoutCounter );
+
+        TransactionCommitProcess localCommitProcess = mock( TransactionCommitProcess.class );
+
+        LocalSessionPool sessionPool = new LocalSessionPool( coreMember );
+        CurrentReplicatedLockState lockState = lockState( 0 );
+        final ReplicatedTransactionStateMachine stateMachine = new ReplicatedTransactionStateMachine(
+                localCommitProcess, sessionPool.getGlobalSession(), lockState, txFutures );
+
+
+        ReplicatedTransactionCommitProcess commitProcess = new ReplicatedTransactionCommitProcess(
+                replicator, sessionPool, stateMachine, 100,
+                NullLogService.getInstance(), txFutures );
+
+        // when
+        commitProcess.commit( tx(), NULL, INTERNAL );
+
+        // then
+        assertEquals(2, replicator.timesReplicated());
+    }
+
+    @Test
+    public void shouldFailTransactionIfLockSessionChanges() throws Exception
+    {
+        // given
+        CoreMember coreMember = new CoreMember( new AdvertisedSocketAddress( "core:1" ),
+                new AdvertisedSocketAddress( "raft:1" ) );
+
+        TriggeredReplicator replicator = new TriggeredReplicator();
+        CommittingTransactions txFutures = new StubCommittingTransactionsRegistry( replicator );
+
+        TransactionCommitProcess localCommitProcess = mock( TransactionCommitProcess.class );
+
+        LocalSessionPool sessionPool = new LocalSessionPool( coreMember );
+        CurrentReplicatedLockState lockState = lockState( 1 );
+
+        final ReplicatedTransactionStateMachine stateMachine = new ReplicatedTransactionStateMachine(
+                localCommitProcess, sessionPool.getGlobalSession(), lockState, txFutures );
+
+        ReplicatedTransactionCommitProcess commitProcess = new ReplicatedTransactionCommitProcess(
+                replicator, sessionPool, stateMachine, 1,
+                NullLogService.getInstance(), txFutures );
+
+        // when
+        try
+        {
+            commitProcess.commit( tx(), NULL, INTERNAL );
+            fail( "Should have thrown exception.");
+        }
+        catch( TransactionFailureException e )
+        {
+            // expected
+        }
+    }
+
+    public CurrentReplicatedLockState lockState( int lockSessionId )
+    {
+        CurrentReplicatedLockState lockState = mock( CurrentReplicatedLockState.class );
+        when( lockState.currentLockSession() ).thenReturn( new StubLockSession( lockSessionId ) );
+        return lockState;
+    }
+
+    private class TriggeredReplicator implements Replicator
+    {
+        private ReplicatedContentListener listener;
+        private int timesReplicated = 0;
+        private ReplicatedContent content;
+
+        @Override
+        public void replicate( ReplicatedContent content ) throws ReplicationFailedException
+        {
+            this.content = content;
+            timesReplicated++;
+        }
+
+        @Override
+        public void subscribe( ReplicatedContentListener listener )
+        {
+            this.listener = listener;
+        }
+
+        @Override
+        public void unsubscribe( ReplicatedContentListener listener )
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        public void triggerReplication()
+        {
+            listener.onReplicated( content, 1 );
+        }
+
+        public int timesReplicated()
+        {
+            return timesReplicated;
+        }
+    }
+
+    private TransactionToApply tx()
+    {
+        TransactionRepresentation tx = mock( TransactionRepresentation.class );
+        when( tx.additionalHeader() ).thenReturn( new byte[]{} );
+        return new TransactionToApply( tx );
+    }
+
+    private class StubCommittingTransactionsRegistry implements CommittingTransactions
+    {
+        CommittingTransactions registry = new CommittingTransactionsRegistry();
+
+        private final TriggeredReplicator replicator;
+        private final AtomicInteger timeoutCounter;
+
+        public StubCommittingTransactionsRegistry( TriggeredReplicator replicator )
+        {
+            this( replicator, new AtomicInteger( 0 ) );
+        }
+
+        public StubCommittingTransactionsRegistry( TriggeredReplicator replicator, AtomicInteger timeoutCounter )
+        {
+            this.replicator = replicator;
+            this.timeoutCounter = timeoutCounter;
+        }
+
+        @Override
+        public CommittingTransaction register( LocalOperationId localOperationId )
+        {
+            return new FutureTxId( registry.register( localOperationId ) );
+        }
+
+        @Override
+        public CommittingTransaction retrieve( LocalOperationId localOperationId )
+        {
+            return registry.retrieve( localOperationId );
+        }
+
+        class FutureTxId implements CommittingTransaction
+        {
+            private final CommittingTransaction delegate;
+
+            public FutureTxId( CommittingTransaction delegate )
+            {
+                this.delegate = delegate;
+            }
+
+            @Override
+            public long waitUntilCommitted( long timeout, TimeUnit unit )
+                    throws InterruptedException, TimeoutException, TransactionFailureException
+            {
+                replicator.triggerReplication();
+                if ( timeoutCounter.getAndDecrement() > 0 )
+                {
+                    throw new TimeoutException();
+                }
+                else
+                {
+                    return delegate.waitUntilCommitted( timeout, unit );
+                }
+            }
+
+            @Override
+            public void notifySuccessfullyCommitted( long txId )
+            {
+                delegate.notifySuccessfullyCommitted( txId );
+            }
+
+            @Override
+            public void notifyCommitFailed( TransactionFailureException e )
+            {
+                delegate.notifyCommitFailed( e );
+            }
+
+            @Override
+            public void close()
+            {
+                delegate.close();
+            }
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/StubLockSession.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/StubLockSession.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import org.neo4j.coreedge.server.core.CurrentReplicatedLockState;
+
+class StubLockSession implements CurrentReplicatedLockState.LockSession
+{
+    private final int id;
+
+    StubLockSession( int id )
+    {
+        this.id = id;
+    }
+
+    @Override
+    public int id()
+    {
+        return id;
+    }
+
+    @Override
+    public boolean isMine()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
- If the future waiting for a transaction to commit timed out
  we would loop indefinitely trying to commit it.
- Only create one future per operation id.
- Extract CommittingTransactionsRegistry from
  ReplicatedTransactionStateMachine.
