### PR TITLE
Correct voting logic.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/Ballot.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/Ballot.java
@@ -21,9 +21,9 @@ package org.neo4j.coreedge.raft;
 
 public class Ballot
 {
-    public static <MEMBER> boolean shouldVoteFor( MEMBER candidate, long requestTerm, long contextTerm,
-                                                  long contextLastAppended, long requestLastLogIndex,
+    public static <MEMBER> boolean shouldVoteFor( MEMBER candidate, long contextTerm, long requestTerm,
                                                   long contextLastLogTerm, long requestLastLogTerm,
+                                                  long contextLastAppended, long requestLastLogIndex,
                                                   MEMBER votedFor )
     {
         if ( requestTerm < contextTerm )
@@ -31,11 +31,14 @@ public class Ballot
             return false;
         }
 
-        boolean termOk = contextLastLogTerm <= requestLastLogTerm;
-        boolean appendedOk = contextLastAppended <= requestLastLogIndex;
-        boolean requesterLogUpToDate = termOk && appendedOk;
-        boolean votedForOtherInSameTerm = (requestTerm == contextTerm &&
-                !(votedFor == null || votedFor.equals( candidate )));
+        boolean requestLogEndsAtHigherTerm = requestLastLogTerm > contextLastLogTerm;
+        boolean logsEndAtSameTerm = requestLastLogTerm == contextLastLogTerm;
+        boolean requestLogAtLeastAsLongAsMyLog = requestLastLogIndex >= contextLastAppended;
+        boolean requesterLogUpToDate = requestLogEndsAtHigherTerm ||
+                (logsEndAtSameTerm && requestLogAtLeastAsLongAsMyLog);
+
+        boolean votedForOtherInSameTerm = requestTerm == contextTerm &&
+                votedFor != null && !votedFor.equals( candidate );
 
         return requesterLogUpToDate && !votedForOtherInSameTerm;
     }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
@@ -170,10 +170,10 @@ public class Follower implements RaftMessageHandler
                     outcome.setVotedFor( null );
                 }
 
-                boolean willVoteForCandidate = shouldVoteFor( req.candidate(), req.term(), outcome.getTerm(), ctx
-                                .entryLog().appendIndex(),
-                        req.lastLogIndex(), ctx.entryLog().readEntryTerm( ctx.entryLog().appendIndex() ),
-                        req.lastLogTerm(), outcome.getVotedFor() );
+                boolean willVoteForCandidate = shouldVoteFor( req.candidate(), outcome.getTerm(), req.term(),
+                        ctx.entryLog().readEntryTerm( ctx.entryLog().appendIndex() ), req.lastLogTerm(),
+                        ctx.entryLog().appendIndex(), req.lastLogIndex(),
+                        outcome.getVotedFor() );
 
                 if ( willVoteForCandidate )
                 {

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/BallotTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/BallotTest.java
@@ -29,50 +29,175 @@ import static org.junit.Assert.assertTrue;
 @RunWith(MockitoJUnitRunner.class)
 public class BallotTest
 {
-    Object A = new Object();
-    Object B = new Object();
+    Object candidate = new Object();
+    Object otherMember = new Object();
+
+    long logTerm = 10;
+    long currentTerm = 20;
+    long appendIndex = 1000;
 
     @Test
-    public void shouldVoteFalseInOldTerm()
+    public void shouldAcceptRequestWithIdenticalLog()
     {
-        // when + then
-        assertFalse( Ballot.shouldVoteFor( A, 4 /*request term */, 5 /*context term */, -1, -1, -1, -1, null ) );
+        assertTrue( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm,
+                appendIndex,
+                appendIndex,
+                null
+        ) );
     }
 
     @Test
-    public void shouldVoteFalseIfLogNotUpToDateBecauseOfTerm()
+    public void shouldRejectRequestFromOldTerm()
     {
-        // when + then
-        assertFalse( Ballot.shouldVoteFor( A, 0, 0, 0, 0, 1 /*context last log term */, 0 /*request last log term */,
-                null ) );
+        assertFalse( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm - 1,
+                logTerm,
+                logTerm,
+                appendIndex,
+                appendIndex,
+                null
+        ) );
     }
 
     @Test
