### PR TITLE
Respect Java heap size constraints when checking Java version

### DIFF
--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/fake-java
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/fake-java
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 
+[[ "${FAKE_JAVA_DISABLE_RECORD_ARGS:-}" ]] || echo -n "$@" >../java-args
+
 if [ "$1" == "-version" ]; then
   echo "java version \"${FAKE_JAVA_VERSION:-1.8.0_51}\"
 Java(TM) SE Runtime Environment (build 1.8.0_51-b16)
@@ -14,5 +16,3 @@ echo "stderr from java" >&2
 if [[ "${FAKE_JAVA_SLEEP:-}" ]]; then
   sleep "${FAKE_JAVA_SLEEP}"
 fi
-
-echo -n "$@" >../java-args

--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/fixture.sh
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/fixture.sh
@@ -6,6 +6,10 @@ fake_install() {
   chmod +x neo4j-home/bin/neo4j-arbiter
 }
 
+clear_config() {
+  rm -f neo4j-home/conf/*
+}
+
 set_config() {
   name=$1
   value=$2

--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/runners.sh
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/runners.sh
@@ -4,5 +4,5 @@ run_console() {
 
 run_daemon() {
   FAKE_JAVA_SLEEP=1 neo4j-home/bin/neo4j start &&
-  neo4j-home/bin/neo4j stop
+  FAKE_JAVA_DISABLE_RECORD_ARGS="t" neo4j-home/bin/neo4j stop
 }

--- a/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
@@ -6,6 +6,8 @@ test_description="Test Java arguments"
 fake_install
 
 for run_command in run_console run_daemon; do
+  clear_config
+
   test_expect_success "should specify -server" "
     ${run_command} &&
     test_expect_java_arg '-server'
@@ -51,5 +53,14 @@ for run_command in run_console run_daemon; do
     test_expect_java_arg ':$(neo4j_home)/plugins/*'
   "
 done
+
+test_expect_success "should set heap size constraints when checking version" "
+  clear_config &&
+  set_config 'wrapper.java.initmemory' '512' neo4j-wrapper.conf &&
+  set_config 'wrapper.java.maxmemory' '1024' neo4j-wrapper.conf &&
+  neo4j-home/bin/neo4j status || true &&
+  test_expect_java_arg '-Xms512m' &&
+  test_expect_java_arg '-Xmx1024m'
+"
 
 test_done


### PR DESCRIPTION
At least one user has reported that with their unusual memory
configuration, the JVM with default heap size consumes too much memory
just to report its version.
