### PR TITLE
Fix eagerness bugs and add more tests

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/QueryGraph.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/QueryGraph.scala
@@ -35,9 +35,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
                       hints: Set[Hint] = Set.empty,
                       shortestPathPatterns: Set[ShortestPathPattern] = Set.empty,
                       mutatingPatterns: Seq[MutatingPattern] = Seq.empty)
-  extends UpdateGraph with PageDocFormatting { // with ToPrettyString[QueryGraph] {
-//  def toDefaultPrettyString(formatter: DocFormatter) =
-//    toPrettyString(formatter)(InternalDocHandler.docGen)
+  extends UpdateGraph with PageDocFormatting {
 
   def size = patternRelationships.size
 
@@ -257,6 +255,13 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
   }
 
   def writeOnly = !containsReads && containsUpdates
+
+  def createsNodes: Boolean = mutatingPatterns.exists {
+    case _: CreateNodePattern => true
+    case _: MergeNodePattern => true
+    case MergeRelationshipPattern(nodesToCreate, _, _, _, _) => nodesToCreate.nonEmpty
+    case _ => false
+  }
 
   def addMutatingPatterns(patterns: MutatingPattern*): QueryGraph =
     copy(mutatingPatterns = mutatingPatterns ++ patterns)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/UpdateGraph.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/UpdateGraph.scala
@@ -243,7 +243,7 @@ trait UpdateGraph {
 
   /*
   * Checks for overlap between what node props are read in query graph
-  * and what is updated with SET here
+  * and what is updated with SET here (properties added by create/merge directly is handled elsewhere)
   */
   private def setNodePropertyOverlap(qg: QueryGraph): Boolean = {
 


### PR DESCRIPTION
Fix bug when merge creates properties.
When a node pattern is matched with a property predicate, a later `MERGE` with
the same predicate should cause an eager plan to be inserted.

Fix bug where the read pattern and the write pattern uses the same nodes, but the
direction of the relationship is reversed.
- Add more eagerness acceptance tests
- Add separate assert parameter for optimal number of eagerness