-    public void shouldVoteFalseIfLogNotUpToDateBecauseOfIndex()
+    public void shouldRejectRequestIfCandidateLogEndsAtLowerTerm()
     {
-        // when + then
-        assertFalse( Ballot.shouldVoteFor( A, 0, 0, 1/*context last appended */, 0/*request last log index*/, 0, 0,
-                null ) );
+        assertFalse( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm - 1,
+                appendIndex,
+                appendIndex,
+                null
+        ) );
     }
 
     @Test
-    public void shouldVoteFalseIfAlreadyVotedForOtherCandidate()
+    public void shouldRejectRequestIfLogsEndInSameTermButCandidateLogIsShorter()
     {
-        // when + then
-        assertFalse( Ballot.shouldVoteFor( A, 0, 0, 0, 0, 0, 0, B ) );
+        assertFalse( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm,
+                appendIndex,
+                appendIndex - 1,
+                null
+        ) );
     }
 
     @Test
-    public void shouldVoteTrueIfAlreadyVotedForCandidate()
+    public void shouldAcceptRequestIfLogsEndInSameTermAndCandidateLogIsSameLength()
     {
-        // when + then
-        assertTrue( Ballot.shouldVoteFor( A, 0, 0, 0, 0, 0, 0, A ) );
+        assertTrue( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm,
+                appendIndex,
+                appendIndex,
+                null
+        ) );
     }
 
     @Test
-    public void shouldVoteTrueForNewCandidateWithUpToDateLog()
+    public void shouldAcceptRequestIfLogsEndInSameTermAndCandidateLogIsLonger()
     {
-        // when + then
-        assertTrue( Ballot.shouldVoteFor( A, 0, 0, 0, 0, 0, 0, null ) );
+        assertTrue( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm,
+                appendIndex,
+                appendIndex + 1,
+                null
+        ) );
+    }
+
+    @Test
+    public void shouldAcceptRequestIfLogsEndInHigherTermAndCandidateLogIsShorter()
+    {
+        assertTrue( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm + 1,
+                appendIndex,
+                appendIndex - 1,
+                null
+        ) );
+    }
+
+    @Test
+    public void shouldAcceptRequestIfLogEndsAtHigherTermAndCandidateLogIsSameLength()
+    {
+        assertTrue( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm + 1,
+                appendIndex,
+                appendIndex,
+                null
+        ) );
+    }
+
+    @Test
+    public void shouldAcceptRequestIfLogEndsAtHigherTermAndCandidateLogIsLonger()
+    {
+        assertTrue( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm + 1,
+                appendIndex,
+                appendIndex + 1,
+                null
+        ) );
+    }
+
+    @Test
+    public void shouldRejectRequestIfAlreadyVotedForOtherCandidate()
+    {
+        assertFalse( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm,
+                appendIndex,
+                appendIndex,
+                otherMember
+        ) );
+    }
+
+    @Test
+    public void shouldAcceptRequestIfAlreadyVotedForCandidate()
+    {
+        assertTrue( Ballot.shouldVoteFor(
+                candidate,
+                currentTerm,
+                currentTerm,
+                logTerm,
+                logTerm,
+                appendIndex,
+                appendIndex,
+                candidate
+        ) );
     }
 }


### PR DESCRIPTION
"Raft determines which of two logs is more up-to-date by comparing
the index and term of the last entries in the logs.
If the logs have last entries with different terms, then the log with
the later term is more up-to-date.
If the logs end with the same term, then whichever log is longer is
more up-to-date."

Previously the code required the candidate log to be at least as long
as the follower's log, even if the candidate's log ended at a later
term. That was incorrect.
