### PR TITLE
3.0 reset abort

### DIFF
--- a/community/bolt/src/docs/dev/messaging.asciidoc
+++ b/community/bolt/src/docs/dev/messaging.asciidoc
@@ -114,8 +114,15 @@ B1 01 8C 4D  79 43 6C 69  65 6E 74 2F  31 2E 30 A3
 ==== RESET
 
 The `RESET` message is a client message used to return the current session to a "clean" state.
+It will cause the session to `IGNORE` any message it is currently processing, as well as any message before `RESET` that had not yet begun processing.
+This allows `RESET` to abort long-running operations.
+It also means clients must be careful about pipelining `RESET`.
+Only send this if you are not currently waiting for a result from a prior message, or if you want to explicitly abort any prior message.
+
 The following actions are performed by `RESET`:
 
+- force any currently processing message to abort with `IGNORE`
+- force any pending messages that have not yet started processing to be `IGNORED`
 - clear any outstanding `FAILURE` state
 - dispose of any outstanding result records
 - rollback the current transaction (if any)

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredSessions.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredSessions.java
@@ -113,6 +113,12 @@ public class MonitoredSessions implements Sessions
         }
 
         @Override
+        public void interrupt()
+        {
+            delegate.interrupt();
+        }
+
+        @Override
         public void close()
         {
             delegate.close();

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Session.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Session.java
@@ -155,6 +155,22 @@ public interface Session extends AutoCloseable
      */
     <A> void reset( A attachment, Callback<Void,A> callback );
 
+    /**
+     * This is a special mechanism, it is the only method on this interface
+     * that is thread safe. When this is invoked, the machine will make attempts
+     * at interrupting any currently running action,
+     * and will then ignore all inbound messages until a {@link #reset(Object, Callback) reset}
+     * message is received. If this is called multiple times, an equivalent number
+     * of reset messages must be received before the SSM goes back to a good state.
+     *
+     * You can imagine this is as a "call ahead" mechanism used by RESET to
+     * cancel any statements ahead of it in line, without compromising the single-
+     * threaded processing of messages that the state machine does.
+     *
+     * This can be used to cancel a long-running statement or transaction.
+     */
+    void interrupt();
+
     @Override
     void close();
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReportingSession.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReportingSession.java
@@ -83,6 +83,12 @@ public class ErrorReportingSession implements Session
     }
 
     @Override
+    public void interrupt()
+    {
+
+    }
+
+    @Override
     public void close()
     {
     }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/StandardStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/StandardStateMachineSPI.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.bolt.v1.runtime.internal;
 
 import java.util.Map;

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/StandardStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/StandardStateMachineSPI.java
@@ -1,0 +1,102 @@
+package org.neo4j.bolt.v1.runtime.internal;
+
+import java.util.Map;
+
+import org.neo4j.bolt.security.auth.Authentication;
+import org.neo4j.bolt.security.auth.AuthenticationException;
+import org.neo4j.bolt.v1.runtime.spi.RecordStream;
+import org.neo4j.bolt.v1.runtime.spi.StatementRunner;
+import org.neo4j.concurrent.DecayingFlags;
+import org.neo4j.kernel.api.AccessMode;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.Log;
+import org.neo4j.udc.UsageData;
+import org.neo4j.udc.UsageDataKeys;
+
+class StandardStateMachineSPI implements SessionStateMachine.SPI
+{
+    private final UsageData usageData;
+    private final GraphDatabaseFacade db;
+    private final StatementRunner statementRunner;
+    private final ErrorReporter errorReporter;
+    private final Log log;
+    private final Authentication authentication;
+    private final ThreadToStatementContextBridge txBridge;
+    private final DecayingFlags featureUsage;
+
+    StandardStateMachineSPI( UsageData usageData, GraphDatabaseFacade db, StatementRunner statementRunner,
+            LogService logging, Authentication authentication, ThreadToStatementContextBridge txBridge )
+    {
+        this.usageData = usageData;
+        this.db = db;
+        this.statementRunner = statementRunner;
+        this.txBridge = txBridge;
+        this.featureUsage = usageData.get( UsageDataKeys.features );
+        this.errorReporter = new ErrorReporter( logging, this.usageData );
+        this.log = logging.getInternalLog( SessionStateMachine.class );
+        this.authentication = authentication;
+    }
+
+    @Override
+    public void reportError( Neo4jError err )
+    {
+        errorReporter.report( err );
+    }
+
+    @Override
+    public void reportError( String message, Throwable cause )
+    {
+        log.error( message, cause );
+    }
+
+    @Override
+    public KernelTransaction beginTransaction( KernelTransaction.Type type, AccessMode mode )
+    {
+        db.beginTransaction( type, mode );
+        return txBridge.getKernelTransactionBoundToThisThread( false );
+    }
+
+    @Override
+    public void bindTransactionToCurrentThread( KernelTransaction tx )
+    {
+        txBridge.bindTransactionToCurrentThread( tx );
+    }
+
+    @Override
+    public void unbindTransactionFromCurrentThread()
+    {
+        txBridge.unbindTransactionFromCurrentThread();
+    }
+
+    @Override
+    public RecordStream run( SessionStateMachine ctx, String statement, Map<String,Object> params )
+            throws KernelException
+    {
+
+        featureUsage.flag( UsageDataKeys.Features.bolt );
+        return statementRunner.run( ctx, statement, params );
+    }
+
+    @Override
+    public void authenticate( Map<String,Object> authToken ) throws AuthenticationException
+    {
+        authentication.authenticate( authToken );
+    }
+
+    @Override
+    public void udcRegisterClient( String clientName )
+    {
+        usageData.get( UsageDataKeys.clientNames ).add( clientName );
+    }
+
+    @Override
+    public Statement currentStatement()
+    {
+        return txBridge.get();
+    }
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/concurrent/SessionWorker.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/concurrent/SessionWorker.java
@@ -116,4 +116,14 @@ public class SessionWorker implements Runnable
             work.accept( session );
         }
     }
