### PR TITLE
Handle leading/trailing whitespace in importer

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.lang.Character.isWhitespace;
 import static java.lang.reflect.Modifier.isStatic;
 
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
@@ -564,8 +565,16 @@ public class Extractors
         @Override
         protected boolean extract0( char[] data, int offset, int length )
         {
-            // TODO Figure out a way to do this conversion without round tripping to String
-            value = Float.parseFloat( String.valueOf( data, offset, length ) );
+            try
+            {
+                // TODO Figure out a way to do this conversion without round tripping to String
+                // parseFloat automatically handles leading/trailing whitespace so no need for us to do it
+                value = Float.parseFloat( String.valueOf( data, offset, length ) );
+            }
+            catch ( NumberFormatException ignored )
+            {
+                throw new NumberFormatException( "Not a number: \"" + String.valueOf( data, offset, length ) + "\"" );
+            }
             return true;
         }
 
@@ -599,8 +608,16 @@ public class Extractors
         @Override
         protected boolean extract0( char[] data, int offset, int length )
         {
-            // TODO Figure out a way to do this conversion without round tripping to String
-            value = Double.parseDouble( String.valueOf( data, offset, length ) );
+            try
+            {
+                // TODO Figure out a way to do this conversion without round tripping to String
+                // parseDouble automatically handles leading/trailing whitespace so no need for us to do it
+                value = Double.parseDouble( String.valueOf( data, offset, length ) );
+            }
+            catch ( NumberFormatException ignored )
+            {
+                throw new NumberFormatException( "Not a number: \"" + String.valueOf( data, offset, length ) + "\"" );
+            }
             return true;
         }
 
@@ -811,6 +828,7 @@ public class Extractors
             {
                 int numberOfChars = charsToNextDelimiter( data, offset+charIndex, length-charIndex );
                 // TODO Figure out a way to do this conversion without round tripping to String
+                // parseFloat automatically handles leading/trailing whitespace so no need for us to do it
                 value[arrayIndex] = Float.parseFloat( String.valueOf( data, offset+charIndex, numberOfChars ) );
                 charIndex += numberOfChars;
             }
@@ -835,6 +853,7 @@ public class Extractors
             {
                 int numberOfChars = charsToNextDelimiter( data, offset+charIndex, length-charIndex );
                 // TODO Figure out a way to do this conversion without round tripping to String
+                // parseDouble automatically handles leading/trailing whitespace so no need for us to do it
                 value[arrayIndex] = Double.parseDouble( String.valueOf( data, offset+charIndex, numberOfChars ) );
                 charIndex += numberOfChars;
             }
@@ -864,25 +883,51 @@ public class Extractors
         }
     }
 
-    private static long extractLong( char[] data, int offset, int length )
+    private static long extractLong( char[] data, int originalOffset, int fullLength )
     {
-        if ( length == 0 )
+        long result = 0;
+        boolean negate = false;
+        int offset = originalOffset;
+        int length = fullLength;
+
+        // Leading whitespace can be ignored
+        while ( length > 0 && isWhitespace( data[offset] ) )
         {
-            throw new NumberFormatException( "For input string \"" + String.valueOf( data, offset, length ) + "\"" );
+            offset++;
+            length--;
+        }
+        // Trailing whitespace can be ignored
+        while ( length > 0 && isWhitespace( data[offset + length - 1] ) )
+        {
+            length--;
         }
 
-        long result = 0;
-        int i = 0;
-        boolean negate = false;
-        if ( data[offset] == '-' )
+        if ( length > 0 && data[offset] == '-' )
         {
             negate = true;
-            i++;
+            offset++;
+            length--;
         }
-        for ( ; i < length; i++ )
+
+        if ( length < 1 )
         {
-            result = result*10 + digit( data[offset+i] );
+            throw new NumberFormatException(
+                    "Not an integer: \"" + String.valueOf( data, originalOffset, fullLength ) + "\"" );
         }
+
+        try
+        {
+            for (int i = 0; i < length; i++ )
+            {
+                result = result * 10 + digit( data[offset + i] );
+            }
+        }
+        catch ( NumberFormatException ignored )
+        {
+            throw new NumberFormatException(
+                    "Not an integer: \"" + String.valueOf( data, originalOffset, fullLength ) + "\"" );
+        }
+
         return negate ? -result : result;
     }
 
@@ -891,7 +936,7 @@ public class Extractors
         int digit = ch - '0';
         if ( (digit < 0) || (digit > 9) )
         {
-            throw new NumberFormatException( "Invalid digit character '" + ch + "'" );
+            throw new NumberFormatException();
         }
         return digit;
     }
