### PR TITLE
Add skip-findbugs profile to skip findbugs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -448,6 +448,26 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>skip-findbugs</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>skipFindbugs</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <dependencyManagement>


### PR DESCRIPTION
This is useful if you want to quickly build the code without waiting for
analysis.

Active the profile with `-DskipFindbugs`.