+
+    /**
+     * Interrupt this worker, making it cancel any currently active message
+     * processing, and then ignore all inbound messages until a RESET message
+     * is recieved.
+     */
+    public void interrupt()
+    {
+        session.interrupt();
+    }
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/concurrent/SessionWorkerFacade.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/concurrent/SessionWorkerFacade.java
@@ -75,7 +75,14 @@ public class SessionWorkerFacade implements Session
     @Override
     public <A> void reset( final A attachment, final Callback<Void,A> callback )
     {
+        worker.interrupt();
         queue( session -> session.reset( attachment, callback ) );
+    }
+
+    @Override
+    public void interrupt()
+    {
+        worker.interrupt();
     }
 
     @Override

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredSessionsTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredSessionsTest.java
@@ -165,6 +165,12 @@ public class MonitoredSessionsTest
         }
 
         @Override
+        public void interrupt()
+        {
+
+        }
+
+        @Override
         public void close()
         {
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/RecordingCallback.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/RecordingCallback.java
@@ -33,10 +33,18 @@ import org.neo4j.bolt.v1.runtime.internal.Neo4jError;
 import org.neo4j.bolt.v1.runtime.spi.ImmutableRecord;
 import org.neo4j.bolt.v1.runtime.spi.Record;
 import org.neo4j.bolt.v1.runtime.spi.RecordStream;
+import org.neo4j.helpers.collection.Iterables;
 
 public class RecordingCallback<V, A> implements Session.Callback<V,A>
 {
     private final BlockingQueue<Call> calls = new ArrayBlockingQueue<>( 64 );
+
+    /** Used for toString etc. to help debugging */
+    private final List<Call> seenCalls = new LinkedList<>();
+
+    private List<Call> results = new LinkedList<>();
+    private List<Neo4jError> errors = new LinkedList<>();
+    private boolean ignored;
 
     public Call next() throws InterruptedException
     {
@@ -45,12 +53,9 @@ public class RecordingCallback<V, A> implements Session.Callback<V,A>
         {
             throw new RuntimeException( "Waited 10 seconds for message, but no message arrived." );
         }
+        seenCalls.add( msg );
         return msg;
     }
-
-    private List<Call> results = new LinkedList<>();
-    private List<Neo4jError> errors = new LinkedList<>();
-    private boolean ignored;
 
     @Override
     public void started( A attachment )
@@ -146,6 +151,12 @@ public class RecordingCallback<V, A> implements Session.Callback<V,A>
         {
             return false;
         }
+
+        @Override
+        public String toString()
+        {
+            return getClass().getSimpleName();
+        }
     }
 
     public static class Success extends Call
@@ -154,6 +165,12 @@ public class RecordingCallback<V, A> implements Session.Callback<V,A>
         public boolean isSuccess()
         {
             return true;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "SUCCESS";
         }
     }
 
