### PR TITLE
Thorough changes to format and language in upgrade manuals.

### DIFF
--- a/community/neo4j/src/docs/ops/upgrades.asciidoc
+++ b/community/neo4j/src/docs/ops/upgrades.asciidoc
@@ -4,89 +4,74 @@
 :manual-base-url: http://neo4j.com/docs/{neo4j-version}
 :manual-ha-upgrade-guide: {manual-base-url}/ha-upgrade-guide.html
 :manual-cypher-compatibility: {manual-base-url}/cypher-compatibility.html
+:neo4j-releases-download-page: http://neo4j.com/download/other-releases
 
-[IMPORTANT]
-This section describes upgrading a single Neo4j instance.
-To upgrade a Neo4j HA cluster (Neo4j Enterprise) a very specific procedure must be followed.
+This section describes upgrading a _single_ Neo4j instance.
+To upgrade a _Neo4j HA cluster (Neo4j Enterprise)_, a very specific procedure must be followed.
 Please see
 ifndef::upgradetext[<<ha-upgrade-guide>>.]
 ifdef::upgradetext['Upgrade of a Neo4j HA Cluster' at {manual-ha-upgrade-guide}.]
 
-Each Neo4j version supports upgrading from a limited number of previous versions.
-These upgrades are either automatic, or require explicit configuration to allow them.
-Upgrades between patch releases within the same minor version are automatic.
-Upgrading to the latest patch release is recommended before upgrading to new major or minor versions.
-
-A database created by an older version of Neo4j will be upgraded during startup when opened by the target version of Neo4j.
-
-The following Neo4j versions, where _x_ stands for the latest patch release, can be upgraded to Neo4j {neo4j-version}:
-
-1.9.x -> {neo4j-version}::
-<<explicit-upgrade,Explicit configuration is required>>
-
-2.0.x -> {neo4j-version}::
-<<explicit-upgrade,Explicit configuration is required>>
-
-2.1.x -> {neo4j-version}::
-<<explicit-upgrade,Explicit configuration is required>>
-
-2.2.x -> {neo4j-version}::
-<<explicit-upgrade,Explicit configuration is required>>
-
-[NOTE]
-Downgrade is only supported between Neo4j versions that allow for automatic store upgrades.
-This typically means only within patch releases of the same Neo4j version.
-
-[[automatic-upgrade]]
-== Automatic Store Upgrade
-
-To perform an automatic store upgrade:
-
-. Cleanly shut down the older version of Neo4j, if it is running.
-
-. Install Neo4j {neo4j-version}, and set it up to use the same database store directory (typically _data/graph.db_).
-
-. Make a copy of the database.
-+
-[IMPORTANT]
-It is strongly advised to make a copy of the database store directory at this time, to use as a backup in case rollback/downgrade is required.
-This is not necessary if a backup has been made using the
-ifndef::upgradetext[<<operations-backup, online backup tool>>, ]
-ifdef::upgradetext[online backup tool (see http://neo4j.com/docs/{neo4j-version}/operations-backup.html), ]
-available with Neo4j Enterprise.
-
-. Start up Neo4j.
-
-. Any database store upgrade required will occur during startup.
-
-[[explicit-upgrade]]
-== Explicit Store Upgrade
-
-To perform an explicit store upgrade:
-
-. Install Neo4j {neo4j-version}, and set it up to use the same database store directory (typically _data/graph.db_).
-. Cleanly shut down the older version of Neo4j, if it is running.
-. Set the Neo4j configuration parameter `allow_store_upgrade=true` in your _conf/neo4j.properties_ file.
-  Neo4j will fail to start without this configuration set.
-. Start up Neo4j.
-. The database store upgrade will occur during startup.
-. The `allow_store_upgrade` configuration parameter should be removed, set to `false` or commented out.
-. Information about the upgrade and a progress indicator are logged into the _messages.log_ file, inside the database store directory.
+Throughout this instruction, the files used to store the Neo4j data are referred to as `database files`.
+The location of these files is specified by configuring the `org.neo4j.server.database.location` variable in `conf/neo4j-server.properties`.
 
 [CAUTION]
 .Disk space requirements
 ====
-An explicit upgrade will require substantial free disk space, as it must make an entire copy of the database store.
-The upgraded store version may also require larger store files overall.
-It is suggested to have available free disk space equivalent to at least 1.5 times the size of the existing store.
+An upgrade requires substantial free disk space, as it makes an entire copy of the database.
+The upgraded database may also require larger data files overall.
+
+It is recommended to make available an extra 50% disk space on top of the existing database files.
+
+In addition to this, don't forget to reserve the disk space needed for the pre-upgrade backup.
 ====
+
+[[supported-upgrade-paths]]
+== Supported upgrade paths
+
+Before upgrading to a new major or minor release, the database must first be upgraded to the latest version within the relevant release.
+The latest version is available at this page: {neo4j-releases-download-page}.
+The following Neo4j upgrade paths are supported:
+
+* 1.9.latest -> {neo4j-version}
+
+* 2.0.latest -> {neo4j-version}
+
+* 2.1.latest -> {neo4j-version}
+
+* 2.2.latest -> {neo4j-version}
+
+* 2.3.any -> {neo4j-version}
+
+
+[[upgrade-instructions]]
+== Upgrade instructions
+
+. Cleanly shut down the database if it is running.
+. Make a backup copy of the database files. 
+  If using the 
+ifndef::upgradetext[<<operations-backup, online backup tool>>]
+ifdef::upgradetext[online backup tool (see http://neo4j.com/docs/{neo4j-version}/operations-backup.html)]
+available with Neo4j Enterprise, ensure that backups have completed successfully.
+
+. Install Neo4j {neo4j-version}.
+. Review the parameter settings in the files under conf directory in the previous installation, and transfer any custom set parameters to the {neo4j-version} installation.
+  Be aware of parameters that have changed names between versions.
+  Also, ensure that you configure the {neo4j-version} installation to use the same database file directory as the previous installation.
+. Set the Neo4j configuration parameter `allow_store_upgrade=true` in the `conf/neo4j.properties` file of the {neo4j-version} installation.
+  Neo4j will fail to start without this configuration.
+. Start up Neo4j {neo4j-version}.
+. The database upgrade will take place during startup.
+. Information about the upgrade and a progress indicator are logged into the `messages.log` file inside the database file directory.
+. When upgrade has finished, the `allow_store_upgrade` should be set to `false` or be removed. 
+. It is good practice to make a full backup immediately after the backup.
 
 [NOTE]
 .Cypher compatibility
 ====
-The Cypher language is rapidly evolving, and may change between Neo4j versions.
-However, Neo4j supports compatibility directives for Cypher, that allow explicitly selecting a language version.
-This is possible to do for individual statements, or globally, as described in the
+The Cypher language may evolve between Neo4j versions.
+For backward compatibility, Neo4j provides directives which allow explicitly selecting a previous Cypher language version.
+This is possible to do globally or for individual statements, as described in the
 ifndef::upgradetext[<<cypher-compatibility, Cypher Compatibility section>>.]
 ifdef::upgradetext[Cypher Compatibility section at {manual-cypher-compatibility}.]
 ====

--- a/enterprise/ha/src/docs/dev/upgrade-guide.asciidoc
+++ b/enterprise/ha/src/docs/dev/upgrade-guide.asciidoc
@@ -1,138 +1,46 @@
 [[ha-upgrade-guide]]
 = Upgrade of a Neo4j HA Cluster
 
-[CAUTION]
-Before attempting any of the upgrades described here, please
-<<operations-backup, backup your database store!>>
+Upgrading a Neo4j HA cluster to Neo4j {neo4j-version} requires following a specific process in order to ensure that the cluster remains consistent, and that all cluster instances are able to join and participate in the cluster following their upgrade.
+Neo4j {neo4j-version} does not support rolling upgrades.
 
-To upgrade a Neo4j HA cluster to Neo4j {neo4j-version} requires following a specific process which ensures that the cluster remains consistent and all cluster instances are able to join and participate following their upgrade.
+== Back up the Neo4j database
+- Before starting any upgrade procedure, it is _very important_ to make a full backup of your database.
+- For detailed instructions on backing up your Neo4j database, <<operations-backup, refer to the backup guide.>>
 
-Neo4j {neo4j-version} does not support rolling upgrades, only the standard upgrade procedure is available.
+== Shut down the cluster
+- Shut down the database slave instances one by one. 
+- Shut down the master last.
 
-////
-Neo4j supports two approaches to HA cluster upgrades,
-the <<ha-standard-upgrade, standard upgrade process>> and the
-<<ha-rolling-upgrade, rolling upgrade process for zero downtime>>.
+== Upgrade the master
+ . Install Neo4j {neo4j-version} on the master, keeping the database files untouched.
+ . Disable HA in the configuration, by setting  the variable `org.neo4j.server.database.mode=SINGLE` in `conf/neo4j.properties`.
+ . <<deployment-upgrading,Upgrade as described for a single instance of Neo4j>>
+ . When upgrade has finished, shut down Neo4j again.
+ . Re-enable HA in the configuration by setting `org.neo4j.server.database.mode=HA` in `conf/neo4j.properties`.
+ . Make a full backup of the Neo4j database.
+   Please note that backups from before the upgrade are no longer valid for update via the incremental online backup. 
+   Therefore it is important to perform a _full backup_, using an empty target directory, at this point.
 
-[NOTE]
-It is strongly recommended to follow the <<ha-standard-upgrade, standard
-upgrade process>> over the <<ha-rolling-upgrade, rolling upgrade process>>, as
-it is much simpler and less likely to encounter issues.
-////
+== Upgrade the slaves
+On each slave:
 
-[IMPORTANT]
-After upgrade is complete, existing backups will not be suitable for updating
-via the <<operations-backup, incremental online backup>>. Please ensure that
-the first backup after upgrading uses an empty target directory, and thus
-performs a full backup.
-
-[[ha-standard-upgrade]]
-== Standard upgrade ==
-
-In order to perform a cluster upgrade to Neo4j {neo4j-version}, you need to first
-upgrade the database store on a single instance, and then allow that store to
-propagate out to slaves.
-
-=== Steps ===
-
-The following process is recommended:
-
-.Backup
-- Before anything else, <<operations-backup, backup your database store!>>
-
-.Shut down the cluster
-- Shut down all instances. This is usually best done one instance after the
-  other, rather than all at once. It is also strongly recommended to shut down
-  the master of the cluster last.
-
-.Upgrade the database store on the previous master
- . Install Neo4j {neo4j-version} on the previous master, keeping the database
-  store (typically _data/graph.db_) from the previous version.
- . Disable HA in the configuration, by setting `org.neo4j.server.database.mode=SINGLE`.
- . <<deployment-upgrading,Upgrade as described for a single instance of Neo4j>> (this may involve configuring with `allow_store_upgrade=true`, as described in <<explicit-upgrade, "Explicit Upgrades">>).
- . Once upgraded, shut down Neo4j again.
- . Re-enable HA in the configuration, by setting `org.neo4j.server.database.mode=HA` again.
-
-.Upgrade the slaves
-- Install Neo4j {neo4j-version} on all previous slaves *and remove their database store* (typically _data/graph.db_).
-  _Slaves should not be started with a previous store present._
-- Note: The security configuration of the master is _not_ propagated to the slaves.
-  See <<rest-api-security-copy-config>> for more information.
-
-.Restart the cluster
- . Start the previous master instance.
- . Start each slave, one after the other.
-   Once each slave has joined the cluster, it will sync the store from the master instance.
+. Remove all database files.
+. Install Neo4j {neo4j-version}.
+. Review the parameter settings in the files under conf directory in the previous installation, and transfer any custom set parameters to the {neo4j-version} installation.
+  Be aware of parameters that have changed names between versions.
+  Also, ensure that you configure the {neo4j-version} installation to use the same database file directory as the previous installation.
+. If applicable, copy security the security configuration from the master, since this is not propagated automatically. 
+  See <<rest-api-security-copy-config>> for instructions.
 
 [TIP]
-For larger databases, it is possible to manually copy the database store from the previous master _after it has completed the upgrade_ to the slaves before starting
-them.
-This will avoid the need for them to sync from the master when starting.
+At this point it is an alternative is to manually copy database files from the master to the slaves.
+Doing so will avoid the need to sync from the master when starting.
+This can save considerable time when upgrading large databases.
 
-////
-[[ha-rolling-upgrade]]
-== Rolling upgrade ==
 
-Upgrading a Neo4j cluster without disrupting its operation is referred to as a
-_rolling upgrade_.
+== Restart the cluster
+ . Start the master instance.
+ . Start the slaves, one by one.
+   Once a slave has joined the cluster, it will sync the database from the master instance.
 
-[IMPORTANT]
-*Neo4j {neo4j-version} only supports rolling upgrades from Neo4j 2.0.x
-and previous Neo4j 2.1.x patch releases*.
-
-[CAUTION]
-It is not possible to downgrade a Neo4j cluster without downtime.
-
-In order to perform a rolling upgrade to Neo4j {neo4j-version}, you need to first
-upgrade the database store and then replace the database store of each cluster
-instance with the upgraded version, one at a time, with the cluster master done last.
-
-=== Steps ===
-
-The following process is recommended:
-
-.Backup
-- Before anything else, <<operations-backup, backup your database store!>>
-
-.Upgrade a single database store
-- Perform upgrade, using one slave instance to do so:
- . Shut down a single slave instance.
- . Install Neo4j {neo4j-version} on that instance, keeping the database store (typically _data/graph.db_) from the previous version.
- . Disable HA in the configuration, by setting `org.neo4j.server.database.mode=SINGLE`.
- . <<deployment-upgrading,Upgrade as described for a single instance of Neo4j>>. This may involve configuring with `allow_store_upgrade=true`, as described in <<explicit-upgrade, "Explicit Upgrades">>).
- . Once upgraded, shut down Neo4j again.
- . Copy the upgraded database store (typically _data/graph.db_) to a separate location.
-
-[WARNING]
-You *must* also ensure any external application will not attempt to access this instance while it performs the upgrade in `SINGLE` mode.
-You should either disable access externally (e.g. in the load balancer), or by reconfiguring the port Neo4j will listen on, such that it cannot be found (e.g. temporarily set `org.neo4j.server.webserver.port=7470`).
-
-.Rejoin the slave to the cluster:
-. Re-enable HA in the configuration (setting `org.neo4j.server.database.mode=HA`).
-  Also restore any webserver port changes.
-. Start up, and allow to join the cluster.
-
-.Upgrade remaining slaves
-- Repeat for each remaining slave:
- . Shut down the slave.
- . Replace the entire database store directory (typically _data/graph.db_) with the upgraded copy.
- . Start up slave, allow to join the cluster and sync any new transactions.
-
-.Upgrade the master
-. Shut down the master
-. Wait for failover to occur to one of the slaves.
-. Replace the entire database store directory (typically _data/graph.db_) with the upgraded copy.
-. Start up the old master, and allow to join the cluster.
-  It will now be a slave.
-
-Your entire cluster has now been completely upgraded to Neo4j {neo4j-version}.
-////
-
-[[ha-downgrade]]
-== Downgrading ==
-
-Downgrade is only supported between Neo4j versions between which automatic upgrades are possible.
-This typically means only within patch releases of the same Neo4j version.
-See <<deployment-upgrading>> for more information.
-
-Downgrade follows the same process as for <<ha-standard-upgrade, standard upgrade>>.


### PR DESCRIPTION
The purpose of these changes is to make the instructions easier to read and follow.

General language changes - taken out some verboseness and tried to make instructions more to the point. Taken out expressions like “recommended” and made more forceful instructions around backups.

References to “explicit” and “automatic” upgrades have been removed, as it was confusing to the reader. The difference in procedure was really only whether you have to set the ‘allow_store_upgrade’ or not. I have put the two together into one procedure, instructing the operator to always set the ‘allow_store_upgrade’ parameter prior to upgrade. The risk is that some older-school dbas may upgrade a patch release without setting the parameter and finding that it works after all, but I’d argue I that the benefit of the collapsed instructions exceeds the risk. There is also the caution about Neo making a full copy of the database at upgrade, which is only applicable for when there is a format update. The downside is that a patch upgrade may be more work than necessary if they have to assemble disk space when in reality they don’t need it. Is this a problem in reality?

Let me know what you think!
@jjaderberg , @benbc , @igorborojevic 

Note: Must find out how UPGRADE.txt (in root directory of distributions) is getting generated. Currently it is an exact copy of the manual's upgrade page.
