### PR TITLE
new-credentials changed to new_credentials

### DIFF
--- a/community/bolt/src/docs/dev/examples.asciidoc
+++ b/community/bolt/src/docs/dev/examples.asciidoc
@@ -42,15 +42,14 @@ Client: 60 60 B0 17
 Client: 00 00 00 01  00 00 00 00  00 00 00 00  00 00 00 00
 Server: 00 00 00 01
 
-Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credentials": "neo4j", "new-credentials": "secret"}
+Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credentials": "neo4j", "new_credentials": "secret"}
 
     00 40 B1 01  8C 4D 79 43  6C 69 65 6E  74 2F 31 2E
     30 A4 86 73  63 68 65 6D  65 85 62 61  73 69 63 89
     70 72 69 6E  63 69 70 61  6C 85 6E 65  6F 34 6A 8B
     63 72 65 64  65 6E 74 69  61 6C 73 85  6E 65 6F 34
-    6A 8F 00 16  6E 65 77 2D  63 72 65 64  65 6E 74 69
+    6A 8F 00 16  6E 65 77 5F  63 72 65 64  65 6E 74 69
     61 6C 73 86  73 65 63 72  65 74 00 00
-
 
 Server: SUCCESS { }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/Authentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/Authentication.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * </ul>
  * <p>
  *
- * For updating the credentials the new credentials is supplied with the key <code>new-credentials</code>.
+ * For updating the credentials the new credentials is supplied with the key <code>new_credentials</code>.
  */
 public interface Authentication
 {
@@ -55,5 +55,5 @@ public interface Authentication
     String SCHEME_KEY = "scheme";
     String PRINCIPAL = "principal";
     String CREDENTIALS = "credentials";
-    String NEW_CREDENTIALS = "new-credentials";
+    String NEW_CREDENTIALS = "new_credentials";
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
@@ -128,7 +128,7 @@ public class BasicAuthenticationTest
 
         // When
         authentication.authenticate( map( "scheme", "basic", "principal", "bob", "credentials", "secret",
-                "new-credentials", "secret2" ) );
+                "new_credentials", "secret2" ) );
     }
 
     @Test
@@ -144,7 +144,7 @@ public class BasicAuthenticationTest
 
         // When
         authentication.authenticate( map( "scheme", "basic", "principal", "bob", "credentials", "secret",
-                "new-credentials", "secret2" ) );
+                "new_credentials", "secret2" ) );
     }
 
     @Test
@@ -163,7 +163,7 @@ public class BasicAuthenticationTest
         // When
         // When
         authentication.authenticate( map( "scheme", "basic", "principal", "bob", "credentials", "secret",
-                "new-credentials", "secret2" ) );
+                "new_credentials", "secret2" ) );
     }
 
     @Test

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -126,7 +126,7 @@ public class AuthenticationIT
                 .send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
                 .send( TransportTestUtil.chunk(
                         init( "TestClient/1.1", map( "principal", "neo4j",
-                                "credentials", "neo4j", "new-credentials", "secret", "scheme", "basic" ) ) ) );
+                                "credentials", "neo4j", "new_credentials", "secret", "scheme", "basic" ) ) ) );
 
         // Then
         assertThat( client, eventuallyRecieves( new byte[]{0, 0, 0, 1} ) );


### PR DESCRIPTION
`new-credentials` is not a valid json property name which
makes it cumbersome to use in languages that supports json natively
or have easy conversion between objects and `maps` or `dictionaries`.
