### PR TITLE
A PlannerQuery with an aggregation should exposed only symbols in horizon

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -243,4 +243,19 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
 
     result.toList should equal(List(Map("foo" -> 42, "bar" -> 42, "baz" -> Map("y" -> 1))))
   }
+
+  test("should not project too much when aggregating in a WITH before merge and after a WITH with filter") {
+    val n = createLabeledNode(Map("prop" -> 42), "A")
+
+    val query =
+      """|UNWIND [42] as props
+         |WITH props WHERE props > 32
+         |WITH distinct props as p
+         |MERGE (a:A {prop:p})
+         |RETURN a.prop as prop""".stripMargin
+
+    val result = executeWithAllPlannersAndCompatibilityMode(query)
+
+    result.toList should equal(List(Map("prop" -> 42)))
+  }
 }


### PR DESCRIPTION
When constructing the tail of a PlannerQuery with an
AggregationHorizon, that tail could wrongly access all the symbols in
the horizon and in the previous query graph rather than only the
symbols in the horizon.
