### PR TITLE
Prefix and seek queries regression

### DIFF
--- a/community/bolt/LICENSES.txt
+++ b/community/bolt/LICENSES.txt
@@ -5,6 +5,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 Apache Software License, Version 2.0
   Apache Commons Lang
   ConcurrentLinkedHashMap
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/bolt/NOTICE.txt
+++ b/community/bolt/NOTICE.txt
@@ -28,6 +28,7 @@ Third-party licenses
 Apache Software License, Version 2.0
   Apache Commons Lang
   ConcurrentLinkedHashMap
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/consistency-check-legacy/LICENSES.txt
+++ b/community/consistency-check-legacy/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/consistency-check-legacy/NOTICE.txt
+++ b/community/consistency-check-legacy/NOTICE.txt
@@ -27,6 +27,7 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/consistency-check/LICENSES.txt
+++ b/community/consistency-check/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/consistency-check/NOTICE.txt
+++ b/community/consistency-check/NOTICE.txt
@@ -27,6 +27,7 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/cypher/cypher/LICENSES.txt
+++ b/community/cypher/cypher/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/cypher/cypher/NOTICE.txt
+++ b/community/cypher/cypher/NOTICE.txt
@@ -27,6 +27,7 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/import-tool/LICENSES.txt
+++ b/community/import-tool/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/import-tool/NOTICE.txt
+++ b/community/import-tool/NOTICE.txt
@@ -27,6 +27,7 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/lucene-index-upgrade/pom.xml
+++ b/community/lucene-index-upgrade/pom.xml
@@ -13,7 +13,7 @@
         <license-text.header>GPL-3-header.txt</license-text.header>
         <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
         <lucene4.version>4.10.4</lucene4.version>
-        <lucene5.version>5.4.0</lucene5.version>
+        <lucene5.version>5.5.0</lucene5.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>

--- a/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/LuceneLegacyIndexUpgrader.java
+++ b/community/lucene-index-upgrade/src/main/java/org/neo4j/upgrade/lucene/LuceneLegacyIndexUpgrader.java
@@ -66,8 +66,8 @@ public class LuceneLegacyIndexUpgrader
     private static final String LIBRARY_DIRECTORY = "lib";
     private static final String RESOURCE_SEPARATOR = "/";
     private static final String LUCENE4_CORE_JAR_NAME = "lucene-core-4.10.4.jar";
-    private static final String LUCENE5_CORE_JAR_NAME = "lucene-core-5.4.0.jar";
-    private static final String LUCENE5_BACKWARD_CODECS_NAME = "lucene-backward-codecs-5.4.0.jar";
+    private static final String LUCENE5_CORE_JAR_NAME = "lucene-core-5.5.0.jar";
+    private static final String LUCENE5_BACKWARD_CODECS_NAME = "lucene-backward-codecs-5.5.0.jar";
     private static final String SEGMENTS_FILE_NAME_PREFIX = "segments";
 
     private final Path indexRootPath;

