### PR TITLE
Add a timer to arbiter's shutdown hook in case of deadlock

### DIFF
--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/StandaloneClusterClient.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/StandaloneClusterClient.java
@@ -73,7 +73,7 @@ public class StandaloneClusterClient
     {
         life.add( logging );
         life.add( clusterClient );
-        timer = new Timer();
+        timer = new Timer( true );
         addShutdownHook();
         life.start();
     }


### PR DESCRIPTION
ClusterJoin blocks, which causes a deadlock with the stop method.
Timer ensures a shutdown is possible without `kill -9 ...`.
