### PR TITLE
Improve robustness of HA-test infrastructure

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -96,8 +97,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
 import static org.neo4j.helpers.ArrayUtil.contains;
 import static org.neo4j.helpers.collection.Iterables.count;
-import static org.neo4j.helpers.collection.Iterables.filter;
-import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.fs.FileUtils.copyRecursively;
 
@@ -913,9 +912,9 @@ public class ClusterManager
         public Iterable<HighlyAvailableGraphDatabase> getAllMembers( HighlyAvailableGraphDatabase... except )
         {
             Set<HighlyAvailableGraphDatabase> exceptSet = new HashSet<>( asList( except ) );
-            return filter( db -> !exceptSet.contains( db ), map( from -> {
-                return from.get( DEFAULT_TIMEOUT_SECONDS );
-            }, members.values() ) );
+
+            return members.values().stream().map( proxy -> proxy.get( DEFAULT_TIMEOUT_SECONDS ) )
+                    .filter( db -> !exceptSet.contains( db ) ).collect( Collectors.toList());
         }
 
         public Iterable<ObservedClusterMembers> getArbiters()

--- a/enterprise/ha/src/test/java/jmx/HaBeanIT.java
+++ b/enterprise/ha/src/test/java/jmx/HaBeanIT.java
@@ -198,7 +198,7 @@ public class HaBeanIT
             masterShutdown.repair();
         }
         cluster.await( ClusterManager.masterAvailable() );
-        cluster.await( ClusterManager.masterSeesSlavesAsAvailable( 2 ) );
+        cluster.await( ClusterManager.allSeesAllAsAvailable() );
         for ( HighlyAvailableGraphDatabase db : cluster.getAllMembers() )
         {
             int mastersFound = 0;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
@@ -180,7 +180,7 @@ public class TransactionThroughMasterSwitchStressIT
         cluster.await( memberSeesOtherMemberAsFailed( master, slave ) );
 
         // Fail master and wait for master to go to pending, since cluster lost quorum
-        RepairKit masterRepair = cluster.fail( master, NetworkFlag.IN );
+        RepairKit masterRepair = cluster.fail( master, false, NetworkFlag.IN );
         cluster.await( memberThinksItIsRole( master, UNKNOWN ) );
 
         // Then Immediately repair

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -147,7 +147,8 @@ public class ClusterRule extends ExternalResource implements ClusterBuilder<Clus
     }
 
     /**
-     * Starts cluster with the configuration provided at instantiation time.
+     * Starts cluster with the configuration provided at instantiation time. This method will not return until the
+     * cluster is up and all members report each other as available.
      */
     public ClusterManager.ManagedCluster startCluster() throws Exception
     {
@@ -165,7 +166,9 @@ public class ClusterRule extends ExternalResource implements ClusterBuilder<Clus
         {
             throw new RuntimeException( throwable );
         }
-        return this.cluster = clusterManager.getDefaultCluster();
+        cluster = clusterManager.getDefaultCluster();
+        cluster.await( allSeesAllAsAvailable() );
+        return cluster;
     }
 
     @Override


### PR DESCRIPTION
builds on https://github.com/neo4j/neo4j/pull/6322

Makes operations such as fail, shutdown, and start, respect the implicit
assumptions made about them, e.g. that once fail returns, the specific
instance has been marked as failed and the cluster knows about it.

These specific assumptions were false and made tests flaky. The
multi-threaded nature here previously had no such guarantees and if a
thread switch, garbage collection, or [insert favorite explanation here]
occurred, the function might very well return before the instance had
been failed/shutdown.

As a requirement to this, the handling and detection of arbiter
instances had to be improved as well.
