### PR TITLE
Better error messages

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/ProcedureSignature.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/spi/ProcedureSignature.scala
@@ -58,6 +58,8 @@ case class ProcedureSignature(name: ProcedureName,
                               outputSignature: Seq[FieldSignature],
                               mode: ProcedureCallMode = LazyReadOnlyCallMode)
 
-case class ProcedureName(namespace: Seq[String], name: String)
+case class ProcedureName(namespace: Seq[String], name: String) {
+  override def toString = s"""${namespace.mkString(".")}.$name"""
+}
 
 case class FieldSignature(name: String, typ: CypherType)

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
@@ -90,7 +90,7 @@ public class ProceduresTest
     }
 
     @Test
-    public void shouldNotAllowCallingNonExistantProcedure() throws Throwable
+    public void shouldNotAllowCallingNonExistingProcedure() throws Throwable
     {
         // Expect
         exception.expect( ProcedureException.class );
@@ -105,7 +105,7 @@ public class ProceduresTest
     }
 
     @Test
-    public void shouldNotAllowRegisteringConflicingName() throws Throwable
+    public void shouldNotAllowRegisteringConflictingName() throws Throwable
     {
         // Given
         procs.register( procedure );
@@ -145,7 +145,7 @@ public class ProceduresTest
     }
 
     @Test
-    public void shouldSignalNonExistantProcedure() throws Throwable
+    public void shouldSignalNonExistingProcedure() throws Throwable
     {
         // Expect
         exception.expect( ProcedureException.class );

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -81,6 +81,24 @@ public class ProcedureIT
     }
 
     @Test
+    public void shouldGiveNiceErrorMessageOnWrongStaticType() throws Throwable
+    {
+        //Expect
+        exception.expect( QueryExecutionException.class );
+        exception.expectMessage(
+                "Parameter `name` for procedure `org.neo4j.procedure.simpleArgument`\n" +
+                "expects value of type String but got value of type Integer.\n\n" +
+                "Usage: CALL org.neo4j.procedure.simpleArgument(<name>)\n" +
+                "Parameters:\n" +
+                "    name (type Integer)"  );
+        // When
+        try ( Transaction ignore = db.beginTx() )
+        {
+            Result res = db.execute( "CALL org.neo4j.procedure.simpleArgument('42')");
+        }
+    }
+
+    @Test
     public void shouldCallProcedureWithGenericArgument() throws Throwable
     {
         // Given


### PR DESCRIPTION
When calling a procedure with the wrong static types we can provide a nice
error message instructing the user how to properly call the procedure.
