### PR TITLE
Use relative references in PropertyRecordFormat and RelationshipRecordFormat

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/aligned/PropertyRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/aligned/PropertyRecordFormat.java
@@ -26,7 +26,10 @@ import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 
+
 import static org.neo4j.kernel.impl.store.format.aligned.Reference.PAGE_CURSOR_ADAPTER;
+import static org.neo4j.kernel.impl.store.format.aligned.Reference.toAbsolute;
+import static org.neo4j.kernel.impl.store.format.aligned.Reference.toRelative;
 
 /**
  * {@link PropertyRecord} format which currently has some wasted space in the end due to hard coded
@@ -52,9 +55,10 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
             long headerByte, boolean inUse ) throws IOException
     {
         int blockCount = (int) (headerByte >>> 4);
+        long recordId = record.getId();
         record.initialize( inUse,
-                Reference.decode( cursor, PAGE_CURSOR_ADAPTER ),
-                Reference.decode( cursor, PAGE_CURSOR_ADAPTER ) );
+                toAbsolute( Reference.decode( cursor, PAGE_CURSOR_ADAPTER ), recordId ),
+                toAbsolute( Reference.decode( cursor, PAGE_CURSOR_ADAPTER ), recordId ) );
         while ( blockCount-- > 0 )
         {
             record.addLoadedBlock( cursor.getLong() );
@@ -66,8 +70,9 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
             throws IOException
     {
         cursor.putByte( (byte) ((record.inUse() ? IN_USE_BIT : 0) | numberOfBlocks( record ) << 4) );
-        Reference.encode( record.getPrevProp(), cursor, PAGE_CURSOR_ADAPTER );
-        Reference.encode( record.getNextProp(), cursor, PAGE_CURSOR_ADAPTER );
+        long recordId = record.getId();
+        Reference.encode( toRelative( record.getPrevProp(), recordId), cursor, PAGE_CURSOR_ADAPTER );
+        Reference.encode( toRelative( record.getNextProp(), recordId), cursor, PAGE_CURSOR_ADAPTER );
         for ( PropertyBlock block : record )
         {
             for ( long propertyBlock : block.getValueBlocks() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/aligned/Reference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/aligned/Reference.java
@@ -227,4 +227,27 @@ enum Reference
         throw new UnsupportedOperationException( "Reference with first byte " + firstByte + " wasn't recognized"
                 + " as a reference" );
     }
+
+
+    /**
+     * Convert provided reference to be relative to basisReference
+     * @param reference reference that will be converter to relative
+     * @param basisReference conversion basis
+     * @return reference relative to basisReference
+     */
+    public static long toRelative( long reference, long basisReference )
+    {
+        return Math.subtractExact( reference , basisReference );
+    }
+
+    /**
+     * Convert provided relative to basis reference into absolute
+     * @param relativeReference relative reference to convert
+     * @param basisReference basis reference
+     * @return absolute reference
+     */
+    public static long toAbsolute( long relativeReference, long basisReference )
+    {
+        return Math.addExact( relativeReference, basisReference );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/aligned/RelationshipRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/aligned/RelationshipRecordFormat.java
@@ -20,9 +20,13 @@
 package org.neo4j.kernel.impl.store.format.aligned;
 
 import java.io.IOException;
+
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.impl.store.format.aligned.Reference.DataAdapter;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+
+import static org.neo4j.kernel.impl.store.format.aligned.Reference.toAbsolute;
+import static org.neo4j.kernel.impl.store.format.aligned.Reference.toRelative;
 
 class RelationshipRecordFormat extends BaseAlignedRecordFormat<RelationshipRecord>
 {
@@ -49,15 +53,16 @@ class RelationshipRecordFormat extends BaseAlignedRecordFormat<RelationshipRecor
             boolean inUse, DataAdapter<PageCursor> adapter )
     {
         int type = cursor.getShort() & 0xFFFF;
+        long recordId = record.getId();
         record.initialize( inUse,
-                decode( cursor, adapter, headerByte, HAS_PROPERTY_BIT, NULL ),
-                decode( cursor, adapter ),
-                decode( cursor, adapter ),
+                decode( cursor, adapter, headerByte, HAS_PROPERTY_BIT, NULL  ),
+                decode( cursor, adapter  ),
+                decode( cursor, adapter  ),
                 type,
-                decode( cursor, adapter ),
-                decode( cursor, adapter, headerByte, HAS_START_NEXT_BIT, NULL ),
-                decode( cursor, adapter ),
-                decode( cursor, adapter, headerByte, HAS_END_NEXT_BIT, NULL ),
+                toAbsolute( decode( cursor, adapter ), recordId ),
+                toAbsolute( decode( cursor, adapter, headerByte, HAS_START_NEXT_BIT, NULL ), recordId ),
+                toAbsolute( decode( cursor, adapter ), recordId ),
+                toAbsolute( decode( cursor, adapter, headerByte, HAS_END_NEXT_BIT, NULL ), recordId ),
                 has( headerByte, FIRST_IN_START_BIT ),
                 has( headerByte, FIRST_IN_END_BIT ) );
     }
@@ -77,14 +82,15 @@ class RelationshipRecordFormat extends BaseAlignedRecordFormat<RelationshipRecor
     @Override
     protected int requiredDataLength( RelationshipRecord record )
     {
-        return  2 + // type
-                length( record.getNextProp(), NULL ) +
-                length( record.getFirstNode() ) +
-                length( record.getSecondNode() ) +
-                length( record.getFirstPrevRel() ) +
-                length( record.getFirstNextRel(), NULL ) +
-                length( record.getSecondPrevRel() ) +
-                length( record.getSecondNextRel(), NULL );
+        long id = record.getId();
+        return Short.BYTES + // type
+               length( record.getNextProp(), NULL ) +
+               length( record.getFirstNode() ) +
+               length( record.getSecondNode() ) +
+               length( toRelative( record.getFirstPrevRel(), id ) ) +
+               length( toRelative( record.getFirstNextRel(), id ), NULL ) +
+               length( toRelative( record.getSecondPrevRel(), id ) ) +
+               length( toRelative( record.getSecondNextRel(), id ), NULL );
     }
 
     @Override
@@ -92,12 +98,15 @@ class RelationshipRecordFormat extends BaseAlignedRecordFormat<RelationshipRecor
             throws IOException
     {
         cursor.putShort( (short) record.getType() );
+        long recordId = record.getId();
         encode( cursor, adapter, record.getNextProp(), NULL );
         encode( cursor, adapter, record.getFirstNode() );
         encode( cursor, adapter, record.getSecondNode() );
-        encode( cursor, adapter, record.getFirstPrevRel() );
-        encode( cursor, adapter, record.getFirstNextRel(), NULL );
-        encode( cursor, adapter, record.getSecondPrevRel() );
-        encode( cursor, adapter, record.getSecondNextRel(), NULL );
+        encode( cursor, adapter, toRelative( record.getFirstPrevRel(), recordId ) );
+        encode( cursor, adapter, toRelative( record.getFirstNextRel(), recordId ), NULL );
+        encode( cursor, adapter, toRelative( record.getSecondPrevRel(), recordId ) );
+        encode( cursor, adapter, toRelative( record.getSecondNextRel(), recordId ), NULL );
     }
+
+
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/aligned/PropertyRecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/aligned/PropertyRecordFormatTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.aligned;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.io.ByteUnit;
+import org.neo4j.io.pagecache.StubPageCursor;
+import org.neo4j.kernel.impl.store.IntStoreHeader;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class PropertyRecordFormatTest
+{
+
+    private static final int DATA_SIZE = 100;
+
+    @Test
+    public void writeAndReadRecordWithRelativeReferences() throws IOException
+    {
+        PropertyRecordFormat format = new PropertyRecordFormat();
+        int recordSize = format.getRecordSize( new IntStoreHeader( DATA_SIZE ) );
+        StubPageCursor cursor = new StubPageCursor( 0, (int) ByteUnit.kibiBytes( 4 ) );
+        long recordId = 0xF1F1F1F1F1F1L;
+        int recordOffset = cursor.getOffset();
+
+        PropertyRecord record = createRecord( format, recordId );
+        format.write( record, cursor, recordSize, null);
+
+        PropertyRecord recordFromStore = format.newRecord();
+        recordFromStore.setId( recordId  );
+        resetCursor( cursor, recordOffset );
+        format.read( recordFromStore, cursor, RecordLoad.NORMAL, recordSize, null );
+
+        // records should be the same
+        assertEquals( record.getNextProp(), recordFromStore.getNextProp() );
+        assertEquals( record.getPrevProp(), recordFromStore.getPrevProp() );
+
+        // now lets try to read same data into a record with different id - we should get different absolute references
+        resetCursor( cursor, recordOffset );
+        PropertyRecord recordWithOtherId = format.newRecord();
+        recordWithOtherId.setId( 1L  );
+        format.read( recordWithOtherId, cursor, RecordLoad.NORMAL, recordSize, null );
+
+        assertNotEquals( record.getNextProp(), recordWithOtherId.getNextProp() );
+        assertNotEquals( record.getPrevProp(), recordWithOtherId.getPrevProp() );
+    }
+
+    private void resetCursor( StubPageCursor cursor, int recordOffset )
+    {
+        cursor.setOffset( recordOffset );
+    }
+
+    private PropertyRecord createRecord( PropertyRecordFormat format, long recordId )
+    {
+        PropertyRecord record = format.newRecord();
+        record.setInUse( true );
+        record.setId( recordId );
+        record.setNextProp( 1L );
+        record.setPrevProp( 3L );
+        return record;
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/aligned/ReferenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/aligned/ReferenceTest.java
@@ -26,16 +26,15 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.neo4j.io.pagecache.StubPageCursor;
-import org.neo4j.kernel.impl.store.format.aligned.Reference;
 import org.neo4j.test.RandomRule;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.kernel.impl.store.format.aligned.Reference.PAGE_CURSOR_ADAPTER;
 
 public class ReferenceTest
 {
-    public final @Rule RandomRule random = new RandomRule();
+    @Rule
+    public final RandomRule random = new RandomRule();
     private final ByteBuffer buffer = ByteBuffer.allocateDirect( 100 );
     private final StubPageCursor cursor = new StubPageCursor( 0, buffer );
 
@@ -49,6 +48,19 @@ public class ReferenceTest
             long reference = limit( random.nextLong(), mask );
             assertDecodedMatchesEncoded( reference );
         }
+    }
+
+    @Test
+    public void relativeReferenceConvertion()
+    {
+        long basis = 0xBABE;
+        long absoluteReference = 0xCAFEBABE;
+
+        long relative = Reference.toRelative( absoluteReference, basis );
+        assertEquals( "Should be equal to difference of reference and base reference", 0xCAFE0000, relative );
+
+        long absoluteCandidate = Reference.toAbsolute( relative, basis );
+        assertEquals( "Converted reference should be equal to initial value", absoluteReference, absoluteCandidate );
     }
 
     private long numberOfBits( int count )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/aligned/RelationshipRecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/aligned/RelationshipRecordFormatTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.aligned;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.io.ByteUnit;
+import org.neo4j.io.pagecache.StubPageCursor;
+import org.neo4j.kernel.impl.store.IntStoreHeader;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class RelationshipRecordFormatTest
+{
+    private static final int DATA_SIZE = 100;
+
+    @Test
+    public void writeAndReadRecordWithRelativeReferences() throws IOException
+    {
+        RelationshipRecordFormat format = new RelationshipRecordFormat( new CommunityRecordIO<RelationshipRecord>() );
+        int recordSize = format.getRecordSize( new IntStoreHeader( DATA_SIZE ) );
+        StubPageCursor cursor = new StubPageCursor( 0, (int) ByteUnit.kibiBytes( 4 ) );
+        long recordId = 0xF1F1F1F1F1F1L;
+        int recordOffset = cursor.getOffset();
+
+        RelationshipRecord record = createRecord( format, recordId );
+        format.write( record, cursor, recordSize, null);
+
+        RelationshipRecord recordFromStore = format.newRecord();
+        recordFromStore.setId( recordId  );
+        resetCursor( cursor, recordOffset );
+        format.read( recordFromStore, cursor, RecordLoad.NORMAL, recordSize, null );
+
+        // records should be the same
+        assertEquals( record.getFirstNextRel(), recordFromStore.getFirstNextRel() );
+        assertEquals( record.getFirstNode(), recordFromStore.getFirstNode() );
+        assertEquals( record.getFirstPrevRel(), recordFromStore.getFirstPrevRel() );
+        assertEquals( record.getSecondNextRel(), recordFromStore.getSecondNextRel() );
+        assertEquals( record.getSecondNode(), recordFromStore.getSecondNode() );
+        assertEquals( record.getSecondPrevRel(), recordFromStore.getSecondPrevRel() );
+
+        // now lets try to read same data into a record with different id - we should get different absolute references
+        resetCursor( cursor, recordOffset );
+        RelationshipRecord recordWithOtherId = format.newRecord();
+        recordWithOtherId.setId( 1L  );
+        format.read( recordWithOtherId, cursor, RecordLoad.NORMAL, recordSize, null );
+
+        assertNotEquals( record.getFirstNextRel(), recordWithOtherId.getFirstNextRel() );
+        assertNotEquals( record.getFirstPrevRel(), recordWithOtherId.getFirstPrevRel() );
+        assertNotEquals( record.getSecondNextRel(), recordWithOtherId.getSecondNextRel() );
+        assertNotEquals( record.getSecondPrevRel(), recordWithOtherId.getSecondPrevRel() );
+    }
+
+    private void resetCursor( StubPageCursor cursor, int recordOffset )
+    {
+        cursor.setOffset( recordOffset );
+    }
+
+    private RelationshipRecord createRecord( RelationshipRecordFormat format, long recordId )
+    {
+        RelationshipRecord record = format.newRecord();
+        record.setInUse( true );
+        record.setId( recordId );
+        record.setFirstNextRel( 1L );
+        record.setFirstNode( 2L );
+        record.setFirstPrevRel( 3L );
+        record.setSecondNextRel( 4L );
+        record.setSecondNode( 5L );
+        record.setSecondPrevRel( 6L );
+        return record;
+    }
+
+}


### PR DESCRIPTION
New record formats will try to minimise size of reference to next and previous by using relative to id value.
