### PR TITLE
Decouples PhysicalLogFile from transaction specific concepts

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
@@ -566,8 +566,7 @@ public class NeoStores implements AutoCloseable
             @Override
             public long initialVersion()
             {
-                return ((MetaDataStore) getOrCreateStore( StoreType.META_DATA ))
-                        .getLastCommittedTransactionId();
+                return ((MetaDataStore) getOrCreateStore( StoreType.META_DATA )).getLastCommittedTransactionId();
             }
         } );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogHeaderCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogHeaderCache.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import org.neo4j.helpers.collection.LruCache;
+
+public class LogHeaderCache
+{
+    private final LruCache<Long /*log version*/, Long /*last committed tx*/> logHeaderCache;
+
+    public LogHeaderCache( int headerCacheSize )
+    {
+        this.logHeaderCache = new LruCache<>( "Log header cache", headerCacheSize );
+    }
+
+    public void clear()
+    {
+        logHeaderCache.clear();
+    }
+
+    public void putHeader( long logVersion, long previousLogLastCommittedTx )
+    {
+        logHeaderCache.put( logVersion, previousLogLastCommittedTx );
+    }
+
+    public long getLogHeader( long logVersion )
+    {
+        Long value = logHeaderCache.get( logVersion );
+        return value == null ? -1 : value;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileInformation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileInformation.java
@@ -29,17 +29,17 @@ public class PhysicalLogFileInformation implements LogFileInformation
     }
 
     private final PhysicalLogFiles logFiles;
-    private final TransactionMetadataCache transactionMetadataCache;
+    private final LogHeaderCache logHeaderCache;
     private final TransactionIdStore transactionIdStore;
     private final LogVersionToTimestamp logVersionToTimestamp;
 
     public PhysicalLogFileInformation( PhysicalLogFiles logFiles,
-                                       TransactionMetadataCache transactionMetadataCache,
+                                       LogHeaderCache logHeaderCache,
                                        TransactionIdStore transactionIdStore,
                                        LogVersionToTimestamp logVersionToTimestamp )
     {
         this.logFiles = logFiles;
-        this.transactionMetadataCache = transactionMetadataCache;
+        this.logHeaderCache = logHeaderCache;
         this.transactionIdStore = transactionIdStore;
         this.logVersionToTimestamp = logVersionToTimestamp;
     }
@@ -64,7 +64,7 @@ public class PhysicalLogFileInformation implements LogFileInformation
     @Override
     public long getFirstCommittedTxId( long version ) throws IOException
     {
-        long logHeader = transactionMetadataCache.getLogHeader( version );
+        long logHeader = logHeaderCache.getLogHeader( version );
         if ( logHeader != -1 )
         {   // It existed in cache
             return logHeader + 1;
@@ -74,7 +74,7 @@ public class PhysicalLogFileInformation implements LogFileInformation
         if ( logFiles.versionExists( version ) )
         {
             long previousVersionLastCommittedTx = logFiles.extractHeader( version ).lastCommittedTxId;
-            transactionMetadataCache.putHeader( version, previousVersionLastCommittedTx );
+            logHeaderCache.putHeader( version, previousVersionLastCommittedTx );
             return previousVersionLastCommittedTx + 1;
         }
         return -1;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionStore.java
@@ -46,11 +46,13 @@ public class ReadOnlyTransactionStore extends LifecycleAdapter implements Logica
             throws IOException
     {
         PhysicalLogFiles logFiles = new PhysicalLogFiles( fromPath, fs );
-        TransactionMetadataCache transactionMetadataCache = new TransactionMetadataCache( 10, 100 );
+        TransactionMetadataCache transactionMetadataCache = new TransactionMetadataCache( 100 );
+        LogHeaderCache logHeaderCache = new LogHeaderCache( 10 );
         final ReadOnlyTransactionIdStore transactionIdStore = new ReadOnlyTransactionIdStore( pageCache, fromPath );
         PhysicalLogFile logFile = life.add( new PhysicalLogFile( fs, logFiles, 0,
-                transactionIdStore, new ReadOnlyLogVersionRepository( pageCache, fromPath ),
-                monitors.newMonitor( PhysicalLogFile.Monitor.class ), transactionMetadataCache ) );
+                transactionIdStore::getLastCommittedTransactionId,
+                new ReadOnlyLogVersionRepository( pageCache, fromPath ),
+                monitors.newMonitor( PhysicalLogFile.Monitor.class ), logHeaderCache ) );
         LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader =
                 new VersionAwareLogEntryReader<>( new RecordStorageCommandReaderFactory() );
         physicalStore = new PhysicalLogicalTransactionStore( logFile, transactionMetadataCache, logEntryReader );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionMetadataCache.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionMetadataCache.java
@@ -24,29 +24,15 @@ import org.neo4j.helpers.collection.LruCache;
 public class TransactionMetadataCache
 {
     private final LruCache<Long /*tx id*/, TransactionMetadata> txStartPositionCache;
-    private final LruCache<Long /*log version*/, Long /*last committed tx*/> logHeaderCache;
 
-    public TransactionMetadataCache( int headerCacheSize, int transactionCacheSize )
+    public TransactionMetadataCache( int transactionCacheSize )
     {
-        this.logHeaderCache = new LruCache<>( "Log header cache", headerCacheSize );
         this.txStartPositionCache = new LruCache<>( "Tx start position cache", transactionCacheSize );
     }
 
     public void clear()
     {
-        logHeaderCache.clear();
         txStartPositionCache.clear();
-    }
-
-    public void putHeader( long logVersion, long previousLogLastCommittedTx )
-    {
-        logHeaderCache.put( logVersion, previousLogLastCommittedTx );
-    }
-
-    public long getLogHeader( long logVersion )
-    {
-        Long value = logHeaderCache.get( logVersion );
-        return value == null ? -1 : value;
     }
 
     public TransactionMetadata getTransactionMetadata( long txId )

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
@@ -35,6 +35,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageCommandReaderFactory;
 import org.neo4j.kernel.impl.transaction.DeadSimpleLogVersionRepository;
 import org.neo4j.kernel.impl.transaction.DeadSimpleTransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
 import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
@@ -177,8 +178,8 @@ public class RecoveryTest
                 }
             }, monitor ) );
 
