### PR TITLE
Fix non-unique index sampling for numeric fields

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/NonUniqueLuceneIndexSampler.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/NonUniqueLuceneIndexSampler.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.neo4j.helpers.TaskControl;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.index.sampling.NonUniqueIndexSampler;
 import org.neo4j.register.Register;
@@ -69,7 +70,7 @@ public class NonUniqueLuceneIndexSampler extends LuceneIndexSampler
                     Terms terms = readerContext.reader().terms( fieldName );
                     if ( terms != null )
                     {
-                        TermsEnum termsEnum = terms.iterator();
+                        TermsEnum termsEnum = LuceneDocumentStructure.originalTerms( terms, fieldName );
                         BytesRef termsRef;
                         while ( (termsRef = termsEnum.next()) != null )
                         {


### PR DESCRIPTION
Currently sampler goes over all terms for the given index and includes term's string value and it's document frequency in the resulting sample.

For sufficiently large numeric values Lucene stores more than one term per value. See javadoc for class `org.apache.lucene.search.NumericRangeQuery` for more details about this format. It makes sampling count more values than were actually inserted.

This commit makes non-unique index sampling count numeric values that were actually inserted as property values. All intermediate/special terms are filtered out.
