### PR TITLE
Auto-generated documentation for built-in procedures

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -131,6 +131,9 @@ the relevant Commercial Agreement.
                   <arg value="org.neo4j.graphdb.factory.GraphDatabaseSettings" />
                   <arg value="${project.build.directory}/docs/ops/configuration-attributes.asciidoc" />
                 </java>
+                <java classname="org.neo4j.kernel.impl.proc.ProcedureAsciiDocGenerator" classpathref="maven.test.classpath" failonerror="true">
+                  <arg value="${project.build.directory}/docs/ops/builtin-procedures.asciidoc" />
+                </java>
               </target>
             </configuration>
             <goals><goal>run</goal></goals>

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -44,11 +44,12 @@ import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.KernelAPI;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.builtinprocs.BuiltInProcedures;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.dependency.HighestSelectionStrategy;
 import org.neo4j.kernel.guard.Guard;
@@ -163,6 +164,7 @@ import org.neo4j.storageengine.api.StoreReadLayer;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTNode;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTPath;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTRelationship;
+import static org.neo4j.kernel.builtinprocs.BuiltInProcedures.BUILTINS;
 import static org.neo4j.kernel.impl.transaction.log.pruning.LogPruneStrategyFactory.fromConfigValue;
 
 public class NeoStoreDataSource implements Lifecycle, IndexProviders
@@ -820,11 +822,17 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         //register API
         procedures.registerComponent( GraphDatabaseService.class,
                 (ctx) -> dependencyResolver.resolveDependency( GraphDatabaseService.class ) );
+        procedures.registerComponent( DependencyResolver.class, (ctx) -> dependencyResolver );
+        procedures.registerComponent( Statement.class, (ctx) -> ctx.get( ReadOperations.statement ) );
 
         Log proceduresLog = logService.getUserLog( Procedures.class  );
         procedures.registerComponent( Log.class, (ctx) -> proceduresLog );
 
-        BuiltInProcedures.addTo( procedures );
+        for ( Class procs : BUILTINS )
+        {
+            procedures.register( procs );
+        }
+
         procedures.loadFromDirectory( config.get( GraphDatabaseSettings.plugin_dir ) );
         return procedures;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
@@ -135,19 +135,21 @@ public class ProcedureSignature
     }
 
     private final ProcedureName name;
+    private final String description;
     private final List<FieldSignature> inputSignature;
     private final List<FieldSignature> outputSignature;
 
-    public ProcedureSignature( ProcedureName name, List<FieldSignature> inputSignature, List<FieldSignature> outputSignature )
+    public ProcedureSignature( ProcedureName name, List<FieldSignature> inputSignature, List<FieldSignature> outputSignature, String description )
     {
         this.name = name;
+        this.description = description;
         this.inputSignature = unmodifiableList( inputSignature );
         this.outputSignature = unmodifiableList( outputSignature );
     }
 
     public ProcedureSignature( ProcedureName name )
     {
-        this( name, Collections.emptyList(), Collections.emptyList() );
+        this( name, Collections.emptyList(), Collections.emptyList(), "N/A" );
     }
 
     public ProcedureName name()
@@ -163,6 +165,12 @@ public class ProcedureSignature
     public List<FieldSignature> outputSignature()
     {
         return outputSignature;
+    }
+
+    /** Optional human-readable description of this procedure. */
+    public String description()
+    {
+        return description;
     }
 
     @Override
@@ -198,10 +206,18 @@ public class ProcedureSignature
         private final ProcedureName name;
         private final List<FieldSignature> inputSignature = new LinkedList<>();
         private final List<FieldSignature> outputSignature = new LinkedList<>();
+        private String description = "N/A";
 
         public Builder( String[] namespace, String name )
         {
             this.name = new ProcedureName( namespace, name );
+        }
+
+        /** Define an input field */
+        public Builder description( String description )
+        {
+            this.description = description;
+            return this;
         }
 
         /** Define an input field */
