### PR TITLE
Inline RAFT message processing.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
@@ -245,7 +245,7 @@ public class RaftInstance<MEMBER> implements LeaderLocator<MEMBER>, Inbound.Mess
         try
         {
             handlingMessage = true;
-            Outcome<MEMBER> outcome = currentRole.role.handle( (RaftMessages.Message<MEMBER>) incomingMessage, state, log );
+            Outcome<MEMBER> outcome = currentRole.handler.handle( (RaftMessages.Message<MEMBER>) incomingMessage, state, log );
 
             handleOutcome( outcome );
             currentRole = outcome.getNewRole();

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessages.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessages.java
@@ -78,6 +78,12 @@ public interface RaftMessages
         {
             return message;
         }
+
+        @Override
+        public String toString()
+        {
+            return format( "Directed{to=%s, message=%s}", to, message );
+        }
     }
 
     interface Vote
@@ -355,7 +361,7 @@ public interface RaftMessages
             @Override
             public String toString()
             {
-                return String.format( "AppendEntries.Response from %s {term=%d, success=%s, matchIndex=%d, appendIndex=%d}",
+                return format( "AppendEntries.Response from %s {term=%d, success=%s, matchIndex=%d, appendIndex=%d}",
                         from, term, success, matchIndex, appendIndex );
             }
         }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Appending.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Appending.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.AppendLogEntry;
+import org.neo4j.coreedge.raft.outcome.BatchAppendLogEntries;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.outcome.ShipCommand;
+import org.neo4j.coreedge.raft.outcome.TruncateLogCommand;
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+
+public class Appending
+{
+    public static <MEMBER> void handleAppendEntriesRequest(
+            ReadableRaftState<MEMBER> state, Outcome<MEMBER> outcome, RaftMessages.AppendEntries.Request<MEMBER> request )
+            throws RaftStorageException
+    {
+        if ( request.leaderTerm() < state.term() )
+        {
+            RaftMessages.AppendEntries.Response<MEMBER> appendResponse = new RaftMessages.AppendEntries.Response<>(
+                    state.myself(), state.term(), false, -1, state.entryLog().appendIndex() );
+
+            outcome.addOutgoingMessage( new RaftMessages.Directed<>( request.from(), appendResponse ) );
+            return;
+        }
+
+        outcome.renewElectionTimeout();
+        outcome.setNextTerm( request.leaderTerm() );
+        outcome.setLeader( request.from() );
+        outcome.setLeaderCommit( request.leaderCommit() );
+
+        if ( !Follower.logHistoryMatches( state, request.prevLogIndex(), request.prevLogTerm() ) )
+        {
+            assert request.prevLogIndex() > -1 && request.prevLogTerm() > -1;
+            RaftMessages.AppendEntries.Response<MEMBER> appendResponse = new RaftMessages.AppendEntries.Response<>(
+                    state.myself(), request.leaderTerm(), false, -1, state.entryLog().appendIndex() );
+
+            outcome.addOutgoingMessage( new RaftMessages.Directed<>( request.from(), appendResponse ) );
+            return;
+        }
+
+        long baseIndex = request.prevLogIndex() + 1;
+        int offset;
+
+                /* Find possible truncation point. */
+        for ( offset = 0; offset < request.entries().length; offset++ )
+        {
+            long logTerm = state.entryLog().readEntryTerm( baseIndex + offset );
+
+            if( baseIndex + offset > state.entryLog().appendIndex() )
+            {
+                /* entry doesn't exist */
+                break;
+            }
+            else if ( logTerm != request.entries()[offset].term() )
+            {
+                outcome.addLogCommand( new TruncateLogCommand( baseIndex + offset ) );
+                break;
+            }
+        }
+
+        if( offset < request.entries().length )
+        {
+            outcome.addLogCommand( new BatchAppendLogEntries( baseIndex, offset, request.entries() ) );
+        }
+
+        Follower.commitToLogOnUpdate( state, request.prevLogIndex() + request.entries().length, request.leaderCommit
+                (), outcome );
+
+        long endMatchIndex = request.prevLogIndex() + request.entries().length; // this is the index of the last incoming entry
+        if ( endMatchIndex >= 0 )
+        {
+            RaftMessages.AppendEntries.Response<MEMBER> appendResponse = new RaftMessages.AppendEntries.Response<>( state.myself(), request.leaderTerm(), true, endMatchIndex, endMatchIndex );
+            outcome.addOutgoingMessage( new RaftMessages.Directed<>( request.from(), appendResponse ) );
+        }
+    }
+
+    public static <MEMBER> void appendNewEntry( ReadableRaftState<MEMBER> ctx, Outcome<MEMBER> outcome, ReplicatedContent
+            content ) throws RaftStorageException
+    {
+        long prevLogIndex = ctx.entryLog().appendIndex();
+        long prevLogTerm = prevLogIndex == -1 ? -1 :
+                prevLogIndex > ctx.lastLogIndexBeforeWeBecameLeader() ?
+                        ctx.term() :
+                        ctx.entryLog().readLogEntry( prevLogIndex ).term();
+
+        RaftLogEntry newLogEntry = new RaftLogEntry( ctx.term(), content );
+
+        outcome.addShipCommand( new ShipCommand.NewEntry( prevLogIndex, prevLogTerm, newLogEntry ) );
+        outcome.addLogCommand( new AppendLogEntry( prevLogIndex + 1, newLogEntry ) );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Candidate.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Candidate.java
@@ -52,7 +52,7 @@ public class Candidate implements RaftMessageHandler
                 }
 
                 outcome.setNextRole( FOLLOWER );
-                outcome.addOutgoingMessage( new RaftMessages.Directed<>( ctx.myself(), message ) );
+                Heart.beat( ctx, outcome, (RaftMessages.Heartbeat<MEMBER>) message );
                 break;
             }
 
@@ -71,7 +71,7 @@ public class Candidate implements RaftMessageHandler
                 }
 
                 outcome.setNextRole( FOLLOWER );
-                outcome.addOutgoingMessage( new RaftMessages.Directed<>( ctx.myself(), req ) );
+                Appending.handleAppendEntriesRequest( ctx, outcome, req );
                 break;
             }
 
@@ -101,7 +101,7 @@ public class Candidate implements RaftMessageHandler
                             ctx.term(), ctx.myself(), outcome.getVotesForMe() );
 
                     outcome.setLeader( ctx.myself() );
-                    Leader.appendNewEntry( ctx, outcome, new NewLeaderBarrier() );
+                    Appending.appendNewEntry( ctx, outcome, new NewLeaderBarrier() );
 
                     outcome.setLastLogIndexBeforeWeBecameLeader( ctx.entryLog().appendIndex() );
                     outcome.setNextRole( LEADER );
@@ -115,11 +115,9 @@ public class Candidate implements RaftMessageHandler
 
                 if ( req.term() > ctx.term() )
                 {
-                    outcome.setNextTerm( req.term() );
                     outcome.getVotesForMe().clear();
-
                     outcome.setNextRole( FOLLOWER );
-                    outcome.addOutgoingMessage( new RaftMessages.Directed<>( ctx.myself(), req ) );
+                    Voting.handleVoteRequest( ctx, outcome, req );
                     break;
                 }
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
@@ -24,24 +24,21 @@ import java.util.Set;
 import org.neo4j.coreedge.raft.RaftMessageHandler;
 import org.neo4j.coreedge.raft.RaftMessages;
 import org.neo4j.coreedge.raft.RaftMessages.AppendEntries;
