### PR TITLE
A config option for using enterprise record format in exceptional cases.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -560,7 +560,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                         labelTokens, relationshipTypeTokens, schemaStateChangeCallback, constraintSemantics, scheduler,
                         tokenNameLookup, lockService, schemaIndexProvider, indexingServiceMonitor, databaseHealth,
                         labelScanStore, legacyIndexProviderLookup, indexConfigStore, legacyIndexTransactionOrdering,
-                        InternalRecordFormatSelector.select() ) );
+                        InternalRecordFormatSelector.select(config, logService) ) );
     }
 
     private TransactionLogModule buildTransactionLogs(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -90,6 +90,7 @@ public abstract class GraphDatabaseFacadeFactory
 
         // Kept here to have it not be publicly documented.
         public static final Setting<String> lock_manager = setting( "lock_manager", Settings.STRING, "" );
+        public static final Setting<String> record_format = setting( "record_format", Settings.STRING, "" );
         public static final Setting<String> tracer =
                 setting( "dbms.tracer", Settings.STRING, (String) null ); // 'null' default.
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LabelTokenStore.java
@@ -23,7 +23,7 @@ import java.io.File;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
@@ -44,11 +44,11 @@ public class LabelTokenStore extends TokenStore<LabelTokenRecord, Token>
             PageCache pageCache,
             LogProvider logProvider,
             DynamicStringStore nameStore,
-            RecordFormat<LabelTokenRecord> recordFormat,
-            String storeVersion )
+            RecordFormats recordFormats)
     {
         super( file, config, IdType.LABEL_TOKEN, idGeneratorFactory, pageCache,
-                logProvider, nameStore, TYPE_DESCRIPTOR, new Token.Factory(), recordFormat, storeVersion );
+                logProvider, nameStore, TYPE_DESCRIPTOR, new Token.Factory(), recordFormats.labelToken(),
+                recordFormats.storeVersion() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
@@ -471,8 +471,7 @@ public class NeoStores implements AutoCloseable
     {
         File storeFile = getStoreFile( storeName );
         return initialize( new NodeStore( storeFile, config, idGeneratorFactory, pageCache, logProvider,
-                (DynamicArrayStore) getOrCreateStore( StoreType.NODE_LABEL ), recordFormats.node(),
-                recordFormats.storeVersion() ) );
+                (DynamicArrayStore) getOrCreateStore( StoreType.NODE_LABEL ), recordFormats ) );
     }
 
     CommonAbstractStore createPropertyKeyTokenStore( String storeName )
@@ -489,15 +488,14 @@ public class NeoStores implements AutoCloseable
         return initialize( new PropertyStore( storeFile, config, idGeneratorFactory, pageCache, logProvider,
                 (DynamicStringStore) getOrCreateStore( StoreType.PROPERTY_STRING ),
                 (PropertyKeyTokenStore) getOrCreateStore( StoreType.PROPERTY_KEY_TOKEN ),
-                (DynamicArrayStore) getOrCreateStore( StoreType.PROPERTY_ARRAY ), recordFormats.property(),
-                recordFormats.storeVersion() ) );
+                (DynamicArrayStore) getOrCreateStore( StoreType.PROPERTY_ARRAY ), recordFormats ) );
     }
 
     CommonAbstractStore createRelationshipStore( String storeName )
     {
         File file = getStoreFile( storeName );
         return initialize( new RelationshipStore( file, config, idGeneratorFactory, pageCache, logProvider,
-                recordFormats.relationship(), recordFormats.storeVersion() ) );
+                recordFormats ) );
     }
 
     CommonAbstractStore createDynamicStringStore( String storeName, IdType idType,
@@ -518,16 +516,14 @@ public class NeoStores implements AutoCloseable
         File storeFile = getStoreFile( storeName );
         return initialize( new RelationshipTypeTokenStore( storeFile, config, idGeneratorFactory,
                 pageCache, logProvider,
-                (DynamicStringStore) getOrCreateStore( StoreType.RELATIONSHIP_TYPE_TOKEN_NAME ),
-                recordFormats.relationshipTypeToken(), recordFormats.storeVersion() ) );
+                (DynamicStringStore) getOrCreateStore( StoreType.RELATIONSHIP_TYPE_TOKEN_NAME ), recordFormats ) );
     }
 
     CommonAbstractStore createLabelTokenStore( String storeName )
     {
         File fileName = getStoreFile( storeName );
         return initialize( new LabelTokenStore( fileName, config, idGeneratorFactory, pageCache,
-                logProvider, (DynamicStringStore) getOrCreateStore( StoreType.LABEL_TOKEN_NAME ),
-                recordFormats.labelToken(), recordFormats.storeVersion() ) );
+                logProvider, (DynamicStringStore) getOrCreateStore( StoreType.LABEL_TOKEN_NAME ), recordFormats ) );
     }
 
     CommonAbstractStore createSchemaStore( String storeName )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -71,11 +71,10 @@ public class NodeStore extends ComposableRecordStore<NodeRecord,NoStoreHeader>
             PageCache pageCache,
             LogProvider logProvider,
             DynamicArrayStore dynamicLabelStore,
