### PR TITLE
Add minimal yes/no tracking of major features used to UDC.

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -65,7 +65,6 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
-import org.neo4j.server.security.auth.BasicAuthManager;
 import org.neo4j.udc.UsageData;
 
 import static org.neo4j.bolt.BoltKernelExtension.EncryptionLevel.OPTIONAL;
@@ -254,8 +253,6 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
             Sessions sessions )
     {
         PrimitiveLongObjectMap<BiFunction<Channel,Boolean,BoltProtocol>> availableVersions = longObjectMap();
-
-
         availableVersions.put(
                 BoltProtocolV1.VERSION,
                 ( channel, isEncrypted ) -> new BoltProtocolV1( logging, sessions.newSession( isEncrypted ), channel )

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TestSessions.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TestSessions.java
@@ -66,11 +66,13 @@ public class TestSessions implements TestRule, Sessions
                 gdb = (GraphDatabaseFacade) new TestGraphDatabaseFactory().newImpermanentDatabase( config );
                 Neo4jJobScheduler scheduler = life.add( new Neo4jJobScheduler() );
                 DependencyResolver resolver = gdb.getDependencyResolver();
-                ThreadToStatementContextBridge txBridge =
-                        resolver.resolveDependency( ThreadToStatementContextBridge.class );
-                StandardSessions sessions = life.add( new StandardSessions( gdb, new UsageData(),
-                        NullLogService.getInstance(), txBridge ) );
-                actual = new ThreadedSessions( sessions, scheduler, NullLogService.getInstance() );
+                StandardSessions sessions = life.add(
+                        new StandardSessions( gdb, new UsageData( scheduler ), NullLogService.getInstance(),
+                                resolver.resolveDependency( ThreadToStatementContextBridge.class ))
+                );
+                actual = new ThreadedSessions(
+                        sessions,
+                        scheduler, NullLogService.getInstance() );
 
                 life.start();
                 try

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
@@ -23,10 +23,12 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.udc.UsageData;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class ErrorReporterTest
@@ -37,7 +39,7 @@ public class ErrorReporterTest
         // Given
         AssertableLogProvider provider = new AssertableLogProvider();
         ErrorReporter reporter =
-                new ErrorReporter( provider.getLog( "userlog" ), new UsageData() );
+                new ErrorReporter( provider.getLog( "userlog" ), new UsageData( mock( JobScheduler.class ) ) );
 
         Throwable cause = new Throwable( "This is not an error we know how to handle." );
         Neo4jError error = Neo4jError.from( cause );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineTest.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKeys;
 
@@ -57,7 +58,7 @@ public class SessionStateMachineTest
     private final ThreadToStatementContextBridge txBridge = mock( ThreadToStatementContextBridge.class );
     private final Transaction tx = mock( TopLevelTransaction.class );
     private final KernelTransaction ktx = mock( KernelTransaction.class );
-    private final UsageData usageData = new UsageData();
+    private final UsageData usageData = new UsageData( mock( JobScheduler.class ) );
     private final StatementRunner runner = mock( StatementRunner.class );
     private final SessionStateMachine machine = new SessionStateMachine(
             usageData, db, txBridge, runner, NullLogService.getInstance(), Authentication.NONE );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/StateMachineErrorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/StateMachineErrorTest.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.udc.UsageData;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -51,6 +52,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.failedWith;
+import static org.neo4j.helpers.collection.MapUtil.map;
 
 public class StateMachineErrorTest
 {
@@ -60,6 +62,7 @@ public class StateMachineErrorTest
     private ThreadToStatementContextBridge txBridge = mock( ThreadToStatementContextBridge.class );
     private StatementRunner runner = mock( StatementRunner.class );
     private TopLevelTransaction tx = mock( TopLevelTransaction.class );
+    private JobScheduler scheduler = mock(JobScheduler.class );
 
     @Before
     public void setup()
@@ -88,9 +91,9 @@ public class StateMachineErrorTest
 
     private SessionStateMachine newIdleMachine()
     {
-        SessionStateMachine machine = new SessionStateMachine( new UsageData(), db, txBridge, runner, NullLogService
+        SessionStateMachine machine = new SessionStateMachine( new UsageData( scheduler ), db, txBridge, runner, NullLogService
                 .getInstance(), Authentication.NONE );
-        machine.init( "FunClient", Collections.<String, Object>emptyMap(), null, Session.Callback.NO_OP );
+        machine.init( "FunClient", map(), null, Session.Callback.NO_OP );
         return machine;
     }
 
@@ -218,8 +221,8 @@ public class StateMachineErrorTest
     {
         // Given
         RecordingCallback messages = new RecordingCallback();
-        SessionStateMachine machine = new SessionStateMachine( new UsageData(), db, txBridge, runner, NullLogService
-                .getInstance(), Authentication.NONE  );
+        SessionStateMachine machine = new SessionStateMachine( new UsageData( scheduler ), db, txBridge, runner, NullLogService
+                .getInstance(), Authentication.NONE );
 
         // When
         machine.run( "RETURN 1", null, null, messages );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -34,9 +34,6 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.AvailabilityGuard;
-import org.neo4j.kernel.internal.StoreLocker;
-import org.neo4j.kernel.internal.StoreLockerLifecycleAdapter;
-import org.neo4j.kernel.internal.Version;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.extension.KernelExtensions;
@@ -54,6 +51,9 @@ import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.kernel.info.JvmChecker;
 import org.neo4j.kernel.info.JvmMetadataRepository;
+import org.neo4j.kernel.internal.StoreLocker;
+import org.neo4j.kernel.internal.StoreLockerLifecycleAdapter;
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
@@ -126,8 +126,6 @@ public class PlatformModule
 
         this.storeDir = providedStoreDir.getAbsoluteFile();
 
-        // Database system information, used by UDC
-        dependencies.satisfyDependency( new UsageData() );
 
         fileSystem = dependencies.satisfyDependency( createFileSystemAbstraction() );
 
@@ -136,6 +134,9 @@ public class PlatformModule
         dependencies.satisfyDependency( monitors );
 
         jobScheduler = life.add( dependencies.satisfyDependency( createJobScheduler() ) );
+
+        // Database system information, used by UDC
+        dependencies.satisfyDependency( life.add( new UsageData( jobScheduler ) ) );
 
         // If no logging was passed in from the outside then create logging and register
         // with this life

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -91,8 +91,8 @@ public interface JobScheduler extends Lifecycle
      * This is an exhaustive list of job types that run in the database. It should be expanded as needed for new groups
      * of jobs.
      *
-     * For now, this does naming only, but it will allow us to define per-group configuration, such as how to handle
-     * failures, shared threads and (later on) affinity strategies.
+     * For now, this does minimal configuration, but opens up for things like common
+     * failure handling, shared threads and affinity strategies.
      */
     class Groups
     {
@@ -150,6 +150,11 @@ public interface JobScheduler extends Lifecycle
          * Reporting thread for Metrics events
          */
         public static final Group metricsEvent = new Group( "MetricsEvent", POOLED );
+
+        /**
+         * UDC timed events.
+         */
+        public static Group udc  = new Group( "UsageDataCollection", POOLED );
     }
 
     interface JobHandle

--- a/community/kernel/src/main/java/org/neo4j/udc/UsageData.java
+++ b/community/kernel/src/main/java/org/neo4j/udc/UsageData.java
@@ -21,6 +21,12 @@ package org.neo4j.udc;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static java.util.concurrent.TimeUnit.DAYS;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.udc;
+
 /**
  * An in-memory storage location for usage metadata.
  * Any component is allowed to publish it's usage date here, and it can be any object,
@@ -29,9 +35,16 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * This service is meant as a diagnostic and informational tool, notably used by UDC.
  */
-public class UsageData
+public class UsageData extends LifecycleAdapter
 {
     private final ConcurrentHashMap<UsageDataKey, Object> store = new ConcurrentHashMap<>();
+    private final JobScheduler scheduler;
+    private JobScheduler.JobHandle featureDecayJob;
+
+    public UsageData( JobScheduler scheduler )
+    {
+        this.scheduler = scheduler;
+    }
 
     public <T> void set( UsageDataKey<T> key, T value )
     {
@@ -58,4 +71,18 @@ public class UsageData
         return (T) o;
     }
 
+    @Override
+    public void stop() throws Throwable
+    {
+        if( featureDecayJob != null )
+        {
+            featureDecayJob.cancel( false );
+        }
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        featureDecayJob = scheduler.schedule( udc, get( UsageDataKeys.features )::sweep, 1, DAYS );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/udc/UsageDataKeys.java
+++ b/community/kernel/src/main/java/org/neo4j/udc/UsageDataKeys.java
@@ -21,6 +21,8 @@ package org.neo4j.udc;
 
 import java.util.function.Supplier;
 
+import org.neo4j.concurrent.DecayingFlags;
+import org.neo4j.concurrent.DecayingFlags.Key;
 import org.neo4j.concurrent.RecentK;
 import org.neo4j.kernel.impl.factory.Edition;
 import org.neo4j.kernel.impl.factory.OperationalMode;
@@ -53,4 +55,25 @@ public class UsageDataKeys
     /** Cluster server ID */
     public static final UsageDataKey<String> serverId = key( "neo4j.serverId" );
 
+    public interface Features
+    {
+        // Note: The indexes used here is how we track which feature a flag
+        //       refers to. Be very careful about re-using indexes so features
+        //       don't get confused.
+        Key http_cypher_endpoint = new Key( 0 );
+        Key http_tx_endpoint = new Key( 1 );
+        Key http_batch_endpoint = new Key( 2 );
+
+        Key bolt = new Key( 3 );
+    }
+
+    /**
+     * Tracks features in use, including decay such that features that are not
+     * used for a while are marked as no longer in use.
+     *
+     * Decay is handled by an external mechanism invoking a 'sweep' method on this
+     * DecayingFlags instance. See usages of this field to find where that happens.
+     */
+    public static final UsageDataKey<DecayingFlags> features = key( "neo4j.features",
+            (Supplier<DecayingFlags>) () -> new DecayingFlags( 7/*days*/ ) );
 }

--- a/community/kernel/src/test/java/org/neo4j/sysinfo/UsageDataTest.java
+++ b/community/kernel/src/test/java/org/neo4j/sysinfo/UsageDataTest.java
@@ -21,10 +21,12 @@ package org.neo4j.sysinfo;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKey;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.neo4j.udc.UsageDataKey.key;
 
 public class UsageDataTest
@@ -33,7 +35,7 @@ public class UsageDataTest
     public void shouldPutAndRetrieve() throws Throwable
     {
         // Given
-        UsageData ms = new UsageData();
+        UsageData ms = new UsageData( mock( JobScheduler.class ) );
         UsageDataKey<String> key = key( "hello" );
 
         // When

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/DecayingFlags.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/DecayingFlags.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import java.util.Arrays;
+
+import static javax.xml.bind.DatatypeConverter.printHexBinary;
+
+/**
+ * This is a concurrent data structure used to track
+ * some set if boolean flags. Any time a flag is set to high,
+ * it'll remain high for a period of time, after which
+ * it'll fall back to low again. How long the flags stay high
+ * depend on how often they are toggled - meaning this uses
+ * both recency and frequency to determine which flags to keep
+ * high.
+ *
+ * The more often a flag is toggled high, the longer it'll
+ * take before it resets to low - if a flag gets set more
+ * often than sweep is called, it will always be high.
+ *
+ * This data structure is coordination free, but sacrifices
+ * accuracy for performance.
+ *
+ * Intended usage is that you'd have a set of keys you care
+ * about, and set a max time where you'd like to mark a key
+ * as low if that time passes; say 7 days.
+ *
+ * So, you'd set {@link #keepalive} to 7, and then you'd
+ * schedule a thread to call {@link #sweep()} once per day.
+ * Now, flags that were toggled once will be set to low again
+ * the next day, while flags that were extensively used will
+ * take up to seven days before falling back to low.
+ *
+ * Flags that are toggled at or more than once every day will
+ * always be high.
+ */
+public class DecayingFlags
+{
+    /**
+     * A flag in the set, with a unique index pointing
+     * to the bit that correlates to this flag.
+     */
+    public static class Key
+    {
+        private final int index;
+
+        public Key( int index )
+        {
+            this.index = index;
+        }
+
+        public int index()
+        {
+            return index;
+        }
+    }
+
+    /**
+     * To model the time-based "decay" of the flags,
+     * each flag is represented as an int that counts
+     * the number of times the flag has been toggled, up to
+     * {@link #keepalive}. Each time #sweep is called, all
+     * flags are decremented by 1, once a flag reaches 0 it
+     * is considered low.
+     *
+     * This way, if a flag is not "renewed", the flag will
+     * eventually fall back to low.
+     */
+    private int[] flags;
+
+    /**
+     * The max number of sweep iteration a flag is kept alive
+     * if it is not toggled. The more toggles seen in a flag,
+     * the more likely it is to hit this threshold.
+     */
+    private final int keepalive;
+
+
+    /**
+     * @param keepalive controls the maximum length of time
+     *                     a flag will stay toggled if it is not
+     *                     renewed, expressed as the number of times
+     *                     {@link #sweep()} needs to be called.
+     */
+    public DecayingFlags( int keepalive )
+    {
+        this.keepalive = keepalive;
+        this.flags = new int[16];
+    }
+
+    public void flag( Key key )
+    {
+        // We dynamically size this up as needed
+        if( key.index >= flags.length )
+        {
+            resize( key.index );
+        }
+
+        int flag = flags[key.index];
+        if( flag < keepalive )
+        {
+            flags[key.index] = flag + 1;
+        }
+    }
+
+    /**
+     * This is how decay happens, the interval at which
+     * this method is called controls how long unused
+     * flags are kept 'high'. Each invocation of this will
+     * decrement the flag counters by 1, marking any that
+     * reach 0 as low.
+     */
+    public void sweep()
+    {
+        for ( int i = 0; i < flags.length; i++ )
+        {
+            int count = flags[i];
+            if( count > 0 )
+            {
+                flags[i] = count - 1;
+            }
+        }
+    }
+
+    private synchronized void resize( int minSize )
+    {
+        int newSize = flags.length;
+        while( newSize < minSize )
+        {
+            newSize += 16;
+        }
+
+        if( flags.length < newSize )
+        {
+            flags = Arrays.copyOf( flags, newSize );
+        }
+    }
+
+    public String asHex()
+    {
+        // Convert the flags to a byte-array, each
+        // flag represented as a single bit.
+        byte[] bits = new byte[flags.length / 8];
+
+        // Go over the flags, eight at a time to align
+        // with sticking eight bits at a time into the
+        // output array.
+        for ( int i = 0; i < flags.length; i+=8 )
+        {
+            bits[i/8] = (byte)(
+                (bit(i)   << 7) |
+                (bit(i+1) << 6) |
+                (bit(i+2) << 5) |
+                (bit(i+3) << 4) |
+                (bit(i+4) << 3) |
+                (bit(i+5) << 2) |
+                (bit(i+6) << 1) |
+                (bit(i+7)) ) ;
+        }
+        return printHexBinary(bits);
+    }
+
+    private int bit( int idx )
+    {
+        return flags[idx] > 0 ? 1 : 0;
+    }
+}

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/DecayingFlagsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/DecayingFlagsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DecayingFlagsTest
+{
+    @Test
+    public void shouldTrackToggle() throws Throwable
+    {
+        // Given
+        DecayingFlags.Key myFeature = new DecayingFlags.Key( 1 );
+        DecayingFlags set = new DecayingFlags( 1 );
+
+        // When
+        set.flag( myFeature );
+
+        // Then
+        assertEquals( "4000", set.asHex() );
+    }
+
+    @Test
+    public void shouldTrackMultipleFlags() throws Throwable
+    {
+        // Given
+        DecayingFlags.Key featureA = new DecayingFlags.Key( 1 );
+        DecayingFlags.Key featureB = new DecayingFlags.Key( 3 );
+        DecayingFlags set = new DecayingFlags( 2 );
+
+        // When
+        set.flag( featureA );
+        set.flag( featureA );
+        set.flag( featureB );
+
+        // Then
+        assertEquals( "5000", set.asHex() );
+    }
+
+    @Test
+    public void toggleShouldDecay() throws Throwable
+    {
+        // Given
+        DecayingFlags.Key featureA = new DecayingFlags.Key( 1 );
+        DecayingFlags.Key featureB = new DecayingFlags.Key( 3 );
+        DecayingFlags set = new DecayingFlags( 2 );
+
+        // And given Feature A has been used quite a bit, while
+        // feature B is not quite as popular..
+        set.flag( featureA );
+        set.flag( featureA );
+        set.flag( featureB );
+
+        // When
+        set.sweep();
+
+        // Then
+        assertEquals( "4000", set.asHex() );
+
+        // When
+        set.sweep();
+
+        // Then
+        assertEquals( "0000", set.asHex() );
+    }
+
+    @Test
+    public void resetFlagShouldRecoverIfToggledAgain() throws Throwable
+    {
+        // Given
+        DecayingFlags.Key featureA = new DecayingFlags.Key( 9 );
+        DecayingFlags set = new DecayingFlags( 2 );
+
+        set.flag( featureA );
+
+        // When
+        set.sweep();
+
+        // Then
+        assertEquals( "0000", set.asHex() );
+
+        // When
+        set.flag( featureA );
+
+        // Then
+        assertEquals( "0040", set.asHex() );
+    }
+}

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -80,6 +80,7 @@ import org.neo4j.server.security.auth.BasicAuthManager;
 import org.neo4j.server.web.SimpleUriBuilder;
 import org.neo4j.server.web.WebServer;
 import org.neo4j.server.web.WebServerProvider;
+import org.neo4j.udc.UsageData;
 
 import static java.lang.Math.round;
 import static java.lang.String.format;
@@ -554,6 +555,8 @@ public abstract class AbstractNeoServer implements NeoServer
         singletons.add( new TransactionFilter( database ) );
         singletons.add( new LoggingProvider( logProvider ) );
         singletons.add( providerForSingleton( logProvider.getLog( NeoServer.class ), Log.class ) );
+
+        singletons.add( providerForSingleton( resolveDependency( UsageData.class ), UsageData.class ) );
 
         return singletons;
     }

--- a/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/CypherService.java
@@ -37,6 +37,10 @@ import org.neo4j.server.rest.repr.CypherResultRepresentation;
 import org.neo4j.server.rest.repr.InputFormat;
 import org.neo4j.server.rest.repr.InvalidArgumentsException;
 import org.neo4j.server.rest.repr.OutputFormat;
+import org.neo4j.udc.UsageData;
+
+import static org.neo4j.udc.UsageDataKeys.Features.http_cypher_endpoint;
+import static org.neo4j.udc.UsageDataKeys.features;
 
 @Path("/cypher")
 public class CypherService
@@ -50,15 +54,17 @@ public class CypherService
     private static final String PROFILE_PARAM = "profile";
 
     private final CypherExecutor cypherExecutor;
+    private final UsageData usage;
     private final OutputFormat output;
     private final InputFormat input;
 
     public CypherService( @Context CypherExecutor cypherExecutor, @Context InputFormat input,
-                          @Context OutputFormat output )
+                          @Context OutputFormat output, @Context UsageData usage )
     {
         this.cypherExecutor = cypherExecutor;
         this.input = input;
         this.output = output;
+        this.usage = usage;
     }
 
     public OutputFormat getOutputFormat()
@@ -74,6 +80,7 @@ public class CypherService
                            @QueryParam( INCLUDE_PLAN_PARAM ) boolean includePlan,
                            @QueryParam( PROFILE_PARAM ) boolean profile) throws BadInputException {
 
+        usage.get( features ).flag( http_cypher_endpoint );
         Map<String,Object> command = input.readMap( body );
 
         if( !command.containsKey(QUERY_KEY) ) {

--- a/community/server/src/main/java/org/neo4j/server/rest/web/TransactionalService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/TransactionalService.java
@@ -45,7 +45,10 @@ import org.neo4j.server.rest.transactional.TransactionHandle;
 import org.neo4j.server.rest.transactional.TransactionTerminationHandle;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
 import org.neo4j.server.rest.transactional.error.TransactionLifecycleException;
+import org.neo4j.udc.UsageData;
 
+import static org.neo4j.udc.UsageDataKeys.Features.http_tx_endpoint;
+import static org.neo4j.udc.UsageDataKeys.features;
 
 /**
  * This does basic mapping from HTTP to {@link org.neo4j.server.rest.transactional.TransactionFacade}, and should not
@@ -55,11 +58,13 @@ import org.neo4j.server.rest.transactional.error.TransactionLifecycleException;
 public class TransactionalService
 {
     private final TransactionFacade facade;
+    private final UsageData usage;
     private final TransactionUriScheme uriScheme;
 
-    public TransactionalService( @Context TransactionFacade facade, @Context UriInfo uriInfo )
+    public TransactionalService( @Context TransactionFacade facade, @Context UriInfo uriInfo, @Context UsageData usage )
     {
         this.facade = facade;
+        this.usage = usage;
         this.uriScheme = new TransactionUriBuilder( uriInfo );
     }
 
@@ -71,6 +76,7 @@ public class TransactionalService
     {
         try
         {
+            usage.get( features ).flag( http_tx_endpoint );
             TransactionHandle transactionHandle = facade.newTransactionHandle( uriScheme, false, AccessMode.FULL );
             return createdResponse( transactionHandle, executeStatements( input, transactionHandle, uriInfo.getBaseUri(), request ) );
         }

--- a/community/server/src/test/java/org/neo4j/server/modules/RESTApiModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/RESTApiModuleTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Dependencies;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.database.Database;
@@ -53,7 +54,7 @@ public class RESTApiModuleTest
         Config config = new Config( params );
 
         Dependencies deps = new Dependencies();
-        deps.satisfyDependency( new UsageData() );
+        deps.satisfyDependency( new UsageData( mock( JobScheduler.class ) ) );
 
         Database db = mock(Database.class);
 

--- a/community/udc/src/main/java/org/neo4j/ext/udc/UdcConstants.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/UdcConstants.java
@@ -30,6 +30,8 @@ public class UdcConstants
     public static final String DATABASE_MODE = "databasemode";
     public static final String SERVER_ID = "serverid";
 
+    public static final String FEATURES = "features";
+
     public static final String USER_AGENTS = "ua";
     public static final String VERSION = "v";
     public static final String REVISION = "revision";

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollector.java
@@ -48,6 +48,7 @@ import static org.neo4j.ext.udc.UdcConstants.CLUSTER_HASH;
 import static org.neo4j.ext.udc.UdcConstants.DATABASE_MODE;
 import static org.neo4j.ext.udc.UdcConstants.DISTRIBUTION;
 import static org.neo4j.ext.udc.UdcConstants.EDITION;
+import static org.neo4j.ext.udc.UdcConstants.FEATURES;
 import static org.neo4j.ext.udc.UdcConstants.HEAP_SIZE;
 import static org.neo4j.ext.udc.UdcConstants.ID;
 import static org.neo4j.ext.udc.UdcConstants.LABEL_IDS_IN_USE;
@@ -146,6 +147,8 @@ public class DefaultUdcInformationCollector implements UdcInformationCollector
         add( udcFields, RELATIONSHIP_IDS_IN_USE, determineRelationshipIdsInUse() );
         add( udcFields, LABEL_IDS_IN_USE, determineLabelIdsInUse() );
         add( udcFields, PROPERTY_IDS_IN_USE, determinePropertyIdsInUse() );
+
+        add( udcFields, FEATURES, usageData.get( UsageDataKeys.features ).asHex() );
 
         udcFields.putAll( determineSystemProperties() );
         return udcFields;

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
@@ -34,6 +34,7 @@ import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdRange;
 import org.neo4j.kernel.impl.store.id.IdType;
+import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKeys;
 
@@ -41,10 +42,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.neo4j.udc.UsageDataKeys.Features.bolt;
 
 public class DefaultUdcInformationCollectorTest
 {
-    private final UsageData usageData = new UsageData();
+    private final UsageData usageData = new UsageData( mock( JobScheduler.class ) );
     private final DefaultUdcInformationCollector collector = new DefaultUdcInformationCollector(
             new Config(), null,
             new StubIdGeneratorFactory(), mock( StartupStatistics.class ), usageData );
@@ -126,6 +128,16 @@ public class DefaultUdcInformationCollectorTest
             fail("Expected \"SteveBrookClient/1.0,MayorClient/1.0\" or \"MayorClient/1.0,SteveBrookClient/1.0\", " +
                  "got \""+userAgents+"\"");
         }
+    }
+
+    @Test
+    public void shouldIncludePopularFeatures() throws Throwable
+    {
+        // Given
+        usageData.get( UsageDataKeys.features ).flag( bolt );
+
+        // When & Then
+        assertEquals( "1000", collector.getUdcParams().get( UdcConstants.FEATURES ) );
     }
 
     private static class StubIdGeneratorFactory implements IdGeneratorFactory


### PR DESCRIPTION
- Expand usage data collection to track yes/no on if the following
  features have been in use in the past seven days:
  - Bolt Protocol
  - HTTP Cypher Endpoint
  - HTTP Batch Endpoint
  - HTTP TX Endpoint

As always, this is easily turned off by disabling UDC in configuration.
This will help improve the product by getting better data on which
features are popular and which features see almost no use, which in
turn can help guide further investigation to improve the overall UX
of Neo4j.

The implementation itself is designed to sit on semi-hot-paths, consisting
of a lossy lock-free data structure that tracks feature usage, marking features
as unused if they have been idle for more than four days. 

The overhead of this tracking to a feature is one non-volatile read and,
for features that are used less than four times per day, one non-volatile write per
invocation of the feature tracked.
