### PR TITLE
Add `AccessMode` to KernelTransaction, allowing access control.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/AccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/AccessMode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+/** Controls the capabilities of a {@link KernelTransaction}. */
+public enum AccessMode
+{
+    /** Allows reading data and schema, but not writing. */
+    READ
+    {
+        @Override
+        public boolean allowsWrites()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean allowsSchemaWrites()
+        {
+            return false;
+        }
+    },
+
+    /** Allows all operations. */
+    FULL
+    {
+        @Override
+        public boolean allowsWrites()
+        {
+            return true;
+        }
+
+        @Override
+        public boolean allowsSchemaWrites()
+        {
+            return true;
+        }
+    };
+
+    public abstract boolean allowsWrites();
+    public abstract boolean allowsSchemaWrites();
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -112,6 +112,17 @@ public interface KernelTransaction extends AutoCloseable
     boolean isOpen();
 
     /**
+     * @return the mode this transaction is currently executing in.
+     */
+    AccessMode mode();
+
+    /**
+     * Set the mode this transaction should execute in. This controls which capabilities the transaction has.
+     * @param mode mode to use.
+     */
+    void setMode( AccessMode mode );
+
+    /**
      * @return {@code true} if {@link #markForTermination()} has been invoked, otherwise {@code false}.
      */
     boolean shouldBeTerminated();

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
@@ -72,7 +72,7 @@ import static org.mockito.Mockito.when;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @RunWith( Parameterized.class )
-public class KernelTransactionImplementationTest
+public class KernelTransactionImplementationTest extends KernelTransactionTestBase
 {
     @Parameterized.Parameter( 0 )
     public ThrowingConsumer<KernelTransaction,Exception> transactionConsumer;
@@ -430,57 +430,5 @@ public class KernelTransactionImplementationTest
             verify( this.transactionMonitor, times( 1 ) ).upgradeToWriteTransaction();
         }
         verifyNoMoreInteractions( transactionMonitor );
-    }
-
-    private final StorageEngine storageEngine = mock( StorageEngine.class );
-    private final NeoStores neoStores = mock( NeoStores.class );
-    private final MetaDataStore metaDataStore = mock( MetaDataStore.class );
-    private final StoreReadLayer readLayer = mock( StoreReadLayer.class );
-    private final TransactionHooks hooks = new TransactionHooks();
-    private final LegacyIndexTransactionState legacyIndexState = mock( LegacyIndexTransactionState.class );
-    private final TransactionMonitor transactionMonitor = mock( TransactionMonitor.class );
-    private final CapturingCommitProcess commitProcess = new CapturingCommitProcess();
-    private final TransactionHeaderInformation headerInformation = mock( TransactionHeaderInformation.class );
-    private final TransactionHeaderInformationFactory headerInformationFactory =
-            mock( TransactionHeaderInformationFactory.class );
-    private final FakeClock clock = new FakeClock();
-    private final KernelTransactions kernelTransactions = mock( KernelTransactions.class );
-
-    @Before
-    public void before()
-    {
-        when( headerInformation.getAdditionalHeader() ).thenReturn( new byte[0] );
-        when( headerInformationFactory.create() ).thenReturn( headerInformation );
-        when( readLayer.acquireStatement() ).thenReturn( mock( StoreStatement.class ) );
-        when( neoStores.getMetaDataStore() ).thenReturn( metaDataStore );
-        when( storageEngine.storeReadLayer() ).thenReturn( readLayer );
-    }
-
-    private KernelTransactionImplementation newTransaction()
-    {
-        return newTransaction( 0 );
-    }
-
-    private KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted )
-    {
-        return new KernelTransactionImplementation( null, null, new NoOpClient(), hooks, null, null, headerInformationFactory,
-                commitProcess, transactionMonitor, legacyIndexState, kernelTransactions, clock, TransactionTracer.NULL,
-                storageEngine, lastTransactionIdWhenStarted );
-    }
-
-    public class CapturingCommitProcess implements TransactionCommitProcess
-    {
-        private long txId = 1;
-        private TransactionRepresentation transaction;
-
-        @Override
-        public long commit( TransactionToApply batch, CommitEvent commitEvent,
-                            TransactionApplicationMode mode ) throws TransactionFailureException
-        {
-            assert transaction == null : "Designed to only allow one transaction";
-            assert batch.next() == null : "Designed to only allow one transaction";
-            transaction = batch.transactionRepresentation();
-            return txId++;
-        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionTestBase.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api;
+
+import org.junit.Before;
+
+import org.neo4j.helpers.FakeClock;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
+import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
+import org.neo4j.kernel.impl.api.KernelTransactions;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
+import org.neo4j.kernel.impl.api.TransactionHooks;
+import org.neo4j.kernel.impl.api.TransactionToApply;
+import org.neo4j.kernel.impl.api.store.StoreStatement;
+import org.neo4j.kernel.impl.locking.NoOpClient;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
+import org.neo4j.kernel.impl.transaction.TransactionMonitor;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
+import org.neo4j.storageengine.api.StorageEngine;
+import org.neo4j.storageengine.api.StoreReadLayer;
+import org.neo4j.storageengine.api.TransactionApplicationMode;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class KernelTransactionTestBase
+{
+    protected final StorageEngine storageEngine = mock( StorageEngine.class );
+    protected final NeoStores neoStores = mock( NeoStores.class );
+    protected final MetaDataStore metaDataStore = mock( MetaDataStore.class );
+    protected final StoreReadLayer readLayer = mock( StoreReadLayer.class );
+    protected final TransactionHooks hooks = new TransactionHooks();
+    protected final LegacyIndexTransactionState legacyIndexState = mock( LegacyIndexTransactionState.class );
+    protected final TransactionMonitor transactionMonitor = mock( TransactionMonitor.class );
+    protected final CapturingCommitProcess commitProcess = new CapturingCommitProcess();
+    protected final TransactionHeaderInformation headerInformation = mock( TransactionHeaderInformation.class );
+    protected final TransactionHeaderInformationFactory headerInformationFactory =  mock( TransactionHeaderInformationFactory.class );
+    protected final FakeClock clock = new FakeClock();
+    protected final KernelTransactions kernelTransactions = mock( KernelTransactions.class );
+
+    @Before
+    public void before()
+    {
+        when( headerInformation.getAdditionalHeader() ).thenReturn( new byte[0] );
+        when( headerInformationFactory.create() ).thenReturn( headerInformation );
+        when( readLayer.acquireStatement() ).thenReturn( mock( StoreStatement.class ) );
+        when( neoStores.getMetaDataStore() ).thenReturn( metaDataStore );
+        when( storageEngine.storeReadLayer() ).thenReturn( readLayer );
+    }
+
+    public KernelTransactionImplementation newTransaction()
+    {
+        return newTransaction( 0 );
+    }
+
+    public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted )
+    {
+        return new KernelTransactionImplementation( null, null, new NoOpClient(), hooks, null, null, headerInformationFactory,
+                commitProcess, transactionMonitor, legacyIndexState, kernelTransactions, clock, TransactionTracer.NULL,
+                storageEngine, lastTransactionIdWhenStarted );
+    }
+
+    public class CapturingCommitProcess implements TransactionCommitProcess
+    {
+        private long txId = 1;
+        public TransactionRepresentation transaction;
+
+        @Override
+        public long commit( TransactionToApply batch, CommitEvent commitEvent,
+                            TransactionApplicationMode mode ) throws TransactionFailureException
+        {
+            assert transaction == null : "Designed to only allow one transaction";
+            assert batch.next() == null : "Designed to only allow one transaction";
+            transaction = batch.transactionRepresentation();
+            return txId++;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAccessModeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAccessModeTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.neo4j.kernel.api.AccessMode;
+import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.KernelTransactionTestBase;
+import org.neo4j.kernel.api.exceptions.KernelException;
+
+import static org.junit.Assert.assertNotNull;
+
+public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
+{
+    @Rule public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldNotAllowWriteAccessInReadMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction();
+        tx.setMode( AccessMode.READ );
+
+        // Expect
+        exception.expect( KernelException.class );
+
+        // When
+        tx.acquireStatement().dataWriteOperations();
+    }
+
+    @Test
+    public void shouldNotAllowSchemaWriteAccessInReadMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction();
+        tx.setMode( AccessMode.READ );
+
+        // Expect
+        exception.expect( KernelException.class );
+
+        // When
+        tx.acquireStatement().schemaWriteOperations();
+    }
+
+    @Test
+    public void shouldAllowWritesInFullMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction();
+        tx.setMode( AccessMode.FULL );
+
+        // When
+        DataWriteOperations writes = tx.acquireStatement().dataWriteOperations();
+
+        // Then
+        assertNotNull( writes );
+    }
+
+    @Test
+    public void shoulAllowSchemaWriteAccessInFullMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction();
+        tx.setMode( AccessMode.FULL );
+
+        // When
+        DataWriteOperations writes = tx.acquireStatement().dataWriteOperations();
+
+        // Then
+        assertNotNull( writes );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.neo4j.kernel.api.AccessMode;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -194,6 +195,18 @@ public class ConstraintIndexCreatorTest
                 public boolean isOpen()
                 {
                     return true;
+                }
+
+                @Override
+                public AccessMode mode()
+                {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public void setMode( AccessMode mode )
+                {
+                    throw new UnsupportedOperationException();
                 }
 
                 @Override


### PR DESCRIPTION
In order to support read/write separation in procedures, we want to ensure
that read-only procedures are prohibited from writing. This allows us to
control the access modes for a running kernel transaction, which means we
can "lock it down" when a read-only procedure is called.

This approach is helpful because it avoids lots of complexity associated
with back-porting read-only support to the binary cypher compiler releases.
