### PR TITLE
Wiggle in SPI for GraphDatabaseFacade.

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.bolt;
 
+import io.netty.channel.Channel;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import org.bouncycastle.operator.OperatorCreationException;
+
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -26,11 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-
-import io.netty.channel.Channel;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import org.bouncycastle.operator.OperatorCreationException;
 
 import org.neo4j.bolt.security.ssl.Certificates;
 import org.neo4j.bolt.security.ssl.KeyStoreFactory;
@@ -90,8 +90,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 
         @Description( "Set the encryption level for Neo4j Bolt protocol ports" )
         public static final Setting<EncryptionLevel> tls_level =
-                setting( "tls.level", options( EncryptionLevel.class ),
-                        OPTIONAL.name() );
+                setting( "tls.level", options( EncryptionLevel.class ), OPTIONAL.name() );
 
         @Description( "Host and port for the Neo4j Bolt Protocol" )
         public static final Setting<HostnamePort> socket_address =

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/StateMachineErrorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/StateMachineErrorTest.java
@@ -36,7 +36,7 @@ import org.neo4j.cypher.SyntaxException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
-import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.logging.NullLogService;

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.{CypherCompiler, _}
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
+import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade
 import org.neo4j.kernel.impl.query.{QueryEngineProvider, QueryExecutionMonitor, QuerySession}
@@ -251,7 +252,9 @@ class ExecutionEngine(graph: GraphDatabaseService, logProvider: LogProvider = Nu
     }
     optGraphAs[GraphDatabaseFacade]
       .andThen(g => {
-      Option(g.platformModule.config.get(setting))
+        // TODO: Config should be passed in as a dependency to Cypher, not pulled out of casted interfaces
+        val config: Config = g.getDependencyResolver.resolveDependency(classOf[Config])
+        Option(config.get(setting))
     })
       .andThen(_.getOrElse(defaultValue))
       .applyOrElse(graph, (_: GraphDatabaseService) => defaultValue)

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/ExecutionResultTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/javacompat/ExecutionResultTest.java
@@ -33,7 +33,9 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.test.ImpermanentDatabaseRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -226,11 +228,11 @@ public class ExecutionResultTest
         }
     }
 
-    private org.neo4j.kernel.TopLevelTransaction activeTransaction()
+    private TopLevelTransaction activeTransaction()
     {
         ThreadToStatementContextBridge bridge = db.getDependencyResolver().resolveDependency(
                 ThreadToStatementContextBridge.class );
-        return bridge.getTopLevelTransactionBoundToThisThread( false );
+        KernelTransaction kernelTransaction = bridge.getTopLevelTransactionBoundToThisThread( false );
+        return kernelTransaction == null ? null : new TopLevelTransaction( kernelTransaction, null );
     }
-
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -30,8 +30,11 @@ import org.neo4j.graphdb._
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.io.fs.FileUtils
-import org.neo4j.kernel.{NeoStoreDataSource, TopLevelTransaction}
+import org.neo4j.kernel.{NeoStoreDataSource}
 import org.neo4j.test.TestGraphDatabaseFactory
+import org.neo4j.kernel.NeoStoreDataSource
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction
+import org.neo4j.test.{ImpermanentGraphDatabase, TestGraphDatabaseFactory}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LazyTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LazyTest.scala
@@ -42,6 +42,7 @@ import org.neo4j.graphdb._
 import org.neo4j.helpers.collection.Iterables.asResourceIterable
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.{ReadOperations, Statement}
+import org.neo4j.kernel.configuration.Config
 import org.neo4j.kernel.impl.api.OperationsFacade
 import org.neo4j.kernel.impl.core.{NodeManager, NodeProxy, ThreadToStatementContextBridge}
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore
@@ -190,6 +191,7 @@ class LazyTest extends ExecutionEngineFunSuite {
     val dependencies = mock[DependencyResolver]
     val bridge = mock[ThreadToStatementContextBridge]
     val monitors = new org.neo4j.kernel.monitoring.Monitors()
+    val config = new Config()
 
     val fakeDataStatement = mock[OperationsFacade]
     val fakeReadStatement = mock[ReadOperations]
@@ -208,6 +210,7 @@ class LazyTest extends ExecutionEngineFunSuite {
     when(dependencies.resolveDependency(classOf[NodeManager])).thenReturn(nodeManager)
     when(dependencies.resolveDependency(classOf[TransactionIdStore])).thenReturn(idStore)
     when(dependencies.resolveDependency(classOf[org.neo4j.kernel.monitoring.Monitors])).thenReturn(monitors)
+    when(dependencies.resolveDependency(classOf[Config])).thenReturn(config)
     when(fakeGraph.beginTx()).thenReturn(tx)
     val n0 = mock[Node]
     val n1 = mock[Node]

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
@@ -129,7 +129,7 @@ public class ShortestPath implements PathFinder<Path>
             GraphDatabaseService service = node.getGraphDatabase();
             if ( service instanceof GraphDatabaseFacade )
             {
-                Monitors monitors = ((GraphDatabaseFacade) service).platformModule.monitors;
+                Monitors monitors = ((GraphDatabaseFacade) service).getDependencyResolver().resolveDependency( Monitors.class );
                 dataMonitor = monitors.newMonitor( DataMonitor.class );
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -47,6 +47,7 @@ import static org.neo4j.kernel.configuration.Settings.LONG;
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.PATH;
 import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
 import static org.neo4j.kernel.configuration.Settings.illegalValueMessage;
 import static org.neo4j.kernel.configuration.Settings.list;
@@ -200,7 +201,7 @@ public abstract class GraphDatabaseSettings
             "only.")
     @Internal
     @Deprecated
-    public static final Setting<String> node_keys_indexable = setting("node_keys_indexable", STRING, NO_DEFAULT, illegalValueMessage( "must be a comma-separated list of keys to be indexed", matches( ANY ) ) );
+    public static final Setting<List<String>> node_keys_indexable = setting("node_keys_indexable", STRING_LIST, "" );
 
     @Description("Controls the auto indexing feature for relationships. Setting it to `false` shuts it down, " +
             "while `true` enables it by default for properties "
@@ -214,7 +215,7 @@ public abstract class GraphDatabaseSettings
             "_relationships_ only." )
     @Internal
     @Deprecated
-    public static final Setting<String> relationship_keys_indexable = setting("relationship_keys_indexable", STRING, NO_DEFAULT, illegalValueMessage( "must be a comma-separated list of keys to be indexed", matches( ANY ) ) );
+    public static final Setting<List<String>> relationship_keys_indexable = setting("relationship_keys_indexable", STRING_LIST, "" );
 
     // Index sampling
     @Description("Enable or disable background index sampling")

--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -206,7 +206,7 @@ public class AvailabilityGuard
         }
     }
 
