### PR TITLE
Change the dependency of the 2.3 Cypher compiler to the released 2.3.1

### DIFF
--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-2.3</artifactId>
-      <version>2.3.2-SNAPSHOT</version>
+      <version>2.3.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_3.scala
@@ -22,10 +22,11 @@ package org.neo4j.cypher.internal.compatibility
 import java.io.PrintWriter
 import java.util
 
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.EntityAccessor
 import org.neo4j.cypher.{QueryStatistics, _}
 import org.neo4j.cypher.internal._
 import org.neo4j.cypher.internal.compiler.{v3_0, v2_3}
-import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ExecutionPlan => ExecutionPlan_v2_3, InternalExecutionResult, EntityAccessor}
+import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{ExecutionPlan => ExecutionPlan_v2_3, InternalExecutionResult}
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.cypher.internal.compiler.v2_3.planDescription.{Argument, InternalPlanDescription, PlanDescriptionArgumentSerializer}
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{PlanContext, QueryContext}
@@ -161,10 +162,10 @@ trait CompatibilityFor2_3 {
 
     val preparedQueryForV_2_3 =
       Try(compiler.prepareQuery(preParsedQuery.statement,
-                                preParsedQuery.rawStatement,
-                                as2_3(preParsedQuery.notificationLogger),
-                                preParsedQuery.planner.name,
-                                Some(as2_3(preParsedQuery.offset)), tracer))
+        preParsedQuery.rawStatement,
+        as2_3(preParsedQuery.notificationLogger),
+        //                                preParsedQuery.planner.name,
+        Some(as2_3(preParsedQuery.offset)), tracer))
     new ParsedQuery {
       def isPeriodicCommit = preparedQueryForV_2_3.map(_.isPeriodicCommit).getOrElse(false)
 
@@ -281,8 +282,8 @@ case class ExecutionResultWrapperFor2_3(inner: InternalExecutionResult, planner:
           addArgument(PlannerImpl(planner.name)).
           addArgument(Runtime(runtime.toTextOutput)).
           addArgument(RuntimeImpl(runtime.name))
-    )
-  }
+      )
+    }
 
   def close() = exceptionHandlerFor2_3.runSafely{ inner.close() }
 
@@ -437,9 +438,8 @@ case class CompatibilityFor2_3Cost(graph: GraphDatabaseService,
       case CypherRuntime.compiled => Some(CompiledRuntimeName)
     }
 
-    val nodeManager = graph.asInstanceOf[GraphDatabaseAPI].getDependencyResolver.resolveDependency(classOf[NodeManager])
     CypherCompilerFactory.costBasedCompiler(
-      graph, new EntityAccessorWrapper2_3(nodeManager), config, clock, GeneratedQueryStructure, new WrappedMonitors2_3( kernelMonitors ),
+      graph, config, clock, GeneratedQueryStructure, new WrappedMonitors2_3( kernelMonitors ),
       new StringInfoLogger2_3( log ), rewriterSequencer, plannerName, runtimeName)
   }
 
@@ -451,11 +451,8 @@ case class CompatibilityFor2_3Rule(graph: GraphDatabaseService,
                                    clock: Clock,
                                    kernelMonitors: KernelMonitors,
                                    kernelAPI: KernelAPI) extends CompatibilityFor2_3 {
-  protected val compiler = {
-    val nodeManager = graph.asInstanceOf[GraphDatabaseAPI].getDependencyResolver.resolveDependency(classOf[NodeManager])
-    CypherCompilerFactory.ruleBasedCompiler(
-            graph, new EntityAccessorWrapper2_3(nodeManager), config, clock, new WrappedMonitors2_3( kernelMonitors ), rewriterSequencer)
-  }
+  protected val compiler = CypherCompilerFactory.ruleBasedCompiler(
+    graph, config, clock, new WrappedMonitors2_3( kernelMonitors ), rewriterSequencer)
 
   override val queryCacheSize: Int = config.queryCacheSize
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor2_3.scala
@@ -142,8 +142,8 @@ class ExceptionTranslatingQueryContextFor2_3(inner: QueryContext) extends Delega
   override def getRelTypeName(id: Int) =
     translateException(super.getRelTypeName(id))
 
-  override def lockingExactUniqueIndexSearch(index: IndexDescriptor, value: Any) =
-    translateException(super.lockingExactUniqueIndexSearch(index, value))
+  override def uniqueIndexSeek(index: IndexDescriptor, value: Any) =
+    translateException(super.uniqueIndexSeek(index, value))
 
   override def commitAndRestartTx() =
     translateException(super.commitAndRestartTx())
@@ -206,4 +206,3 @@ class ExceptionTranslatingQueryContextFor2_3(inner: QueryContext) extends Delega
     case e : KernelConstraintViolationException => throw new ConstraintValidationException(e.getMessage, e)
   }
 }
-

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -27,8 +27,6 @@ import org.neo4j.cypher.InternalException
 import org.neo4j.cypher.internal.compiler.v2_3.MinMaxOrdering.{BY_NUMBER, BY_STRING, BY_VALUE}
 import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.DirectionConverter.toGraphDb
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions
-import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{KernelPredicate, OnlyDirectionExpander, TypeAndDirectionExpander}
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.JavaConversionSupport._
 import org.neo4j.cypher.internal.compiler.v2_3.helpers.{BeansAPIRelationshipIterator, JavaConversionSupport}
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
@@ -36,7 +34,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.spi._
 import org.neo4j.cypher.internal.frontend.v2_3.{Bound, EntityNotFoundException, FailedIndexException, SemanticDirection}
 import org.neo4j.graphdb.RelationshipType._
 import org.neo4j.graphdb._
