### PR TITLE
Renamed and unify fixedPoint

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/CNFNormalizer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/CNFNormalizer.scala
@@ -23,7 +23,8 @@ import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.Rewritable._
 import org.neo4j.cypher.internal.frontend.v3_0.Foldable._
-import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, bottomUp, inSequence, repeat}
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.fixedPoint
+import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, bottomUp, inSequence}
 
 case class CNFNormalizer()(implicit monitor: AstRewritingMonitor) extends Rewriter {
 
@@ -103,7 +104,7 @@ object flattenBooleanOperators extends Rewriter {
     })(p.position)
   }
 
-  private val instance = inSequence(bottomUp(firstStep), repeat(bottomUp(secondStep)))
+  private val instance = inSequence(bottomUp(firstStep), fixedPoint(bottomUp(secondStep)))
 }
 
 object simplifyPredicates extends Rewriter {
@@ -122,5 +123,5 @@ object simplifyPredicates extends Rewriter {
     case p@Ors(exps) if exps.size == 1    => exps.head
   }
 
-  private val instance = repeat(bottomUp(step))
+  private val instance = fixedPoint(bottomUp(step))
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/inlineProjections.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/inlineProjections.scala
@@ -20,8 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters
 
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
-import org.neo4j.cypher.internal.compiler.v3_0.helpers.Converge.iterateUntilConverged
 import org.neo4j.cypher.internal.compiler.v3_0.planner.CantHandleQueryException
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.fixedPoint
 import org.neo4j.cypher.internal.frontend.v3_0.{replace, Rewriter, TypedRewriter}
 
 case object inlineProjections extends Rewriter {
@@ -73,7 +73,7 @@ case object inlineProjections extends Rewriter {
   }
 
   private def findAllDependencies(variable: Variable, context: InliningContext): Set[Variable] = {
-    val (dependencies, _) = iterateUntilConverged[(Set[Variable], List[Variable])]({
+    val (dependencies, _) = fixedPoint[(Set[Variable], List[Variable])]({
       case (deps, Nil) =>
         (deps, Nil)
       case (deps, queue) =>

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/isolateAggregation.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/isolateAggregation.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.AggregationNameGenerator
-import org.neo4j.cypher.internal.compiler.v3_0.helpers.Converge.iterateUntilConverged
-import org.neo4j.cypher.internal.frontend.v3_0.{topDown, replace, Rewriter, bottomUp}
+import org.neo4j.cypher.internal.frontend.v3_0.ast._
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.fixedPoint
+import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, replace, topDown}
 
 /**
  * This rewriter makes sure that aggregations are on their own in RETURN/WITH clauses, so
@@ -55,7 +55,7 @@ case object isolateAggregation extends Rewriter {
         case clause =>
           val originalExpressions = getExpressions(clause)
 
-          val expressionsToGoToWith: Set[Expression] = iterateUntilConverged {
+          val expressionsToGoToWith: Set[Expression] = fixedPoint {
             (expressions: Set[Expression]) => expressions.flatMap {
               case e if hasAggregateButIsNotAggregate(e) =>
                 e match {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LegacyExecutablePlanBuilder.scala
@@ -27,12 +27,11 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.values.{KeyToken, TokenT
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InterpretedExecutionPlanBuilder.interpretedToExecutionPlan
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders.prepare.KeyTokenResolver
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders.{DisconnectedShortestPathEndPointsBuilder, _}
-import org.neo4j.cypher.internal.compiler.v3_0.helpers.Converge.iterateUntilConverged
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_0.SyntaxException
-import org.neo4j.cypher.internal.frontend.v3_0.helpers.NonEmptyList
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.{fixedPoint, NonEmptyList}
 
 trait ExecutionPlanInProgressRewriter {
   def rewrite(in: ExecutionPlanInProgress)(implicit context: PipeMonitor): ExecutionPlanInProgress
@@ -92,7 +91,7 @@ class LegacyExecutablePlanBuilder(monitors: Monitors, config: CypherCompilerConf
     val initialPSQ = PartiallySolvedQuery(inputQuery).rewriteFromTheTail(groupAndRewriteInequalities)
 
     def untilConverged(in: ExecutionPlanInProgress): ExecutionPlanInProgress =
-      iterateUntilConverged { input: ExecutionPlanInProgress =>
+      fixedPoint { input: ExecutionPlanInProgress =>
         val result = phases(input, context)
         if (!result.query.isSolved) {
           produceAndThrowException(result)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/LogicalPlanRewriter.scala
@@ -20,10 +20,11 @@
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.rewriter
 
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
-import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, repeat}
+import org.neo4j.cypher.internal.frontend.v3_0.Rewriter
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.fixedPoint
 
 case class LogicalPlanRewriter(rewriterSequencer: String => RewriterStepSequencer) extends Rewriter {
-  val instance: Rewriter = repeat(rewriterSequencer("LogicalPlanRewriter")(
+  val instance = fixedPoint(rewriterSequencer("LogicalPlanRewriter")(
     fuseSelections,
     unnestApply,
     simplifyEquality,

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport2.scala
@@ -34,6 +34,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, PlanContext, ProcedureName, ProcedureSignature}
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.fixedPoint
 import org.neo4j.cypher.internal.frontend.v3_0.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.frontend.v3_0.{Foldable, PropertyKeyId, SemanticTable, _}
@@ -173,7 +174,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
           val context = LogicalPlanningContext(planContext, logicalPlanProducer, metrics, newTable, queryGraphSolver, QueryGraphSolverInput.empty)
           val plannerQuery = unionQuery.queries.head
           val resultPlan = planner.internalPlan(plannerQuery)(context)
-          SemanticPlan(resultPlan.endoRewrite(repeat(unnestApply)), newTable)
+          SemanticPlan(resultPlan.endoRewrite(fixedPoint(unnestApply)), newTable)
       }
     }
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/UnnestEmptyApplyTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/UnnestEmptyApplyTest.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.rewriter
 
-import org.neo4j.cypher.internal.compiler.v3_0.helpers.Converge.iterateUntilConverged
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.fixedPoint
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
 class UnnestEmptyApplyTest extends CypherFunSuite with LogicalPlanningTestSupport {
@@ -232,5 +232,5 @@ class UnnestEmptyApplyTest extends CypherFunSuite with LogicalPlanningTestSuppor
   }
 
   private def rewrite(p: LogicalPlan): LogicalPlan =
-    iterateUntilConverged((p: LogicalPlan) => p.endoRewrite(unnestApply))(p)
+    fixedPoint((p: LogicalPlan) => p.endoRewrite(unnestApply))(p)
 }

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/Rewritable.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/Rewritable.scala
@@ -198,15 +198,3 @@ case class replace(strategy: (Replacer => (AnyRef => AnyRef))) extends Rewriter 
 
   def apply(that: AnyRef): AnyRef = cont(that)
 }
-
-case class repeat(rewriter: Rewriter) extends Rewriter {
-  @tailrec
-  final def apply(that: AnyRef): AnyRef = {
-    val t = rewriter.apply(that)
-    if (t == that) {
-      t
-    } else {
-      apply(t)
-    }
-  }
-}

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/helpers/fixedPoint.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/helpers/fixedPoint.scala
@@ -17,20 +17,20 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v3_0.helpers.Converge
+package org.neo4j.cypher.internal.frontend.v3_0.helpers
 
-object iterateUntilConverged {
+import scala.annotation.tailrec
 
-  def apply[A](f: (A => A)): (A => A) = {
-    (seed: A) => {
-      var current = seed
-      var next = f(current)
-      while (current != next) {
-        current = next
-        next = f(current)
-      }
+object fixedPoint {
 
-      current
-    }
+  def apply[A](f: A => A): A => A = inner(f, _)
+
+  @tailrec
+  private def inner[A](f: A => A, that: A): A = {
+    val t = f(that)
+    if (t == that)
+      t
+    else
+      inner(f, t)
   }
 }

--- a/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/RepeatTest.scala
+++ b/community/cypher/frontend-3.0/src/test/scala/org/neo4j/cypher/internal/frontend/v3_0/RepeatTest.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_0
 
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.fixedPoint
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
 class RepeatTest extends CypherFunSuite {
@@ -37,7 +38,7 @@ class RepeatTest extends CypherFunSuite {
     count = 0
 
     // when
-    val output = repeat(mockedRewriter)(result)
+    val output = fixedPoint(mockedRewriter)(result)
 
     // then
     output should equal(result)
@@ -49,7 +50,7 @@ class RepeatTest extends CypherFunSuite {
     count = 0
 
     // when
-    val output = repeat(mockedRewriter)(new Object)
+    val output = fixedPoint(mockedRewriter)(new Object)
 
     // then
     output should equal(result)


### PR DESCRIPTION
There where two different implementations of the same thing:
iterateUntilConverged and the repeat rewriter. This commit throws one away,
 and renames the remaining one to fixedPoint, the mathematical name for
 this concept.
