### PR TITLE
Keep track of last applied command inside the state machine.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/LastAppliedTrackingStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/LastAppliedTrackingStateMachine.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import java.io.IOException;
+
+import org.neo4j.coreedge.raft.replication.ReplicatedContent;
+
+import static java.lang.Math.max;
+
+public class LastAppliedTrackingStateMachine implements StateMachine
+{
+    public static final long NOTHING_APPLIED = -1;
+
+    private final StateMachine stateMachine;
+    private long lastApplied = NOTHING_APPLIED;
+
+    public LastAppliedTrackingStateMachine( StateMachine stateMachine )
+    {
+        this.stateMachine = stateMachine;
+    }
+
+    @Override
+    public void applyCommand( ReplicatedContent content, long logIndex )
+    {
+        stateMachine.applyCommand( content, logIndex );
+        lastApplied = max( logIndex, lastApplied );
+    }
+
+    @Override
+    public void flush() throws IOException
+    {
+        stateMachine.flush();
+    }
+
+    public long lastApplied()
+    {
+        return lastApplied;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
@@ -29,6 +29,7 @@ import org.neo4j.coreedge.raft.net.Inbound;
 import org.neo4j.coreedge.raft.net.Outbound;
 import org.neo4j.coreedge.raft.replication.LeaderOnlyReplicator;
 import org.neo4j.coreedge.raft.replication.shipping.RaftLogShippingManager;
+import org.neo4j.coreedge.raft.state.LastAppliedTrackingStateMachine;
 import org.neo4j.coreedge.raft.state.StateMachine;
 import org.neo4j.coreedge.raft.state.StateMachines;
 import org.neo4j.coreedge.raft.state.StateStorage;
@@ -74,7 +75,7 @@ public class RaftInstanceBuilder<MEMBER>
     private StateStorage<RaftMembershipState<MEMBER>> raftMembership =
             new StubStateStorage<>( new RaftMembershipState<>() );
     private Monitors monitors = new Monitors();
-    private StateMachine stateMachine = new StateMachines();
+    private LastAppliedTrackingStateMachine stateMachine = new LastAppliedTrackingStateMachine( new StateMachines() );
     private int flushAfter = 1;
 
     public RaftInstanceBuilder( MEMBER member, int expectedClusterSize, RaftGroup.Builder<MEMBER> memberSetBuilder )
@@ -142,7 +143,7 @@ public class RaftInstanceBuilder<MEMBER>
         return this;
     }
 
-    public RaftInstanceBuilder<MEMBER> stateMachine( StateMachine stateMachine )
+    public RaftInstanceBuilder<MEMBER> stateMachine( LastAppliedTrackingStateMachine stateMachine )
     {
         this.stateMachine = stateMachine;
         return this;

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftInstanceLogTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftInstanceLogTest.java
@@ -28,6 +28,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.neo4j.coreedge.raft.RaftInstance;
 import org.neo4j.coreedge.raft.RaftInstanceBuilder;
 import org.neo4j.coreedge.raft.ReplicatedInteger;
+import org.neo4j.coreedge.raft.state.LastAppliedTrackingStateMachine;
 import org.neo4j.coreedge.raft.state.StateMachine;
 import org.neo4j.coreedge.server.RaftTestMember;
 import org.neo4j.coreedge.server.RaftTestMemberSetBuilder;
@@ -62,7 +63,7 @@ public class RaftInstanceLogTest
 
         raft = new RaftInstanceBuilder<>( myself, 3, RaftTestMemberSetBuilder.INSTANCE )
                 .raftLog( testEntryLog )
-                .stateMachine( stateMachine )
+                .stateMachine( new LastAppliedTrackingStateMachine( stateMachine ) )
                 .build();
     }
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/LastAppliedTrackingStateMachineTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/LastAppliedTrackingStateMachineTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.state;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.ReplicatedInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import static org.neo4j.coreedge.raft.state.LastAppliedTrackingStateMachine.NOTHING_APPLIED;
+
+public class LastAppliedTrackingStateMachineTest
+{
+    @Test
+    public void shouldInitiallyHaveNothingApplied() throws Exception
+    {
+        // given
+        LastAppliedTrackingStateMachine lastAppliedTrackingStateMachine = new LastAppliedTrackingStateMachine( mock( StateMachines.class ) );
+
+        // then
+        assertEquals( NOTHING_APPLIED, lastAppliedTrackingStateMachine.lastApplied() );
+    }
+
+    @Test
+    public void shouldKeepTrackOfTheLastAppliedIndex() throws Exception
+    {
+        // given
+        LastAppliedTrackingStateMachine lastAppliedTrackingStateMachine = new LastAppliedTrackingStateMachine( mock( StateMachines.class ) );
+
+        // when
+        lastAppliedTrackingStateMachine.applyCommand( ReplicatedInteger.valueOf( 1 ), 1 );
+
+        // then
+        assertEquals( 1, lastAppliedTrackingStateMachine.lastApplied() );
+    }
+
+    @Test
+    public void shouldKeepHighestIndexSeenSoFar() throws Exception
+    {
+        // given
+        LastAppliedTrackingStateMachine lastAppliedTrackingStateMachine = new LastAppliedTrackingStateMachine( mock( StateMachines.class ) );
+
+        // when
+        lastAppliedTrackingStateMachine.applyCommand( ReplicatedInteger.valueOf( 1 ), 9 );
+        lastAppliedTrackingStateMachine.applyCommand( ReplicatedInteger.valueOf( 1 ), 1 );
+
+        // then
+        assertEquals( 9, lastAppliedTrackingStateMachine.lastApplied() );
+    }
+}


### PR DESCRIPTION
This ensures that RaftInstance doesn't try to apply commands that were
already applied by RaftLogReplay.
