### PR TITLE
Fixes issue with failure handling and recovery in ReplicatedTransactionSM

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/GlobalSessionTrackerState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/GlobalSessionTrackerState.java
@@ -36,6 +36,9 @@ public interface GlobalSessionTrackerState<MEMBER>
     /**
      * Tracks the operation and returns true iff this operation should be allowed.
      */
-    boolean validateAndTrackOperationAtLogIndex( GlobalSession<MEMBER> globalSession, LocalOperationId localOperationId,
-                                                 long logIndex );
+    boolean validateOperation( GlobalSession<MEMBER> globalSession, LocalOperationId localOperationId );
+
+    void update( GlobalSession<MEMBER> globalSession, LocalOperationId localOperationId, long logIndex );
+
+    long logIndex();
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/OnDiskGlobalSessionTrackerState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/session/OnDiskGlobalSessionTrackerState.java
@@ -65,27 +65,35 @@ public class OnDiskGlobalSessionTrackerState<MEMBER> extends LifecycleAdapter im
     }
 
     @Override
-    public boolean validateAndTrackOperationAtLogIndex( GlobalSession<MEMBER> globalSession, LocalOperationId
-            localOperationId, long logIndex )
+    public boolean validateOperation( GlobalSession<MEMBER> globalSession, LocalOperationId
+            localOperationId )
+    {
+        return inMemoryGlobalSessionTrackerState.validateOperation( globalSession, localOperationId );
+    }
+
+    @Override
+    public void update( GlobalSession<MEMBER> globalSession, LocalOperationId localOperationId, long logIndex )
     {
         InMemoryGlobalSessionTrackerState<MEMBER> temp =
                 new InMemoryGlobalSessionTrackerState<>( inMemoryGlobalSessionTrackerState );
 
-        boolean stateUpdated = temp.validateAndTrackOperationAtLogIndex( globalSession, localOperationId, logIndex );
+        temp.update( globalSession, localOperationId, logIndex );
 
-        if ( stateUpdated )
+        try
         {
-            try
-            {
-                statePersister.persistStoreData( temp );
-                inMemoryGlobalSessionTrackerState = temp;
-            }
-            catch ( IOException e )
-            {
-                throw new RuntimeException( e );
-            }
+            statePersister.persistStoreData( temp );
+            inMemoryGlobalSessionTrackerState = temp;
         }
-        return stateUpdated;
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    public long logIndex()
+    {
+        return inMemoryGlobalSessionTrackerState.logIndex();
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionFactory.java
@@ -43,8 +43,8 @@ import org.neo4j.storageengine.api.StorageCommand;
 
 public class ReplicatedTransactionFactory
 {
-    public static ReplicatedTransaction createImmutableReplicatedTransaction(
-            TransactionRepresentation tx, GlobalSession globalSession, LocalOperationId localOperationId ) throws IOException
+    public static <T> ReplicatedTransaction<T> createImmutableReplicatedTransaction(
+            TransactionRepresentation tx, GlobalSession<T> globalSession, LocalOperationId localOperationId ) throws IOException
     {
         ByteBuf transactionBuffer = Unpooled.buffer();
 
@@ -58,7 +58,7 @@ public class ReplicatedTransactionFactory
         byte[] txBytes = Arrays.copyOf( transactionBuffer.array(), transactionBuffer.writerIndex() );
         transactionBuffer.release();
 
-        return new ReplicatedTransaction( txBytes, globalSession, localOperationId );
+        return new ReplicatedTransaction<>( txBytes, globalSession, localOperationId );
     }
 
     public static TransactionRepresentation extractTransactionRepresentation( ReplicatedTransaction replicatedTransaction, byte[] extraHeader ) throws IOException

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -403,7 +403,7 @@ public class EnterpriseCoreEditionModule
                                                                    final Dependencies dependencies,
                                                                    final LogService logging,
                                                                    Monitors monitors,
-                                                                   GlobalSessionTrackerState globalSessionTrackerState )
+                                                                   GlobalSessionTrackerState<CoreMember> globalSessionTrackerState )
     {
         return ( appender, applier, config ) -> {
             TransactionRepresentationCommitProcess localCommit =
@@ -411,7 +411,7 @@ public class EnterpriseCoreEditionModule
             dependencies.satisfyDependencies( localCommit );
 
             CommittingTransactions committingTransactions = new CommittingTransactionsRegistry();
-            ReplicatedTransactionStateMachine replicatedTxStateMachine = new ReplicatedTransactionStateMachine(
+            ReplicatedTransactionStateMachine<CoreMember> replicatedTxStateMachine = new ReplicatedTransactionStateMachine<>(
                     localCommit, localSessionPool.getGlobalSession(), currentReplicatedLockState,
                     committingTransactions, globalSessionTrackerState );
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/session/BaseGlobalSessionTrackerStateTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/session/BaseGlobalSessionTrackerStateTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.session;
+
+import java.util.UUID;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.server.RaftTestMember;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public abstract class BaseGlobalSessionTrackerStateTest
+{
+    RaftTestMember coreA = RaftTestMember.member( 1 );
+    RaftTestMember coreB = RaftTestMember.member( 2 );
+
+    GlobalSession sessionA = new GlobalSession( UUID.randomUUID(), coreA );
+    GlobalSession sessionA2 = new GlobalSession( UUID.randomUUID(), coreA );
+
+    GlobalSession sessionB = new GlobalSession( UUID.randomUUID(), coreB );
+
+    protected abstract GlobalSessionTrackerState<RaftTestMember> instantiateSessionTracker();
+
+    @Test
+    public void firstValidSequenceNumberIsZero()
+    {
+        GlobalSessionTrackerState sessionTracker = instantiateSessionTracker();
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 0 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 1, -1 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 1, -1 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 2, 1 ) ) );
+    }
+
+    @Test
+    public void repeatedOperationsAreRejected()
+    {
+        GlobalSessionTrackerState sessionTracker = instantiateSessionTracker();
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 0 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 0 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+    }
+
+    @Test
+    public void seriesOfOperationsAreAccepted()
+    {
+        GlobalSessionTrackerState sessionTracker = instantiateSessionTracker();
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 0 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 1 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 1 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 2 ) ) );
+    }
+
+    @Test
+    public void gapsAreNotAllowed()
+    {
+        GlobalSessionTrackerState sessionTracker = instantiateSessionTracker();
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 0 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 1 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 1 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 3 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 3 ), 0 );
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 2 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 2 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 3 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 3 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 4 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 4 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 6 ) ) );
+    }
+
+    @Test
+    public void localSessionsAreIndependent()
+    {
+        GlobalSessionTrackerState sessionTracker = instantiateSessionTracker();
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 0 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 0 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 1 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 1 ), 0 );
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 1, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 1, 0 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 1, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 1, 0 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 1, 1 ) ) );
+    }
+
+    @Test
+    public void globalSessionsAreIndependent()
+    {
+        GlobalSessionTrackerState sessionTracker = instantiateSessionTracker();
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 0 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionB, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionB, new LocalOperationId( 0, 0 ), 0 );
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 1, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 1, 0 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionB, new LocalOperationId( 1, 0 ) ) );
+        sessionTracker.update( sessionB, new LocalOperationId( 1, 0 ), 0 );
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 2, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 2, 0 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 2, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 2, 0 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionB, new LocalOperationId( 2, 0 ) ) );
+        sessionTracker.update( sessionB, new LocalOperationId( 2, 0 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionA, new LocalOperationId( 2, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 2, 0 ), 0 );
+        assertFalse( sessionTracker.validateOperation( sessionB, new LocalOperationId( 2, 0 ) ) );
+    }
+
+    @Test
+    public void newGlobalSessionUnderSameOwnerResetsCorrespondingLocalSessionTracker()
+    {
+        GlobalSessionTrackerState sessionTracker = instantiateSessionTracker();
+
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 0 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionA, new LocalOperationId( 0, 1 ) ) );
+        sessionTracker.update( sessionA, new LocalOperationId( 0, 1 ), 0 );
+
+        assertFalse( sessionTracker.validateOperation( sessionA2, new LocalOperationId( 0, 2 ) ) );
+        sessionTracker.update( sessionA2, new LocalOperationId( 0, 2 ), 0 );
+
+        assertTrue( sessionTracker.validateOperation( sessionA2, new LocalOperationId( 0, 0 ) ) );
+        sessionTracker.update( sessionA2, new LocalOperationId( 0, 0 ), 0 );
+        assertTrue( sessionTracker.validateOperation( sessionA2, new LocalOperationId( 0, 1 ) ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachinePersistenceTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachinePersistenceTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.replication.tx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.mockito.stubbing.Stubber;
+import org.neo4j.coreedge.raft.replication.session.GlobalSession;
+import org.neo4j.coreedge.raft.replication.session.GlobalSessionTrackerState;
+import org.neo4j.coreedge.raft.replication.session.InMemoryGlobalSessionTrackerState;
+import org.neo4j.coreedge.raft.replication.session.LocalOperationId;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.coreedge.server.core.locks.LockTokenManager;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+
+public class ReplicatedTransactionStateMachinePersistenceTest
+{
+    @Test
+    public void shouldNotRejectUncommittedTransactionsAfterCrashEvenIfSessionTrackerSaysSo() throws Exception
+    {
+        // given
+        TransactionCommitProcess commitProcess = mock( TransactionCommitProcess.class );
+        when( commitProcess.commit( any(), any(), any() ) ).thenThrow( new TransactionFailureException( "testing" ) )
+                .thenReturn( 123L );
+
+        ReplicatedTransactionStateMachine<RaftTestMember> rtsm = new ReplicatedTransactionStateMachine<>(
+                commitProcess,
+                new GlobalSession<>( UUID.randomUUID(), RaftTestMember.member( 1 ) ),
+                mock( LockTokenManager.class, RETURNS_MOCKS ),
+                new CommittingTransactionsRegistry(),
+                new InMemoryGlobalSessionTrackerState<>() );
+
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( Collections.emptySet() );
+        ReplicatedTransaction<RaftTestMember> rtx =
+                ReplicatedTransactionFactory.createImmutableReplicatedTransaction( tx, new GlobalSession<>( UUID
+                        .randomUUID(), RaftTestMember.member( 2 ) ), new LocalOperationId( 1, 0 ) );
+        rtsm.setLastCommittedIndex( 99 );
+
+        // when
+        try
+        {
+            rtsm.onReplicated( rtx, 100 );
+            fail( "test design throws exception here" );
+        }
+        catch ( TransactionFailureException thrownByTestDesign )
+        {
+            // expected
+        }
+        reset( commitProcess ); // ignore all previous interactions, we care what happens from now on
+        rtsm.setLastCommittedIndex( 99 );
+        rtsm.onReplicated( rtx, 100 );
+
+        // then
+        verify( commitProcess, times( 1 ) ).commit( any(), any(), any() );
+    }
+
+    @Test
+    public void shouldUpdateSessionStateOnRecoveryEvenIfTxCommittedOnFirstTry() throws Exception
+    {
+        // given
+        TransactionCommitProcess commitProcess = mock( TransactionCommitProcess.class );
+
+        GlobalSessionTrackerState<RaftTestMember> sessionTracker = mock( GlobalSessionTrackerState.class );
+        when( sessionTracker.validateOperation( any(), any() ) ).thenReturn( true );
+
+        Stubber stubber = doThrow( new RuntimeException() );
+        stubber.when( sessionTracker ).update( any(), any(), anyLong() );
+        stubber.doNothing().when( sessionTracker ).update( any(), any(), anyLong() );
+
+        ReplicatedTransactionStateMachine<RaftTestMember> rtsm = new ReplicatedTransactionStateMachine<>(
+                commitProcess,
+                new GlobalSession<>( UUID.randomUUID(), RaftTestMember.member( 1 ) ),
+                mock( LockTokenManager.class, RETURNS_MOCKS ),
+                new CommittingTransactionsRegistry(),
+                sessionTracker );
+
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( Collections.emptySet() );
+        ReplicatedTransaction<RaftTestMember> rtx =
+                ReplicatedTransactionFactory.createImmutableReplicatedTransaction( tx,
+                        new GlobalSession<>( UUID.randomUUID(), RaftTestMember.member( 2 ) ),
+                        new LocalOperationId( 1, 0 ) );
+
+        // when
+        // we try to commit but fail on session update, and then try to do recovery
+        try
+        {
+            // transaction gets committed at log index 99. It will reach the tx log but not the session state
+            rtsm.onReplicated( rtx, 99 );
+            fail( "test setup should have resulted in an exception by now" );
+        }
+        catch ( RuntimeException totallyExpectedByTestSetup )
+        {
+            // dully ignored
+        }
+        // reset state so we can do proper validation below
+        reset( commitProcess );
+
+        // now let's do recovery. The log contains the last tx, so the last committed log index is the previous: 99
+        rtsm.setLastCommittedIndex( 99 );
+
+        // however, the raft log will give us the same tx, as we did not return successfully from the last
+        // onReplicated()
+        rtsm.onReplicated( rtx, 99 );
+
+        // then
+        // there should be no commit of tx, but an update on the session state
+        verifyZeroInteractions( commitProcess );
+        verify( sessionTracker, times( 2 ) ).update( any(), any(), eq( 99L ) );
+    }
+
+    @Test
+    public void shouldSkipUpdatingSessionStateForSameIndexAfterSuccessfulUpdate() throws Exception
+    {
+        // given
+        TransactionCommitProcess commitProcess = mock( TransactionCommitProcess.class );
+
+        InMemoryGlobalSessionTrackerState<RaftTestMember> sessionTrackerState = spy( new
+                InMemoryGlobalSessionTrackerState<>() );
+        ReplicatedTransactionStateMachine<RaftTestMember> rtsm = new ReplicatedTransactionStateMachine<>(
+                commitProcess,
+                new GlobalSession<>( UUID.randomUUID(), RaftTestMember.member( 1 ) ),
+                mock( LockTokenManager.class, RETURNS_MOCKS ),
+                new CommittingTransactionsRegistry(),
+                sessionTrackerState );
+
+        TransactionRepresentation tx = new PhysicalTransactionRepresentation( Collections.emptySet() );
+        ReplicatedTransaction<RaftTestMember> rtx =
+                ReplicatedTransactionFactory.createImmutableReplicatedTransaction( tx,
+                        new GlobalSession<>( UUID.randomUUID(), RaftTestMember.member( 2 ) ),
+                        new LocalOperationId( 1, 0 ) );
+
+        // when
+        // we commit a tx normally
+        final int commitAtRaftLogIndex = 99;
+        rtsm.onReplicated( rtx, commitAtRaftLogIndex );
+
+        // simply verify that things were properly updated
+        assertEquals( commitAtRaftLogIndex, sessionTrackerState.logIndex() );
+
+        // when the same replicated content is passed in again
+        rtsm.onReplicated( rtx, commitAtRaftLogIndex );
+
+        // then
+        verify( commitProcess, times( 1 ) ).commit( any(), any(), any() );
+        verify( sessionTrackerState, times( 1 ) ).update( any(), any(), eq( 99L ) );
+    }
+}


### PR DESCRIPTION
There was an issue with RTSM in combination with SessionTrackingState persistence,
 where a crash in between updating the session tracker and committing the tx in the
 logical log could lead to failure to actually commit the tx on recovery. This issue
 is now replicated in tests and fixed. The fix involves separating out the
 verification and update functionalities of GlobalSessionTrackerState, in order
 to invert the order of updating session state and committing in the logical log.
This commit also takes the opportunity to make sure that GlobalSessionTrackerState
 persistence is idempotent with respect to raft log entry replays.
