### PR TITLE
Built-in-procedures should use `in-use` when possible

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CallProcedureAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CallProcedureAcceptanceTest.scala
@@ -56,7 +56,7 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     result.toList shouldBe empty
   }
 
-  test("removing labels from nodes does not remove labels from label store") {
+  test("sys.db.labels should be empty when all labels are removed") {
     // Given
     createLabeledNode("A")
     execute("MATCH (a:A) REMOVE a:A")
@@ -65,11 +65,10 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     val result = execute("CALL sys.db.labels")
 
     // Then
-    result.toList should equal(
-      List(Map("label" -> "A")))
+    result shouldBe empty
   }
 
-  test("removing all the nodes does not remove labels from label store") {
+  test("sys.db.labels should be empty when all nodes are removed") {
     // Given
     createLabeledNode("A")
     execute("MATCH (a) DETACH DELETE a")
@@ -78,8 +77,7 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     val result = execute("CALL sys.db.labels")
 
     // Then
-    result.toList should equal(
-      List(Map("label" -> "A")))
+    result shouldBe empty
   }
 
   test("should be able to find types from built-in-procedure") {
@@ -94,9 +92,9 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     // Then
     result.toList should equal(
       List(
-        Map("relationshipTypes" -> "A"),
-        Map("relationshipTypes" -> "B"),
-        Map("relationshipTypes" -> "C")))
+        Map("relationshipType" -> "A"),
+        Map("relationshipType" -> "B"),
+        Map("relationshipType" -> "C")))
   }
 
   test("sys.db.relationshipType work on an empty database") {
@@ -105,10 +103,10 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     val result = execute("CALL sys.db.relationshipTypes")
 
     // Then
-    result.toList shouldBe empty
+    result shouldBe empty
   }
 
-  test("removing all the relationships does not remove relationship types from the store") {
+  test("sys.db.relationshipTypes should be empty when all relationships are removed") {
     // Given
     // Given
     relate(createNode(), createNode(), "A")
@@ -120,11 +118,7 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     val result = execute("CALL sys.db.relationshipTypes")
 
     // Then
-    result.toList should equal(
-      List(
-        Map("relationshipTypes" -> "A"),
-        Map("relationshipTypes" -> "B"),
-        Map("relationshipTypes" -> "C")))
+    result shouldBe empty
   }
 
   test("should be able to find propertyKeys from built-in-procedure") {
@@ -137,9 +131,9 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     // Then
     result.toList should equal(
       List(
-        Map("propertyKeys" -> "A"),
-        Map("propertyKeys" -> "B"),
-        Map("propertyKeys" -> "C")))
+        Map("propertyKey" -> "A"),
+        Map("propertyKey" -> "B"),
+        Map("propertyKey" -> "C")))
   }
 
   test("sys.db.propertyKeys works on an empty database") {
@@ -163,15 +157,16 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     // Then
     result.toList should equal(
       List(
-        Map("propertyKeys" -> "A"),
-        Map("propertyKeys" -> "B"),
-        Map("propertyKeys" -> "R")))
+        Map("propertyKey" -> "A"),
+        Map("propertyKey" -> "B"),
+        Map("propertyKey" -> "R")))
   }
 
   test("removing all nodes and relationship does not remove properties from the store") {
     // Given
     relate(createNode("A" -> 1), createNode("B" -> 1), "R" ->1)
     execute("MATCH (a) DETACH DELETE a")
+    println(execute("MATCH (a) RETURN count(a)").toList)
 
     // When
     val result = execute("CALL sys.db.propertyKeys")
@@ -179,9 +174,9 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     // Then
     result.toList should equal(
       List(
-        Map("propertyKeys" -> "A"),
-        Map("propertyKeys" -> "B"),
-        Map("propertyKeys" -> "R")))
+        Map("propertyKey" -> "A"),
+        Map("propertyKey" -> "B"),
+        Map("propertyKey" -> "R")))
   }
 
   test("should be able to call procedure with explicit arguments") {
@@ -262,8 +257,6 @@ class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
     // Then
     an [InvalidArgumentException] shouldBe thrownBy(execute("CALL my.first.proc('ten', 10, 42)"))
   }
