### PR TITLE
Adaptive work-ahead queue size in ParallelBatchImporter

### DIFF
--- a/community/import-tool/LICENSES.txt
+++ b/community/import-tool/LICENSES.txt
@@ -3,6 +3,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Lang
   Lucene Core
 ------------------------------------------------------------------------------
 

--- a/community/import-tool/NOTICE.txt
+++ b/community/import-tool/NOTICE.txt
@@ -26,5 +26,6 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Lang
   Lucene Core
 

--- a/community/import-tool/pom.xml
+++ b/community/import-tool/pom.xml
@@ -81,10 +81,5 @@ the relevant Commercial Agreement.
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Batch.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Batch.java
@@ -31,6 +31,12 @@ import org.neo4j.unsafe.impl.batchimport.staging.Step;
  */
 public class Batch<INPUT,RECORD extends PrimitiveRecord>
 {
+    /**
+     * Used in a scenario where a step merely needs to signal that the next step in the stage should execute,
+     * not necessarily that it needs any data from the previous step.
+     */
+    public static final Batch EMPTY = new Batch<>( null );
+
     public final INPUT[] input;
     public RECORD[] records;
     public int[] propertyBlocksLengths;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -45,19 +45,6 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
      */
     int denseNodeThreshold();
 
-    /**
-     * Rough max number of processors (CPU cores) simultaneously used in total by importer at any given time.
-     * This value should be set while taking the necessary IO threads into account; the page cache and the operating
-     * system will require a couple of threads between them, to handle the IO workload the importer generates.
-     * Defaults to the value provided by the {@link Runtime#availableProcessors() jvm}. There's a discrete
-     * number of threads that needs to be used just to get the very basics of the import working,
-     * so for that reason there's no lower bound to this value.
-     *   "Processor" in the context of the batch importer is different from "thread" since when discovering
-     * how many processors are fully in use there's a calculation where one thread takes up 0 < fraction <= 1
-     * of a processor.
-     */
-    int maxNumberOfProcessors();
-
     class Default
             extends org.neo4j.unsafe.impl.batchimport.staging.Configuration.Default
             implements Configuration
@@ -91,21 +78,9 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
         }
 
         @Override
-        public int workAheadSize()
-        {
-            return 20;
-        }
-
-        @Override
         public int denseNodeThreshold()
         {
             return Integer.parseInt( GraphDatabaseSettings.dense_node_threshold.getDefaultValue() );
-        }
-
-        @Override
-        public int maxNumberOfProcessors()
-        {
-            return Runtime.getRuntime().availableProcessors();
         }
 
         @Override