--- a/community/lucene-index/LICENSES.txt
+++ b/community/lucene-index/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/lucene-index/NOTICE.txt
+++ b/community/lucene-index/NOTICE.txt
@@ -27,6 +27,7 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/lucene-index/pom.xml
+++ b/community/lucene-index/pom.xml
@@ -91,6 +91,11 @@ the relevant Commercial Agreement.
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-queryparser</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-codecs</artifactId>
+    </dependency>
+
 
     <dependency>
       <groupId>junit</groupId>

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/FullTxData.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/FullTxData.java
@@ -377,7 +377,7 @@ class FullTxData extends TxData
         try
         {
             IndexReader newReader = this.reader == null ?
-                                    DirectoryReader.open( this.writer, true ) :
+                                    DirectoryReader.open( this.writer ) :
                                     DirectoryReader.openIfChanged( (DirectoryReader) this.reader );
             if ( newReader == this.reader )
             {

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
@@ -226,7 +226,7 @@ public class LuceneDataSource extends LifecycleAdapter
             // TODO: this cast should always succeed, maybe check nonetheless?
             DirectoryReader reader = (DirectoryReader) searcher.getSearcher().getIndexReader();
             IndexWriter writer = searcher.getWriter();
-            IndexReader reopened = DirectoryReader.openIfChanged( reader, writer, true );
+            IndexReader reopened = DirectoryReader.openIfChanged( reader, writer );
             if ( reopened != null )
             {
                 IndexSearcher newSearcher = newIndexSearcher( searcher.getIdentifier(), reopened );
@@ -305,7 +305,7 @@ public class LuceneDataSource extends LifecycleAdapter
             if ( searcher == null )
             {
                 IndexWriter writer = newIndexWriter( identifier );
-                IndexReader reader = DirectoryReader.open( writer, true );
+                IndexReader reader = DirectoryReader.open( writer );
                 IndexSearcher indexSearcher = newIndexSearcher( identifier, reader );
                 searcher = new IndexReference( identifier, indexSearcher, writer );
                 indexSearchers.put( identifier, searcher );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
@@ -560,28 +560,17 @@ public class DocValuesCollector extends SimpleCollector
         }
 
         @Override
+        public DocIdSetIterator iterator()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public int docID()
         {
             throw new UnsupportedOperationException();
         }
 
-        @Override
-        public int nextDoc() throws IOException
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public int advance( int target ) throws IOException
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long cost()
-        {
-            return scores.length;
-        }
     }
 
     private static final class DocsInIndexOrderIterator extends AbstractIndexHits<Document>

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/IndexPartition.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/partition/IndexPartition.java
@@ -51,7 +51,7 @@ public class IndexPartition implements Closeable
         this.indexFolder = partitionFolder;
         this.directory = directory;
         this.indexWriter = new IndexWriter( directory, writerConfig );
-        this.searcherManager = new SearcherManager( indexWriter, true, new SearcherFactory() );
+        this.searcherManager = new SearcherManager( indexWriter, new SearcherFactory() );
     }
 
     public IndexWriter getIndexWriter()

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
@@ -205,7 +205,7 @@ public class LuceneDocumentStructure
     /**
      * Simple implementation of prefix query that mimics old lucene way of handling prefix queries.
      * According to benchmarks this implementation is faster then
-     * {@link org.apache.lucene.search.PhraseQuery} because we do not construct automaton  which is
+     * {@link org.apache.lucene.search.PrefixQuery} because we do not construct automaton  which is
      * extremely expensive.
      */
     private static class PrefixMultiTermsQuery extends MultiTermQuery

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/IndexReaderStub.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/IndexReaderStub.java
@@ -42,8 +42,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
-import static com.sun.corba.se.spi.activation.IIOP_CLEAR_TEXT.value;
-
 public class IndexReaderStub extends LeafReader
 {
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructureTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructureTest.java
@@ -23,8 +23,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.NumericRangeQuery;
-import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
@@ -32,6 +32,8 @@ import org.junit.Test;
 
 import static junit.framework.Assert.assertNull;
 import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
 import static org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure.NODE_ID_KEY;
 import static org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure.newSeekQuery;
 import static org.neo4j.kernel.api.impl.schema.ValueEncoding.Array;
@@ -173,8 +175,9 @@ public class LuceneDocumentStructureTest
     public void shouldBuildRangeSeekByStringQueryForStrings() throws Exception
     {
         // given
-        TermRangeQuery query =
-                (TermRangeQuery) LuceneDocumentStructure.newRangeSeekByStringQuery( "foo", false, null, true );
+        ConstantScoreQuery constantQuery =
+                (ConstantScoreQuery) LuceneDocumentStructure.newRangeSeekByStringQuery( "foo", false, null, true );
+        TermRangeQuery query = (TermRangeQuery) constantQuery.getQuery();
 
         // then
         assertEquals( "string", query.getField() );
@@ -198,9 +201,10 @@ public class LuceneDocumentStructureTest
     public void shouldBuildRangeSeekByPrefixQueryForStrings() throws Exception
     {
         // given
-        PrefixQuery query = LuceneDocumentStructure.newRangeSeekByPrefixQuery( "Prefix" );
+        ConstantScoreQuery query = (ConstantScoreQuery) LuceneDocumentStructure.newRangeSeekByPrefixQuery( "Prefix" );
+        MultiTermQuery prefixQuery = (MultiTermQuery) query.getQuery();
 
         // then
-        assertEquals( "Prefix", query.getPrefix().text() );
+        assertThat("Should contain term value", prefixQuery.toString(), containsString( "Prefix" ) );
     }
 }

--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -22,6 +22,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -45,6 +45,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/neo4j/LICENSES.txt
+++ b/community/neo4j/LICENSES.txt
@@ -5,6 +5,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 Apache Software License, Version 2.0
   Apache Commons Lang
   ConcurrentLinkedHashMap
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/neo4j/NOTICE.txt
+++ b/community/neo4j/NOTICE.txt
@@ -28,6 +28,7 @@ Third-party licenses
 Apache Software License, Version 2.0
   Apache Commons Lang
   ConcurrentLinkedHashMap
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -22,6 +22,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -45,6 +45,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/core-edge/LICENSES.txt
+++ b/enterprise/core-edge/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   hazelcast-all
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/core-edge/NOTICE.txt
+++ b/enterprise/core-edge/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   hazelcast-all
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/ha/LICENSES.txt
+++ b/enterprise/ha/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/ha/NOTICE.txt
+++ b/enterprise/ha/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   Apache Commons Lang
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/neo4j-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-enterprise/LICENSES.txt
@@ -7,6 +7,7 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Graphite Integration for Metrics
   hazelcast-all
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -29,6 +29,7 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Graphite Integration for Metrics
   hazelcast-all
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -24,6 +24,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -46,6 +46,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -24,6 +24,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -46,6 +46,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/manual/cypher/graphgist/LICENSES.txt
+++ b/manual/cypher/graphgist/LICENSES.txt
@@ -8,6 +8,7 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/manual/cypher/graphgist/NOTICE.txt
+++ b/manual/cypher/graphgist/NOTICE.txt
@@ -31,6 +31,7 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/manual/embedded-examples/LICENSES.txt
+++ b/manual/embedded-examples/LICENSES.txt
@@ -5,6 +5,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 Apache Software License, Version 2.0
   Apache Commons Lang
   ConcurrentLinkedHashMap
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/manual/embedded-examples/NOTICE.txt
+++ b/manual/embedded-examples/NOTICE.txt
@@ -28,6 +28,7 @@ Third-party licenses
 Apache Software License, Version 2.0
   Apache Commons Lang
   ConcurrentLinkedHashMap
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/LICENSES.txt
@@ -24,6 +24,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
@@ -47,6 +47,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -85,6 +85,7 @@
         <include>org.apache.lucene:lucene-core</include>
         <include>org.apache.lucene:lucene-analyzers-common</include>
         <include>org.apache.lucene:lucene-queryparser</include>
+        <include>org.apache.lucene:lucene-codecs</include>
         <include>org.scala-lang:*</include>
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
@@ -97,6 +97,7 @@
         <include>org.apache.lucene:lucene-core</include>
         <include>org.apache.lucene:lucene-analyzers-common</include>
         <include>org.apache.lucene:lucene-queryparser</include>
+        <include>org.apache.lucene:lucene-codecs</include>
         <include>org.scala-lang:*</include>
         <include>org.parboiled:*</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
@@ -117,9 +118,7 @@
         <exclude>org.neo4j:*</exclude>
         <exclude>org.neo4j.doc:*</exclude>
         <exclude>jline:jline</exclude>
-        <exclude>org.apache.lucene:lucene-core</exclude>
-        <exclude>org.apache.lucene:lucene-analyzers-common</exclude>
-        <exclude>org.apache.lucene:lucene-queryparser</exclude>
+        <exclude>org.apache.lucene:*</exclude>
         <exclude>org.scala-lang:*</exclude>
         <exclude>org.parboiled:*</exclude>
         <exclude>org.neo4j.app:windows-service-wrapper:*</exclude>

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -24,6 +24,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -47,6 +47,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
@@ -98,6 +98,7 @@
         <include>org.apache.lucene:lucene-core</include>
         <include>org.apache.lucene:lucene-analyzers-common</include>
         <include>org.apache.lucene:lucene-queryparser</include>
+        <include>org.apache.lucene:lucene-codecs</include>
         <include>io.netty:netty</include>
         <include>org.scala-lang:*</include>
         <include>org.parboiled:*</include>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
@@ -95,6 +95,7 @@
         <include>org.apache.lucene:lucene-core</include>
         <include>org.apache.lucene:lucene-analyzers-common</include>
         <include>org.apache.lucene:lucene-queryparser</include>
+        <include>org.apache.lucene:lucene-codecs</include>
         <include>io.netty:netty</include>
         <include>com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru</include>
         <include>org.scala-lang:*</include>

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
@@ -26,6 +26,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -48,6 +48,7 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <pico.version>2.14.3</pico.version>
     <licensing.prepend.text>notice-agpl-prefix.txt</licensing.prepend.text>
     <licensing.phase>compile</licensing.phase>
-    <lucene.version>5.4.0</lucene.version>
+    <lucene.version>5.5.0</lucene.version>
     <logback-classic.version>1.1.2</logback-classic.version>
     <bouncycastle.version>1.53</bouncycastle.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
@@ -472,6 +472,11 @@
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-core</artifactId>
+        <version>${lucene.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.lucene</groupId>
+        <artifactId>lucene-codecs</artifactId>
         <version>${lucene.version}</version>
       </dependency>
       <dependency>

--- a/tools/LICENSES.txt
+++ b/tools/LICENSES.txt
@@ -8,6 +8,7 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Guava: Google Core Libraries for Java
   javax.inject
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory

--- a/tools/NOTICE.txt
+++ b/tools/NOTICE.txt
@@ -30,6 +30,7 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Guava: Google Core Libraries for Java
   javax.inject
+  Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory


### PR DESCRIPTION
Switch to latest available lucene 5.5 version.
Introduce custom PrefixMultiTermsQuery and use it instead of default PrefixQuery to avoid expensive internal automaton creation.
Switch posting format to BlockTreeOrdsPostingsFormat by default.

Both of optimisations are pluggable and can be switched off by corresponding feature toggle.
Please note: switching posting format will require index regeneration.