@@ -220,7 +236,7 @@ public class ProcedureSignature
 
         public ProcedureSignature build()
         {
-            return new ProcedureSignature(name, inputSignature, outputSignature );
+            return new ProcedureSignature(name, inputSignature, outputSignature, description );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
@@ -25,8 +25,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.Function;
 
+import org.neo4j.function.ThrowingFunction;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.Procedure;
@@ -50,9 +50,9 @@ public class FieldInjections
     {
         private final Field field;
         private final MethodHandle setter;
-        private final Function<Procedure.Context,?> supplier;
+        private final ThrowingFunction<Procedure.Context, ?, ProcedureException> supplier;
 
-        public FieldSetter( Field field, MethodHandle setter, Function<Procedure.Context,?> supplier )
+        public FieldSetter( Field field, MethodHandle setter, ThrowingFunction<Procedure.Context, ?, ProcedureException> supplier )
         {
             this.field = field;
             this.setter = setter;
@@ -106,7 +106,7 @@ public class FieldInjections
     {
         try
         {
-            Function<Procedure.Context,?> supplier = components.supplierFor( field.getType() );
+            ThrowingFunction<Procedure.Context, ?, ProcedureException> supplier = components.supplierFor( field.getType() );
             if( supplier == null )
             {
                 throw new ProcedureException( Status.Procedure.FailedRegistration,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Namespace.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Namespace.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.graphdb.factory;
+package org.neo4j.kernel.impl.proc;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -25,13 +25,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to add description of settings in {@link GraphDatabaseSettings}. These can then be accessed through the {@link GraphDatabaseSettingsResourceBundle}.
- *
- * This is deprecated, it will be moved out of the public API in 1.11.
+ * Internal mechanism to override the default namespace for a procedure class.
  */
+@Target( ElementType.TYPE )
 @Retention( RetentionPolicy.RUNTIME )
-@Target( {ElementType.TYPE, ElementType.FIELD, ElementType.METHOD } )
-public @interface Description
+public @interface Namespace
 {
-    String value();
+    String[] value();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureAsciiDocGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureAsciiDocGenerator.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.ProcedureSignature;
+import org.neo4j.kernel.builtinprocs.BuiltInProcedures;
+import org.neo4j.kernel.configuration.AsciiDocItem;
+import org.neo4j.kernel.configuration.AsciiDocListGenerator;
+
+import static java.util.stream.Collectors.toList;
+
+/** Produces asciidoc documentation from procedures. */
+public class ProcedureAsciiDocGenerator
+{
+    public static void main(String ... args) throws KernelException, IOException
+    {
+        // Default - generate for standard builtins
+        File output = null;
+        if(args.length > 0)
+        {
+            output = new File(args[0]).getAbsoluteFile();
+        }
+
+        String doc = new ProcedureAsciiDocGenerator()
+                .generateDocsFor( "builtin_procedures", "Built in procedures", BuiltInProcedures.BUILTINS);
+
+        if(output != null)
+        {
+            System.out.println("Saving docs for built-in procedures in '" + output.getAbsolutePath() + "'.");
+            FileUtils.writeToFile(output, doc, false);
+        } else
+        {
+            System.out.println(doc);
+        }
+    }
+    public String generateDocsFor( String tableId, String tableTitle, Class ... procedureClasses ) throws KernelException
+    {
+        StringBuilder details = new StringBuilder();
+        List<AsciiDocItem> items =
+            signatures( procedureClasses )
+                .map( ( sig ) -> {
+                    describeProcedure( sig, details );
+                    return sig;
+                })
+                .map( ( sig ) -> new AsciiDocItem(
+                        procedureId( sig ),
+                        sig.name().toString(),
+                        sig.description() ) )
+                .collect( toList() );
+
+        String table = new AsciiDocListGenerator( tableId, tableTitle, true ).generateListAndTableCombo( items );
+        return table + details.toString();
+    }
+
+    private String procedureId( ProcedureSignature sig )
+    {
+        return "builtinproc_" + sig.name().toString().replace( ".", "_" );
+    }
+
+    private void describeProcedure( ProcedureSignature sig, StringBuilder out )
+    {
+        // This is a small table generated for each procedure, which contains the
+        // full description and the procedure signature.
+        out.append( "[[" ).append( procedureId( sig ) ).append( "]]\n" );
+        out.append( "." ).append( sig.name().toString() ).append( "\n" );
+        out.append( "[cols=\"<1h,<4\"]\n" );
+        out.append( "|===\n" );
+        out.append( "|Signature |").append( sig.toString() ).append( "\n" );
+        out.append( "|Description |").append( sig.description() ).append( "\n" );
+        out.append( "|===\n\n" );
+    }
+
+    private Stream<ProcedureSignature> signatures( Class[] procedureClasses ) throws KernelException
+    {
+        TypeMappers types = new TypeMappers();
+        ComponentRegistry components = new ComponentRegistry();
+
+        // For the purposes of generating documentation, register a fallback injection provider
+        // that pretends any component is fine for injection, so we don't have to emulate all
+        // the real injectors used at runtime.
+        components.registerFallback( (cls) -> ((ctx) -> null) );
+
+        ReflectiveProcedureCompiler compiler = new ReflectiveProcedureCompiler( types, components );
+
+        List<ProcedureSignature> signatures = new ArrayList<>();
+        for ( Class procedureClass : procedureClasses )
+        {
+            signatures.addAll( compiler
+                    .compile( procedureClass )
+                    .stream().map( Procedure::signature )
+                    .collect( toList()) );
+        }
+
+        return signatures.stream()
+                .sorted( (a,b) -> a.toString().compareTo( b.toString() ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -22,9 +22,9 @@ package org.neo4j.kernel.impl.proc;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
-import java.util.function.Function;
 
 import org.neo4j.collection.RawIterator;
+import org.neo4j.function.ThrowingFunction;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.Procedure;
@@ -88,7 +88,7 @@ public class Procedures
      * @param cls the type of component to be registered (this is what users 'ask' for in their field declaration)
      * @param supplier a function that supplies the actual component, given the context of a procedure invocation
      */
-    public synchronized <T> void registerComponent( Class<T> cls, Function<Procedure.Context, T> supplier )
+    public synchronized <T> void registerComponent( Class<T> cls, ThrowingFunction<Procedure.Context, T, ProcedureException> supplier )
     {
         components.register( cls, supplier );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
@@ -97,10 +97,14 @@ public class BuiltinProceduresIT extends KernelIntegrationTest
 
         // Then
         assertThat( asList( stream ), contains(
-                equalTo( new Object[]{"sys.db.labels", "sys.db.labels() :: (label :: STRING?)"} ),
-                equalTo( new Object[]{"sys.db.procedures", "sys.db.procedures() :: (name :: STRING?, signature :: STRING?)"} ),
-                equalTo( new Object[]{"sys.db.propertyKeys", "sys.db.propertyKeys() :: (propertyKey :: STRING?)"}),
-                equalTo( new Object[]{"sys.db.relationshipTypes", "sys.db.relationshipTypes() :: (relationshipType :: STRING?)"})
+                equalTo( new Object[]{"sys.db.labels", "sys.db.labels() :: (label :: STRING?)",
+                        "Retrieve a list of all labels that are currently in use."} ),
+                equalTo( new Object[]{"sys.db.procedures", "sys.db.procedures() :: (name :: STRING?, signature :: STRING?, description :: STRING?)",
+                        "Retrieve a list of all procedures that are currently registered."} ),
+                equalTo( new Object[]{"sys.db.propertyKeys", "sys.db.propertyKeys() :: (propertyKey :: STRING?)",
+                        "Retrieve a list of all property keys that are currently in use."}),
+                equalTo( new Object[]{"sys.db.relationshipTypes", "sys.db.relationshipTypes() :: (relationshipType :: STRING?)",
+                        "Retrieve a list of all relationship types that are currently in use."})
         ));
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureAsciiDocGeneratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureAsciiDocGeneratorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import org.junit.Test;
+
+import java.util.stream.Stream;
+
+import org.neo4j.graphdb.factory.Description;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class ProcedureAsciiDocGeneratorTest
+{
+    @Test
+    public void generatesAsciiTable() throws Throwable
+    {
+        // When
+        String docs = new ProcedureAsciiDocGenerator().generateDocsFor( "myProcedures", "My Procedures", MyDocumentedProcedures.class );
+
+        // Then
+        assertThat( docs, containsString(
+              "[[myProcedures]]\n" +
+              ".My Procedures\n" +
+              "ifndef::nonhtmloutput[]\n" +
+              "\n" +
+              "[options=\"header\"]\n" +
+              "|===\n" +
+              "|Name|Description\n" +
+              "|<<builtinproc_sys_coolstuff_theProcedure,sys.coolstuff.theProcedure(someInput :: STRING?, moreInput :: INTEGER?) :: (someOutput :: " +
+              "STRING?, moreOutput :: FLOAT?)>>|This procedure exists solely for the purposes of this test.\n" +
+              "|===\n" +
+              "endif::nonhtmloutput[]\n" +
+              "\n" +
+              "ifdef::nonhtmloutput[]\n" +
+              "\n" +
+              "* <<builtinproc_sys_coolstuff_theProcedure,sys.coolstuff.theProcedure(someInput :: STRING?, moreInput :: INTEGER?) :: (someOutput :: " +
+              "STRING?, moreOutput :: FLOAT?)>>: This procedure exists solely for the purposes of this test.\n" +
+              "endif::nonhtmloutput[]\n" +
+              "\n") );
+    }
+
+    @Namespace( {"sys", "coolstuff"} )
+    public static class MyDocumentedProcedures
+    {
+        @ReadOnlyProcedure
+        @Description( "This procedure exists solely for the purposes of this test." )
+        public Stream<MyOutput> theProcedure( @Name( "someInput" ) String someInput, @Name( "moreInput" ) long moreInput )
+        {
+            return null;
+        }
+
+        public static class MyOutput
+        {
+            public String someOutput;
+            public double moreOutput;
+        }
+    }
+}


### PR DESCRIPTION
- Convert builtin procedures to annotation-defined procedures
- Treat @Description annotation (unofficially) as adding description to
  procedures
- Add internal annotation @Namespace to override the namespace in a
  procedure definition.
- Add utility for generating documentation based on above.
