### PR TITLE
Read/write separation for procedures.

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
@@ -122,7 +122,7 @@ object CypherCompilerFactory {
     val parser = new CypherParser
     val checker = new SemanticChecker
     val rewriter = new ASTRewriter(rewriterSequencer)
-    val pipeBuilder = new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer)
+    val pipeBuilder = new DelegatingProcedureExecutablePlanBuilder(new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer))
 
     val execPlanBuilder = new ExecutionPlanBuilder(graph, clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
     val planCacheFactory = () => new LRUCache[Statement, ExecutionPlan](config.queryCacheSize)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/DelegatingQueryContext.scala
@@ -193,6 +193,9 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
 
   override def callReadOnlyProcedure(signature: ProcedureSignature, args: Seq[Any]) =
     inner.callReadOnlyProcedure(signature, args)
+
+  override def callReadWriteProcedure(signature: ProcedureSignature, args: Seq[Any]) =
+    inner.callReadWriteProcedure(signature, args)
 }
 
 class DelegatingOperations[T <: PropertyContainer](protected val inner: Operations[T]) extends Operations[T] {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/ProcedureSignature.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/ProcedureSignature.scala
@@ -28,14 +28,14 @@ sealed trait ProcedureMode {
   def call(ctx: QueryContext, signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]]
 }
 
-case object procReadOnly extends ProcedureMode {
+case object ProcReadOnly extends ProcedureMode {
   override val queryType: InternalQueryType = READ_ONLY
 
   override def call(ctx: QueryContext, signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]] =
     ctx.callReadOnlyProcedure(signature, args)
 }
 
-case object procReadWrite extends ProcedureMode {
+case object ProcReadWrite extends ProcedureMode {
   override val queryType: InternalQueryType = READ_WRITE
 
   override def call(ctx: QueryContext, signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]] =
@@ -45,7 +45,7 @@ case object procReadWrite extends ProcedureMode {
 case class ProcedureSignature(name: ProcedureName,
                               inputSignature: Seq[FieldSignature],
                               outputSignature: Seq[FieldSignature],
-                              mode: ProcedureMode = procReadOnly )
+                              mode: ProcedureMode = ProcReadOnly )
 
 case class ProcedureName(namespace: Seq[String], name: String)
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/ProcedureSignature.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/ProcedureSignature.scala
@@ -19,11 +19,33 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.spi
 
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{InternalQueryType, READ_ONLY, READ_WRITE}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols.CypherType
+
+sealed trait ProcedureMode {
+  val queryType: InternalQueryType
+
+  def call(ctx: QueryContext, signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]]
+}
+
+case object procReadOnly extends ProcedureMode {
+  override val queryType: InternalQueryType = READ_ONLY
+
+  override def call(ctx: QueryContext, signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]] =
+    ctx.callReadOnlyProcedure(signature, args)
+}
+
+case object procReadWrite extends ProcedureMode {
+  override val queryType: InternalQueryType = READ_WRITE
+
+  override def call(ctx: QueryContext, signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]] =
+    ctx.callReadWriteProcedure(signature, args)
+}
 
 case class ProcedureSignature(name: ProcedureName,
                               inputSignature: Seq[FieldSignature],
-                              outputSignature: Seq[FieldSignature] )
+                              outputSignature: Seq[FieldSignature],
+                              mode: ProcedureMode = procReadOnly )
 
 case class ProcedureName(namespace: Seq[String], name: String)
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/QueryContext.scala
@@ -163,6 +163,8 @@ trait QueryContext extends TokenContext {
   def lockRelationships(relIds: Long*)
 
   def callReadOnlyProcedure(signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]]
+
+  def callReadWriteProcedure(signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]]
 }
 
 trait Operations[T <: PropertyContainer] {

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/ExecutionResult.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/javacompat/ExecutionResult.java
@@ -213,6 +213,9 @@ public class ExecutionResult implements ResourceIterable<Map<String,Object>>, Re
         return innerIterator(); // legacy method - don't convert exceptions...
     }
 