-            RecordFormat<NodeRecord> recordFormat,
-            String storeVersion )
+            RecordFormats recordFormats)
     {
         super( fileName, config, IdType.NODE, idGeneratorFactory, pageCache, logProvider, TYPE_DESCRIPTOR,
-                recordFormat, storeVersion, NO_STORE_HEADER_FORMAT );
+                recordFormats.node(), recordFormats.storeVersion(), NO_STORE_HEADER_FORMAT );
         this.dynamicLabelStore = dynamicLabelStore;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -72,7 +72,7 @@ public class PropertyStore extends ComposableRecordStore<PropertyRecord,NoStoreH
             DynamicStringStore stringPropertyStore,
             PropertyKeyTokenStore propertyKeyTokenStore,
             DynamicArrayStore arrayPropertyStore,
-           RecordFormats recordFormats)
+            RecordFormats recordFormats)
     {
         super( fileName, configuration, IdType.PROPERTY, idGeneratorFactory, pageCache, logProvider, TYPE_DESCRIPTOR,
                 recordFormats.property(), recordFormats.storeVersion(), NO_STORE_HEADER_FORMAT );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -32,7 +32,7 @@ import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -72,11 +72,10 @@ public class PropertyStore extends ComposableRecordStore<PropertyRecord,NoStoreH
             DynamicStringStore stringPropertyStore,
             PropertyKeyTokenStore propertyKeyTokenStore,
             DynamicArrayStore arrayPropertyStore,
-            RecordFormat<PropertyRecord> recordFormat,
-            String storeVersion )
+           RecordFormats recordFormats)
     {
         super( fileName, configuration, IdType.PROPERTY, idGeneratorFactory, pageCache, logProvider, TYPE_DESCRIPTOR,
-                recordFormat, storeVersion, NO_STORE_HEADER_FORMAT );
+                recordFormats.property(), recordFormats.storeVersion(), NO_STORE_HEADER_FORMAT );
         this.stringStore = stringPropertyStore;
         this.propertyKeyTokenStore = propertyKeyTokenStore;
         this.arrayStore = arrayPropertyStore;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
@@ -20,9 +20,10 @@
 package org.neo4j.kernel.impl.store;
 
 import java.io.File;
+
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
@@ -43,11 +44,11 @@ public class RelationshipStore extends ComposableRecordStore<RelationshipRecord,
             IdGeneratorFactory idGeneratorFactory,
             PageCache pageCache,
             LogProvider logProvider,
-            RecordFormat<RelationshipRecord> recordFormat,
-            String storeVersion )
+            RecordFormats recordFormats)
     {
         super( fileName, configuration, IdType.RELATIONSHIP, idGeneratorFactory,
-                pageCache, logProvider, TYPE_DESCRIPTOR, recordFormat, storeVersion, NO_STORE_HEADER_FORMAT );
+                pageCache, logProvider, TYPE_DESCRIPTOR, recordFormats.relationship(), recordFormats.storeVersion(),
+                NO_STORE_HEADER_FORMAT );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipTypeTokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipTypeTokenStore.java
@@ -23,11 +23,11 @@ import java.io.File;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
-import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.RelationshipTypeToken;
-import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.logging.LogProvider;
@@ -47,12 +47,11 @@ public class RelationshipTypeTokenStore extends TokenStore<RelationshipTypeToken
             PageCache pageCache,
             LogProvider logProvider,
             DynamicStringStore nameStore,
