### PR TITLE
Correctly read configuration when accessing keys in Bolt

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.bolt;
 
-import io.netty.channel.Channel;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import org.bouncycastle.operator.OperatorCreationException;
-
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -31,6 +26,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+
+import io.netty.channel.Channel;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import org.bouncycastle.operator.OperatorCreationException;
 
 import org.neo4j.bolt.security.ssl.Certificates;
 import org.neo4j.bolt.security.ssl.KeyStoreFactory;
@@ -208,7 +208,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
                     requireEncryption = true;
                     // no break here
                 case OPTIONAL:
-                    KeyStoreInformation keyStore = createKeyStore( connector, log );
+                    KeyStoreInformation keyStore = createKeyStore( config, log );
                     sslCtx = SslContextBuilder.forServer( keyStore.getCertificatePath(), keyStore.getPrivateKeyPath() ).build();
                     break;
                 default:

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/CertificatesIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/CertificatesIT.java
@@ -32,7 +32,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Set;
 
-import org.neo4j.bolt.BoltKernelExtension;
 import org.neo4j.bolt.security.ssl.Certificates;
 import org.neo4j.bolt.v1.transport.socket.client.SecureSocketConnection;
 import org.neo4j.helpers.HostnamePort;
@@ -40,7 +39,8 @@ import org.neo4j.helpers.HostnamePort;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.neo4j.bolt.BoltKernelExtension.Settings.connector;
+import static org.neo4j.bolt.BoltKernelExtension.Settings.tls_certificate_file;
+import static org.neo4j.bolt.BoltKernelExtension.Settings.tls_key_file;
 
 public class CertificatesIT
 {
@@ -50,8 +50,8 @@ public class CertificatesIT
 
     @Rule
     public Neo4jWithSocket server = new Neo4jWithSocket( settings -> {
-        settings.put( connector( 0, BoltKernelExtension.Settings.tls_certificate_file ), certFile.getAbsolutePath() );
-        settings.put( connector( 0, BoltKernelExtension.Settings.tls_key_file ), keyFile.getAbsolutePath() );
+        settings.put( tls_certificate_file, certFile.getAbsolutePath() );
+        settings.put( tls_key_file, keyFile.getAbsolutePath() );
     } );
 
     @Test


### PR DESCRIPTION
We previously erroneously read the key configuration out of the Bolt
connector settings groups. But that configuration is defined once for
the entire server, not per-connector. As a result we always used the
default locations for the keys, not those that had been configured.
