### PR TITLE
Fix initialization of query statistics

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionResult.scala
@@ -74,7 +74,7 @@ case class QueryStatistics(nodesCreated: Int = 0,
       constraintsRemoved > 0
 
   override def toString = {
-    val builder = new StringBuilder("\n")
+    val builder = new StringBuilder
 
     includeIfNonZero(builder, "Nodes created: ", nodesCreated)
     includeIfNonZero(builder, "Relationships created: ", relationshipsCreated)


### PR DESCRIPTION
The query statistics were initialized to a nonempty StringBuilder, causing the
`nothing happened` placeholder to never come into effect.
