### PR TITLE
Add support for secondary unit in commands

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplierFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TransactionApplierFacade.java
@@ -28,7 +28,8 @@ import org.neo4j.storageengine.api.StorageCommand;
 
 /**
  * Wraps several {@link TransactionApplier}s. In this case, each individual visit-call will delegate to {@link
- * #visit(Command)} instead, which will call each wrapped {@link TransactionApplier} in turn. In {@link #close()},
+ * #visit(StorageCommand)} instead, which will call each wrapped {@link TransactionApplier} in turn. In
+ * {@link #close()},
  * the appliers are closed in reversed order.
  */
 public class TransactionApplierFacade extends TransactionApplier.Adapter

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -355,7 +355,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
 
         // Schema index application
         appliers.add( new IndexBatchTransactionApplier( indexingService, labelScanStoreSync, indexUpdatesSync,
-                neoStores.getNodeStore(), neoStores.getPropertyStore(), new PropertyLoader( neoStores ),
+                neoStores.getNodeStore(), new PropertyLoader( neoStores ),
                 indexUpdatesConverter, mode ) );
 
         // Legacy index application

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/AbstractBaseRecord.java
@@ -87,7 +87,7 @@ public abstract class AbstractBaseRecord implements CloneableInPublic
     }
 
     /**
-     * Sets a secondary record unit ID for this record. If this is set to something other than {@code -1}
+     * Sets a secondary record unit ID for this record. If this is set to something other than {@link #NO_ID}
      * then {@link #requiresSecondaryUnit()} will return {@code true}.
      * Setting this id is separate from setting {@link #requiresSecondaryUnit()} since this secondary unit id
      * may be used to just free that id at the time of updating in the store if a record goes from two to one unit.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/Record.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/Record.java
@@ -45,16 +45,19 @@ public enum Record
     NO_LABELS_FIELD( (byte)0, 0 );
 
     public static final byte CREATED_IN_TX = 2;
+    public static final byte REQUIRE_SECONDARY_UNIT = 4;
+    public static final byte HAS_SECONDARY_UNIT = 8;
+
 
     private byte byteValue;
     private int intValue;
 
-    private Record( Record from )
+    Record( Record from )
     {
         this( from.byteValue, from.intValue );
     }
 
-    private Record( byte byteValue, int intValue )
+    Record( byte byteValue, int intValue )
     {
         this.byteValue = byteValue;
         this.intValue = intValue;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplier.java
@@ -68,7 +68,7 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
     public IndexBatchTransactionApplier( IndexingService indexingService,
             WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanStoreSync,
             WorkSync<IndexingService,IndexUpdatesWork> indexUpdatesSync,
-            NodeStore nodeStore, PropertyStore propertyStore, PropertyLoader propertyLoader,
+            NodeStore nodeStore, PropertyLoader propertyLoader,
             PropertyPhysicalToLogicalConverter indexUpdateConverter,
             TransactionApplicationMode mode )
     {
@@ -76,7 +76,7 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
         this.labelScanStoreSync = labelScanStoreSync;
         this.indexUpdatesSync = indexUpdatesSync;
         this.indexUpdateConverter = indexUpdateConverter;
-        this.transactionApplier = new SingleTransactionApplier( nodeStore, propertyStore, propertyLoader, mode );
+        this.transactionApplier = new SingleTransactionApplier( nodeStore, propertyLoader, mode );
     }
 
     @Override
@@ -117,17 +117,15 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
     private class SingleTransactionApplier extends TransactionApplier.Adapter
     {
         private final NodeStore nodeStore;
-        private final PropertyStore propertyStore;
         private final PropertyLoader propertyLoader;
         private final TransactionApplicationMode mode;
         private final NodePropertyCommandsExtractor indexUpdatesExtractor = new NodePropertyCommandsExtractor();
         private List<IndexRule> createdIndexes;
 
-        public SingleTransactionApplier( NodeStore nodeStore, PropertyStore propertyStore,
-                PropertyLoader propertyLoader, TransactionApplicationMode mode )
+        public SingleTransactionApplier( NodeStore nodeStore, PropertyLoader propertyLoader,
+                TransactionApplicationMode mode )
         {
             this.nodeStore = nodeStore;
-            this.propertyStore = propertyStore;
             this.propertyLoader = propertyLoader;
             this.mode = mode;
         }
@@ -164,7 +162,7 @@ public class IndexBatchTransactionApplier extends BatchTransactionApplier.Adapte
         private IndexUpdates createIndexUpdates()
         {
             return mode == TransactionApplicationMode.RECOVERY ? new RecoveryIndexUpdates() :
-                new OnlineIndexUpdates( nodeStore, propertyStore, propertyLoader, indexUpdateConverter );
+                new OnlineIndexUpdates( nodeStore, propertyLoader, indexUpdateConverter );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
@@ -42,16 +42,7 @@ public class LogEntryWriter
     public LogEntryWriter( FlushableChannel channel )
     {
         this.channel = channel;
-        this.serializer = new Visitor<StorageCommand,IOException>()
-        {
-            @Override
-            public boolean visit( StorageCommand command ) throws IOException
-            {
-                writeLogEntryHeader( COMMAND );
-                command.serialize( channel );
-                return false;
-            }
-        };
+        this.serializer = new StorageCommandSerializer( channel );
     }
 
     private void writeLogEntryHeader( byte type ) throws IOException
@@ -91,5 +82,23 @@ public class LogEntryWriter
         writeLogEntryHeader( CHECK_POINT );
         channel.putLong( logPosition.getLogVersion() ).
                 putLong( logPosition.getByteOffset() );
+    }
+
+    private class StorageCommandSerializer implements Visitor<StorageCommand,IOException>
+    {
+        private final FlushableChannel channel;
+
+        public StorageCommandSerializer( FlushableChannel channel )
+        {
+            this.channel = channel;
+        }
+
+        @Override
+        public boolean visit( StorageCommand command ) throws IOException
+        {
+            writeLogEntryHeader( COMMAND );
+            command.serialize( channel );
+            return false;
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/OnlineIndexUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/OnlineIndexUpdates.java
@@ -64,19 +64,16 @@ import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
 public class OnlineIndexUpdates implements IndexUpdates
 {
     private final NodeStore nodeStore;
-    private final PropertyStore propertyStore;
     private final PropertyLoader propertyLoader;
     private final PropertyPhysicalToLogicalConverter converter;
     private final Collection<NodePropertyUpdate> updates = new ArrayList<>();
     private NodeRecord nodeRecord;
 
     public OnlineIndexUpdates( NodeStore nodeStore,
-                             PropertyStore propertyStore,
                              PropertyLoader propertyLoader,
                              PropertyPhysicalToLogicalConverter converter )
     {
         this.nodeStore = nodeStore;
-        this.propertyStore = propertyStore;
         this.propertyLoader = propertyLoader;
         this.converter = converter;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
@@ -61,8 +61,8 @@ public class IndexBatchTransactionApplierTest
         TransactionToApply tx = mock( TransactionToApply.class );
         PropertyStore propertyStore = mock( PropertyStore.class );
         try ( IndexBatchTransactionApplier applier = new IndexBatchTransactionApplier( indexing, labelScanSync,
-                indexUpdatesSync, mock( NodeStore.class ), propertyStore,
-                mock( PropertyLoader.class ), new PropertyPhysicalToLogicalConverter( propertyStore ),
+                indexUpdatesSync, mock( NodeStore.class ), mock( PropertyLoader.class ),
+                new PropertyPhysicalToLogicalConverter( propertyStore ),
                 TransactionApplicationMode.INTERNAL ) )
         {
             try ( TransactionApplier txApplier = applier.startTx( tx ) )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
@@ -931,7 +931,7 @@ public class NeoStoreTransactionApplierTest
     private BatchTransactionApplier newIndexApplier()
     {
         return new IndexBatchTransactionApplier( indexingService, labelScanStoreSynchronizer,
-                indexUpdatesSync, nodeStore, propertyStore, new PropertyLoader( neoStores ),
+                indexUpdatesSync, nodeStore, new PropertyLoader( neoStores ),
                 new PropertyPhysicalToLogicalConverter( propertyStore ), INTERNAL );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionIndexApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoTransactionIndexApplierTest.java
@@ -95,8 +95,8 @@ public class NeoTransactionIndexApplierTest
     {
         PropertyStore propertyStore = mock( PropertyStore.class );
         return new IndexBatchTransactionApplier( indexingService,
-                labelScanStoreSynchronizer, indexUpdatesSync, mock( NodeStore.class ), propertyStore, mock(
-                PropertyLoader.class ), new PropertyPhysicalToLogicalConverter( propertyStore ),
+                labelScanStoreSynchronizer, indexUpdatesSync, mock( NodeStore.class ),
+                mock(PropertyLoader.class ), new PropertyPhysicalToLogicalConverter( propertyStore ),
                 TransactionApplicationMode.INTERNAL );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupCommandV2_2Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupCommandV2_2Test.java
@@ -32,7 +32,7 @@ import org.neo4j.storageengine.api.CommandReader;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class RelationshipGroupCommandTest
+public class RelationshipGroupCommandV2_2Test
 {
     @Test
     public void shouldSerializeAndDeserializeUnusedRecords() throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
@@ -1174,7 +1174,7 @@ public class TransactionRecordStateTest
         transaction.accept( extractor );
 
         OnlineIndexUpdates lazyIndexUpdates = new OnlineIndexUpdates( neoStores.getNodeStore(),
-                neoStores.getPropertyStore(), new PropertyLoader( neoStores ),
+                new PropertyLoader( neoStores ),
                 new PropertyPhysicalToLogicalConverter( neoStores.getPropertyStore() ) );
         lazyIndexUpdates.feed( extractor.propertyCommandsByNodeIds(), extractor.nodeCommandsById() );
         return lazyIndexUpdates;


### PR DESCRIPTION
Add support for secondary unit during RelationshipCommand, RelationshipGroupCommand, PropertyCommands serialisation;
support secondary unit in PhysicalLogCommandReaderV3_0.
