### PR TITLE
Support AccessMode.NONE

### DIFF
--- a/community/bolt/src/docs/dev/examples.asciidoc
+++ b/community/bolt/src/docs/dev/examples.asciidoc
@@ -25,16 +25,16 @@ Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credenti
     6A 00 00
 
 Server: FAILURE { "code": "Neo.ClientError.Security.CredentialsExpired",
-                  "message": "The credentials have expired and needs to be updated."}
+                  "message": "The credentials have expired and need to be updated."}
 
-    00 74 B1 7F  A2 84 63 6F  64 65 D0 2B  4E 65 6F 2E
+    00 73 B1 7F  A2 84 63 6F  64 65 D0 2B  4E 65 6F 2E
     43 6C 69 65  6E 74 45 72  72 6F 72 2E  53 65 63 75
     72 69 74 79  2E 43 72 65  64 65 6E 74  69 61 6C 73
     45 78 70 69  72 65 64 87  6D 65 73 73  61 67 65 D0
-    35 54 68 65  20 63 72 65  64 65 6E 74  69 61 6C 73
+    34 54 68 65  20 63 72 65  64 65 6E 74  69 61 6C 73
     20 68 61 76  65 20 65 78  70 69 72 65  64 20 61 6E
-    64 20 6E 65  65 64 73 20  74 6F 20 62  65 20 75 70
-    64 61 74 65  64 2E 00 00
+    64 20 6E 65  65 64 20 74  6F 20 62 65  20 75 70 64
+    61 74 65 64  2E 00 00
 
 Server: <disconnect>
 Client: <connect>

--- a/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
@@ -93,7 +93,7 @@ public class BasicAuthenticationTest
         // Expect
         exception.expect( AuthenticationException.class );
         exception.expect( hasStatus( Status.Security.CredentialsExpired ) );