+    /**
+     * @return this result as a {@link Stream}
+     */
     @Override
     public Stream<Map<String,Object>> stream()
     {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_0.scala
@@ -27,6 +27,8 @@ import org.neo4j.cypher.internal.spi.v3_0.ExceptionTranslationSupport
 import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 import org.neo4j.kernel.api.index.IndexDescriptor
 
+import scala.collection.Iterator
+
 class ExceptionTranslatingQueryContextFor3_0(inner: QueryContext) extends DelegatingQueryContext(inner) with ExceptionTranslationSupport {
   override def setLabelsOnNode(node: Long, labelIds: Iterator[Int]): Int =
     translateException(super.setLabelsOnNode(node, labelIds))
@@ -121,9 +123,11 @@ class ExceptionTranslatingQueryContextFor3_0(inner: QueryContext) extends Delega
   override def dropRelationshipPropertyExistenceConstraint(relTypeId: Int, propertyKeyId: Int) =
     translateException(super.dropRelationshipPropertyExistenceConstraint(relTypeId, propertyKeyId))
 
-  override def callReadOnlyProcedure(signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]] = {
+  override def callReadOnlyProcedure(signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]] =
     translateIterator(super.callReadOnlyProcedure(signature, args))
-  }
+
+  override def callReadWriteProcedure(signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]] =
+    translateIterator(super.callReadWriteProcedure(signature, args))
 
   override def withAnyOpenQueryContext[T](work: (QueryContext) => T): T =
     super.withAnyOpenQueryContext(qc =>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundPlanContext.scala
@@ -133,10 +133,10 @@ class TransactionBoundPlanContext(initialStatement: Statement, val gdb: GraphDat
   }
 
   private def asCypherProcMode(mode: KernelProcedureSignature.Mode): ProcedureMode = mode match {
-    case KernelProcedureSignature.Mode.READ_ONLY => procReadOnly
-    case KernelProcedureSignature.Mode.READ_WRITE => procReadWrite
+    case KernelProcedureSignature.Mode.READ_ONLY => ProcReadOnly
+    case KernelProcedureSignature.Mode.READ_WRITE => ProcReadWrite
     case _ => throw new CypherExecutionException(
-      "Unable to execute procedure, because it requires an unrecognized excution mode: " + mode.name(), null )
+      "Unable to execute procedure, because it requires an unrecognized execution mode: " + mode.name(), null )
   }
 
   private def asCypherType(neoType: AnyType): CypherType = neoType match {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal
 
 import org.neo4j.cypher.internal.compatibility.{ExecutionResultWrapperFor3_0, exceptionHandlerFor3_0}
-import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{CompiledExecutionResult, InternalExecutionResult, READ_WRITE}
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{AcceptingExecutionResult, CompiledExecutionResult, InternalExecutionResult, READ_WRITE}
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.{Planner, Runtime}
 import org.neo4j.cypher.internal.compiler.v3_0.{PipeExecutionResult, PlannerName, RuntimeName}
@@ -39,7 +39,7 @@ object RewindableExecutionResult {
                                                                                .addArgument(Planner(planner.name)).addArgument(Runtime(runtime.name))
           }
         }
-      case other: CompiledExecutionResult =>
+      case other: AcceptingExecutionResult =>
         exceptionHandlerFor3_0.runSafely {
           other.toEagerIterableResult(planner, runtime)
         }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LabelActionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/LabelActionTest.scala
@@ -205,4 +205,6 @@ class SnitchingQueryContext extends QueryContext {
   override def callReadOnlyProcedure(signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]] = ???
 
   override def indexSeekByContains(index: IndexDescriptor, value: String): scala.Iterator[Node] = ???
+
+  override def callReadWriteProcedure(signature: ProcedureSignature, args: Seq[Any]): Iterator[Array[AnyRef]] = ???
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/DataWriteOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/DataWriteOperations.java
@@ -21,12 +21,15 @@ package org.neo4j.kernel.api;
 
 import java.util.Map;
 
+import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.RelationshipTypeIdNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.legacyindex.AutoIndexingKernelException;
 import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
+import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 
@@ -141,4 +144,7 @@ public interface DataWriteOperations extends TokenWriteOperations
     void nodeLegacyIndexDrop( String indexName ) throws LegacyIndexNotFoundKernelException;
 
     void relationshipLegacyIndexDrop( String indexName ) throws LegacyIndexNotFoundKernelException;
+
+    /** Invoke a read/write procedure by name */
+    RawIterator<Object[], ProcedureException> procedureCallWrite( ProcedureSignature.ProcedureName name, Object[] input ) throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -561,9 +561,6 @@ public interface ReadOperations
     //== PROCEDURE OPERATIONS ===================
     //===========================================
 
-    /** For read procedures, this key will be available in the invocation context as a means to access the current read statement. */
-    CallableProcedure.Key<ReadOperations> readOperations = CallableProcedure.Key.key("statementContext.read", ReadOperations.class );
-
     /** For managed procedures, this gives access to the current statement. */
     CallableProcedure.Key<Statement> statement = CallableProcedure.Key.key("statement", Statement.class );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
@@ -137,23 +137,42 @@ public class ProcedureSignature
     private final ProcedureName name;
     private final List<FieldSignature> inputSignature;
     private final List<FieldSignature> outputSignature;
+    private final Mode mode;
 
-    public ProcedureSignature( ProcedureName name, List<FieldSignature> inputSignature, List<FieldSignature> outputSignature )
+    /**
+     * The procedure mode affects how the procedure will execute, and which capabilities
+     * it requires.
+     */
+    public enum Mode
+    {
+        /** This procedure will only perform read operations against the graph */
+        READ_ONLY,
+        /** This procedure may perform both read and write operations against the graph */
+        READ_WRITE
+    }
+
+    public ProcedureSignature( ProcedureName name,
+                               List<FieldSignature> inputSignature,
+                               List<FieldSignature> outputSignature,
+                               Mode mode )
     {
         this.name = name;
         this.inputSignature = unmodifiableList( inputSignature );
         this.outputSignature = unmodifiableList( outputSignature );
+        this.mode = mode;
     }
 
     public ProcedureSignature( ProcedureName name )
     {
-        this( name, Collections.emptyList(), Collections.emptyList() );
+        this( name, Collections.emptyList(), Collections.emptyList(), Mode.READ_ONLY );
     }
 
     public ProcedureName name()
     {
         return name;
     }
