### PR TITLE
Fix utf8 failure on ibm jdk

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/SunMiscUTF8Encoder.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/utf8/SunMiscUTF8Encoder.java
@@ -77,7 +77,7 @@ public class SunMiscUTF8Encoder implements UTF8Encoder
             }
 
             char[] rawChars = (char[]) getCharArray.invoke( input );
-            int len = (int)arrayEncode.invoke( charsetEncoder, rawChars, 0, rawChars.length, out );
+            int len = (int)arrayEncode.invoke( charsetEncoder, rawChars, 0, input.length(), out );
 
             if( len == -1 )
             {


### PR DESCRIPTION
UTF8 serialization was relying on that the size of `char[] value`  in
`java.lang.String` always has the same size as the actual number of characters
in the String. This lead to encoding failures when running on ibm jdk.