-            life.add( new PhysicalLogFile( fs, logFiles, 50, transactionIdStore, logVersionRepository,
-                    mock( PhysicalLogFile.Monitor.class ), new TransactionMetadataCache( 10, 100 ) ) );
+            life.add( new PhysicalLogFile( fs, logFiles, 50, transactionIdStore::getLastCommittedTransactionId,
+                    logVersionRepository, mock( PhysicalLogFile.Monitor.class ), new LogHeaderCache( 10 ) ) );
 
             life.start();
 
@@ -247,8 +248,8 @@ public class RecoveryTest
                 }
             }, monitor ));
 
-            life.add( new PhysicalLogFile( fs, logFiles, 50, transactionIdStore, logVersionRepository, mock( PhysicalLogFile.Monitor.class),
-                    new TransactionMetadataCache( 10, 100 )) );
+            life.add( new PhysicalLogFile( fs, logFiles, 50, transactionIdStore::getLastCommittedTransactionId,
+                    logVersionRepository, mock( PhysicalLogFile.Monitor.class), new LogHeaderCache( 10 ) ) );
 
             life.start();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.api;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -30,31 +29,13 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.neo4j.function.ThrowingConsumer;
-import org.neo4j.helpers.FakeClock;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
-import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
-import org.neo4j.kernel.impl.api.KernelTransactions;
-import org.neo4j.kernel.impl.api.TransactionCommitProcess;
-import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
-import org.neo4j.kernel.impl.api.TransactionHooks;
-import org.neo4j.kernel.impl.api.TransactionToApply;
-import org.neo4j.kernel.impl.api.store.StoreStatement;
-import org.neo4j.kernel.impl.locking.NoOpClient;
-import org.neo4j.kernel.impl.store.MetaDataStore;
-import org.neo4j.kernel.impl.store.NeoStores;
-import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
-import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.Command;
-import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
-import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.storageengine.api.StorageCommand;
-import org.neo4j.storageengine.api.StorageEngine;
-import org.neo4j.storageengine.api.StoreReadLayer;
-import org.neo4j.storageengine.api.TransactionApplicationMode;
 import org.neo4j.storageengine.api.lock.ResourceLocker;
 import org.neo4j.test.DoubleLatch;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/NoChangeWriteTransactionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/NoChangeWriteTransactionTest.java
