### PR TITLE
Improve unwind to not materialize collections and avoid OOM

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/MathFunction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/MathFunction.scala
@@ -241,15 +241,29 @@ case class RandFunction() extends Expression {
 
 case class RangeFunction(start: Expression, end: Expression, step: Expression) extends Expression with NumericHelper {
   def apply(ctx: ExecutionContext)(implicit state: QueryState): Any = {
-    val startVal = asLong(start(ctx))
-    val inclusiveEndVal = asLong(end(ctx))
     val stepVal = asLong(step(ctx))
-
     if (stepVal == 0L)
       throw new InvalidArgumentException("step argument to range() cannot be zero")
 
-    val exclusiveEndVal = inclusiveEndVal + stepVal.signum
-    (startVal until exclusiveEndVal by stepVal).toIterable
+    val startVal = asLong(start(ctx))
+    val inclusiveEndVal = asLong(end(ctx))
+    val check: (Long, Long) => Boolean = if (stepVal.signum > 0) _ <= _ else _ >= _
+
+    // due to the limitations of the scala collection library we need to implement iterator on long ranges manually:
+    // the scala one cannot be longer than MaxInt in length since it is an IndexedSeq which is indexed by Ints... :(
+    new Iterable[Long] {
+      override def iterator: Iterator[Long] = new Iterator[Long] {
+        private var current = startVal
+
+        override def hasNext: Boolean = check(current, inclusiveEndVal)
+
+        override def next(): Long = {
+          val c = current
+          current = current + stepVal
+          c
+        }
+      }
+    }
   }
 
   def arguments = Seq(start, end, step)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UnwindPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/UnwindPipe.scala
@@ -24,18 +24,15 @@ import org.neo4j.cypher.internal.compiler.v2_2.commands.expressions.Expression
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.CollectionSupport
 import org.neo4j.cypher.internal.compiler.v2_2.planDescription.{InternalPlanDescription, PlanDescriptionImpl, SingleChild}
 
+import scala.annotation.tailrec
+
 case class UnwindPipe(source: Pipe, collection: Expression, identifier: String)
                      (val estimatedCardinality: Option[Double] = None)(implicit monitor: PipeMonitor)
   extends PipeWithSource(source, monitor) with CollectionSupport with RonjaPipe {
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe
     state.decorator.registerParentPipe(this)
-
-    input.flatMap {
-      context =>
-        val seq = makeTraversable(collection(context)(state))
-        seq.map(x => context.newWith1(identifier, x))
-    }
+    if (input.hasNext) new UnwindIterator(input, state) else Iterator.empty
   }
 
   def planDescription: InternalPlanDescription =
@@ -51,4 +48,36 @@ case class UnwindPipe(source: Pipe, collection: Expression, identifier: String)
   }
 
   def withEstimatedCardinality(estimated: Double) = copy()(Some(estimated))
+
+  private class UnwindIterator(input: Iterator[ExecutionContext], state: QueryState) extends Iterator[ExecutionContext] {
+    private var context: ExecutionContext = null
+    private var unwindIterator: Iterator[Any] = null
+    private var nextItem: ExecutionContext = null
+
+    prefetch()
+
+    override def hasNext: Boolean = nextItem != null
+
+    override def next(): ExecutionContext = {
+      if (hasNext) {
+        val ret = nextItem
+        prefetch()
+        ret
+      } else Iterator.empty.next()
+    }
+
+    @tailrec
+    private def prefetch() {
+      nextItem = null
+      if (unwindIterator != null && unwindIterator.hasNext) {
+        nextItem = context.newWith1(identifier, unwindIterator.next())
+      } else {
+        if (input.hasNext) {
+          context = input.next()
+          unwindIterator = makeTraversable(collection(context)(state)).iterator
+          prefetch()
+        }
+      }
+    }
+  }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/RangeFunctionTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/RangeFunctionTest.scala
@@ -41,6 +41,10 @@ class RangeFunctionTest extends CypherFunSuite {
     range(2147483647L, 2147483648L, 1L).toSeq should be(Seq(2147483647L, 2147483648L))
   }
 
+  test("should work on ranges having length bigger than Int.MaxValue") {
+    range(1L, Int.MaxValue + 1000L, 1L).iterator // should not blow up...
+  }
+
   private def range(start: Long, end: Long, step: Long): Iterable[Long] = {
     val expr = RangeFunction(Literal(start), Literal(end), Literal(step))
     expr(ExecutionContext.empty)(QueryStateHelper.empty).asInstanceOf[Iterable[Long]]

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UnwindAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/UnwindAcceptanceTest.scala
@@ -149,4 +149,10 @@ class UnwindAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSu
         Map("X" -> 2, "Y" -> 4, "Z" -> 6, "ZS" -> List(5, 6), "YS" -> List(3, 4), "XS" -> List(1, 2)))
     )
   }
+
+  test("should unwind a long range without going OOM") {
+    val expectedResult = 20000000
+    val result = executeScalarWithAllPlanners[Long](s"unwind range(1,$expectedResult) as i return count(*) as c")
+    result should equal(expectedResult)
+  }
 }


### PR DESCRIPTION
The problem was that the map + flatMap would potentially materialize
really huge collections of items and cause OOM.

Fix also a problem when colling iterator on scala ranges with
longs. It would fail if the range length is bigger than Int.MaxValue.
