### PR TITLE
Support LOAD CSV in cost-based planner

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
@@ -430,10 +430,10 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
   test("unrelated nodes with same property should not clash") {
     // given
     graph.createConstraint("Person", "id")
-    executeWithCostPlannerOnly("MERGE (a:Item {id:1}) MERGE (b:Person {id:1})")
+    graph.execute("MERGE (a:Item {id:1}) MERGE (b:Person {id:1})")
 
     // when
-    executeWithCostPlannerOnly("MERGE (a:Item {id:2}) MERGE (b:Person {id:1})")
+    updateWithBothPlanners("MERGE (a:Item {id:2}) MERGE (b:Person {id:1})")
 
     // then does not throw
   }
@@ -626,7 +626,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
         ))
 
     // when
-    executeWithCostPlannerOnly(
+    updateWithBothPlanners(
       "MATCH (foo) WITH foo.x AS x, foo.y AS y " +
         "MERGE (c:N {x: x, y: y+1}) " +
         "MERGE (a:N {x: x, y: y}) " +

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/PredicateSplitter.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/PredicateSplitter.scala
@@ -86,7 +86,7 @@ case class PredicateSplitter(rewrites: Map[Ref[Clause], Seq[Clause]]) {
   }
 
   object statementRewriter extends Rewriter {
-    val instance = topDown(Rewriter.lift {
+    private val instance = topDown(Rewriter.lift {
       case query: SingleQuery =>
         val oldClauses = query.clauses
         val newClauses = oldClauses.flatMap {
@@ -96,9 +96,6 @@ case class PredicateSplitter(rewrites: Map[Ref[Clause], Seq[Clause]]) {
         query.copy(clauses = newClauses)(query.position)
     })
 
-    override def apply(in: AnyRef): AnyRef = {
-      val result = instance(in)
-      result
-    }
+    override def apply(in: AnyRef): AnyRef = instance(in)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/collapseInCollections.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/collapseInCollections.scala
@@ -30,11 +30,11 @@ These can later be turned into index lookups or node-by-id ops
  */
 case object collapseInCollections extends Rewriter {
 
-  override def apply(that: AnyRef) = bottomUp(instance)(that)
+  override def apply(that: AnyRef) = instance(that)
 
   case class InValue(lhs: Expression, expr: Expression)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = bottomUp(Rewriter.lift {
     case predicate@Ors(exprs) =>
       // Find all the expressions we want to rewrite
       val (const: List[Expression], nonRewritable: List[Expression]) = exprs.toList.partition {
@@ -61,5 +61,5 @@ case object collapseInCollections extends Rewriter {
         case head :: Nil => head
         case l => Ors(l.toSet)(predicate.position)
       }
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/copyVariables.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/copyVariables.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.ast.Variable
 import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, bottomUp}
 
 case object copyVariables extends Rewriter {
-  private val instance = Rewriter.lift { case variable: Variable => variable.copyId }
+  private val instance = bottomUp(Rewriter.lift { case variable: Variable => variable.copyId })
 
-  def apply(that: AnyRef): AnyRef = bottomUp(instance).apply(that)
+  def apply(that: AnyRef): AnyRef = instance.apply(that)
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/literalReplacement.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/literalReplacement.scala
@@ -26,12 +26,12 @@ object literalReplacement {
   type LiteralReplacements = IdentityMap[Literal, Parameter]
 
   case class ExtractParameterRewriter(replaceableLiterals: LiteralReplacements) extends Rewriter {
-    def apply(that: AnyRef): AnyRef = bottomUp(rewriter).apply(that)
+    def apply(that: AnyRef): AnyRef = rewriter.apply(that)
 
-    private val rewriter: Rewriter = Rewriter.lift {
+    private val rewriter: Rewriter = bottomUp(Rewriter.lift {
       case l: Literal =>
         replaceableLiterals.getOrElse(l, l)
-    }
+    })
   }
 
   private val literalMatcher: PartialFunction[Any, (LiteralReplacements, LiteralReplacements => LiteralReplacements) => LiteralReplacements] = {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/namePatternElements.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/namePatternElements.scala
@@ -26,14 +26,14 @@ import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, bottomUp}
 
 case object nameAllPatternElements extends Rewriter {
 
-  override def apply(in: AnyRef): AnyRef = bottomUp(namingRewriter).apply(in)
+  override def apply(in: AnyRef): AnyRef = namingRewriter.apply(in)
 
   val namingRewriter: Rewriter = bottomUp(Rewriter.lift {
-    case pattern: NodePattern if !pattern.variable.isDefined =>
+    case pattern: NodePattern if pattern.variable.isEmpty =>
       val syntheticName = UnNamedNameGenerator.name(pattern.position.bumped())
       pattern.copy(variable = Some(Variable(syntheticName)(pattern.position)))(pattern.position)
 
-    case pattern: RelationshipPattern if !pattern.variable.isDefined  =>
+    case pattern: RelationshipPattern if pattern.variable.isEmpty  =>
       val syntheticName = UnNamedNameGenerator.name(pattern.position.bumped())
       pattern.copy(variable = Some(Variable(syntheticName)(pattern.position)))(pattern.position)
   })
@@ -41,11 +41,11 @@ case object nameAllPatternElements extends Rewriter {
 
 case object namePatternPredicatePatternElements extends Rewriter {
 
-  override def apply(in: AnyRef): AnyRef = bottomUp(instance).apply(in)
+  override def apply(in: AnyRef): AnyRef = instance.apply(in)
 
-  val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = bottomUp(Rewriter.lift {
     case expr: PatternExpression =>
       val (rewrittenExpr, _) = PatternExpressionPatternElementNamer(expr)
       rewrittenExpr
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeArgumentOrder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeArgumentOrder.scala
@@ -19,9 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters
 
-import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
-import org.neo4j.cypher.internal.frontend.v3_0.{topDown, Rewriter}
+import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, topDown}
 
 // TODO: Support n.prop <op> m.prop, perhaps by
 //  either killing this and just looking on both lhs and rhs all over the place or
@@ -29,9 +28,9 @@ import org.neo4j.cypher.internal.frontend.v3_0.{topDown, Rewriter}
 //
 case object normalizeArgumentOrder extends Rewriter {
 
-  override def apply(that: AnyRef): AnyRef = topDown(instance)(that)
+  override def apply(that: AnyRef): AnyRef = instance(that)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = topDown(Rewriter.lift {
 
     // move id(n) on equals to the left
     case predicate @ Equals(func@FunctionInvocation(_, _, _), _) if func.function.contains(functions.Id) =>
@@ -55,7 +54,7 @@ case object normalizeArgumentOrder extends Rewriter {
       } else {
         inequality
       }
-  }
+  })
 }
 
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeComparisons.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeComparisons.scala
@@ -24,9 +24,9 @@ import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, topDown}
 
 case object normalizeComparisons extends Rewriter {
 
-  override def apply(that: AnyRef): AnyRef = topDown(instance)(that)
+  override def apply(that: AnyRef): AnyRef = instance(that)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = topDown(Rewriter.lift {
     case c@NotEquals(lhs, rhs) =>
       NotEquals(lhs.endoRewrite(copyVariables), rhs.endoRewrite(copyVariables))(c.position)
     case c@Equals(lhs, rhs) =>
@@ -41,5 +41,5 @@ case object normalizeComparisons extends Rewriter {
       GreaterThanOrEqual(lhs.endoRewrite(copyVariables), rhs.endoRewrite(copyVariables))(c.position)
     case c@InvalidNotEquals(lhs, rhs) =>
       InvalidNotEquals(lhs.endoRewrite(copyVariables), rhs.endoRewrite(copyVariables))(c.position)
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeNotEquals.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeNotEquals.scala
@@ -24,10 +24,10 @@ import org.neo4j.cypher.internal.frontend.v3_0.ast.{Not, Equals, NotEquals}
 
 case object normalizeNotEquals extends Rewriter {
 
-  override def apply(that: AnyRef): AnyRef = topDown(instance)(that)
+  override def apply(that: AnyRef): AnyRef = instance(that)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = topDown(Rewriter.lift {
     case p @ NotEquals(lhs, rhs) =>
       Not(Equals(lhs, rhs)(p.position))(p.position)   // not(1 = 2)  <!===!>     1 != 2
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeReturnClauses.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeReturnClauses.scala
@@ -40,7 +40,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.ast._
  */
 case class normalizeReturnClauses(mkException: (String, InputPosition) => CypherException) extends Rewriter {
 
-  def apply(that: AnyRef): AnyRef = bottomUp(instance).apply(that)
+  def apply(that: AnyRef): AnyRef = instance.apply(that)
 
   private val clauseRewriter: (Clause => Seq[Clause]) = {
     case clause @ Return(_, ri, None, _, _) =>
@@ -87,8 +87,8 @@ case class normalizeReturnClauses(mkException: (String, InputPosition) => Cypher
       Seq(clause)
   }
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = bottomUp(Rewriter.lift {
     case query @ SingleQuery(clauses) =>
       query.copy(clauses = clauses.flatMap(clauseRewriter))(query.position)
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeSargablePredicates.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeSargablePredicates.scala
@@ -25,9 +25,9 @@ import org.neo4j.cypher.internal.frontend.v3_0.ast.functions.Exists
 
 case object normalizeSargablePredicates extends Rewriter {
 
-  override def apply(that: AnyRef): AnyRef = topDown(instance)(that)
+  override def apply(that: AnyRef): AnyRef = instance(that)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = topDown(Rewriter.lift {
 
     // turn n.prop IS NOT NULL into exists(n.prop)
     case predicate@IsNotNull(property@Property(_, _)) =>
@@ -36,5 +36,5 @@ case object normalizeSargablePredicates extends Rewriter {
     // remove not from inequality expressions by negating them
     case Not(inequality: InequalityExpression) =>
       inequality.negated
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeWithClauses.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/normalizeWithClauses.scala
@@ -51,7 +51,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.ast._
  */
 case class normalizeWithClauses(mkException: (String, InputPosition) => CypherException) extends Rewriter {
 
-  def apply(that: AnyRef): AnyRef = bottomUp(instance).apply(that)
+  def apply(that: AnyRef): AnyRef = instance.apply(that)
 
   private val clauseRewriter: (Clause => Seq[Clause]) = {
     case clause @ With(_, ri, None, _, _, None) =>
@@ -204,8 +204,8 @@ case class normalizeWithClauses(mkException: (String, InputPosition) => CypherEx
     }
   }
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = bottomUp(Rewriter.lift {
     case query @ SingleQuery(clauses) =>
       query.copy(clauses = clauses.flatMap(clauseRewriter))(query.position)
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/projectFreshSortExpressions.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/projectFreshSortExpressions.scala
@@ -35,9 +35,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, bottomUp, replace}
  */
 case object projectFreshSortExpressions extends Rewriter {
 
-  def apply(that: AnyRef): AnyRef = {
-    bottomUp(instance).apply(that)
-  }
+  override def apply(that: AnyRef): AnyRef = instance.apply(that)
 
   private val clauseRewriter: (Clause => Seq[Clause]) = {
     case clause @ With(_, _, None, _, _, None) =>
@@ -72,7 +70,7 @@ case object projectFreshSortExpressions extends Rewriter {
       Seq(clause)
   }
 
-  private val instance: Rewriter = replace(replacer => {
+  private val instance: Rewriter = bottomUp(replace(replacer => {
 
     case expr: Expression =>
       replacer.stop(expr)
@@ -82,7 +80,7 @@ case object projectFreshSortExpressions extends Rewriter {
 
     case astNode =>
       replacer.expand(astNode)
-  })
+  }))
 
   private implicit class ItemSetContainer[T](input: Option[T]) {
     def extract[K](f: T => Set[K]): Set[K] =

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/projectNamedPaths.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/projectNamedPaths.scala
@@ -78,8 +78,7 @@ case object projectNamedPaths extends Rewriter {
       case expr: PathExpression =>
         expr
     }
-    val result = topDown(applicator)(input)
-    result
+    topDown(applicator)(input)
   }
 
   private def collectProjectibles(input: AnyRef): Projectibles = input.treeFold(Projectibles.empty) {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/reattachAliasedExpressions.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/reattachAliasedExpressions.scala
@@ -24,9 +24,9 @@ import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.ast.Return
 
 case object reattachAliasedExpressions extends Rewriter {
-  def apply(in: AnyRef): AnyRef = bottomUp(findingRewriter).apply(in)
+  override def apply(in: AnyRef): AnyRef = findingRewriter.apply(in)
 
-  private val findingRewriter: Rewriter = Rewriter.lift {
+  private val findingRewriter: Rewriter = bottomUp(Rewriter.lift {
     case clause: Return =>
       val innerRewriter = expressionRewriter(clause.returnItems.items)
       clause.copy(
@@ -38,7 +38,7 @@ case object reattachAliasedExpressions extends Rewriter {
       clause.copy(
         orderBy = clause.orderBy.endoRewrite(innerRewriter)
       )(clause.position)
-  }
+  })
 
   private def expressionRewriter(items: Seq[ReturnItem]): Rewriter = {
     val aliasedExpressions: Map[String, Expression] = items.map { returnItem =>

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/rewriteEqualityToInCollection.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/rewriteEqualityToInCollection.scala
@@ -28,9 +28,9 @@ either index lookup or node-by-id operations
  */
 case object rewriteEqualityToInCollection extends Rewriter {
 
-  override def apply(that: AnyRef) = bottomUp(instance)(that)
+  override def apply(that: AnyRef) = instance(that)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = bottomUp(Rewriter.lift {
     // id(a) = value => id(a) IN [value]
     case predicate@Equals(func@FunctionInvocation(_, _, IndexedSeq(idExpr)), idValueExpr)
       if func.function.contains(functions.Id) =>
@@ -43,5 +43,5 @@ case object rewriteEqualityToInCollection extends Rewriter {
     // a.prop = value => a.prop IN [value]
     case predicate@Equals(prop@Property(id: Variable, propKeyName), idValueExpr) =>
       In(prop, Collection(Seq(idValueExpr))(idValueExpr.position))(predicate.position)
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -33,7 +33,7 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: Lis
 
   case class ExecutionWorkflowBuilder() extends ExecutionResultBuilder {
     private val taskCloser = new TaskCloser
-    private var externalResource: ExternalResource = new CSVResources(taskCloser)
+    private var externalResource: ExternalCSVResource = new CSVResources(taskCloser)
     private var maybeQueryContext: Option[QueryContext] = None
     private var pipeDecorator: PipeDecorator = NullPipeDecorator
     private var exceptionDecorator: CypherException => CypherException = identity

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LoadCsvPeriodicCommitObserver.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LoadCsvPeriodicCommitObserver.scala
@@ -21,12 +21,12 @@ package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 
 import java.net.URL
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.ExternalResource
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.ExternalCSVResource
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_0.{CypherException, LoadCsvStatusWrapCypherException}
 
-class LoadCsvPeriodicCommitObserver(batchRowCount: Long, resources: ExternalResource, queryContext: QueryContext)
-  extends ExternalResource with ((CypherException) => CypherException) {
+class LoadCsvPeriodicCommitObserver(batchRowCount: Long, resources: ExternalCSVResource, queryContext: QueryContext)
+  extends ExternalCSVResource with ((CypherException) => CypherException) {
 
   val updateCounter = new UpdateCounter
   var outerLoadCSVIterator: Option[LoadCsvIterator] = None

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/LoadCSVBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/LoadCSVBuilder.scala
@@ -39,7 +39,7 @@ class LoadCSVBuilder extends PlanBuilder {
     val item: LoadCSV = findLoadCSVItem(plan).get
     plan.copy(
       query = plan.query.copy(start = plan.query.start.replace(Unsolved(item), Solved(item))),
-      pipe = new LoadCSVPipe(plan.pipe, if (item.withHeaders) HasHeaders else NoHeaders, item.url, item.variable, item.fieldTerminator)
+      pipe = new LoadCSVPipe(plan.pipe, if (item.withHeaders) HasHeaders else NoHeaders, item.url, item.variable, item.fieldTerminator)()
     )
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/procs/CallProcedureExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/procs/CallProcedureExecutionPlan.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.executionplan.procs
 
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.commands.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{ExecutionPlan, InternalExecutionResult, READ_ONLY}
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.{ExternalResource, QueryState}
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.{ExternalCSVResource, QueryState}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.{Id, NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{FieldSignature, GraphStatistics, ProcedureSignature, QueryContext}
 import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionContext, ExecutionMode, ExplainExecutionResult, ExplainMode, ProcedurePlannerName, ProcedureRuntimeName, TaskCloser}
@@ -45,7 +45,7 @@ case class CallProcedureExecutionPlan(signature: ProcedureSignature, args: Seq[E
   override def run(ctx: QueryContext, planType: ExecutionMode,
                    params: Map[String, Any]): InternalExecutionResult = {
 
-    val state = new QueryState(ctx, ExternalResource.empty, params)
+    val state = new QueryState(ctx, ExternalCSVResource.empty, params)
     val input = if (commandExpressions.nonEmpty) commandExpressions.map(_.apply(ExecutionContext.empty)(state))
     else {
       signature.inputSignature.map { f =>

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ExternalCSVResource.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ExternalCSVResource.scala
@@ -25,8 +25,8 @@ trait ExternalCSVResource {
   def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]]
 }
 
-object ExternalResource {
-  def empty: ExternalResource = new ExternalResource {
+object ExternalCSVResource {
+  def empty: ExternalCSVResource = new ExternalCSVResource {
     override def getCsvIterator(url: URL, fieldTerminator: Option[String]): Iterator[Array[String]] = Iterator.empty
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ExternalCSVResource.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ExternalCSVResource.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.pipes
 
 import java.net.URL
 
-trait ExternalResource {
+trait ExternalCSVResource {
   def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]]
 }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
@@ -32,7 +32,7 @@ import scala.collection.mutable
 
 
 class QueryState(val query: QueryContext,
-                 val resources: ExternalResource,
+                 val resources: ExternalCSVResource,
                  val params: Map[String, Any],
                  val decorator: PipeDecorator = NullPipeDecorator,
                  val timeReader: TimeReader = new TimeReader,

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/UnwindPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/UnwindPipe.scala
@@ -39,7 +39,7 @@ case class UnwindPipe(source: Pipe, collection: Expression, variable: String)
   }
 
   def planDescriptionWithoutCardinality: InternalPlanDescription =
-    PlanDescriptionImpl(this.id, "UNWIND", SingleChild(source.planDescription), Seq(), variables)
+    PlanDescriptionImpl(this.id, "Unwind", SingleChild(source.planDescription), Seq(), variables)
 
   def symbols = source.symbols.add(variable, collection.getType(source.symbols).legacyIteratedType)
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/QueryProjection.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/QueryProjection.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner
 
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.CSVFormat
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{IdName, LazyMode, StrictnessMode}
 import org.neo4j.cypher.internal.frontend.v3_0.InternalException
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
@@ -155,6 +156,14 @@ case class UnwindProjection(variable: IdName, exp: Expression) extends QueryHori
   override def exposedSymbols(qg: QueryGraph) = qg.allCoveredIds + variable
 
   override def dependingExpressions = Seq(exp)
+
+  override def preferredStrictness = None
+}
+
+case class LoadCSVProjection(variable: IdName, url: Expression, format: CSVFormat, fieldTerminator: Option[StringLiteral]) extends QueryHorizon {
+  override def exposedSymbols(qg: QueryGraph) = qg.allCoveredIds + variable
+
+  override def dependingExpressions = Seq(url)
 
   override def preferredStrictness = None
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -452,7 +452,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
   implicit val table: SemanticTable = context.semanticTable
 
   private object buildPipeExpressions extends Rewriter {
-    val instance = Rewriter.lift {
+    private val instance = bottomUp(Rewriter.lift {
       case compilerAst.NestedPlanExpression(patternPlan, pattern) =>
         val pos = pattern.position
         val pipe = recurse(patternPlan)
@@ -461,9 +461,9 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
         val pathExpression: PathExpression = ast.PathExpression(step)(pos)
         val result = compilerAst.NestedPipeExpression(pipe, pathExpression)(pos)
         result
-    }
+    })
 
-    def apply(that: AnyRef): AnyRef = bottomUp(instance).apply(that)
+    override def apply(that: AnyRef): AnyRef = instance.apply(that)
   }
 
   private def buildExpression(expr: ast.Expression)(implicit planContext: PlanContext): CommandExpression = {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -29,9 +29,8 @@ import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.{True, _}
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.builders.prepare.KeyTokenResolver
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{Effects, PipeInfo, PlanFingerprint, ReadsAllNodes}
 import org.neo4j.cypher.internal.compiler.v3_0.pipes._
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{Limit => LimitPlan, LoadCSV => LoadCSVPlan, Skip => SkipPlan, _}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CantHandleQueryException, logical}
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{InstrumentedGraphStatistics, PlanContext}
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
 import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionContext, Monitors, ast => compilerAst, pipes}
@@ -257,10 +256,10 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
     case Sort(_, sortItems) =>
       SortPipe(source, sortItems.map(translateSortDescription))()
 
-    case plans.Skip(_, count) =>
+    case SkipPlan(_, count) =>
       SkipPipe(source, buildExpression(count))()
 
-    case plans.Limit(_, count, DoNotIncludeTies) =>
+    case LimitPlan(_, count, DoNotIncludeTies) =>
       (source, count) match {
         case (SortPipe(inner, sortDescription), SignedDecimalIntegerLiteral("1")) =>
           Top1Pipe(inner, sortDescription.toList)()
@@ -272,7 +271,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
           LimitPipe(source, buildExpression(count))()
       }
 
-    case plans.Limit(_, count, IncludeTies) =>
+    case LimitPlan(_, count, IncludeTies) =>
       (source, count) match {
         case (SortPipe(inner, sortDescription), SignedDecimalIntegerLiteral("1")) =>
           Top1WithTiesPipe(inner, sortDescription.toList)()
@@ -302,6 +301,9 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
 
     case UnwindCollection(_, variable, collection) =>
       UnwindPipe(source, toCommandExpression(collection), variable.name)()
+
+    case LoadCSVPlan(_, url, variableName, format, fieldTerminator) =>
+      LoadCSVPipe(source, format, toCommandExpression(url), variableName.name, fieldTerminator)()
 
     case ProduceResult(columns, _) =>
       ProduceResultsPipe(source, columns)()

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/Eagerness.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/Eagerness.scala
@@ -149,7 +149,7 @@ object Eagerness {
       U : Unwind
      */
 
-    private val instance: Rewriter = Rewriter.lift {
+    private val instance: Rewriter = fixedPoint(bottomUp(Rewriter.lift {
 
       // L Ax (E R) => E Ax (L R)
       case apply@Apply(lhs, eager@Eager(inner)) =>
@@ -187,8 +187,8 @@ object Eagerness {
       case apply@Apply(lhs, remove@RemoveLabels(rhs, idName, labelNames)) =>
         remove.copy(source = Apply(lhs, rhs)(apply.solved), idName, labelNames)(apply.solved)
 
-    }
+    }))
 
-    override def apply(input: AnyRef) = fixedPoint(bottomUp(instance)).apply(input)
+    override def apply(input: AnyRef) = instance.apply(input)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PatternExpressionPatternElementNamer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PatternExpressionPatternElementNamer.scala
@@ -53,15 +53,15 @@ object PatternExpressionPatternElementNamer {
   }
 
   private case class namePatternElementsFromMap(map: Map[PatternElement, Variable]) extends Rewriter {
-    def apply(that: AnyRef): AnyRef = topDown(instance).apply(that)
+    override def apply(that: AnyRef): AnyRef = instance.apply(that)
 
-    private val instance: Rewriter = Rewriter.lift {
+    private val instance: Rewriter = topDown(Rewriter.lift {
       case pattern: NodePattern if map.contains(pattern) =>
         pattern.copy(variable = Some(map(pattern)))(pattern.position)
       case pattern: RelationshipChain if map.contains(pattern) =>
         val rel = pattern.relationship
         pattern.copy(relationship = rel.copy(variable = Some(map(pattern)))(rel.position))(pattern.position)
-    }
+    })
   }
 }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanEventHorizon.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanEventHorizon.scala
@@ -52,6 +52,9 @@ case object PlanEventHorizon
       case UnwindProjection(variable, expression) =>
         context.logicalPlanProducer.planUnwind(plan, variable, expression)
 
+      case LoadCSVProjection(variableName, url, format, fieldTermiator) =>
+        context.logicalPlanProducer.planLoadCSV(plan, variableName, url, format, fieldTermiator)
+
       case _ =>
         throw new CantHandleQueryException
     }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/StatisticsBackedCardinalityModel.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/StatisticsBackedCardinalityModel.scala
@@ -82,6 +82,10 @@ class StatisticsBackedCardinalityModel(queryGraphCardinalityModel: QueryGraphCar
     case _: UnwindProjection =>
       in * Multiplier(10)
 
+    // Load CSV
+    case _: LoadCSVProjection =>
+      in
+
     case _: RegularQueryProjection =>
       in
   }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LoadCSV.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LoadCSV.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2015 "Neo Technology,"
+ * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LoadCSV.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/LoadCSV.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
+
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.CSVFormat
+import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression
+
+case class LoadCSV(source: LogicalPlan,
+                   url: Expression,
+                   variableName: IdName,
+                   format: CSVFormat,
+                   fieldTerminator: Option[String])
+                  (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan {
+
+  override def availableSymbols = source.availableSymbols + variableName
+
+  override def lhs = Some(source)
+
+  override def rhs = None
+
+  override def mapExpressions(f: (Set[IdName], Expression) => Expression): LogicalPlan =
+    copy(url = f(source.availableSymbols, url))(solved)
+
+  override def strictness: StrictnessMode = source.strictness
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/fuseSelections.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/fuseSelections.scala
@@ -24,10 +24,10 @@ import org.neo4j.cypher.internal.frontend.v3_0.{bottomUp, Rewriter}
 
 case object fuseSelections extends Rewriter {
 
-  def apply(input: AnyRef) = bottomUp(instance).apply(input)
+  override def apply(input: AnyRef) = instance.apply(input)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = bottomUp(Rewriter.lift {
     case topSelection@Selection(predicates1, Selection(predicates2, lhs)) =>
       Selection(predicates1 ++ predicates2, lhs)(topSelection.solved)
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/removeIdenticalPlans.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/removeIdenticalPlans.scala
@@ -21,7 +21,6 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.rewriter
 
 import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
-import org.neo4j.cypher.internal.frontend.v3_0.Foldable._
 import org.neo4j.cypher.internal.frontend.v3_0.bottomUp.BottomUpRewriter
 import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, bottomUp}
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/removeIdenticalPlans.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/removeIdenticalPlans.scala
@@ -32,7 +32,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, bottomUp}
  */
 case object removeIdenticalPlans extends Rewriter {
 
-  def apply(input: AnyRef) = {
+  override def apply(input: AnyRef) = {
     var seenPlans = IdentitySet.empty[LogicalPlan]
 
     val rewriter: BottomUpRewriter = bottomUp(Rewriter.lift {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/simplifyEquality.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/simplifyEquality.scala
@@ -23,10 +23,10 @@ import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.{Rewriter, bottomUp}
 
 case object simplifyEquality extends Rewriter {
-  def apply(input: AnyRef) = bottomUp(instance).apply(input)
+  override def apply(input: AnyRef) = instance.apply(input)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = bottomUp(Rewriter.lift {
     case in@In(exp, Collection(values@Seq(idValueExpr))) if values.size == 1 =>
       Equals(exp, idValueExpr)(in.position)
-  }
+  })
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/CSVResources.scala
@@ -76,7 +76,7 @@ class CSVResources(cleaner: TaskCloser) extends ExternalCSVResource {
           while (seeker.seek(mark, intDelimiter)) {
             val success = seeker.tryExtract(mark, extractor)
             buffer += (if (success) extractor.value() else null)
-            if (mark.isEndOfLine) break
+            if (mark.isEndOfLine) break()
         }}
 
         if (buffer.isEmpty) {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/CSVResources.scala
@@ -27,7 +27,7 @@ import java.util.zip.{GZIPInputStream, InflaterInputStream}
 
 import org.neo4j.csv.reader._
 import org.neo4j.cypher.internal.compiler.v3_0.TaskCloser
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.ExternalResource
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.ExternalCSVResource
 import org.neo4j.cypher.internal.frontend.v3_0.LoadExternalResourceException
 
 import scala.collection.mutable.ArrayBuffer
@@ -49,7 +49,7 @@ object CSVResources {
   }
 }
 
-class CSVResources(cleaner: TaskCloser) extends ExternalResource {
+class CSVResources(cleaner: TaskCloser) extends ExternalCSVResource {
 
   def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]] = {
     val inputStream = openStream(url)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/CheckForEagerLoadCsvTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/CheckForEagerLoadCsvTest.scala
@@ -28,13 +28,13 @@ class CheckForEagerLoadCsvTest extends CypherFunSuite {
   implicit val monitor = mock[PipeMonitor]
 
   test("should notify for EagerPipe on top of LoadCsvPipe") {
-    val pipe = EagerPipe(LoadCSVPipe(AllNodesScanPipe("a")(), HasHeaders, Literal("foo"), "bar", None))()
+    val pipe = EagerPipe(LoadCSVPipe(AllNodesScanPipe("a")(), HasHeaders, Literal("foo"), "bar", None)())()
 
     checkForEagerLoadCsv(pipe) should equal(Some(EagerLoadCsvNotification))
   }
 
   test("should not notify for LoadCsv on top of eager pipe") {
-    val pipe = LoadCSVPipe(EagerPipe(AllNodesScanPipe("a")())(), HasHeaders, Literal("foo"), "bar", None)
+    val pipe = LoadCSVPipe(EagerPipe(AllNodesScanPipe("a")())(), HasHeaders, Literal("foo"), "bar", None)()
 
     checkForEagerLoadCsv(pipe) should equal(None)
   }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
@@ -51,7 +51,7 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   private val checker = CheckForLoadCsvAndMatchOnLargeLabel(planContext, THRESHOLD)
 
   test("should notify when doing LoadCsv on top of large label scan") {
-    val loadCsvPipe = LoadCSVPipe(SingleRowPipe(), HasHeaders, Literal("foo"), "bar", None)
+    val loadCsvPipe = LoadCSVPipe(SingleRowPipe(), HasHeaders, Literal("foo"), "bar", None)()
     val pipe = NodeStartPipe(loadCsvPipe, "foo",
       NodeByLabelEntityProducer(NodeByLabel("bar", labelOverThreshold), indexFor(labelOverThreshold)))()
 
@@ -59,7 +59,7 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   }
 
   test("should not notify when doing LoadCsv on top of a large label scan") {
-    val loadCsvPipe = LoadCSVPipe(SingleRowPipe(), HasHeaders, Literal("foo"), "bar", None)
+    val loadCsvPipe = LoadCSVPipe(SingleRowPipe(), HasHeaders, Literal("foo"), "bar", None)()
     val pipe = NodeStartPipe(loadCsvPipe, "foo",
       NodeByLabelEntityProducer(NodeByLabel("bar", labelUnderThrehsold), indexFor(labelUnderThrehsold)))()
 
@@ -68,7 +68,7 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
 
   test("should not notify when doing LoadCsv on top of large label scan") {
     val startPipe = NodeStartPipe(SingleRowPipe(), "foo", NodeByLabelEntityProducer(NodeByLabel("bar", labelOverThreshold), indexFor(labelOverThreshold)))()
-    val pipe = LoadCSVPipe(startPipe, HasHeaders, Literal("foo"), "bar", None)
+    val pipe = LoadCSVPipe(startPipe, HasHeaders, Literal("foo"), "bar", None)()
 
     checker(pipe) should equal(None)
   }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LoadCsvPeriodicCommitObserverTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/LoadCsvPeriodicCommitObserverTest.scala
@@ -23,7 +23,7 @@ import java.net.URL
 
 import org.mockito.Matchers
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.ExternalResource
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.ExternalCSVResource
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
@@ -31,7 +31,7 @@ class LoadCsvPeriodicCommitObserverTest extends CypherFunSuite {
 
   var resourceUnderTest: LoadCsvPeriodicCommitObserver = _
   var queryContext: QueryContext = _
-  var resource: ExternalResource = _
+  var resource: ExternalCSVResource = _
   val url: URL = new URL("file:///tmp/something.csv")
 
   test("writing should not trigger tx restart until next csv line is fetched") {
@@ -74,7 +74,7 @@ class LoadCsvPeriodicCommitObserverTest extends CypherFunSuite {
 
   override protected def beforeEach() {
     queryContext = mock[QueryContext]
-    resource = mock[ExternalResource]
+    resource = mock[ExternalCSVResource]
     resourceUnderTest = new LoadCsvPeriodicCommitObserver(1, resource, queryContext)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/PipeEffectsTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/PipeEffectsTest.scala
@@ -58,7 +58,7 @@ class PipeEffectsTest extends CypherFunSuite with TableDrivenPropertyChecks {
   NodeStartPipe(SingleRowPipe(), "n", mock[EntityProducer[Node]])()
     -> Effects(ReadsAllNodes).asLeafEffects,
 
-  LoadCSVPipe(SingleRowPipe(), null, Literal("apa"), "line", None)
+  LoadCSVPipe(SingleRowPipe(), null, Literal("apa"), "line", None)()
     -> Effects(),
 
   EmptyResultPipe(SingleRowPipe())

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryStateHelper.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryStateHelper.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable
 object QueryStateHelper {
   def empty: QueryState = emptyWith()
 
-  def emptyWith(query: QueryContext = null, resources: ExternalResource = null,
+  def emptyWith(query: QueryContext = null, resources: ExternalCSVResource = null,
                 params: Map[String, Any] = Map.empty, decorator: PipeDecorator = NullPipeDecorator,
                 initialContext: Option[ExecutionContext] = None) =
     new QueryState(query = query, resources = resources, params = params, decorator = decorator,

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/cleanUpEagerTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/rewriter/cleanUpEagerTest.scala
@@ -19,9 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.rewriter
 
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.fixedPoint
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.NoHeaders
 import org.neo4j.cypher.internal.compiler.v3_0.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
-import org.neo4j.cypher.internal.frontend.v3_0.helpers.fixedPoint
+import org.neo4j.cypher.internal.frontend.v3_0.ast.StringLiteral
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
 class cleanUpEagerTest extends CypherFunSuite with LogicalPlanningTestSupport {
@@ -71,6 +73,25 @@ class cleanUpEagerTest extends CypherFunSuite with LogicalPlanningTestSupport {
             IdName("i"), null)(solved),
           IdName("i"), null)(solved),
         Map.empty)(solved))
+  }
+
+  test("should move eager on top of load csv to below it") {
+    val leaf = newMockedLogicalPlan()
+    val url = StringLiteral("file:///tmp/foo.csv")(pos)
+    val loadCSV = LoadCSV(leaf, url, IdName("a"), NoHeaders, None)(solved)
+    val eager = Eager(loadCSV)(solved)
+    val topPlan = Projection(eager, Map.empty)(solved)
+
+    rewrite(topPlan) should equal(Projection(LoadCSV(Eager(leaf)(solved), url, IdName("a"), NoHeaders, None)(solved), Map.empty)(solved))
+  }
+
+  test("should not rewrite plan with eager below load csv") {
+    val leaf = newMockedLogicalPlan()
+    val eager = Eager(leaf)(solved)
+    val loadCSV = LoadCSV(eager, StringLiteral("file:///tmp/foo.csv")(pos), IdName("a"), NoHeaders, None)(solved)
+    val topPlan = Projection(loadCSV, Map.empty)(solved)
+
+    rewrite(topPlan) should equal(topPlan)
   }
 
   private def rewrite(p: LogicalPlan): LogicalPlan =

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/profiler/ProfilerTest.scala
@@ -165,7 +165,7 @@ class ProfilerTest extends CypherFunSuite {
 
     val pipe1 = SingleRowPipe()
     val ctx1 = mock[QueryContext]
-    val state1 = QueryStateHelper.emptyWith(ctx1, mock[ExternalResource])
+    val state1 = QueryStateHelper.emptyWith(ctx1, mock[ExternalCSVResource])
 
     val profiled1 = profiler.decorate(pipe1, state1)
     profiled1.query.createNode()
@@ -173,7 +173,7 @@ class ProfilerTest extends CypherFunSuite {
 
     val pipe2 = SingleRowPipe()
     val ctx2 = mock[QueryContext]
-    val state2 = QueryStateHelper.emptyWith(ctx2, mock[ExternalResource])
+    val state2 = QueryStateHelper.emptyWith(ctx2, mock[ExternalCSVResource])
 
 
     val profiled2 = profiler.decorate(pipe2, state2)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/EagerizationAcceptanceTest.scala
@@ -1273,7 +1273,7 @@ class EagerizationAcceptanceTest
     assertNumberOfEagerness(query, 0)
   }
 
-  ignore("should not be eager when merging on already bound variables") {
+  test("should not be eager when merging on already bound variables") {
     val query = "MERGE (city:City) MERGE (country:Country) MERGE (city)-[:IN]->(country) RETURN count(*)"
 
     val result = updateWithBothPlanners(query)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -278,8 +278,15 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     result.notifications shouldBe empty
   }
 
-  test("should warn for load csv + eager") {
+  test("should not warn for eager before load csv") {
     val result = innerExecute("EXPLAIN MATCH (n) DELETE n WITH * LOAD CSV FROM 'file:///ignore/ignore.csv' AS line MERGE () RETURN line")
+
+    result should use("LoadCSV", "Eager")
+    result.notifications should not contain EagerLoadCsvNotification
+  }
+
+  test("should warn for eager after load csv") {
+    val result = innerExecute("EXPLAIN MATCH (n) LOAD CSV FROM 'file:///ignore/ignore.csv' AS line WITH * DELETE n MERGE () RETURN line")
 
     result should use("LoadCSV", "Eager")
     result.notifications should contain(EagerLoadCsvNotification)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -279,7 +279,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
   }
 
   test("should warn for load csv + eager") {
-    val result = innerExecute("EXPLAIN LOAD CSV FROM 'file:///ignore/ignore.csv' AS line MATCH () CREATE () RETURN line")
+    val result = innerExecute("EXPLAIN MATCH (n) DELETE n WITH * LOAD CSV FROM 'file:///ignore/ignore.csv' AS line MERGE () RETURN line")
 
     result should use("LoadCSV", "Eager")
     result.notifications should contain(EagerLoadCsvNotification)
@@ -309,28 +309,28 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
   test("should warn for large label scans combined with load csv") {
     1 to 11 foreach { _ => createLabeledNode("A") }
     val result = innerExecute("EXPLAIN LOAD CSV FROM 'file:///ignore/ignore.csv' AS line MATCH (a:A) RETURN *")
-    result should use("LoadCSV", "NodeByLabel")
+    result should use("LoadCSV", "NodeByLabelScan")
     result.notifications should contain(LargeLabelWithLoadCsvNotification)
   }
 
   test("should warn for large label scans with merge combined with load csv") {
     1 to 11 foreach { _ => createLabeledNode("A") }
     val result = innerExecute("EXPLAIN LOAD CSV FROM 'file:///ignore/ignore.csv' AS line MERGE (a:A) RETURN *")
-    result should use("LoadCSV", "UpdateGraph")
+    result should use("LoadCSV", "AntiConditionalApply")
     result.notifications should contain(LargeLabelWithLoadCsvNotification)
   }
 
   test("should not warn for small label scans combined with load csv") {
     createLabeledNode("A")
     val result = innerExecute("EXPLAIN LOAD CSV FROM 'file:///ignore/ignore.csv' AS line MATCH (a:A) RETURN *")
-    result should use("LoadCSV", "NodeByLabel")
+    result should use("LoadCSV", "NodeByLabelScan")
     result.notifications should not contain LargeLabelWithLoadCsvNotification
   }
 
   test("should not warn for small label scans with merge combined with load csv") {
     createLabeledNode("A")
     val result = innerExecute("EXPLAIN LOAD CSV FROM 'file:///ignore/ignore.csv' AS line MERGE (a:A) RETURN *")
-    result should use("LoadCSV", "UpdateGraph")
+    result should use("LoadCSV", "AntiConditionalApply")
     result.notifications should not contain LargeLabelWithLoadCsvNotification
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/QueryStateHelper.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/QueryStateHelper.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0
 
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.{ExternalResource, NullPipeDecorator, PipeDecorator, QueryState}
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.{ExternalCSVResource, NullPipeDecorator, PipeDecorator, QueryState}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{QueryContext, UpdateCountingQueryContext}
 import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.graphdb.{GraphDatabaseService, Transaction}
@@ -34,7 +34,7 @@ import scala.collection.mutable
 object QueryStateHelper {
   def empty: QueryState = newWith()
 
-  def newWith(db: GraphDatabaseService = null, query: QueryContext = null, resources: ExternalResource = null,
+  def newWith(db: GraphDatabaseService = null, query: QueryContext = null, resources: ExternalCSVResource = null,
                 params: Map[String, Any] = Map.empty, decorator: PipeDecorator = NullPipeDecorator) =
     new QueryState(query = query, resources = resources, params = params, decorator = decorator, triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty)
 

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/QueryPlanTest.scala
@@ -425,7 +425,7 @@ class QueryPlanTest extends DocumentingTestBase with SoftReset {
       text =
         """Takes a collection of values and returns one row per item in the collection.""".stripMargin,
       queryText = """UNWIND range(1,5) as value return value;""",
-      assertions = (p) => assertThat(p.executionPlanDescription().toString, containsString("UNWIND"))
+      assertions = (p) => assertThat(p.executionPlanDescription().toString, containsString("Unwind"))
     )
   }
 }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/captureStateAsGraphViz.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/captureStateAsGraphViz.scala
@@ -54,9 +54,9 @@ object captureStateAsGraphViz extends GraphIcing {
 }
 
 case class replaceSingleObject(from: Content, to: Content) extends Rewriter {
-  def apply(input: AnyRef) = bottomUp(instance).apply(input)
+  override def apply(input: AnyRef) = instance.apply(input)
 
-  private val instance: Rewriter = Rewriter.lift {
+  private val instance: Rewriter = bottomUp(Rewriter.lift {
     case x if x == from => to
-  }
+  })
 }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/contentAndResultMerger.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/contentAndResultMerger.scala
@@ -49,7 +49,7 @@ object contentAndResultMerger {
   private class ContentReplacer(rewrites: Map[QueryResultPlaceHolder, Content]) extends Rewriter {
     override def apply(value: AnyRef): AnyRef = instance(value)
 
-    val instance: Rewriter = bottomUp(Rewriter.lift {
+    private val instance: Rewriter = bottomUp(Rewriter.lift {
       case q: QueryResultPlaceHolder => rewrites(q)
     })
   }


### PR DESCRIPTION
Also addresses issues with object creation related to use of `bottomUp` and `topDown`.

This PR is based upon #6222, and should only be merged afterwards.
