### PR TITLE
fix for having long strings in tx logs

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IoPrimitiveUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IoPrimitiveUtils.java
@@ -56,7 +56,7 @@ public abstract class IoPrimitiveUtils
     {
         short lengthShort = channel.getShort();
         byte lengthByte = channel.get();
-        int length = (lengthByte << 16) | lengthShort;
+        int length = (lengthByte << 16) | (lengthShort & 0xFFFF);
         byte[] chars = new byte[length];
         channel.get( chars, length );
         return new String(chars, "UTF-8");

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/InMemoryLogChannel.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/InMemoryLogChannel.java
@@ -27,9 +27,21 @@ import org.neo4j.io.fs.StoreChannel;
 
 public class InMemoryLogChannel implements WritableLogChannel, ReadableLogChannel
 {
-    private final byte[] bytes = new byte[1000];
-    private final ByteBuffer asWriter = ByteBuffer.wrap( bytes );
-    private final ByteBuffer asReader = ByteBuffer.wrap( bytes );
+    private final byte[] bytes;
+    private final ByteBuffer asWriter;
+    private final ByteBuffer asReader;
+
+    public InMemoryLogChannel()
+    {
+        this(1000);
+    }
+
+    public InMemoryLogChannel( int bufferSize )
+    {
+        bytes = new byte[bufferSize];
+        asWriter = ByteBuffer.wrap( bytes );
+        asReader = ByteBuffer.wrap( bytes );
+    }
 
     public void reset()
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderReaderTest.java
@@ -33,7 +33,6 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.log.InMemoryLogChannel;
 import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
-import org.neo4j.kernel.impl.util.StringBuilderStringLogger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;


### PR DESCRIPTION
This fixes an issue causing a NegativeArraySizeException when reading from a log containing an write operation of a string larger 32k to a manual index.
The cause for this is that conversion of short to int must be masked to prevent misbehaviour if the short value is negative (short is signed!).
Needed to enhance InMemoryLogChannel to support a configurable buffer size.
