### PR TITLE
Add a configuration option to disable shortestpath fallback

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathExhaustiveForbiddenAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathExhaustiveForbiddenAcceptanceTest.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.internal.frontend.v3_0.{ExhaustiveShortestPathForbiddenException => InternalExhaustiveShortestPathForbiddenException}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, ExhaustiveShortestPathForbiddenException}
+import org.neo4j.graphdb.Node
+import org.neo4j.graphdb.config.Setting
+import org.neo4j.graphdb.factory.GraphDatabaseSettings
+
+import scala.collection.mutable
+
+class ShortestPathExhaustiveForbiddenAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+  override def databaseConfig(): Map[Setting[_], String] =
+    Map(GraphDatabaseSettings.forbid_exhaustive_shortestpath -> "true")
+
+  test("should fail at run time when using the shortest path fallback") {
+    // when
+    val exception = the [ExhaustiveShortestPathForbiddenException] thrownBy executeWithCostPlannerOnly(
+      s"""MATCH p = shortestPath((src:$topLeft)-[*0..]-(dst:$topLeft))
+          |WHERE ANY(n in nodes(p) WHERE n:$topRight)
+          |RETURN nodes(p) AS nodes""".stripMargin)
+
+    // then
+    exception should have message InternalExhaustiveShortestPathForbiddenException.ERROR_MSG
+  }
+
+  val dim = 4
+  val dMax = dim - 1
+  val topLeft = "CELL00"
+  val topRight = s"CELL0${dMax}"
+  val bottomLeft = s"CELL${dMax}0"
+  val bottomRight = s"CELL${dMax}${dMax}"
+  val middle = s"CELL${dMax/2}${dMax/2}"
+  val nodesByName: mutable.Map[String, Node] = mutable.Map[String, Node]()
+
+  override protected def initTest(): Unit = {
+    super.initTest()
+    0 to dMax foreach { row =>
+      0 to dMax foreach { col =>
+        val name = s"$row$col"
+        val node = createLabeledNode(Map("name" -> name, "row" -> row, "col" -> col), s"CELL$row$col", s"ROW$row", s"COL$col")
+        nodesByName(name) = node
+        if (row > 0) {
+          relate(nodesByName(s"${row - 1}$col"), nodesByName(name), "DOWN", s"r${row - 1}-${row}c$col")
+        }
+        if (col > 0) {
+          relate(nodesByName(s"$row${col - 1}"), nodesByName(name), "RIGHT", s"r${row}c${col - 1}${col}")
+        }
+      }
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
@@ -65,6 +65,7 @@ case class CypherCompilerConfiguration(queryCacheSize: Int,
                                        useErrorsOverWarnings: Boolean,
                                        idpMaxTableSize: Int,
                                        idpIterationDuration: Long,
+                                       errorIfShortestPathFallbackUsedAtRuntime: Boolean,
                                        nonIndexedLabelWarningThreshold: Long)
 
 object CypherCompilerFactory {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ErrorPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ErrorPipe.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.pipes
+
+import org.neo4j.cypher.internal.compiler.v3_0.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v3_0.executionplan.Effects
+import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
+import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
+
+case class ErrorPipe(source: Pipe, exception: Exception)(val estimatedCardinality: Option[Double] = None)(implicit pipeMonitor: PipeMonitor)
+  extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
+  override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
+    throw exception
+
+  override def planDescriptionWithoutCardinality: InternalPlanDescription =
+    source.planDescription.andThen(this.id, "Error", variables)
+
+  override def withEstimatedCardinality(estimated: Double): Pipe with RonjaPipe = copy()(Some(estimated))
+
+  override def localEffects: Effects = Effects()
+
+  override def symbols: SymbolTable = source.symbols
+
+  override def dup(sources: List[Pipe]): Pipe = {
+    val (head :: Nil) = sources
+    copy(source = head)(estimatedCardinality)
+  }
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
@@ -86,6 +86,7 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
 
     val context = LogicalPlanningContext(planContext, logicalPlanProducer, metrics, semanticTable,
       queryGraphSolver, notificationLogger = notificationLogger, useErrorsOverWarnings = config.useErrorsOverWarnings,
+      errorIfShortestPathFallbackUsedAtRuntime = config.errorIfShortestPathFallbackUsedAtRuntime,
       config = QueryPlannerConfiguration.default.withUpdateStrategy(updateStrategy))
 
     val plan = queryPlanner.plan(unionQuery)(context)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -369,6 +369,9 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
     case Eager(_) =>
       EagerPipe(source)()
 
+    case ErrorPlan(_, ex) =>
+      ErrorPipe(source, ex)()
+
     case RepeatableRead(_) =>
       RepeatableReadPipe(source)()
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/LogicalPlanningContext.scala
@@ -35,6 +35,7 @@ case class LogicalPlanningContext(planContext: PlanContext,
                                   input: QueryGraphSolverInput = QueryGraphSolverInput.empty,
                                   notificationLogger: InternalNotificationLogger = devNullLogger,
                                   useErrorsOverWarnings: Boolean = false,
+                                  errorIfShortestPathFallbackUsedAtRuntime: Boolean = false,
                                   config: QueryPlannerConfiguration = QueryPlannerConfiguration.default) {
   def withStrictness(strictness: StrictnessMode) = copy(input = input.withPreferredStrictness(strictness))
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/ErrorPlan.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/ErrorPlan.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans
+
+import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
+
+case class ErrorPlan(inner: LogicalPlan, exception: Exception)(val solved: PlannerQuery with CardinalityEstimation)
+  extends LogicalPlan with LogicalPlanWithoutExpressions {
+
+  override val lhs: Option[LogicalPlan] = Some(inner)
+
+  override val rhs: Option[LogicalPlan] = None
+
+  override def availableSymbols: Set[IdName] = inner.availableSymbols
+
+  override def strictness: StrictnessMode = inner.strictness
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
@@ -28,8 +28,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{DeleteExpr
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{LogicalPlanningContext, SortDescription}
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
-import org.neo4j.cypher.internal.frontend.v3_0.{InternalException, SemanticDirection, ast}
-
+import org.neo4j.cypher.internal.frontend.v3_0.{InternalException, SemanticDirection, ast, _}
 
 /*
  * The responsibility of this class is to produce the correct solved PlannerQuery when creating logical plans.
@@ -600,6 +599,9 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends Colle
 
   def planEager(inner: LogicalPlan) =
     Eager(inner)(inner.solved)
+
+  def planError(inner: LogicalPlan, exception: ExhaustiveShortestPathForbiddenException) =
+    ErrorPlan(inner, exception)(inner.solved)
 
   implicit def estimatePlannerQuery(plannerQuery: PlannerQuery)(implicit context: LogicalPlanningContext): PlannerQuery with CardinalityEstimation = {
     val cardinality = cardinalityModel(plannerQuery, context.input, context.semanticTable)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/planShortestPaths.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/planShortestPaths.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Ascending, Logic
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.expandSolverStep
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{Predicate, QueryGraph}
+import org.neo4j.cypher.internal.frontend.v3_0.notification.ExhaustiveShortestPathForbiddenNotification
 import org.neo4j.cypher.internal.frontend.v3_0.{ExhaustiveShortestPathForbiddenException, InternalException}
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.ast.functions.Length
@@ -73,6 +74,9 @@ case object planShortestPaths {
                                             unsafePredicates: Seq[Expression],
                                             queryGraph: QueryGraph)
                                            (implicit context: LogicalPlanningContext): LogicalPlan = {
+    // create warning for planning a shortest path fallback
+    context.notificationLogger += ExhaustiveShortestPathForbiddenNotification(shortestPath.expr.position)
+
     val lpp = context.logicalPlanProducer
 
     // Plan FindShortestPaths within an Apply with an Optional so we get null rows when

--- a/community/cypher/cypher-compiler-3.0/src/test/java/org/neo4j/cypher/internal/compiler/v3_0/pipes/ErrorPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/java/org/neo4j/cypher/internal/compiler/v3_0/pipes/ErrorPipeTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.pipes
+
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+
+class ErrorPipeTest extends CypherFunSuite {
+
+  private implicit val pipeMonitor = mock[PipeMonitor]
+
+  test("should throw an exception when used") {
+    val exception = new RuntimeException("Boom!")
+    val pipe = new ErrorPipe(mock[Pipe], exception)(None)
+
+    val thrown = the [RuntimeException] thrownBy pipe.createResults(QueryStateHelper.empty)
+
+    thrown should be theSameInstanceAs exception
+  }
+}

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
@@ -40,7 +40,8 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
     useErrorsOverWarnings = false,
     nonIndexedLabelWarningThreshold = 10000,
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
-    idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit
+    idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
+    errorIfShortestPathFallbackUsedAtRuntime = false
   )
   val planBuilder = new LegacyExecutablePlanBuilder(mock[Monitors], config, RewriterStepSequencer.newValidating)
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -177,9 +177,10 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
     statsDivergenceThreshold = 0.5,
     queryPlanTTL = 1000,
     useErrorsOverWarnings = false,
-    nonIndexedLabelWarningThreshold = 10000,
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
-    idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit
+    idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
+    errorIfShortestPathFallbackUsedAtRuntime = false,
+    nonIndexedLabelWarningThreshold = 10000
   )
 
   def produceLogicalPlan(queryText: String)(implicit planner: CostBasedExecutablePlanBuilder, planContext: PlanContext): LogicalPlan = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -152,3 +152,5 @@ class LoadExternalResourceException(message: String, cause: Throwable) extends C
 class LoadCsvStatusWrapCypherException(extraInfo: String, cause: CypherException) extends CypherException(s"${cause.getMessage} (${extraInfo})", cause) {
   val status = cause.status
 }
+
+class ExhaustiveShortestPathForbiddenException(message: String, cause: Throwable) extends CypherExecutionException(message, cause)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
@@ -227,7 +227,7 @@ class ExecutionEngine(graph: GraphDatabaseService, logProvider: LogProvider = Nu
       graph, GraphDatabaseSettings.cypher_planner, CypherPlanner.default.name))
     val runtime = CypherRuntime(optGraphSetting[String](
       graph, GraphDatabaseSettings.cypher_runtime, CypherRuntime.default.name))
-    val useErrorsOverWarnings: java.lang.Boolean = optGraphSetting[java.lang.Boolean](
+    val useErrorsOverWarnings = optGraphSetting[java.lang.Boolean](
       graph, GraphDatabaseSettings.cypher_hints_error,
       GraphDatabaseSettings.cypher_hints_error.getDefaultValue.toBoolean)
     val idpMaxTableSize: Int = optGraphSetting[java.lang.Integer](
@@ -236,13 +236,18 @@ class ExecutionEngine(graph: GraphDatabaseService, logProvider: LogProvider = Nu
     val idpIterationDuration: Long = optGraphSetting[java.lang.Long](
       graph, GraphDatabaseSettings.cypher_idp_solver_duration_threshold,
       GraphDatabaseSettings.cypher_idp_solver_duration_threshold.getDefaultValue.toLong)
+
+    val errorIfShortestPathFallbackUsedAtRuntime = optGraphSetting[java.lang.Boolean](
+      graph, GraphDatabaseSettings.forbid_exhaustive_shortestpath,
+      GraphDatabaseSettings.forbid_exhaustive_shortestpath.getDefaultValue.toBoolean
+    )
     if (((version != CypherVersion.v2_3) || (version != CypherVersion.v3_0)) && (planner == CypherPlanner.greedy || planner == CypherPlanner.idp || planner == CypherPlanner.dp)) {
       val message = s"Cannot combine configurations: ${GraphDatabaseSettings.cypher_parser_version.name}=${version.name} " +
         s"with ${GraphDatabaseSettings.cypher_planner.name} = ${planner.name}"
       log.error(message)
       throw new IllegalStateException(message)
     }
-    new CypherCompiler(graph, kernel, kernelMonitors, version, planner, runtime, useErrorsOverWarnings, idpMaxTableSize, idpIterationDuration, logProvider)
+    new CypherCompiler(graph, kernel, kernelMonitors, version, planner, runtime, useErrorsOverWarnings, idpMaxTableSize, idpIterationDuration, errorIfShortestPathFallbackUsedAtRuntime, logProvider)
   }
 
   private def getPlanCacheSize: Int =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal
 
-import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compatibility.exceptionHandlerFor3_0
+import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.frontend.v3_0.InputPosition
 import org.neo4j.cypher.{InvalidArgumentException, SyntaxException, _}
 import org.neo4j.graphdb.GraphDatabaseService
@@ -29,7 +29,6 @@ import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseAPI
 import org.neo4j.kernel.api.KernelAPI
 import org.neo4j.kernel.configuration.Config
-import org.neo4j.kernel.impl.factory.GraphDatabaseFacade
 import org.neo4j.kernel.monitoring.{Monitors => KernelMonitors}
 import org.neo4j.logging.{Log, LogProvider}
 
@@ -73,6 +72,7 @@ class CypherCompiler(graph: GraphDatabaseService,
                      useErrorsOverWarnings: Boolean,
                      idpMaxTableSize: Int,
                      idpIterationDuration: Long,
+                     errorIfShortestPathFallbackUsedAtRuntime: Boolean,
                      logProvider: LogProvider) {
   import org.neo4j.cypher.internal.CypherCompiler._
 
@@ -85,6 +85,7 @@ class CypherCompiler(graph: GraphDatabaseService,
     useErrorsOverWarnings = useErrorsOverWarnings,
     idpMaxTableSize = idpMaxTableSize,
     idpIterationDuration = idpIterationDuration,
+    errorIfShortestPathFallbackUsedAtRuntime = errorIfShortestPathFallbackUsedAtRuntime,
     nonIndexedLabelWarningThreshold = getNonIndexedLabelWarningThreshold
   )
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -350,6 +350,8 @@ case class ExecutionResultWrapperFor3_0(inner: InternalExecutionResult, planner:
       NotificationCode.MISSING_PROPERTY_NAME.notification(pos.asInputPosition, NotificationDetail.Factory.propertyName(name))
     case UnboundedShortestPathNotification(pos) =>
       NotificationCode.UNBOUNDED_SHORTEST_PATH.notification(pos.asInputPosition)
+    case ExhaustiveShortestPathForbiddenNotification(pos) =>
+      NotificationCode.EXHAUSTIVE_SHORTEST_PATH.notification(pos.asInputPosition)
   }
 
   override def accept[EX <: Exception](visitor: ResultVisitor[EX]) = exceptionHandlerFor3_0.runSafely {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -95,6 +95,9 @@ object exceptionHandlerFor3_0 extends MapToPublicExceptions[CypherException] {
 
   def cypherExecutionException(message: String, cause: Throwable) = throw new CypherExecutionException(message, cause)
 
+  override def shortestPathFallbackDisableRuntimeException(message: String, cause: Throwable): CypherException =
+    throw new ExhaustiveShortestPathForbiddenException(message, cause)
+
   def labelScanHintException(variable: String, label: String, message: String, cause: Throwable) =
     throw new LabelScanHintException(variable, label, message, cause)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -29,7 +29,6 @@ import org.neo4j.cypher.internal.frontend.v3_0.notification.CartesianProductNoti
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.spi.v3_0.GeneratedQueryStructure
 import org.neo4j.helpers.Clock
-import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.logging.NullLog
 
 class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with GraphDatabaseTestSupport {
@@ -101,8 +100,6 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
   }
 
   private def createCompiler() = {
-    val nodeManager = graph.getDependencyResolver.resolveDependency(classOf[NodeManager])
-
     CypherCompilerFactory.costBasedCompiler(
       graph,
       CypherCompilerConfiguration(
@@ -112,6 +109,7 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
         useErrorsOverWarnings = false,
         idpMaxTableSize = 128,
         idpIterationDuration = 1000,
+        errorIfShortestPathFallbackUsedAtRuntime = false,
         nonIndexedLabelWarningThreshold = 10000L
       ),
       Clock.SYSTEM_CLOCK,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -236,6 +236,7 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
     useErrorsOverWarnings = false,
     nonIndexedLabelWarningThreshold = 10000,
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
-    idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit
+    idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
+    errorIfShortestPathFallbackUsedAtRuntime = false
   )
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -25,7 +25,6 @@ import org.neo4j.cypher.internal.compatibility.WrappedMonitors3_0
 import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v3_0.{CypherCompilerFactory, InfoLogger, _}
 import org.neo4j.cypher.internal.spi.v3_0.GeneratedQueryStructure
-import org.neo4j.kernel.impl.core.NodeManager
 
 class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
 
@@ -169,8 +168,6 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
   }
 
   def createCurrentCompiler = {
-    val nodeManager = graph.getDependencyResolver.resolveDependency(classOf[NodeManager])
-
     CypherCompilerFactory.costBasedCompiler(
       graph = graph,
       CypherCompilerConfiguration(
@@ -180,6 +177,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
         useErrorsOverWarnings = false,
         idpMaxTableSize = 128,
         idpIterationDuration = 1000,
+        errorIfShortestPathFallbackUsedAtRuntime = false,
         nonIndexedLabelWarningThreshold = 10000L
       ),
       clock = CLOCK,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
@@ -53,7 +53,8 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     useErrorsOverWarnings = false,
     idpMaxTableSize = 128,
     idpIterationDuration = 1000,
-    nonIndexedLabelWarningThreshold = 10000
+    nonIndexedLabelWarningThreshold = 10000,
+    errorIfShortestPathFallbackUsedAtRuntime = true
   )
 
   val compilers = Seq[(String, GraphDatabaseService => CypherCompiler)](

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
@@ -49,6 +49,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
         useErrorsOverWarnings = false,
         idpMaxTableSize = 128,
         idpIterationDuration = 1000,
+        errorIfShortestPathFallbackUsedAtRuntime = false,
         nonIndexedLabelWarningThreshold = 10000L
       ),
       clock, GeneratedQueryStructure,

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/notification/InternalNotification.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/notification/InternalNotification.scala
@@ -53,3 +53,5 @@ case class MissingRelTypeNotification(position: InputPosition, relType: String) 
 case class MissingPropertyNameNotification(position: InputPosition, name: String) extends InternalNotification
 
 case class UnboundedShortestPathNotification(position: InputPosition) extends InternalNotification
+
+case class ExhaustiveShortestPathForbiddenNotification(position: InputPosition) extends InternalNotification

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/spi/MapToPublicExceptions.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/spi/MapToPublicExceptions.scala
@@ -71,4 +71,6 @@ trait MapToPublicExceptions[T <: Throwable] {
   def cypherTypeException(message: String, cause: Throwable): T
 
   def cypherExecutionException(message: String, cause: Throwable): T
+
+  def shortestPathFallbackDisableRuntimeException(message: String, cause: Throwable): T
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -96,6 +96,14 @@ public abstract class GraphDatabaseSettings
             + "If true, then non-conformance will result in an error, otherwise only a warning is generated." )
     public static final Setting<Boolean> cypher_hints_error = setting( "dbms.cypher.hints.error", BOOLEAN, FALSE );
 
+    @Description( "If set to true it will disable the shortest path fallback. That means that no full path enumeration" +
+                  "will be performed in case shortest path algorithms cannot be used. This might happen in case of" +
+                  "existential predicates on the path, e.g., when searching for the shortest path containing a node" +
+                  "with property 'name=Emil'. The problem is that graph algorithms work only on universal predicates," +
+                  "e.g., when searching for the shortest where all nodes have label 'Person'.  Note that disabling " +
+                  "shortest path fallback (i.e., setting this property to true) might cause errors at runtime." )
+    public static final Setting<Boolean> forbid_exhaustive_shortestpath = setting( "dbms.cypher.forbid.exhaustive.shortestpath", BOOLEAN, FALSE );
+
     @Description( "Set this to specify the default runtime for the default language version." )
     @Internal
     public static final Setting<String> cypher_runtime = setting(

--- a/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/impl/notification/NotificationCode.java
@@ -121,6 +121,13 @@ public enum NotificationCode
             Status.Statement.UnboundedPatternWarning,
             "Using shortest path with an unbounded pattern will likely result in long execution times. " +
             "It is recommended to use an upper limit to the number of node hops in your pattern."
+    ),
+    EXHAUSTIVE_SHORTEST_PATH(
+            SeverityLevel.WARNING,
+            Status.Statement.ExhaustiveShortestPathWarning,
+            "Using shortest path with an exhaustive search fallback might cause query slow down since shortest path " +
+            "graph algorithms might not work for this use case. It is recommended to introduce a WITH to separate the " +
+            "MATCH containing the shortest path from the existential predicates on that path."
     )
     ;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
+import javax.crypto.ShortBufferException;
+
 import static java.lang.String.format;
 
 import static org.neo4j.kernel.api.exceptions.Status.Classification.ClientError;
@@ -176,7 +178,12 @@ public interface Status
         LabelMissingWarning( ClientNotification, "The provided label is not in the database." ),
         RelTypeMissingWarning( ClientNotification, "The provided relationship type is not in the database." ),
         PropertyNameMissingWarning( ClientNotification, "The provided property name is not in the database" ),
-        UnboundedPatternWarning( ClientNotification, "The provided pattern is unbounded, consider adding an upper limit to the number of node hops."  );
+        UnboundedPatternWarning( ClientNotification, "The provided pattern is unbounded, consider adding an upper limit to the number of node hops."  ),
+        ExhaustiveShortestPathWarning( ClientNotification, "Exhaustive shortest path has been planned for your query " +
+                                                           "that means that shortest path graph algorithm might not be " +
+                                                           "used to find the shortest path.  Hence an exhaustive " +
+                                                           "enumeration of all paths might be used in order to find " +
+                                                           "the requested shortest path." );
 
         private final Code code;
 


### PR DESCRIPTION
Shortestpath fallback enumerates all the paths in order to find the
shortest one, indeed in some cases graph algorithms cannot be used
(e.g., when using existential predicates on the path).  Since this
enumeration can be very expensive the user can decide to disable
fallback and the query will fail at runtime with an exception if the
graph algorithm is unable to find any path.

The default value for this config is false, which means that fallback
is enabled.
