### PR TITLE
Remove non-existent services

### DIFF
--- a/advanced/management/src/main/resources/META-INF/services/com.sun.tools.jconsole.JConsolePlugin
+++ b/advanced/management/src/main/resources/META-INF/services/com.sun.tools.jconsole.JConsolePlugin
@@ -1,1 +1,0 @@
-org.neo4j.management.impl.jconsole.Neo4jPlugin

--- a/advanced/management/src/main/resources/META-INF/services/org.neo4j.jmx.impl.ManagementBeanProvider
+++ b/advanced/management/src/main/resources/META-INF/services/org.neo4j.jmx.impl.ManagementBeanProvider
@@ -1,4 +1,3 @@
-org.neo4j.management.impl.CacheBean
 org.neo4j.management.impl.LockManagerBean
 org.neo4j.management.impl.IndexSamplingManagerBean
 org.neo4j.management.impl.MemoryMappingBean

--- a/community/kernel/src/main/resources/META-INF/services/org.neo4j.kernel.impl.cache.CacheProvider
+++ b/community/kernel/src/main/resources/META-INF/services/org.neo4j.kernel.impl.cache.CacheProvider
@@ -1,4 +1,0 @@
-org.neo4j.kernel.impl.cache.SoftCacheProvider
-org.neo4j.kernel.impl.cache.WeakCacheProvider
-org.neo4j.kernel.impl.cache.StrongCacheProvider
-org.neo4j.kernel.impl.cache.NoCacheProvider


### PR DESCRIPTION
Be aware when forward merge to 3.0 that the advance services have been moved in enterprise so the changes should be applied there.
