### PR TITLE
API docs for @Procedure

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CallProcedureAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/CallProcedureAcceptanceTest.scala
@@ -23,10 +23,11 @@ import org.neo4j.collection.RawIterator
 import org.neo4j.cypher.{CypherExecutionException, CypherTypeException, ExecutionEngineFunSuite, InvalidArgumentException}
 import org.neo4j.kernel.api.KernelAPI
 import org.neo4j.kernel.api.exceptions.ProcedureException
-import org.neo4j.kernel.api.proc.Procedure.Context
+import org.neo4j.kernel.api.proc.{CallableProcedure, Neo4jTypes}
+import CallableProcedure.Context
 import org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature
 import org.neo4j.kernel.api.proc.Neo4jTypes
-import org.neo4j.kernel.api.proc.Procedure.BasicProcedure
+import CallableProcedure.BasicProcedure
 
 class CallProcedureAcceptanceTest extends ExecutionEngineFunSuite {
 

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/ExecutionResult.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/ExecutionResult.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.neo4j.cypher.CypherException;
 import org.neo4j.graphdb.ExecutionPlanDescription;
@@ -210,6 +211,13 @@ public class ExecutionResult implements ResourceIterable<Map<String,Object>>, Re
     public ResourceIterator<Map<String, Object>> iterator()
     {
         return innerIterator(); // legacy method - don't convert exceptions...
+    }
+
+    @Override
+    public Stream<Map<String,Object>> stream()
+    {
+        // Need to implement to disambiguate Iterable/Iterator stream
+        return iterator().stream();
     }
 
     @Override

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/IndexHits.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/index/IndexHits.java
@@ -21,6 +21,7 @@ package org.neo4j.graphdb.index;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -88,6 +89,12 @@ public interface IndexHits<T> extends ResourceIterator<T>, ResourceIterable<T>
      * ignore any consecutive call (for convenience).
      */
     void close();
+
+    @Override
+    default Stream<T> stream()
+    {
+        return iterator().stream();
+    }
 
     /**
      * Returns the first and only item from the result iterator, or {@code null}

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -154,6 +154,10 @@ the relevant Commercial Agreement.
               <packages>org.neo4j.graphdb:org.neo4j.graphdb.*</packages>
             </group>
             <group>
+              <title>Procedures</title>
+              <packages>org.neo4j.procedure:org.neo4j.procedure.*</packages>
+            </group>
+            <group>
               <title>Helpers</title>
               <packages>org.neo4j.helpers:org.neo4j.helpers.*</packages>
             </group>

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelAPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelAPI.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.api;
 
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 
 /**
  * The main API through which access to the Neo4j kernel is made, both read
@@ -60,5 +60,5 @@ public interface KernelAPI
      *
      * @param signature signature of the procedure
      */
-    void registerProcedure( Procedure signature ) throws ProcedureException;
+    void registerProcedure( CallableProcedure signature ) throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -44,7 +44,7 @@ import org.neo4j.kernel.api.exceptions.schema.IndexBrokenKernelException;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
@@ -554,10 +554,10 @@ public interface ReadOperations
     //===========================================
 
     /** For read procedures, this key will be available in the invocation context as a means to access the current read statement. */
-    Procedure.Key<ReadOperations> readOperations = Procedure.Key.key("statementContext.read", ReadOperations.class );
+    CallableProcedure.Key<ReadOperations> readOperations = CallableProcedure.Key.key("statementContext.read", ReadOperations.class );
 
     /** For managed procedures, this gives access to the current statement. */
-    Procedure.Key<Statement> statement = Procedure.Key.key("statement", Statement.class );
+    CallableProcedure.Key<Statement> statement = CallableProcedure.Key.key("statement", Statement.class );
 
     /** Fetch a procedure given its signature. */
     ProcedureSignature procedureGet( ProcedureSignature.ProcedureName name ) throws ProcedureException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableProcedure.java
@@ -26,7 +26,7 @@ import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 
-public interface Procedure
+public interface CallableProcedure
 {
     ProcedureSignature signature();
     RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException;
@@ -79,7 +79,7 @@ public interface Procedure
         }
     }
 
