### PR TITLE
Use the random server selection strategy when pulling.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/ConnectToRandomCoreServer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/ConnectToRandomCoreServer.java
@@ -30,8 +30,9 @@ import org.neo4j.coreedge.server.CoreMember;
 public class ConnectToRandomCoreServer implements EdgeToCoreConnectionStrategy
 {
     private final EdgeDiscoveryService discoveryService;
+    private final Random random = new Random();
 
-    public ConnectToRandomCoreServer( EdgeDiscoveryService discoveryService)
+    public ConnectToRandomCoreServer( EdgeDiscoveryService discoveryService )
     {
         this.discoveryService = discoveryService;
     }
@@ -40,17 +41,18 @@ public class ConnectToRandomCoreServer implements EdgeToCoreConnectionStrategy
     @Override
     public AdvertisedSocketAddress coreServer()
     {
-        final Random random = new Random();
-
         final ClusterTopology clusterTopology = discoveryService.currentTopology();
-        int randomSize = random.nextInt( clusterTopology.getMembers().size() );
+        int skippedServers = random.nextInt( clusterTopology.getMembers().size() );
 
         final Iterator<CoreMember> iterator = clusterTopology.getMembers().iterator();
-        AdvertisedSocketAddress result = null;
-        for ( int i = 0; i <= randomSize; i++ )
+
+        CoreMember member;
+        do
         {
-            result = iterator.next().getCoreAddress();
+            member = iterator.next();
         }
-        return result;
+        while ( skippedServers --> 0 );
+
+        return member.getCoreAddress();
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EnterpriseEdgeEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/edge/EnterpriseEdgeEditionModule.java
@@ -159,7 +159,7 @@ public class EnterpriseEdgeEditionModule extends EditionModule
         TxPollingClient txPollingClient = life.add(
                 new TxPollingClient( platformModule.jobScheduler, config.get( HaSettings.pull_interval ),
                         platformModule.dependencies.provideDependency( TransactionIdStore.class ), edgeToCoreClient,
-                        applyPulledTransactions, discoveryService ) );
+                        applyPulledTransactions, new ConnectToRandomCoreServer( discoveryService ) ) );
 
         StoreFetcher storeFetcher = new StoreFetcher( platformModule.logging.getInternalLogProvider(),
                 new DefaultFileSystemAbstraction(), platformModule.pageCache,


### PR DESCRIPTION
The random strategy was already in use for store copy, but it also makes
sense for the recurring transaction pulling, as a first and simple solution
for load balancing, handling topology changes, etc.

Previously we would just select the first server in the stable topology.
