### PR TITLE
Support open options DELETE_ON_CLOSE and EXCLUSIVE for PageCache.map()

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -22,6 +22,7 @@ package org.neo4j.io.pagecache;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
 
 /**
  * A page caching mechanism that allows caching multiple files and accessing their data
@@ -43,15 +44,20 @@ public interface PageCache extends AutoCloseable
      * @param file The file to map.
      * @param pageSize The file page size to use for this mapping. If the file is already mapped with a different page
      * size, an exception will be thrown.
-     * @param openOptions The set of open options to use for mapping this file. The
-     * {@link java.nio.file.StandardOpenOption#READ} and {@link java.nio.file.StandardOpenOption#WRITE} options always
-     * implicitly specified. The {@link java.nio.file.StandardOpenOption#CREATE} open option will create the given
-     * file if it does not already exist, and the {@link java.nio.file.StandardOpenOption#TRUNCATE_EXISTING} will
-     * truncate any existing file <em>iff</em> it has not already been mapped.
+     * @param openOptions The set of open options to use for mapping this file.
+     * The {@link StandardOpenOption#READ} and {@link StandardOpenOption#WRITE} options always implicitly specified.
+     * The {@link StandardOpenOption#CREATE} open option will create the given file if it does not already exist, and
+     * the {@link StandardOpenOption#TRUNCATE_EXISTING} will truncate any existing file <em>iff</em> it has not already
+     * been mapped.
+     * The {@link StandardOpenOption#DELETE_ON_CLOSE} will cause the file to be deleted after the last unmapping.
+     * The {@link PageCacheOpenOptions#EXCLUSIVE} will cause the {@code map} method to throw if the file is already
+     * mapped. Otherwise, the file will be mapped exclusively, and subsequent attempts at mapping the file will fail
+     * with an exception until the exclusively mapped file is closed.
      * All other options are either silently ignored, or will cause an exception to be thrown.
      * @throws java.nio.file.NoSuchFileException if the given file does not exist, and the
-     * {@link java.nio.file.StandardOpenOption#CREATE} option was not specified.
-     * @throws IOException if the file could otherwise not be mapped.
+     * {@link StandardOpenOption#CREATE} option was not specified.
+     * @throws IOException if the file could otherwise not be mapped. Causes include the file being locked, or exclusive
+     * mapping conflicts.
      */
     PagedFile map( File file, int pageSize, OpenOption... openOptions ) throws IOException;
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCacheOpenOptions.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCacheOpenOptions.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache;
+
+import java.io.File;
+import java.nio.file.OpenOption;
+
+/**
+ * {@link OpenOption}s that are specific to {@link PageCache#map(File, int, OpenOption...)},
+ * and not normally supported by file systems.
+ */
+public enum PageCacheOpenOptions implements OpenOption
+{
+    /**
+     * Only allow a single mapping of the given file.
+     */
+    EXCLUSIVE
+}

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageSwapper.java
@@ -106,10 +106,16 @@ public interface PageSwapper
     File file();
 
     /**
-     * Close and release all resources associated with the file underlying this
-     * PageSwapper.
+     * Close and release all resources associated with the file underlying this PageSwapper.
      */
     void close() throws IOException;
+
+    /**
+     * Close and release all resources associated with the file underlying this PageSwapper, and then delete that file.
+     * @throws IOException If an {@link IOException} occurs during either the closing or the deleting of the file. This
+     * may leave the file on the file system.
+     */
+    void closeAndDelete() throws IOException;
 
     /**
      * Forces all writes done by this PageSwapper to the underlying storage device, such that the writes are durable

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/SingleFilePageSwapper.java
@@ -695,6 +695,13 @@ public class SingleFilePageSwapper implements PageSwapper
     }
 
     @Override
+    public synchronized void closeAndDelete() throws IOException
+    {
+        close();
+        fs.deleteFile( file );
+    }
+
+    @Override
     public void force() throws IOException
     {
         try

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageSwapper.java
@@ -76,6 +76,12 @@ public class DelegatingPageSwapper implements PageSwapper
         delegate.truncate();
     }
 
+    @Override
+    public void closeAndDelete() throws IOException
+    {
+        delegate.closeAndDelete();
+    }
+
     public long read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
     {
         return delegate.read( startFilePageId, pages, arrayOffset, length );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DummyPageSwapper.java
@@ -79,6 +79,11 @@ public class DummyPageSwapper implements PageSwapper
     }
 
     @Override
+    public void closeAndDelete() throws IOException
+    {
+    }
+
+    @Override
     public long read( long startFilePageId, Page[] pages, int arrayOffset, int length ) throws IOException
     {
         return 0;


### PR DESCRIPTION
The `StandardOpenOption.DELETE_ON_CLOSE` will be useful for migrations.
Specifically, it has a use when migrating a store to a block device based storage system.
The `PageCacheOpenOption.EXCLUSIVE` may find use in the counts store, and generally in places where we want to ensure a single point of access to a file.
