### PR TITLE
Introduce a script to import databases by path

### DIFF
--- a/community/server/src/docs/man/neo4j-admin.1.asciidoc
+++ b/community/server/src/docs/man/neo4j-admin.1.asciidoc
@@ -1,0 +1,32 @@
+= NEO4J-ADMIN(1)
+:author: The Neo4j Team
+
+== NAME
+neo4j-admin - Neo4j administration
+
+[[neo4j-admin-manpage]]
+== SYNOPSIS
+
+*neo4j-admin* <command>
+
+[[neo4j-admin-manpage-description]]
+== DESCRIPTION
+
+Neo4j is a graph database, perfect for working with highly connected data.
+The `neo4j` command is used to control the Neo4j Server.
+
+The preferred way to install Neo4j on Linux systems is by using prebuilt installation packages.
+For information regarding Windows, see http://neo4j.com/docs/stable/powershell.html.
+
+[[neo4j-admin-manpage-commands]]
+== COMMANDS
+
+*import*::
+    Create a new database by importing existing data.
+
+    ----
+    neo4j-admin import --mode=database --database=<database-name> --from=<source-directory>
+    ----
+
+    Import a database from a pre-3.0 Neo4j installation. <source-directory> is the database location (e.g.
+    <neo4j-root>/data/graph.db).

--- a/manual/contents/src/manpages.asciidoc
+++ b/manual/contents/src/manpages.asciidoc
@@ -6,6 +6,7 @@ Manpages
 The Neo4j Unix manual pages are included on the following pages.
 
 * <<neo4j-manpage,neo4j>>
+* <<neo4j-admin-manpage,neo4j-admin>>
 * <<shell-manpage,neo4j-shell>>
 * <<neo4j-import-manpage,neo4j-import>>
 * <<neo4j-backup-manpage,neo4j-backup>>
@@ -16,7 +17,8 @@ The Neo4j Unix manual pages are included on the following pages.
 [subs="none"]
 ++++++++++++++++++++++++++++++++++++++
 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j.1.xml"></xi:include> 
-<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j-shell.1.xml"></xi:include> 
+<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j-admin.1.xml"></xi:include>
+<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j-shell.1.xml"></xi:include>
 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j-import.1.xml"></xi:include> 
 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="neo4j-backup.1.xml"></xi:include> 
 ++++++++++++++++++++++++++++++++++++++

--- a/manual/manual/Makefile
+++ b/manual/manual/Makefile
@@ -14,7 +14,7 @@ make_dir                   = $(tools_dir)/make
 
 include $(make_dir)/context-manual.make
 
-manpage_list = "neo4j server" "neo4j-shell shell" "neo4j-backup backup" "neo4j-import import-tool"
+manpage_list = "neo4j server" "neo4j-admin server" "neo4j-shell shell" "neo4j-backup backup" "neo4j-import import-tool"
 
 webhelp_dist: initialize install-extensions manpages copy-images docbook docbook-html year-check
 # cleanup

--- a/manual/manual/pom.xml
+++ b/manual/manual/pom.xml
@@ -357,6 +357,7 @@
               <sourceDirectory>${project.build.directory}/manpages</sourceDirectory>
             <postProcess>
               <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j.1" destfile="${project.build.directory}/manpages/neo4j.1.gz"/>
