### PR TITLE
Introduce a custom UTF8 encoder if sun.misc tools are available.

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackedOutputArray.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackedOutputArray.java
@@ -51,7 +51,10 @@ public class PackedOutputArray implements PackOutput
     @Override
     public PackOutput writeBytes( ByteBuffer buffer ) throws IOException
     {
-        data.write( buffer.array() );
+        while(buffer.remaining() > 0)
+        {
+            data.writeByte( buffer.get() );
+        }
         return this;
     }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/SunMiscUTF8Encoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/SunMiscUTF8Encoder.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.packstream.utf8;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.getInteger;
+
+/**
+ * This is a specialized UTF-8 encoder that solves two predicaments:
+ *
+ * 1) There's no way using public APIs to do GC-free string encoding unless
+ *    you build a custom encoder, and GC output from UTF-8 encoding causes
+ *    production instability
+ * 2) The ArrayEncoder provided by HotSpot is 2 orders faster for UTF-8 encoding
+ *    for a massive amount of real-world strings due to specialized handling of
+ *    ascii, and we can't import that since we need to compile on IBM J9
+ *
+ * We can't solve (1) without solving (2), because the default GC-spewing String#getBytes()
+ * uses the optimized ArrayEncoder, meaning it's easy to write an encoder that
+ * is GC-free, but then it'll be two orders slower than the stdlib, and vice
+ * versa.
+ *
+ * This solves both issues using MethodHandles. Future work here could include
+ * writing a custom UTF-8 encoder (which could then avoid using ArrayEncoder),
+ * as well as stopping use of String's for the main database paths.
+ * We already have  Token, which
+ * could easily contain pre-encoded UTF-8 data, and "runtime" Strings could be
+ * handled with a custom type that is more stability friendly, for instance
+ * by building on to StringProperty.
+ */
+public class SunMiscUTF8Encoder implements UTF8Encoder
+{
+    private static final int BUFFER_SIZE = getInteger( SunMiscUTF8Encoder.class, "buffer_size", 1024*16 );
+    private static final int fallbackAtStringLength =
+            (int)(BUFFER_SIZE / StandardCharsets.UTF_8.newEncoder().averageBytesPerChar());
+    private static final MethodHandle getCharArray = charArrayGetter();
+    private static final MethodHandle arrayEncode = arrayEncode();
+
+    private final CharsetEncoder charsetEncoder = StandardCharsets.UTF_8.newEncoder();
+
+    private final byte[] out = new byte[BUFFER_SIZE];
+    private final ByteBuffer outBuf = ByteBuffer.wrap( out );
+    private final UTF8Encoder fallbackEncoder = new VanillaUTF8Encoder();
+
+    @Override
+    public ByteBuffer encode( String input )
+    {
+        try
+        {
+            // If it's unlikely we will fit the encoded data, just use stdlib encoder
+            if( input.length() > fallbackAtStringLength )
+            {
+                return fallbackEncoder.encode( input );
+            }
+
+            char[] rawChars = (char[]) getCharArray.invoke( input );
+            int len = (int)arrayEncode.invoke( charsetEncoder, rawChars, 0, rawChars.length, out );
+
+            if( len == -1 )
+            {
+                return fallbackEncoder.encode( input );
+            }
+
+            outBuf.position(0);
+            outBuf.limit(len);
+            return outBuf;
+        }
+        catch( ArrayIndexOutOfBoundsException e )
+        {
+            // This happens when we can't fit the encoded string.
+            // We try and avoid this altogether by falling back to the
+            // vanilla encoder if the string looks like it'll not fit -
+            // but this is probabilistic since we don't know until we've encoded.
+            // So, if our guess is wrong, we fall back here instead.
+            return fallbackEncoder.encode( input );
+        }
+        catch ( Throwable e )
+        {
+            throw new AssertionError( "This encoder depends on sun.nio.cs.ArrayEncoder, which failed to load: " +
+                                      e.getMessage(), e );
+        }
+    }
+
+    private static MethodHandle arrayEncode()
+    {
+        // Because we need to be able to compile on IBM's JVM, we can't
+        // depend on ArrayEncoder. Unfortunately, ArrayEncoders encode method
+        // is twoish orders of magnitude faster than regular encoders for ascii
+        // so we go through the hurdle of calling that encode method via
+        // a MethodHandle.
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try
+        {
+
+            return lookup.unreflect( Class.forName( "sun.nio.cs.ArrayEncoder" )
+                    .getMethod( "encode", char[].class, int.class, int.class, byte[].class ) );
+        }
+        catch ( Throwable e )
+        {
+            throw new AssertionError(
+                    "This encoder depends on sun.nio.cs.ArrayEncoder, which failed to load: " +
+                    e.getMessage(), e );
+        }
+    }
+
+    private static MethodHandle charArrayGetter()
+    {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try
+        {
+            Field value = String.class.getDeclaredField( "value" );
+            value.setAccessible( true );
+            return lookup.unreflectGetter( value );
+        }
+        catch ( Throwable e )
+        {
+            throw new AssertionError(
+                    "This encoder depends being able to access raw char[] in java.lang.String, which failed: " +
+                    e.getMessage(), e );
+        }
+    }
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/UTF8Encoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/UTF8Encoder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.packstream.utf8;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A non-thread-safe UTF8 encoding interface, delegates to near-zero GC overhead
+ * UTF8 implementations on HotSpot, falls back to stdlib encoder if on other JVM.
+ *
+ * This implementation solves a major GC bottleneck in that we don't have to
+ * allocate objects to encode most strings.
+ *
+ * We currently do "bulk" encoding, where the whole string is turned
+ * into UTF-8 before it gets returned. This is simply a limitation in
+ * PackStream currently in that we need to know the length of utf-8
+ * strings up-front, so we can't stream them out.
+ *
+ * This becomes an issue for very large strings, and should be remedied
+ * in Bolt V2 by introducing streaming options for Strings in the same
+ * manner we've discussed adding streaming lists.
+ *
+ * Once that is resolved, we could have a method here that took a
+ * WritableByteChannel or similar instead.
+ */
+public interface UTF8Encoder
+{
+    /**
+     * @return a ByteBuffer with the encoded string. This will be overwritten
+     *         the next time you call this method, so use it or loose it!
+     */
+    ByteBuffer encode( String input );
+
+    static UTF8Encoder fastestAvailableEncoder()
+    {
+        try
+        {
+            return (UTF8Encoder)Class
+                    .forName("org.neo4j.bolt.v1.packstream.utf8.SunMiscUTF8Encoder")
+                    .getConstructor()
+                    .newInstance();
+        }
+        catch ( Exception e )
+        {
+            return new VanillaUTF8Encoder();
+        }
+    }
+
+
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/VanillaUTF8Encoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/VanillaUTF8Encoder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.packstream.utf8;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Simple encoder that delegates to String#getBytes()
+ */
+public class VanillaUTF8Encoder implements UTF8Encoder
+{
+    @Override
+    public ByteBuffer encode( String input )
+    {
+        return ByteBuffer.wrap( input.getBytes( StandardCharsets.UTF_8 ) );
+    }
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackStreamTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackStreamTest.java
@@ -284,27 +284,6 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackByteArrays() throws Throwable
-    {
-        // Given
-        Machine machine = new Machine( 17000000 );
-
-        for ( int i = 0; i < 24; i++ )
-        {
-            byte[] array = new byte[(int) Math.pow( 2, i )];
-
-            // When
-            machine.reset();
-            machine.packer().pack( array );
-            machine.packer().flush();
-
-            // Then
-            byte[] value = newUnpacker( machine.output() ).unpackBytes();
-            assertThat( value, equalTo( array ) );
-        }
-    }
-
-    @Test
     public void testCanPackAndUnpackStrings() throws Throwable
     {
         // Given
@@ -326,24 +305,6 @@ public class PackStreamTest
     }
 
     @Test
-    public void testCanPackAndUnpackBytes() throws Throwable
-    {
-        // Given
-        Machine machine = new Machine();
-        byte[] bytes = "ABCDEFGHIJ".getBytes();
-
-        // When
-        PackStream.Packer packer = machine.packer();
-        packer.pack( bytes );
-        packer.flush();
-
-        // Then
-        byte[] value = newUnpacker( machine.output() ).unpackBytes();
-        assertThat( value, equalTo( bytes ) );
-
-    }
-
-    @Test
     public void testCanPackAndUnpackString() throws Throwable
     {
         // Given
@@ -353,23 +314,6 @@ public class PackStreamTest
         // When
         PackStream.Packer packer = machine.packer();
         packer.pack( abcdefghij );
-        packer.flush();
-
-        // Then
-        String value = newUnpacker( machine.output() ).unpackString();
-        assertThat( value, equalTo( abcdefghij ) );
-    }
-
-    @Test
-    public void testCanPackAndUnpackStringFromBytes() throws Throwable
-    {
-        // Given
-        Machine machine = new Machine();
-        String abcdefghij = "ABCDEFGHIJ";
-
-        // When
-        PackStream.Packer packer = machine.packer();
-        packer.packString( abcdefghij.getBytes() );
         packer.flush();
 
         // Then

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/utf8/UTF8EncoderTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/utf8/UTF8EncoderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.packstream.utf8;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class UTF8EncoderTest
+{
+    @Test
+    public void shouldEncodeDecode() throws Throwable
+    {
+        assertEncodes( "" );
+        assertEncodes( "a" );
+        assertEncodes( "ä" );
+        assertEncodes( "äa" );
+        assertEncodes( "基本上，電腦只是處理數位。它們指定一個數位，來儲存字母或其他字元。在創造Unicode之前，有數百種指定這些數位的編碼系統。沒有一個編碼可以包含足夠的字元，例如：單單歐洲共同體就需要好幾種不同的編碼來包括所有的語言。即使是單一種語言，例如英語，也沒有哪一個編碼可以適用於所有的字母、標點符號，和常用的技術符號" );
+        assertEncodes( new String( new byte[(int) Math.pow( 2, 18 )] ) ); // bigger than default buffer size
+    }
+
+    private void assertEncodes( String val )
+    {
+        assertEquals( val,  encodeDecode( val ) );
+    }
+
+
+    private String encodeDecode( String original )
+    {
+        ByteBuffer encoded = UTF8Encoder.fastestAvailableEncoder().encode( original );
+        byte[] b = new byte[encoded.remaining()];
+        encoded.get( b );
+        return new String( b, StandardCharsets.UTF_8 );
+    }
+}


### PR DESCRIPTION
Large scale testing, and then small-scale profiling, showed Bolt to
have a high GC overhead for standard use cases. Profiling showed a
massive overhead in UTF8 encoding, which is not present in REST
API since Jackson implements extensive caching of encoded Strings.

This changes alters the GC behavior in profiling from being heavily skewed 
towards Bolt String encoding to Bolt not showing up as an allocation hotspot.

Mainline distributions of the JVM come with no-GC UTF8 encoders, but
these APIs are imperfect and parts of them are not stdlib.

This introduces a wrapper encoder that will use this low-overhead
ArrayEncoder if it is available, and fall back to regular
String.getBytes() if not.
