### PR TITLE
Improve error message on DelegateInvocationHandler

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -112,6 +112,15 @@ public interface Status
         "in a way that it will wait indefinitely, and the database has aborted it. Retrying this transaction " +
         "will most likely be successful."),
 
+        InstanceStateChanged( TransientError,
+                "Transactions rely on assumptions around the state of the Neo4j instance they " +
+                "execute on. For instance, transactions in a cluster may expect that " +
+                "they are executing on an instance that can perform writes. However, " +
+                "instances may change state while the transaction is running. This causes " +
+                "assumptions the instance has made about how to execute the transaction " +
+                "to be violated - meaning the transaction must be rolled " +
+                "back. If you see this error, you should retry your operation in a new transaction."),
+
         EventHandlerThrewException( ClientError, "A transaction event handler threw an exception. The transaction " +
         "will be rolled back." ),
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
@@ -163,7 +163,7 @@ public class DelegateInvocationHandler<T> implements InvocationHandler
      * we don't want to change the API from throwing `TransactionFailureException` for
      * backwards compat reasons, we throw this sub-class that adds a status code.
      */
-    public static class StateChangedTransactionFailureException extends TransactionFailureException implements Status.HasStatus
+    static class StateChangedTransactionFailureException extends TransactionFailureException implements Status.HasStatus
     {
         public StateChangedTransactionFailureException( String msg )
         {


### PR DESCRIPTION
This error didn't have a status code, leading to hundreds of "unknown error occurred, please report this error" in the user log any time there's a HA role switch, which is making it meh to debug HA cluster logs, since the interesting portions will have a lot of these errors.
