### PR TITLE
Fix compiled runtime after removal of kernel deps

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompatibilityTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompatibilityTest.scala
@@ -63,8 +63,7 @@ class CypherCompatibilityTest extends ExecutionEngineFunSuite with RunWithConfig
     }
   }
 
-  //TODO fix this test
-  ignore("should handle profile") {
+  test("should handle profile") {
     runWithConfig() {
       (engine: ExecutionEngine) =>
         assertProfiled(engine, "CYPHER 2.3 runtime=interpreted PROFILE MATCH (n) RETURN n")


### PR DESCRIPTION
#6083 changed the interface that the compiled runtime implements. This reflects these changes after updating the backwards dependency to 2.3.2-SNAPSHOT after #6200 was merged.
