### PR TITLE
Stop warnings about literal maps keys

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/checkForUnresolvedTokens.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/checkForUnresolvedTokens.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_0.planner
 
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticTable
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{PropertyKeyName, RelTypeName, LabelName, Query}
+import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.notification.{MissingPropertyNameNotification, MissingRelTypeNotification, MissingLabelNotification, InternalNotification}
 
 /**
@@ -41,7 +41,7 @@ object checkForUnresolvedTokens extends ((Query, SemanticTable) => Seq[InternalN
       case rel@RelTypeName(name) if isEmptyRelType(name) => acc =>
         (acc :+ MissingRelTypeNotification(rel.position, name), Some(identity))
 
-      case prop@PropertyKeyName(name) if isEmptyPropertyName(name) => acc =>
+      case Property(_, prop@PropertyKeyName(name)) if isEmptyPropertyName(name) => acc =>
         (acc :+ MissingPropertyNameNotification(prop.position, name), Some(identity))
 
     }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CheckForUnresolvedTokensTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CheckForUnresolvedTokensTest.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{Query, Statement, SingleQuery}
-import org.neo4j.cypher.internal.frontend.v3_0.notification.{MissingPropertyNameNotification, MissingRelTypeNotification, MissingLabelNotification}
-import org.neo4j.cypher.internal.frontend.v3_0.{PropertyKeyId, RelTypeId, InputPosition, LabelId, SemanticTable}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.Query
+import org.neo4j.cypher.internal.frontend.v3_0.notification.{MissingLabelNotification, MissingPropertyNameNotification, MissingRelTypeNotification}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_0.{InputPosition, LabelId, PropertyKeyId, RelTypeId, SemanticTable}
 
 class CheckForUnresolvedTokensTest extends CypherFunSuite with AstRewritingTestSupport {
 
@@ -87,11 +87,11 @@ class CheckForUnresolvedTokensTest extends CypherFunSuite with AstRewritingTestS
     val semanticTable = new SemanticTable
 
     //when
-    val ast = parse("MATCH (a {prop: 42}) RETURN a")
+    val ast = parse("MATCH (a) WHERE a.prop = 42 RETURN a")
 
     //then
     checkForUnresolvedTokens(ast, semanticTable) should equal(Seq(
-      MissingPropertyNameNotification(InputPosition(10, 1, 11), "prop")))
+      MissingPropertyNameNotification(InputPosition(18, 1, 19), "prop")))
   }
 
   test("don't warn when property key name is there") {
@@ -101,6 +101,17 @@ class CheckForUnresolvedTokensTest extends CypherFunSuite with AstRewritingTestS
 
     //when
     val ast = parse("MATCH (a {prop: 42}) RETURN a")
+
+    //then
+    checkForUnresolvedTokens(ast, semanticTable) shouldBe empty
+  }
+
+  test("don't warn for literal maps") {
+    //given
+    val semanticTable = new SemanticTable
+
+    //when
+    val ast = parse("RETURN {prop: 'foo'}")
 
     //then
     checkForUnresolvedTokens(ast, semanticTable) shouldBe empty

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NotificationAcceptanceTest.scala
@@ -404,5 +404,9 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     res.notifications should not be empty
   }
 
+  test("should not warn about literal maps") {
+    val res = innerExecute("explain return { id: 42 } ")
 
+    res.notifications should be(empty)
+  }
 }


### PR DESCRIPTION
The planner mistakenly treated map keys as if they were property
keys, and since they might not exist in the store, issued warnings
for misspelled property keys.