@@ -903,19 +948,36 @@ public class Extractors
         Boolean.TRUE.toString().getChars( 0, BOOLEAN_TRUE_CHARACTERS.length, BOOLEAN_TRUE_CHARACTERS, 0 );
     }
 
-    private static boolean extractBoolean( char[] data, int offset, int length )
+    private static boolean extractBoolean( char[] data, int originalOffset, int fullLength )
     {
-        if ( BOOLEAN_TRUE_CHARACTERS.length != length )
+        int offset = originalOffset;
+        int length = fullLength;
+        // Leading whitespace can be ignored
+        while ( length > 0 && isWhitespace( data[offset] ) )
+        {
+            offset++;
+            length--;
+        }
+        // Trailing whitespace can be ignored
+        while ( length > 0 && isWhitespace( data[offset + length - 1] ) )
+        {
+            length--;
+        }
+
+        // See if the rest exactly match "true"
+        if ( length != BOOLEAN_TRUE_CHARACTERS.length )
         {
             return false;
         }
-        for ( int i = 0; i < length; i++ )
+
+        for ( int i = 0; i < BOOLEAN_TRUE_CHARACTERS.length && i < length; i++ )
         {
-            if ( data[offset+i] != BOOLEAN_TRUE_CHARACTERS[i] )
+            if ( data[offset + i] != BOOLEAN_TRUE_CHARACTERS[i] )
             {
                 return false;
             }
         }
+
         return true;
     }
 

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolNumericalFailureTests.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolNumericalFailureTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tooling;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.SuppressOutput;
+import org.neo4j.unsafe.impl.batchimport.input.InputException;
+
+import static org.junit.Assert.fail;
+import static org.neo4j.tooling.ImportToolTest.assertExceptionContains;
+import static org.neo4j.tooling.ImportToolTest.importTool;
+
+/**
+ * Tests that we fail correctly when given strings which can't be interpreted as numbers when configured to interpret
+ * them as such.
+ */
+@RunWith( Parameterized.class )
+public class ImportToolNumericalFailureTests
+{
+    @Parameters( name = "{index}: {0}, \"{1}\", \"{2}\"" )
+    public static List<Object[]> types()
+    {
+        ArrayList<Object[]> params = new ArrayList<>();
+
+        for ( String type : Arrays.asList( "int", "long", "short", "byte", "float", "double" ) )
+        {
+            for ( String val : Arrays.asList( " 1 7 ", " -1 7 ", " - 1 ", "   ", "   -  ", "-", "1. 0", "1 .", ".",
+                    "1E 10", " . 1" ) )
+            {
+                // Only include decimals for floating point
+                if ( val.contains( "." ) && !( type.equals( "float" ) || type.equals( "double" ) ) )
+                {
+                    continue;
+                }
+
+                final String error;
+                if ( type.equals( "float" ) || type.equals( "double" ) )
+                {
+                    error = "Not a number: \"" + val + "\"";
+                }
+                else
+                {
+                    error = "Not an integer: \"" + val + "\"";
+                }
+
+                String[] args = new String[3];
+                args[0] = type;
+                args[1] = val;
+                args[2] = error;
+
+                params.add( args );
+            }
+        }
+
+        return params;
+    }
+
+    @Parameter
+    public String type;
+
+    @Parameter( value = 1 )
+    public String val;
+
+    @Parameter( value = 2 )
+    public String expectedError;
+
+    @Rule
+    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
+    @Rule
+    public final SuppressOutput suppressOutput = SuppressOutput.suppress( SuppressOutput.System.values() );
+
+    private int dataIndex;
+
+    @Test
+    public void test() throws Exception
+    {
+        // GIVEN
+        File data = file( fileName( "whitespace.csv" ) );
+        try ( PrintStream writer = new PrintStream( data ) )
+        {
+            writer.println( ":LABEL,adult:" + type );
+            writer.println( "PERSON," + val );
+        }
+
+        try
+        {
+            // WHEN
+            importTool( "--into", dbRule.getStoreDirAbsolutePath(), "--quote", "'", "--nodes", data.getAbsolutePath() );
+            // THEN
+            fail( "Expected import to fail" );
+        }
+        catch ( Exception e )
+        {
+            assertExceptionContains( e, expectedError, InputException.class );
+        }
+    }
+
+    private String fileName( String name )
+    {
+        return dataIndex++ + "-" + name;
+    }
+
+    private File file( String localname )
+    {
+        return new File( dbRule.getStoreDir(), localname );
+    }
+}

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
@@ -199,6 +200,365 @@ public class ImportToolTest
             nodes = dbRule.findNodes( DynamicLabel.label( "SECOND 4096" ) );
             assertEquals( 1, IteratorUtil.asList( nodes ).size() );
         }
