### PR TITLE
Config to enable/disable raft-messages.log

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
@@ -167,4 +167,8 @@ public class CoreEdgeClusterSettings
     @Description("The number of operations to be processed before the state machines flush to disk")
     public static final Setting<Integer> state_machine_flush_window_size =
             setting( "core_edge.state_machine_flush_window_size", INTEGER, "100" );
+
+    @Description("Enable or disable the dump of all network messages pertaining to the RAFT protocol")
+    public static final Setting<Boolean> raft_messages_log_enable =
+            setting( "core_edge.raft_messages_log_enable", BOOLEAN, "false");
 }


### PR DESCRIPTION
 It is disabled by default as per production norms.