-
-
 
   test("should fail if implicit argument is missing") {
     // Given

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -28,6 +28,8 @@ import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyConstraint;
@@ -95,6 +97,7 @@ public interface ReadOperations
 
     /** Returns the relationship types currently stored in the database */
     Iterator<Token> relationshipTypesGetAllTokens();
+
 
     int labelCount();
 
@@ -552,7 +555,10 @@ public interface ReadOperations
     //===========================================
 
     /** For read procedures, this key will be available in the invocation context as a means to access the current read statement. */
-    Procedure.Key<ReadOperations> readStatement = Procedure.Key.key("statementContext.read", ReadOperations.class );
+    Procedure.Key<ReadOperations> readOperations = Procedure.Key.key("statementContext.read", ReadOperations.class );
+
+    /** For managed procedures, this gives access to the current statement. */
+    Procedure.Key<Statement> statement = Procedure.Key.key("statement", Statement.class );
 
     /** Fetch a procedure given its signature. */
     ProcedureSignature procedureGet( ProcedureSignature.ProcedureName name ) throws ProcedureException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListLabelsProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListLabelsProcedure.java
@@ -20,16 +20,17 @@
 package org.neo4j.kernel.builtinprocs;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.graphdb.Label;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.api.proc.Procedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature.ProcedureName;
-import org.neo4j.storageengine.api.Token;
+import org.neo4j.kernel.impl.api.TokenAccess;
 
-import static org.neo4j.kernel.api.ReadOperations.readStatement;
-import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 import static org.neo4j.helpers.collection.Iterables.asRawIterator;
 import static org.neo4j.helpers.collection.Iterables.map;
+import static org.neo4j.kernel.api.ReadOperations.statement;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
 public class ListLabelsProcedure extends Procedure.BasicProcedure
 {
@@ -41,7 +42,7 @@ public class ListLabelsProcedure extends Procedure.BasicProcedure
     @Override
     public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
     {
-        RawIterator<Token,ProcedureException> tokens = asRawIterator( ctx.get( readStatement ).labelsGetAllTokens() );
-        return map(  ( token ) -> new Object[]{ token.name() }, tokens );
+        RawIterator<Label,ProcedureException> labels = asRawIterator( TokenAccess.LABELS.inUse( ctx.get( statement ) ) );
+        return map( ( l) -> new Object[]{l.name()}, labels );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListPropertyKeysProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListPropertyKeysProcedure.java
@@ -24,24 +24,24 @@ import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.api.proc.Procedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
-import org.neo4j.storageengine.api.Token;
+import org.neo4j.kernel.impl.api.TokenAccess;
 
-import static org.neo4j.kernel.api.ReadOperations.readStatement;
-import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 import static org.neo4j.helpers.collection.Iterables.asRawIterator;
 import static org.neo4j.helpers.collection.Iterables.map;
+import static org.neo4j.kernel.api.ReadOperations.statement;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
 public class ListPropertyKeysProcedure extends Procedure.BasicProcedure
 {
     public ListPropertyKeysProcedure( ProcedureSignature.ProcedureName name )
     {
-        super( procedureSignature( name ).out( name.name(), Neo4jTypes.NTString ).build() );
+        super( procedureSignature( name ).out( "propertyKey", Neo4jTypes.NTString ).build() );
     }
 
     @Override
     public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
     {
-        RawIterator<Token,ProcedureException> tokens = asRawIterator( ctx.get( readStatement ).propertyKeyGetAllTokens() );
-        return map(  ( token ) -> new Object[]{ token.name() }, tokens );
+        RawIterator<String,ProcedureException> labels = asRawIterator( TokenAccess.PROPERTY_KEYS.inUse( ctx.get( statement ) ) );
+        return map( ( key) -> new Object[]{key}, labels );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListRelationshipTypesProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListRelationshipTypesProcedure.java
@@ -20,28 +20,30 @@
 package org.neo4j.kernel.builtinprocs;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.api.proc.Procedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
-import org.neo4j.storageengine.api.Token;
+import org.neo4j.kernel.impl.api.TokenAccess;
 
-import static org.neo4j.kernel.api.ReadOperations.readStatement;
-import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 import static org.neo4j.helpers.collection.Iterables.asRawIterator;
 import static org.neo4j.helpers.collection.Iterables.map;
+import static org.neo4j.kernel.api.ReadOperations.statement;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
 public class ListRelationshipTypesProcedure extends Procedure.BasicProcedure
 {
     public ListRelationshipTypesProcedure( ProcedureSignature.ProcedureName name )
     {
-        super( procedureSignature( name ).out(  name.name(), Neo4jTypes.NTString ).build());
+        super( procedureSignature( name ).out( "relationshipType", Neo4jTypes.NTString ).build());
     }
 
     @Override
     public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
     {
-        RawIterator<Token,ProcedureException> tokens = asRawIterator( ctx.get( readStatement ).relationshipTypesGetAllTokens() );
-        return map(  ( token ) -> new Object[]{ token.name() }, tokens );
+        RawIterator<RelationshipType,ProcedureException> types =
+                asRawIterator( TokenAccess.RELATIONSHIP_TYPES.inUse( ctx.get( statement ) ) );
+        return map( ( l) -> new Object[]{l.name()}, types );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -29,6 +29,9 @@ import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.LegacyIndexHits;
 import org.neo4j.kernel.api.ReadOperations;
@@ -671,7 +674,8 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     {
         statement.assertOpen();
         Procedure.BasicContext ctx = new Procedure.BasicContext();
-        ctx.put( ReadOperations.readStatement, this );
+        ctx.put( ReadOperations.readOperations, this );
+        ctx.put( ReadOperations.statement, statement );
         return procedures.call( ctx, name, input );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
@@ -43,8 +43,11 @@ public class BuiltinProceduresIT extends KernelIntegrationTest
     public void listAllLabels() throws Throwable
     {
         // Given
+
         DataWriteOperations ops = dataWriteOperationsInNewTransaction();
-        ops.labelGetOrCreateForName( "MyLabel" );
+        long nodeId = ops.nodeCreate();
+        int labelId = ops.labelGetOrCreateForName( "MyLabel" );
+        ops.nodeAddLabel( nodeId, labelId );
         commit();
 
         // When
@@ -74,7 +77,8 @@ public class BuiltinProceduresIT extends KernelIntegrationTest
     {
         // Given
         DataWriteOperations ops = dataWriteOperationsInNewTransaction();
-        ops.relationshipTypeGetOrCreateForName( "MyRelType" );
+        int relType = ops.relationshipTypeGetOrCreateForName( "MyRelType" );
+        ops.relationshipCreate( relType, ops.nodeCreate(), ops.nodeCreate() );
         commit();
 
         // When

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
@@ -92,7 +92,7 @@ public class ProceduresKernelIT extends KernelIntegrationTest
             @Override
             public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
             {
-                return RawIterator.<Object[], ProcedureException>of( new Object[]{ ctx.get( ReadOperations.readStatement ) } );
+                return RawIterator.<Object[], ProcedureException>of( new Object[]{ ctx.get( ReadOperations.readOperations ) } );
             }
         } );
 


### PR DESCRIPTION
The built-in procedures for listing labels and relationship types should only
list those that are currently in-use.