-    private static enum Availability
+    private enum Availability
     {
         AVAILABLE,
         UNAVAILABLE,
@@ -221,6 +221,15 @@ public class AvailabilityGuard
     public boolean isAvailable()
     {
         return availability() == Availability.AVAILABLE;
+    }
+
+
+    /**
+     * Check if the database has been shut down.
+     */
+    public boolean isShutdown()
+    {
+        return availability() == Availability.SHUTDOWN;
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -78,10 +78,6 @@ public class NodeProxy
 
         void failTransaction();
 
-        Relationship lazyRelationshipProxy( long id );
-
-        Relationship newRelationshipProxy( long id );
-
         Relationship newRelationshipProxy( long id, long startNodeId, int typeId, long endNodeId );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/AbstractAutoIndexerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/AbstractAutoIndexerImpl.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.coreapi;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.StringTokenizer;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.index.AutoIndexer;
@@ -30,7 +30,6 @@ import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.graphdb.index.ReadableIndex;
 import org.neo4j.kernel.PropertyTracker;
-import org.neo4j.kernel.lifecycle.Lifecycle;
 
 /**
  * Default implementation of the AutoIndexer, binding to the beforeCommit hook
@@ -39,9 +38,9 @@ import org.neo4j.kernel.lifecycle.Lifecycle;
  * @param <T> The database primitive type auto indexed/**
  */
 abstract class AbstractAutoIndexerImpl<T extends PropertyContainer> implements
-        PropertyTracker<T>, AutoIndexer<T>, Lifecycle
+        PropertyTracker<T>, AutoIndexer<T>
 {
-    protected final Set<String> propertyKeysToInclude = new HashSet<String>();
+    protected final Set<String> propertyKeysToInclude = new HashSet<>();
 
     private volatile boolean enabled;
 
@@ -123,27 +122,6 @@ abstract class AbstractAutoIndexerImpl<T extends PropertyContainer> implements
      * @return The Index used by this AutoIndexer
      */
     protected abstract Index<T> getIndexInternal();
-
-    protected Set<String> parseConfigList(String list)
-    {
-        if ( list == null )
-        {
-            return Collections.emptySet();
-        }
-
-        Set<String> toReturn = new HashSet<String>();
-        StringTokenizer tokenizer = new StringTokenizer(list, "," );
-        String currentToken;
-        while ( tokenizer.hasMoreTokens() )
-        {
-            currentToken = tokenizer.nextToken();
-            if ( ( currentToken = currentToken.trim() ).length() > 0 )
-            {
-                toReturn.add( currentToken );
-            }
-        }
-        return toReturn;
-    }
 
     /**
      * Simple implementation of the AutoIndex interface, as a wrapper around a

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexManagerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexManagerImpl.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.coreapi;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.Node;
@@ -34,17 +35,15 @@ import org.neo4j.graphdb.index.RelationshipIndex;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
-import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 
 public class IndexManagerImpl implements IndexManager
 {
-
-    private final ThreadToStatementContextBridge transactionBridge;
+    private final Supplier<Statement> transactionBridge;
     private final IndexProvider provider;
     private final AutoIndexer<Node> nodeAutoIndexer;
     private final RelationshipAutoIndexer relAutoIndexer;
 
-    public IndexManagerImpl( ThreadToStatementContextBridge bridge,
+    public IndexManagerImpl( Supplier<Statement> bridge,
                              IndexProvider provider,
                              AutoIndexer<Node> nodeAutoIndexer,
                              RelationshipAutoIndexer relAutoIndexer )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/NodeAutoIndexerImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/NodeAutoIndexerImpl.java
@@ -19,12 +19,11 @@
  */
 package org.neo4j.kernel.impl.coreapi;
 
+import java.util.Collection;
+
 import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.config.Setting;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 
 /**
  * Implementation of an AutoIndexer for Node primitives. It
@@ -34,55 +33,23 @@ import org.neo4j.kernel.impl.core.NodeManager;
  */
 public class NodeAutoIndexerImpl extends AbstractAutoIndexerImpl<Node>
 {
-    public static abstract class Configuration
-    {
-        public static final Setting<Boolean> node_auto_indexing = GraphDatabaseSettings.node_auto_indexing;
-        public static final Setting<String> node_keys_indexable = GraphDatabaseSettings.node_keys_indexable;
-    }
-
     static final String NODE_AUTO_INDEX = "node_auto_index";
-    private Config config;
-    private IndexProvider indexProvider;
-    private NodeManager nodeManager;
+    private final IndexProvider indexProvider;
+    private final GraphDatabaseFacade.SPI spi;
 
-    public NodeAutoIndexerImpl( Config config, IndexProvider indexProvider, NodeManager nodeManager )
+    public NodeAutoIndexerImpl( boolean enabled, Collection<String> propertiesToIndex, IndexProvider indexProvider, GraphDatabaseFacade.SPI spi )
     {
         super();
-        this.config = config;
         this.indexProvider = indexProvider;
-        this.nodeManager = nodeManager;
-    }
-
-    @Override
-    public void init()
-            throws Throwable
-    {
-    }
-
-    @Override
-    public void start()
-    {
-        setEnabled( config.get( Configuration.node_auto_indexing ) );
-        propertyKeysToInclude.addAll( parseConfigList( config.get( Configuration.node_keys_indexable ) ) );
-    }
-
-    @Override
-    public void stop()
-            throws Throwable
-    {
-    }
-
-    @Override
-    public void shutdown()
-            throws Throwable
-    {
+        this.spi = spi;
+        setEnabled( enabled );
+        propertyKeysToInclude.addAll( propertiesToIndex );
     }
 
     @Override
     protected Index<Node> getIndexInternal()
     {
-        return indexProvider.getOrCreateNodeIndex(
-                NODE_AUTO_INDEX, null );
+        return indexProvider.getOrCreateNodeIndex( NODE_AUTO_INDEX, null );
     }
 
     @Override
@@ -91,13 +58,11 @@ public class NodeAutoIndexerImpl extends AbstractAutoIndexerImpl<Node>
         super.setEnabled( enabled );
         if ( enabled )
         {
-            nodeManager.addNodePropertyTracker(
-                    this );
+            spi.addNodePropertyTracker( this );
         }
         else
         {
-            nodeManager.removeNodePropertyTracker(
-                    this );
+            spi.removeNodePropertyTracker( this );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/RelationshipLegacyIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/RelationshipLegacyIndexProxy.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel.impl.coreapi;
 
+import java.util.function.Supplier;
+
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
@@ -26,14 +29,13 @@ import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.graphdb.index.RelationshipIndex;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
-import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 
 public class RelationshipLegacyIndexProxy extends LegacyIndexProxy<Relationship> implements RelationshipIndex
 {
-    public RelationshipLegacyIndexProxy( String name, LegacyIndexProxy.Lookup lookup,
-            ThreadToStatementContextBridge statementContextBridge )
+    public RelationshipLegacyIndexProxy( String name, GraphDatabaseService gds,
+                                         Supplier<Statement> statementContextBridge )
     {
-        super( name, Type.RELATIONSHIP, lookup, statementContextBridge );
+        super( name, Type.RELATIONSHIP, gds, statementContextBridge );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/StandardNodeActions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/StandardNodeActions.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.coreapi;
+
+import java.util.function.Supplier;
+
+import org.neo4j.function.ThrowingAction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.impl.core.NodeProxy;
+import org.neo4j.kernel.impl.core.RelationshipProxy;
+
+public class StandardNodeActions implements NodeProxy.NodeActions
+{
+    private final Supplier<Statement> stmt;
+    private final Supplier<KernelTransaction> currentTx;
+    private final ThrowingAction<RuntimeException> assertInOpenTransaction;
+    private final RelationshipProxy.RelationshipActions relationshipActions;
+    private final GraphDatabaseService gds;
+
+    public StandardNodeActions( Supplier<Statement> stmt,
+                                Supplier<KernelTransaction> currentTx,
+                                ThrowingAction<RuntimeException> assertTransactionOpen,
+                                RelationshipProxy.RelationshipActions relationshipActions,
+                                GraphDatabaseService gds )
+    {
+        this.stmt = stmt;
+        this.currentTx = currentTx;
+        this.assertInOpenTransaction = assertTransactionOpen;
+        this.relationshipActions = relationshipActions;
+        this.gds = gds;
+    }
+
+    @Override
+    public Statement statement()
+    {
+        return stmt.get();
+    }
+
+    @Override
+    public GraphDatabaseService getGraphDatabase()
+    {
+        return gds;
+    }
+
+    @Override
+    public void assertInUnterminatedTransaction()
+    {
+        assertInOpenTransaction.apply();
+    }
+
+    @Override
+    public void failTransaction()
+    {
+        currentTx.get().failure();
+    }
+
+    @Override
+    public Relationship newRelationshipProxy( long id, long startNodeId, int typeId, long endNodeId )
+    {
+        return new RelationshipProxy( relationshipActions, id, startNodeId, typeId, endNodeId );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/StandardRelationshipActions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/StandardRelationshipActions.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.coreapi;
+
+import java.util.function.LongFunction;
+import java.util.function.Supplier;
+
+import org.neo4j.function.ThrowingAction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.exceptions.RelationshipTypeIdNotFoundKernelException;
+import org.neo4j.kernel.impl.core.RelationshipProxy.RelationshipActions;
+
+public class StandardRelationshipActions implements RelationshipActions
+{
+    private final Supplier<Statement> stmt;
+    private final Supplier<KernelTransaction> currentTransaction;
+    private final ThrowingAction<RuntimeException> assertInOpenTransaction;
+    private final LongFunction<Node> newNodeProxy;
+    private final GraphDatabaseService gds;
+
+    public StandardRelationshipActions( Supplier<Statement> stmt, Supplier<KernelTransaction> currentTransaction,
+                                        ThrowingAction<RuntimeException> assertInOpenTransaction,
+                                        LongFunction<Node> newNodeProxy, GraphDatabaseService gds )
+    {
+        this.stmt = stmt;
+        this.currentTransaction = currentTransaction;
+        this.assertInOpenTransaction = assertInOpenTransaction;
+        this.newNodeProxy = newNodeProxy;
+        this.gds = gds;
+    }
+
+    @Override
+    public Statement statement()
+    {
+        return stmt.get();
+    }
+
+    @Override
+    public Node newNodeProxy( long nodeId )
+    {
+        return newNodeProxy.apply( nodeId );
+    }
+
+    @Override
+    public RelationshipType getRelationshipTypeById( int type )
+    {
+        try
+        {
+            return RelationshipType.withName( statement().readOperations().relationshipTypeGetName( type ) );
+        }
+        catch ( RelationshipTypeIdNotFoundKernelException e )
+        {
+            throw new IllegalStateException( "Kernel API returned non-existent relationship type: " + type );
+        }
+    }
+
+    @Override
+    public GraphDatabaseService getGraphDatabaseService()
+    {
+        return gds;
+    }
+
+    @Override
+    public void failTransaction()
+    {
+        currentTransaction.get().failure();
+    }
+
+    @Override
+    public void assertInUnterminatedTransaction()
+    {
+        assertInOpenTransaction.apply();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/AbstractConstraintCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/AbstractConstraintCreator.java
@@ -38,6 +38,6 @@ abstract class AbstractConstraintCreator
 
     protected final void assertInUnterminatedTransaction()
     {
-        actions.assertInUnterminatedTransaction();
+        actions.assertInOpenTransaction();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/IndexCreatorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/IndexCreatorImpl.java
@@ -78,6 +78,6 @@ public class IndexCreatorImpl implements IndexCreator
 
     protected void assertInUnterminatedTransaction()
     {
-        actions.assertInUnterminatedTransaction();
+        actions.assertInOpenTransaction();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/IndexDefinitionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/IndexDefinitionImpl.java
@@ -114,6 +114,6 @@ public class IndexDefinitionImpl implements IndexDefinition
 
     protected void assertInUnterminatedTransaction()
     {
-        actions.assertInUnterminatedTransaction();
+        actions.assertInOpenTransaction();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/InternalSchemaActions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/InternalSchemaActions.java
@@ -59,5 +59,5 @@ public interface InternalSchemaActions
 
     String getUserMessage( KernelException e );
 
-    void assertInUnterminatedTransaction();
+    void assertInOpenTransaction();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/PropertyConstraintDefinition.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/PropertyConstraintDefinition.java
@@ -64,6 +64,6 @@ abstract class PropertyConstraintDefinition implements ConstraintDefinition
 
     protected void assertInUnterminatedTransaction()
     {
-        actions.assertInUnterminatedTransaction();
+        actions.assertInOpenTransaction();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.factory;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.neo4j.graphdb.DatabaseShutdownException;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotInTransactionException;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.event.KernelEventHandler;
+import org.neo4j.graphdb.event.TransactionEventHandler;
+import org.neo4j.graphdb.security.URLAccessValidationError;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.PropertyTracker;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
+import org.neo4j.kernel.impl.query.QuerySession;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.lifecycle.LifecycleException;
+import org.neo4j.logging.Logger;
+
+/**
+ * This implements the backend for the "classic" Core API - meaning the surface-layer-of-the-database, thread bound API. It's a thin veneer to wire the
+ * various components the kernel and related utilities expose in a way that {@link GraphDatabaseFacade} likes.
+ * @see org.neo4j.kernel.impl.factory.GraphDatabaseFacade.SPI
+ */
+class ClassicCoreSPI implements GraphDatabaseFacade.SPI
+{
+    private final PlatformModule platform;
+    private final DataSourceModule dataSource;
+    private final Logger msgLog;
+    private final EditionModule edition;
+
+    public ClassicCoreSPI( PlatformModule platform, DataSourceModule dataSource, Logger msgLog, EditionModule edition )
+    {
+        this.platform = platform;
+        this.dataSource = dataSource;
+        this.msgLog = msgLog;
+        this.edition = edition;
+    }
+
+    @Override
+    public boolean databaseIsAvailable( long timeout )
+    {
+        return platform.availabilityGuard.isAvailable( timeout );
+    }
+
+    @Override
+    public Result executeQuery( String query, Map<String,Object> parameters, QuerySession querySession )
+    {
+        try
+        {
+            assertDatabaseAvailable();
+            return dataSource.queryExecutor.get().executeQuery( query, parameters, querySession );
+        }
+        catch ( QueryExecutionKernelException e )
+        {
+            throw e.asUserException();
+        }
+    }
+
+    @Override
+    public DependencyResolver resolver()
+    {
+        return platform.dependencies;
+    }
+
+    @Override
+    public void registerKernelEventHandler( KernelEventHandler handler )
+    {
+        dataSource.kernelEventHandlers.registerKernelEventHandler( handler );
+    }
+
+    @Override
+    public void unregisterKernelEventHandler( KernelEventHandler handler )
+    {
+        dataSource.kernelEventHandlers.unregisterKernelEventHandler( handler );
+    }
+
+    @Override
+    public <T> void registerTransactionEventHandler( TransactionEventHandler<T> handler )
+    {
+        dataSource.transactionEventHandlers.registerTransactionEventHandler( handler );
+    }
+
+    @Override
+    public <T> void unregisterTransactionEventHandler( TransactionEventHandler<T> handler )
+    {
+        dataSource.transactionEventHandlers.unregisterTransactionEventHandler( handler );
+    }
+
+    @Override
+    public StoreId storeId()
+    {
+        return dataSource.storeId.get();
+    }
+
+    @Override
+    public String storeDir()
+    {
+        return platform.storeDir.getAbsolutePath();
+    }
+
+    @Override
+    public void addNodePropertyTracker( PropertyTracker<Node> tracker )
+    {
+        dataSource.nodeManager.addNodePropertyTracker( tracker );
+    }
+
+    @Override
+    public void removeNodePropertyTracker( PropertyTracker<Node> tracker )
+    {
+        dataSource.nodeManager.removeNodePropertyTracker( tracker );
+    }
+
+    @Override
+    public void addRelationshipPropertyTracker( PropertyTracker<Relationship> tracker )
+    {
+        dataSource.nodeManager.addRelationshipPropertyTracker( tracker );
+    }
+
+    @Override
+    public void removeRelationshipPropertyTracker( PropertyTracker<Relationship> tracker )
+    {
+        dataSource.nodeManager.removeRelationshipPropertyTracker( tracker );
+    }
+
+    @Override
+    public URL validateURLAccess( URL url ) throws URLAccessValidationError
+    {
+        return platform.urlAccessRule.validate( platform.config, url );
+    }
+
+    @Override
+    public String name()
+    {
+        return platform.databaseInfo.toString();
+    }
+
+    @Override
+    public void shutdown()
+    {
+        try
+        {
+            msgLog.log( "Shutdown started" );
+            platform.availabilityGuard.shutdown();
+            platform.life.shutdown();
+        }
+        catch ( LifecycleException throwable )
+        {
+            msgLog.log( "Shutdown failed", throwable );
+            throw throwable;
+        }
+    }
+
+    @Override
+    public KernelTransaction beginTransaction()
+    {
+        try
+        {
+            assertDatabaseAvailable();
+            KernelTransaction kernelTx = dataSource.kernelAPI.get().newTransaction();
+            kernelTx.registerCloseListener( (s) -> dataSource.threadToTransactionBridge.unbindTransactionFromCurrentThread() );
+            dataSource.threadToTransactionBridge.bindTransactionToCurrentThread( kernelTx );
+            return kernelTx;
+        }
+        catch ( TransactionFailureException e )
+        {
+            throw new org.neo4j.graphdb.TransactionFailureException( e.getMessage(), e );
+        }
+    }
+
+    @Override
+    public KernelTransaction currentTransaction()
+    {
+        assertDatabaseAvailable();
+        KernelTransaction tx = dataSource.threadToTransactionBridge.getKernelTransactionBoundToThisThread( false );
+        if( tx == null )
+        {
+            throw new NotInTransactionException();
+        }
+        return tx;
+    }
+
+    @Override
+    public boolean isInOpenTransaction()
+    {
+        return dataSource.threadToTransactionBridge.hasTransaction();
+    }
+
+    @Override
+    public Statement currentStatement()
+    {
+        return dataSource.threadToTransactionBridge.get();
+    }
+
+    private void assertDatabaseAvailable()
+    {
+        try
+        {
+            platform.availabilityGuard.await( edition.transactionStartTimeout );
+        }
+        catch ( AvailabilityGuard.UnavailableException e )
+        {
+            if( platform.availabilityGuard.isShutdown())
+            {
+                throw new DatabaseShutdownException();
+            }
+            throw new org.neo4j.graphdb.TransactionFailureException( e.getMessage() );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -19,12 +19,9 @@
  */
 package org.neo4j.kernel.impl.factory;
 
-import java.io.File;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.LongFunction;
-import java.util.function.Supplier;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -41,7 +38,7 @@ import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.graphdb.event.KernelEventHandler;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.graphdb.index.IndexManager;
@@ -49,17 +46,10 @@ import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.graphdb.security.URLAccessValidationError;
 import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
 import org.neo4j.graphdb.traversal.TraversalDescription;
-import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.helpers.collection.PrefetchingResourceIterator;
 import org.neo4j.helpers.collection.ResourceClosingIterator;
-import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.impl.store.id.IdType;
-import org.neo4j.kernel.KernelEventHandlers;
-import org.neo4j.kernel.PlaceboTransaction;
-import org.neo4j.kernel.TopLevelTransaction;
-import org.neo4j.kernel.TransactionEventHandlers;
-import org.neo4j.kernel.api.KernelAPI;
+import org.neo4j.kernel.PropertyTracker;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
@@ -72,34 +62,41 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.properties.Property;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.TokenAccess;
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
-import org.neo4j.kernel.impl.core.NodeManager;
-import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.core.NodeProxy;
+import org.neo4j.kernel.impl.core.RelationshipProxy;
+import org.neo4j.kernel.impl.coreapi.IndexManagerImpl;
+import org.neo4j.kernel.impl.coreapi.IndexProviderImpl;
+import org.neo4j.kernel.impl.coreapi.NodeAutoIndexerImpl;
+import org.neo4j.kernel.impl.coreapi.PlaceboTransaction;
+import org.neo4j.kernel.impl.coreapi.RelationshipAutoIndexerImpl;
+import org.neo4j.kernel.impl.coreapi.StandardNodeActions;
+import org.neo4j.kernel.impl.coreapi.StandardRelationshipActions;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
+import org.neo4j.kernel.impl.coreapi.schema.SchemaImpl;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
-import org.neo4j.kernel.impl.query.QueryExecutionEngine;
-import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
+import org.neo4j.kernel.impl.query.QuerySession;
 import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.traversal.BidirectionalTraversalDescriptionImpl;
 import org.neo4j.kernel.impl.traversal.MonoDirectionalTraversalDescription;
-import org.neo4j.kernel.lifecycle.LifeSupport;
-import org.neo4j.kernel.lifecycle.LifecycleException;
-import org.neo4j.logging.Log;
 import org.neo4j.storageengine.api.EntityType;
 
 import static java.lang.String.format;
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.map;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.node_auto_indexing;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.node_keys_indexable;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.relationship_auto_indexing;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.relationship_keys_indexable;
 import static org.neo4j.helpers.collection.IteratorUtil.emptyIterator;
 import static org.neo4j.kernel.impl.api.operations.KeyReadOperations.NO_SUCH_LABEL;
 import static org.neo4j.kernel.impl.api.operations.KeyReadOperations.NO_SUCH_PROPERTY_KEY;
 
 /**
- * Implementation of the GraphDatabaseService/GraphDatabaseService interfaces. This delegates to the
- * services created by the {@link org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory}.
- *
- * To make a custom GraphDatabaseFacade, the best option is to subclass an existing GraphDatabaseFacadeFactory. Another
- * alternative, used by legacy database implementations, is to subclass this class and call
- * {@link org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory#newFacade(java.io.File, java.util.Map, org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Dependencies, GraphDatabaseFacade)} in the constructor.
+ * Implementation of the GraphDatabaseService/GraphDatabaseService interfaces - the "Core API". Given an {@link SPI} implementation, this provides users with
+ * a clean facade to interact with the database.
  */
 public class GraphDatabaseFacade
     implements GraphDatabaseAPI
@@ -107,71 +104,100 @@ public class GraphDatabaseFacade
     private static final long MAX_NODE_ID = IdType.NODE.getMaxValue();
     private static final long MAX_RELATIONSHIP_ID = IdType.RELATIONSHIP.getMaxValue();
 
-    private boolean initialized = false;
-
-    private ThreadToStatementContextBridge threadToTransactionBridge;
-    private NodeManager nodeManager;
-    private IndexManager indexManager;
     private Schema schema;
-    private AvailabilityGuard availabilityGuard;
-    private Log msgLog;
-    private LifeSupport life;
-    private Supplier<KernelAPI> kernel;
-    private Supplier<QueryExecutionEngine> queryExecutor;
-    private KernelEventHandlers kernelEventHandlers;
-    private TransactionEventHandlers transactionEventHandlers;
+    private IndexManager indexManager;
+    private NodeProxy.NodeActions nodeActions;
+    private RelationshipProxy.RelationshipActions relActions;
+    private Config config;
+    private SPI spi;
 
-    private long transactionStartTimeout;
-    private DependencyResolver dependencies;
-    private Supplier<StoreId> storeId;
-    protected File storeDir;
+    /**
+     * This is what you need to implemenent to get your very own {@link GraphDatabaseFacade}. This SPI exists as a thin layer to make it easy to provide
+     * alternate {@link org.neo4j.graphdb.GraphDatabaseService} instances without having to re-implement this whole API implementation.
+     */
+    public interface SPI
+    {
+        /** Check if database is available, waiting up to {@code timeout} if it isn't. If the timeout expires before database available, this returns false */
+        boolean databaseIsAvailable( long timeout );
 
-    public PlatformModule platformModule;
-    public EditionModule editionModule;
-    public DataSourceModule dataSourceModule;
+        DependencyResolver resolver();
+
+        StoreId storeId();
+        String storeDir();
+
+        /** Eg. Neo4j Enterprise HA, Neo4j Community Standalone.. */
+        String name();
+
+        void shutdown();
+
+        /**
+         * Begin a new kernel transaction. If a transaction is already associated to the current context
+         * (meaning, non-null is returned from {@link #currentTransaction()}), this should fail.
+         * @throws org.neo4j.graphdb.TransactionFailureException if unable to begin, or a transaction already exists.
+         */
+        KernelTransaction beginTransaction();
+
+        /**
+         * Retrieve the transaction associated with the current context. For the classic implementation of the Core API, the context is the current thread.
+         * Must not return null, and must return the underlying transaction even if it has been terminated.
+         *
+         * @throws org.neo4j.graphdb.NotInTransactionException if no transaction present
+         * @throws org.neo4j.graphdb.DatabaseShutdownException if the database has been shut down
+         */
+        KernelTransaction currentTransaction();
+
+        /** true if {@link #currentTransaction()} would return a transaction. */
+        boolean isInOpenTransaction();
+
+        /** Acquire a statement to perform work with */
+        Statement currentStatement();
+
+        /** Execute a cypher statement */
+        Result executeQuery( String query, Map<String, Object> parameters, QuerySession querySession );
+
+        // Methods below smell a bit - at least the property trackers should go to kernel API somewhere, probably the others as well
+        void addNodePropertyTracker( PropertyTracker<Node> tracker );
+        void removeNodePropertyTracker( PropertyTracker<Node> tracker );
+        void addRelationshipPropertyTracker( PropertyTracker<Relationship> tracker );
+        void removeRelationshipPropertyTracker( PropertyTracker<Relationship> tracker );
+
+        void registerKernelEventHandler( KernelEventHandler handler );
+        void unregisterKernelEventHandler( KernelEventHandler handler );
+
+        <T> void registerTransactionEventHandler( TransactionEventHandler<T> handler );
+        <T> void unregisterTransactionEventHandler( TransactionEventHandler<T> handler );
+
+        URL validateURLAccess( URL url ) throws URLAccessValidationError;
+    }
 
     protected GraphDatabaseFacade()
     {
     }
 
     /**
-     * When {@link org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory#newFacade(java.io.File, java.util.Map, org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Dependencies, GraphDatabaseFacade)} has created the different
-     * modules of a database, it calls this method so that the facade can get access to the created services.
-     *
-     * @param platformModule
-     * @param editionModule
-     * @param dataSourceModule
+     * Create a new Core API facade, backed by the given SPI.
      */
-    public void init(PlatformModule platformModule, EditionModule editionModule, DataSourceModule dataSourceModule)
+    public void init( Config config, SPI spi )
     {
-        this.platformModule = platformModule;
-        this.editionModule = editionModule;
-        this.dataSourceModule = dataSourceModule;
-        this.threadToTransactionBridge = dataSourceModule.threadToTransactionBridge;
-        this.nodeManager = dataSourceModule.nodeManager;
-        this.indexManager = dataSourceModule.indexManager;
-        this.schema = dataSourceModule.schema;
-        this.availabilityGuard = platformModule.availabilityGuard;
-        this.msgLog = platformModule.logging.getInternalLog( getClass() );
-        this.life = platformModule.life;
-        this.kernel = dataSourceModule.kernelAPI;
-        this.queryExecutor = dataSourceModule.queryExecutor;
-        this.kernelEventHandlers = dataSourceModule.kernelEventHandlers;
-        this.transactionEventHandlers = dataSourceModule.transactionEventHandlers;
-        this.transactionStartTimeout = editionModule.transactionStartTimeout;
-        this.dependencies = platformModule.dependencies;
-        this.storeId = dataSourceModule.storeId;
-        this.storeDir = platformModule.storeDir;
+        IndexProviderImpl idxProvider = new IndexProviderImpl( this, spi::currentStatement );
 
-        initialized = true;
+        this.spi = spi;
+        this.config = config;
+        this.relActions = new StandardRelationshipActions( spi::currentStatement, spi::currentTransaction,
+                this::assertTransactionOpen, (id) -> new NodeProxy( nodeActions, id ), this );
+        this.nodeActions = new StandardNodeActions( spi::currentStatement, spi::currentTransaction, this::assertTransactionOpen, relActions, this );
+        this.schema = new SchemaImpl( spi::currentStatement );
+        this.indexManager = new IndexManagerImpl( spi::currentStatement, idxProvider,
+                new NodeAutoIndexerImpl( config.get( node_auto_indexing ), config.get( node_keys_indexable ), idxProvider, spi ),
+                new RelationshipAutoIndexerImpl( config.get( relationship_auto_indexing ), config.get( relationship_keys_indexable ), idxProvider, spi ) );
     }
 
     @Override
     public Node createNode()
     {
-        try ( Statement statement = threadToTransactionBridge.get() )
+        try ( Statement statement = spi.currentStatement() )
         {
-            return nodeManager.newNodeProxyById( statement.dataWriteOperations().nodeCreate() );
+            return new NodeProxy( nodeActions, statement.dataWriteOperations().nodeCreate() );
         }
         catch ( InvalidTransactionTypeKernelException e )
         {
@@ -182,7 +208,7 @@ public class GraphDatabaseFacade
     @Override
     public Node createNode( Label... labels )
     {
-        try ( Statement statement = threadToTransactionBridge.get() )
+        try ( Statement statement = spi.currentStatement() )
         {
             long nodeId = statement.dataWriteOperations().nodeCreate();
             for ( Label label : labels )
@@ -197,7 +223,7 @@ public class GraphDatabaseFacade
                     throw new NotFoundException( "No node with id " + nodeId + " found.", e );
                 }
             }
-            return nodeManager.newNodeProxyById( nodeId );
+            return new NodeProxy( nodeActions, nodeId );
         }
         catch ( ConstraintValidationKernelException e )
         {
@@ -221,7 +247,7 @@ public class GraphDatabaseFacade
             throw new NotFoundException( format( "Node %d not found", id ),
                     new EntityNotFoundException( EntityType.NODE, id ) );
         }
-        try ( Statement statement = threadToTransactionBridge.get() )
+        try ( Statement statement = spi.currentStatement() )
         {
             if ( !statement.readOperations().nodeExists( id ) )
             {
@@ -229,7 +255,7 @@ public class GraphDatabaseFacade
                         new EntityNotFoundException( EntityType.NODE, id ) );
             }
 
-            return nodeManager.newNodeProxyById( id );
+            return new NodeProxy( nodeActions, id );
         }
     }
 
@@ -241,7 +267,7 @@ public class GraphDatabaseFacade
             throw new NotFoundException( format( "Relationship %d not found", id ),
                     new EntityNotFoundException( EntityType.RELATIONSHIP, id ));
         }
-        try ( Statement statement = threadToTransactionBridge.get() )
+        try ( Statement statement = spi.currentStatement() )
         {
             if ( !statement.readOperations().relationshipExists( id ) )
             {
@@ -249,72 +275,45 @@ public class GraphDatabaseFacade
                         new EntityNotFoundException( EntityType.RELATIONSHIP, id ));
             }
 
-            return nodeManager.newRelationshipProxy( id );
+            return new RelationshipProxy( relActions, id );
         }
     }
 
     @Override
     public IndexManager index()
     {
-        // TODO: txManager.assertInUnterminatedTransaction();
         return indexManager;
     }
 
     @Override
     public Schema schema()
     {
-        threadToTransactionBridge.assertInUnterminatedTransaction();
+        assertTransactionOpen();
         return schema;
     }
 
     @Override
     public boolean isAvailable( long timeout )
     {
-        return availabilityGuard.isAvailable( timeout );
+        return spi.databaseIsAvailable( timeout );
     }
 
     @Override
     public void shutdown()
     {
-        if (initialized)
-        {
-            try
-            {
-                msgLog.info( "Shutdown started" );
-                availabilityGuard.shutdown();
-                life.shutdown();
-            }
-            catch ( LifecycleException throwable )
-            {
-                msgLog.warn( "Shutdown failed", throwable );
-                throw throwable;
-            }
-        }
+        spi.shutdown();
     }
 
     @Override
-     public Transaction beginTx()
-     {
-         checkAvailability();
+    public Transaction beginTx()
+    {
+        if( spi.isInOpenTransaction() )
+        {
+            return new PlaceboTransaction( spi::currentTransaction, spi::currentStatement );
+        }
 
-         TopLevelTransaction topLevelTransaction =
-                 threadToTransactionBridge.getTopLevelTransactionBoundToThisThread( false );
-         if ( topLevelTransaction != null )
-         {
-             return new PlaceboTransaction( topLevelTransaction );
-         }
-
-         try
-         {
-             KernelTransaction transaction = kernel.get().newTransaction();
-             topLevelTransaction = new TopLevelTransaction( transaction, threadToTransactionBridge );
-             threadToTransactionBridge.bindTransactionToCurrentThread( topLevelTransaction );
-             return topLevelTransaction;
-         }
-         catch ( org.neo4j.kernel.api.exceptions.TransactionFailureException e )
-         {
-             throw new TransactionFailureException( "Failure to begin transaction", e );
-         }
+        KernelTransaction kernelTx = spi.beginTransaction();
+        return new TopLevelTransaction( kernelTx, spi::currentStatement );
      }
 
      @Override
@@ -326,36 +325,15 @@ public class GraphDatabaseFacade
     @Override
     public Result execute( String query, Map<String, Object> parameters ) throws QueryExecutionException
     {
-        checkAvailability();
-
-        try
-        {
-            return queryExecutor.get().executeQuery( query, parameters, QueryEngineProvider.embeddedSession() );
-        }
-        catch ( QueryExecutionKernelException e )
-        {
-            throw e.asUserException();
-        }
-    }
-
-    private void checkAvailability()
-    {
-        try
-        {
-            availabilityGuard.await( transactionStartTimeout );
-        }
-        catch ( AvailabilityGuard.UnavailableException e )
-        {
-            throw new TransactionFailureException( e.getMessage() );
-        }
+        return spi.executeQuery( query, parameters, QueryEngineProvider.embeddedSession() );
     }
 
     @Override
     public ResourceIterable<Node> getAllNodes()
     {
-        threadToTransactionBridge.assertInUnterminatedTransaction();
+        assertTransactionOpen();
         return () -> {
-            Statement statement = threadToTransactionBridge.get();
+            Statement statement = spi.currentStatement();
             return map2nodes( statement.readOperations().nodesGetAll(), statement );
         };
     }
@@ -363,9 +341,9 @@ public class GraphDatabaseFacade
     @Override
     public ResourceIterable<Relationship> getAllRelationships()
     {
-        threadToTransactionBridge.assertInUnterminatedTransaction();
+        assertTransactionOpen();
         return () -> {
-            final Statement statement = threadToTransactionBridge.get();
+            final Statement statement = spi.currentStatement();
             final PrimitiveLongIterator ids = statement.readOperations().relationshipsGetAll();
             return new PrefetchingResourceIterator<Relationship>()
             {
@@ -378,7 +356,7 @@ public class GraphDatabaseFacade
                 @Override
                 protected Relationship fetchNextOrNull()
                 {
-                    return ids.hasNext() ? nodeManager.newRelationshipProxy( ids.next() ) : null;
+                    return ids.hasNext() ? new RelationshipProxy( relActions, ids.next() ) : null;
                 }
             };
         };
@@ -404,36 +382,40 @@ public class GraphDatabaseFacade
 
     private <T> ResourceIterable<T> all( final TokenAccess<T> tokens )
     {
-        threadToTransactionBridge.assertInUnterminatedTransaction();
-        return () -> tokens.inUse( threadToTransactionBridge.get() );
+        assertTransactionOpen();
+        return () -> tokens.inUse( spi.currentStatement() );
     }
 
     @Override
     public KernelEventHandler registerKernelEventHandler(
             KernelEventHandler handler )
     {
-        return kernelEventHandlers.registerKernelEventHandler( handler );
+        spi.registerKernelEventHandler( handler );
+        return handler;
     }
 
     @Override
     public <T> TransactionEventHandler<T> registerTransactionEventHandler(
             TransactionEventHandler<T> handler )
     {
-        return transactionEventHandlers.registerTransactionEventHandler( handler );
+        spi.registerTransactionEventHandler( handler );
+        return handler;
     }
 
     @Override
     public KernelEventHandler unregisterKernelEventHandler(
             KernelEventHandler handler )
     {
-        return kernelEventHandlers.unregisterKernelEventHandler( handler );
+        spi.unregisterKernelEventHandler( handler );
+        return handler;
     }
 
     @Override
     public <T> TransactionEventHandler<T> unregisterTransactionEventHandler(
             TransactionEventHandler<T> handler )
     {
-        return transactionEventHandlers.unregisterTransactionEventHandler( handler );
+        spi.unregisterTransactionEventHandler( handler );
+        return handler;
     }
 
     @Override
@@ -475,7 +457,7 @@ public class GraphDatabaseFacade
 
     private ResourceIterator<Node> nodesByLabelAndProperty( Label myLabel, String key, Object value )
     {
-        Statement statement = threadToTransactionBridge.get();
+        Statement statement = spi.currentStatement();
 
         ReadOperations readOps = statement.readOperations();
         int propertyId = readOps.propertyKeyGetForName( key );
@@ -484,7 +466,7 @@ public class GraphDatabaseFacade
         if ( propertyId == NO_SUCH_PROPERTY_KEY || labelId == NO_SUCH_LABEL )
         {
             statement.close();
-            return IteratorUtil.emptyIterator();
+            return emptyIterator();
         }
 
         IndexDescriptor descriptor = findAnyIndexByLabelAndProperty( readOps, propertyId, labelId );
@@ -535,7 +517,7 @@ public class GraphDatabaseFacade
 
     private ResourceIterator<Node> allNodesWithLabel( final Label myLabel )
     {
-        Statement statement = threadToTransactionBridge.get();
+        Statement statement = spi.currentStatement();
 
         int labelId = statement.readOperations().labelGetForName( myLabel.name() );
         if ( labelId == KeyReadOperations.NO_SUCH_LABEL )
@@ -545,57 +527,55 @@ public class GraphDatabaseFacade
         }
 
         final PrimitiveLongIterator nodeIds = statement.readOperations().nodesGetForLabel( labelId );
-        return ResourceClosingIterator.newResourceIterator( statement, map(
-                (LongFunction<Node>) nodeId -> nodeManager.newNodeProxyById( nodeId ), nodeIds ) );
+        return ResourceClosingIterator.newResourceIterator( statement, map( nodeId -> new NodeProxy( nodeActions, nodeId ), nodeIds ) );
     }
 
     private ResourceIterator<Node> map2nodes( PrimitiveLongIterator input, Statement statement )
     {
-        return ResourceClosingIterator.newResourceIterator( statement, map(
-                (LongFunction<Node>) id -> nodeManager.newNodeProxyById( id ), input ) );
+        return ResourceClosingIterator.newResourceIterator( statement, map( id -> new NodeProxy( nodeActions, id ), input ) );
     }
 
     @Override
     public TraversalDescription traversalDescription()
     {
-        return new MonoDirectionalTraversalDescription( threadToTransactionBridge );
+        return new MonoDirectionalTraversalDescription( spi::currentStatement );
     }
 
     @Override
     public BidirectionalTraversalDescription bidirectionalTraversalDescription()
     {
-        return new BidirectionalTraversalDescriptionImpl( threadToTransactionBridge );
+        return new BidirectionalTraversalDescriptionImpl( spi::currentStatement );
     }
 
     // GraphDatabaseAPI
     @Override
     public DependencyResolver getDependencyResolver()
     {
-        return dependencies;
+        return spi.resolver();
     }
 
     @Override
     public StoreId storeId()
     {
-        return storeId.get();
+        return spi.storeId();
     }
 
     @Override
     public URL validateURLAccess( URL url ) throws URLAccessValidationError
     {
-        return platformModule.urlAccessRule.validate( platformModule.config, url );
+        return spi.validateURLAccess( url );
     }
 
     @Override
     public String getStoreDir()
     {
-        return storeDir.toString();
+        return spi.storeDir();
     }
 
     @Override
     public String toString()
     {
-        return platformModule.databaseInfo + " ["+storeDir+"]";
+        return spi.name() + " ["+getStoreDir()+"]";
     }
 
     private static class PropertyValueFilteringNodeIdIterator extends PrimitiveLongCollections.PrimitiveLongBaseIterator
@@ -637,6 +617,14 @@ public class GraphDatabaseFacade
                 }
             }
             return false;
+        }
+    }
+
+    private void assertTransactionOpen()
+    {
+        if( spi.currentTransaction().shouldBeTerminated() )
+        {
+            throw new TransactionTerminatedException();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -125,12 +125,12 @@ public abstract class GraphDatabaseFacadeFactory
         PlatformModule platform = createPlatform( storeDir, params, dependencies, graphDatabaseFacade );
         EditionModule edition = createEdition( platform );
         final DataSourceModule dataSource = createDataSource( dependencies, platform, edition );
+        Logger msgLog = platform.logging.getInternalLog( getClass() ).infoLogger();
 
         // Start it
-        graphDatabaseFacade.init( platform, edition, dataSource );
+        graphDatabaseFacade.init( platform.config, new ClassicCoreSPI( platform, dataSource, msgLog, edition ) );
 
         Throwable error = null;
-        Logger msgLog = platform.logging.getInternalLog( getClass() ).infoLogger();
         try
         {
             // Done after create to avoid a redundant

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -1223,7 +1223,7 @@ public class BatchInserterImpl implements BatchInserter
         }
 
         @Override
-        public void assertInUnterminatedTransaction()
+        public void assertInOpenTransaction()
         {
             // BatchInserterImpl always is expected to be running in one big single "transaction"
         }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
@@ -60,7 +60,7 @@ public class GraphDatabaseServiceTest
         catch ( Exception e )
         {
             // Then
-            assertThat( e.getClass().getName(), CoreMatchers.equalTo( TransactionFailureException.class.getName() ) );
+            assertThat( e.getClass().getName(), CoreMatchers.equalTo( DatabaseShutdownException.class.getName() ) );
         }
     }
 
@@ -246,7 +246,7 @@ public class GraphDatabaseServiceTest
             }
         }
 
-        assertThat( result.get().getClass(), CoreMatchers.<Object>equalTo( TransactionFailureException.class ) );
+        assertThat( result.get().getClass(), CoreMatchers.<Object>equalTo( DatabaseShutdownException.class ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -37,7 +37,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
-import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.factory.CommunityEditionModule;
 import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;

--- a/community/kernel/src/test/java/org/neo4j/kernel/NodeAutoIndexerImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/NodeAutoIndexerImplTest.java
@@ -21,11 +21,12 @@ package org.neo4j.kernel;
 
 import org.junit.Test;
 
+import java.util.Collections;
+
 import org.neo4j.graphdb.Node;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.kernel.impl.coreapi.IndexProvider;
 import org.neo4j.kernel.impl.coreapi.NodeAutoIndexerImpl;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
@@ -33,16 +34,16 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class NodeAutoIndexerImplTest
 {
+
+    private final IndexProvider indexProvider = mock( IndexProvider.class, RETURNS_MOCKS );
+    private final NodeAutoIndexerImpl index = new NodeAutoIndexerImpl( true, Collections.emptyList(), indexProvider, mock( GraphDatabaseFacade.SPI.class ) );
+
     @Test
     public void shouldNotRemoveFromIndexForNonAutoIndexedProperty() throws Exception
     {
         // Given
         String indexedPropertyName = "someProperty";
         String nonIndexedPropertyName = "someOtherProperty";
-
-        IndexProvider indexProvider = mock( IndexProvider.class, RETURNS_MOCKS );
-        NodeAutoIndexerImpl index = new NodeAutoIndexerImpl( mock( Config.class ), indexProvider,
-                mock( NodeManager.class ) );
         index.startAutoIndexingProperty( indexedPropertyName );
 
         // When
@@ -58,10 +59,6 @@ public class NodeAutoIndexerImplTest
         // Given
         String indexedPropertyName = "someProperty";
         String nonIndexedPropertyName = "someOtherProperty";
-
-        IndexProvider indexProvider = mock( IndexProvider.class, RETURNS_MOCKS );
-        NodeAutoIndexerImpl index = new NodeAutoIndexerImpl( mock( Config.class ), indexProvider,
-                mock( NodeManager.class ) );
         index.startAutoIndexingProperty( indexedPropertyName );
 
         // When
@@ -77,10 +74,6 @@ public class NodeAutoIndexerImplTest
         // Given
         String indexedPropertyName = "someProperty";
         String nonIndexedPropertyName = "someOtherProperty";
-
-        IndexProvider indexProvider = mock( IndexProvider.class, RETURNS_MOCKS );
-        NodeAutoIndexerImpl index = new NodeAutoIndexerImpl( mock( Config.class ), indexProvider,
-                mock( NodeManager.class ) );
         index.startAutoIndexingProperty( indexedPropertyName );
 
         // When

--- a/community/kernel/src/test/java/org/neo4j/kernel/TopLevelTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TopLevelTransactionTest.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
@@ -44,7 +44,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.locking.Lock;
@@ -945,7 +945,7 @@ public class UniqueConstraintCompatibility extends IndexProviderCompatibilityTes
 
     // -- Set Up: Advanced transaction handling
 
-    private final Map<Transaction, TopLevelTransaction> txMap = new IdentityHashMap<>();
+    private final Map<Transaction,KernelTransaction> txMap = new IdentityHashMap<>();
 
     private void suspend( Transaction tx ) throws Exception
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeManagerTest.java
@@ -31,7 +31,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.PlaceboTransaction;
+import org.neo4j.kernel.impl.coreapi.PlaceboTransaction;
 import org.neo4j.kernel.PropertyTracker;
 import org.neo4j.test.TestGraphDatabaseFactory;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
@@ -105,14 +105,6 @@ public class NodeProxySingleRelationshipTest
     {
         NodeProxy.NodeActions nodeActions = mock( NodeProxy.NodeActions.class );
         final RelationshipProxy.RelationshipActions relActions = mock( RelationshipProxy.RelationshipActions.class );
-        when( nodeActions.newRelationshipProxy( anyLong() ) ).thenAnswer( new Answer<RelationshipProxy>()
-        {
-            @Override
-            public RelationshipProxy answer( InvocationOnMock invocation ) throws Throwable
-            {
-                return new RelationshipProxy( relActions, (Long)invocation.getArguments()[0] );
-            }
-        } );
         when( nodeActions.newRelationshipProxy( anyLong(), anyLong(), anyInt(), anyLong() ) ).then(
                 new Answer<Relationship>()
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
@@ -119,14 +119,14 @@ public class RelationshipProxyTest extends PropertyContainerProxyTest
             end = db.createNode();
             relationship = start.createRelationshipTo( end, type );
             tx.success();
+
+            // WHEN
+            String toString = relationship.toString();
+
+            // THEN
+            assertEquals( "(" + start.getId() + ")-[" + type + "," + relationship.getId() + "]->(" + end.getId() + ")",
+                    toString );
         }
-
-        // WHEN
-        String toString = relationship.toString();
-
-        // THEN
-        assertEquals( "(" + start.getId() + ")-[" + type + "," + relationship.getId() + "]->(" + end.getId() + ")",
-                toString );
     }
 
     private void verifyIds( RelationshipActions actions, long relationshipId, long nodeId1, int typeId, long nodeId2 )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jApiExceptions.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestNeo4jApiExceptions.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.core;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -34,7 +35,8 @@ import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TestNeo4jApiExceptions
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -19,13 +19,11 @@
  */
 package org.neo4j.kernel.impl.coreapi;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
@@ -45,13 +43,10 @@ import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.storageengine.api.StoreReadLayer;
 
 import static java.util.Arrays.asList;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.kernel.api.properties.Property.stringProperty;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asLabelCursor;
@@ -302,14 +297,6 @@ public class TxStateTransactionDataViewTest
     {
         NodeProxy.NodeActions nodeActions = mock( NodeProxy.NodeActions.class );
         final RelationshipProxy.RelationshipActions relActions = mock( RelationshipProxy.RelationshipActions.class );
-        when( nodeActions.lazyRelationshipProxy( anyLong() ) ).thenAnswer( new Answer<RelationshipProxy>()
-        {
-            @Override
-            public RelationshipProxy answer( InvocationOnMock invocation ) throws Throwable
-            {
-                return new RelationshipProxy( relActions, (Long) invocation.getArguments()[0] );
-            }
-        } );
         return new TxStateTransactionDataSnapshot( state, nodeActions, relActions, ops );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreTest.java
@@ -128,7 +128,7 @@ public class RelationshipGroupStoreTest
     private void newDb( int denseNodeThreshold )
     {
         db = new ImpermanentGraphDatabase( MapUtil.stringMap( "dense_node_threshold", "" + denseNodeThreshold ) );
-        fs = db.platformModule.fileSystem;
+        fs = db.getDependencyResolver().resolveDependency( FileSystemAbstraction.class );
     }
 
     private void createAndVerify( Integer customThreshold )

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.server.rest.transactional;
 
-import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
@@ -29,7 +29,7 @@ class TransitionalTxManagementKernelTransaction
     private final TransactionTerminator txTerminator;
     private final ThreadToStatementContextBridge bridge;
 
-    private TopLevelTransaction suspendedTransaction;
+    private KernelTransaction suspendedTransaction;
 
     TransitionalTxManagementKernelTransaction( TransactionTerminator txTerminator, ThreadToStatementContextBridge bridge )
     {

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Begin.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Begin.java
@@ -21,8 +21,9 @@ package org.neo4j.shell.kernel.apps;
 
 import java.rmi.RemoteException;
 
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.Service;
-import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.shell.App;
 import org.neo4j.shell.AppCommandParser;
@@ -52,7 +53,7 @@ public class Begin extends NonTransactionProvidingApp
             return Continuation.INPUT_COMPLETE;
         }
 
-        TopLevelTransaction tx = currentTransaction( getServer() );
+        KernelTransaction tx = currentTransaction( getServer() );
 
         // This is a "begin" app so it will leave a transaction open. Don't close it in here
         getServer().getDb().beginTx();
@@ -95,7 +96,7 @@ public class Begin extends NonTransactionProvidingApp
         return substring.equals( line.toUpperCase() );
     }
 
-    public static TopLevelTransaction currentTransaction( GraphDatabaseShellServer server )
+    public static KernelTransaction currentTransaction( GraphDatabaseShellServer server )
     {
         return server.getDb().getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class )
                 .getTopLevelTransactionBoundToThisThread( false );

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Commit.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Commit.java
@@ -22,7 +22,8 @@ package org.neo4j.shell.kernel.apps;
 import java.rmi.RemoteException;
 
 import org.neo4j.helpers.Service;
-import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.shell.App;
 import org.neo4j.shell.AppCommandParser;
 import org.neo4j.shell.Continuation;
@@ -52,7 +53,7 @@ public class Commit extends NonTransactionProvidingApp
 
         Integer txCount = session.getCommitCount();
 
-        TopLevelTransaction tx = Begin.currentTransaction( getServer() );
+        KernelTransaction tx = Begin.currentTransaction( getServer() );
         if ( txCount == null || txCount.equals( 0 ) )
         {
             if ( tx != null )

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rollback.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Rollback.java
@@ -21,9 +21,9 @@ package org.neo4j.shell.kernel.apps;
 
 import java.rmi.RemoteException;
 
-import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.helpers.Service;
-import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.shell.App;
 import org.neo4j.shell.AppCommandParser;
 import org.neo4j.shell.Continuation;
@@ -51,7 +51,7 @@ public class Rollback extends NonTransactionProvidingApp
             return Continuation.INPUT_COMPLETE;
         }
 
-        TopLevelTransaction tx = Begin.currentTransaction( getServer() );
+        KernelTransaction tx = Begin.currentTransaction( getServer() );
         if ( tx == null )
         {
             throw Commit.fail( session, "Not in a transaction" );

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Using.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Using.java
@@ -24,7 +24,8 @@ import java.rmi.RemoteException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.Service;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
@@ -45,7 +46,7 @@ public class Using extends Start
         {
             ThreadToStatementContextBridge manager =
                 graphDatabaseAPI.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
-            TopLevelTransaction tx = manager.getTopLevelTransactionBoundToThisThread( true );
+            KernelTransaction tx = manager.getTopLevelTransactionBoundToThisThread( true );
             manager.unbindTransactionFromCurrentThread();
 
             try

--- a/enterprise/ha/src/test/java/org/neo4j/ha/UpdatePullerSwitchIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/UpdatePullerSwitchIT.java
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.ha.SlaveUpdatePuller;
@@ -43,7 +44,6 @@ import org.neo4j.test.ha.ClusterRule;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import static org.neo4j.kernel.ha.HaSettings.tx_push_factor;
 
 public class UpdatePullerSwitchIT
@@ -109,8 +109,8 @@ public class UpdatePullerSwitchIT
 
     private void verifyUpdatePullerThreads()
     {
-        InstanceId masterId = managedCluster.getMaster().platformModule.config.get( ClusterSettings.server_id );
-        InstanceId slaveId = managedCluster.getAnySlave().platformModule.config.get( ClusterSettings.server_id );
+        InstanceId masterId = managedCluster.getMaster().getDependencyResolver().resolveDependency( Config.class ).get( ClusterSettings.server_id );
+        InstanceId slaveId = managedCluster.getAnySlave().getDependencyResolver().resolveDependency( Config.class ).get( ClusterSettings.server_id );
         Map<Thread,StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
         Set<Thread> threads = allStackTraces.keySet();
         assertFalse( "Master should not have any puller threads", findThreadWithPrefix( threads,

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
@@ -40,7 +40,7 @@ import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.Exceptions;
-import org.neo4j.kernel.TopLevelTransaction;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.api.ConstraintHaIT.NodePropertyExistenceConstraintHaIT;
 import org.neo4j.kernel.api.ConstraintHaIT.RelationshipPropertyExistenceConstraintHaIT;
 import org.neo4j.kernel.api.ConstraintHaIT.UniquenessConstraintHaIT;
@@ -416,7 +416,7 @@ public class ConstraintHaIT
             // And given that I begin a transaction that will create a constraint violation
             slave.beginTx();
             createConstraintViolation( slave, type, key, "Foo" );
-            TopLevelTransaction slaveTx = txBridge.getTopLevelTransactionBoundToThisThread( true );
+            KernelTransaction slaveTx = txBridge.getTopLevelTransactionBoundToThisThread( true );
             txBridge.unbindTransactionFromCurrentThread();
 
             // When I create a constraint


### PR DESCRIPTION
Introduces a thin abstraction between GraphDatabaseFacade and Kernel
components. The purpose is to allow alternate GraphDatabaseService instances
without having to re-implement the whole API.

With this change, the Procedures work can provide users a GDS instance that
can easily be tweaked to only allow reads and to disable #shutdown(), for
instance.

This seemed like a useful way to both significantly simply the Procedures
implementation, while also improving compartmentalization. It's by no means
done or perfect, but a nice step towards separating the Core API and Kernel.

Before:

```
+----------+    +--------+
| Graph    |    | Kernel |
| Database +--->+ Stuff  |
| Facade   |    |        |
+----------+    +--------+
```

After:

```
+----------+    +--------+    +--------+
| Graph    |    | Spiffy |    | Kernel |
| Database +--->+ SPI    +--->+ Stuff  |
| Facade   |    |        |    |        |
+----------+    +--------+    +--------+
```
