### PR TITLE
Make fixed_ascending the default HA push strategy.

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HaSettings.java
@@ -34,7 +34,7 @@ import static org.neo4j.kernel.configuration.Settings.INTEGER;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.options;
 import static org.neo4j.kernel.configuration.Settings.setting;
-import static org.neo4j.kernel.ha.HaSettings.TxPushStrategy.fixed_descending;
+import static org.neo4j.kernel.ha.HaSettings.TxPushStrategy.fixed_ascending;
 
 /**
  * Settings for High Availability mode
@@ -91,7 +91,7 @@ public class HaSettings
     public static final Setting<Integer> tx_push_factor = setting( "ha.tx_push_factor", INTEGER, "1", min( 0 ) );
 
     @Description( "Push strategy of a transaction to a slave during commit." )
-    public static final Setting<TxPushStrategy> tx_push_strategy = setting( "ha.tx_push_strategy", options( TxPushStrategy.class ), fixed_descending.name() );
+    public static final Setting<TxPushStrategy> tx_push_strategy = setting( "ha.tx_push_strategy", options( TxPushStrategy.class ), fixed_ascending.name() );
 
     @Description( "Size of batches of transactions applied on slaves when pulling from master" )
     public static final Setting<Integer> pull_apply_batch_size = setting( "ha.pull_apply_batch_size", INTEGER, "100" );

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.properties
@@ -81,11 +81,11 @@ ha.pull_interval=10
 #ha.tx_push_factor=1
 
 # Strategy the master will use when pushing data to slaves (if the push factor
-# is greater than 0). There are two options available "fixed" (default) or
-# "round_robin". Fixed will start by pushing to slaves ordered by server id
-# (highest first) improving performance since the slaves only have to cache up
-# one transaction at a time.
-#ha.tx_push_strategy=fixed
+# is greater than 0). There are three options available "fixed_ascending" (default),
+# "fixed_descending" or "round_robin". Fixed strategies will start by pushing to
+# slaves ordered by server id (accordingly with qualifier) and are useful when
+# planning for a stable fail-over based on ids.
+#ha.tx_push_strategy=fixed_ascending
 
 # Policy for how to handle branched data.
 #branched_data_policy=keep_all


### PR DESCRIPTION
I believe this was the outcome of previous discussions on the subject, thus fixing it.