-            RecordFormat<RelationshipTypeTokenRecord> recordFormat,
-            String storeVersion )
+            RecordFormats recordFormats)
     {
-        super( fileName, config, IdType.RELATIONSHIP_TYPE_TOKEN, idGeneratorFactory, pageCache,
-                logProvider, nameStore, TYPE_DESCRIPTOR, new RelationshipTypeToken.Factory(), recordFormat,
-                storeVersion );
+        super( fileName, config, IdType.RELATIONSHIP_TYPE_TOKEN, idGeneratorFactory, pageCache, logProvider, nameStore,
+                TYPE_DESCRIPTOR, new RelationshipTypeToken.Factory(), recordFormats.relationshipTypeToken(),
+                recordFormats.storeVersion() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
@@ -26,11 +26,12 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
-import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.logging.LogProvider;
 
 /**
@@ -84,7 +85,7 @@ public class StoreFactory
             FileSystemAbstraction fileSystemAbstraction, LogProvider logProvider )
     {
         this( storeDir, config, idGeneratorFactory, pageCache, fileSystemAbstraction, logProvider,
-                InternalRecordFormatSelector.select() );
+                InternalRecordFormatSelector.select( config, NullLogService.getInstance() ));
     }
 
     public StoreFactory( File storeDir, Config config,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/InternalRecordFormatSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/InternalRecordFormatSelector.java
@@ -23,7 +23,6 @@ import org.neo4j.helpers.Service;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
-import org.neo4j.kernel.impl.locking.community.CommunityLockManger;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.store.format.lowlimit.LowLimit;
 
@@ -42,23 +41,28 @@ public class InternalRecordFormatSelector
             String candidateId = candidate.getKeys().iterator().next();
             if ( candidateId.equals( key ) )
             {
-                return candidate.newInstance();
+                return LowLimit.RECORD_FORMATS;
+                //todo: uncomment and return correct format after migration PR is merged.
+                //return candidate.newInstance();
             }
             else if ( key.equals( "" ) )
             {
                 logging.getInternalLog( CommunityFacadeFactory.class )
-                        .info( "No locking implementation specified, defaulting to '" + candidateId + "'" );
+                        .info( "No record format specified, defaulting to '" + candidateId + "'" );
+                return LowLimit.RECORD_FORMATS;
+                //todo: uncomment and return correct format after migration PR is merged.
+                //return candidate.newInstance();
             }
         }
 
-        if ( key.equals( "community" ) )
-        {
-            return LowLimit.RECORD_FORMATS;
-        }
-        else if ( key.equals( "" ) )
+        if ( key.equals( "" ) )
         {
             logging.getInternalLog( CommunityFacadeFactory.class )
                     .info( "No record format specified, defaulting to 'community'" );
+            return LowLimit.RECORD_FORMATS;
+        }
+        else if ( key.equals( "community" ) )
+        {
             return LowLimit.RECORD_FORMATS;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserterImpl.java
@@ -52,8 +52,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
-import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
-import org.neo4j.kernel.internal.StoreLocker;
 import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.RelationshipPropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
@@ -144,6 +142,8 @@ import org.neo4j.kernel.impl.transaction.state.RelationshipCreator;
 import org.neo4j.kernel.impl.transaction.state.RelationshipGroupGetter;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.Listener;
+import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
+import org.neo4j.kernel.internal.StoreLocker;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
@@ -272,7 +272,7 @@ public class BatchInserterImpl implements BatchInserter
         this.idGeneratorFactory = new DefaultIdGeneratorFactory( fileSystem );
 
         StoreFactory sf = new StoreFactory( this.storeDir, config, idGeneratorFactory, pageCache, fileSystem,
-                logService.getInternalLogProvider(), InternalRecordFormatSelector.select() );
+                logService.getInternalLogProvider(), InternalRecordFormatSelector.select(config, logService) );
 
         if ( dump )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
@@ -45,12 +45,12 @@ import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
 public class LabelTokenStoreTest
 {
     private final File file = mock( File.class );
-    private final Config config = mock( Config.class );
     private final IdGeneratorFactory generatorFactory = mock( IdGeneratorFactory.class );
     private final PageCache cache = mock( PageCache.class );
     private final LogProvider logProvider = mock( LogProvider.class );
     private final DynamicStringStore dynamicStringStore = mock( DynamicStringStore.class );
     private final PageCursor pageCursor = mock( PageCursor.class );
+    private final Config config = new Config();
 
     @Test
     public void forceGetRecordSkipInUsecheck() throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
@@ -27,8 +27,9 @@ import java.io.IOException;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
-import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.logging.LogProvider;
@@ -37,7 +38,6 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector.select;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.FORCE;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
@@ -74,7 +74,7 @@ public class LabelTokenStoreTest
         public UnusedLabelTokenStore() throws IOException
         {
             super( file, config, generatorFactory, cache, logProvider, dynamicStringStore,
-                    select().labelToken(), select().storeVersion() );
+                    select( config, NullLogService.getInstance() ) );
             storeFile = mock( PagedFile.class );
 
             when( storeFile.io( any( Long.class ), any( Integer.class ) ) ).thenReturn( pageCursor );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyStoreTest.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -29,10 +26,14 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.JumpingIdGeneratorFactory;
+import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
@@ -42,12 +43,10 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 
 import static java.util.Collections.singletonMap;
-
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
 import static org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector.select;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.FORCE;
 
@@ -83,7 +82,7 @@ public class PropertyStoreTest
         final PropertyStore store = new PropertyStore( path, config, new JumpingIdGeneratorFactory( 1 ), pageCache,
                 NullLogProvider.getInstance(), stringPropertyStore,
                 mock( PropertyKeyTokenStore.class ), mock( DynamicArrayStore.class ),
-                select().property(), select().storeVersion() );
+                select(config, NullLogService.getInstance()) );
         store.initialise( true );
 
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreIdTestFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreIdTestFactory.java
@@ -19,14 +19,18 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
+
+import static org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector.select;
 
 public class StoreIdTestFactory
 {
+    private static RecordFormats select = select(new Config(), NullLogService.getInstance());
+
     private static long currentStoreVersionAsLong()
     {
-        RecordFormats select = InternalRecordFormatSelector.select();
         return MetaDataStore.versionStringToLong( select.storeVersion() );
     }
 
@@ -38,7 +42,6 @@ public class StoreIdTestFactory
     public static StoreId newStoreIdForCurrentVersion( long creationTime, long randomId, long upgradeTime, long
             upgradeId )
     {
-        RecordFormats select = InternalRecordFormatSelector.select();
         return new StoreId( creationTime, randomId, MetaDataStore.versionStringToLong( select.storeVersion() ),
                 upgradeTime, upgradeId );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestIdGeneratorRebuilding.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestIdGeneratorRebuilding.java
@@ -32,9 +32,10 @@ import java.util.List;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
+import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.logging.NullLogProvider;
@@ -45,7 +46,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
-
 import static org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector.select;
 
 public class TestIdGeneratorRebuilding
@@ -81,7 +81,7 @@ public class TestIdGeneratorRebuilding
         DynamicArrayStore labelStore = mock( DynamicArrayStore.class );
         NodeStore store = new NodeStore( storeFile, config, new DefaultIdGeneratorFactory( fs ),
                 pageCacheRule.getPageCache( fs ), NullLogProvider.getInstance(), labelStore,
-                select().node(), select().storeVersion() );
+                select(config, NullLogService.getInstance()) );
         store.initialise( true );
         store.makeStoreOk();
 
@@ -186,7 +186,7 @@ public class TestIdGeneratorRebuilding
         DynamicArrayStore labelStore = mock( DynamicArrayStore.class );
         NodeStore store = new NodeStore( storeFile, config, new DefaultIdGeneratorFactory( fs ),
                 pageCacheRule.getPageCache( fs ), NullLogProvider.getInstance(), labelStore,
-                select().node(), select().storeVersion() );
+                select( config, NullLogService.getInstance() ) );
         store.initialise( true );
         store.makeStoreOk();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/UpgradeStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/UpgradeStoreIT.java
@@ -37,19 +37,20 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.UTF8;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.impl.store.format.lowlimit.LowLimit;
-import org.neo4j.kernel.impl.store.format.lowlimit.DynamicRecordFormat;
-import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
-import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
-import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.format.lowlimit.DynamicRecordFormat;
+import org.neo4j.kernel.impl.store.format.lowlimit.LowLimit;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
@@ -61,7 +62,6 @@ import org.neo4j.unsafe.batchinsert.BatchInserters;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.helpers.collection.IteratorUtil.first;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.AbstractNeo4jTestCase.deleteFileOrDirectory;
@@ -381,7 +381,7 @@ public class UpgradeStoreIT
                 PageCache pageCache )
         {
             super( fileName, config, new NoLimitIdGeneratorFactory( fs ), pageCache, NullLogProvider.getInstance(),
-                    stringStore, select().relationshipTypeToken(), select().storeVersion() );
+                    stringStore, select(config, NullLogService.getInstance() ) );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/lowlimit/LowLimitTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/lowlimit/LowLimitTest.java
@@ -21,15 +21,18 @@ package org.neo4j.kernel.impl.store.format.lowlimit;
 
 import org.junit.Test;
 
-import org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.NullLogService;
 
 import static org.junit.Assert.assertEquals;
+import static org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector.select;
 
 public class LowLimitTest
 {
     @Test
     public void shouldResolveLowLimitsRecordFormat() throws Exception
     {
-        assertEquals( LowLimit.RECORD_FORMATS.storeVersion(), InternalRecordFormatSelector.select().storeVersion() );
+        assertEquals( LowLimit.RECORD_FORMATS.storeVersion(),
+                select( new Config(), NullLogService.getInstance() ).storeVersion() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
@@ -39,6 +39,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.index.NodePropertyUpdate;
 import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.BatchTransactionApplier;
 import org.neo4j.kernel.impl.api.CommandVisitor;
 import org.neo4j.kernel.impl.api.TransactionToApply;
@@ -48,12 +49,12 @@ import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.locking.NoOpClient;
+import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageCommandReaderFactory;
 import org.neo4j.kernel.impl.store.DynamicArrayStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.RecordStore;
-import org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
@@ -106,6 +107,7 @@ import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.change;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.remove;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
+import static org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector.select;
 import static org.neo4j.kernel.impl.store.record.IndexRule.indexRule;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.FORCE;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
@@ -1086,9 +1088,9 @@ public class TransactionRecordStateTest
     public void shouldPrepareRelevantRecords() throws Exception
     {
         // GIVEN
-        PrepareTrackingRecordFormats format = new PrepareTrackingRecordFormats( InternalRecordFormatSelector.select() );
-        NeoStores neoStores = neoStoresRule.open( format,
-                GraphDatabaseSettings.dense_node_threshold.name(), "1" );
+        NeoStores neoStores = neoStoresRule.open( GraphDatabaseSettings.dense_node_threshold.name(), "1" );
+        PrepareTrackingRecordFormats format =
+                new PrepareTrackingRecordFormats( select( new Config(), NullLogService.getInstance() ) );
 
         // WHEN
         TransactionRecordState state = newTransactionRecordState( neoStores );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
@@ -55,6 +55,7 @@ import org.neo4j.kernel.impl.store.DynamicArrayStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
@@ -107,7 +108,6 @@ import static org.neo4j.kernel.api.index.NodePropertyUpdate.add;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.change;
 import static org.neo4j.kernel.api.index.NodePropertyUpdate.remove;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
-import static org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector.select;
 import static org.neo4j.kernel.impl.store.record.IndexRule.indexRule;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.FORCE;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
@@ -1088,9 +1088,10 @@ public class TransactionRecordStateTest
     public void shouldPrepareRelevantRecords() throws Exception
     {
         // GIVEN
-        NeoStores neoStores = neoStoresRule.open( GraphDatabaseSettings.dense_node_threshold.name(), "1" );
-        PrepareTrackingRecordFormats format =
-                new PrepareTrackingRecordFormats( select( new Config(), NullLogService.getInstance() ) );
+        PrepareTrackingRecordFormats format = new PrepareTrackingRecordFormats(
+                InternalRecordFormatSelector.select( new Config(), NullLogService.getInstance() ) );
+        NeoStores neoStores = neoStoresRule.open( format,
+                GraphDatabaseSettings.dense_node_threshold.name(), "1" );
 
         // WHEN
         TransactionRecordState state = newTransactionRecordState( neoStores );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.CommandVisitor;
+import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
@@ -59,7 +60,6 @@ import org.neo4j.storageengine.api.schema.SchemaRule;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector.select;
 
 public class WriteTransactionCommandOrderingTest
@@ -207,7 +207,7 @@ public class WriteTransactionCommandOrderingTest
         public RecordingPropertyStore( AtomicReference<List<String>> currentRecording )
         {
             super( null, new Config(), null, null, NullLogProvider.getInstance(), null, null, null,
-                    select().property(), select().storeVersion() );
+                    select( new Config(), NullLogService.getInstance() ) );
             this.currentRecording = currentRecording;
         }
 
@@ -235,7 +235,7 @@ public class WriteTransactionCommandOrderingTest
         public RecordingNodeStore( AtomicReference<List<String>> currentRecording )
         {
             super( null, new Config(), null, null, NullLogProvider.getInstance(), null,
-                    select().node(), select().storeVersion() );
+                    select( new Config(), NullLogService.getInstance() ) );
             this.currentRecording = currentRecording;
         }
 
@@ -271,7 +271,7 @@ public class WriteTransactionCommandOrderingTest
         public RecordingRelationshipStore( AtomicReference<List<String>> currentRecording )
         {
             super( null, new Config(), null, null, NullLogProvider.getInstance(),
-                    select().relationship(), select().storeVersion() );
+                    select( new Config(), NullLogService.getInstance() ) );
             this.currentRecording = currentRecording;
         }
 

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
@@ -24,13 +24,14 @@ import java.io.File;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.logging.NullLog;
 import org.neo4j.logging.NullLogProvider;
 
@@ -50,7 +51,6 @@ public class NeoStoresRule extends ExternalResource
     private EphemeralFileSystemAbstraction efs;
     private PageCache pageCache;
     private StoreFactory storeFactory;
-    private final RecordFormats format = InternalRecordFormatSelector.select();
 
     public NeoStoresRule( Class<?> testClass )
     {
@@ -59,15 +59,11 @@ public class NeoStoresRule extends ExternalResource
 
     public NeoStores open( String... config )
     {
-        return open( InternalRecordFormatSelector.select(), config );
-    }
-
-    public NeoStores open( RecordFormats format, String... config )
-    {
         efs = new EphemeralFileSystemAbstraction();
         Config conf = new Config( stringMap( config ) );
         ConfiguringPageCacheFactory pageCacheFactory = new ConfiguringPageCacheFactory( efs, conf, NULL,
                 NullLog.getInstance() );
+        RecordFormats format = InternalRecordFormatSelector.select( conf, NullLogService.getInstance() );
         pageCache = pageCacheFactory.getOrCreatePageCache();
         return open( efs, pageCache, format, config );
     }
@@ -81,10 +77,6 @@ public class NeoStoresRule extends ExternalResource
         storeFactory = new StoreFactory( storeDir, configuration, new DefaultIdGeneratorFactory( fs ),
                 pageCache, fs, NullLogProvider.getInstance(), format );
         return neoStores = storeFactory.openAllNeoStores( true );
-    }
-
-    public NeoStores reopen() {
-        return storeFactory.openAllNeoStores();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
@@ -59,11 +59,16 @@ public class NeoStoresRule extends ExternalResource
 
     public NeoStores open( String... config )
     {
+        Config conf = new Config( stringMap( config ) );
+        return open( InternalRecordFormatSelector.select( conf, NullLogService.getInstance() ), config );
+    }
+
+    public NeoStores open( RecordFormats format, String... config )
+    {
         efs = new EphemeralFileSystemAbstraction();
         Config conf = new Config( stringMap( config ) );
         ConfiguringPageCacheFactory pageCacheFactory = new ConfiguringPageCacheFactory( efs, conf, NULL,
                 NullLog.getInstance() );
-        RecordFormats format = InternalRecordFormatSelector.select( conf, NullLogService.getInstance() );
         pageCache = pageCacheFactory.getOrCreatePageCache();
         return open( efs, pageCache, format, config );
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.store.format.highlimit;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.neo4j.helpers.collection.MapUtil;
@@ -26,16 +27,51 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.lowlimit.LowLimit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class HighLimitTest
 {
+    @Ignore("Waiting on store migration work")
     @Test
     public void shouldResolveHighLimitsRecordFormat() throws Exception
     {
         Config config = new Config( MapUtil.stringMap( "record_format", "highlimit" ) );
         RecordFormats formatSelector = InternalRecordFormatSelector.select( config, NullLogService.getInstance() );
         assertEquals( HighLimit.RECORD_FORMATS.storeVersion(), formatSelector.storeVersion() );
+    }
+
+    @Test
+    public void shouldResolveCommunityRecordFormat() throws Exception
+    {
+        Config config = new Config( MapUtil.stringMap( "record_format", "community" ) );
+        RecordFormats formatSelector = InternalRecordFormatSelector.select( config, NullLogService.getInstance() );
+        assertEquals( LowLimit.RECORD_FORMATS.storeVersion(), formatSelector.storeVersion() );
+    }
+
+    @Ignore("Waiting on store migration work")
+    @Test
+    public void shouldResolveNoRecordFormatToHighLimitDefault() throws Exception
+    {
+        Config config = new Config();
+        RecordFormats formatSelector = InternalRecordFormatSelector.select( config, NullLogService.getInstance() );
+        assertEquals( HighLimit.RECORD_FORMATS.storeVersion(), formatSelector.storeVersion() );
+    }
+
+    @Test
+    public void shouldNotResolveNoneExistingRecordFormat() throws Exception
+    {
+        Config config = new Config( MapUtil.stringMap( "record_format", "notAValidRecordFormat" ) );
+        try
+        {
+            RecordFormats formatSelector = InternalRecordFormatSelector.select( config, NullLogService.getInstance() );
+            fail( "Should not be possible to specify non-existing format" );
+        }
+        catch ( IllegalArgumentException ignored )
+        {
+            // Success
+        }
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitTest.java
@@ -19,19 +19,23 @@
  */
 package org.neo4j.kernel.impl.store.format.highlimit;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 
 import static org.junit.Assert.assertEquals;
 
 public class HighLimitTest
 {
-    @Ignore("enable once other features are done.")
     @Test
     public void shouldResolveHighLimitsRecordFormat() throws Exception
     {
-        assertEquals( HighLimit.RECORD_FORMATS.storeVersion(), InternalRecordFormatSelector.select().storeVersion());
+        Config config = new Config( MapUtil.stringMap( "record_format", "highlimit" ) );
+        RecordFormats formatSelector = InternalRecordFormatSelector.select( config, NullLogService.getInstance() );
+        assertEquals( HighLimit.RECORD_FORMATS.storeVersion(), formatSelector.storeVersion() );
     }
 }


### PR DESCRIPTION
We had managed to do this without using a config option, but when trying to do recovery-robustness on both record formats this new config seems to be the path of least resistance. This PR only introduces this config option, copying how we do it with lock managers. 
