### PR TITLE
Fix failover not working in certain scenarios.

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AbstractContextImpl.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.logging.ConsoleLogger;
 import org.neo4j.kernel.logging.Logging;
 
-import static org.neo4j.helpers.collection.Iterables.limit;
 import static org.neo4j.helpers.collection.Iterables.toList;
 
 class AbstractContextImpl
@@ -103,9 +102,7 @@ class AbstractContextImpl
     @Override
     public List<URI> getAcceptors()
     {
-        // Only use 2f+1 acceptors
-        return toList( limit( commonState.configuration()
-                .getAllowedFailures() * 2 + 1, commonState.configuration().getMemberURIs() ) );
+        return commonState.configuration().getMemberURIs();
     }
 
     @Override

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterConfiguration.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterConfiguration.java
@@ -46,7 +46,6 @@ public class ClusterConfiguration
     private final List<URI> candidateMembers;
     private Map<InstanceId, URI> members;
     private Map<String, InstanceId> roles = new HashMap<String, InstanceId>();
-    private int allowedFailures = 1;
 
     public ClusterConfiguration( String name, StringLogger logger, String... members )
     {
@@ -176,7 +175,8 @@ public class ClusterConfiguration
 
     public int getAllowedFailures()
     {
-        return allowedFailures;
+        assert members.size() > 0;
+        return (members.size() - 1) / 2;
     }
 
     public void left()
@@ -258,10 +258,6 @@ public class ClusterConfiguration
 
         ClusterConfiguration that = (ClusterConfiguration) o;
 
-        if ( allowedFailures != that.allowedFailures )
-        {
-            return false;
-        }
         if ( !candidateMembers.equals( that.candidateMembers ) )
         {
             return false;
@@ -289,7 +285,6 @@ public class ClusterConfiguration
         result = 31 * result + candidateMembers.hashCode();
         result = 31 * result + members.hashCode();
         result = 31 * result + roles.hashCode();
-        result = 31 * result + allowedFailures;
         return result;
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestFailover.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestFailover.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.kernel.impl.ha.ClusterManager;
+import org.neo4j.test.LoggerRule;
+import org.neo4j.test.TargetDirectory;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.ha.ClusterManager.clusterOfSize;
+
+@RunWith( Parameterized.class )
+public class TestFailover
+{
+    @Rule
+    public LoggerRule logger = new LoggerRule();
+    public TargetDirectory dir = TargetDirectory.forTest( getClass() );
+
+    // parameters
+    private int clusterSize;
+
+    @Parameters( name = "clusterSize:{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { 3 },
+                { 4 },
+                { 5 },
+                { 6 },
+                { 7 },
+        });
+    }
+
+    public TestFailover( int clusterSize )
+    {
+        this.clusterSize = clusterSize;
+    }
+
+    private void testFailOver( int clusterSize ) throws Throwable
+    {
+        // given
+        ClusterManager clusterManager = new ClusterManager( clusterOfSize( clusterSize ), dir.cleanDirectory( "failover" ), stringMap(
+                ClusterSettings.default_timeout.name(),    "1",
+                ClusterSettings.heartbeat_interval.name(), "1",
+                ClusterSettings.heartbeat_timeout.name(),  "2" ) );
+
+        clusterManager.start();
+        ClusterManager.ManagedCluster cluster = clusterManager.getDefaultCluster();
+
+        cluster.await( ClusterManager.allSeesAllAsAvailable() );
+        HighlyAvailableGraphDatabase oldMaster = cluster.getMaster();
+
+        // When
+        long start = System.nanoTime();
+        ClusterManager.RepairKit repairKit = cluster.fail( oldMaster );
+        logger.getLogger().warn( "Shut down master" );
+
+        // Then
+        cluster.await( ClusterManager.masterAvailable( oldMaster ) );
+        long end = System.nanoTime();
+
+        logger.getLogger().warn( "Failover took:" + (end - start) / 1000000 + "ms" );
+
+        repairKit.repair();
+        Thread.sleep( 3000 ); // give repaired instance chance to cleanly rejoin and exit faster
+
+        clusterManager.stop();
+    }
+
+    @Test
+    public void testFailOver() throws Throwable
+    {
+        testFailOver( clusterSize );
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestFailoverWithAdditionalSlaveFailures.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestFailoverWithAdditionalSlaveFailures.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.kernel.impl.ha.ClusterManager;
+import org.neo4j.kernel.impl.ha.ClusterManager.RepairKit;
+import org.neo4j.test.LoggerRule;
+import org.neo4j.test.TargetDirectory;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
+import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
+
+@RunWith( Parameterized.class )
+public class TestFailoverWithAdditionalSlaveFailures
+{
+    @Rule
+    public LoggerRule logger = new LoggerRule();
+    public TargetDirectory dir = TargetDirectory.forTest( getClass() );
+
+    // parameters
+    private int clusterSize;
+    private int[] slavesToFail;
+
+    @Parameters( name = "{index} clusterSize:{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {5, new int[]{1}},
+                {5, new int[]{2}},
+                {5, new int[]{3}},
+                {5, new int[]{4}},
+
+                {6, new int[]{1}},
+                {6, new int[]{3}},
+                {6, new int[]{5}},
+
+                {7, new int[]{1, 2}},
+                {7, new int[]{3, 4}},
+                {7, new int[]{5, 6}},
+        });
+    }
+
+    public TestFailoverWithAdditionalSlaveFailures( int clusterSize, int[] slavesToFail )
+    {
+        this.clusterSize = clusterSize;
+        this.slavesToFail = slavesToFail;
+    }
+
+    @Test
+    public void testFailoverWithAdditionalSlave() throws Throwable
+    {
+        testFailoverWithAdditionalSlave( clusterSize, slavesToFail );
+    }
+
+    private void testFailoverWithAdditionalSlave( int clusterSize, int[] slaveIndexes ) throws Throwable
+    {
+        ClusterManager manager = new ClusterManager( ClusterManager.clusterOfSize( clusterSize ),
+                TargetDirectory.forTest( getClass() ).cleanDirectory( "testCluster" ), stringMap(
+                ClusterSettings.default_timeout.name(),    "1",
+                ClusterSettings.heartbeat_interval.name(), "1",
+                ClusterSettings.heartbeat_timeout.name(),  "2" ) );
+
+        try
+        {
+            manager.start();
+            ClusterManager.ManagedCluster cluster = manager.getDefaultCluster();
+
+            cluster.await( allSeesAllAsAvailable() );
+            cluster.await( masterAvailable() );
+
+            Collection<HighlyAvailableGraphDatabase> failed = new ArrayList<>();
+            Collection<RepairKit> repairKits = new ArrayList<>();
+
+            for ( int slaveIndex : slaveIndexes )
+            {
+                HighlyAvailableGraphDatabase nthSlave = getNthSlave( cluster, slaveIndex );
+                failed.add( nthSlave );
+                RepairKit repairKit = cluster.fail( nthSlave );
+                repairKits.add( repairKit );
+            }
+
+            HighlyAvailableGraphDatabase oldMaster = cluster.getMaster();
+            failed.add( oldMaster );
+            repairKits.add( cluster.fail( oldMaster ) );
+
+            cluster.await( masterAvailable( toArray( failed ) ) );
+
+            for ( RepairKit repairKit : repairKits )
+            {
+                repairKit.repair();
+            }
+
+            Thread.sleep( 3000 ); // give repaired instances a chance to cleanly rejoin and exit faster
+        }
+        finally
+        {
+            manager.shutdown();
+        }
+    }
+
+    private HighlyAvailableGraphDatabase getNthSlave( ClusterManager.ManagedCluster cluster, int slaveOrder )
+    {
+        assert slaveOrder > 0;
+        HighlyAvailableGraphDatabase slave = null;
+
+        List<HighlyAvailableGraphDatabase> excluded = new ArrayList<>();
+        while( slaveOrder-->0 )
+        {
+            slave = cluster.getAnySlave( toArray( excluded ) );
+            excluded.add( slave );
+        }
+
+        return slave;
+    }
+
+    private HighlyAvailableGraphDatabase[] toArray( Collection<HighlyAvailableGraphDatabase> excluded )
+    {
+        return excluded.toArray( new HighlyAvailableGraphDatabase[excluded.size()] );
+    }
+}


### PR DESCRIPTION
The issue would affect clusters with size of 5 and higher and
only if there were two failures (concurrently or subsequently)
of instances that by happenstance got sorted early in an internal
list of members, and subsequently among the few included in the paxos
algorithm in an attempt of being more efficient, but leading to the
effect of essentially trying to reach a decision on who is to become
the new master using dead members instead of alive ones, halting progress.

This optimization is unnecessary and was thus removed.

Tests for a plethora of additional failover scenarios has been added.
