### PR TITLE
Add explicit override to help IntelliJ.

### DIFF
--- a/community/primitive-collections/src/main/java/org/neo4j/cursor/Cursor.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/cursor/Cursor.java
@@ -32,4 +32,6 @@ package org.neo4j.cursor;
  */
 public interface Cursor<T> extends RawCursor<T,RuntimeException>
 {
+    @Override
+    void close();
 }


### PR DESCRIPTION
It otherwise complains with:
Unhandled exception from auto-closeable resource:EXCEPTION