+              <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-admin.1" destfile="${project.build.directory}/manpages/neo4j-admin.1.gz"/>
               <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-shell.1" destfile="${project.build.directory}/manpages/neo4j-shell.1.gz"/>
               <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-backup.1" destfile="${project.build.directory}/manpages/neo4j-backup.1.gz"/>
               <gzip src="${project.build.directory}/docbkx/manpages/man1/neo4j-import.1" destfile="${project.build.directory}/manpages/neo4j-import.1.gz"/>

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -352,7 +352,7 @@ main() {
   check_java
   setup_arbiter_options
 
-  case "$1" in
+  case "${1:-}" in
     console)
       do_console
       ;;

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Copyright (c) 2016 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+set -o errexit -o nounset -o pipefail
+[[ "${TRACE:-}" ]] && set -o xtrace
+
+PROGRAM="$(basename "$0")"
+NEO4J_ROOT="$(cd "$(dirname "$0")"/.. && dirs -l +0)"
+readonly PROGRAM NEO4J_ROOT
+
+cmd_import_args() {
+  declare database=''
+  declare source=''
+  declare mode=''
+
+  while [[ -n "${1:-}" ]]; do
+    declare arg="$1"
+    shift
+    case "${arg}" in
+      -h|--help)
+        usage
+        ;;
+      -d)
+        if [[ -n "${1:-}" ]]; then
+          database="${1}"
+          shift
+        fi
+        ;;
+      --database=*)
+        set -- "-d" "${arg#*=}" "$@"
+        ;;
+      -f)
+        if [[ -n "${1:-}" ]]; then
+          source="${1}"
+          shift
+        fi
+        ;;
+      --from=*)
+        set -- "-f" "${arg#*=}" "$@"
+        ;;
+      -m)
+        if [[ -n "${1:-}" ]]; then
+          mode="${1}"
+          shift
+        fi
+        ;;
+      --mode=*)
+        set -- "-m" "${arg#*=}" "$@"
+        ;;
+      --database|--from|--mode)
+        ;;
+      *)
+        bad_usage "unrecognized import argument '${arg}'"
+        ;;
+    esac
+  done
+
+  [[ -z "${database}" ]] && bad_usage "you must provide the --database option with an argument"
+  [[ -z "${source}" ]] && bad_usage "you must provide the --from option with an argument"
+  [[ -z "${mode}" ]] && bad_usage "you must provide the --mode option with an argument"
+
+  retval=("${database}" "${source}" "${mode}")
+}
+
+cmd_import() {
+  cmd_import_args "$@"
+  declare -r database="${retval[0]}" source="${retval[1]}" mode="${retval[2]}"
+  shift 3
+
+  case "${mode}" in
+    database)
+      cp -r "${source}" "${NEO4J_ROOT}/data/databases/${database}"
+      ;;
+    *)
+      bad_usage "unrecognised mode '${mode}'"
+      ;;
+  esac
+}
+
+bad_usage() {
+  echo "Error: $1" >&2
+  echo >&2
+  echo "$(usage)" >&2
+  exit 1
+}
+
+usage() {
+  echo "Usage:
+
+  ${PROGRAM} import --mode=<mode> --database=<database-name> --from=<source-directory>
+
+    Create a new database by importing existing data.
+
+    --mode=database
+
+      Import a database from a pre-3.0 Neo4j installation. <source-directory> is the database location (e.g.
+      <neo4j-root>/data/graph.db).
+
+  ${PROGRAM} help
+
+    Display this help text.
+"
+  exit 0
+}
+
+main() {
+  [[ -z "${1:-}" ]] && bad_usage "you must provide a command"
+  declare -r command="$1"
+  shift
+  case "${command}" in
+    import)         cmd_import "$@" ;;
+    help|--help|-h) usage ;;
+    *)              bad_usage "unrecognised command '${command}'" ;;
+  esac
+}
+
+main "$@"

--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/assertions.sh
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/assertions.sh
@@ -17,15 +17,68 @@ test_expect_java_arg() {
 }
 
 test_expect_stdout_matching() {
-	expected_pattern=$1
-	shift
-	stdout="$("$@")"
-	echo "${stdout}" | grep "${expected_pattern}"
-	exit_code="$?"
-	if [[ "${exit_code}" -eq 0 ]]; then
-		return 0
-	fi
+  expected_pattern=$1
+  shift
 
-	echo >&2 "test_expect_stdout_matching: expected '${expected_pattern}' but got '${stdout}'"
-	return 1
+  stdout="$("$@")"
+  err="$?"
+  [[ "${err}" -ne 0 ]] && return "${err}"
+
+  echo "${stdout}" | grep "${expected_pattern}" >/dev/null
+  exit_code="$?"
+  if [[ "${exit_code}" -eq 0 ]]; then
+    return 0
+  fi
+
+  echo >&2 "test_expect_stdout_matching: expected '${expected_pattern}' but got '${stdout}'"
+  return 1
+}
+
+test_expect_stderr_matching() {
+  expected_pattern=$1
+  shift
+
+  stdout="$("$@" 2>&1)"
+  err="$?"
+  [[ "${err}" -ne 0 ]] && return "${err}"
+
+  echo "${stdout}" | grep "${expected_pattern}" >/dev/null
+  exit_code="$?"
+  if [[ "${exit_code}" -eq 0 ]]; then
+    return 0
+  fi
+
+  echo >&2 "test_expect_stdout_matching: expected '${expected_pattern}' but got '${stdout}'"
+  return 1
+}
+
+test_expect_file_matching() {
+  expected_pattern=$1
+  content="$(cat ${2})"
+  echo "${content}" | grep "${expected_pattern}" >/dev/null
+  exit_code="$?"
+  if [[ "${exit_code}" -eq 0 ]]; then
+    return 0
+  fi
+
+  echo >&2 "test_expect_stdout_matching: expected '${expected_pattern}' but got '${content}'"
+  return 1
+}
+
+assert_equals() {
+  actual="$1"
+  expected="$2"
+  if [[ ! "${actual}" = "${expected}" ]]; then
+    echo >&2 "Expected '${expected}' but got '${actual}'"
+    return 1
+  fi
+}
+
+assert_failure_with_stderr() {
+  expected_pattern="$1"
+  shift
+  test_expect_code 1 "$@" 2>neo4j.stderr
+  err="$?"
+  [[ "${err}" -ne 0 ]] && return "${err}"
+  test_expect_file_matching "${expected_pattern}" neo4j.stderr
 }