-import org.neo4j.graphdb.traversal.{Evaluators, TraversalDescription, Uniqueness}
+import org.neo4j.graphdb.traversal.{Evaluators, TraversalDescription}
 import org.neo4j.kernel.api._
 import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, AlreadyIndexedException}
@@ -44,10 +42,7 @@ import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
 import org.neo4j.kernel.impl.api.KernelStatement
 import org.neo4j.kernel.impl.core.{RelationshipProxy, ThreadToStatementContextBridge}
 import org.neo4j.graphdb.security.URLAccessValidationError
-import org.neo4j.kernel.GraphDatabaseAPI
-import java.util.function.Predicate
-import org.neo4j.graphalgo.impl.path.ShortestPath.ShortestPathPredicate
-import org.neo4j.graphalgo.impl.path.ShortestPath
+import org.neo4j.kernel.{GraphDatabaseAPI, Uniqueness}
 
 import scala.collection.JavaConverters._
 import scala.collection.{Iterator, mutable}
@@ -275,7 +270,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   def indexScan(index: IndexDescriptor) =
     mapToScalaENFXSafe(statement.readOperations().nodesGetFromIndexScan(index))(nodeOps.getById)
 
-  override def lockingExactUniqueIndexSearch(index: IndexDescriptor, value: Any): Option[Node] = {
+  def uniqueIndexSeek(index: IndexDescriptor, value: Any): Option[Node] = {
     val nodeId: Long = statement.readOperations().nodeGetFromUniqueIndexSeek(index, value)
     if (StatementConstants.NO_SUCH_NODE == nodeId) None else Some(nodeOps.getById(nodeId))
   }
@@ -424,7 +419,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       val indexDescriptor = statement.readOperations().indexGetForLabelAndPropertyKey(labelId, propertyKeyId)
       if(statement.readOperations().indexGetState(indexDescriptor) == InternalIndexState.FAILED)
         throw new FailedIndexException(indexDescriptor.userDescription(tokenNameLookup))
-     IdempotentResult(indexDescriptor, wasCreated = false)
+      IdempotentResult(indexDescriptor, wasCreated = false)
   }
 
   def dropIndexRule(labelId: Int, propertyKeyId: Int) =
@@ -513,53 +508,6 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       baseTraversalDescription.expand(expander.build())
     }
     traversalDescription.traverse(realNode).iterator().asScala
-  }
-
-  override def singleShortestPath(left: Node, right: Node, depth: Int, expander: expressions.Expander, pathPredicate: KernelPredicate[Path],
-                                  filters: Seq[KernelPredicate[PropertyContainer]]): Option[Path] = {
-    val pathFinder = buildPathFinder(depth, expander, pathPredicate, filters)
-
-    Option(pathFinder.findSinglePath(left, right))
-  }
-
-  private def buildPathFinder(depth: Int, expander: expressions.Expander, pathPredicate: KernelPredicate[Path],
-                      filters: Seq[KernelPredicate[PropertyContainer]]): ShortestPath = {
-    val startExpander = expander match {
-      case OnlyDirectionExpander(_, _, dir) =>
-        PathExpanderBuilder.allTypes(toGraphDb(dir))
-      case TypeAndDirectionExpander(_,_,typDirs) =>
-        typDirs.foldLeft(PathExpanderBuilder.empty()) {
-          case (acc, (typ, dir)) => acc.add(DynamicRelationshipType.withName(typ), toGraphDb(dir))
-        }
-    }
-
-    val expanderWithNodeFilters = expander.nodeFilters.foldLeft(startExpander) {
-      case (acc, filter) => acc.addNodeFilter(new Predicate[PropertyContainer] {
-        override def test(t: PropertyContainer): Boolean = filter.test(t)
-      })
-    }
-    val expanderWithAllPredicates = expander.relFilters.foldLeft(expanderWithNodeFilters) {
-      case (acc, filter) => acc.addRelationshipFilter(new Predicate[PropertyContainer] {
-        override def test(t: PropertyContainer): Boolean = filter.test(t)
-      })
-    }
-    val shortestPathPredicate = new ShortestPathPredicate {
-      override def test(path: Path): Boolean = pathPredicate.test(path)
-    }
-
-    new ShortestPath(depth, expanderWithAllPredicates.build(), shortestPathPredicate) {
-      override protected def filterNextLevelNodes(nextNode: Node): Node =
-        if (filters.isEmpty) nextNode
-        else if (filters.forall(filter => filter test nextNode)) nextNode
-        else null
-    }
-  }
-
-  override def allShortestPath(left: Node, right: Node, depth: Int, expander: expressions.Expander, pathPredicate: KernelPredicate[Path],
-                               filters: Seq[KernelPredicate[PropertyContainer]]): scala.Iterator[Path] = {
-    val pathFinder = buildPathFinder(depth, expander, pathPredicate, filters)
-
-    pathFinder.findAllPaths(left, right).iterator().asScala
   }
 
   def nodeCountByCountStore(labelId: Int): Long = {


### PR DESCRIPTION
Neo4j should only depend on released versions of older compilers.

Once 2.3.2 is released, revert this, and merge #6205.