@@ -27,7 +27,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.kernel.GraphDatabaseAPI;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.ImpermanentDatabaseRule;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -238,7 +238,7 @@ public class NeoStoresTest
         {
             nodeIds[i] = nextId( Node.class );
             transaction.nodeDoCreate( nodeIds[i] );
-            nodeAddProperty( nodeIds[i], index( "nisse" ), new Integer( 10 - i ) );
+            nodeAddProperty( nodeIds[i], index( "nisse" ), 10 - i );
         }
         for ( int i = 0; i < 2; i++ )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogHeaderCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/LogHeaderCacheTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache;
+
+public class LogHeaderCacheTest
+{
+    @Test
+    public void shouldReturnNegativeNumberWhenThereIsNoHeaderInTheCache()
+    {
+        // given
+        final LogHeaderCache cache = new LogHeaderCache( 2 );
+
+        // when
+        final long logHeader = cache.getLogHeader( 5 );
+
+        // then
+        assertEquals( -1, logHeader );
+    }
+
+    @Test
+    public void shouldReturnTheHeaderIfInTheCache()
+    {
+        // given
+        final LogHeaderCache cache = new LogHeaderCache( 2 );
+
+        // when
+        cache.putHeader( 5, 3 );
+        final long logHeader = cache.getLogHeader( 5 );
+
+        // then
+        assertEquals( 3, logHeader );
+    }
+
+    @Test
+    public void shouldClearTheCache()
+    {
+        // given
+        final LogHeaderCache cache = new LogHeaderCache( 2 );
+
+        // when
+        cache.putHeader( 5, 3 );
+        cache.clear();
+        final long logHeader = cache.getLogHeader( 5 );
+
+        // then
+        assertEquals( -1, logHeader );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalLogFileInformationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PhysicalLogFileInformationTest.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.transaction;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFileInformation;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
@@ -37,7 +38,7 @@ public class PhysicalLogFileInformationTest
 {
 
     private PhysicalLogFiles logFiles = mock( PhysicalLogFiles.class );
-    private TransactionMetadataCache transactionMetadataCache = mock( TransactionMetadataCache.class );
+    private LogHeaderCache logHeaderCache = mock( LogHeaderCache.class );
     private TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
     private PhysicalLogFileInformation.LogVersionToTimestamp
             logVersionToTimestamp = mock( PhysicalLogFileInformation.LogVersionToTimestamp.class );
@@ -45,31 +46,31 @@ public class PhysicalLogFileInformationTest
     @Test
     public void shouldReadAndCacheFirstCommittedTransactionIdForAGivenVersionWhenNotCached() throws Exception
     {
-        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles,
-                transactionMetadataCache, transactionIdStore, logVersionToTimestamp );
+        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles, logHeaderCache, transactionIdStore,
+                logVersionToTimestamp );
         long expected = 5;
 
-        long version = 10l;
-        when( transactionMetadataCache.getLogHeader( version ) ).thenReturn( -1l );
+        long version = 10L;
+        when( logHeaderCache.getLogHeader( version ) ).thenReturn( -1L );
         when( logFiles.versionExists( version ) ).thenReturn( true );
         when( logFiles.extractHeader( version ) ).thenReturn(
-                new LogHeader( (byte) -1/*ignored*/, -1l/*ignored*/, expected - 1l )
+                new LogHeader( (byte) -1/*ignored*/, -1L/*ignored*/, expected - 1L )
         );
 
         long firstCommittedTxId = info.getFirstCommittedTxId( version );
         assertEquals( expected, firstCommittedTxId );
-        verify( transactionMetadataCache, times( 1 ) ).putHeader( version, expected - 1 );
+        verify( logHeaderCache, times( 1 ) ).putHeader( version, expected - 1 );
     }
 
     @Test
     public void shouldReadFirstCommittedTransactionIdForAGivenVersionWhenCached() throws Exception
     {
-        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles,
-                transactionMetadataCache, transactionIdStore, logVersionToTimestamp );
+        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles, logHeaderCache, transactionIdStore,
+                logVersionToTimestamp );
         long expected = 5;
 
