### PR TITLE
Reintroduces KTI pooling

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CountsRecordState.java
@@ -33,6 +33,7 @@ import org.neo4j.storageengine.api.StorageCommand;
 import org.neo4j.register.Registers;
 
 import static java.util.Objects.requireNonNull;
+
 import static org.neo4j.kernel.api.ReadOperations.ANY_LABEL;
 import static org.neo4j.kernel.api.ReadOperations.ANY_RELATIONSHIP_TYPE;
 import static org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory.indexSampleKey;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/IndexReaderFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/IndexReaderFactory.java
@@ -63,6 +63,7 @@ public interface IndexReaderFactory
             return reader;
         }
 
+        @Override
         public IndexReader newUnCachedReader( IndexDescriptor descriptor ) throws IndexNotFoundKernelException
         {
             IndexProxy index = indexingService.getIndexProxy( descriptor );
@@ -78,6 +79,7 @@ public interface IndexReaderFactory
                 {
                     indexReader.close();
                 }
+                indexReaders.clear();
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -243,7 +243,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         if ( currentStatement == null )
         {
             currentStatement = new KernelStatement( this, this, locks, operations,
-                    storageEngine.storeReadLayer().acquireStatement(), procedures );
+                    storeLayer.acquireStatement(), procedures );
         }
         currentStatement.acquire();
         return currentStatement;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatements.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatements.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storageengine.impl.recordstorage;
