### PR TITLE
Remove the StoreDirectory JMX property

### DIFF
--- a/community/jmx/src/main/java/org/neo4j/jmx/Kernel.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/Kernel.java
@@ -36,9 +36,6 @@ public interface Kernel
     @Description( "The name of the mounted database" )
     String getDatabaseName();
 
-    @Description( "The location where the Neo4j store is located" )
-    String getStoreDirectory();
-
     @Description( "The version of Neo4j" )
     String getKernelVersion();
 

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/KernelBean.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/KernelBean.java
@@ -112,12 +112,6 @@ public class KernelBean extends Neo4jMBean implements Kernel
         return databaseName;
     }
 
-    @Override
-    public String getStoreDirectory()
-    {
-        return storePath;
-    }
-
     private class DataSourceInfo
             implements DataSourceManager.Listener
     {

--- a/enterprise/management/src/main/java/org/neo4j/management/Neo4jManager.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/Neo4jManager.java
@@ -371,12 +371,6 @@ public final class Neo4jManager extends KernelProxy implements Kernel
     }
 
     @Override
-    public String getStoreDirectory()
-    {
-        return proxy.getStoreDirectory();
-    }
-
-    @Override
     public String getStoreId()
     {
         return proxy.getStoreId();


### PR DESCRIPTION
This is a small security risk because it exposes information about the
server's filesystem. And it is no longer useful in 3.0 now that we
refer to databases by name rather than path.