-        long version = 10l;
-        when( transactionMetadataCache.getLogHeader( version ) ).thenReturn( expected - 1 );
+        long version = 10L;
+        when( logHeaderCache.getLogHeader( version ) ).thenReturn( expected - 1 );
 
         long firstCommittedTxId = info.getFirstCommittedTxId( version );
         assertEquals( expected, firstCommittedTxId );
@@ -78,35 +79,35 @@ public class PhysicalLogFileInformationTest
     @Test
     public void shouldReadAndCacheFirstCommittedTransactionIdWhenNotCached() throws Exception
     {
-        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles,
-                transactionMetadataCache, transactionIdStore, logVersionToTimestamp );
+        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles, logHeaderCache, transactionIdStore,
+                logVersionToTimestamp );
         long expected = 5;
 
-        long version = 10l;
+        long version = 10L;
         when( logFiles.getHighestLogVersion() ).thenReturn( version );
-        when( transactionMetadataCache.getLogHeader( version ) ).thenReturn( -1l );
+        when( logHeaderCache.getLogHeader( version ) ).thenReturn( -1L );
         when( logFiles.versionExists( version ) ).thenReturn( true );
         when( logFiles.extractHeader( version ) ).thenReturn(
-                new LogHeader( (byte) -1/*ignored*/, -1l/*ignored*/, expected - 1l )
+                new LogHeader( (byte) -1/*ignored*/, -1L/*ignored*/, expected - 1L )
         );
         when( logFiles.hasAnyTransaction( version ) ).thenReturn( true );
 
         long firstCommittedTxId = info.getFirstExistingTxId();
         assertEquals( expected, firstCommittedTxId );
-        verify( transactionMetadataCache, times( 1 ) ).putHeader( version, expected - 1 );
+        verify( logHeaderCache, times( 1 ) ).putHeader( version, expected - 1 );
     }
 
     @Test
     public void shouldReadFirstCommittedTransactionIdWhenCached() throws Exception
     {
-        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles,
-                transactionMetadataCache, transactionIdStore, logVersionToTimestamp );
+        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles, logHeaderCache, transactionIdStore,
+                logVersionToTimestamp );
         long expected = 5;
 
-        long version = 10l;
+        long version = 10L;
         when( logFiles.getHighestLogVersion() ).thenReturn( version );
         when( logFiles.versionExists( version ) ).thenReturn( true );
-        when( transactionMetadataCache.getLogHeader( version ) ).thenReturn( expected -1 );
+        when( logHeaderCache.getLogHeader( version ) ).thenReturn( expected -1 );
         when( logFiles.hasAnyTransaction( version ) ).thenReturn( true );
 
         long firstCommittedTxId = info.getFirstExistingTxId();
@@ -116,10 +117,10 @@ public class PhysicalLogFileInformationTest
     @Test
     public void shouldReturnNothingWhenThereAreNoTransactions() throws Exception
     {
-        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles,
-                transactionMetadataCache, transactionIdStore, logVersionToTimestamp );
+        PhysicalLogFileInformation info = new PhysicalLogFileInformation( logFiles, logHeaderCache, transactionIdStore,
+                logVersionToTimestamp );
 
-        long version = 10l;
+        long version = 10L;
         when( logFiles.getHighestLogVersion() ).thenReturn( version );
         when( logFiles.hasAnyTransaction( version ) ).thenReturn( false );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionMetadataCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/TransactionMetadataCacheTest.java