@@ -193,6 +210,12 @@ public class RecordingCallback<V, A> implements Session.Callback<V,A>
         {
             return meta;
         }
+
+        @Override
+        public String toString()
+        {
+            return "SUCCESS " + meta;
+        }
     }
 
     public static class Ignored extends Call
@@ -201,6 +224,12 @@ public class RecordingCallback<V, A> implements Session.Callback<V,A>
         public boolean isIgnored()
         {
             return true;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "IGNORED";
         }
     }
 
@@ -244,5 +273,11 @@ public class RecordingCallback<V, A> implements Session.Callback<V,A>
             }
         } );
         return values.toArray( new Record[values.size()] );
+    }
+
+    @Override
+    public String toString()
+    {
+        return Iterables.toString( seenCalls, ", " );
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionMatchers.java
@@ -43,7 +43,7 @@ public class SessionMatchers
             @Override
             public void describeTo( Description description )
             {
-
+                description.appendText( "SUCCESS" );
             }
         };
     }
@@ -132,7 +132,7 @@ public class SessionMatchers
             @Override
             public void describeTo( Description description )
             {
-                description.appendText( "ignored" );
+                description.appendText( "IGNORED" );
             }
         };
     }
@@ -165,7 +165,7 @@ public class SessionMatchers
             @Override
             public void describeTo( Description description )
             {
-                description.appendList( "[", "\n", "]", asList(messages) );
+                description.appendList( "[", ", ", "]", asList(messages) );
             }
         };
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionMatchers.java
@@ -136,4 +136,37 @@ public class SessionMatchers
             }
         };
     }