+
+    public Mode mode() { return mode; }
 
     public List<FieldSignature> inputSignature()
     {
@@ -198,10 +217,17 @@ public class ProcedureSignature
         private final ProcedureName name;
         private final List<FieldSignature> inputSignature = new LinkedList<>();
         private final List<FieldSignature> outputSignature = new LinkedList<>();
+        private Mode mode = Mode.READ_ONLY;
 
         public Builder( String[] namespace, String name )
         {
             this.name = new ProcedureName( namespace, name );
+        }
+
+        public Builder mode( Mode mode )
+        {
+            this.mode = mode;
+            return this;
         }
 
         /** Define an input field */
@@ -220,7 +246,7 @@ public class ProcedureSignature
 
         public ProcedureSignature build()
         {
-            return new ProcedureSignature(name, inputSignature, outputSignature );
+            return new ProcedureSignature(name, inputSignature, outputSignature, mode );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListProceduresProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/ListProceduresProcedure.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.api.proc.ProcedureSignature;
 
 import static org.neo4j.helpers.collection.Iterables.asRawIterator;
 import static org.neo4j.helpers.collection.Iterables.map;
-import static org.neo4j.kernel.api.ReadOperations.readOperations;
+import static org.neo4j.kernel.api.ReadOperations.statement;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTString;
 
 public class ListProceduresProcedure extends CallableProcedure.BasicProcedure
@@ -45,7 +45,7 @@ public class ListProceduresProcedure extends CallableProcedure.BasicProcedure
     @Override
     public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
     {
-        Set<ProcedureSignature> procedureSignatures = ctx.get( readOperations ).proceduresGetAll();
+        Set<ProcedureSignature> procedureSignatures = ctx.get( statement ).readOperations().proceduresGetAll();
         ArrayList<ProcedureSignature> sorted = new ArrayList<>( procedureSignatures );
         sorted.sort( (a,b) -> a.name().toString().compareTo( b.name().toString() ) );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -52,7 +52,7 @@ public class KernelStatement implements TxStateHolder, Statement
         this.locks = locks;
         this.txStateHolder = txStateHolder;
         this.storeStatement = storeStatement;
-        this.facade = new OperationsFacade( this, operations, procedures );
+        this.facade = new OperationsFacade( transaction, this, operations, procedures );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.CallableProcedure;
-import org.neo4j.procedure.Resource;
+import org.neo4j.procedure.Context;
 
 /**
  * Injects annotated fields with appropriate values.
@@ -129,7 +129,7 @@ public class FieldInjections
 
     private void assertValidForInjection( Class<?> cls, Field field ) throws ProcedureException
     {
-        if( !field.isAnnotationPresent( Resource.class ) )
+        if( !field.isAnnotationPresent( Context.class ) )
         {
             throw new ProcedureException(  Status.Procedure.FailedRegistration,
                     "Field `%s` on `%s` is not annotated as a @Resource and is not static. " +

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
@@ -127,6 +127,11 @@ public class OutputMappers
     public OutputMapper mapper( Method method ) throws ProcedureException
     {
         Class<?> cls = method.getReturnType();
+        if( cls == Void.class || cls == void.class )
+        {
+            return new OutputMapper( new FieldSignature[0], new FieldMapper[0] );
+        }
+
         if ( cls != Stream.class )
         {
             throw new ProcedureException( Status.Procedure.FailedRegistration,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
@@ -147,6 +147,8 @@ public class OutputMappers
 
     public OutputMapper mapper( Class<?> userClass ) throws ProcedureException
     {
+        assertIsValidRecordClass( userClass );
+
         List<Field> fields = instanceFields( userClass );
         FieldSignature[] signature = new FieldSignature[fields.size()];
         FieldMapper[] fieldMappers = new FieldMapper[fields.size()];
@@ -183,6 +185,24 @@ public class OutputMappers
         }
 
         return new OutputMapper( signature, fieldMappers );
+    }
+
+    private void assertIsValidRecordClass( Class<?> userClass ) throws ProcedureException
+    {
+        if( userClass.isPrimitive() || userClass.isArray()
+            || userClass.getPackage() != null && userClass.getPackage().getName().startsWith( "java." ) )
+        {
+            throw new ProcedureException( Status.Procedure.TypeError,
+                    "Procedures must return a Stream of records, where a record is a concrete class " +
+                    "that you define, with public non-final fields defining the fields in the record. " +
+                    "If you'd like your procedure to return `%s`, you could define a record class like:\n" +
+                    "public class Output {\n" +
+                    "    public %s out;\n" +
+                    "}\n" +
+                    "\n" +
+                    "And then define your procedure as returning `Stream<Output>`.",
+                    userClass.getSimpleName(), userClass.getSimpleName() );
+        }
     }
 
     private List<Field> instanceFields( Class<?> userClass )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -134,7 +134,9 @@ public class ReflectiveProcedureCompiler
 
     private ProcedureName extractName( Class<?> procDefinition, Method m )
     {
-        String[] namespace = procDefinition.getPackage().getName().split( "\\." );
+        Package pkg = procDefinition.getPackage();
+        // Package is null if class is in root package
+        String[] namespace = pkg == null ? new String[0] : pkg.getName().split( "\\." );
         String name = m.getName();
         return new ProcedureName( namespace, name );
     }

--- a/community/kernel/src/main/java/org/neo4j/procedure/Context.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Context.java
@@ -19,22 +19,23 @@
  */
 package org.neo4j.procedure;
 
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation marks a {@link Procedure} as performing updates to the graph.
- * <p>
- * This is <i>required</i> if the procedure performs write operations.
+ * This marks a field in a class with {@link Procedure} methods as part of the context the procedure is invoked in.
+ * Practically, this means that before the procedure is called, fields with this annotation are automatically
+ * populated with implementations of the specified APIs.
+ *
+ * In fact, apart from static fields, <i>only</i> fields with this annotation are allowed in classses that
+ * define procedure. Each of the fields must be public and non-final.
+ *
+ * @see Procedure
  */
-@Target( ElementType.METHOD )
+@Target( ElementType.FIELD )
 @Retention( RetentionPolicy.RUNTIME )
-public @interface PerformsWriteOperations
+public @interface Context
 {
-    // Implementation note: this is not yet enforced, but is an important part of the
-    // contract with the user. Without this annotation, we do not guarantee writes will
-    // work.
 }

--- a/community/kernel/src/main/java/org/neo4j/procedure/PerformsWrites.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/PerformsWrites.java
@@ -19,23 +19,19 @@
  */
 package org.neo4j.procedure;
 
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This marks a field in a class with {@link Procedure} methods as a resource for the procedures to use.
- * What this means is that before the procedure is called, fields with this annotation will be automatically
- * populated with the appropriate resource.
- *
- * In fact, apart from static fields, <i>only</i> fields with this annotation are allowed in classses that
- * define procedure. Each of the fields must be public and non-final.
- *
- * @see Procedure
+ * This annotation marks a {@link Procedure} as performing updates to the graph.
+ * <p>
+ * This is <i>required</i> if the procedure performs write operations.
  */
-@Target( ElementType.FIELD )
+@Target( ElementType.METHOD )
 @Retention( RetentionPolicy.RUNTIME )
-public @interface Resource
+public @interface PerformsWrites
 {
 }

--- a/community/kernel/src/main/java/org/neo4j/procedure/Procedure.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Procedure.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  * involves one or more resources, such as a {@link org.neo4j.graphdb.GraphDatabaseService}.
  * <p>
  * By default, procedures are read-only. If you want to perform writes to the
- * database, you need to add the {@link PerformsWriteOperations} annotation to your method as well.
+ * database, you need to add the {@link PerformsWrites} annotation to your method as well.
  *
  * <h2>Input declaration</h2>
  * A procedure can accept input arguments, which is defined in the arguments to the
@@ -77,11 +77,11 @@ import java.lang.annotation.Target;
  * <h2>Resource declarations</h2>
  * The procedure method itself can contain arbitrary Java code - but in order to work with the underlying graph,
  * it must have access to the graph API. This is done by declaring fields in the procedure class, and annotating
- * them with the {@link Resource} annotation. Fields declared this way are automatically injected with the
+ * them with the {@link Context} annotation. Fields declared this way are automatically injected with the
  * requested resource. This is how procedures gain access to APIs to do work with.
  * <p>
  * All fields in the class containing the procedure declaration must either be static; or it must be public, non-final
- * and annotated with {@link Resource}.
+ * and annotated with {@link Context}.
  * <p>
  * Resources supported by default are as follows:
  * <ul>

--- a/community/kernel/src/main/java/org/neo4j/procedure/impl/ProcedureExample.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/impl/ProcedureExample.java
@@ -25,11 +25,11 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
-import org.neo4j.procedure.Resource;
+import org.neo4j.procedure.Context;
 
 public class ProcedureExample
 {
-    @Resource
+    @Context
     public GraphDatabaseService db;
 
     /**

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.api;
 
 import org.neo4j.helpers.Clock;
-import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.KernelTransactions;
@@ -30,6 +29,7 @@ import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionHooks;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
+import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataStatementArgumentVerificationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataStatementArgumentVerificationTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.proc.Procedures;
 
@@ -102,6 +103,6 @@ public class DataStatementArgumentVerificationTest
 
     private OperationsFacade stubStatement()
     {
-        return new OperationsFacade( mock( KernelStatement.class ), null, new Procedures() );
+        return new OperationsFacade( mock(KernelTransaction.class), mock( KernelStatement.class ), null, new Procedures() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageStatement;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -28,10 +28,10 @@ import java.util.function.Supplier;
 
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
-import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ReentrantLockService;
+import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -33,7 +33,6 @@ import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
 import org.neo4j.kernel.api.exceptions.legacyindex.AutoIndexingKernelException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
-import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
@@ -43,6 +42,7 @@ import org.neo4j.kernel.impl.api.operations.SchemaStateOperations;
 import org.neo4j.kernel.impl.api.operations.SchemaWriteOperations;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
+import org.neo4j.kernel.impl.proc.Procedures;
 
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.inOrder;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/ProceduresKernelIT.java
@@ -122,7 +122,7 @@ public class ProceduresKernelIT extends KernelIntegrationTest
             @Override
             public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
             {
-                return RawIterator.<Object[], ProcedureException>of( new Object[]{ ctx.get( ReadOperations.readOperations ) } );
+                return RawIterator.<Object[], ProcedureException>of( new Object[]{ ctx.get( ReadOperations.statement ) } );
             }
         } );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.util.Map;
+
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -34,15 +35,14 @@ import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.index.IndexDescriptor;
-import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.storageengine.api.StoreReadLayer;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.neo4j.graphdb.Label.label;
 
 /**

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/FieldInjectionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/FieldInjectionsTest.java
@@ -26,7 +26,7 @@ import org.junit.rules.ExpectedException;
 import java.util.List;
 
 import org.neo4j.kernel.api.exceptions.ProcedureException;
-import org.neo4j.procedure.Resource;
+import org.neo4j.procedure.Context;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -105,7 +105,7 @@ public class FieldInjectionsTest
 
     public static class ProcedureWithPrivateMemberField
     {
-        @Resource
+        @Context
         private boolean someState = false;
     }
 
@@ -116,13 +116,13 @@ public class FieldInjectionsTest
 
     public static class ParentProcedure
     {
-        @Resource
+        @Context
         public int parentField;
     }
 
     public static class ChildProcedure extends ParentProcedure
     {
-        @Resource
+        @Context
         public int childField;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/OutputMappersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/OutputMappersTest.java
@@ -147,6 +147,29 @@ public class OutputMappersTest
         mapper( RecordWithNonStringKeyMap.class );
     }
 
+    @Test
+    public void shouldWarnAgainstStdLibraryClassesSinceTheseIndicateUserError() throws Throwable
+    {
+        // Impl note: We may want to change this behavior and actually allow procedures to return `Long` etc,
+        //            with a default column name. So Stream<Long> would become records like (out: Long)
+        //            Drawback of that is that it'd cause cognitive dissonance, it's not obvious what's a record
+        //            and what is a primitive value..
+
+        // Expect
+        exception.expect( ProcedureException.class );
+        exception.expectMessage( "Procedures must return a Stream of records, where a record is a concrete class that you define, with public non-final " +
+                                 "fields defining the fields in the record. If you'd like your procedure to return `Long`, you could define a record class " +
+                                 "like:\n" +
+                                 "public class Output {\n" +
+                                 "    public Long out;\n" +
+                                 "}\n" +
+                                 "\n" +
+                                 "And then define your procedure as returning `Stream<Output>`." );
+
+        // When
+        mapper(Long.class);
+    }
+
     private OutputMapper mapper( Class<?> clazz ) throws ProcedureException
     {
         return new OutputMappers( new TypeMappers() ).mapper( clazz );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
@@ -17,27 +17,27 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.api.proc;
-
-import java.util.List;
+package org.neo4j.kernel.impl.proc;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.List;
+
 import org.neo4j.collection.RawIterator;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.proc.ProcedureSignature;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.helpers.collection.IteratorUtil.asList;
-import static org.neo4j.kernel.api.proc.Neo4jTypes.NTAny;
 import static org.neo4j.kernel.api.proc.CallableProcedure.Key.key;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTAny;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
 public class ProceduresTest

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
@@ -31,7 +31,7 @@ import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.procedure.Procedure;
-import org.neo4j.procedure.Resource;
+import org.neo4j.procedure.Context;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -101,7 +101,7 @@ public class ResourceInjectionTest
 
     public static class ProcedureWithInjectedAPI
     {
-        @Resource
+        @Context
         public MyAwesomeAPI api;
 
         @Procedure
@@ -113,7 +113,7 @@ public class ResourceInjectionTest
 
     public static class procedureWithUnknownAPI
     {
-        @Resource
+        @Context
         public UnknownAPI api;
 
         @Procedure

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -47,6 +47,7 @@ import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.factory.CommunityCommitProcessFactory;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
@@ -91,7 +92,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 new StartupStatisticsProvider(), null,
                 new CommunityCommitProcessFactory(), mock( AutoIndexing.class ), pageCache,
                 new StandardConstraintSemantics(), monitors,
-                new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler ) );
+                new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler ), mock(Procedures.class) );
 
         return dataSource;
     }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -140,7 +140,7 @@ public class Neo4jRule implements TestRule, TestServerBuilder
     }
 
     @Override
-    public TestServerBuilder withProcedure( Class<?> procedureClass )
+    public Neo4jRule withProcedure( Class<?> procedureClass )
     {
         builder = builder.withProcedure( procedureClass );
         return this;

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -65,108 +66,65 @@ public class ProcedureIT
     private GraphDatabaseService db;
 
     @Test
-    public void shouldLoadProcedureFromPluginDirectory() throws Throwable
+    public void shouldCallProcedureWithParameterMap() throws Throwable
     {
         // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-
-        // When
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-            .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-            .newGraphDatabase();
-
-        // Then
         try ( Transaction ignore = db.beginTx() )
         {
-            Result res1 = db.execute( "CALL org.neo4j.procedure.integrationTestMe" );
-            assertThat( res1.next(), equalTo( map( "someVal", 1337L ) ));
-            assertFalse( res1.hasNext() );
-
-            Result res2 = db.execute( "CALL org.neo4j.procedure.simpleArgument(42)" );
-            assertThat( res2.next(), equalTo( map( "someVal", 42L ) ));
-            assertFalse( res2.hasNext() );
-        }
-    }
-
-    @Test
-    public void shouldLoadBeAbleToCallMethodWithParameterMap() throws Throwable
-    {
-        // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-
-        // When
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-            .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-            .newGraphDatabase();
-
-        // Then
-        try ( Transaction ignore = db.beginTx() )
-        {
+            // When
             Result res = db.execute( "CALL org.neo4j.procedure.simpleArgument", map( "name", 42L ) );
+
+            // Then
             assertThat( res.next(), equalTo( map( "someVal", 42L ) ) );
             assertFalse( res.hasNext() );
         }
     }
 
     @Test
-    public void shouldLoadBeAbleToCallProcedureWithGenericArgument() throws Throwable
+    public void shouldCallProcedureWithGenericArgument() throws Throwable
     {
         // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-
-        // When
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-            .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-            .newGraphDatabase();
-
-        // Then
         try ( Transaction ignore = db.beginTx() )
         {
+            // When
             Result res = db.execute(
                     "CALL org.neo4j.procedure.genericArguments([ ['graphs'], ['are'], ['everywhere']], " +
                     "[ [[1, 2, 3]], [[4, 5]]] )" );
+
+            // Then
             assertThat( res.next(), equalTo( map( "someVal", 5L ) ) );
             assertFalse( res.hasNext() );
         }
     }
 
     @Test
-    public void shouldLoadBeAbleToCallProcedureWithMapArgument() throws Throwable
+    public void shouldCallProcedureWithMapArgument() throws Throwable
     {
         // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-
-        // When
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-            .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-            .newGraphDatabase();
-
-        // Then
         try ( Transaction ignore = db.beginTx() )
         {
+            // When
             Result res = db.execute(
                     "CALL org.neo4j.procedure.mapArgument({foo: 42, bar: 'hello'})" );
+
+            // Then
             assertThat( res.next(), equalTo( map( "someVal", 2L ) ) );
             assertFalse( res.hasNext() );
         }
     }
 
     @Test
-    public void shouldLoadBeAbleToCallProcedureWithNodeReturn() throws Throwable
+    public void shouldCallProcedureWithNodeReturn() throws Throwable
     {
         // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-
-        // When
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-            .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-            .newGraphDatabase();
-
-        // Then
         try ( Transaction ignore = db.beginTx() )
         {
             long nodeId = db.createNode().getId();
+
+            // When
             Result res = db.execute( "CALL org.neo4j.procedure.node({id})", map( "id", nodeId ) );
+
+            // Then
             Node node = (Node) res.next().get( "node" );
             assertThat(node.getId(), equalTo( nodeId ));
             assertFalse( res.hasNext() );
@@ -176,9 +134,6 @@ public class ProcedureIT
     @Test
     public void shouldGiveHelpfulErrorOnMissingProcedure() throws Throwable
     {
-        // Given
-        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
-
         // Expect
         exception.expect( QueryExecutionException.class );
         exception.expectMessage( "There is no procedure with the name `someProcedureThatDoesNotExist` " +
@@ -193,34 +148,26 @@ public class ProcedureIT
     public void shouldGiveHelpfulErrorOnExceptionMidStream() throws Throwable
     {
         // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-                .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-                .newGraphDatabase();
+        // run in tx to avoid having to wait for tx rollback on shutdown
+        try( Transaction ignore = db.beginTx() )
+        {
+            Result result = db.execute( "CALL org.neo4j.procedure.throwsExceptionInStream" );
 
-        Result result = db.execute( "CALL org.neo4j.procedure.throwsExceptionInStream" );
+            // Expect
+            exception.expect( QueryExecutionException.class );
+            exception.expectMessage(
+                    "Failed to call procedure `org.neo4j.procedure.throwsExceptionInStream() :: (someVal :: INTEGER?)`: " +
+                    "Kaboom" );
 
-        // Expect
-        exception.expect( QueryExecutionException.class );
-        exception.expectMessage(
-                "Failed to call procedure `org.neo4j.procedure.throwsExceptionInStream() :: (someVal :: INTEGER?)`: " +
-                "Kaboom" );
-
-        // When
-        result.next();
+            // When
+            result.next();
+        }
     }
 
     @Test
-    public void shouldLoadBeAbleToCallProcedureWithAccessToDB() throws Throwable
+    public void shouldCallProcedureWithAccessToDB() throws Throwable
     {
-        // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-
         // When
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
-            .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-            .newGraphDatabase();
-
         try ( Transaction ignore = db.beginTx() )
         {
             db.createNode( label( "Person" ) ).setProperty( "name", "Buddy Holly" );
@@ -240,12 +187,10 @@ public class ProcedureIT
     public void shouldLogLikeThereIsNoTomorrow() throws Throwable
     {
         // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-
-        // When
         AssertableLogProvider logProvider = new AssertableLogProvider();
 
-        GraphDatabaseService db = new TestGraphDatabaseFactory()
+        db.shutdown();
+        db = new TestGraphDatabaseFactory()
             .setInternalLogProvider( logProvider )
             .setUserLogProvider( logProvider  )
             .newImpermanentDatabaseBuilder()
@@ -272,13 +217,6 @@ public class ProcedureIT
     @Test
     public void readOnlyProcedureCannotWrite() throws Throwable
     {
-        // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-        db = new TestGraphDatabaseFactory()
-                .newImpermanentDatabaseBuilder()
-                .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-                .newGraphDatabase();
-
         // Expect
         exception.expect( QueryExecutionException.class );
         exception.expectMessage( "Write operations are not allowed" );
@@ -293,13 +231,6 @@ public class ProcedureIT
     @Test
     public void procedureMarkedForWritingCanWrite() throws Throwable
     {
-        // Given
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-        db = new TestGraphDatabaseFactory()
-                .newImpermanentDatabaseBuilder()
-                .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
-                .newGraphDatabase();
-
         // When
         try ( Transaction tx = db.beginTx() )
         {
@@ -316,10 +247,48 @@ public class ProcedureIT
         }
     }
 
-    @Before
-    public void setUp()
+    @Test
+    public void shouldNotBeAbleToCallWriteProcedureThroughReadProcedure() throws Throwable
     {
-        this.db = null;
+        // Expect
+        exception.expect( QueryExecutionException.class );
+        exception.expectMessage( "Write operations are not allowed" );
+
+        // When
+        try ( Transaction ignore = db.beginTx() )
+        {
+            db.execute( "CALL org.neo4j.procedure.readOnlyCallingWriteProcedure" ).next();
+        }
+    }
+
+    @Test
+    public void procedureMarkedForWritingCanCallOtherWritingProcedure() throws Throwable
+    {
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            // TODO: #hasNext should not be needed here, result of writes should be eagerized
+            db.execute( "CALL org.neo4j.procedure.writeProcedureCallingWriteProcedure()" ).hasNext();
+            tx.success();
+        }
+
+        // Then
+        try( Transaction tx = db.beginTx() )
+        {
+            assertEquals(1, db.getAllNodes().stream().count());
+            tx.success();
+        }
+    }
+
+    @Before
+    public void setUp() throws IOException
+    {
+        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
+        db = new TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig( GraphDatabaseSettings.plugin_dir, plugins.getRoot().getAbsolutePath() )
+                .newGraphDatabase();
+
     }
 
     @After
@@ -447,6 +416,23 @@ public class ProcedureIT
         {
             db.createNode();
             return Stream.empty();
+        }
+
+        @Procedure
+        public Stream<Output> readOnlyCallingWriteProcedure()
+        {
+            return db.execute("CALL org.neo4j.procedure.writingProcedure")
+                    .stream()
+                    .map( (row) -> new Output( 0 ) );
+        }
+
+        @Procedure
+        @PerformsWrites
+        public Stream<Output> writeProcedureCallingWriteProcedure()
+        {
+            return db.execute("CALL org.neo4j.procedure.writingProcedure")
+                    .stream()
+                    .map( (row) -> new Output( 0 ) );
         }
     }
 }

--- a/manual/contents/pom.xml
+++ b/manual/contents/pom.xml
@@ -143,6 +143,13 @@
       <groupId>org.neo4j.doc</groupId>
       <artifactId>neo4j-cypher-docs</artifactId>
       <version>${neo4j.version}</version>
+      <classifier>sources</classifier>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j.doc</groupId>
+      <artifactId>neo4j-cypher-docs</artifactId>
+      <version>${neo4j.version}</version>
       <classifier>test-sources</classifier>
       <scope>provided</scope>
     </dependency>
@@ -374,7 +381,7 @@
               <excludes>META-INF,META-INF/**</excludes>
               <type>jar</type>
               <outputDirectory>${docs.sourcecode}</outputDirectory>
-              <includeArtifactIds>neo4j-examples,neo4j-server-examples</includeArtifactIds>
+              <includeArtifactIds>neo4j-examples,neo4j-server-examples,neo4j-cypher-docs</includeArtifactIds>
             </configuration>
           </execution>
         </executions>

--- a/manual/cypher/cypher-docs/LICENSES.txt
+++ b/manual/cypher/cypher-docs/LICENSES.txt
@@ -4,11 +4,8 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   Apache Commons Lang
-  ConcurrentLinkedHashMap
   Lucene Core
-  opencsv
-  parboiled-core
-  parboiled-scala
+  Lucene Memory
 ------------------------------------------------------------------------------
 
                                  Apache License
@@ -254,38 +251,6 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
-
-
-------------------------------------------------------------------------------
-BSD License
-  ASM Core
-  Scala Compiler
-------------------------------------------------------------------------------
-
-Copyright (c) <year>, <copyright holder>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 

--- a/manual/cypher/cypher-docs/NOTICE.txt
+++ b/manual/cypher/cypher-docs/NOTICE.txt
@@ -27,16 +27,9 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   Apache Commons Lang
-  ConcurrentLinkedHashMap
   Lucene Core
-  opencsv
-  parboiled-core
-  parboiled-scala
+  Lucene Memory
 
 BSD - Scala License
   Scala Library
-
-BSD License
-  ASM Core
-  Scala Compiler
 

--- a/manual/cypher/cypher-docs/pom.xml
+++ b/manual/cypher/cypher-docs/pom.xml
@@ -81,6 +81,10 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-kernel</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-kernel</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/manual/cypher/cypher-docs/src/docs/dev/general.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/general.asciidoc
@@ -29,4 +29,8 @@ include::ql/unwind/index.asciidoc[]
 
 include::ql/union/index.asciidoc[]
 
+:leveloffset: 2
+
+include::ql/call/index.asciidoc[]
+
 :leveloffset: 0

--- a/manual/cypher/cypher-docs/src/docs/dev/ql/call/index.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/ql/call/index.asciidoc
@@ -1,0 +1,34 @@
+[[query-call]]
+= Call
+
+[abstract]
+The `CALL` clause is used to call a procedure deployed in the database.
+
+The examples showing how to use arguments when invoking procedures all use the following procedure:
+
+[snippet,java]
+----
+component=neo4j-cypher-docs
+source=org/neo4j/procedure/example/IndexingProcedure.java
+classifier=sources
+tag=indexingProcedure
+----
+
+[NOTE]
+This clause cannot be combined with other clauses.
+
+:leveloffset: 2
+
+include::call-a-procedure.asciidoc[]
+
+:leveloffset: 2
+
+include::call-a-procedure-with-literal-arguments.asciidoc[]
+
+:leveloffset: 2
+
+include::call-a-procedure-with-parameter-arguments.asciidoc[]
+
+:leveloffset: 2
+
+include::call-a-procedure-with-mixed-literal-and-parameter-arguments.asciidoc[]

--- a/manual/cypher/cypher-docs/src/main/java/org/neo4j/procedure/example/IndexingProcedure.java
+++ b/manual/cypher/cypher-docs/src/main/java/org/neo4j/procedure/example/IndexingProcedure.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.example;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.PerformsWrites;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.Context;
+
+// START SNIPPET: indexingProcedure
+public class IndexingProcedure
+{
+    @Context
+    public GraphDatabaseService db;
+
+    /**
+     * Adds a node to a named legacy index. Useful to, for instance, update
+     * a full-text index through cypher.
+     * @param indexName the name of the index in question
+     * @param nodeId id of the node to add to the index
+     * @param propKey property to index (value is read from the node)
+     */
+    @Procedure
+    @PerformsWrites
+    public void addNodeToIndex( @Name("indexName") String indexName,
+                                @Name("node") long nodeId,
+                                @Name("propKey" ) String propKey )
+    {
+        Node node = db.getNodeById( nodeId );
+        db.index()
+          .forNodes( indexName )
+          .add( node, propKey, node.getProperty( propKey ) );
+    }
+}
+// END SNIPPET: indexingProcedure

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CallTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CallTest.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.docgen
+
+import org.junit.Test
+import org.neo4j.cypher.QueryStatisticsTestSupport
+import org.neo4j.graphdb.{Label, Node}
+import org.neo4j.kernel.GraphDatabaseAPI
+import org.neo4j.kernel.impl.proc.Procedures
+import org.neo4j.procedure.example.IndexingProcedure
+
+class CallTest extends DocumentingTestBase with QueryStatisticsTestSupport with HardReset {
+
+  var nodeId:Long = -1
+
+  override def section = "Call"
+
+  override def hardReset() = {
+    super.hardReset()
+    db.getDependencyResolver.resolveDependency(classOf[Procedures]).register( classOf[IndexingProcedure] )
+    db.inTx {
+      val node = db.createNode(Label.label("User"), Label.label("Administrator"))
+      node.setProperty("name", "Adrian")
+      nodeId = node.getId
+    }
+  }
+
+  @Test def call_a_procedure() {
+    testQuery(
+      title = "Call a procedure",
+      text = "This invokes the built-in procedure 'sys.db.labels', which lists all in-use labels in the database.",
+      queryText = "CALL sys.db.labels",
+      optionalResultExplanation = "",
+      assertions = (p) => assert(p.hasNext) )
+  }
+
+  @Test def call_a_procedure_with_literal_arguments() {
+    testQuery(
+      title = "Call a procedure with literal arguments",
+      text = "This invokes the example procedure `org.neo4j.procedure.example.addNodeToIndex` using arguments that are written out directly in the statement text. This is called literal arguments.",
+      queryText = "CALL org.neo4j.procedure.example.addNodeToIndex('users', "+nodeId+", 'name')",
+      optionalResultExplanation = "Since our example procedure does not return any result, the result is empty.",
+      assertions = (p) => assert(!p.hasNext) )
+  }
+
+  @Test def call_a_procedure_with_parameter_arguments() {
+    testQuery(
+      title = "Call a procedure with parameter arguments",
+      text = "This invokes the example procedure `org.neo4j.procedure.example.addNodeToIndex` using parameters. The procedure arguments are satisfied by matching the parameter keys to the named procedure arguments.",
+      queryText = "CALL org.neo4j.procedure.example.addNodeToIndex",
+      parameters = Map("indexName"->"users", "node"->nodeId, "propKey"-> "name"),
+      optionalResultExplanation = "Since our example procedure does not return any result, the result is empty.",
+      assertions = (p) => assert(!p.hasNext) )
+  }
+
+  @Test def call_a_procedure_with_mixed_arguments() {
+    testQuery(
+      title = "Call a procedure with mixed literal and parameter arguments",
+      text = "This invokes the example procedure `org.neo4j.procedure.example.addNodeToIndex` using both literal and parameterized arguments.",
+      queryText = "CALL org.neo4j.procedure.example.addNodeToIndex('users', {node}, 'name')",
+      parameters = Map("node"->nodeId),
+      optionalResultExplanation = "Since our example procedure does not return any result, the result is empty.",
+      assertions = (p) => assert(!p.hasNext) )
+  }
+}


### PR DESCRIPTION
This utilizes the KernelTX `AccessMode` to set the current transaction in read-only mode when invoking read-only procedures. It also introduces a separate mode to invoke writing procedures, sitting on `DataWriteOperations`. 

`ProcedureSignature` now includes a mode that encodes the execution mode of a procedure, and the cypher runtime uses this to choose which of the two kernel primitives to use to invoke the procedure. 
