### PR TITLE
Explicity use SHA-512 for self generated certificates

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -20,6 +20,7 @@
 package org.neo4j.server;
 
 import org.apache.commons.configuration.Configuration;
+import org.bouncycastle.operator.OperatorCreationException;
 
 import java.io.File;
 import java.io.IOException;
@@ -491,7 +492,7 @@ public abstract class AbstractNeoServer implements NeoServer
         {
             throw new ServerStartupException( "TLS certificate error occurred, unable to start server: " + e.getMessage(), e );
         }
-        catch( IOException e )
+        catch( IOException | OperatorCreationException e )
         {
             throw new ServerStartupException( "IO problem while loading or creating TLS certificates: " + e.getMessage(), e );
         }

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/Certificates.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/Certificates.java
@@ -19,36 +19,49 @@
  */
 package org.neo4j.server.security.ssl;
 
-import io.netty.handler.ssl.util.SelfSignedCertificate;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
+import org.bouncycastle.util.io.pem.PemWriter;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Collection;
+import java.util.Date;
 import java.util.LinkedList;
 import javax.crypto.NoSuchPaddingException;
-
-import org.neo4j.io.fs.FileUtils;
 
 public class Certificates
 {
@@ -57,9 +70,14 @@ public class Certificates
     private static final String CERTIFICATE_TYPE = "X.509";
     private static final String DEFAULT_ENCRYPTION = "RSA";
     private final SecureRandom random;
+    /** Current time minus 1 year, just in case software clock goes back due to time synchronization */
+    private static final Date NOT_BEFORE = new Date( System.currentTimeMillis() - 86400000L * 365 );
+    /** The maximum possible value in X.509 specification: 9999-12-31 23:59:59 */
+    private static final Date NOT_AFTER = new Date( 253402300799000L );
+    private static final Provider PROVIDER = new BouncyCastleProvider();
 
-    {
-        Security.addProvider(new BouncyCastleProvider());
+    static {
+        Security.addProvider( PROVIDER );
     }
 
     public Certificates()
@@ -68,15 +86,28 @@ public class Certificates
     }
 
     public void createSelfSignedCertificate(File certificatePath, File privateKeyPath, String hostName)
-            throws GeneralSecurityException, IOException
+            throws GeneralSecurityException, IOException, OperatorCreationException
     {
-        SelfSignedCertificate cert = new SelfSignedCertificate(hostName, random, 1024);
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance( DEFAULT_ENCRYPTION );
+        keyGen.initialize( 1024, random );
+        KeyPair keypair = keyGen.generateKeyPair();
 
-        certificatePath.getParentFile().mkdirs();
-        privateKeyPath.getParentFile().mkdirs();
+        // Prepare the information required for generating an X.509 certificate.
+        X500Name owner = new X500Name( "CN=" + hostName );
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                owner, new BigInteger( 64, random ), NOT_BEFORE, NOT_AFTER, owner, keypair.getPublic() );
 
-        FileUtils.moveFile( cert.certificate(), certificatePath );
-        FileUtils.moveFile( cert.privateKey(), privateKeyPath );
+        PrivateKey privateKey = keypair.getPrivate();
+        ContentSigner signer = new JcaContentSignerBuilder( "SHA512WithRSAEncryption" ).build( privateKey );
+        X509CertificateHolder certHolder = builder.build( signer );
+        X509Certificate cert = new JcaX509CertificateConverter().setProvider( PROVIDER ).getCertificate( certHolder );
+
+        //check so that cert is valid
+        cert.verify( keypair.getPublic() );
+
+        //write to disk
+        writePem( "CERTIFICATE", cert.getEncoded(), certificatePath );
+        writePem( "PRIVATE KEY", privateKey.getEncoded(), privateKeyPath );
     }
 
     public Certificate[] loadCertificates(File certFile) throws CertificateException, IOException
@@ -108,7 +139,7 @@ public class Certificates
     public PrivateKey loadPrivateKey(File privateKeyFile)
             throws IOException, NoSuchAlgorithmException,
             InvalidKeySpecException, NoSuchPaddingException,
-            InvalidKeyException, InvalidAlgorithmParameterException 
+            InvalidKeyException, InvalidAlgorithmParameterException
     {
         try(PemReader r = new PemReader( new FileReader( privateKeyFile ) ))
         {
@@ -151,6 +182,16 @@ public class Certificates
             KeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
 
             return KeyFactory.getInstance( DEFAULT_ENCRYPTION ).generatePrivate(keySpec);
+        }
+    }
+
+    private void writePem( String type, byte[] encodedContent, File path ) throws IOException
+    {
+        path.getParentFile().mkdirs();
+        try ( PemWriter writer = new PemWriter( new FileWriter( path ) ) )
+        {
+            writer.writeObject( new PemObject( type, encodedContent ) );
+            writer.flush();
         }
     }
 }


### PR DESCRIPTION
The default in 2.3 was SHA1 which is a suboptimal choice