+
+    public static Matcher<RecordingCallback> recorded( Matcher<? super RecordingCallback.Call> ... messages )
+    {
+        return new TypeSafeMatcher<RecordingCallback>()
+        {
+            @Override
+            protected boolean matchesSafely( RecordingCallback recordingCallback )
+            {
+                for ( Matcher<? super RecordingCallback.Call> message : messages )
+                {
+                    try
+                    {
+                        if(!message.matches( recordingCallback.next() ))
+                        {
+                            return false;
+                        }
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        throw new RuntimeException( e );
+                    }
+                }
+
+                return true;
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendList( "[", "\n", "]", asList(messages) );
+            }
+        };
+    }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime.internal;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.bolt.security.auth.AuthenticationException;
+import org.neo4j.bolt.v1.messaging.MessageHandler;
+import org.neo4j.bolt.v1.messaging.message.DiscardAllMessage;
+import org.neo4j.bolt.v1.messaging.message.Message;
+import org.neo4j.bolt.v1.messaging.message.PullAllMessage;
+import org.neo4j.bolt.v1.messaging.message.ResetMessage;
+import org.neo4j.bolt.v1.messaging.message.RunMessage;
+import org.neo4j.bolt.v1.messaging.msgprocess.TransportBridge;
+import org.neo4j.bolt.v1.runtime.Session;
+import org.neo4j.bolt.v1.runtime.integration.RecordingCallback;
+import org.neo4j.bolt.v1.runtime.internal.concurrent.ThreadedSessions;
+import org.neo4j.bolt.v1.runtime.spi.RecordStream;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.api.AccessMode;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.logging.NullLog;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.recorded;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.success;
+import static org.neo4j.bolt.v1.runtime.internal.SessionStateMachine.State.IDLE;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class ResetFuzzTest
+{
+    // Because RESET has a "call ahead" mechanism where it will interrupt
+    // the session before RESET arrives in order to purge any statements
+    // ahead in the message queue, we use this test to convince ourselves
+    // there is no code path where RESET causes a session to not go back
+    // to a good state.
+
+    private final int seed = new Random().nextInt();
+
+    private final Random rand = new Random( seed );
+    private final LifeSupport life = new LifeSupport();
+    /** We track the number of un-closed transactions, and fail if we ever leak one */
+    private final AtomicLong liveTransactions = new AtomicLong();
+    private final Neo4jJobScheduler scheduler = life.add(new Neo4jJobScheduler());
+    private final SessionStateMachine ssm = new SessionStateMachine( new FuzzStubSPI() );
+    private final ThreadedSessions sessions =
+            new ThreadedSessions( ( enc ) -> ssm, scheduler, NullLogService.getInstance() );
+
+    private final List<Message> messages = asList(
+        new RunMessage( "test", map() ),
+        new DiscardAllMessage(),
+        new PullAllMessage(),
+        new ResetMessage()
+    );
+
+    private final List<Message> sent = new LinkedList<>();
+
+    @Test
+    public void shouldAlwaysReturnToIdleAfterReset() throws Throwable
+    {
+        // given
+        life.start();
+        Session session = sessions.newSession();
+        session.init( "Test/0.0.0", map(), null, Session.Callback.NO_OP );
+
+        TransportBridge bridge = new TransportBridge(
+                NullLog.getInstance(), session, new MessageHandler.Adapter<>(), ( () -> {} ) );
+
+        // 5 seconds lead to testing ~1M permutations on my 5-year old MBP, so
+        // 2 seconds seemed like a sensible balance, testing 300K permutations or
+        // so per run without taking up too much test time. Simply bump this to
+        // run a longer test. This was green at 300 second runs when this is written.
+        long deadline = System.currentTimeMillis() + 2 * 1000;
+
+        // when
+        while( System.currentTimeMillis() < deadline )
+        {
+            dispatchRandomMessages( bridge );
+            assertSessionWorks( session );
+        }
+    }
+
+    private void assertSessionWorks( Session session )
+    {
+        RecordingCallback recorder = new RecordingCallback();
+        session.reset( null, recorder );
+
+        try
+        {
+            assertThat( recorder, recorded( success() ) );
+            assertThat( ssm.state(), equalTo( IDLE ) );
+            assertThat( liveTransactions.get(), equalTo( 0L ));
+        }
+        catch( AssertionError e )
+        {
+            throw new AssertionError( String.format( "Expected session to return to good state after RESET, but " +
+                                                     "assertion failed: %s.%n" +
+                                                     "Seed: %s%n" +
+                                                     "Messages sent:%n" +
+                                                     "%s",
+                    e.getMessage(), seed, Iterables.toString( sent, "\n" ) ), e );
+        }
+    }
+
+    private void dispatchRandomMessages( MessageHandler session )
+    {
+        for ( int i = 0; i < 50; i++ )
+        {
+            Message message = messages.get( rand.nextInt( messages.size() ) );
+            sent.add( message );
+            message.dispatch( session );
+        }
+    }
+
+    @After
+    public void cleanup()
+    {
+        life.shutdown();
+    }
+
+    /**
+     * We can't use mockito to create this, because it stores all invocations,
+     * so we run out of RAM in like five seconds.
+     */
+    private class FuzzStubSPI implements SessionStateMachine.SPI
+    {
+        @Override
+        public void reportError( Neo4jError err )
+        {
+
+        }
+
+        @Override
+        public void reportError( String message, Throwable cause )
+        {
+
+        }
+
+        @Override
+        public KernelTransaction beginTransaction( KernelTransaction.Type type, AccessMode mode )
+        {
+            liveTransactions.incrementAndGet();
+            return new CloseTrackingKernelTransaction();
+        }
+
+        @Override
+        public void bindTransactionToCurrentThread( KernelTransaction tx )
+        {
+
+        }
+
+        @Override
+        public void unbindTransactionFromCurrentThread()
+        {
+
+        }
+
+        @Override
+        public RecordStream run( SessionStateMachine ctx, String statement, Map<String,Object> params )
+                throws KernelException
+        {
+            return RecordStream.EMPTY;
+        }
+
+        @Override
+        public void authenticate( Map<String,Object> authToken ) throws AuthenticationException
+        {
+
+        }
+
+        @Override
+        public void udcRegisterClient( String clientName )
+        {
+
+        }
+
+        @Override
+        public Statement currentStatement()
+        {
+            return null;
+        }
+    }
+
+    /**
+     * Used to track begin/close of transactions, ensuring we never leak
+     * a transaction.
+     */
+    private class CloseTrackingKernelTransaction implements KernelTransaction
+    {
+        @Override
+        public Statement acquireStatement()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void success()
+        {
+
+        }
+
+        @Override
+        public void failure()
+        {
+
+        }
+
+        @Override
+        public void close() throws TransactionFailureException
+        {
+            liveTransactions.decrementAndGet();
+        }
+
+        @Override
+        public boolean isOpen()
+        {
+            return false;
+        }
+
+        @Override
+        public AccessMode mode()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean shouldBeTerminated()
+        {
+            return false;
+        }
+
+        @Override
+        public void markForTermination()
+        {
+
+        }
+
+        @Override
+        public void registerCloseListener( CloseListener listener )
+        {
+
+        }
+
+        @Override
+        public Type transactionType()
+        {
+            return null;
+        }
+
+        @Override
+        public Revertable restrict( AccessMode read )
+        {
+            return null;
+        }
+    }
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineResetTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineResetTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime.internal;
+
+import org.junit.Test;
+
+import org.neo4j.bolt.v1.runtime.integration.RecordingCallback;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.bolt.v1.runtime.Session.Callback.noOp;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.ignored;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.recorded;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.success;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class SessionStateMachineResetTest
+{
+    @Test
+    public void shouldKillMessagesAheadInLine() throws Throwable
+    {
+        // Given
+        RecordingCallback recorder = new RecordingCallback();
+        SessionStateMachine ssm = new SessionStateMachine( mock( SessionStateMachine.SPI.class ) );
+        ssm.init( "bob/1.0", map(), null, noOp() );
+
+        // When
+        ssm.interrupt();
+        
+        // Then
+        ssm.run( "hello", map(), null, recorder );
+        ssm.reset( null, recorder );
+        ssm.run( "hello", map(), null, recorder );
+        assertThat( recorder, recorded(
+            ignored(),
+            success(),
+            success()
+        ));
+    }
+
+    @Test
+    public void multipleInterruptsShouldBeMatchedWithMultipleResets() throws Throwable
+    {
+        // Given
+        RecordingCallback recorder = new RecordingCallback();
+        SessionStateMachine ssm = new SessionStateMachine( mock( SessionStateMachine.SPI.class ) );
+        ssm.init( "bob/1.0", map(), null, noOp() );
+
+        // When
+        ssm.interrupt();
+        ssm.interrupt();
+
+        // Then
+        ssm.run( "hello", map(), null, recorder );
+        ssm.reset( null, recorder );
+        ssm.run( "hello", map(), null, recorder );
+        assertThat( recorder, recorded(
+                ignored(),
+                ignored(),
+                ignored()
+        ));
+
+        recorder = new RecordingCallback(); // to get a clean recording
+
+        // But when
+        ssm.reset( null, recorder );
+
+        // Then
+        ssm.run( "hello", map(), null, recorder );
+        assertThat( recorder, recorded(
+                success(),
+                success()
+        ));
+    }
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
@@ -43,7 +43,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.bolt.v1.messaging.message.Messages.init;
 import static org.neo4j.bolt.v1.messaging.message.Messages.pullAll;
-import static org.neo4j.bolt.v1.messaging.message.Messages.reset;
 import static org.neo4j.bolt.v1.messaging.message.Messages.run;
 import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.msgRecord;
 import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.msgSuccess;
@@ -129,32 +128,6 @@ public class TransportSessionIT
                 msgRecord( eqRecord( equalTo( 1L ), equalTo( 1L ) ) ),
                 msgRecord( eqRecord( equalTo( 2L ), equalTo( 4L ) ) ),
                 msgRecord( eqRecord( equalTo( 3L ), equalTo( 9L ) ) ),
-                msgSuccess() ) );
-    }
-
-    @Test
-    public void shouldResetWhileRecordsOutstanding() throws Throwable
-    {
-        // When
-        client.connect( address )
-                .send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
-                .send( TransportTestUtil.chunk(
-                        init( "TestClient/1.1", emptyMap() ),
-                        run( "RETURN 1 AS n" ),
-                        reset(),
-                        run( "UNWIND [1,2,3] AS a RETURN a, a * a AS a_squared" ),
-                        pullAll() ) );
-
-        // Then
-        assertThat( client, eventuallyRecieves( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyRecieves(
-                msgSuccess(),
-                msgSuccess( map( "fields", asList( "n" ) ) ),
-                msgSuccess(),
-                msgSuccess( map( "fields", asList( "a", "a_squared" ) ) ),
-                msgRecord( eqRecord( equalTo( 1l ), equalTo( 1l ) ) ),
-                msgRecord( eqRecord( equalTo( 2l ), equalTo( 4l ) ) ),
-                msgRecord( eqRecord( equalTo( 3l ), equalTo( 9l ) ) ),
                 msgSuccess() ) );
     }
 


### PR DESCRIPTION
- RESET processes just like before, but if there are pending messages
  ahead of RESET on a session, the system will now make best-effort at
  `IGNORE`-ing those.
- If there is currently a transaction processing on the session,
  that transaction will be marked for termination, leading to a FAILURE
  message reply.

All in all, this change makes no difference to current implementations
that would wait for processing to complete before sending RESET anyway,
but means RESET can now be used to kill a long-running statement.