+    }
+
+    @Test
+    public void shouldIgnoreWhitespaceAroundIntegers() throws Exception
+    {
+        // GIVEN
+        // Faster to do all successful in one import than in N separate tests
+        List<String> values = Arrays.asList( "17", "    21", "99   ", "  34  ", "-34", "        -12", "-92 " );
+
+        File data = file( fileName( "whitespace.csv" ) );
+        try ( PrintStream writer = new PrintStream( data ) )
+        {
+            writer.println( ":LABEL,name,s:short,b:byte,i:int,l:long,f:float,d:double" );
+
+            // For each test value
+            for ( String value : values )
+            {
+                // Save value as a String in name
+                writer.print( "PERSON,'" + value + "'" );
+                // For each numerical type
+                for ( int j = 0; j < 6; j++ )
+                {
+                    writer.print( "," + value );
+                }
+                // End line
+                writer.println();
+            }
+        }
+
+        // WHEN
+        importTool( "--into", dbRule.getStoreDirAbsolutePath(), "--quote", "'", "--nodes", data.getAbsolutePath() );
+
+        // THEN
+        int nodeCount = 0;
+        try ( Transaction tx = dbRule.beginTx() )
+        {
+            for ( Node node : dbRule.getAllNodes() )
+            {
+                nodeCount++;
+                String name = (String) node.getProperty( "name" );
+
+                String expected = name.trim();
+
+                assertEquals( 7, node.getAllProperties().size() );
+                for ( String key : node.getPropertyKeys() )
+                {
+                    if ( key.equals( "name" ) )
+                    {
+                        continue;
+                    }
+                    else if ( key.equals( "f" ) || key.equals( "d" ) )
+                    {
+                        // Floating points have decimals
+                        expected = String.valueOf( Double.parseDouble( expected ) );
+                    }
+
+                    assertEquals( "Wrong value for " + key, expected, node.getProperty( key ).toString() );
+                }
+            }
+
+            tx.success();
+        }
+
+        assertEquals( values.size(), nodeCount );
+    }
+
+    @Test
+    public void shouldIgnoreWhitespaceAroundDecimalNumbers() throws Exception
+    {
+        // GIVEN
+        // Faster to do all successful in one import than in N separate tests
+        List<String> values = Arrays.asList( "1.0", "   3.5", "45.153    ", "   925.12   ", "-2.121", "   -3.745",
+                "-412.153    ", "   -5.12   " );
+
+        File data = file( fileName( "whitespace.csv" ) );
+        try ( PrintStream writer = new PrintStream( data ) )
+        {
+            writer.println( ":LABEL,name,f:float,d:double" );
+
+            // For each test value
+            for ( String value : values )
+            {
+                // Save value as a String in name
+                writer.print( "PERSON,'" + value + "'" );
+                // For each numerical type
+                for ( int j = 0; j < 2; j++ )
+                {
+                    writer.print( "," + value );
+                }
+                // End line
+                writer.println();
+            }
+        }
+
+        // WHEN
+        importTool( "--into", dbRule.getStoreDirAbsolutePath(), "--quote", "'", "--nodes", data.getAbsolutePath() );
+
+        // THEN
+        int nodeCount = 0;
+        try ( Transaction tx = dbRule.beginTx() )
+        {
+            for ( Node node : dbRule.getAllNodes() )
+            {
+                nodeCount++;
+                String name = (String) node.getProperty( "name" );
+
+                double expected = Double.parseDouble( name.trim() );
+
+                assertEquals( 3, node.getAllProperties().size() );
+                for ( String key : node.getPropertyKeys() )
+                {
+                    if ( key.equals( "name" ) )
+                    {
+                        continue;
+                    }
+
+                    assertTrue( "Wrong value for " + key,
+                            expected == Double.valueOf( node.getProperty( key ).toString() ) );
+                }
+            }
+
+            tx.success();
+        }
+
+        assertEquals( values.size(), nodeCount );
+    }
+
+    @Test
+    public void shouldIgnoreWhitespaceAroundBooleans() throws Exception
+    {
+        // GIVEN
+        File data = file( fileName( "whitespace.csv" ) );
+        try ( PrintStream writer = new PrintStream( data ) )
+        {
+            writer.println( ":LABEL,name,adult:boolean" );
+
+            writer.println( "PERSON,'t1',true" );
+            writer.println( "PERSON,'t2',  true" );
+            writer.println( "PERSON,'t3',true  " );
+            writer.println( "PERSON,'t4',  true  " );
+
+            writer.println( "PERSON,'f1',false" );
+            writer.println( "PERSON,'f2',  false" );
+            writer.println( "PERSON,'f3',false  " );
+            writer.println( "PERSON,'f4',  false  " );
+            writer.println( "PERSON,'f5',  truebutactuallyfalse  " );
+
+            writer.println( "PERSON,'f6',  non true things are interpreted as false  " );
+        }
+
+        // WHEN
+        importTool( "--into", dbRule.getStoreDirAbsolutePath(), "--quote", "'", "--nodes", data.getAbsolutePath() );
+
+        // THEN
+        try ( Transaction tx = dbRule.beginTx() )
+        {
+            for ( Node node : dbRule.getAllNodes() )
+            {
+                String name = (String) node.getProperty( "name" );
+                if ( name.startsWith( "t" ) )
+                {
+                    assertTrue( "Wrong value on " + name, (boolean) node.getProperty( "adult" ) );
+                }
+                else
+                {
+                    assertFalse( "Wrong value on " + name, (boolean) node.getProperty( "adult" ) );
+                }
+            }
+
+            int nodeCount = count( at( dbRule ).getAllNodes() );
+            assertEquals( 10, nodeCount );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldIgnoreWhitespaceInAndAroundIntegerArrays() throws Exception
+    {
+        // GIVEN
+        // Faster to do all successful in one import than in N separate tests
+        String[] values = new String[]{ "   17", "21", "99   ", "  34  ", "-34", "        -12", "-92 " };
+
+        File data = writeArrayCsv(
+                new String[]{ "s:short[]", "b:byte[]", "i:int[]", "l:long[]", "f:float[]", "d:double[]" }, values );
+
+        // WHEN
+        importTool( "--into", dbRule.getStoreDirAbsolutePath(), "--quote", "'", "--nodes", data.getAbsolutePath() );
+
+        // THEN
+        // Expected value for integer types
+        String iExpected = "[";
+        for ( String value : values )
+        {
+            iExpected += value.trim() + ", ";
+        }
+        iExpected = iExpected.substring( 0, iExpected.length() - 2 ) + "]";
+
+        // Expected value for floating point types
+        String fExpected = "[";
+        for ( String value : values )
+        {
+            fExpected += Double.valueOf( value.trim() ) + ", ";
+        }
+        fExpected = fExpected.substring( 0, fExpected.length() - 2 ) + "]";
+
+        int nodeCount = 0;
+        try ( Transaction tx = dbRule.beginTx() )
+        {
+            for ( Node node : dbRule.getAllNodes() )
+            {
+                nodeCount++;
+
+                assertEquals( 6, node.getAllProperties().size() );
+                for ( String key : node.getPropertyKeys() )
+                {
+                    Object things = node.getProperty( key );
+                    String result = "";
+                    String expected = iExpected;
+                    switch ( key )
+                    {
+                    case "s":
+                        result = Arrays.toString( (short[]) things );
+                        break;
+                    case "b":
+                        result = Arrays.toString( (byte[]) things );
+                        break;
+                    case "i":
+                        result = Arrays.toString( (int[]) things );
+                        break;
+                    case "l":
+                        result = Arrays.toString( (long[]) things );
+                        break;
+                    case "f":
+                        result = Arrays.toString( (float[]) things );
+                        expected = fExpected;
+                        break;
+                    case "d":
+                        result = Arrays.toString( (double[]) things );
+                        expected = fExpected;
+                        break;
+                    }
+
+                    assertEquals( expected, result );
+                }
+            }
+
+            tx.success();
+        }
+
+        assertEquals( 1, nodeCount );
+    }
+
+    @Test
+    public void shouldIgnoreWhitespaceInAndAroundDecimalArrays() throws Exception
+    {
+        // GIVEN
+        // Faster to do all successful in one import than in N separate tests
+        String[] values =
+                new String[]{ "1.0", "   3.5", "45.153    ", "   925.12   ", "-2.121", "   -3.745", "-412.153    ",
+                        "   -5.12   " };
+
+        File data = writeArrayCsv( new String[]{ "f:float[]", "d:double[]" }, values );
+
+        // WHEN
+        importTool( "--into", dbRule.getStoreDirAbsolutePath(), "--quote", "'", "--nodes", data.getAbsolutePath() );
+
+        // THEN
+        String expected = "[";
+        for ( String value : values )
+        {
+            expected += value.trim() + ", ";
+        }
+        expected = expected.substring( 0, expected.length() - 2 ) + "]";
+
+        int nodeCount = 0;
+        try ( Transaction tx = dbRule.beginTx() )
+        {
+            for ( Node node : dbRule.getAllNodes() )
+            {
+                nodeCount++;
+
+                assertEquals( 2, node.getAllProperties().size() );
+                for ( String key : node.getPropertyKeys() )
+                {
+                    Object things = node.getProperty( key );
+                    String result = "";
+                    switch ( key )
+                    {
+                    case "f":
+                        result = Arrays.toString( (float[]) things );
+                        break;
+                    case "d":
+                        result = Arrays.toString( (double[]) things );
+                        break;
+                    }
+
+                    assertEquals( expected, result );
+                }
+            }
+
+            tx.success();
+        }
+
+        assertEquals( 1, nodeCount );
+    }
+
+    @Test
+    public void shouldIgnoreWhitespaceInAndAroundBooleanArrays() throws Exception
+    {
+        // GIVEN
+        // Faster to do all successful in one import than in N separate tests
+        String[] values =
+                new String[]{ "true", "  true", "true   ", "  true  ", " false ", "false ", " false", "bla bla",
+                        " truebutnotreally  " };
+
+        String expected = "[";
+        for ( String value : values )
+        {
+            if ( value.contains( "bla" ) )
+            {
+                expected += "false, ";
+            }
+            else if ( value.contains( "notreally" ) )
+            {
+                expected += "false]";
+            }
+            else
+            {
+                expected += value.trim() + ", ";
+            }
+        }
+
+        File data = writeArrayCsv( new String[]{ "b:boolean[]" }, values );
+
+        // WHEN
+        importTool( "--into", dbRule.getStoreDirAbsolutePath(), "--quote", "'", "--nodes", data.getAbsolutePath() );
+
+        // THEN
+        int nodeCount = 0;
+        try ( Transaction tx = dbRule.beginTx() )
+        {
+            for ( Node node : dbRule.getAllNodes() )
+            {
+                nodeCount++;
+
+                assertEquals( 1, node.getAllProperties().size() );
+                for ( String key : node.getPropertyKeys() )
+                {
+                    Object things = node.getProperty( key );
+                    String result = Arrays.toString( (boolean[]) things );
+
+                    assertEquals( expected, result );
+                }
+            }
+
+            tx.success();
+        }
+
+        assertEquals( 1, nodeCount );
     }
 
     @Test
@@ -1176,6 +1536,45 @@ public class ImportToolTest
         }
     }
 