-import org.neo4j.coreedge.raft.RaftMessages.AppendEntries.Response;
 import org.neo4j.coreedge.raft.RaftMessages.Heartbeat;
 import org.neo4j.coreedge.raft.log.RaftStorageException;
-import org.neo4j.coreedge.raft.outcome.BatchAppendLogEntries;
 import org.neo4j.coreedge.raft.outcome.CommitCommand;
 import org.neo4j.coreedge.raft.outcome.Outcome;
-import org.neo4j.coreedge.raft.outcome.TruncateLogCommand;
 import org.neo4j.coreedge.raft.state.ReadableRaftState;
 import org.neo4j.logging.Log;
 
 import static java.lang.Long.min;
-import static org.neo4j.coreedge.raft.Ballot.shouldVoteFor;
+
 import static org.neo4j.coreedge.raft.roles.Role.CANDIDATE;
 import static org.neo4j.coreedge.raft.roles.Role.FOLLOWER;
 
 public class Follower implements RaftMessageHandler
 {
-    private static <MEMBER> boolean logHistoryMatches( ReadableRaftState<MEMBER> ctx, long prevLogIndex, long prevLogTerm )
+    public static <MEMBER> boolean logHistoryMatches( ReadableRaftState<MEMBER> ctx, long prevLogIndex, long prevLogTerm )
             throws RaftStorageException
     {
         // NOTE: A previous log index of -1 means no history,
@@ -52,7 +49,7 @@ public class Follower implements RaftMessageHandler
         return prevLogIndex == -1 || ctx.entryLog().readEntryTerm( prevLogIndex ) == prevLogTerm;
     }
 
-    private static <MEMBER> boolean commitToLogOnUpdate( ReadableRaftState<MEMBER> ctx, long indexOfLastNewEntry,
+    public static <MEMBER> boolean commitToLogOnUpdate( ReadableRaftState<MEMBER> ctx, long indexOfLastNewEntry,
             long leaderCommit, Outcome<MEMBER> outcome )
     {
         long newCommitIndex = min( leaderCommit, indexOfLastNewEntry );
@@ -75,115 +72,19 @@ public class Follower implements RaftMessageHandler
         {
             case HEARTBEAT:
             {
-                Heartbeat<MEMBER> req = (Heartbeat<MEMBER>) message;
-
-                if ( req.leaderTerm() < ctx.term() )
-                {
-                    break;
-                }
-
-                outcome.renewElectionTimeout();
-                outcome.setNextTerm( req.leaderTerm() );
-                outcome.setLeader( req.from() );
-                outcome.setLeaderCommit( req.commitIndex() );
-
-                if ( !logHistoryMatches( ctx, req.commitIndex(), req.commitIndexTerm() ) )
-                {
-                    break;
-                }
-
-                commitToLogOnUpdate( ctx, req.commitIndex(), req.commitIndex(), outcome );
+                Heart.beat( ctx, outcome, (Heartbeat<MEMBER>) message );
                 break;
             }
 
             case APPEND_ENTRIES_REQUEST:
             {
-                AppendEntries.Request<MEMBER> req = (AppendEntries.Request<MEMBER>) message;
-
-                if ( req.leaderTerm() < ctx.term() )
-                {
-                    Response<MEMBER> appendResponse = new Response<>(
-                            ctx.myself(), ctx.term(), false, -1, ctx.entryLog().appendIndex() );
-
-                    outcome.addOutgoingMessage( new RaftMessages.Directed<>( req.from(), appendResponse ) );
-                    break;
-                }
-
-                outcome.renewElectionTimeout();
-                outcome.setNextTerm( req.leaderTerm() );
-                outcome.setLeader( req.from() );
-                outcome.setLeaderCommit( req.leaderCommit() );
-
-                if ( !logHistoryMatches( ctx, req.prevLogIndex(), req.prevLogTerm() ) )
-                {
-                    assert req.prevLogIndex() > -1 && req.prevLogTerm() > -1;
-                    Response<MEMBER> appendResponse = new Response<>(
-                            ctx.myself(), req.leaderTerm(), false, -1, ctx.entryLog().appendIndex() );
-
-                    outcome.addOutgoingMessage( new RaftMessages.Directed<>( req.from(), appendResponse ) );
-                    break;
-                }
-
-                long baseIndex = req.prevLogIndex() + 1;
-                int offset;
-
-                /* Find possible truncation point. */
-                for ( offset = 0; offset < req.entries().length; offset++ )
-                {
-                    long logTerm = ctx.entryLog().readEntryTerm( baseIndex + offset );
-
-                    if( baseIndex + offset > ctx.entryLog().appendIndex() )
-                    {
-                        /* entry doesn't exist */
-                        break;
-                    }
-                    else if ( logTerm != req.entries()[offset].term() )
-                    {
-                        outcome.addLogCommand( new TruncateLogCommand( baseIndex + offset ) );
-                        break;
-                    }
-                }
-
-                if( offset < req.entries().length )
-                {
-                    outcome.addLogCommand( new BatchAppendLogEntries( baseIndex, offset, req.entries() ) );
-                }
-
-                commitToLogOnUpdate( ctx, req.prevLogIndex() + req.entries().length, req.leaderCommit(), outcome );
-
-                long endMatchIndex = req.prevLogIndex() + req.entries().length; // this is the index of the last incoming entry
-                if ( endMatchIndex >= 0 )
-                {
-                    Response<MEMBER> appendResponse = new Response<>( ctx.myself(), req.leaderTerm(), true, endMatchIndex, endMatchIndex );
-                    outcome.addOutgoingMessage( new RaftMessages.Directed<>( req.from(), appendResponse ) );
-                }
+                Appending.handleAppendEntriesRequest( ctx, outcome, (AppendEntries.Request<MEMBER>) message );
                 break;
             }
 
             case VOTE_REQUEST:
             {
-                RaftMessages.Vote.Request<MEMBER> req = (RaftMessages.Vote.Request<MEMBER>) message;
-
-                if ( req.term() > ctx.term() )
-                {
-                    outcome.setNextTerm( req.term() );
-                    outcome.setVotedFor( null );
-                }
-
-                boolean willVoteForCandidate = shouldVoteFor( req.candidate(), outcome.getTerm(), req.term(),
-                        ctx.entryLog().readEntryTerm( ctx.entryLog().appendIndex() ), req.lastLogTerm(),
-                        ctx.entryLog().appendIndex(), req.lastLogIndex(),
-                        outcome.getVotedFor() );
-
-                if ( willVoteForCandidate )
-                {
-                    outcome.setVotedFor( req.from() );
-                    outcome.renewElectionTimeout();
-                }
-
-                outcome.addOutgoingMessage( new RaftMessages.Directed<>( req.from(), new RaftMessages.Vote.Response<>(
-                        ctx.myself(), outcome.getTerm(),
-                        willVoteForCandidate ) ) );
+                Voting.handleVoteRequest( ctx, outcome, (RaftMessages.Vote.Request<MEMBER>) message );
                 break;
             }
 
@@ -217,4 +118,5 @@ public class Follower implements RaftMessageHandler
 
         return outcome;
     }
+
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Heart.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Heart.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+
+public class Heart
+{
+    public static <MEMBER> void beat( ReadableRaftState<MEMBER> state, Outcome<MEMBER> outcome, RaftMessages.Heartbeat<MEMBER> request ) throws RaftStorageException
+    {
+        if ( request.leaderTerm() < state.term() )
+        {
+            return;
+        }
+
+        outcome.renewElectionTimeout();
+        outcome.setNextTerm( request.leaderTerm() );
+        outcome.setLeader( request.from() );
+        outcome.setLeaderCommit( request.commitIndex() );
+
+        if ( !Follower.logHistoryMatches( state, request.commitIndex(), request.commitIndexTerm() ) )
+        {
+            return;
+        }
+
+        Follower.commitToLogOnUpdate( state, request.commitIndex(), request.commitIndex(), outcome );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Role.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Role.java
@@ -27,10 +27,10 @@ public enum Role
     CANDIDATE( new Candidate() ),
     LEADER( new Leader() );
 
-    public final RaftMessageHandler role;
+    public final RaftMessageHandler handler;
 
-    Role( RaftMessageHandler role )
+    Role( RaftMessageHandler handler )
     {
-        this.role = role;
+        this.handler = handler;
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/VotingTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/VotingTest.java
@@ -23,11 +23,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.neo4j.coreedge.raft.roles.Voting;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
-public class BallotTest
+public class VotingTest
 {
     Object candidate = new Object();
     Object otherMember = new Object();
@@ -39,7 +41,7 @@ public class BallotTest
     @Test
     public void shouldAcceptRequestWithIdenticalLog()
     {
-        assertTrue( Ballot.shouldVoteFor(
+        assertTrue( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,
@@ -54,7 +56,7 @@ public class BallotTest
     @Test
     public void shouldRejectRequestFromOldTerm()
     {
-        assertFalse( Ballot.shouldVoteFor(
+        assertFalse( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm - 1,
@@ -69,7 +71,7 @@ public class BallotTest
     @Test
     public void shouldRejectRequestIfCandidateLogEndsAtLowerTerm()
     {
-        assertFalse( Ballot.shouldVoteFor(
+        assertFalse( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,
@@ -84,7 +86,7 @@ public class BallotTest
     @Test
     public void shouldRejectRequestIfLogsEndInSameTermButCandidateLogIsShorter()
     {
-        assertFalse( Ballot.shouldVoteFor(
+        assertFalse( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,
@@ -99,7 +101,7 @@ public class BallotTest
     @Test
     public void shouldAcceptRequestIfLogsEndInSameTermAndCandidateLogIsSameLength()
     {
-        assertTrue( Ballot.shouldVoteFor(
+        assertTrue( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,
@@ -114,7 +116,7 @@ public class BallotTest
     @Test
     public void shouldAcceptRequestIfLogsEndInSameTermAndCandidateLogIsLonger()
     {
-        assertTrue( Ballot.shouldVoteFor(
+        assertTrue( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,
@@ -129,7 +131,7 @@ public class BallotTest
     @Test
     public void shouldAcceptRequestIfLogsEndInHigherTermAndCandidateLogIsShorter()
     {
-        assertTrue( Ballot.shouldVoteFor(
+        assertTrue( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,
@@ -144,7 +146,7 @@ public class BallotTest
     @Test
     public void shouldAcceptRequestIfLogEndsAtHigherTermAndCandidateLogIsSameLength()
     {
-        assertTrue( Ballot.shouldVoteFor(
+        assertTrue( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,
@@ -159,7 +161,7 @@ public class BallotTest
     @Test
     public void shouldAcceptRequestIfLogEndsAtHigherTermAndCandidateLogIsLonger()
     {
-        assertTrue( Ballot.shouldVoteFor(
+        assertTrue( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,
@@ -174,7 +176,7 @@ public class BallotTest
     @Test
     public void shouldRejectRequestIfAlreadyVotedForOtherCandidate()
     {
-        assertFalse( Ballot.shouldVoteFor(
+        assertFalse( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,
@@ -189,7 +191,7 @@ public class BallotTest
     @Test
     public void shouldAcceptRequestIfAlreadyVotedForCandidate()
     {
-        assertTrue( Ballot.shouldVoteFor(
+        assertTrue( Voting.shouldVoteFor(
                 candidate,
                 currentTerm,
                 currentTerm,

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/AppendEntriesRequestTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/AppendEntriesRequestTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.neo4j.coreedge.raft.RaftMessages.AppendEntries.Response;
+import org.neo4j.coreedge.raft.ReplicatedString;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.BatchAppendLogEntries;
+import org.neo4j.coreedge.raft.outcome.CommitCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.outcome.TruncateLogCommand;
+import org.neo4j.coreedge.raft.state.RaftState;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.coreedge.raft.MessageUtils.messageFor;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesRequest;
+import static org.neo4j.coreedge.raft.roles.AppendEntriesRequestTest.ContentGenerator.content;
+import static org.neo4j.coreedge.raft.state.RaftStateBuilder.raftState;
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+
+@RunWith(Parameterized.class)
+public class AppendEntriesRequestTest
+{
+    @Parameterized.Parameters(name = "{0} with leader {1} terms ahead.")
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList( new Object[][]{
+                {Role.FOLLOWER, 0}, {Role.FOLLOWER, 1}, {Role.LEADER, 1}, {Role.CANDIDATE, 1}
+        } );
+    }
+
+    @Parameterized.Parameter(value = 0)
+    public Role role;
+
+    @Parameterized.Parameter(value = 1)
+    public int leaderTermDifference;
+
+    private RaftTestMember myself = member( 0 );
+    private RaftTestMember leader = member( 1 );
+
+    @Test
+    public void shouldAcceptInitialEntry() throws Exception
+    {
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        RaftLogEntry logEntry = new RaftLogEntry( leaderTerm, content() );
+
+        // when
+        Outcome<RaftTestMember> outcome = role.handler.handle( appendEntriesRequest()
+                .from( leader )
+                .leaderTerm( leaderTerm )
+                .prevLogIndex( -1 )
+                .prevLogTerm( -1 )
+                .logEntry( logEntry )
+                .build(), state, log() );
+
+        // then
+        assertTrue( ((Response) messageFor( outcome, leader )).success() );
+        assertThat( outcome.getLogCommands(), hasItem( new BatchAppendLogEntries( 0, 0, new RaftLogEntry[]{ logEntry } ) ) );
+    }
+
+    @Test
+    public void shouldAcceptInitialEntries() throws Exception
+    {
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        RaftLogEntry logEntry1 = new RaftLogEntry( leaderTerm, content() );
+        RaftLogEntry logEntry2 = new RaftLogEntry( leaderTerm, content() );
+
+        // when
+        Outcome<RaftTestMember> outcome = role.handler.handle( appendEntriesRequest()
+                .from( leader )
+                .leaderTerm( leaderTerm )
+                .prevLogIndex( -1 )
+                .prevLogTerm( -1 )
+                .logEntry( logEntry1 )
+                .logEntry( logEntry2 )
+                .build(), state, log() );
+
+        // then
+        assertTrue( ((Response) messageFor( outcome, leader )).success() );
+        assertThat( outcome.getLogCommands(), hasItem( new BatchAppendLogEntries( 0, 0,
+                new RaftLogEntry[]{logEntry1, logEntry2} ) ) );
+    }
+
+    @Test
+    public void shouldRejectDiscontinuousEntries() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+
+        // when
+        Outcome<RaftTestMember> outcome = role.handler.handle( appendEntriesRequest()
+                .from( leader )
+                .leaderTerm( leaderTerm )
+                .prevLogIndex( state.entryLog().appendIndex() + 1 )
+                .prevLogTerm( leaderTerm )
+                .logEntry( new RaftLogEntry( leaderTerm, content() ) )
+                .build(), state, log() );
+
+        // then
+        Response response = (Response) messageFor( outcome, leader );
+        assertEquals( state.entryLog().appendIndex(), response.appendIndex() );
+        assertFalse( response.success() );
+    }
+
+    @Test
+    public void shouldAcceptContinuousEntries() throws Exception
+    {
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .entryLog( raftLog )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        raftLog.append( new RaftLogEntry( leaderTerm, content() ) );
+
+        // when
+        Outcome<RaftTestMember> outcome = role.handler.handle( appendEntriesRequest()
+                .from( leader )
+                .leaderTerm( leaderTerm )
+                .prevLogIndex( raftLog.appendIndex() )
+                .prevLogTerm( leaderTerm )
+                .logEntry( new RaftLogEntry( leaderTerm, content() ) )
+                .build(), state, log() );
+
+        // then
+        assertTrue( ((Response) messageFor( outcome, leader )).success() );
+    }
+
+    @Test
+    public void shouldTruncateOnReceiptOfConflictingEntry() throws Exception
+    {
+        // given
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .term( 5 )
+                .entryLog( raftLog )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        raftLog.append( new RaftLogEntry( state.term() - 1, content() ) );
+
+        // when
+        Outcome<RaftTestMember> outcome = role.handler.handle( appendEntriesRequest()
+                .from( leader )
+                .leaderTerm( leaderTerm )
+                .prevLogIndex( raftLog.appendIndex() - 1 )
+                .prevLogTerm( -1 )
+                .logEntry( new RaftLogEntry( leaderTerm, content() ) )
+                .build(), state, log() );
+
+        // then
+        assertTrue( ((Response) messageFor( outcome, leader )).success() );
+        assertThat( outcome.getLogCommands(), hasItem( new TruncateLogCommand( 0 ) ) );
+    }
+
+    @Test
+    public void shouldCommitEntry() throws Exception
+    {
+        // given
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        RaftState<RaftTestMember> state = raftState()
+                .entryLog( raftLog )
+                .myself( myself )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        raftLog.append( new RaftLogEntry( leaderTerm, content() ) );
+
+        // when
+        Outcome<RaftTestMember> outcome = role.handler.handle( appendEntriesRequest()
+                .from( leader )
+                .leaderTerm( leaderTerm )
+                .prevLogIndex( raftLog.appendIndex() )
+                .prevLogTerm( leaderTerm )
+                .leaderCommit( 0 )
+                .build(), state, log() );
+
+        // then
+        assertTrue( ((Response) messageFor( outcome, leader )).success() );
+        assertThat( outcome.getLogCommands(), hasItem( new CommitCommand( 0 ) ) );
+    }
+
+    @Test
+    public void shouldAppendNewEntryAndCommitPreviouslyAppendedEntry() throws Exception
+    {
+        // given
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        RaftState<RaftTestMember> state = raftState()
+                .entryLog( raftLog )
+                .myself( myself )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        RaftLogEntry previouslyAppendedEntry = new RaftLogEntry( leaderTerm, content() );
+        raftLog.append( previouslyAppendedEntry );
+        RaftLogEntry newLogEntry = new RaftLogEntry( leaderTerm, content() );
+
+        // when
+        Outcome<RaftTestMember> outcome = role.handler.handle( appendEntriesRequest()
+                .from( leader )
+                .leaderTerm( leaderTerm )
+                .prevLogIndex( raftLog.appendIndex() )
+                .prevLogTerm( leaderTerm )
+                .logEntry( newLogEntry )
+                .leaderCommit( 0 )
+                .build(), state, log() );
+
+        // then
+        assertTrue( ((Response) messageFor( outcome, leader )).success() );
+        assertThat( outcome.getLogCommands(), hasItem( new CommitCommand( 0 ) ) );
+        assertThat( outcome.getLogCommands(), hasItem( new BatchAppendLogEntries( 1, 0,
+                new RaftLogEntry[]{ newLogEntry } ) ) );
+    }
+
+    @Test
+    public void shouldNotCommitAheadOfMatchingHistory() throws Exception
+    {
+        // given
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        RaftState<RaftTestMember> state = raftState()
+                .entryLog( raftLog )
+                .myself( myself )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        RaftLogEntry previouslyAppendedEntry = new RaftLogEntry( leaderTerm, content() );
+        raftLog.append( previouslyAppendedEntry );
+
+        // when
+        Outcome<RaftTestMember> outcome = role.handler.handle( appendEntriesRequest()
+                .from( leader )
+                .leaderTerm( leaderTerm )
+                .prevLogIndex( raftLog.appendIndex() + 1 )
+                .prevLogTerm( leaderTerm )
+                .leaderCommit( 0 )
+                .build(), state, log() );
+
+
+        // then
+        assertFalse( ((Response) messageFor( outcome, leader )).success() );
+        assertThat( outcome.getLogCommands(), empty() );
+    }
+
+    public RaftState<RaftTestMember> newState() throws RaftStorageException
+    {
+        return raftState().myself( myself ).build();
+    }
+
+    private Log log()
+    {
+        return NullLogProvider.getInstance().getLog( getClass() );
+    }
+
+    static class ContentGenerator
+    {
+        private static int count = 0;
+
+        public static ReplicatedString content()
+        {
+            return new ReplicatedString( String.format( "content#%d", count++ ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/FollowerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/FollowerTest.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.coreedge.raft.roles;
 
-import java.util.Iterator;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -29,43 +27,27 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.neo4j.coreedge.raft.RaftMessages;
 import org.neo4j.coreedge.raft.RaftMessages.Message;
 import org.neo4j.coreedge.raft.RaftMessages.Timeout.Election;
-import org.neo4j.coreedge.raft.RaftMessages.Vote;
 import org.neo4j.coreedge.raft.ReplicatedString;
-import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
-import org.neo4j.coreedge.raft.log.RaftLog;
 import org.neo4j.coreedge.raft.log.RaftLogEntry;
 import org.neo4j.coreedge.raft.log.RaftStorageException;
 import org.neo4j.coreedge.raft.net.Inbound;
-import org.neo4j.coreedge.raft.outcome.CommitCommand;
-import org.neo4j.coreedge.raft.outcome.LogCommand;
 import org.neo4j.coreedge.raft.outcome.Outcome;
-import org.neo4j.coreedge.raft.replication.ReplicatedContent;
 import org.neo4j.coreedge.raft.state.RaftState;
 import org.neo4j.coreedge.server.RaftTestMember;
 import org.neo4j.logging.Log;
-import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import static org.neo4j.coreedge.raft.MessageUtils.messageFor;
 import static org.neo4j.coreedge.raft.RaftMessages.AppendEntries;
 import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesRequest;
-import static org.neo4j.coreedge.raft.TestMessageBuilders.appendEntriesResponse;
-import static org.neo4j.coreedge.raft.TestMessageBuilders.heartbeat;
-import static org.neo4j.coreedge.raft.TestMessageBuilders.voteRequest;
 import static org.neo4j.coreedge.raft.roles.Role.CANDIDATE;
-import static org.neo4j.coreedge.raft.roles.Role.FOLLOWER;
 import static org.neo4j.coreedge.raft.state.RaftStateBuilder.raftState;
 import static org.neo4j.coreedge.server.RaftTestMember.member;
-import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 
 
@@ -77,77 +59,9 @@ public class FollowerTest
     /* A few members that we use at will in tests. */
     private RaftTestMember member1 = member( 1 );
     private RaftTestMember member2 = member( 2 );
-    private RaftTestMember leader = member( 3 );
 
     @Mock
     private Inbound inbound;
-
-    private LogProvider logProvider = NullLogProvider.getInstance();
-
-    private static final int HIGHEST_TERM = 99;
-
-    @Test
-    public void followerShouldUpdateTermToCurrentMessage() throws Exception
-    {
-        // Given
-        RaftState<RaftTestMember> state = raftState().build();
-
-
-        Follower follower = new Follower();
-
-        // When
-        Outcome<RaftTestMember> outcome = follower.handle( voteRequest().from( member1 ).term( HIGHEST_TERM )
-                .lastLogIndex( 0 ).lastLogTerm( -1 )
-                .build(), state, log() );
-
-        // Then
-        assertEquals( HIGHEST_TERM, outcome.getTerm() );
-    }
-
-    @Test
-    public void shouldVoteOnceOnlyPerTerm() throws Exception
-    {
-        // given
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .votingMembers( asSet( myself, member1, member2 ) )
-                .build();
-
-        Follower follower = new Follower();
-
-        // when
-        Outcome<RaftTestMember> outcome1 = follower.handle( voteRequest().from( member1 ).term( 1 ).build(), state,
-                log() );
-        state.update( outcome1 );
-        Outcome<RaftTestMember> outcome2 = follower.handle( voteRequest().from( member2 ).term( 1 ).build(), state,
-                log() );
-
-        // then
-        assertEquals( new Vote.Response<>( myself, 1, true ), messageFor( outcome1, member1 ) );
-        assertEquals( new Vote.Response<>( myself, 1, false ), messageFor( outcome2,  member2 ) );
-
-    }
-
-    @Test
-    public void followersShouldRejectAnyMessageWithOldTermAndStayAFollower() throws Exception
-    {
-        // given
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .votingMembers( asSet( myself, member1, member2 ) )
-
-                .build();
-
-        Follower follower = new Follower();
-
-        // when
-        Outcome<RaftTestMember> outcome = follower.handle( voteRequest().from( member1 ).term( state.term() - 1 )
-                .lastLogIndex( 0 ).lastLogTerm( -1 ).build(), state, log() );
-
-        // then
-        assertEquals( new Vote.Response<>( myself, state.term(), false ), messageFor( outcome, member1 ) );
-        assertEquals( FOLLOWER, outcome.getNewRole() );
-    }
 
     @Test
     public void followerShouldTransitToCandidateAndInstigateAnElectionAfterTimeout() throws Exception
@@ -173,33 +87,6 @@ public class FollowerTest
     }
 
     @Test
-    public void followerShouldVoteForOnlyOneCandidatePerElection() throws Exception
-    {
-        // given
-        RaftState<RaftTestMember> state = raftState().build();
-
-        Follower follower = new Follower();
-
-        // when
-        final long startingTerm = state.term() + 1;
-
-        Outcome<RaftTestMember> outcome1 = follower.handle( voteRequest().from( member1 ).term( startingTerm )
-                .lastLogIndex( 0 )
-                .lastLogTerm( -1 ).build(), state, log() );
-
-        // This updates state.term() as a side-effect
-        state.update( outcome1 );
-
-        Outcome<RaftTestMember> outcome2 = follower.handle( voteRequest().from( member2 ).term( state.term() )
-                .lastLogIndex( 0 )
-                .lastLogTerm( -1 ).build(), state, log() );
-
-        // then
-        assertThat( messageFor( outcome1,  member1 ), instanceOf( Vote.Response.class ) );
-        assertFalse( ((Vote.Response) messageFor( outcome2, member2 )).voteGranted() );
-    }
-
-    @Test
     public void shouldBecomeCandidateOnReceivingElectionTimeoutMessage() throws Exception
     {
         // given
@@ -217,117 +104,6 @@ public class FollowerTest
         assertEquals( CANDIDATE, outcome.getNewRole() );
     }
 
-    @Test
-    public void followerShouldRejectEntriesForWhichItDoesNotHavePrecedentInItsLog() throws Exception
-    {
-        // given
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .votingMembers( asSet( myself, member1, member2 ) )
-                .build();
-
-        Follower follower = new Follower();
-
-        // when
-        Outcome<RaftTestMember> outcome = follower.handle( new RaftMessages.AppendEntries.Request<>( myself, 99,
-                99, 0, new RaftLogEntry[] { new RaftLogEntry( 99, ContentGenerator.content() ) }, 99 ), state, log() );
-
-        // then
-        Message<RaftTestMember> response = messageFor( outcome,  myself );
-        assertThat( response, instanceOf( AppendEntries.Response.class ) );
-        assertFalse( ((AppendEntries.Response) response).success() );
-    }
-
-    @Test
-    public void followerShouldAcceptEntriesForWhichItHasPrecedentInItsLog() throws Exception
-    {
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .build();
-
-        Follower follower = new Follower();
-
-        state.update( follower.handle( new RaftMessages.AppendEntries.Request<>( myself, 0, -1, -1,
-                new RaftLogEntry[] { new RaftLogEntry( 0, ContentGenerator.content() ) }, 0 ), state, log() ) );
-
-        // when
-        Outcome<RaftTestMember> outcome = follower.handle( new RaftMessages.AppendEntries.Request<>( myself, 0,
-                0, 0, new RaftLogEntry[] { new RaftLogEntry( 0, ContentGenerator.content() ) }, 1 ), state, log() );
-
-        state.update( outcome );
-
-        // then
-        Message<RaftTestMember> response = messageFor( outcome, myself );
-        assertThat( response, instanceOf( AppendEntries.Response.class ) );
-        assertTrue( ((AppendEntries.Response) response).success() );
-    }
-
-    @Test
-    public void followerShouldOverwriteSomeAppendedEntriesOnReceiptOfConflictingCommittedEntries() throws Exception
-    {
-        // given
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .build();
-
-        Follower follower = new Follower();
-
-        appendSomeEntriesToLog( state, follower, 9, 0 );
-
-        // when
-        Outcome<RaftTestMember> outcome = follower.handle( new AppendEntries.Request<>( myself, 1, -1, -1,
-                new RaftLogEntry[] { new RaftLogEntry( 1, new ReplicatedString( "commit this!" ) ) }, 0 ), state, log() );
-        state.update( outcome );
-
-        // then
-        assertEquals( 0, state.entryLog().commitIndex() );
-    }
-
-    @Test
-    public void followerWithEmptyLogShouldCommitEntriesWithHigherTerm() throws Exception
-    {
-        // given
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .build();
-
-        Follower follower = new Follower();
-
-        // when
-        Outcome<RaftTestMember> outcome = follower.handle( new AppendEntries.Request<>( myself, 1, -1, -1,
-                new RaftLogEntry[] { new RaftLogEntry( 1, new ReplicatedString( "commit this!" ) ) }, 0 ), state, log() );
-        state.update( outcome );
-
-        // then
-        assertEquals( 0, state.entryLog().commitIndex() );
-        assertEquals( 1, state.term() );
-    }
-
-    @Test
-    public void followerWithNonEmptyLogShouldOverwriteAppendedEntriesOnReceiptOfCommittedEntryWithHigherTerm()
-            throws Exception
-    {
-        // given
-        int term = 1;
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .term( term )
-                .build();
-
-        Follower follower = new Follower();
-
-        appendSomeEntriesToLog( state, follower, 9, term );
-
-        // when leader says it agrees with some of the existing log
-        Outcome<RaftTestMember> outcome = follower.handle( new AppendEntries.Request<>( member1, 2, 3, 1,
-                new RaftLogEntry[] { new RaftLogEntry( 2, new ReplicatedString( "commit this!" ) ) }, 4 ), state, log() );
-        state.update( outcome );
-
-        // then
-        assertEquals( 4, state.entryLog().commitIndex() );
-        assertEquals( 2, state.term() );
-    }
-    
     @Test
     public void followerReceivingHeartbeatIndicatingClusterIsAheadShouldElicitAppendResponse() throws Exception
     {
@@ -359,118 +135,6 @@ public class FollowerTest
     }
 
     @Test
-    public void heartbeatShouldNotResultInCommitIfReferringToFutureEntries() throws Exception
-    {
-        int term = 1;
-        int followerAppendIndex = 9;
-
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .term( term )
-                .build();
-
-
-        Follower follower = new Follower();
-        appendSomeEntriesToLog( state, follower, followerAppendIndex, term );
-
-        RaftMessages.Heartbeat<RaftTestMember> heartbeat = heartbeat().from( member1 )
-                .commitIndex( followerAppendIndex + 2 ) // The leader is talking about committing stuff we don't know about
-                .commitIndexTerm( term ) // And is in the same term
-                .leaderTerm( term + 2 )
-                .build();
-
-        Outcome<RaftTestMember> outcome = follower.handle( heartbeat, state, log() );
-
-        // Then there should be no actions taken against the log
-        assertFalse( outcome.getLogCommands().iterator().hasNext() );
-    }
-
-    @Test
-    public void heartbeatShouldNotResultInCommitIfHistoryMismatches() throws Exception
-    {
-        int term = 1;
-        int followerAppendIndex = 9;
-
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .term( term )
-                .build();
-
-
-        Follower follower = new Follower();
-        appendSomeEntriesToLog( state, follower, followerAppendIndex, term );
-
-        RaftMessages.Heartbeat<RaftTestMember> heartbeat = heartbeat().from( member1 )
-                .commitIndex( followerAppendIndex ) // The leader suggests that we commit stuff we have appended
-                .commitIndexTerm( term + 2 ) // but in a different term
-                .leaderTerm( term + 2 ) // And is in a term that is further in the future
-                .build();
-
-        Outcome<RaftTestMember> outcome = follower.handle( heartbeat, state, log() );
-
-        assertFalse( outcome.getLogCommands().iterator().hasNext() );
-    }
-
-    @Test
-    public void historyShouldResultInCommitIfHistoryMatches() throws Exception
-    {
-        int term = 1;
-        int followerAppendIndex = 9;
-
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .term( term )
-                .build();
-
-        Follower follower = new Follower();
-        appendSomeEntriesToLog( state, follower, followerAppendIndex, term );
-
-        RaftMessages.Heartbeat<RaftTestMember> heartbeat = heartbeat().from( member1 )
-                .commitIndex( followerAppendIndex - 1) // The leader suggests that we commit stuff we have appended
-                .commitIndexTerm( term ) // in the same term
-                .leaderTerm( term + 2 ) // with the leader in the future
-                .build();
-
-        Outcome<RaftTestMember> outcome = follower.handle( heartbeat, state, log() );
-
-        Iterator<LogCommand> iterator = outcome.getLogCommands().iterator();
-        assertTrue( iterator.hasNext() );
-        LogCommand logCommand = iterator.next();
-        assertFalse( iterator.hasNext() );
-        assertThat( logCommand, instanceOf( CommitCommand.class ) );
-        CommitCommand commit = (CommitCommand) logCommand;
-        CapturingRaftLog capture = new CapturingRaftLog();
-        commit.applyTo( capture );
-        assertEquals( followerAppendIndex - 1, capture.commitIndex() );
-    }
-
-    @Test
-    public void shouldAppendMultipleEntries() throws Exception
-    {
-        // given
-        int term = 1;
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .term( term )
-                .build();
-
-        Follower follower = new Follower();
-
-        RaftLogEntry[] entries = {
-                new RaftLogEntry( 1, new ReplicatedString( "commit this!" ) ),
-                new RaftLogEntry( 1, new ReplicatedString( "commit this as well!" ) ),
-                new RaftLogEntry( 1, new ReplicatedString( "commit this too!" ) )
-        };
-
-        Outcome<RaftTestMember> outcome = follower.handle(
-                new AppendEntries.Request<>( member1, 1, -1, -1, entries, -1 ), state, log() );
-        state.update( outcome );
-
-        // then
-        assertEquals( 2, state.entryLog().appendIndex() );
-    }
-
-    @Test
     public void shouldTruncateIfTermDoesNotMatch() throws Exception
     {
         // given
@@ -483,7 +147,7 @@ public class FollowerTest
         Follower follower = new Follower();
 
         state.update( follower.handle( new AppendEntries.Request<>( member1, 1, -1, -1,
-                new RaftLogEntry[] {
+                new RaftLogEntry[]{
                         new RaftLogEntry( 2, ContentGenerator.content() ),
                 },
                 -1 ), state, log() ) );
@@ -560,71 +224,6 @@ public class FollowerTest
         assertFalse( outcome.electionTimeoutRenewed() );
     }
 
-    @Test
-    public void shouldNotCommitAheadOfMatchingHistory() throws Exception
-    {
-        // given
-        int LEADER_COMMIT = 10;
-        int LEADER1_TERM = 1;
-        int LEADER2_TERM = 2;
-
-        InMemoryRaftLog raftLog = new InMemoryRaftLog();
-
-        raftLog.append( new RaftLogEntry( LEADER1_TERM, ReplicatedString.valueOf( "gryffindor" ) ) ); // (0) we committed this far already
-        raftLog.commit( 0 );
-        raftLog.append( new RaftLogEntry( LEADER1_TERM, ReplicatedString.valueOf( "hufflepuff" ) ) ); // (1) we should only commit up to this, because this is how far we match
-        raftLog.append( new RaftLogEntry( LEADER1_TERM, ReplicatedString.valueOf( "ravenclaw" ) ) ); // (2) leader will have committed including this and more
-
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .entryLog( raftLog )
-                .term( 1 )
-                .build();
-
-        Follower follower = new Follower();
-        Outcome<RaftTestMember> outcome;
-
-        // when - append request matching history and truncating
-        RaftLogEntry[] newEntries = {
-                new RaftLogEntry( LEADER2_TERM, new ReplicatedString( "slytherin" ) ), // (1 - overwrite and truncate)
-        };
-
-        outcome = follower.handle( new RaftMessages.AppendEntries.Request<>( myself, LEADER2_TERM, 0, LEADER1_TERM, newEntries, LEADER_COMMIT ), state, log() );
-
-        // then
-        assertThat( outcome.getLogCommands(), hasItem( new CommitCommand( 1 ) ) );
-    }
-
-    @Test
-    public void shouldIncludeLatestAppendedInResponse() throws Exception
-    {
-        // given: just a single appended entry at follower
-        RaftLogEntry entryA = new RaftLogEntry( 1, ReplicatedString.valueOf( "b" ) );
-
-        InMemoryRaftLog raftLog = new InMemoryRaftLog();
-        raftLog.append( entryA );
-
-        RaftState<RaftTestMember> state = raftState()
-                .myself( myself )
-                .entryLog( raftLog )
-                .term( 1 )
-                .build();
-
-        Follower follower = new Follower();
-
-        RaftLogEntry entryB = new RaftLogEntry( 1, ReplicatedString.valueOf( "b" ) );
-
-        // when: append request for item way forward (index=10, term=2)
-        Outcome<RaftTestMember> outcome = follower.handle(
-                new RaftMessages.AppendEntries.Request<>( leader, 2, 10, 2,
-                        new RaftLogEntry[]{entryB}, 10 ), state, log() );
-
-        // then: respond with false and how far ahead we are
-        assertThat( single( outcome.getOutgoingMessages()).message(), equalTo(
-                appendEntriesResponse().from( myself ).term( 2 ).appendIndex( 0 ).matchIndex( -1 ).failure()
-                        .build() ) );
-    }
-
     private void appendSomeEntriesToLog( RaftState<RaftTestMember> raft, Follower follower, int numberOfEntriesToAppend, int
             term ) throws RaftStorageException
     {
@@ -655,78 +254,6 @@ public class FollowerTest
 
     private Log log()
     {
-        return logProvider.getLog( getClass() );
-    }
-
-    private static final class CapturingRaftLog implements RaftLog
-    {
-
-        private long commitIndex;
-
-        @Override
-        public void replay() throws Throwable
-        {
-
-        }
-
-        @Override
-        public void registerListener( Listener consumer )
-        {
-
-        }
-
-        @Override
-        public long append( RaftLogEntry entry ) throws RaftStorageException
-        {
-            return 0;
-        }
-
-        @Override
-        public void truncate( long fromIndex ) throws RaftStorageException
-        {
-
-        }
-
-        @Override
-        public void commit( long commitIndex ) throws RaftStorageException
-        {
-            this.commitIndex = commitIndex;
-        }
-
-        @Override
-        public long appendIndex()
-        {
-            return 0;
-        }
-
-        @Override
-        public long commitIndex()
-        {
-            return commitIndex;
-        }
-
-        @Override
-        public RaftLogEntry readLogEntry( long logIndex ) throws RaftStorageException
-        {
-            return null;
-        }
-
-        @Override
-        public ReplicatedContent readEntryContent( long logIndex ) throws RaftStorageException
-        {
-            return null;
-        }
-
-        @Override
-        public long readEntryTerm( long logIndex ) throws RaftStorageException
-        {
-            return 0;
-        }
-
-        @Override
-        public boolean entryExists( long logIndex )
-        {
-            return false;
-        }
+        return NullLogProvider.getInstance().getLog( getClass() );
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/HeartbeatTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/HeartbeatTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.outcome.CommitCommand;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.RaftState;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.coreedge.raft.TestMessageBuilders.heartbeat;
+import static org.neo4j.coreedge.raft.roles.AppendEntriesRequestTest.ContentGenerator.content;
+import static org.neo4j.coreedge.raft.state.RaftStateBuilder.raftState;
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+
+@RunWith(Parameterized.class)
+public class HeartbeatTest
+{
+    @Parameterized.Parameters(name = "{0} with leader {1} terms ahead.")
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList( new Object[][]{
+                {Role.FOLLOWER, 0}, {Role.FOLLOWER, 1}, {Role.LEADER, 1}, {Role.CANDIDATE, 1}
+        } );
+    }
+
+    @Parameterized.Parameter(value = 0)
+    public Role role;
+
+    @Parameterized.Parameter(value = 1)
+    public int leaderTermDifference;
+
+    private RaftTestMember myself = member( 0 );
+    private RaftTestMember leader = member( 1 );
+
+    @Test
+    public void shouldNotResultInCommitIfReferringToFutureEntries() throws Exception
+    {
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .entryLog( raftLog )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        raftLog.append( new RaftLogEntry( leaderTerm, content() ) );
+
+        RaftMessages.Heartbeat<RaftTestMember> heartbeat = heartbeat()
+                .from( leader )
+                .commitIndex( raftLog.appendIndex() + 1) // The leader is talking about committing stuff we don't know about
+                .commitIndexTerm( leaderTerm ) // And is in the same term
+                .leaderTerm( leaderTerm )
+                .build();
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( heartbeat, state, log() );
+
+        assertThat( outcome.getLogCommands(), empty());
+    }
+
+    @Test
+    public void shouldNotResultInCommitIfHistoryMismatches() throws Exception
+    {
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .entryLog( raftLog )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        raftLog.append( new RaftLogEntry( leaderTerm, content() ) );
+
+        RaftMessages.Heartbeat<RaftTestMember> heartbeat = heartbeat()
+                .from( leader )
+                .commitIndex( raftLog.appendIndex()) // The leader is talking about committing stuff we don't know about
+                .commitIndexTerm( leaderTerm ) // And is in the same term
+                .leaderTerm( leaderTerm )
+                .build();
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( heartbeat, state, log() );
+
+        assertThat( outcome.getLogCommands(), hasItem(new CommitCommand( 0 )) );
+    }
+
+    @Test
+    public void shouldResultInCommitIfHistoryMatches() throws Exception
+    {
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        RaftState<RaftTestMember> state = raftState()
+                .myself( myself )
+                .entryLog( raftLog )
+                .build();
+
+        long leaderTerm = state.term() + leaderTermDifference;
+        raftLog.append( new RaftLogEntry( leaderTerm - 1, content() ) );
+
+        RaftMessages.Heartbeat<RaftTestMember> heartbeat = heartbeat()
+                .from( leader )
+                .commitIndex( raftLog.appendIndex()) // The leader is talking about committing stuff we don't know about
+                .commitIndexTerm( leaderTerm ) // And is in the same term
+                .leaderTerm( leaderTerm )
+                .build();
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( heartbeat, state, log() );
+
+        assertThat( outcome.getLogCommands(), empty() );
+
+    }
+
+    private Log log()
+    {
+        return NullLogProvider.getInstance().getLog( getClass() );
+    }
+
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/NonFollowerVoteRequestTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/NonFollowerVoteRequestTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.RaftState;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static java.util.Arrays.asList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import static org.neo4j.coreedge.raft.MessageUtils.messageFor;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.voteRequest;
+import static org.neo4j.coreedge.raft.state.RaftStateBuilder.raftState;
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+
+@RunWith(Parameterized.class)
+public class NonFollowerVoteRequestTest
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection data() {
+        return asList( Role.CANDIDATE, Role.LEADER );
+    }
+
+    @Parameterized.Parameter
+    public Role role;
+
+    private RaftTestMember myself = member( 0 );
+    private RaftTestMember member1 = member( 1 );
+
+    @Test
+    public void shouldRejectVoteRequestFromCurrentTerm() throws Exception
+    {
+        RaftState<RaftTestMember> state = newState();
+
+        // when
+        final long candidateTerm = state.term();
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( voteRequest().from( member1 ).term( candidateTerm )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertFalse( ((RaftMessages.Vote.Response) messageFor( outcome, member1 )).voteGranted() );
+        assertEquals( role, outcome.getNewRole() );
+    }
+
+    @Test
+    public void shouldRejectVoteRequestFromPreviousTerm() throws Exception
+    {
+        RaftState<RaftTestMember> state = newState();
+
+        // when
+        final long candidateTerm = state.term() - 1;
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( voteRequest().from( member1 ).term( candidateTerm )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertFalse( ((RaftMessages.Vote.Response) messageFor( outcome, member1 )).voteGranted() );
+        assertEquals( role, outcome.getNewRole() );
+    }
+
+    public RaftState<RaftTestMember> newState() throws RaftStorageException
+    {
+        return raftState().myself( myself ).build();
+    }
+
+    private Log log()
+    {
+        return NullLogProvider.getInstance().getLog( getClass() );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/VoteRequestTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/VoteRequestTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.roles;
+
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftStorageException;
+import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.state.RaftState;
+import org.neo4j.coreedge.server.RaftTestMember;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static java.util.Arrays.asList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.coreedge.raft.MessageUtils.messageFor;
+import static org.neo4j.coreedge.raft.TestMessageBuilders.voteRequest;
+import static org.neo4j.coreedge.raft.state.RaftStateBuilder.raftState;
+import static org.neo4j.coreedge.server.RaftTestMember.member;
+
+/**
+ * Most behaviour for handling vote requests is identical for all roles.
+ */
+@RunWith(Parameterized.class)
+public class VoteRequestTest
+{
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection data() {
+        return asList( Role.values() );
+    }
+
+    @Parameterized.Parameter
+    public Role role;
+
+    private RaftTestMember myself = member( 0 );
+    private RaftTestMember member1 = member( 1 );
+    private RaftTestMember member2 = member( 2 );
+
+    @Test
+    public void shouldVoteForCandidateInLaterTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = newState();
+
+        // when
+        final long candidateTerm = state.term() + 1;
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( voteRequest().from( member1 ).term( candidateTerm )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertTrue( ((RaftMessages.Vote.Response) messageFor( outcome, member1 )).voteGranted() );
+    }
+
+    @Test
+    public void shouldDenyForCandidateInPreviousTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = newState();
+
+        // when
+        final long candidateTerm = state.term() - 1;
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( voteRequest().from( member1 ).term( candidateTerm )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertFalse( ((RaftMessages.Vote.Response) messageFor( outcome, member1 )).voteGranted() );
+        assertEquals( role, outcome.getNewRole() );
+    }
+
+    @Test
+    public void shouldVoteForOnlyOneCandidatePerTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = newState();
+
+        // when
+        final long candidateTerm = state.term() + 1;
+
+        Outcome<RaftTestMember> outcome1 = role.handler.handle( voteRequest().from( member1 ).term( candidateTerm )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        state.update( outcome1 );
+
+        Outcome<RaftTestMember> outcome2 = role.handler.handle( voteRequest().from( member2 ).term( candidateTerm )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertFalse( ((RaftMessages.Vote.Response) messageFor( outcome2, member2 )).voteGranted() );
+    }
+
+    @Test
+    public void shouldStayInCurrentRoleOnRequestFromCurrentTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = newState();
+
+        // when
+        final long candidateTerm = state.term();
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( voteRequest().from( member1 ).term( candidateTerm )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertEquals( role, outcome.getNewRole() );
+    }
+
+    @Test
+    public void shouldMoveToFollowerIfRequestIsFromLaterTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = newState();
+
+        // when
+        final long candidateTerm = state.term() + 1;
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( voteRequest().from( member1 ).term( candidateTerm )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertEquals( Role.FOLLOWER, outcome.getNewRole() );
+    }
+
+    @Test
+    public void shouldUpdateTermIfRequestIsFromLaterTerm() throws Exception
+    {
+        // given
+        RaftState<RaftTestMember> state = newState();
+
+        // when
+        final long candidateTerm = state.term() + 1;
+
+        Outcome<RaftTestMember> outcome = role.handler.handle( voteRequest().from( member1 ).term( candidateTerm )
+                .lastLogIndex( 0 )
+                .lastLogTerm( -1 ).build(), state, log() );
+
+        // then
+        assertEquals( candidateTerm, outcome.getTerm() );
+    }
+
+    public RaftState<RaftTestMember> newState() throws RaftStorageException
+    {
+        return raftState().myself( myself ).build();
+    }
+
+    private Log log()
+    {
+        return NullLogProvider.getInstance().getLog( getClass() );
+    }
+
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ClusterSafetyViolations.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ClusterSafetyViolations.java
@@ -91,7 +91,7 @@ public class ClusterSafetyViolations
         Set<Long> termThatHaveALeader = new HashSet<>();
         for ( Map.Entry<RaftTestMember, Role> entry : state.roles.entrySet() )
         {
-            RaftMessageHandler role = entry.getValue().role;
+            RaftMessageHandler role = entry.getValue().handler;
             if ( role instanceof Leader )
             {
                 long term = state.states.get( entry.getKey() ).term();

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/ProcessMessage.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/ProcessMessage.java
@@ -53,7 +53,7 @@ public class ProcessMessage implements Action
         }
         ComparableRaftState memberState = previous.states.get( member );
         ComparableRaftState newMemberState = new ComparableRaftState( memberState );
-        Outcome<RaftTestMember> outcome = previous.roles.get( member ).role.handle( message, memberState, log );
+        Outcome<RaftTestMember> outcome = previous.roles.get( member ).handler.handle( message, memberState, log );
         newMemberState.update( outcome );
 
         for ( RaftMessages.Directed<RaftTestMember> outgoingMessage : outcome.getOutgoingMessages() )


### PR DESCRIPTION
Process RAFT messages directly inside the role handlers, thereby removing
the need to change role, and having to send the message back for later
processing by that role.

The tests have been restructured to reflect the requirement for
some messages to be handled in mostly the same way, regardless of
the current role.
