### PR TITLE
Skip findbugs by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,6 +460,26 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>skip-findbugs</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>skipFindbugs</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>findbugs-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,7 @@
     <profile>
       <id>skip-findbugs</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
+        <activeByDefault>true</activeByDefault>
         <property>
           <name>skipFindbugs</name>
         </property>


### PR DESCRIPTION
I think it has become clear that it is not (yet!) suitable to always run findbugs.

This PR revives a commit by @apcj but turns it on by default. The default may change
in the future, depending on other events.

So if you want to run findbugs together with your build, you can do:

```
mvn install -DskipFindbugs=false
```
