### PR TITLE
Status codes for unavailability and improve error messages.

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/NotInTransactionException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/NotInTransactionException.java
@@ -28,7 +28,8 @@ public class NotInTransactionException extends RuntimeException
 {
     public NotInTransactionException()
     {
-        super();
+        super("The requested operation cannot be performed, because it has to be performed in a transaction. " +
+              "Ensure you are wrapping your operation in the appropriate transaction boilerplate and try again.");
     }
 
     public NotInTransactionException( String message )

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransactionTerminatedException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/TransactionTerminatedException.java
@@ -27,6 +27,10 @@ public class TransactionTerminatedException extends TransactionFailureException
 {
     public TransactionTerminatedException()
     {
-        super( "The transaction has been terminated." );
+        super( "The transaction has been terminated, no new operations in it " +
+               "are allowed. This normally happens because a client explicitly asks to terminate the transaction, " +
+               "for instance to stop a long-running operation. It may also happen because an operator has asked the " +
+               "database to be shut down, or because the current instance is about to perform a cluster role change. " +
+               "Simply retry your operation in a new transaction, and you should see a successful result." );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/GraphDatabaseServiceTest.java
@@ -22,6 +22,7 @@ package org.neo4j.graphdb;
 import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -43,6 +44,8 @@ import static org.junit.Assert.fail;
 
 public class GraphDatabaseServiceTest
 {
+    @Rule public ExpectedException exception = ExpectedException.none();
+
     @Test
     public void givenShutdownDatabaseWhenBeginTxThenExceptionIsThrown() throws Exception
     {
@@ -51,17 +54,11 @@ public class GraphDatabaseServiceTest
 
         db.shutdown();
 
+        // Expect
+        exception.expect( DatabaseShutdownException.class );
+
         // When
-        try
-        {
-            db.beginTx();
-            fail();
-        }
-        catch ( Exception e )
-        {
-            // Then
-            assertThat( e.getClass().getName(), CoreMatchers.equalTo( DatabaseShutdownException.class.getName() ) );
-        }
+        db.beginTx();
     }
 
     @Test


### PR DESCRIPTION
More parts of legacy code where exceptions are missing `Status`, causing big error reports in QA runs, took the opportunity to improve error messages as well.
