### PR TITLE
Remove race conditions from shell script tests

### DIFF
--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -261,6 +261,28 @@
           </dependency>
         </dependencies>
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>shell-script-tests</id>
+            <phase>test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <inherited>false</inherited>
+            <configuration>
+              <executable>./run-tests.sh</executable>
+              <workingDirectory>src/tests/shell-scripts</workingDirectory>
+              <arguments>
+                <argument>--verbose</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/assertions.sh
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/assertions.sh
@@ -1,11 +1,19 @@
 test_expect_java_arg() {
   arg="$1"
-  if grep --fixed-strings --regexp "${arg}" java-args >/dev/null ; then
-    return 0
-  fi
+  end="$((SECONDS+5))"
+  while true; do
+    if grep --fixed-strings --regexp "${arg}" java-args >&2 ; then
+      break
+    fi
 
-	echo >&2 "test_expect_java_arg: expected argument '$arg' but got '$(cat java-args)'"
-	return 1
+    if [[ "${SECONDS}" -ge "${end}" ]]; then
+      echo >&2 "test_expect_java_arg: expected argument '$arg' but got '$(cat java-args)'"
+      return 1
+    fi
+
+    echo >&2 "waiting for java args"
+    sleep 1
+  done
 }
 
 test_expect_stdout_matching() {

--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/fake-java
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/fake-java
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-[[ "${FAKE_JAVA_DISABLE_RECORD_ARGS:-}" ]] || echo -n "$@" >../java-args
+args="$@"
+record_args() {
+  [[ "${FAKE_JAVA_DISABLE_RECORD_ARGS:-}" ]] || echo -n "${args}" >../java-args
+}
+trap record_args EXIT
 
 if [ "$1" == "-version" ]; then
   echo "java version \"${FAKE_JAVA_VERSION:-1.8.0_51}\"
@@ -12,8 +16,6 @@ fi
 
 echo "stdout from java"
 echo "stderr from java" >&2
-
-echo -n "$@" >../java-args
 
 while [ -f "${JAVA_SENTINEL:-}" ]; do
   sleep 0.1


### PR DESCRIPTION
o Make sure that `fake-java` writes out its args even if it gets killed
  by `neo4j stop` before it's run to completion.
o When asserting on Java args, give `fake-java` a chance to complete
  every time.
