### PR TITLE
Fix queries having multiple pattern sharing same rel names but different node names

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/QueryGraph.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/QueryGraph.scala
@@ -186,11 +186,16 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
           rel.coveredIds.contains(node) && !qg.patternRelationships.contains(rel)
         }
 
-        queue.enqueue(filteredPatterns.toSeq.map(_.otherSide(node)): _*)
+        val patternsWithSameName =
+          patternRelationships.filterNot(filteredPatterns).filter { r => filteredPatterns.exists(_.name == r.name) }
 
+        queue.enqueue(filteredPatterns.toSeq.map(_.otherSide(node)): _*)
+        queue.enqueue(patternsWithSameName.toSeq.flatMap(r => Seq(r.left, r.right)): _*)
+
+        val patternsInConnectedComponent = filteredPatterns ++ patternsWithSameName
         qg = qg
           .addPatternNodes(node)
-          .addPatternRelationships(filteredPatterns.toSeq)
+          .addPatternRelationships(patternsInConnectedComponent.toSeq)
 
         val alreadyHaveArguments = qg.argumentIds.nonEmpty
 

--- a/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryGraphConnectedComponentsTest.scala
+++ b/community/cypher/cypher-compiler-2.3/src/test/scala/org/neo4j/cypher/internal/compiler/v2_3/planner/logical/QueryGraphConnectedComponentsTest.scala
@@ -34,11 +34,14 @@ class QueryGraphConnectedComponentsTest
   private val A = IdName("a")
   private val B = IdName("b")
   private val C = IdName("c")
+  private val D = IdName("d")
   private val X = IdName("x")
+  private val Y = IdName("y")
   private val A_to_B = PatternRelationship(IdName("r1"), (A, B), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
   private val B_to_A = PatternRelationship(IdName("r3"), (B, A), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
   private val C_to_X = PatternRelationship(IdName("r7"), (C, X), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
   private val B_to_X = PatternRelationship(IdName("r12"), (B, X), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
+  private val D_to_Y = PatternRelationship(IdName("r12"), (D, Y), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
   private val identA = ident(A.name)
   private val identB = ident(B.name)
 
@@ -245,5 +248,15 @@ class QueryGraphConnectedComponentsTest
 
     val components = graph.connectedComponents
     components should equal(Seq(graph))
+  }
+
+  test("two pattern with same rel name should be in the same connected component") {
+    // MATCH (d)-[r]->(y), (b)-[r]->(x)
+    val graph = QueryGraph(
+      patternNodes = Set(B, X, D, Y),
+      patternRelationships = Set(B_to_X, D_to_Y)
+    )
+
+    graph.connectedComponents should equal(Seq(graph))
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/VarLengthAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/VarLengthAcceptanceTest.scala
@@ -323,6 +323,26 @@ class VarLengthAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     result.columnAs("c").toSet should be(generation(5))
   }
 
+  test("should use variable of already matched rel in a varlenght path") {
+    eengine.execute("""create
+                      |(_0:`Node` ),
+                      |(_1:`Node` ),
+                      |(_2:`Node` ),
+                      |(_3:`Node` ),
+                      |_0-[:EDGE]->_1,
+                      |_1-[:EDGE]->_2,
+                      |_2-[:EDGE]->_3""".stripMargin)
+
+    val result = executeWithAllPlanners("""MATCH ()-[r:`EDGE`]-()
+                                          |WITH r
+                                          |MATCH p=(n)-[*0..1]-()-[r]-()-[*0..1]-(m)
+                                          |RETURN count(p) as c""".stripMargin)
+
+    result.columnAs[Long]("c").toList should equal(List(32))
+    result.close()
+  }
+
+
   def haveNoneRelFilter: Matcher[InternalExecutionResult] = new Matcher[InternalExecutionResult] {
     override def apply(result: InternalExecutionResult): MatchResult = {
       val plan: InternalPlanDescription = result.executionPlanDescription()


### PR DESCRIPTION
The problem was that connected compoenents in QueryGraph wasn't
pulling in relationships having the same name but different names for
the end points.  Hence the query plan was not correct and the query
would fail at runtime.