@@ -33,7 +33,7 @@ public class TransactionMetadataCacheTest
     public void shouldReturnNullWhenMissingATxInTheCache()
     {
         // given
-        final TransactionMetadataCache cache = new TransactionMetadataCache( 2, 2 );
+        final TransactionMetadataCache cache = new TransactionMetadataCache( 2 );
 
         // when
         final TransactionMetadataCache.TransactionMetadata metadata = cache.getTransactionMetadata( 42 );
@@ -46,7 +46,7 @@ public class TransactionMetadataCacheTest
     public void shouldReturnTheTxValueTIfInTheCached()
     {
         // given
-        final TransactionMetadataCache cache = new TransactionMetadataCache( 2, 2 );
+        final TransactionMetadataCache cache = new TransactionMetadataCache( 2 );
         final LogPosition position = new LogPosition( 3, 4 );
         final int txId = 42;
         final int masterId = 0;
@@ -66,7 +66,7 @@ public class TransactionMetadataCacheTest
     public void shouldThrowWhenCachingATxWithNegativeOffsetPosition()
     {
         // given
-        final TransactionMetadataCache cache = new TransactionMetadataCache( 2, 2 );
+        final TransactionMetadataCache cache = new TransactionMetadataCache( 2 );
         final LogPosition position = new LogPosition( 3, -1 );
         final int txId = 42;
         final int masterId = 0;
@@ -84,37 +84,10 @@ public class TransactionMetadataCacheTest
     }
 
     @Test
-    public void shouldReturnNegativeNumberWhenThereIsNoHeaderInTheCache()
+    public void shouldClearTheCache()
     {
         // given
-        final TransactionMetadataCache cache = new TransactionMetadataCache( 2, 2 );
-
-        // when
-        final long logHeader = cache.getLogHeader( 5 );
-
-        // then
-        assertEquals( -1, logHeader );
-    }
-
-    @Test
-    public void shouldReturnTheHeaderIfInTheCache()
-    {
-        // given
-        final TransactionMetadataCache cache = new TransactionMetadataCache( 2, 2 );
-
-        // when
-        cache.putHeader( 5, 3 );
-        final long logHeader = cache.getLogHeader( 5 );
-
-        // then
-        assertEquals( 3, logHeader );
-    }
-
-    @Test
-    public void shouldClearTheCaches()
-    {
-        // given
-        final TransactionMetadataCache cache = new TransactionMetadataCache( 2, 2 );
+        final TransactionMetadataCache cache = new TransactionMetadataCache( 2 );
         final LogPosition position = new LogPosition( 3, 4 );
         final int txId = 42;
         final int masterId = 0;
@@ -123,13 +96,10 @@ public class TransactionMetadataCacheTest
 
         // when
         cache.cacheTransactionMetadata( txId, position, masterId, authorId, checksum );
-        cache.putHeader( 5, 3 );
         cache.clear();
-        final long logHeader = cache.getLogHeader( 5 );
         final TransactionMetadataCache.TransactionMetadata metadata = cache.getTransactionMetadata( txId );
 
         // then
-        assertEquals( -1, logHeader );
         assertNull( metadata );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderConcurrencyTest.java
@@ -81,7 +81,7 @@ public class BatchingTransactionAppenderConcurrencyTest
     private final LogAppendEvent logAppendEvent = LogAppendEvent.NULL;
     private final LogFile logFile = mock( LogFile.class );
     private final LogRotation logRotation = LogRotation.NO_ROTATION;
-    private final TransactionMetadataCache transactionMetadataCache = new TransactionMetadataCache( 10, 10 );
+    private final TransactionMetadataCache transactionMetadataCache = new TransactionMetadataCache( 10 );
     private final TransactionIdStore transactionIdStore = new DeadSimpleTransactionIdStore();
     private final IdOrderingQueue legacyIndexTransactionOrdering = IdOrderingQueue.BYPASS;
     private final DatabaseHealth databaseHealth = mock( DatabaseHealth.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderTest.java
@@ -82,7 +82,7 @@ public class BatchingTransactionAppenderTest
     private final DatabaseHealth databaseHealth = mock( DatabaseHealth.class );
     private final LogFile logFile = mock( LogFile.class );
     private final TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
-    private final TransactionMetadataCache positionCache = new TransactionMetadataCache( 10, 10 );
+    private final TransactionMetadataCache positionCache = new TransactionMetadataCache( 10 );
 
     @Test
     public void shouldAppendSingleTransaction() throws Exception
@@ -208,7 +208,7 @@ public class BatchingTransactionAppenderTest
 
         when( transactionIdStore.getLastCommittedTransactionId() ).thenReturn( latestCommittedTxWhenStarted );
 
-        LogEntryStart start = new LogEntryStart( 0, 0, 0l, latestCommittedTxWhenStarted, null,
+        LogEntryStart start = new LogEntryStart( 0, 0, 0L, latestCommittedTxWhenStarted, null,
                 LogPosition.UNSPECIFIED );
         LogEntryCommit commit = new OnePhaseCommit( latestCommittedTxWhenStarted + 2, 0l );
         CommittedTransactionRepresentation transaction =
@@ -280,7 +280,7 @@ public class BatchingTransactionAppenderTest
         doThrow( failure ).when( flushable ).flush();
         LogFile logFile = mock( LogFile.class );
         when( logFile.getWriter() ).thenReturn( channel );
-        TransactionMetadataCache metadataCache = new TransactionMetadataCache( 10, 10 );
+        TransactionMetadataCache metadataCache = new TransactionMetadataCache( 10 );
         TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
         when( transactionIdStore.nextCommittingTransactionId() ).thenReturn( txId );
         Mockito.reset( databaseHealth );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFileTest.java
@@ -58,9 +58,8 @@ public class PhysicalLogFileTest
         String name = "log";
         LifeSupport life = new LifeSupport();
         PhysicalLogFiles logFiles = new PhysicalLogFiles( directory.directory(), name, fs );
-        life.add( new PhysicalLogFile( fs, logFiles, 1000,
-                transactionIdStore, logVersionRepository, mock( Monitor.class ),
-                new TransactionMetadataCache( 10, 100 ) ));
+        life.add( new PhysicalLogFile( fs, logFiles, 1000, transactionIdStore::getLastCommittedTransactionId,
+                logVersionRepository, mock( Monitor.class ), new LogHeaderCache( 10 ) ) );
 
         // WHEN
         life.start();
@@ -82,8 +81,8 @@ public class PhysicalLogFileTest
         PhysicalLogFiles logFiles = new PhysicalLogFiles( directory.directory(), name, fs );
         Monitor monitor = mock( Monitor.class );
         LogFile logFile = life.add( new PhysicalLogFile( fs, logFiles, 1000,
-                transactionIdStore, logVersionRepository, monitor,
-                new TransactionMetadataCache( 10, 100 ) ) );
+                transactionIdStore::getLastCommittedTransactionId, logVersionRepository, monitor,
+                new LogHeaderCache( 10 ) ) );
 
         // WHEN
         try
@@ -120,8 +119,8 @@ public class PhysicalLogFileTest
         LifeSupport life = new LifeSupport();
         PhysicalLogFiles logFiles = new PhysicalLogFiles( directory.directory(), name, fs );
         LogFile logFile = life.add( new PhysicalLogFile( fs, logFiles, 50,
-                transactionIdStore, logVersionRepository, mock( Monitor.class ),
-                new TransactionMetadataCache( 10, 100 ) ) );
+                transactionIdStore::getLastCommittedTransactionId, logVersionRepository, mock( Monitor.class ),
+                new LogHeaderCache( 10 ) ) );
 
         // WHEN
         life.start();
@@ -172,8 +171,8 @@ public class PhysicalLogFileTest
         LifeSupport life = new LifeSupport();
         PhysicalLogFiles logFiles = new PhysicalLogFiles( directory.directory(), name, fs );
         LogFile logFile = life.add( new PhysicalLogFile( fs, logFiles, 50,
-                transactionIdStore, logVersionRepository, mock( Monitor.class ),
-                new TransactionMetadataCache( 10, 100 )) );
+                transactionIdStore::getLastCommittedTransactionId, logVersionRepository, mock( Monitor.class ),
+                new LogHeaderCache( 10 ) ) );
         life.start();
         FlushablePositionAwareChannel writer = logFile.getWriter();
         LogPositionMarker mark = new LogPositionMarker();

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -22,13 +22,11 @@ package org.neo4j.backup;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerTest.java
@@ -85,7 +85,7 @@ public class ResponsePackerTest
 
                         // Move the target transaction id forward one step, effectively always keeping it out of reach
                         transactionIdStore.setLastCommittedAndClosedTransactionId(
-                                transactionIdStore.getLastCommittedTransactionId()+1, 0, 0, 0 );
+                                transactionIdStore.getLastCommittedTransactionId() + 1, 0, 0, 0 );
                         return true;
                     }
                 };

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TransactionLogCatchUpWriter.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TransactionLogCatchUpWriter.java
@@ -26,6 +26,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogFile;
+import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
@@ -61,9 +62,9 @@ public class TransactionLogCatchUpWriter implements TxPullResponseListener, Auto
         logFiles = new PhysicalLogFiles( storeDir, fs );
         logVersionRepository = new ReadOnlyLogVersionRepository( pageCache, storeDir );
         LogFile logFile = life.add( new PhysicalLogFile( fs, logFiles, Long.MAX_VALUE /*don't rotate*/,
-                new ReadOnlyTransactionIdStore( pageCache, storeDir ), logVersionRepository,
+                new ReadOnlyTransactionIdStore( pageCache, storeDir )::getLastCommittedTransactionId, logVersionRepository,
                 new Monitors().newMonitor( PhysicalLogFile.Monitor.class ),
-                new TransactionMetadataCache( 10, 100 ) ) );
+                new LogHeaderCache( 10 ) ) );
         life.start();
 
         FlushableChannel channel = logFile.getWriter();

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPollingClient.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/tx/edge/TxPollingClient.java
@@ -22,7 +22,6 @@ package org.neo4j.coreedge.catchup.tx.edge;
 import java.util.function.Supplier;
 
 import org.neo4j.coreedge.catchup.storecopy.edge.CoreClient;
