### PR TITLE
Reduce flakiness of tests

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -992,6 +992,13 @@ public class ClusterManager
             members.remove( serverId );
             life.remove( db );
             db.shutdown();
+            // Sleep a little to help ensure that the shutdown thread has completed before we return
+            try
+            {
+                Thread.sleep( 50L );
+            }
+            catch ( InterruptedException ignored )
+            {}
             return wrap( new StartDatabaseAgainKit( this, serverId ) );
         }
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
@@ -63,10 +63,12 @@ import static org.neo4j.qa.tooling.DumpProcessInformationRule.localVm;
 
 public class TransactionConstraintsIT
 {
+    private static final int SLAVE_ONLY_ID = 1;
+
     @ClassRule
     public static final ClusterRule clusterRule = new ClusterRule( TransactionConstraintsIT.class )
             .withSharedSetting( HaSettings.pull_interval, "0" )
-            .withInstanceSetting( HaSettings.slave_only,  (serverId) -> serverId == 1 ? "true" : "false" );
+            .withInstanceSetting( HaSettings.slave_only,  (serverId) -> serverId == SLAVE_ONLY_ID ? "true" : "false" );
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -152,7 +154,7 @@ public class TransactionConstraintsIT
     private HighlyAvailableGraphDatabase getSlaveOnlySlave()
     {
         HighlyAvailableGraphDatabase db = first( cluster.getAllMembers() );
-        assertEquals( 1, cluster.getServerId( db ).toIntegerIndex() );
+        assertEquals( SLAVE_ONLY_ID, cluster.getServerId( db ).toIntegerIndex() );
         assertFalse( db.isMaster() );
         return db;
     }


### PR DESCRIPTION
First change introduces a slave-only member in cluster test to actually
guarantee who becomes master in tests. Previous method was susceptible
to a race condition.

Second change introduces a small sleep in the shutdown method for test
clusters to reduce likelihood of a race at that point.

Note: I have another PR incoming which will change this sleep to something robust.
