### PR TITLE
Fix initialisation from on disk state.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/StatePersister.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/StatePersister.java
@@ -53,6 +53,7 @@ public class StatePersister<STATE>
         this.marshal = marshal;
         this.currentStoreFile = currentStoreFile;
         this.currentStoreChannel = new PhysicalFlushableChannel( fileSystemAbstraction.open( currentStoreFile, "rw" ) );
+        initialiseStoreFile( currentStoreFile );
         this.databaseHealthSupplier = databaseHealthSupplier;
     }
 
@@ -98,9 +99,13 @@ public class StatePersister<STATE>
     {
         if ( fileSystemAbstraction.fileExists( nextStore ) )
         {
-            fileSystemAbstraction.deleteFile( nextStore );
+            fileSystemAbstraction.truncate( nextStore, 0 );
+            return new PhysicalFlushableChannel( fileSystemAbstraction.open( nextStore, "rw" ) );
         }
-        return new PhysicalFlushableChannel( fileSystemAbstraction.create( nextStore ) );
+        else
+        {
+            return new PhysicalFlushableChannel( fileSystemAbstraction.create( nextStore ) );
+        }
     }
 
     public synchronized void close() throws IOException

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/OnDiskTermStateTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/OnDiskTermStateTest.java
@@ -47,13 +47,6 @@ public class OnDiskTermStateTest
     @Rule
     public TargetDirectory.TestDirectory testDir = TargetDirectory.testDirForTest( getClass() );
 
-    private OnDiskTermState createTermState( FileSystemAbstraction fileSystem ) throws IOException
-    {
-        final Supplier mock = mock( Supplier.class );
-        when( mock.get() ).thenReturn( mock( DatabaseHealth.class ) );
-
-        return new OnDiskTermState( fileSystem, testDir.directory(), 100, mock );
-    }
 
     @Test
     public void shouldCallWriteAllAndForceOnVoteUpdate() throws Exception

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/PersistedStateIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/PersistedStateIT.java
@@ -88,14 +88,14 @@ public class PersistedStateIT
     {
         EphemeralFileSystemAbstraction normalFSA = new EphemeralFileSystemAbstraction();
         /*
-         * Magic number warning. For a rotation threshold of 14, 998 operations on file A falls on creation of the
+         * Magic number warning. For a rotation threshold of 14, 998 operations on file A falls on truncation of the
          * file during rotation. This has been discovered via experimentation. The end result is that there is a
          * failure to create the file to rotate to. This should be recoverable.
          */
         AdversarialFileSystemAbstraction breakingFSA = new AdversarialFileSystemAbstraction(
                 new MethodGuardedAdversary(
                         new CountingAdversary( 20, true ),
-                        FileSystemAbstraction.class.getMethod( "create", File.class ) ),
+                        FileSystemAbstraction.class.getMethod( "truncate", File.class, long.class ) ),
                 normalFSA );
         SelectiveFileSystemAbstraction combinedFSA = new SelectiveFileSystemAbstraction(
                 new File( testDir.directory(), "long.a" ), breakingFSA, normalFSA );
@@ -114,8 +114,8 @@ public class PersistedStateIT
         }
         catch ( Exception expected )
         {
-            // this stack trace should contain FSA.create()
-            ensureStackTraceContainsExpectedMethod( expected.getStackTrace(), "create" );
+            // this stack trace should contain FSA.truncate()
+            ensureStackTraceContainsExpectedMethod( expected.getStackTrace(), "truncate" );
         }
 
         LongState restoredState = new LongState( normalFSA, testDir.directory(), 14 );


### PR DESCRIPTION
Previously the old file was not truncated, potentially leading to
old state being left behind and then partially overwritten. This
would lead to issues when recovery tried to figure out the latest
state, which it does by looking at the last entry in each file.