-import org.neo4j.coreedge.discovery.EdgeDiscoveryService;
 import org.neo4j.coreedge.server.edge.EdgeToCoreConnectionStrategy;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.util.JobScheduler;

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom20IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom20IT.java
@@ -186,11 +186,11 @@ public class StoreMigratorFrom20IT
     {
         MetaDataStore metaDataStore = neoStores.getMetaDataStore();
         assertEquals( 1317392957120L, metaDataStore.getCreationTime() );
-        assertEquals( -472309512128245482l, metaDataStore.getRandomNumber() );
-        assertEquals( 5l, metaDataStore.getCurrentLogVersion() );
+        assertEquals( -472309512128245482L, metaDataStore.getRandomNumber() );
+        assertEquals( 5L, metaDataStore.getCurrentLogVersion() );
         assertEquals( LowLimit.STORE_VERSION, MetaDataStore.versionLongToString(
                 metaDataStore.getStoreVersion() ) );
-        assertEquals( 1042l, metaDataStore.getLastCommittedTransactionId() );
+        assertEquals( 1042L, metaDataStore.getLastCommittedTransactionId() );
     }
 
     private StoreUpgrader upgrader( SchemaIndexMigrator indexMigrator, StoreMigrator storeMigrator )


### PR DESCRIPTION
TransactionMetadataCache is split into transaction specific cache
 and log header cache, which follows better the way it is used.
PhysicalLogFile needs a LogHeaderCache and a last committed id
 provider, which removes all dependence on transaction concepts.

This is in preparation for using PhysicalLogFile to implement a new
 version of the RaftLog.
