### PR TITLE
Don't overflow on aggregation

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/MathFunction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/MathFunction.scala
@@ -249,7 +249,7 @@ case class RangeFunction(start: Expression, end: Expression, step: Expression) e
       throw new InvalidArgumentException("step argument to range() cannot be zero")
 
     val exclusiveEndVal = inclusiveEndVal + stepVal.signum
-    startVal until exclusiveEndVal by stepVal toList
+    (startVal until exclusiveEndVal by stepVal).toIterable
   }
 
   def arguments = Seq(start, end, step)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/MathFunction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/MathFunction.scala
@@ -241,15 +241,15 @@ case class RandFunction() extends Expression {
 
 case class RangeFunction(start: Expression, end: Expression, step: Expression) extends Expression with NumericHelper {
   def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = {
-    val startVal = asInt(start(ctx))
-    val inclusiveEndVal = asInt(end(ctx))
-    val stepVal = asInt(step(ctx))
+    val startVal = asLong(start(ctx))
+    val inclusiveEndVal = asLong(end(ctx))
+    val stepVal = asLong(step(ctx))
 
-    if (stepVal == 0)
+    if (stepVal == 0L)
       throw new InvalidArgumentException("step argument to range() cannot be zero")
 
     val exclusiveEndVal = inclusiveEndVal + stepVal.signum
-    new Range(startVal, exclusiveEndVal, stepVal).toList
+    startVal until exclusiveEndVal by stepVal toList
   }
 
   def arguments = Seq(start, end, step)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/helpers/TypeSafeMathSupport.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/helpers/TypeSafeMathSupport.scala
@@ -31,7 +31,7 @@ trait TypeSafeMathSupport {
       case (l: Byte, r: Byte)   => l + r
       case (l: Byte, r: Double) => l + r
       case (l: Byte, r: Float)  => l + r
-      case (l: Byte, r: Int)    => l + r
+      case (l: Byte, r: Int)    => l + r.toLong
       case (l: Byte, r: Long)   => l + r
       case (l: Byte, r: Short)  => l + r
 
@@ -49,10 +49,10 @@ trait TypeSafeMathSupport {
       case (l: Float, r: Long)   => l + r
       case (l: Float, r: Short)  => l + r
 
-      case (l: Int, r: Byte)   => l + r
+      case (l: Int, r: Byte)   => l.toLong + r
       case (l: Int, r: Double) => l + r
       case (l: Int, r: Float)  => l + r
-      case (l: Int, r: Int)    => l + r
+      case (l: Int, r: Int)    => l.toLong + r.toLong
       case (l: Int, r: Long)   => l + r
       case (l: Int, r: Short)  => l + r
 
@@ -131,7 +131,7 @@ trait TypeSafeMathSupport {
       case (l: Byte, r: Byte)   => l - r
       case (l: Byte, r: Double) => l - r
       case (l: Byte, r: Float)  => l - r
-      case (l: Byte, r: Int)    => l - r
+      case (l: Byte, r: Int)    => l - r.toLong
       case (l: Byte, r: Long)   => l - r
       case (l: Byte, r: Short)  => l - r
 
@@ -152,7 +152,7 @@ trait TypeSafeMathSupport {
       case (l: Int, r: Byte)   => l - r
       case (l: Int, r: Double) => l - r
       case (l: Int, r: Float)  => l - r
-      case (l: Int, r: Int)    => l - r
+      case (l: Int, r: Int)    => l.toLong - r.toLong
       case (l: Int, r: Long)   => l - r
       case (l: Int, r: Short)  => l - r
 
@@ -166,7 +166,7 @@ trait TypeSafeMathSupport {
       case (l: Short, r: Byte)   => l - r
       case (l: Short, r: Double) => l - r
       case (l: Short, r: Float)  => l - r
-      case (l: Short, r: Int)    => l - r
+      case (l: Short, r: Int)    => l - r.toLong
       case (l: Short, r: Long)   => l - r
       case (l: Short, r: Short)  => l - r
 
@@ -181,7 +181,7 @@ trait TypeSafeMathSupport {
       case (l: Byte, r: Byte)   => l * r
       case (l: Byte, r: Double) => l * r
       case (l: Byte, r: Float)  => l * r
-      case (l: Byte, r: Int)    => l * r
+      case (l: Byte, r: Int)    => l * r.toLong
       case (l: Byte, r: Long)   => l * r
       case (l: Byte, r: Short)  => l * r
 
@@ -202,9 +202,9 @@ trait TypeSafeMathSupport {
       case (l: Int, r: Byte)   => l * r
       case (l: Int, r: Double) => l * r
       case (l: Int, r: Float)  => l * r
-      case (l: Int, r: Int)    => l * r
+      case (l: Int, r: Int)    => l.toLong * r.toLong
       case (l: Int, r: Long)   => l * r
-      case (l: Int, r: Short)  => l * r
+      case (l: Int, r: Short)  => l.toLong * r.toLong
 
       case (l: Long, r: Byte)   => l * r
       case (l: Long, r: Double) => l * r
@@ -213,10 +213,10 @@ trait TypeSafeMathSupport {
       case (l: Long, r: Long)   => l * r
       case (l: Long, r: Short)  => l * r
 
-      case (l: Short, r: Byte)   => l * r
+      case (l: Short, r: Byte)   => l.toLong * r
       case (l: Short, r: Double) => l * r
       case (l: Short, r: Float)  => l * r
-      case (l: Short, r: Int)    => l * r
+      case (l: Short, r: Int)    => l * r.toLong
       case (l: Short, r: Long)   => l * r
       case (l: Short, r: Short)  => l * r
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/TypeTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/TypeTest.scala
@@ -30,7 +30,7 @@ class TypeTest extends CypherFunSuite {
 
     val result = calc(op)
 
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Long]
   }
 
   test("plus double int") {
@@ -46,7 +46,7 @@ class TypeTest extends CypherFunSuite {
 
     val result = calc(op)
 
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Long]
   }
 
   test("minus double int") {
@@ -62,7 +62,7 @@ class TypeTest extends CypherFunSuite {
 
     val result = calc(op)
 
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Long]
   }
 
   test("multiply double int") {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/RangeFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/RangeFunctionTest.scala
@@ -26,23 +26,23 @@ import org.neo4j.cypher.internal.compiler.v2_2.pipes.QueryStateHelper
 class RangeFunctionTest extends CypherFunSuite {
 
   test("range returns inclusive collection of integers") {
-    range(0, 10, 1) should be(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-    range(5, 12, 2) should be(Seq(5, 7, 9, 11))
-    range(-3, 5, 1) should be(Seq(-3, -2, -1, 0, 1, 2, 3, 4, 5))
-    range(-30, 50, 10) should be(Seq(-30, -20, -10, 0, 10, 20, 30, 40, 50))
+    range(0, 10, 1).toSeq should be(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    range(5, 12, 2).toSeq should be(Seq(5, 7, 9, 11))
+    range(-3, 5, 1).toSeq should be(Seq(-3, -2, -1, 0, 1, 2, 3, 4, 5))
+    range(-30, 50, 10).toSeq should be(Seq(-30, -20, -10, 0, 10, 20, 30, 40, 50))
   }
 
   test("range returns inclusive collection of integers for negative step values") {
-    range(0, -10, -1) should be(Seq(0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10))
-    range(-5, -12, -2) should be(Seq(-5, -7, -9, -11))
+    range(0, -10, -1).toSeq should be(Seq(0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10))
+    range(-5, -12, -2).toSeq should be(Seq(-5, -7, -9, -11))
   }
 
   test("range should not overflow when more than 32bits") {
-    range(2147483647L, 2147483648L, 1L) should be(Seq(2147483647L, 2147483648L))
+    range(2147483647L, 2147483648L, 1L).toSeq should be(Seq(2147483647L, 2147483648L))
   }
 
-  private def range(start: Long, end: Long, step: Long) = {
+  private def range(start: Long, end: Long, step: Long): Iterable[Long] = {
     val expr = RangeFunction(Literal(start), Literal(end), Literal(step))
-    expr(ExecutionContext.empty)(QueryStateHelper.empty)
+    expr(ExecutionContext.empty)(QueryStateHelper.empty).asInstanceOf[Iterable[Long]]
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/RangeFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/RangeFunctionTest.scala
@@ -37,7 +37,11 @@ class RangeFunctionTest extends CypherFunSuite {
     range(-5, -12, -2) should be(Seq(-5, -7, -9, -11))
   }
 
-  private def range(start: Int, end: Int, step: Int) = {
+  test("range should not overflow when more than 32bits") {
+    range(2147483647L, 2147483648L, 1L) should be(Seq(2147483647L, 2147483648L))
+  }
+
+  private def range(start: Long, end: Long, step: Long) = {
     val expr = RangeFunction(Literal(start), Literal(end), Literal(step))
     expr(ExecutionContext.empty)(QueryStateHelper.empty)
   }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/aggregation/SumFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/aggregation/SumFunctionTest.scala
@@ -30,7 +30,7 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
     val result = aggregateOn(1)
 
     result should equal(1)
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Long]
   }
 
   test("singleValueOfDecimalReturnsDecimal") {
@@ -51,7 +51,7 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
     val result = aggregateOn(1.byteValue(), 1.shortValue())
 
     result should equal(2)
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Long]
   }
 
   test("noNumbersEqualsZero") {
@@ -65,7 +65,7 @@ class SumFunctionTest extends CypherFunSuite with AggregateTest {
     val result = aggregateOn(1, null)
 
     result should equal(1)
-    result shouldBe a [java.lang.Integer]
+    result shouldBe a [java.lang.Long]
   }
 
   test("noNumberValuesThrowAnException") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/AggregationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/AggregationAcceptanceTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher
 import org.neo4j.graphdb.Node
 
 class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
   test("should handle aggregates inside non aggregate expressions") {
     executeWithAllPlanners(
       "MATCH (a { name: 'Andres' })<-[:FATHER]-(child) RETURN {foo:a.name='Andres',kids:collect(child.name)}"
@@ -241,5 +242,10 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
     val result = executeWithCostPlannerOnly(query)
 
     result.toList should equal(List(Map("foo" -> 42, "bar" -> 42, "baz" -> Map("y" -> 1))))
+  }
+
+  test("should not overflow when doing summation") {
+    executeWithAllPlanners("unwind range(1000000,2000000) as i with i limit 3000 return sum(i)").toList should equal(
+      List(Map("sum(i)" -> 3004498500L)))
   }
 }


### PR DESCRIPTION
The changes in `TypeSafeMathSupport` is already fixed in 3.0 so forward merge with caution.
