### PR TITLE
Lucene version upgrade to 5.4.0

### DIFF
--- a/community/lucene-index-upgrade/pom.xml
+++ b/community/lucene-index-upgrade/pom.xml
@@ -13,7 +13,7 @@
         <license-text.header>GPL-3-header.txt</license-text.header>
         <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
         <lucene4.version>4.10.4</lucene4.version>
-        <lucene5.version>5.3.1</lucene5.version>
+        <lucene5.version>5.4.0</lucene5.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>

--- a/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/LuceneLegacyIndexUpgrader.java
+++ b/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/LuceneLegacyIndexUpgrader.java
@@ -66,8 +66,8 @@ public class LuceneLegacyIndexUpgrader
     private static final String LIBRARY_DIRECTORY = "lib";
     private static final String RESOURCE_SEPARATOR = "/";
     private static final String LUCENE4_CORE_JAR_NAME = "lucene-core-4.10.4.jar";
-    private static final String LUCENE5_CORE_JAR_NAME = "lucene-core-5.3.1.jar";
-    private static final String LUCENE5_BACKWARD_CODECS_NAME = "lucene-backward-codecs-5.3.1.jar";
+    private static final String LUCENE5_CORE_JAR_NAME = "lucene-core-5.4.0.jar";
+    private static final String LUCENE5_BACKWARD_CODECS_NAME = "lucene-backward-codecs-5.4.0.jar";
     private static final String SEGMENTS_FILE_NAME_PREFIX = "segments";
 
     private final Path indexRootPath;

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <pico.version>2.14.3</pico.version>
     <licensing.prepend.text>notice-agpl-prefix.txt</licensing.prepend.text>
     <licensing.phase>compile</licensing.phase>
-    <lucene.version>5.3.1</lucene.version>
+    <lucene.version>5.4.0</lucene.version>
     <logback-classic.version>1.1.2</logback-classic.version>
     <bouncycastle.version>1.53</bouncycastle.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>


### PR DESCRIPTION
New version of lucene is already available. Release notes at: http://lucene.apache.org/core/5_4_0/changes/Changes.html
We can be potentially interested in query cache and IndexWriter flush updates.