-        exception.expectMessage( "The credentials have expired and needs to be updated." );
+        exception.expectMessage( "The credentials have expired and need to be updated." );
 
         // When
         authentication.authenticate( map( "scheme", "basic", "principal", "bob", "credentials", "secret" ) );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -98,7 +98,7 @@ public class AuthenticationIT
         // Then
         assertThat( client, eventuallyRecieves( new byte[]{0, 0, 0, 1} ) );
         assertThat( client, eventuallyRecieves( msgFailure( Status.Security.CredentialsExpired,
-                "The credentials have expired and needs to be updated." ) ) );
+                "The credentials have expired and need to be updated." ) ) );
     }
 
     @Test

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -303,11 +303,12 @@ public interface Status
     {
         // client
         AuthenticationFailed( ClientError, "The client provided an incorrect username and/or password." ),
-        CredentialsExpired( ClientError, "The credentials have expired and needs to be updated." ),
+        CredentialsExpired( ClientError, "The credentials have expired and need to be updated." ),
         AuthorizationFailed( ClientError, "The client does not have privileges to perform the operation requested." ),
         AuthenticationRateLimit( ClientError, "The client has provided incorrect authentication details too many times in a row." ),
         ModifiedConcurrently( TransientError, "The user was modified concurrently to this request." ),
-        EncryptionRequired( ClientError, "A TLS encrypted connection is required." );
+        EncryptionRequired( ClientError, "A TLS encrypted connection is required." ),
+        AccessViolation( ClientError, "An attempt was made to perform an unauthorized action." );
 
         private final Code code;
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContextTest.scala
@@ -52,7 +52,9 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     super.beforeEach()
     graph = new GraphDatabaseCypherService(new TestGraphDatabaseFactory().newImpermanentDatabase())
     outerTx = mock[InternalTransaction]
-    statement = new KernelStatement(mock[KernelTransactionImplementation], null, null, null, null, new Procedures())
+    val kernelTransaction = mock[KernelTransactionImplementation]
+    when(kernelTransaction.mode()).thenReturn(AccessMode.FULL)
+    statement = new KernelStatement(kernelTransaction, null, null, null, null, new Procedures())
   }
 
   override def afterEach() {

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationViolationException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationViolationException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.security;
+
+import org.neo4j.kernel.api.exceptions.Status;
+
+/**
+ * Thrown when the database is asked to perform an action that is not authorized based on the AccessMode settings.
+ *
+ * For instance, if attempting to write with READ_ONLY rights.
+ */
+public class AuthorizationViolationException extends RuntimeException implements Status.HasStatus
+{
+    private final Status statusCode = Status.Security.AccessViolation;
+
+    public AuthorizationViolationException( String msg )
+    {
+        super( msg );
+    }
+
+    public AuthorizationViolationException( String msg, Throwable cause )
+    {
+        super( msg, cause );
+    }
+
+    /** The Neo4j status code associated with this exception type. */
+    @Override
+    public Status status()
+    {
+        return statusCode;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/AccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/AccessMode.java
@@ -66,7 +66,29 @@ public enum AccessMode
                 }
             },
 
-    /** Allows reading data and schema, but not writing. */
+    /** Allows writing data */
+    WRITE_ONLY
+            {
+                @Override
+                public boolean allowsReads()
+                {
+                    return false;
+                }
+
+                @Override
+                public boolean allowsWrites()
+                {
+                    return true;
+                }
+
+                @Override
+                public boolean allowsSchemaWrites()
+                {
+                    return false;
+                }
+            },
+
+    /** Allows reading and writing data, but not schema. */
     WRITE
             {
                 @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -58,6 +58,7 @@ public class KernelStatement implements TxStateHolder, Statement
     @Override
     public ReadOperations readOperations()
     {
+        transaction.verifyReadTransaction();
         return facade;
     }
 
@@ -71,7 +72,7 @@ public class KernelStatement implements TxStateHolder, Statement
     public DataWriteOperations dataWriteOperations()
             throws InvalidTransactionTypeKernelException
     {
-        transaction.upgradeToDataTransaction();
+        transaction.verifyDataWriteTransaction();
         return facade;
     }
 
@@ -79,7 +80,7 @@ public class KernelStatement implements TxStateHolder, Statement
     public SchemaWriteOperations schemaWriteOperations()
             throws InvalidTransactionTypeKernelException
     {
-        transaction.upgradeToSchemaTransaction();
+        transaction.verifySchemaWriteTransaction();
         return facade;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -108,7 +108,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                     }
                 };
 
-        TransactionType enableReadTransaction() throws IllegalStateException
+        TransactionType enableReadTransaction()
         {
             return READ_ONLY;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.function.Supplier;
 
 import org.neo4j.collection.pool.Pool;
+import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.helpers.Clock;
 import org.neo4j.kernel.api.AccessMode;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -274,7 +275,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     {
         if( !accessMode.allowsReads() )
         {
-            throw new IllegalStateException(
+            throw new AuthorizationViolationException(
                     String.format( "Read operations are not allowed for `%s` transactions.", accessMode.name() ) );
         }
 
@@ -285,7 +286,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     {
         if( !accessMode.allowsWrites() )
         {
-            throw new InvalidTransactionTypeKernelException(
+            throw new AuthorizationViolationException(
                     String.format( "Write operations are not allowed for `%s` transactions.", accessMode.name() ) );
         }
         transactionType = transactionType.enableDataWriteTransaction();
@@ -295,7 +296,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     {
         if( !accessMode.allowsSchemaWrites() )
         {
-            throw new InvalidTransactionTypeKernelException(
+            throw new AuthorizationViolationException(
                     String.format( "Schema write operations are not allowed for `%s` transactions.", accessMode.name() ) );
         }
         doUpgradeToSchemaTransaction();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.api;
 import org.junit.Test;
 
 import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.kernel.api.AccessMode;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.StorageStatement;
 
@@ -36,6 +37,7 @@ public class KernelStatementTest
     {
         KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
         when( transaction.shouldBeTerminated() ).thenReturn( true );
+        when( transaction.mode() ).thenReturn( AccessMode.FULL );
 
         KernelStatement statement = new KernelStatement(
             transaction, null, null, null, null, null );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAccessModeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAccessModeTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.ExpectedException;
 import org.neo4j.kernel.api.AccessMode;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.KernelTransactionTestBase;
+import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.exceptions.KernelException;
 
@@ -34,6 +35,19 @@ import static org.junit.Assert.assertNotNull;
 public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
 {
     @Rule public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldAllowReadsInReadMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction( AccessMode.READ );
+
+        // When
+        ReadOperations reads = tx.acquireStatement().readOperations();
+
+        // Then
+        assertNotNull( reads );
+    }
 
     @Test
     public void shouldNotAllowWriteAccessInReadMode() throws Throwable
@@ -62,16 +76,55 @@ public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
     }
 
     @Test
-    public void shouldNotAllowSchemaWriteAccessInWriteMode() throws Throwable
+    public void shouldNotAllowReadAccessInWriteOnlyMode() throws Throwable
     {
         // Given
-        KernelTransactionImplementation tx = newTransaction( AccessMode.WRITE );
+        KernelTransactionImplementation tx = newTransaction( AccessMode.WRITE_ONLY );
+
+        // Expect
+        exception.expect( IllegalStateException.class );
+
+        // When
+        tx.acquireStatement().readOperations();
+    }
+
+    @Test
+    public void shouldAllowWriteAccessInWriteOnlyMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction( AccessMode.WRITE_ONLY );
+
+        // When
+        DataWriteOperations writes = tx.acquireStatement().dataWriteOperations();
+
+        // Then
+        assertNotNull( writes );
+    }
+
+    @Test
+    public void shouldNotAllowSchemaWriteAccessInWriteOnlyMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction( AccessMode.WRITE_ONLY );
 
         // Expect
         exception.expect( KernelException.class );
 
         // When
         tx.acquireStatement().schemaWriteOperations();
+    }
+
+    @Test
+    public void shouldAllowReadsInWriteMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction( AccessMode.WRITE );
+
+        // When
+        ReadOperations reads = tx.acquireStatement().readOperations();
+
+        // Then
+        assertNotNull( reads );
     }
 
     @Test
@@ -85,6 +138,32 @@ public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
 
         // Then
         assertNotNull( writes );
+    }
+
+    @Test
+    public void shouldNotAllowSchemaWriteAccessInWriteMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction( AccessMode.WRITE );
+
+        // Expect
+        exception.expect( KernelException.class );
+
+        // When
+        tx.acquireStatement().schemaWriteOperations();
+    }
+
+    @Test
+    public void shouldAllowReadsInFullMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction( AccessMode.FULL );
+
+        // When
+        ReadOperations reads = tx.acquireStatement().readOperations();
+
+        // Then
+        assertNotNull( reads );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAccessModeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAccessModeTest.java
@@ -23,12 +23,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.api.AccessMode;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.KernelTransactionTestBase;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
-import org.neo4j.kernel.api.exceptions.KernelException;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -56,7 +56,7 @@ public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
         KernelTransactionImplementation tx = newTransaction( AccessMode.READ );
 
         // Expect
-        exception.expect( KernelException.class );
+        exception.expect( AuthorizationViolationException.class );
 
         // When
         tx.acquireStatement().dataWriteOperations();
@@ -69,7 +69,7 @@ public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
         KernelTransactionImplementation tx = newTransaction( AccessMode.READ );
 
         // Expect
-        exception.expect( KernelException.class );
+        exception.expect( AuthorizationViolationException.class );
 
         // When
         tx.acquireStatement().schemaWriteOperations();
@@ -82,7 +82,7 @@ public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
         KernelTransactionImplementation tx = newTransaction( AccessMode.WRITE_ONLY );
 
         // Expect
-        exception.expect( IllegalStateException.class );
+        exception.expect( AuthorizationViolationException.class );
 
         // When
         tx.acquireStatement().readOperations();
@@ -108,7 +108,7 @@ public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
         KernelTransactionImplementation tx = newTransaction( AccessMode.WRITE_ONLY );
 
         // Expect
-        exception.expect( KernelException.class );
+        exception.expect( AuthorizationViolationException.class );
 
         // When
         tx.acquireStatement().schemaWriteOperations();
@@ -147,7 +147,7 @@ public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
         KernelTransactionImplementation tx = newTransaction( AccessMode.WRITE );
 
         // Expect
-        exception.expect( KernelException.class );
+        exception.expect( AuthorizationViolationException.class );
 
         // When
         tx.acquireStatement().schemaWriteOperations();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAccessModeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionAccessModeTest.java
@@ -37,6 +37,45 @@ public class KernelTransactionAccessModeTest extends KernelTransactionTestBase
     @Rule public ExpectedException exception = ExpectedException.none();
 
     @Test
+    public void shouldNotAllowReadsInNoneMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction( AccessMode.NONE );
+
+        // Expect
+        exception.expect( AuthorizationViolationException.class );
+
+        // When
+        tx.acquireStatement().readOperations();
+    }
+
+    @Test
+    public void shouldNotAllowWritesInNoneMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction( AccessMode.NONE );
+
+        // Expect
+        exception.expect( AuthorizationViolationException.class );
+
+        // When
+        tx.acquireStatement().dataWriteOperations();
+    }
+
+    @Test
+    public void shouldNotAllowSchemaWritesInNoneMode() throws Throwable
+    {
+        // Given
+        KernelTransactionImplementation tx = newTransaction( AccessMode.NONE );
+
+        // Expect
+        exception.expect( AuthorizationViolationException.class );
+
+        // When
+        tx.acquireStatement().schemaWriteOperations();
+    }
+
+    @Test
     public void shouldAllowReadsInReadMode() throws Throwable
     {
         // Given

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.neo4j.cypher.CypherException;
 import org.neo4j.cypher.InvalidSemanticsException;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.api.AccessMode;
 import org.neo4j.kernel.api.exceptions.KernelException;
@@ -307,7 +308,7 @@ public class TransactionHandle implements TransactionTerminationHandle
                     output.statementResult( result, statement.includeStats(), statement.resultDataContents() );
                     output.notifications( result.getNotifications() );
                 }
-                catch ( KernelException | CypherException e )
+                catch ( KernelException | CypherException | AuthorizationViolationException e )
                 {
                     errors.add( new Neo4jError( e.status(), e ) );
                     break;


### PR DESCRIPTION
Support the concept of an AccessMode.NONE allowing transactions to be created, but no actual operations to be performed. This is required in order to allow admin activities through Cypher that do not touch the database, like password change.