+
+import java.util.function.Supplier;
+
+import org.neo4j.collection.pool.MarshlandPool;
+import org.neo4j.function.Factory;
+import org.neo4j.kernel.impl.api.IndexReaderFactory;
+import org.neo4j.kernel.impl.api.store.StoreStatement;
+import org.neo4j.kernel.impl.locking.LockService;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.storageengine.api.StorageStatement;
+import org.neo4j.storageengine.api.schema.LabelScanReader;
+
+/**
+ * {@link Supplier} of {@link StoreStatement} instances for {@link RecordStorageEngine}.
+ * Internally uses pooling to reduce need for actual instantiation.
+ */
+public class StoreStatements implements Supplier<StorageStatement>, AutoCloseable
+{
+    private final NeoStores neoStores;
+    private final LockService lockService;
+    private final Supplier<IndexReaderFactory> indexReaderFactory;
+    private final Supplier<LabelScanReader> labelScanReader;
+    private final Factory<StoreStatement> factory = new Factory<StoreStatement>()
+    {
+        @Override
+        public StoreStatement newInstance()
+        {
+            return new StoreStatement( neoStores, lockService, indexReaderFactory, labelScanReader, pool );
+        }
+    };
+    private final MarshlandPool<StoreStatement> pool = new MarshlandPool<>( factory );
+
+    public StoreStatements( NeoStores neoStores, LockService lockService,
+            Supplier<IndexReaderFactory> indexReaderFactory, Supplier<LabelScanReader> labelScanReader )
+    {
+        this.neoStores = neoStores;
+        this.lockService = lockService;
+        this.indexReaderFactory = indexReaderFactory;
+        this.labelScanReader = labelScanReader;
+    }
+
+    @Override
+    public StorageStatement get()
+    {
+        return pool.acquire().initialize();
+    }
+
+    @Override
+    public void close()
+    {
+        pool.close();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -19,16 +19,18 @@
  */
 package org.neo4j.kernel.api;
 
+import org.neo4j.collection.pool.Pool;
+import java.util.function.Supplier;
+
 import org.neo4j.helpers.Clock;
-import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
-import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.api.SchemaWriteGuard;
 import org.neo4j.kernel.impl.api.StatementOperationParts;
 import org.neo4j.kernel.impl.api.TransactionHeaderInformation;
 import org.neo4j.kernel.impl.api.TransactionHooks;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
+import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
@@ -48,8 +50,6 @@ public class KernelTransactionFactory
         TransactionHeaderInformationFactory headerInformationFactory = mock( TransactionHeaderInformationFactory.class );
         when( headerInformationFactory.create() ).thenReturn( headerInformation );
 
-        long lastTransactionIdWhenStarted = 0;
-
         StorageEngine storageEngine = mock( StorageEngine.class );
         StoreReadLayer storeReadLayer = mock( StoreReadLayer.class );
         when( storeReadLayer.acquireStatement() ).thenReturn( mock( StorageStatement.class ) );
@@ -57,14 +57,13 @@ public class KernelTransactionFactory
 
         return new KernelTransactionImplementation( mock( StatementOperationParts.class ),
                 mock( SchemaWriteGuard.class ),
-                null, new TransactionHooks(),
+                new TransactionHooks(),
                 mock( ConstraintIndexCreator.class ), new Procedures(), headerInformationFactory,
                 mock( TransactionRepresentationCommitProcess.class ), mock( TransactionMonitor.class ),
-                mock( LegacyIndexTransactionState.class ),
-                mock( KernelTransactions.class ),
+                mock( Supplier.class ),
+                mock( Pool.class ),
                 Clock.SYSTEM_CLOCK,
                 TransactionTracer.NULL,
-                storageEngine,
-                lastTransactionIdWhenStarted );
+                storageEngine ).initialize( 0, new NoOpClient() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionTestBase.java
@@ -21,6 +21,9 @@ package org.neo4j.kernel.api;
 
 import org.junit.Before;
 
+import java.util.function.Supplier;
+
+import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.FakeClock;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
@@ -55,6 +58,7 @@ public class KernelTransactionTestBase
     protected final StoreReadLayer readLayer = mock( StoreReadLayer.class );
     protected final TransactionHooks hooks = new TransactionHooks();
     protected final LegacyIndexTransactionState legacyIndexState = mock( LegacyIndexTransactionState.class );
+    protected final Supplier<LegacyIndexTransactionState> legacyIndexStateSupplier = () -> legacyIndexState;
     protected final TransactionMonitor transactionMonitor = mock( TransactionMonitor.class );
     protected final CapturingCommitProcess commitProcess = new CapturingCommitProcess();
     protected final TransactionHeaderInformation headerInformation = mock( TransactionHeaderInformation.class );
@@ -62,6 +66,7 @@ public class KernelTransactionTestBase
     protected final SchemaWriteGuard schemaWriteGuard = mock( SchemaWriteGuard.class );
     protected final FakeClock clock = new FakeClock();
     protected final KernelTransactions kernelTransactions = mock( KernelTransactions.class );
+    protected final Pool<KernelTransactionImplementation> txPool = mock( Pool.class );
 
     @Before
     public void before()
@@ -80,9 +85,9 @@ public class KernelTransactionTestBase
 
     public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted )
     {
-        return new KernelTransactionImplementation( null, schemaWriteGuard, new NoOpClient(), hooks, null, null,
-                headerInformationFactory, commitProcess, transactionMonitor, legacyIndexState, kernelTransactions,
-                clock, TransactionTracer.NULL, storageEngine, lastTransactionIdWhenStarted );
+        return new KernelTransactionImplementation( null, schemaWriteGuard, hooks, null, null, headerInformationFactory,
+                commitProcess, transactionMonitor, legacyIndexStateSupplier, txPool, clock, TransactionTracer.NULL,
+                storageEngine ).initialize( lastTransactionIdWhenStarted, new NoOpClient() );
     }
 
     public class CapturingCommitProcess implements TransactionCommitProcess

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -24,19 +24,14 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.Collection;
-import java.util.function.Supplier;
-
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
-import org.neo4j.kernel.impl.api.store.StoreStatement;
 import org.neo4j.kernel.impl.locking.Locks;
-import org.neo4j.kernel.impl.locking.ReentrantLockService;
 import org.neo4j.kernel.impl.proc.Procedures;
-import org.neo4j.kernel.impl.store.MetaDataStore;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.lifecycle.LifeSupport;
@@ -191,17 +186,13 @@ public class KernelTransactionsTest
         Locks locks = mock( Locks.class );
         when( locks.newClient() ).thenReturn( mock( Locks.Client.class ) );
 
-        MetaDataStore metaDataStore = mock( MetaDataStore.class );
-        NeoStores neoStores = mock( NeoStores.class );
-
         StoreReadLayer readLayer = mock( StoreReadLayer.class );
         when( readLayer.acquireStatement() ).thenAnswer( new Answer<StorageStatement>()
         {
             @Override
             public StorageStatement answer( InvocationOnMock invocation ) throws Throwable
             {
-                return new StoreStatement( neoStores, new ReentrantLockService(),
-                        mock( Supplier.class ), null );
+                return mock( StorageStatement.class );
             }
         } );
 
@@ -227,7 +218,7 @@ public class KernelTransactionsTest
                 null, null, null, TransactionHeaderInformationFactory.DEFAULT,
                 commitProcess, null,
                 null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
-                tracers, storageEngine, new Procedures(), metaDataStore );
+                tracers, storageEngine, new Procedures(), mock( TransactionIdStore.class ) );
     }
 
     private static TransactionCommitProcess newRememberingCommitProcess( final TransactionRepresentation[] slot )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -26,6 +26,7 @@ import org.mockito.stubbing.Answer;
 import java.util.Collections;
 import java.util.Set;
 
+import org.neo4j.collection.pool.Pool;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.Cursor;
@@ -450,7 +451,7 @@ public class StateHandlingStatementOperationsTest
         StoreStatementWithSingleFreshIndexReader( IndexReader reader )
         {
             super( mock( NeoStores.class ), new ReentrantLockService(), () -> mock( IndexReaderFactory.class ),
-                    () -> mock( LabelScanReader.class ) );
+                    () -> mock( LabelScanReader.class ), mock( Pool.class ) );
             this.reader = reader;
         }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreStatementTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.util.function.Supplier;
 
+import org.neo4j.collection.pool.Pool;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
@@ -45,7 +46,7 @@ public class StoreStatementTest
         when( scanStore.get() ).thenReturn( scanReader );
         StoreStatement statement = new StoreStatement(
                 mock( NeoStores.class ), LockService.NO_LOCK_SERVICE,
-                mock( Supplier.class ), scanStore );
+                mock( Supplier.class ), scanStore, mock( Pool.class ) );
 
         // when
         LabelScanReader actualReader = statement.getLabelScanReader();


### PR DESCRIPTION
Due to observed performance regressions from previously removing those pooling. Also since code has changed around storage engine, the `StoreStatement` instances are now pooled similarly in `RecordStorageEngine` to get benefit of reused store cursors.
