### PR TITLE
Fix enterprise config migration not working.

### DIFF
--- a/advanced/server-advanced/src/test/java/org/neo4j/server/advanced/jmx/ServerManagementTest.java
+++ b/advanced/server-advanced/src/test/java/org/neo4j/server/advanced/jmx/ServerManagementTest.java
@@ -30,7 +30,7 @@ import org.neo4j.server.NeoServer;
 import org.neo4j.server.advanced.AdvancedNeoServer;
 import org.neo4j.server.advanced.helpers.AdvancedServerBuilder;
 import org.neo4j.server.configuration.Configurator;
-import org.neo4j.server.configuration.ServerConfigFactory;
+import org.neo4j.server.configuration.BaseServerConfigLoader;
 import org.neo4j.test.CleanupRule;
 import org.neo4j.test.TargetDirectory;
 
@@ -52,7 +52,7 @@ public class ServerManagementTest
         String dbDirectory1 = baseDir.directory( "db1" ).getAbsolutePath();
         String dbDirectory2 = baseDir.directory( "db2" ).getAbsolutePath();
 
-        Config config = ServerConfigFactory.loadConfig( null,
+        Config config = new BaseServerConfigLoader().loadConfig( null,
                 AdvancedServerBuilder
                         .server()
                         .withDefaultDatabaseTuning()

--- a/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/Bootstrapper.java
@@ -34,12 +34,12 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.server.configuration.BaseServerConfigLoader;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.logging.JULBridge;
 import org.neo4j.server.logging.JettyLogBridge;
 import org.neo4j.server.logging.Netty4LogBridge;
 import static java.lang.String.format;
-import static org.neo4j.server.configuration.ServerConfigFactory.loadConfig;
 import static org.neo4j.server.web.ServerInternalSettings.SERVER_CONFIG_FILE;
 import static org.neo4j.server.web.ServerInternalSettings.SERVER_CONFIG_FILE_KEY;
 
@@ -195,7 +195,6 @@ public abstract class Bootstrapper
      */
     protected Config createConfig( Log log, File file, Pair<String, String>[] configOverrides ) throws IOException
     {
-        return loadConfig( file, new File( System.getProperty( SERVER_CONFIG_FILE_KEY, SERVER_CONFIG_FILE ) ), log, configOverrides );
+        return new BaseServerConfigLoader().loadConfig( file, new File( System.getProperty( SERVER_CONFIG_FILE_KEY, SERVER_CONFIG_FILE ) ), log, configOverrides );
     }
-
 }

--- a/community/server/src/main/java/org/neo4j/server/configuration/BaseServerConfigLoader.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/BaseServerConfigLoader.java
@@ -45,16 +45,16 @@ import static org.neo4j.server.web.ServerInternalSettings.legacy_db_config;
  * [neo4j-server.properties, neo4j.properties]. But both config files are now consolidated internally - the config
  * from both is combined into one config instance.
  */
-public class ServerConfigFactory
+public class BaseServerConfigLoader
 {
-    public static Config loadConfig( File configFile, File legacyConfigFile, Log log, Pair<String, String> ... configOverrides )
+    public Config loadConfig( File configFile, File legacyConfigFile, Log log, Pair<String, String> ... configOverrides )
     {
         return loadConfig( configFile, legacyConfigFile,
                 new File( legacyConfigFile.getParentFile(), ServerInternalSettings.DB_TUNING_CONFIG_FILE_NAME ),
                 log, configOverrides );
     }
 
-    public static Config loadConfig( File configFile, File legacyConfigFile, File legacyDbTuningDefaultFile, Log log, Pair<String, String> ... configOverrides )
+    public Config loadConfig( File configFile, File legacyConfigFile, File legacyDbTuningDefaultFile, Log log, Pair<String, String> ... configOverrides )
     {
         if ( log == null )
         {
@@ -83,7 +83,7 @@ public class ServerConfigFactory
         return config;
     }
 
-    private static void applyUserOverrides( Config config, Pair<String,String>[] configOverrides )
+    private void applyUserOverrides( Config config, Pair<String,String>[] configOverrides )
     {
         Map<String,String> params = config.getParams();
         for ( Pair<String,String> configOverride : configOverrides )
@@ -114,7 +114,7 @@ public class ServerConfigFactory
         config.applyChanges( params );
     }
 
-    public static Iterable<Class<?>> getDefaultSettingsClasses()
+    protected static Iterable<Class<?>> getDefaultSettingsClasses()
     {
         return asList( ServerSettings.class, ServerInternalSettings.class, GraphDatabaseSettings.class );
     }

--- a/community/server/src/main/java/org/neo4j/server/configuration/ConfigurationBuilder.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ConfigurationBuilder.java
@@ -71,7 +71,7 @@ public interface ConfigurationBuilder
             serverProperties.put( ServerSettings.third_party_packages.name(),
                     toStringForThirdPartyPackageProperty( configurator.getThirdpartyJaxRsPackages() ) );
 
-            this.serverConfig = new Config( serverProperties, ServerConfigFactory.getDefaultSettingsClasses() );
+            this.serverConfig = new Config( serverProperties, BaseServerConfigLoader.getDefaultSettingsClasses() );
             // use the db properties directly
             this.dbProperties = configurator.getDatabaseTuningProperties();
         }

--- a/community/server/src/main/java/org/neo4j/server/configuration/PropertyFileConfigurator.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/PropertyFileConfigurator.java
@@ -53,7 +53,7 @@ public class PropertyFileConfigurator implements ConfigurationBuilder
         loadServerProperties( propertiesFile, log );
         loadDatabaseTuningProperties( propertiesFile, log );
 
-        serverConfig = new Config( serverProperties, ServerConfigFactory.getDefaultSettingsClasses() );
+        serverConfig = new Config( serverProperties, BaseServerConfigLoader.getDefaultSettingsClasses() );
     }
 
     @Override

--- a/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
@@ -20,11 +20,13 @@
 package org.neo4j.server;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.util.ArrayList;
 
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.server.ExclusiveServerTestBase;
@@ -35,7 +37,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.forced_kernel_id;
-import static org.neo4j.helpers.ArrayUtil.array;
 import static org.neo4j.helpers.collection.MapUtil.store;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.server.CommunityBootstrapper.start;
@@ -49,18 +50,52 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
     @Rule
     public TemporaryFolder tempDir = new TemporaryFolder();
 
-    private Bootstrapper bootstrapper;
+    protected Bootstrapper bootstrapper;
+
+    protected String[] baseConfig()
+    {
+        return new String[]{};
+    }
+
+    protected String[] completeCommandLineConfig( String... additional )
+    {
+        ArrayList<String> config = new ArrayList<>();
+
+        for ( String baseConfig : baseConfig() )
+        {
+            config.add( baseConfig );
+        }
+
+        for ( String extra : additional )
+        {
+            config.add( extra );
+        }
+
+        return config.toArray( new String[config.size()] );
+    }
+
+    @Before
+    public void before()
+    {
+        bootstrapper = newBootstrapper();
+    }
+
+    @After
+    public void after()
+    {
+        if ( bootstrapper != null )
+        {
+            bootstrapper.stop();
+        }
+    }
 
     protected abstract Bootstrapper newBootstrapper();
 
     @Test
     public void shouldStartStopNeoServerWithoutAnyConfigFiles()
     {
-        // Given
-        bootstrapper = newBootstrapper();
-
         // When
-        int resultCode = start( bootstrapper, array( "-c", configOption( legacy_db_location.name(), tempDir.getRoot().getAbsolutePath() ) ) );
+        int resultCode = start( bootstrapper, completeCommandLineConfig( "-c", configOption( legacy_db_location.name(), tempDir.getRoot().getAbsolutePath() ) ) );
 
         // Then
         assertEquals( Bootstrapper.OK, resultCode );
@@ -71,7 +106,6 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
     public void canSpecifyConfigFile() throws Throwable
     {
         // Given
-        bootstrapper = newBootstrapper();
         File configFile = tempDir.newFile( "neo4j.config" );
 
         store( stringMap(
@@ -79,7 +113,7 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
         ), configFile );
 
         // When
-        start( bootstrapper, array(
+        start( bootstrapper, completeCommandLineConfig(
                 "-C", configFile.getAbsolutePath(),
                 "-c", configOption( legacy_db_location.name(), tempDir.getRoot().getAbsolutePath() ) ) );
 
@@ -91,7 +125,6 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
     public void canOverrideConfigValues() throws Throwable
     {
         // Given
-        bootstrapper = newBootstrapper();
         File configFile = tempDir.newFile( "neo4j.config" );
 
         store( stringMap(
@@ -99,7 +132,7 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
         ), configFile );
 
         // When
-        start( bootstrapper, array(
+        start( bootstrapper, completeCommandLineConfig(
                 "-C", configFile.getAbsolutePath(),
                 "-c", configOption( forced_kernel_id.name(), "mycustomvalue" ),
                 "-c", configOption( legacy_db_location.name(), tempDir.getRoot().getAbsolutePath() ) ) );
@@ -108,16 +141,7 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
         assertThat( bootstrapper.getServer().getConfig().get( forced_kernel_id ), equalTo( "mycustomvalue" ) );
     }
 
-    @After
-    public void cleanup()
-    {
-        if ( bootstrapper != null )
-        {
-            bootstrapper.stop();
-        }
-    }
-
-    private String configOption( String key, String value )
+    protected String configOption( String key, String value )
     {
         return key + "=" + value;
     }

--- a/community/server/src/test/java/org/neo4j/server/configuration/BaseServerConfigLoaderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/BaseServerConfigLoaderTest.java
@@ -37,9 +37,8 @@ import static org.junit.Assert.assertEquals;
 import static org.neo4j.test.SuppressOutput.suppressAll;
 
 import static org.junit.Assert.assertNotNull;
-import static org.neo4j.server.configuration.ServerConfigFactory.loadConfig;
 
-public class ServerConfigFactoryTest
+public class BaseServerConfigLoaderTest
 {
     @Rule
     public final SuppressOutput suppressOutput = suppressAll();
@@ -47,6 +46,7 @@ public class ServerConfigFactoryTest
     public final TemporaryFolder folder = new TemporaryFolder();
 
     private final Log log = NullLog.getInstance();
+    private final BaseServerConfigLoader configLoader = new BaseServerConfigLoader();
 
     @Test
     public void whenDatabaseTuningFilePresentInDefaultLocationShouldLoadItEvenIfNotSpecified() throws IOException
@@ -59,7 +59,7 @@ public class ServerConfigFactoryTest
                 .build();
 
         // when
-        Config config = loadConfig( null, emptyPropertyFile, log );
+        Config config = configLoader.loadConfig( null, emptyPropertyFile, log );
 
         // then
         assertEquals( "fromdefaultlocation", config.get( GraphDatabaseSettings.forced_kernel_id ) );
@@ -82,7 +82,7 @@ public class ServerConfigFactoryTest
                 .build();
 
         // when
-        Config config = loadConfig( null, emptyPropertyFile, log );
+        Config config = configLoader.loadConfig( null, emptyPropertyFile, log );
 
         // then
         assertEquals( "shouldgetloaded", config.get( GraphDatabaseSettings.forced_kernel_id ) );
@@ -99,7 +99,7 @@ public class ServerConfigFactoryTest
                 .build();
 
         // when
-        Config config = loadConfig( null, propertyFile, log );
+        Config config = configLoader.loadConfig( null, propertyFile, log );
 
         // then
         List<ThirdPartyJaxRsPackage> thirdpartyJaxRsPackages = config.get( ServerSettings.third_party_packages );
@@ -118,7 +118,7 @@ public class ServerConfigFactoryTest
         File nonExistentFilePropertiesFile = new File( "/tmp/" + System.currentTimeMillis() );
 
         // When
-        Config config = loadConfig( null, nonExistentFilePropertiesFile, log );
+        Config config = configLoader.loadConfig( null, nonExistentFilePropertiesFile, log );
 
         // Then
         assertNotNull( config );

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfigWrappingConfigurationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfigWrappingConfigurationTest.java
@@ -38,7 +38,7 @@ public class ConfigWrappingConfigurationTest
     public void shouldGetDefaultPropertyByKey() throws Exception
     {
         // GIVEN
-        Config config = new Config( new HashMap<String,String>(), ServerConfigFactory.getDefaultSettingsClasses() );
+        Config config = new Config( new HashMap<String,String>(), BaseServerConfigLoader.getDefaultSettingsClasses() );
         ConfigWrappingConfiguration wrappingConfiguration = new ConfigWrappingConfiguration( config );
 
         // WHEN
@@ -52,7 +52,7 @@ public class ConfigWrappingConfigurationTest
     public void shouldGetPropertyInRightFormat() throws Exception
     {
         // GIVEN
-        Config config = new Config( new HashMap<String,String>(), ServerConfigFactory.getDefaultSettingsClasses() );
+        Config config = new Config( new HashMap<String,String>(), BaseServerConfigLoader.getDefaultSettingsClasses() );
         ConfigWrappingConfiguration wrappingConfiguration = new ConfigWrappingConfiguration( config );
 
         // WHEN
@@ -69,7 +69,7 @@ public class ConfigWrappingConfigurationTest
     {
         // GIVEN
 
-        Config config = new Config( new HashMap<String,String>(), ServerConfigFactory.getDefaultSettingsClasses() );
+        Config config = new Config( new HashMap<String,String>(), BaseServerConfigLoader.getDefaultSettingsClasses() );
         ConfigWrappingConfiguration wrappingConfiguration = new ConfigWrappingConfiguration( config );
 
         // THEN
@@ -79,7 +79,7 @@ public class ConfigWrappingConfigurationTest
     @Test
     public void shouldAbleToAccessRegisteredPropertyByName()
     {
-        Config config = new Config( new HashMap<String,String>(), ServerConfigFactory.getDefaultSettingsClasses() );
+        Config config = new Config( new HashMap<String,String>(), BaseServerConfigLoader.getDefaultSettingsClasses() );
         ConfigWrappingConfiguration wrappingConfiguration = new ConfigWrappingConfiguration( config );
 
         assertEquals( 60000L, wrappingConfiguration.getProperty( ServerSettings.transaction_timeout.name() ) );

--- a/community/server/src/test/java/org/neo4j/server/configuration/ServerConfigLoaderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ServerConfigLoaderTest.java
@@ -37,14 +37,14 @@ import org.neo4j.server.ServerTestUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.neo4j.server.configuration.ServerConfigFactory.loadConfig;
 
-public class ServerConfigTest
+public class ServerConfigLoaderTest
 {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    public final Log log = NullLog.getInstance();
+    private final Log log = NullLog.getInstance();
+    private final BaseServerConfigLoader configLoader = new BaseServerConfigLoader();
 
     @Test
     public void shouldProvideAConfiguration() throws IOException
@@ -54,7 +54,7 @@ public class ServerConfigTest
                 .build();
 
         // when
-        Config config = loadConfig( null, configFile, log );
+        Config config = configLoader.loadConfig( null, configFile, log );
 
         // then
         assertNotNull( config );
@@ -69,7 +69,7 @@ public class ServerConfigTest
                 .build();
 
         // when
-        Config testConf = loadConfig( null, configFile, log );
+        Config testConf = configLoader.loadConfig( null, configFile, log );
 
         // then
         final String EXPECTED_VALUE = "bar";
@@ -86,7 +86,7 @@ public class ServerConfigTest
                 .build();
 
         // when
-        Config testConf = loadConfig( null, configFile, log );
+        Config testConf = configLoader.loadConfig( null, configFile, log );
 
         // then
         assertNotNull( testConf );
@@ -106,7 +106,7 @@ public class ServerConfigTest
                 .build();
 
         // when
-        Config config = loadConfig( null, propertyFileWithDbTuningProperty, log );
+        Config config = configLoader.loadConfig( null, propertyFileWithDbTuningProperty, log );
 
         // then
         assertNotNull( config );
@@ -130,7 +130,7 @@ public class ServerConfigTest
         }
 
         // when
-        Config config = loadConfig( null, file, log );
+        Config config = configLoader.loadConfig( null, file, log );
 
         // then
         List<ThirdPartyJaxRsPackage> thirdpartyJaxRsPackages = config.get( ServerSettings.third_party_packages );

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -45,7 +45,7 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.ServerTestUtils;
 import org.neo4j.server.configuration.Configurator;
-import org.neo4j.server.configuration.ServerConfigFactory;
+import org.neo4j.server.configuration.BaseServerConfigLoader;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.database.Database;
 import org.neo4j.server.database.LifecycleManagingDatabase;
@@ -124,7 +124,8 @@ public class CommunityServerBuilder
         final File configFile = buildBefore();
 
         Log log = logProvider.getLog( getClass() );
-        Config config = ServerConfigFactory.loadConfig( null, configFile, log );
+        BaseServerConfigLoader configLoader = new BaseServerConfigLoader();
+        Config config = configLoader.loadConfig( null, configFile, log );
         return build( configFile, config, GraphDatabaseDependencies.newDependencies().userLogProvider( logProvider )
                 .monitors( new Monitors() ) );
     }

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
@@ -19,11 +19,19 @@
  */
 package org.neo4j.server.enterprise;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.helpers.Pair;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.NeoServer;
 import org.neo4j.server.advanced.AdvancedBootstrapper;
+
+import static org.neo4j.server.web.ServerInternalSettings.SERVER_CONFIG_FILE;
+import static org.neo4j.server.web.ServerInternalSettings.SERVER_CONFIG_FILE_KEY;
 
 public class EnterpriseBootstrapper extends AdvancedBootstrapper
 {
@@ -41,5 +49,11 @@ public class EnterpriseBootstrapper extends AdvancedBootstrapper
             userLogProvider )
     {
         return new EnterpriseNeoServer( configurator, dependencies, userLogProvider );
+    }
+
+    @Override
+    protected Config createConfig( Log log, File file, Pair<String,String>[] configOverrides ) throws IOException
+    {
+        return new EnterpriseServerConfigLoader().loadConfig( file, new File( System.getProperty( SERVER_CONFIG_FILE_KEY, SERVER_CONFIG_FILE ) ), log, configOverrides );
     }
 }

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerConfigLoader.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerConfigLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.enterprise;
+
+import java.io.File;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.helpers.Pair;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.logging.Log;
+import org.neo4j.server.configuration.BaseServerConfigLoader;
+
+import static java.util.Arrays.asList;
+
+public class EnterpriseServerConfigLoader extends BaseServerConfigLoader
+{
+    @Override
+    public Config loadConfig( File configFile, File legacyConfigFile, Log log, Pair<String,String>... configOverrides )
+    {
+        Config config = super.loadConfig( configFile, legacyConfigFile, log, configOverrides );
+        config.registerSettingsClasses( asList( HaSettings.class, ClusterSettings.class ) );
+        return config;
+    }
+}

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
@@ -19,8 +19,15 @@
  */
 package org.neo4j.server.enterprise;
 
+import org.junit.Test;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.server.BaseBootstrapperTest;
 import org.neo4j.server.Bootstrapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.server.CommunityBootstrapper.start;
 
 public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
 {
@@ -28,5 +35,27 @@ public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
     protected Bootstrapper newBootstrapper()
     {
         return new EnterpriseBootstrapper();
+    }
+
+    @Override
+    protected String[] baseConfig()
+    {
+        return new String[]
+                {
+                        "-c", configOption( ClusterSettings.server_id.name(), "1" ),
+                        "-c", configOption( ClusterSettings.initial_hosts.name(), "127.0.0.1:5001" )
+                };
+    }
+
+    @Test
+    public void shouldMigrateFixedPushStrategy() throws Exception
+    {
+        // When
+        start( bootstrapper, completeCommandLineConfig(
+                "-c", configOption( HaSettings.tx_push_strategy.name(), "fixed" )
+        ));
+
+        // Then
+        assertEquals( HaSettings.TxPushStrategy.fixed_descending, bootstrapper.getServer().getConfig().get( HaSettings.tx_push_strategy ) );
     }
 }

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
@@ -25,7 +25,7 @@ import org.neo4j.desktop.config.Installation;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.FormattedLog;
 import org.neo4j.server.configuration.Configurator;
-import org.neo4j.server.configuration.ServerConfigFactory;
+import org.neo4j.server.configuration.BaseServerConfigLoader;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.web.ServerInternalSettings;
 
@@ -50,7 +50,7 @@ public class DesktopConfigurator
 
     public void refresh()
     {
-        config = ServerConfigFactory.loadConfig(
+        config = new BaseServerConfigLoader().loadConfig(
                 /** Future single file, neo4j.conf or similar */
                 null,
 


### PR DESCRIPTION
The ServerConfigFactory, now aptly renamed to the ServerConfigLoader, needs to know
which classes that possibly can carry migrators in an annotation-based scheme. This
was missing for the enterprise settings.

The loader has been extended with an EnterpriseServerConfigLoader that is aware of
enterprise specific settings classes, HaSettings and ClusterSettings. This wires
in the proper migration for these classes of settings. As an additional benefit
it also enables proper validation which wasn't functioning for the very same reason.