+    private File writeArrayCsv( String[] headers, String[] values ) throws FileNotFoundException
+    {
+        File data = file( fileName( "whitespace.csv" ) );
+        try ( PrintStream writer = new PrintStream( data ) )
+        {
+            writer.print( ":LABEL" );
+            for ( String header : headers )
+            {
+                writer.print( "," + header );
+            }
+            // End line
+            writer.println();
+
+            // Save value as a String in name
+            writer.print( "PERSON" );
+            // For each type
+            for ( String ignored : headers )
+            {
+                boolean comma = true;
+                for ( String value : values )
+                {
+                    if ( comma )
+                    {
+                        writer.print( "," );
+                        comma = false;
+                    }
+                    else
+                    {
+                        writer.print( ";" );
+                    }
+                    writer.print( value );
+                }
+            }
+            // End line
+            writer.println();
+        }
+        return data;
+    }
+
     private File data( String... lines ) throws Exception
     {
         File file = file( fileName( "data.csv" ) );
@@ -1586,7 +1985,7 @@ public class ImportToolTest
         };
     }
 
-    private void assertExceptionContains( Exception e, String message, Class<? extends Exception> type )
+    public static void assertExceptionContains( Exception e, String message, Class<? extends Exception> type )
             throws Exception
     {
         if ( !contains( e, message, type ) )
@@ -1613,7 +2012,7 @@ public class ImportToolTest
         };
     }
 
-    private void importTool( String... arguments ) throws IOException
+    public static void importTool( String... arguments ) throws IOException
     {
         ImportTool.main( arguments, true );
     }


### PR DESCRIPTION
When the value is explicitly defined as a non-string, e.g. a number of a boolean, then
leading/trailing whitespace can unambigiuously be removed.
If we were using regular strings this change would simply amount to `val = val.trim()`.

Previously, we un-intentionally supported this for Floats/Doubles, but not any other type.
These changes make behavior consistent, and adds tests (both positive and negative).
