### PR TITLE
Make DISTINCT work with arrays inside nested structures

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DistinctPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DistinctPipe.scala
@@ -40,7 +40,7 @@ case class DistinctPipe(source: Pipe, expressions: Map[String, Expression])(val 
     state.decorator.registerParentPipe(this)
 
     // Run the return item expressions, and replace the execution context's with their values
-    val returnExpressions = input.map(ctx => {
+    val result = input.map(ctx => {
       val newMap = Eagerly.mutableMapValues(expressions, (expression: Expression) => expression(ctx)(state))
       ctx.copy(m = newMap)
     })
@@ -51,9 +51,9 @@ case class DistinctPipe(source: Pipe, expressions: Map[String, Expression])(val 
      */
     var seen = mutable.Set[NiceHasher]()
 
-    returnExpressions.filter {
+    result.filter {
        case ctx =>
-         val values = new NiceHasher(keyNames.map(ctx).toSeq)
+         val values = new NiceHasher(keyNames.map(ctx))
 
          if (seen.contains(values)) {
            false

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/aggregation/DistinctFunction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/aggregation/DistinctFunction.scala
@@ -20,15 +20,15 @@
 package org.neo4j.cypher.internal.compiler.v2_2.pipes.aggregation
 
 import org.neo4j.cypher.internal.compiler.v2_2._
-import commands.expressions.Expression
-import pipes.QueryState
+import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Expression
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.{NiceHasherValue, QueryState}
 
 class DistinctFunction(value: Expression, inner: AggregationFunction) extends AggregationFunction {
-  val seen = scala.collection.mutable.Set[Any]()
+  val seen = scala.collection.mutable.Set[NiceHasherValue]()
   var seenNull = false
 
   def apply(ctx: ExecutionContext)(implicit state: QueryState) {
-    val data = value(ctx)
+    val data = new NiceHasherValue(value(ctx))
 
     if (data == null) {
       if (!seenNull) {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DistinctPipeTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/DistinctPipeTest.scala
@@ -21,13 +21,13 @@ package org.neo4j.cypher.internal.compiler.v2_2.pipes
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.{Expression, Identifier, Literal, Multiply}
-import org.neo4j.cypher.internal.compiler.v2_2.symbols._
+import org.neo4j.cypher.internal.compiler.v2_2.symbols.CTNumber
 
 class DistinctPipeTest extends CypherFunSuite {
 
   private implicit val monitor = mock[PipeMonitor]
 
-  test("distinct_input_passes_through") {
+  test("distinct input passes through") {
     //GIVEN
     val pipe = createDistinctPipe(List(Map("x" -> 1), Map("x" -> 2)))
 
@@ -35,10 +35,10 @@ class DistinctPipeTest extends CypherFunSuite {
     val result = pipe.createResults(QueryStateHelper.empty)
 
     //THEN
-    result.toList should equal( List(Map("x" -> 1), Map("x" -> 2)))
+    result.toList should equal(List(Map("x" -> 1), Map("x" -> 2)))
   }
 
-  test("distinct_executes_expressions") {
+  test("distinct executes expressions") {
     //GIVEN
     val expressions = Map("doubled" -> Multiply(Identifier("x"), Literal(2)))
     val pipe = createDistinctPipe(List(Map("x" -> 1), Map("x" -> 2)), expressions)
@@ -47,10 +47,10 @@ class DistinctPipeTest extends CypherFunSuite {
     val result = pipe.createResults(QueryStateHelper.empty)
 
     //THEN
-    result.toList should equal( List(Map("doubled" -> 2), Map("doubled" -> 4)))
+    result.toList should equal(List(Map("doubled" -> 2), Map("doubled" -> 4)))
   }
 
-  test("undistinct_input_passes_through") {
+  test("undistinct input passes through") {
     //GIVEN
     val pipe = createDistinctPipe(List(Map("x" -> 1), Map("x" -> 1)))
 
@@ -58,10 +58,24 @@ class DistinctPipeTest extends CypherFunSuite {
     val result = pipe.createResults(QueryStateHelper.empty)
 
     //THEN
-    result.toList should equal( List(Map("x" -> 1)))
+    result.toList should equal(List(Map("x" -> 1)))
   }
 
-  def createDistinctPipe(input: List[Map[String, Int]], expressions: Map[String, Expression] = Map("x" -> Identifier("x"))) = {
+  test("distinct deals with maps containing java arrays") {
+    //GIVEN
+    val pipe = createDistinctPipe(List(
+      Map("x" -> Map("prop" -> Array[String]("a", "b"))),
+      Map("x" -> Map("prop" -> Array[String]("a", "b")))))
+
+    //WHEN
+    val result = pipe.createResults(QueryStateHelper.empty).toList
+
+    //THEN
+    result should have size 1
+    result.head("x").asInstanceOf[Map[String,Array[String]]].apply("prop").toSeq should equal(Seq("a", "b"))
+  }
+
+  def createDistinctPipe(input: List[Map[String, Any]], expressions: Map[String, Expression] = Map("x" -> Identifier("x"))) = {
     val source = new FakePipe(input, "x" -> CTNumber)
     new DistinctPipe(source, expressions)()
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ReturnAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ReturnAcceptanceTest.scala
@@ -555,4 +555,24 @@ return coalesce(a.title, a.name)""")
 
     result.toList should equal(List(Map("count(*)" -> 1)))
   }
+
+  test("distinct inside aggregation should work with nested collections inside map") {
+    val propertyCollection = Array("A", "B")
+    createNode("array" -> propertyCollection)
+    createNode("array" -> propertyCollection)
+
+    val result = executeWithAllPlanners("MATCH (n) RETURN count(distinct {foo: [[n.array, n.array], [n.array, n.array]]}) as count")
+
+    result.toList should equal(List(Map("count" -> 1)))
+  }
+
+  test("distinct inside aggregation should work with nested collections of maps inside map") {
+    val propertyCollection = Array("A", "B")
+    createNode("array" -> propertyCollection)
+    createNode("array" -> propertyCollection)
+
+    val result = executeWithAllPlanners("MATCH (n) RETURN count(distinct {foo: [{bar: n.array}, {baz: {apa: n.array}}]}) as count")
+
+    result.toList should equal(List(Map("count" -> 1)))
+  }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ReturnAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ReturnAcceptanceTest.scala
@@ -535,4 +535,24 @@ return coalesce(a.title, a.name)""")
 
     result shouldBe empty
   }
+
+  test("distinct inside aggregation should work with collections inside maps") {
+    val propertyCollection = Array("A", "B")
+    createNode("array" -> propertyCollection)
+    createNode("array" -> propertyCollection)
+
+    val result = executeWithAllPlanners("MATCH (n) RETURN count(distinct {foo: n.array}) as count")
+
+    result.toList should equal(List(Map("count" -> 1)))
+  }
+
+  test("distinct should work with collections inside maps") {
+    val propertyCollection = Array("A", "B")
+    createNode("array" -> propertyCollection)
+    createNode("array" -> propertyCollection)
+
+    val result = executeWithAllPlanners("MATCH (n) WITH distinct {foo: n.array} as map RETURN count(*)")
+
+    result.toList should equal(List(Map("count(*)" -> 1)))
+  }
 }


### PR DESCRIPTION
Property values can be primitive Java arrays, and they should work with aggregation and distinct
when nested inside maps or collections.  
This extends the hashing/compare functions to recursively transform primitive arrays properly.
