### PR TITLE
Disable lucene index searcher query cache.

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/PartitionSearcher.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/PartitionSearcher.java
@@ -38,6 +38,7 @@ public class PartitionSearcher implements Closeable
     {
         this.referenceManager = referenceManager;
         this.indexSearcher = referenceManager.acquire();
+        this.indexSearcher.setQueryCache( null );
     }
 
     public IndexSearcher getIndexSearcher()


### PR DESCRIPTION
Since we do not get any advantages from query caching (since we do not reuse them)
and just wasting memory and time cashing them.
Benchmarks show around 5% throughput increase as result.