-    abstract class BasicProcedure implements Procedure
+    abstract class BasicProcedure implements CallableProcedure
     {
         private final ProcedureSignature signature;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListLabelsProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListLabelsProcedure.java
@@ -23,7 +23,7 @@ import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.Label;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature.ProcedureName;
 import org.neo4j.kernel.impl.api.TokenAccess;
 
@@ -32,7 +32,7 @@ import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.kernel.api.ReadOperations.statement;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
-public class ListLabelsProcedure extends Procedure.BasicProcedure
+public class ListLabelsProcedure extends CallableProcedure.BasicProcedure
 {
     public ListLabelsProcedure( ProcedureName name )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListProceduresProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListProceduresProcedure.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 
 import static org.neo4j.helpers.collection.Iterables.asRawIterator;
@@ -32,7 +32,7 @@ import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.kernel.api.ReadOperations.readOperations;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTString;
 
-public class ListProceduresProcedure extends Procedure.BasicProcedure
+public class ListProceduresProcedure extends CallableProcedure.BasicProcedure
 {
     public ListProceduresProcedure( ProcedureSignature.ProcedureName procedureName )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListPropertyKeysProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListPropertyKeysProcedure.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.builtinprocs;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.impl.api.TokenAccess;
 
@@ -31,7 +31,7 @@ import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.kernel.api.ReadOperations.statement;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
-public class ListPropertyKeysProcedure extends Procedure.BasicProcedure
+public class ListPropertyKeysProcedure extends CallableProcedure.BasicProcedure
 {
     public ListPropertyKeysProcedure( ProcedureSignature.ProcedureName name )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListRelationshipTypesProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListRelationshipTypesProcedure.java
@@ -23,7 +23,7 @@ import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.impl.api.TokenAccess;
 
@@ -32,7 +32,7 @@ import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.kernel.api.ReadOperations.statement;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
-public class ListRelationshipTypesProcedure extends Procedure.BasicProcedure
+public class ListRelationshipTypesProcedure extends CallableProcedure.BasicProcedure
 {
     public ListRelationshipTypesProcedure( ProcedureSignature.ProcedureName name )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -24,7 +24,7 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.TransactionHook;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.internal.DatabaseHealth;
@@ -102,7 +102,7 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     }
 
     @Override
-    public void registerProcedure( Procedure signature ) throws ProcedureException
+    public void registerProcedure( CallableProcedure signature ) throws ProcedureException
     {
         procedures.register( signature );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -30,9 +30,6 @@ import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.Direction;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.LegacyIndexHits;
 import org.neo4j.kernel.api.ReadOperations;
@@ -65,7 +62,7 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.ProcedureSignature.ProcedureName;
 import org.neo4j.kernel.api.properties.DefinedProperty;
@@ -674,7 +671,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
     public RawIterator<Object[], ProcedureException> procedureCallRead( ProcedureName name, Object[] input ) throws ProcedureException
     {
         statement.assertOpen();
-        Procedure.BasicContext ctx = new Procedure.BasicContext();
+        CallableProcedure.BasicContext ctx = new CallableProcedure.BasicContext();
         ctx.put( ReadOperations.readOperations, this );
         ctx.put( ReadOperations.statement, statement );
         return procedures.call( ctx, name, input );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ComponentRegistry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ComponentRegistry.java
@@ -23,31 +23,31 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 
 /**
  * Tracks components that can be injected into user-defined procedures.
  */
 public class ComponentRegistry
 {
-    private final Map<Class<?>, Function<Procedure.Context, ?>> suppliers;
+    private final Map<Class<?>, Function<CallableProcedure.Context, ?>> suppliers;
 
     public ComponentRegistry()
     {
         this( new HashMap<>() );
     }
 
-    public ComponentRegistry( Map<Class<?>,Function<Procedure.Context,?>> suppliers )
+    public ComponentRegistry( Map<Class<?>,Function<CallableProcedure.Context,?>> suppliers )
     {
         this.suppliers = suppliers;
     }
 
-    public Function<Procedure.Context,?> supplierFor( Class<?> type )
+    public Function<CallableProcedure.Context,?> supplierFor( Class<?> type )
     {
         return suppliers.get( type );
     }
 
-    public <T> void register( Class<T> cls, Function<Procedure.Context,T> supplier )
+    public <T> void register( Class<T> cls, Function<CallableProcedure.Context,T> supplier )
     {
         suppliers.put( cls, supplier );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
@@ -29,7 +29,8 @@ import java.util.function.Function;
 
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.procedure.Resource;
 
 /**
  * Injects annotated fields with appropriate values.
@@ -50,16 +51,16 @@ public class FieldInjections
     {
         private final Field field;
         private final MethodHandle setter;
-        private final Function<Procedure.Context,?> supplier;
+        private final Function<CallableProcedure.Context,?> supplier;
 
-        public FieldSetter( Field field, MethodHandle setter, Function<Procedure.Context,?> supplier )
+        public FieldSetter( Field field, MethodHandle setter, Function<CallableProcedure.Context,?> supplier )
         {
             this.field = field;
             this.setter = setter;
             this.supplier = supplier;
         }
 
-        void apply( Procedure.Context ctx, Object object ) throws ProcedureException
+        void apply( CallableProcedure.Context ctx, Object object ) throws ProcedureException
         {
             try
             {
@@ -106,7 +107,7 @@ public class FieldInjections
     {
         try
         {
-            Function<Procedure.Context,?> supplier = components.supplierFor( field.getType() );
+            Function<CallableProcedure.Context,?> supplier = components.supplierFor( field.getType() );
             if( supplier == null )
             {
                 throw new ProcedureException( Status.Procedure.FailedRegistration,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.ProcedureSignature.FieldSignature;
+import org.neo4j.procedure.Name;
 
 /**
  * Given a java method, figures out a valid {@link org.neo4j.kernel.api.proc.ProcedureSignature} field signature.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureJarLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureJarLoader.java
@@ -34,13 +34,13 @@ import java.util.zip.ZipInputStream;
 import org.neo4j.collection.PrefetchingRawIterator;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.logging.Log;
 
 import static java.util.stream.Collectors.toList;
 
 /**
- * Given the location of a jarfile, reads the contents of the jar and returns compiled {@link Procedure} instances.
+ * Given the location of a jarfile, reads the contents of the jar and returns compiled {@link CallableProcedure} instances.
  */
 public class ProcedureJarLoader
 {
@@ -53,19 +53,19 @@ public class ProcedureJarLoader
         this.log = log;
     }
 
-    public List<Procedure> loadProcedures( URL jar ) throws Exception
+    public List<CallableProcedure> loadProcedures( URL jar ) throws Exception
     {
         return loadProcedures( jar, new URLClassLoader( new URL[]{jar}, this.getClass().getClassLoader() ), new LinkedList<>() );
     }
 
-    public List<Procedure> loadProceduresFromDir( File root ) throws IOException, KernelException
+    public List<CallableProcedure> loadProceduresFromDir( File root ) throws IOException, KernelException
     {
         if ( !root.exists() )
         {
             return Collections.emptyList();
         }
 
-        LinkedList<Procedure> out = new LinkedList<>();
+        LinkedList<CallableProcedure> out = new LinkedList<>();
 
         List<URL> list = Stream.of( root.listFiles( ( dir, name ) -> name.endsWith( ".jar" ) ) ).map( this::toURL ).collect( toList() );
         URL[] jarFiles = list.toArray( new URL[list.size()] );
@@ -79,7 +79,7 @@ public class ProcedureJarLoader
         return out;
     }
 
-    private List<Procedure> loadProcedures( URL jar, ClassLoader loader, List<Procedure> target ) throws IOException, KernelException
+    private List<CallableProcedure> loadProcedures( URL jar, ClassLoader loader, List<CallableProcedure> target ) throws IOException, KernelException
     {
         RawIterator<Class<?>,IOException> classes = listClassesIn( jar, loader );
         while ( classes.hasNext() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
@@ -29,19 +29,19 @@ import java.util.stream.Collectors;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 
 public class ProcedureRegistry
 {
-    private final Map<ProcedureSignature.ProcedureName,Procedure> procedures = new HashMap<>();
+    private final Map<ProcedureSignature.ProcedureName,CallableProcedure> procedures = new HashMap<>();
 
     /**
      * Register a new procedure. This method must not be called concurrently with {@link #get(ProcedureSignature.ProcedureName)}.
      *
      * @param proc the procedure.
      */
-    public synchronized void register( Procedure proc ) throws ProcedureException
+    public synchronized void register( CallableProcedure proc ) throws ProcedureException
     {
         ProcedureSignature signature = proc.signature();
         ProcedureSignature.ProcedureName name = signature.name();
@@ -73,7 +73,7 @@ public class ProcedureRegistry
 
     public ProcedureSignature get( ProcedureSignature.ProcedureName name ) throws ProcedureException
     {
-        Procedure proc = procedures.get( name );
+        CallableProcedure proc = procedures.get( name );
         if ( proc == null )
         {
             throw noSuchProcedure( name );
@@ -81,10 +81,10 @@ public class ProcedureRegistry
         return proc.signature();
     }
 
-    public RawIterator<Object[],ProcedureException> call( Procedure.Context ctx, ProcedureSignature.ProcedureName name, Object[] input )
+    public RawIterator<Object[],ProcedureException> call( CallableProcedure.Context ctx, ProcedureSignature.ProcedureName name, Object[] input )
             throws ProcedureException
     {
-        Procedure proc = procedures.get( name );
+        CallableProcedure proc = procedures.get( name );
         if ( proc == null )
         {
             throw noSuchProcedure( name );
@@ -102,6 +102,6 @@ public class ProcedureRegistry
 
     public Set<ProcedureSignature> getAll()
     {
-        return procedures.values().stream().map( Procedure::signature ).collect( Collectors.toSet());
+        return procedures.values().stream().map( CallableProcedure::signature ).collect( Collectors.toSet());
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
@@ -55,7 +55,7 @@ public class Procedures
      * Register a new procedure. This method must not be called concurrently with {@link #get(ProcedureSignature.ProcedureName)}.
      * @param proc the procedure.
      */
-    public synchronized void register( Procedure proc ) throws ProcedureException
+    public synchronized void register( CallableProcedure proc ) throws ProcedureException
     {
         registry.register( proc );
     }
@@ -66,7 +66,7 @@ public class Procedures
      */
     public synchronized void register( Class<?> proc ) throws KernelException
     {
-        for ( Procedure procedure : compiler.compile( proc ) )
+        for ( CallableProcedure procedure : compiler.compile( proc ) )
         {
             register( procedure );
         }
@@ -88,7 +88,7 @@ public class Procedures
      * @param cls the type of component to be registered (this is what users 'ask' for in their field declaration)
      * @param supplier a function that supplies the actual component, given the context of a procedure invocation
      */
-    public synchronized <T> void registerComponent( Class<T> cls, Function<Procedure.Context, T> supplier )
+    public synchronized <T> void registerComponent( Class<T> cls, Function<CallableProcedure.Context, T> supplier )
     {
         components.register( cls, supplier );
     }
@@ -101,7 +101,7 @@ public class Procedures
      */
     public synchronized void loadFromDirectory( File dir ) throws IOException, KernelException
     {
-        for ( Procedure procedure : new ProcedureJarLoader( compiler, log ).loadProceduresFromDir( dir ) )
+        for ( CallableProcedure procedure : new ProcedureJarLoader( compiler, log ).loadProceduresFromDir( dir ) )
         {
             register( procedure );
         }
@@ -117,7 +117,7 @@ public class Procedures
         return registry.getAll();
     }
 
-    public RawIterator<Object[], ProcedureException> call( Procedure.Context ctx, ProcedureSignature.ProcedureName name,
+    public RawIterator<Object[], ProcedureException> call( CallableProcedure.Context ctx, ProcedureSignature.ProcedureName name,
                                                            Object[] input ) throws ProcedureException
     {
         return registry.call( ctx, name, input );

--- a/community/kernel/src/main/java/org/neo4j/procedure/Name.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Name.java
@@ -17,16 +17,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.proc;
+package org.neo4j.procedure;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * This defines the name of an input argument for a procedure. This is used to determine which values from
+ * to use as arguments for the procedure when it is called. For instance, if you are invoking a procedure
+ * using parameters, the name you declare here will map to names of the parameters.
+ */
 @Target( ElementType.PARAMETER )
 @Retention( RetentionPolicy.RUNTIME )
 public @interface Name
 {
+    /**
+     * @return the name of this input argument.
+     */
     String value();
 }

--- a/community/kernel/src/main/java/org/neo4j/procedure/PerformsWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/PerformsWriteOperations.java
@@ -17,15 +17,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.proc;
+package org.neo4j.procedure;
+
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * This annotation marks a {@link Procedure} as performing updates to the graph.
+ * <p>
+ * This is <i>required</i> if the procedure performs write operations.
+ */
 @Target( ElementType.METHOD )
 @Retention( RetentionPolicy.RUNTIME )
-public @interface ReadOnlyProcedure
+public @interface PerformsWriteOperations
 {
+    // Implementation note: this is not yet enforced, but is an important part of the
+    // contract with the user. Without this annotation, we do not guarantee writes will
+    // work.
 }

--- a/community/kernel/src/main/java/org/neo4j/procedure/Procedure.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Procedure.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a method as a Procedure, meaning the method can be called from the
+ * cypher query language.
+ * <p>
+ * Procedures accept input, use that input to perform work, and then return a
+ * {@link java.util.stream.Stream} of {@code Records}. The work performed usually
+ * involves one or more resources, such as a {@link org.neo4j.graphdb.GraphDatabaseService}.
+ * <p>
+ * By default, procedures are read-only. If you want to perform writes to the
+ * database, you need to add the {@link PerformsWriteOperations} annotation to your method as well.
+ *
+ * <h2>Input declaration</h2>
+ * A procedure can accept input arguments, which is defined in the arguments to the
+ * annotated method. Each method argument must be a valid Procedure input type, and
+ * each must be annotated with the {@link Name} annotation, declaring the input name.
+ * <p>
+ * Valid input types are as follows:
+ *
+ * <ul>
+ *     <li>{@link String}</li>
+ *     <li>{@link Long} or {@code long}</li>
+ *     <li>{@link Double} or {@code double}</li>
+ *     <li>{@link Number}</li>
+ *     <li>{@link Boolean} or {@code boolean}</li>
+ *     <li>{@link java.util.Map} with key {@link String} and value {@link Object}</li>
+ *     <li>{@link java.util.List} with element type of any type in this list, including {@link java.util.List}</li>
+ *     <li>{@link Object}, meaning any valid input types</li>
+ * </ul>
+ *
+ * <h2>Output declaration</h2>
+ * A procedure must always return a {@link java.util.stream.Stream} of {@code Records}.
+ * The record is defined per procedure, as a class with only public, non-final fields.
+ * The types, order and names of the fields in this class define the format of the returned records.
+ * <p>
+ * Valid field types are as follows:
+ *
+ * <ul>
+ *     <li>{@link String}</li>
+ *     <li>{@link Long} or {@code long}</li>
+ *     <li>{@link Double} or {@code double}</li>
+ *     <li>{@link Number}</li>
+ *     <li>{@link Boolean} or {@code boolean}</li>
+ *     <li>{@link org.neo4j.graphdb.Node}</li>
+ *     <li>{@link org.neo4j.graphdb.Relationship}</li>
+ *     <li>{@link org.neo4j.graphdb.Path}</li>
+ *     <li>{@link java.util.Map} with key {@link String} and value {@link Object}</li>
+ *     <li>{@link java.util.List} of elements of any valid field type, including {@link java.util.List}</li>
+ *     <li>{@link Object}, meaning any of the valid field types</li>
+ * </ul>
+ *
+ * <h2>Resource declarations</h2>
+ * The procedure method itself can contain arbitrary Java code - but in order to work with the underlying graph,
+ * it must have access to the graph API. This is done by declaring fields in the procedure class, and annotating
+ * them with the {@link Resource} annotation. Fields declared this way are automatically injected with the
+ * requested resource. This is how procedures gain access to APIs to do work with.
+ * <p>
+ * All fields in the class containing the procedure declaration must either be static; or it must be public, non-final
+ * and annotated with {@link Resource}.
+ * <p>
+ * Resources supported by default are as follows:
+ * <ul>
+ *     <li>{@link org.neo4j.graphdb.GraphDatabaseService}</li>
+ *     <li>{@link org.neo4j.logging.Log}</li>
+ * </ul>
+ *
+ * <h2>Lifecycle and state</h2>
+ * The class that declares your procedure method may be re-instantiated before each call. Because of this,
+ * no regular state can be stored in the fields of the procedure.
+ * <p>
+ * If you want to maintain state between invocations to your procedure, simply use a static field. Note that
+ * procedures may be called concurrently, meaning you need to take care to ensure the state you store in
+ * static fields can be safely accessed by multiple callers simultaneously.
+ */
+@Target( ElementType.METHOD )
+@Retention( RetentionPolicy.RUNTIME )
+public @interface Procedure
+{
+}

--- a/community/kernel/src/main/java/org/neo4j/procedure/Resource.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Resource.java
@@ -17,13 +17,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.proc;
+package org.neo4j.procedure;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * This marks a field in a class with {@link Procedure} methods as a resource for the procedures to use.
+ * What this means is that before the procedure is called, fields with this annotation will be automatically
+ * populated with the appropriate resource.
+ *
+ * In fact, apart from static fields, <i>only</i> fields with this annotation are allowed in classses that
+ * define procedure. Each of the fields must be public and non-final.
+ *
+ * @see Procedure
+ */
 @Target( ElementType.FIELD )
 @Retention( RetentionPolicy.RUNTIME )
 public @interface Resource

--- a/community/kernel/src/main/java/org/neo4j/procedure/impl/ProcedureExample.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/impl/ProcedureExample.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.procedure.impl;
 
 import java.util.stream.Stream;

--- a/community/kernel/src/main/java/org/neo4j/procedure/impl/ProcedureExample.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/impl/ProcedureExample.java
@@ -1,0 +1,43 @@
+package org.neo4j.procedure.impl;
+
+import java.util.stream.Stream;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.Resource;
+
+public class ProcedureExample
+{
+    @Resource
+    public GraphDatabaseService db;
+
+    /**
+     * Finds all nodes in the database with more relationships than the specified threshold.
+     * @param threshold only include nodes with at least this many relationships
+     * @return a stream of records describing supernodes in this database
+     */
+    @Procedure
+    public Stream<SuperNode> findSuperNodes( @Name("threshold") long threshold )
+    {
+        return db.getAllNodes().stream()
+                .filter( (node) -> node.getDegree() > threshold )
+                .map( SuperNode::new );
+    }
+
+    /**
+     * Output record for {@link #findSuperNodes(long)}.
+     */
+    public static class SuperNode
+    {
+        public long nodeId;
+        public long degree;
+
+        public SuperNode( Node node )
+        {
+            this.nodeId = node.getId();
+            this.degree = node.getDegree();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/graphdb/ResourceIterableTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/ResourceIterableTest.java
@@ -1,0 +1,33 @@
+package org.neo4j.graphdb;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.neo4j.helpers.collection.IteratorUtil.iterator;
+import static org.neo4j.helpers.collection.ResourceClosingIterator.newResourceIterator;
+
+public class ResourceIterableTest
+{
+    @Test
+    public void streamShouldCloseOnCompleted() throws Throwable
+    {
+        // Given
+        AtomicBoolean closed = new AtomicBoolean( false );
+        ResourceIterator<Integer> resourceIterator = newResourceIterator( () -> closed.set( true ), iterator( new Integer[]{1, 2, 3} ) );
+
+        ResourceIterable<Integer> iterable = () -> resourceIterator;
+
+        // When
+        List<Integer> result = iterable.stream().collect( Collectors.toList() );
+
+        // Then
+        assertEquals( asList(1,2,3), result );
+        assertTrue( closed.get() );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/graphdb/ResourceIterableTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/ResourceIterableTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.graphdb;
 
 import org.junit.Test;

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/proc/ProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/proc/ProceduresTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertThat;
 
 import static org.neo4j.helpers.collection.IteratorUtil.asList;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTAny;
-import static org.neo4j.kernel.api.proc.Procedure.Key.key;
+import static org.neo4j.kernel.api.proc.CallableProcedure.Key.key;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
 public class ProceduresTest
@@ -46,7 +46,7 @@ public class ProceduresTest
 
     private final Procedures procs = new Procedures();
     private final ProcedureSignature signature = procedureSignature( "org", "myproc" ).build();
-    private final Procedure procedure = procedure( signature );
+    private final CallableProcedure procedure = procedure( signature );
 
     @Test
     public void shouldGetRegisteredProcedure() throws Throwable
@@ -81,7 +81,7 @@ public class ProceduresTest
         procs.register( procedure );
 
         // When
-        RawIterator<Object[], ProcedureException> result = procs.call( new Procedure.BasicContext()
+        RawIterator<Object[], ProcedureException> result = procs.call( new CallableProcedure.BasicContext()
         {
         }, signature.name(), new Object[]{1337} );
 
@@ -99,7 +99,7 @@ public class ProceduresTest
                                  "procedure name correctly and that the procedure is properly deployed." );
 
         // When
-        procs.call( new Procedure.BasicContext()
+        procs.call( new CallableProcedure.BasicContext()
         {
         }, signature.name(), new Object[]{1337} );
     }
@@ -161,9 +161,9 @@ public class ProceduresTest
     public void shouldMakeContextAvailable() throws Throwable
     {
         // Given
-        Procedure.Key<String> someKey = key("someKey", String.class);
+        CallableProcedure.Key<String> someKey = key("someKey", String.class);
 
-        procs.register( new Procedure.BasicProcedure(signature)
+        procs.register( new CallableProcedure.BasicProcedure(signature)
         {
             @Override
             public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
@@ -172,7 +172,7 @@ public class ProceduresTest
             }
         } );
 
-        Procedure.BasicContext ctx = new Procedure.BasicContext();
+        CallableProcedure.BasicContext ctx = new CallableProcedure.BasicContext();
         ctx.put( someKey, "hello, world" );
 
         // When
@@ -182,9 +182,9 @@ public class ProceduresTest
         assertThat( asList( result ), contains( equalTo( new Object[]{ "hello, world" } ) ) );
     }
 
-    private Procedure.BasicProcedure procedureWithSignature( final ProcedureSignature signature )
+    private CallableProcedure.BasicProcedure procedureWithSignature( final ProcedureSignature signature )
     {
-        return new Procedure.BasicProcedure(signature)
+        return new CallableProcedure.BasicProcedure(signature)
         {
             @Override
             public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
@@ -194,9 +194,9 @@ public class ProceduresTest
         };
     }
 
-    private Procedure procedure( ProcedureSignature signature )
+    private CallableProcedure procedure( ProcedureSignature signature )
     {
-        return new Procedure.BasicProcedure( signature )
+        return new CallableProcedure.BasicProcedure( signature )
         {
             @Override
             public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -34,7 +34,7 @@ import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelExceptio
 import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.StatementOperationParts;
@@ -240,7 +240,7 @@ public class ConstraintIndexCreatorTest
         }
 
         @Override
-        public void registerProcedure( Procedure signature )
+        public void registerProcedure( CallableProcedure signature )
         {
             throw new UnsupportedOperationException();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
@@ -30,7 +30,7 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -52,7 +52,7 @@ public class ProceduresKernelIT extends KernelIntegrationTest
             .in( "name", NTString )
             .out( "name", NTString ).build();
 
-    private final Procedure procedure = procedure( signature );
+    private final CallableProcedure procedure = procedure( signature );
 
     @Test
     public void shouldGetProcedureByName() throws Throwable
@@ -117,7 +117,7 @@ public class ProceduresKernelIT extends KernelIntegrationTest
     public void registeredProcedureShouldGetReadOperations() throws Throwable
     {
         // Given
-        kernel.registerProcedure( new Procedure.BasicProcedure( signature )
+        kernel.registerProcedure( new CallableProcedure.BasicProcedure( signature )
         {
             @Override
             public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
@@ -133,9 +133,9 @@ public class ProceduresKernelIT extends KernelIntegrationTest
         assertNotNull( asList( stream  ).get( 0 )[0] );
     }
 
-    private static Procedure procedure( final ProcedureSignature signature )
+    private static CallableProcedure procedure( final ProcedureSignature signature )
     {
-        return new Procedure.BasicProcedure( signature )
+        return new CallableProcedure.BasicProcedure( signature )
         {
             @Override
             public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/FieldInjectionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/FieldInjectionsTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.ExpectedException;
 import java.util.List;
 
 import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.procedure.Resource;
 
 import static junit.framework.TestCase.assertEquals;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MethodSignatureCompilerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MethodSignatureCompilerTest.java
@@ -30,6 +30,8 @@ import java.util.stream.Stream;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.api.proc.ProcedureSignature.FieldSignature;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -56,19 +58,19 @@ public class MethodSignatureCompilerTest
 
     public static class ClassWithProcedureWithSimpleArgs
     {
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<MyOutputRecord> echo( @Name("name") String in)
         {
             return Stream.of( new MyOutputRecord( in ));
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<MyOutputRecord> echoWithoutAnnotations( @Name("name")String in1, String in2)
         {
             return Stream.of( new MyOutputRecord( in1 + in2 ));
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<MyOutputRecord> echoWithInvalidType( @Name("name") UnmappableRecord in)
         {
             return Stream.of( new MyOutputRecord( "echo" ));

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -33,8 +33,10 @@ import java.util.stream.Stream;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -50,7 +52,7 @@ public class ReflectiveProcedureWithArgumentsTest
     public void shouldCompileSimpleProcedure() throws Throwable
     {
         // When
-        List<Procedure> procedures = compile( ClassWithProcedureWithSimpleArgs.class );
+        List<CallableProcedure> procedures = compile( ClassWithProcedureWithSimpleArgs.class );
 
         // Then
         TestCase.assertEquals( 1, procedures.size() );
@@ -66,10 +68,10 @@ public class ReflectiveProcedureWithArgumentsTest
     public void shouldRunSimpleProcedure() throws Throwable
     {
         // Given
-        Procedure procedure = compile( ClassWithProcedureWithSimpleArgs.class ).get( 0 );
+        CallableProcedure procedure = compile( ClassWithProcedureWithSimpleArgs.class ).get( 0 );
 
         // When
-        RawIterator<Object[],ProcedureException> out = procedure.apply( new Procedure.BasicContext(), new Object[]{"Pontus", 35L} );
+        RawIterator<Object[],ProcedureException> out = procedure.apply( new CallableProcedure.BasicContext(), new Object[]{"Pontus", 35L} );
 
         // Then
         List<Object[]> collect = asList( out );
@@ -80,10 +82,10 @@ public class ReflectiveProcedureWithArgumentsTest
     public void shouldRunGenericProcedure() throws Throwable
     {
         // Given
-        Procedure procedure = compile( ClassWithProcedureWithGenericArgs.class ).get( 0 );
+        CallableProcedure procedure = compile( ClassWithProcedureWithGenericArgs.class ).get( 0 );
 
         // When
-        RawIterator<Object[],ProcedureException> out = procedure.apply( new Procedure.BasicContext(), new Object[]{
+        RawIterator<Object[],ProcedureException> out = procedure.apply( new CallableProcedure.BasicContext(), new Object[]{
                 Arrays.asList( "Roland", "Eddie", "Susan", "Jake" ),
                 Arrays.asList( 1000L, 23L, 29L, 12L )} );
 
@@ -121,7 +123,7 @@ public class ReflectiveProcedureWithArgumentsTest
 
     public static class ClassWithProcedureWithSimpleArgs
     {
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<MyOutputRecord> listCoolPeople( @Name( "name" ) String name, @Name( "age" ) long age )
         {
             return Stream.of( new MyOutputRecord( name + " is " + age + " years old." ) );
@@ -130,7 +132,7 @@ public class ReflectiveProcedureWithArgumentsTest
 
     public static class ClassWithProcedureWithGenericArgs
     {
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<MyOutputRecord> listCoolPeople( @Name( "names" ) List<String> names,
                                                       @Name( "age" ) List<Long> ages )
         {
@@ -148,14 +150,14 @@ public class ReflectiveProcedureWithArgumentsTest
 
     public static class ClassWithProcedureWithoutAnnotatedArgs
     {
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<MyOutputRecord> listCoolPeople( String name, int age )
         {
             return Stream.of( new MyOutputRecord( name + " is " + age + " years old." ) );
         }
     }
 
-    private List<Procedure> compile( Class<?> clazz ) throws KernelException
+    private List<CallableProcedure> compile( Class<?> clazz ) throws KernelException
     {
         return new ReflectiveProcedureCompiler( new TypeMappers(), new ComponentRegistry() ).compile( clazz );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
@@ -23,14 +23,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.api.proc.Procedure;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.Resource;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -47,10 +48,10 @@ public class ResourceInjectionTest
     public void shouldCompileAndRunProcedure() throws Throwable
     {
         // Given
-        Procedure proc = compile( ProcedureWithInjectedAPI.class ).get( 0 );
+        CallableProcedure proc = compile( ProcedureWithInjectedAPI.class ).get( 0 );
 
         // Then
-        List<Object[]> out = IteratorUtil.asList( proc.apply( new Procedure.BasicContext(), new Object[0] ) );
+        List<Object[]> out = IteratorUtil.asList( proc.apply( new CallableProcedure.BasicContext(), new Object[0] ) );
 
         // Then
         assertThat( out.get( 0 ), equalTo( (new Object[]{"Bonnie"}) ) );
@@ -103,7 +104,7 @@ public class ResourceInjectionTest
         @Resource
         public MyAwesomeAPI api;
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<MyOutputRecord> listCoolPeople()
         {
             return api.listCoolPeople().stream().map( MyOutputRecord::new );
@@ -115,14 +116,14 @@ public class ResourceInjectionTest
         @Resource
         public UnknownAPI api;
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<MyOutputRecord> listCoolPeople()
         {
             return api.listCoolPeople().stream().map( MyOutputRecord::new );
         }
     }
 
-    private List<Procedure> compile( Class<?> clazz ) throws KernelException
+    private List<CallableProcedure> compile( Class<?> clazz ) throws KernelException
     {
         ComponentRegistry components = new ComponentRegistry();
         components.register( MyAwesomeAPI.class, (ctx) -> new MyAwesomeAPI() );

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/TestServerBuilder.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
-import org.neo4j.kernel.impl.proc.ReadOnlyProcedure;
+import org.neo4j.procedure.Procedure;
 
 /**
  * Utility for constructing and starting Neo4j for test purposes.
@@ -108,7 +108,7 @@ public interface TestServerBuilder
 
     /**
      * Configure the server to load the specified procedure definition class. The class should contain one or more
-     * methods annotated with {@link ReadOnlyProcedure}, these will become available to call through
+     * methods annotated with {@link Procedure}, these will become available to call through
      * cypher.
      *
      * @param procedureClass a class containing one or more procedure definitions

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaProceduresTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/JavaProceduresTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import java.util.stream.Stream;
 
-import org.neo4j.kernel.impl.proc.ReadOnlyProcedure;
+import org.neo4j.procedure.Procedure;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.server.HTTP;
@@ -47,13 +47,13 @@ public class JavaProceduresTest
             public long someNumber = 1337;
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<OutputRecord> myProc()
         {
             return Stream.of( new OutputRecord() );
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<OutputRecord> procThatThrows()
         {
             throw new RuntimeException( "This is an exception" );

--- a/community/resource/src/main/java/org/neo4j/graphdb/ResourceIterable.java
+++ b/community/resource/src/main/java/org/neo4j/graphdb/ResourceIterable.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.graphdb;
 
+import java.util.stream.Stream;
+
 /**
  * {@link Iterable} whose {@link ResourceIterator iterators} have associated resources
  * that need to be released.
@@ -74,4 +76,12 @@ public interface ResourceIterable<T> extends Iterable<T>
      */
     @Override
     ResourceIterator<T> iterator();
+
+    /**
+     * @return this iterable as a {@link Stream}
+     */
+    default Stream<T> stream()
+    {
+        return iterator().stream();
+    }
 }

--- a/community/resource/src/main/java/org/neo4j/graphdb/ResourceIterator.java
+++ b/community/resource/src/main/java/org/neo4j/graphdb/ResourceIterator.java
@@ -21,6 +21,10 @@ package org.neo4j.graphdb;
 
 import java.util.Iterator;
 import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.util.Spliterators.spliteratorUnknownSize;
 
 /**
  * Closeable Iterator with associated resources.
@@ -42,6 +46,16 @@ public interface ResourceIterator<T> extends Iterator<T>, Resource
      */
     @Override
     void close();
+
+    /**
+     * @return this iterator as a {@link Stream}
+     */
+    default Stream<T> stream()
+    {
+        return StreamSupport
+                .stream( spliteratorUnknownSize( this, 0 ), false )
+                .onClose( this::close );
+    }
 
     default <R> ResourceIterator<R> map( Function<T,R> map )
     {

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.procedure;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -37,10 +37,7 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.proc.JarBuilder;
-import org.neo4j.kernel.impl.proc.Name;
 import org.neo4j.kernel.impl.proc.Procedures;
-import org.neo4j.kernel.impl.proc.ReadOnlyProcedure;
-import org.neo4j.kernel.impl.proc.Resource;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Log;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -49,11 +46,9 @@ import static java.util.Spliterator.IMMUTABLE;
 import static java.util.Spliterator.ORDERED;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertFalse;
-
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
@@ -340,32 +335,32 @@ public class ProcedureIT
         @Resource
         public Log log;
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<Output> integrationTestMe()
         {
             return Stream.of( new Output() );
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<Output> simpleArgument( @Name( "name" ) long someValue )
         {
             return Stream.of( new Output( someValue ) );
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<Output> genericArguments( @Name( "stringList" ) List<List<String>> stringList,
                 @Name( "longList" ) List<List<List<Long>>> longList )
         {
             return Stream.of( new Output( stringList.size() + longList.size() ) );
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<Output> mapArgument( @Name( "map" )Map<String,Object> map )
         {
             return Stream.of( new Output( map.size() ) );
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<NodeOutput> node( @Name( "id" ) long id )
         {
             NodeOutput nodeOutput = new NodeOutput();
@@ -373,20 +368,20 @@ public class ProcedureIT
             return Stream.of( nodeOutput );
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<Output> throwsExceptionInStream()
         {
             return Stream.generate( () -> { throw new RuntimeException( "Kaboom" ); } );
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<MyOutputRecord> listCoolPeopleInDatabase()
         {
             return stream( spliteratorUnknownSize( db.findNodes( label( "Person" ) ), ORDERED | IMMUTABLE ), false )
                     .map( ( n ) -> new MyOutputRecord( (String) n.getProperty( "name" ) ) );
         }
 
-        @ReadOnlyProcedure
+        @Procedure
         public Stream<Output> logAround()
         {
             log.debug( "1" );

--- a/integrationtests/src/test/java/org/neo4j/procedure/impl/ProcedureExampleTest.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/impl/ProcedureExampleTest.java
@@ -1,0 +1,70 @@
+package org.neo4j.procedure.impl;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.impl.proc.JarBuilder;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class ProcedureExampleTest
+{
+    @Rule
+    public TemporaryFolder plugins = new TemporaryFolder();
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private GraphDatabaseService db;
+
+    @Test
+    public void listSuperNodesShouldWork() throws Throwable
+    {
+        // Given
+        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ProcedureExample.class );
+        db = new TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
+                .newGraphDatabase();
+
+        try ( Transaction ignore = db.beginTx() )
+        {
+            Node node1 = db.createNode();
+            Node node2 = db.createNode();
+            Node node3 = db.createNode();
+
+            node1.createRelationshipTo( node1, RelationshipType.withName( "KNOWS" ) );
+            node1.createRelationshipTo( node2, RelationshipType.withName( "KNOWS" ) );
+            node1.createRelationshipTo( node3, RelationshipType.withName( "KNOWS" ) );
+
+            // When
+            Result res = db.execute( "CALL org.neo4j.procedure.impl.findSuperNodes(2)" );
+
+            // Then
+            assertEquals( map( "degree", 3l, "nodeId", node1.getId() ), res.next() );
+            assertFalse( res.hasNext() );
+        }
+
+    }
+
+    @After
+    public void tearDown()
+    {
+        if ( this.db != null )
+        {
+            this.db.shutdown();
+        }
+    }
+}

--- a/integrationtests/src/test/java/org/neo4j/procedure/impl/ProcedureExampleTest.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/impl/ProcedureExampleTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.procedure.impl;
 
 import org.junit.After;


### PR DESCRIPTION
- Move procedure annotations to org.neo4j.procedure and add API
  documentation
- Add @PerformsWriteOperations annotation to mark writing procedures.
  No enforcement yet, but API contract highlights it as mandatory
