### PR TITLE
Disables relative references in high limit format

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/FullyCoveringRecordKeys.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/FullyCoveringRecordKeys.java
@@ -71,6 +71,8 @@ class FullyCoveringRecordKeys implements RecordKeys
                 assertEquals( written.getFirstNextRel(), read.getFirstNextRel() );
                 assertEquals( written.getSecondPrevRel(), read.getSecondPrevRel() );
                 assertEquals( written.getSecondNextRel(), read.getSecondNextRel() );
+                assertEquals( written.isFirstInFirstChain(), read.isFirstInFirstChain() );
+                assertEquals( written.isFirstInSecondChain(), read.isFirstInSecondChain() );
             }
         };
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/LimitedRecordGenerators.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/LimitedRecordGenerators.java
@@ -67,14 +67,19 @@ public class LimitedRecordGenerators implements RecordGenerators
     @Override
     public Generator<RelationshipTypeTokenRecord> relationshipTypeToken()
     {
-        return (recordSize, format) -> new RelationshipTypeTokenRecord( 0 ).initialize( random.nextBoolean(),
+        return (recordSize, format) -> new RelationshipTypeTokenRecord( randomId() ).initialize( random.nextBoolean(),
                 randomInt( tokenBits ) );
+    }
+
+    private int randomId()
+    {
+        return random.nextInt( 5 );
     }
 
     @Override
     public Generator<RelationshipGroupRecord> relationshipGroup()
     {
-        return (recordSize, format) -> new RelationshipGroupRecord( 0 ).initialize( random.nextBoolean(),
+        return (recordSize, format) -> new RelationshipGroupRecord( randomId() ).initialize( random.nextBoolean(),
                 randomInt( tokenBits ),
                 randomLongOrOccasionallyNull( entityBits ),
                 randomLongOrOccasionallyNull( entityBits ),
@@ -86,7 +91,7 @@ public class LimitedRecordGenerators implements RecordGenerators
     @Override
     public Generator<RelationshipRecord> relationship()
     {
-        return (recordSize, format) -> new RelationshipRecord( 0 ).initialize( random.nextBoolean(),
+        return (recordSize, format) -> new RelationshipRecord( randomId() ).initialize( random.nextBoolean(),
                 randomLongOrOccasionallyNull( propertyBits ),
                 random.nextLong( entityBits ), random.nextLong( entityBits ), randomInt( tokenBits ),
                 randomLongOrOccasionallyNull( entityBits ), randomLongOrOccasionallyNull( entityBits ),
@@ -97,7 +102,7 @@ public class LimitedRecordGenerators implements RecordGenerators
     @Override
     public Generator<PropertyKeyTokenRecord> propertyKeyToken()
     {
-        return (recordSize, format) -> new PropertyKeyTokenRecord( 0 ).initialize( random.nextBoolean(),
+        return (recordSize, format) -> new PropertyKeyTokenRecord( randomId() ).initialize( random.nextBoolean(),
                 random.nextInt( tokenBits ), abs( random.nextInt() ) );
     }
 
@@ -105,7 +110,7 @@ public class LimitedRecordGenerators implements RecordGenerators
     public Generator<PropertyRecord> property()
     {
         return (recordSize, format) -> {
-            PropertyRecord record = new PropertyRecord( 0 );
+            PropertyRecord record = new PropertyRecord( randomId() );
             int maxProperties = random.intBetween( 1, 4 );
             StandaloneDynamicRecordAllocator stringAllocator = new StandaloneDynamicRecordAllocator();
             StandaloneDynamicRecordAllocator arrayAllocator = new StandaloneDynamicRecordAllocator();
@@ -134,7 +139,7 @@ public class LimitedRecordGenerators implements RecordGenerators
     @Override
     public Generator<NodeRecord> node()
     {
-        return (recordSize, format) -> new NodeRecord( 0 ).initialize(
+        return (recordSize, format) -> new NodeRecord( randomId() ).initialize(
                 random.nextBoolean(), randomLongOrOccasionallyNull( propertyBits ), random.nextBoolean(),
                 randomLongOrOccasionallyNull( entityBits ),
                 randomLongOrOccasionallyNull( nodeLabelBits, 0 ) );
@@ -143,7 +148,7 @@ public class LimitedRecordGenerators implements RecordGenerators
     @Override
     public Generator<LabelTokenRecord> labelToken()
     {
-        return (recordSize, format) -> new LabelTokenRecord( 0 ).initialize(
+        return (recordSize, format) -> new LabelTokenRecord( randomId() ).initialize(
                 random.nextBoolean(), random.nextInt( tokenBits ) );
     }
 
@@ -154,7 +159,7 @@ public class LimitedRecordGenerators implements RecordGenerators
             int dataSize = recordSize - format.getRecordHeaderSize();
             int length = random.nextBoolean() ? dataSize : random.nextInt( dataSize );
             long next = length == dataSize ? randomLong( propertyBits ) : nullValue;
-            DynamicRecord record = new DynamicRecord( 1 ).initialize( random.nextBoolean(),
+            DynamicRecord record = new DynamicRecord( random.nextInt( 1, 5 ) ).initialize( random.nextBoolean(),
                     random.nextBoolean(), next, random.nextInt( PropertyType.values().length ), length );
             byte[] data = new byte[record.getLength()];
             random.nextBytes( data );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
@@ -158,6 +158,7 @@ public abstract class RecordFormatTest
             for ( ; i < TEST_ITERATIONS && currentTimeMillis() < endTime; i++ )
             {
                 R written = generator.get( recordSize, format );
+                R read = format.newRecord();
                 try
                 {
                     writeRecord( written, format, storeFile, recordSize, idSequence );
@@ -166,7 +167,7 @@ public abstract class RecordFormatTest
                     long unusedBytes = storeFile.unusedBytes();
                     storeFile.resetMeasurements();
 
-                    readAndVerifyRecord( written, format, key, storeFile, recordSize );
+                    readAndVerifyRecord( written, read, format, key, storeFile, recordSize );
 
                     if ( written.inUse() )
                     {
@@ -193,7 +194,8 @@ public abstract class RecordFormatTest
                 }
                 catch ( Throwable t )
                 {
-                    Exceptions.setMessage( t, t.getMessage() + " : " + written );
+                    Exceptions.setMessage( t, t.getMessage() + " : written:" + written + ", read:" + read +
+                            ", seed:" + random.seed() );
                     throw t;
                 }
             }
@@ -215,13 +217,12 @@ public abstract class RecordFormatTest
         }
     }
 
-    private <R extends AbstractBaseRecord> void readAndVerifyRecord( R written, RecordFormat<R> format,
+    private <R extends AbstractBaseRecord> void readAndVerifyRecord( R written, R read, RecordFormat<R> format,
             RecordKey<R> key, PagedFile storeFile, int recordSize ) throws IOException
     {
         try ( PageCursor cursor = storeFile.io( 0, PagedFile.PF_SHARED_READ_LOCK ) )
         {
             assertedNext( cursor );
-            R read = format.newRecord();
             read.setId( written.getId() );
 
             /**

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
@@ -27,8 +27,6 @@ import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 
 import static org.neo4j.kernel.impl.store.format.highlimit.Reference.PAGE_CURSOR_ADAPTER;
-import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toAbsolute;
-import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toRelative;
 
 /**
  * {@link PropertyRecord} format which currently has some wasted space in the end due to hard coded
@@ -54,10 +52,9 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
             long headerByte, boolean inUse ) throws IOException
     {
         int blockCount = (int) (headerByte >>> 4);
-        long recordId = record.getId();
         record.initialize( inUse,
-                toAbsolute( Reference.decode( cursor, PAGE_CURSOR_ADAPTER ), recordId ),
-                toAbsolute( Reference.decode( cursor, PAGE_CURSOR_ADAPTER ), recordId ) );
+                Reference.decode( cursor, PAGE_CURSOR_ADAPTER ),
+                Reference.decode( cursor, PAGE_CURSOR_ADAPTER ) );
         while ( blockCount-- > 0 )
         {
             record.addLoadedBlock( cursor.getLong() );
@@ -69,9 +66,8 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
             throws IOException
     {
         cursor.putByte( (byte) ((record.inUse() ? IN_USE_BIT : 0) | numberOfBlocks( record ) << 4) );
-        long recordId = record.getId();
-        Reference.encode( toRelative( record.getPrevProp(), recordId), cursor, PAGE_CURSOR_ADAPTER );
-        Reference.encode( toRelative( record.getNextProp(), recordId), cursor, PAGE_CURSOR_ADAPTER );
+        Reference.encode( record.getPrevProp(), cursor, PAGE_CURSOR_ADAPTER );
+        Reference.encode( record.getNextProp(), cursor, PAGE_CURSOR_ADAPTER );
         for ( PropertyBlock block : record )
         {
             for ( long propertyBlock : block.getValueBlocks() )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/Reference.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/Reference.java
@@ -228,7 +228,6 @@ enum Reference
                 + " as a reference" );
     }
 
-
     /**
      * Convert provided reference to be relative to basisReference
      * @param reference reference that will be converter to relative


### PR DESCRIPTION
due to it being broken, as shown by consistency checker.
The reason why the problems with them weren't exposed in RecordFormatTest
was that the generated records always had id 0, which was neutral
with regards to relative references. Testing has now been improved
in this commit to expose these problems.

Properly implementing relative references with the current assumptions
around -1 proved to be complicated in a number of ways, which is
the reason why relative references are now disabled instead of fixed
in this commit.

Relative references can of course be enabled at a later point, but for
now it's valuable to have a functioning format in place.