@@ -146,12 +121,6 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
         public int denseNodeThreshold()
         {
             return config.get( GraphDatabaseSettings.dense_node_threshold );
-        }
-
-        @Override
-        public int maxNumberOfProcessors()
-        {
-            return defaults.maxNumberOfProcessors();
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
@@ -63,5 +63,6 @@ public class NodeStage extends Stage
         add( new LabelScanStorePopulationStep( control(), config, labelScanStore ) );
         add( new EntityStoreUpdaterStep<>( control(), config, nodeStore, propertyStore,
                 writeMonitor, storeUpdateMonitor ) );
+        add( new StoreFlusherStep( control(), config, nodeStore, propertyStore ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStage.java
@@ -54,5 +54,6 @@ public class RelationshipStage extends Stage
                 neoStore.getRelationshipTypeRepository(), cache, specificIds ) );
         add( new EntityStoreUpdaterStep<>( control(), config,
                 relationshipStore, propertyStore, writeMonitor, storeUpdateMonitor ) );
+        add( new StoreFlusherStep( control(), config, relationshipStore, propertyStore ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/StoreFlusherStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/StoreFlusherStep.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
+import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
+import org.neo4j.unsafe.impl.batchimport.staging.ProcessorStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+/**
+ * Flushes stores after a batch of records has been applied.
+ */
+public class StoreFlusherStep extends ProcessorStep<Batch<?,?>>
+{
+    private final RecordStore<?>[] stores;
+
+    public StoreFlusherStep( StageControl control, Configuration config, RecordStore<?>...stores )
+    {
+        super( control, "FLUSH", config, 1 );
+        this.stores = stores;
+    }
+
+    @Override
+    protected void process( Batch<?,?> batch, BatchSender sender ) throws Throwable
+    {
+        // Flush after every batch.
+        // We get vectored, sequential IO when we write with flush, plus it makes future page faulting faster.
+        for ( RecordStore<?> store : stores )
+        {
+            store.flush();
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
@@ -42,10 +42,9 @@ import static org.neo4j.unsafe.impl.batchimport.executor.DynamicTaskExecutor.DEF
 public abstract class ProcessorStep<T> extends AbstractStep<T>
 {
     private TaskExecutor<Sender> executor;
-    private final int workAheadSize;
-    private final int initialProcessorCount = 1;
-    // zero for unlimited
+    // max processors for this step, zero means unlimited, or rather config.maxNumberOfProcessors()
     private final int maxProcessors;
+    private final Configuration config;
     private final LongPredicate catchUp = new LongPredicate()
     {
         @Override
@@ -72,7 +71,7 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
             StatsProvider... additionalStatsProviders )
     {
         super( control, name, config, additionalStatsProviders );
-        this.workAheadSize = config.workAheadSize();
+        this.config = config;
         this.maxProcessors = maxProcessors;
     }
 
@@ -80,7 +79,7 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
     public void start( int orderingGuarantees )
     {
         super.start( orderingGuarantees );
-        this.executor = new DynamicTaskExecutor<>( initialProcessorCount, maxProcessors, workAheadSize,
+        this.executor = new DynamicTaskExecutor<>( 1, maxProcessors, theoreticalMaxProcessors(),
                 DEFAULT_PARK_STRATEGY, name(), new Supplier<Sender>()
                 {
                     @Override
@@ -91,11 +90,16 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
                 } );
     }
 
+    private int theoreticalMaxProcessors()
+    {
+        return maxProcessors == 0 ? config.maxNumberOfProcessors() : maxProcessors;
+    }
+
     @Override
     public long receive( final long ticket, final T batch )
     {
         // Don't go too far ahead
-        long idleTime = await( catchUp, workAheadSize );
+        long idleTime = await( catchUp, executor.numberOfProcessors() );
         incrementQueue();
 
         executor.submit( new Task<Sender>()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/StepStats.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/stats/StepStats.java
@@ -110,12 +110,15 @@ public class StepStats implements StatsProvider
             builder.append( " DONE" );
         }
 
+        int i = 0;
         for ( Key key : keys() )
         {
             Stat stat = stat( key );
             if ( detailLevel.ordinal() >= stat.detailLevel().ordinal() )
             {
-                builder.append( key.shortName() != null ? key.shortName() + ":" : "" ).append( stat );
+                builder.append( i++ > 0 ? " " : "" )
+                       .append( key.shortName() != null ? key.shortName() + ":" : "" )
+                       .append( stat );
             }
         }
         return name + (builder.length() > 0 ? ":" + builder : "");

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/StageTest.java
@@ -44,12 +44,6 @@ public class StageTest
             {
                 return 10;
             }
-
-            @Override
-            public int workAheadSize()
-            {
-                return 20;
-            }
         };
         Stage stage = new Stage( "Test stage", config, ORDER_SEND_DOWNSTREAM );
         long batches = 1000;


### PR DESCRIPTION
Adaptive in that the work-ahead queue size will be individual per step and maximum
that of the number of processors assigned to that step. This has the benefit that
no unnecessary memory is built up in the stages. Previously there was a default
work-ahead queue size of 20 which means that each step might be 20 batches ahead
of its immediate downstream step. If the last step was the slowest and being
faster and faster going backwards there would be 20 batches sitting and waiting
at each step. This would be a problem for batches that occupied a lot of memory,
for example nodes/relationships with plenty of properties.

The flushing of the stores after each batch has been pulled out into its own step
after the store updater step to be able to do flushing in parallel. This is
benefitial simply due to the adaptive work-ahead queue size and the fact that
EntityStoreUpdaterStep has maxProcessors=1. This means that potential eviction
caused by updating records "conflicting" with the store flushing will be minimal
and evicted pages will be close to the ones being evicted,
so random access is minimal. Having work-ahead size == number of processors
(1 in this case, instead of 20 previously) increased write throughput at least
one order of magnitude in very property-heavy scenarios.