--- a/packaging/standalone/src/tests/shell-scripts/sharness.d/fixture.sh
+++ b/packaging/standalone/src/tests/shell-scripts/sharness.d/fixture.sh
@@ -1,9 +1,12 @@
 fake_install() {
-  mkdir -p neo4j-home/bin
-  cp ../../../main/distribution/shell-scripts/bin/* neo4j-home/bin 2>/dev/null
-  chmod +x neo4j-home/bin/neo4j
-  mkdir -p neo4j-home/conf
-  mkdir -p neo4j-home/lib
+  path="neo4j-home"
+
+  mkdir -p "${path}/bin"
+  cp ../../../main/distribution/shell-scripts/bin/* "${path}/bin" 2>/dev/null
+  chmod +x "${path}/bin/neo4j"
+  mkdir -p "${path}/conf"
+  mkdir -p "${path}/data/databases"
+  mkdir -p "${path}/lib"
 }
 
 clear_config() {
@@ -14,7 +17,7 @@ set_config() {
   name=$1
   value=$2
   file=$3
-  echo "${name}=${value}" >>"neo4j-home/conf/${file}"
+  echo "${name}=${value}" >>"neo4j_home/conf/${file}"
 }
 
 set_main_class() {

--- a/packaging/standalone/src/tests/shell-scripts/test-admin-args.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-admin-args.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+test_description="Test neo4j-admin argument handling"
+
+. ./lib/sharness.sh
+fake_install
+
+test_expect_success "should print usage for help command" "
+  test_expect_stdout_matching 'Usage:' neo4j-home/bin/neo4j-admin help &&
+  test_expect_stdout_matching 'Usage:' neo4j-home/bin/neo4j-admin --help &&
+  test_expect_stdout_matching 'Usage:' neo4j-home/bin/neo4j-admin -h
+"
+
+test_expect_success "should fail if command is missing" "
+  assert_failure_with_stderr 'you must provide a command' neo4j-home/bin/neo4j-admin
+"
+
+test_expect_success "should fail if command is unrecognized" "
+  assert_failure_with_stderr 'unrecognised command' neo4j-home/bin/neo4j-admin rubbish
+"
+
+test_expect_success "should fail if --database is missing" "
+  assert_failure_with_stderr 'you must provide the --database option with an argument' \
+    neo4j-home/bin/neo4j-admin import --from=/foo --mode=database
+"
+
+test_expect_success "should fail if --from is missing" "
+  assert_failure_with_stderr 'you must provide the --from option with an argument' \
+    neo4j-home/bin/neo4j-admin import --database=foo --mode=database
+"
+
+test_expect_success "should fail if --mode is missing" "
+  assert_failure_with_stderr 'you must provide the --mode option with an argument' \
+    neo4j-home/bin/neo4j-admin import --database=foo --from=/foo
+"
+
+test_done

--- a/packaging/standalone/src/tests/shell-scripts/test-import-database.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-import-database.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+test_description="Test neo4j-admin import --mode=database"
+
+. ./lib/sharness.sh
+fake_install
+
+mkdir old-db
+touch old-db/a-store-file
+
+test_expect_success "should run successfully" "
+  neo4j-home/bin/neo4j-admin import --mode=database --database=foo.db --from=./old-db
+"
+
+test_expect_success "should move database dirs into data/databases" "
+  [[ -e ./neo4j-home/data/databases/foo.db/a-store-file ]]
+"
+
+test_done


### PR DESCRIPTION
o This is part of the work to change the way we allow operators to
  specify which database is run. Prior to 3.0 we take an arbitrary path;
  from 3.0 onwards we take a name and always find the path under
  data/databases. So we need a way to allow existing databases to be
  pulled into that structure from elsewhere.

o We also introduce the start of a new operational surface:
  neo4j-admin. This script will provide the entry point for all command
  line operational tasks (e.g. import and backup).
