### PR TITLE
Specify sender address for network communication

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupClient.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupClient.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.backup;
 
+import java.io.IOException;
+
 import org.jboss.netty.buffer.ChannelBuffer;
 
 import org.neo4j.com.Client;
@@ -42,21 +44,20 @@ import org.neo4j.kernel.monitoring.Monitors;
 import static org.neo4j.backup.BackupServer.FRAME_LENGTH;
 import static org.neo4j.backup.BackupServer.PROTOCOL_VERSION;
 
-import java.io.IOException;
-
 
 class BackupClient extends Client<TheBackupInterface> implements TheBackupInterface
 {
 
     static final long BIG_READ_TIMEOUT = 40 * 1000;
 
-    public BackupClient( String hostNameOrIp, int port, Logging logging, StoreId storeId, long timeout,
-                         ResponseUnpacker unpacker, ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
+    public BackupClient( String destinationHostNameOrIp, int destinationPort, String originHostNameOrIp,
+            Logging logging, StoreId storeId, long timeout, ResponseUnpacker unpacker,
+            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, storeId, FRAME_LENGTH,
+        super( destinationHostNameOrIp, destinationPort, originHostNameOrIp, logging, storeId, FRAME_LENGTH,
                 new ProtocolVersion( PROTOCOL_VERSION, ProtocolVersion.INTERNAL_PROTOCOL_VERSION ), timeout,
-                Client.DEFAULT_MAX_NUMBER_OF_CONCURRENT_CHANNELS_PER_CLIENT, FRAME_LENGTH, unpacker,
-                byteCounterMonitor, requestMonitor );
+                Client.DEFAULT_MAX_NUMBER_OF_CONCURRENT_CHANNELS_PER_CLIENT, FRAME_LENGTH, unpacker, byteCounterMonitor,
+                requestMonitor );
     }
 
     public Response<Void> fullBackup( StoreWriter storeWriter, final boolean forensics )

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -151,7 +151,7 @@ class BackupService
                 @Override
                 public Response<?> copyStore( StoreWriter writer )
                 {
-                    client = new BackupClient( sourceHostNameOrIp, sourcePort, new DevNullLoggingService(),
+                    client = new BackupClient( sourceHostNameOrIp, sourcePort, null, new DevNullLoggingService(),
                             StoreId.DEFAULT, timeout, ResponseUnpacker.NO_OP_RESPONSE_UNPACKER,
                             monitors.newMonitor( ByteCounterMonitor.class ),
                             monitors.newMonitor( RequestMonitor.class ) );
@@ -265,8 +265,8 @@ class BackupService
         }
     }
 
-    BackupOutcome doIncrementalBackup( String sourceHostNameOrIp, int sourcePort, GraphDatabaseAPI targetDb, long timeout )
-            throws IncrementalBackupNotPossibleException
+    BackupOutcome doIncrementalBackup( String sourceHostNameOrIp, int sourcePort, GraphDatabaseAPI targetDb,
+            long timeout ) throws IncrementalBackupNotPossibleException
     {
         return incrementalWithContext( sourceHostNameOrIp, sourcePort, targetDb, timeout, slaveContextOf( targetDb ) );
     }
@@ -317,7 +317,7 @@ class BackupService
      * @return A backup context, ready to perform
      */
     private BackupOutcome incrementalWithContext( String sourceHostNameOrIp, int sourcePort, GraphDatabaseAPI targetDb,
-                                                  long timeout, RequestContext context ) throws IncrementalBackupNotPossibleException
+            long timeout, RequestContext context ) throws IncrementalBackupNotPossibleException
     {
         DependencyResolver resolver = targetDb.getDependencyResolver();
 
@@ -326,7 +326,7 @@ class BackupService
                 new TransactionCommittingResponseUnpacker( resolver, 100 );
 
         Monitors monitors = resolver.resolveDependency( Monitors.class );
-        BackupClient client = new BackupClient( sourceHostNameOrIp, sourcePort,
+        BackupClient client = new BackupClient( sourceHostNameOrIp, sourcePort, null,
                 resolver.resolveDependency( Logging.class ), targetDb.storeId(), timeout, unpacker,
                 monitors.newMonitor( ByteCounterMonitor.class, BackupClient.class ),
                 monitors.newMonitor( RequestMonitor.class, BackupClient.class ) );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolTest.java
@@ -73,7 +73,7 @@ public class BackupProtocolTest
         int port = BackupServer.DEFAULT_PORT;
         LifeSupport life = new LifeSupport();
 
-        BackupClient client = life.add( new BackupClient( host, port, logging, storeId, 1000,
+        BackupClient client = life.add( new BackupClient( host, port, null, logging, storeId, 1000,
                 mock( ResponseUnpacker.class ), mock( ByteCounterMonitor.class ), mock( RequestMonitor.class ) ) );
         ControlledBackupInterface backup = new ControlledBackupInterface();
         life.add( new BackupServer( backup, new HostnamePort( host, port ), logging, mock( ByteCounterMonitor.class ),

--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpClient.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.com;
 
-import org.jboss.netty.buffer.ChannelBuffer;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
+
+import org.jboss.netty.buffer.ChannelBuffer;
 
 import org.neo4j.com.MadeUpServer.MadeUpRequestType;
 import org.neo4j.com.monitor.RequestMonitor;
@@ -46,7 +46,7 @@ public class MadeUpClient extends Client<MadeUpCommunicationInterface> implement
     public MadeUpClient( int port, StoreId storeIdToExpect, byte internalProtocolVersion,
                          byte applicationProtocolVersion, int chunkSize, ResponseUnpacker responseUnpacker )
     {
-        super( localhost(), port, new DevNullLoggingService(), storeIdToExpect, FRAME_LENGTH,
+        super( localhost(), port, null, new DevNullLoggingService(), storeIdToExpect, FRAME_LENGTH,
                 new ProtocolVersion( applicationProtocolVersion, internalProtocolVersion ),
                 Client.DEFAULT_READ_RESPONSE_TIMEOUT_SECONDS * 1000,
                 Client.DEFAULT_MAX_NUMBER_OF_CONCURRENT_CHANNELS_PER_CLIENT,

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/HighlyAvailableGraphDatabase.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.kernel.ha;
 
-import org.jboss.netty.logging.InternalLoggerFactory;
-
 import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.Map;
+
+import org.jboss.netty.logging.InternalLoggerFactory;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
@@ -48,6 +48,7 @@ import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.helpers.Predicate;
 import org.neo4j.helpers.Provider;
@@ -424,8 +425,9 @@ public class HighlyAvailableGraphDatabase extends InternalAbstractGraphDatabase
         DefaultSlaveFactory slaveFactory = dependencies.satisfyDependency( new DefaultSlaveFactory( logging, monitors,
                 config.get( HaSettings.com_chunk_size ).intValue() ) );
 
+        HostnamePort me = config.get( ClusterSettings.cluster_server );
         Slaves slaves = dependencies.satisfyDependency(
-                life.add( new HighAvailabilitySlaves( members, clusterClient, slaveFactory ) ) );
+                life.add( new HighAvailabilitySlaves( members, clusterClient, slaveFactory, me ) ) );
 
         final TransactionPropagator pusher = life.add( new TransactionPropagator( TransactionPropagator.from( config ),
                 msgLog, slaves, new CommitPusher( jobScheduler ) ) );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient210.java
@@ -76,23 +76,25 @@ public class MasterClient210 extends Client<Master> implements MasterClient
 
     private final long lockReadTimeoutMillis;
 
-    public MasterClient210( String hostNameOrIp, int port, Logging logging, StoreId storeId, long readTimeoutMillis,
-                            long lockReadTimeoutMillis, int maxConcurrentChannels, int chunkSize,
-                            ResponseUnpacker responseUnpacker,
-                            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
+    public MasterClient210( String destinationHostNameOrIp, int destinationPort, String originHostNameOrIp,
+            Logging logging, StoreId storeId, long readTimeoutMillis, long lockReadTimeoutMillis,
+            int maxConcurrentChannels, int chunkSize, ResponseUnpacker responseUnpacker,
+            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, storeId, MasterServer.FRAME_LENGTH, PROTOCOL_VERSION, readTimeoutMillis,
-                maxConcurrentChannels, chunkSize, responseUnpacker, byteCounterMonitor, requestMonitor );
+        super( destinationHostNameOrIp, destinationPort, originHostNameOrIp, logging, storeId,
+                MasterServer.FRAME_LENGTH, PROTOCOL_VERSION, readTimeoutMillis, maxConcurrentChannels, chunkSize,
+                responseUnpacker, byteCounterMonitor, requestMonitor );
         this.lockReadTimeoutMillis = lockReadTimeoutMillis;
     }
 
-    MasterClient210( String hostNameOrIp, int port, Logging logging, StoreId storeId, long readTimeoutMillis,
-                     long lockReadTimeoutMillis, int maxConcurrentChannels, int chunkSize,
-                     ProtocolVersion protocolVersion, ResponseUnpacker responseUnpacker,
-                     ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
+    MasterClient210( String destinationHostNameOrIp, int destinationPort, String originHostNameOrIp, Logging logging,
+            StoreId storeId, long readTimeoutMillis, long lockReadTimeoutMillis, int maxConcurrentChannels,
+            int chunkSize, ProtocolVersion protocolVersion, ResponseUnpacker responseUnpacker,
+            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, storeId, MasterServer.FRAME_LENGTH, protocolVersion, readTimeoutMillis,
-                maxConcurrentChannels, chunkSize, responseUnpacker, byteCounterMonitor, requestMonitor );
+        super( destinationHostNameOrIp, destinationPort, originHostNameOrIp, logging, storeId,
+                MasterServer.FRAME_LENGTH, protocolVersion, readTimeoutMillis, maxConcurrentChannels, chunkSize,
+                responseUnpacker, byteCounterMonitor, requestMonitor );
         this.lockReadTimeoutMillis = lockReadTimeoutMillis;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/MasterClient214.java
@@ -34,12 +34,14 @@ public class MasterClient214 extends MasterClient210
 {
     public static final ProtocolVersion PROTOCOL_VERSION = new ProtocolVersion( (byte) 8, INTERNAL_PROTOCOL_VERSION );
 
-    public MasterClient214( String hostNameOrIp, int port, Logging logging, StoreId storeId, long readTimeoutSeconds,
-                            long lockReadTimeout, int maxConcurrentChannels, int chunkSize, ResponseUnpacker unpacker,
-                            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
+    public MasterClient214( String destinationHostNameOrIp, int destinationPort, String originHostNameOrIp,
+            Logging logging, StoreId storeId, long readTimeoutSeconds, long lockReadTimeout, int maxConcurrentChannels,
+            int chunkSize, ResponseUnpacker unpacker, ByteCounterMonitor byteCounterMonitor,
+            RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, storeId, readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels,
-                chunkSize, PROTOCOL_VERSION, unpacker, byteCounterMonitor, requestMonitor );
+        super( destinationHostNameOrIp, destinationPort, originHostNameOrIp, logging, storeId,
+                readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels, chunkSize, PROTOCOL_VERSION, unpacker,
+                byteCounterMonitor, requestMonitor );
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlaves.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlaves.java
@@ -28,6 +28,7 @@ import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.helpers.Function;
 import org.neo4j.helpers.Functions;
+import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
 import org.neo4j.kernel.ha.com.master.Slave;
 import org.neo4j.kernel.ha.com.master.SlaveFactory;
@@ -52,14 +53,16 @@ public class HighAvailabilitySlaves implements Lifecycle, Slaves
     private final ClusterMembers clusterMembers;
     private final Cluster cluster;
     private final SlaveFactory slaveFactory;
+    private final HostnamePort me;
     private HighAvailabilitySlaves.HASClusterListener clusterListener;
 
-    public HighAvailabilitySlaves( ClusterMembers clusterMembers, Cluster cluster, SlaveFactory slaveFactory )
+    public HighAvailabilitySlaves( ClusterMembers clusterMembers, Cluster cluster, SlaveFactory slaveFactory,
+            HostnamePort me )
     {
         this.clusterMembers = clusterMembers;
         this.cluster = cluster;
         this.slaveFactory = slaveFactory;
-
+        this.me = me;
     }
 
     private Function<ClusterMember, Slave> slaveForMember()
@@ -74,7 +77,7 @@ public class HighAvailabilitySlaves implements Lifecycle, Slaves
                     Slave presentSlave = slaves.get( from );
                     if ( presentSlave == null )
                     {
-                        presentSlave = slaveFactory.newSlave( life, from );
+                        presentSlave = slaveFactory.newSlave( life, from, me.getHost(), me.getPort() );
                         slaves.put( from, presentSlave );
                     }
                     return presentSlave;

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/DefaultSlaveFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/DefaultSlaveFactory.java
@@ -42,10 +42,10 @@ public class DefaultSlaveFactory implements SlaveFactory
     }
 
     @Override
-    public Slave newSlave( LifeSupport life, ClusterMember clusterMember )
+    public Slave newSlave( LifeSupport life, ClusterMember clusterMember, String originHostNameOrIp, int originPort )
     {
         return life.add( new SlaveClient( clusterMember.getInstanceId(), clusterMember.getHAUri().getHost(),
-                clusterMember.getHAUri().getPort(), logging, storeId,
+                clusterMember.getHAUri().getPort(), originHostNameOrIp, logging, storeId,
                 2, // and that's 1 too many, because we push from the master from one thread only anyway
                 chunkSize, monitors.newMonitor( ByteCounterMonitor.class, SlaveClient.class ),
                 monitors.newMonitor( RequestMonitor.class, SlaveClient.class ) ) );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveClient.java
@@ -52,14 +52,15 @@ public class SlaveClient extends Client<Slave> implements Slave
 {
     private final InstanceId machineId;
 
-    public SlaveClient( InstanceId machineId, String hostNameOrIp, int port, Logging logging,
-                        StoreId storeId, int maxConcurrentChannels, int chunkSize,
-                        ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
+    public SlaveClient( InstanceId machineId, String destinationHostNameOrIp, int destinationPort,
+            String originHostNameOrIp, Logging logging, StoreId storeId, int maxConcurrentChannels, int chunkSize,
+            ByteCounterMonitor byteCounterMonitor, RequestMonitor requestMonitor )
     {
-        super( hostNameOrIp, port, logging, storeId, Protocol.DEFAULT_FRAME_LENGTH,
+        super( destinationHostNameOrIp, destinationPort, originHostNameOrIp, logging, storeId,
+                Protocol.DEFAULT_FRAME_LENGTH,
                 new ProtocolVersion( SlaveServer.APPLICATION_PROTOCOL_VERSION, INTERNAL_PROTOCOL_VERSION ),
-                HaSettings.read_timeout.apply( Functions.<String, String>nullFunction() ),
-                maxConcurrentChannels, chunkSize, NO_OP_RESPONSE_UNPACKER, byteCounterMonitor, requestMonitor );
+                HaSettings.read_timeout.apply( Functions.<String,String>nullFunction() ), maxConcurrentChannels,
+                chunkSize, NO_OP_RESPONSE_UNPACKER, byteCounterMonitor, requestMonitor );
         this.machineId = machineId;
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/master/SlaveFactory.java
@@ -25,7 +25,7 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 
 public interface SlaveFactory
 {
-    Slave newSlave( LifeSupport life, ClusterMember clusterMember );
+    Slave newSlave( LifeSupport life, ClusterMember clusterMember, String originHostNameOrIp, int originPort );
 
     void setStoreId( StoreId storeId );
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientFactory.java
@@ -25,6 +25,6 @@ import org.neo4j.kernel.monitoring.Monitors;
 
 public interface MasterClientFactory
 {
-    public MasterClient instantiate( String hostNameOrIp, int port, Monitors monitors,
-                                     StoreId storeId, LifeSupport life );
+    MasterClient instantiate( String destinationHostNameOrIp, int destinationPort, String originHostNameOrIp,
+            Monitors monitors, StoreId storeId, LifeSupport life );
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/MasterClientResolver.java
@@ -49,15 +49,16 @@ public class MasterClientResolver implements MasterClientFactory, ComExceptionHa
     private final InvalidEpochExceptionHandler invalidEpochHandler;
 
     @Override
-    public MasterClient instantiate( String hostNameOrIp, int port, Monitors monitors,
-                                     StoreId storeId, LifeSupport life )
+    public MasterClient instantiate( String destinationHostNameOrIp, int destinationPort, String originHostNameOrIp,
+            Monitors monitors, StoreId storeId, LifeSupport life )
     {
         if ( currentFactory == null )
         {
             assignDefaultFactory();
         }
 
-        MasterClient result = currentFactory.instantiate( hostNameOrIp, port, monitors, storeId, life );
+        MasterClient result = currentFactory.instantiate( destinationHostNameOrIp, destinationPort, originHostNameOrIp,
+                monitors, storeId, life );
         result.setComExceptionHandler( this );
         return result;
     }
@@ -145,13 +146,14 @@ public class MasterClientResolver implements MasterClientFactory, ComExceptionHa
         }
 
         @Override
-        public MasterClient instantiate( String hostNameOrIp, int port, Monitors monitors,
-                                         StoreId storeId, LifeSupport life )
+        public MasterClient instantiate( String destinationHostNameOrIp, int destinationPort, String originHostNameOrIp,
+                Monitors monitors, StoreId storeId, LifeSupport life )
         {
-            return life.add( new MasterClient210( hostNameOrIp, port, logging, storeId, readTimeoutSeconds,
-                    lockReadTimeout, maxConcurrentChannels, chunkSize, responseUnpacker,
-                    monitors.newMonitor( ByteCounterMonitor.class, MasterClient210.class ),
-                    monitors.newMonitor( RequestMonitor.class, MasterClient210.class ) ) );
+            return life.add(
+                    new MasterClient210( destinationHostNameOrIp, destinationPort, originHostNameOrIp, logging,
+                            storeId, readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels, chunkSize,
+                            responseUnpacker, monitors.newMonitor( ByteCounterMonitor.class, MasterClient210.class ),
+                            monitors.newMonitor( RequestMonitor.class, MasterClient210.class ) ) );
         }
     }
 
@@ -164,13 +166,14 @@ public class MasterClientResolver implements MasterClientFactory, ComExceptionHa
         }
 
         @Override
-        public MasterClient instantiate( String hostNameOrIp, int port, Monitors monitors,
-                                         StoreId storeId, LifeSupport life )
+        public MasterClient instantiate( String destinationHostNameOrIp, int destinationPort, String originHostNameOrIp,
+                Monitors monitors, StoreId storeId, LifeSupport life )
         {
-            return life.add( new MasterClient214( hostNameOrIp, port, logging, storeId, readTimeoutSeconds,
-                    lockReadTimeout, maxConcurrentChannels, chunkSize, responseUnpacker,
-                    monitors.newMonitor( ByteCounterMonitor.class, MasterClient214.class ),
-                    monitors.newMonitor( RequestMonitor.class, MasterClient214.class ) ) );
+            return life.add(
+                    new MasterClient214( destinationHostNameOrIp, destinationPort, originHostNameOrIp, logging,
+                            storeId, readTimeoutSeconds, lockReadTimeout, maxConcurrentChannels, chunkSize,
+                            responseUnpacker, monitors.newMonitor( ByteCounterMonitor.class, MasterClient214.class ),
+                            monitors.newMonitor( RequestMonitor.class, MasterClient214.class ) ) );
         }
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.ha.upgrade;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.Random;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.com.RequestContext;
@@ -77,6 +77,7 @@ import org.neo4j.kernel.monitoring.ByteCounterMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.CleanupRule;
 
+import static java.util.Arrays.asList;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doReturn;
@@ -85,9 +86,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import static java.util.Arrays.asList;
-
 import static org.neo4j.com.storecopy.ResponseUnpacker.NO_OP_RESPONSE_UNPACKER;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
@@ -216,18 +214,20 @@ public class MasterClientTest
 
     private MasterClient214 newMasterClient214( StoreId storeId ) throws Throwable
     {
-        return initAndStart( new MasterClient214( MASTER_SERVER_HOST, MASTER_SERVER_PORT, new DevNullLoggingService(),
-                storeId, TIMEOUT, TIMEOUT, 1, CHUNK_SIZE, NO_OP_RESPONSE_UNPACKER,
-                monitors.newMonitor( ByteCounterMonitor.class, MasterClient214.class ),
-                monitors.newMonitor( RequestMonitor.class, MasterClient214.class ) ) );
+        return initAndStart(
+                new MasterClient214( MASTER_SERVER_HOST, MASTER_SERVER_PORT, null, new DevNullLoggingService(),
+                        storeId, TIMEOUT, TIMEOUT, 1, CHUNK_SIZE, NO_OP_RESPONSE_UNPACKER,
+                        monitors.newMonitor( ByteCounterMonitor.class, MasterClient214.class ),
+                        monitors.newMonitor( RequestMonitor.class, MasterClient214.class ) ) );
     }
 
     private MasterClient214 newMasterClient214( StoreId storeId, ResponseUnpacker responseUnpacker ) throws Throwable
     {
-        return initAndStart( new MasterClient214( MASTER_SERVER_HOST, MASTER_SERVER_PORT, new DevNullLoggingService(),
-                storeId, TIMEOUT, TIMEOUT, 1, CHUNK_SIZE, responseUnpacker,
-                monitors.newMonitor( ByteCounterMonitor.class, MasterClient214.class ),
-                monitors.newMonitor( RequestMonitor.class, MasterClient214.class ) ) );
+        return initAndStart(
+                new MasterClient214( MASTER_SERVER_HOST, MASTER_SERVER_PORT, null, new DevNullLoggingService(),
+                        storeId, TIMEOUT, TIMEOUT, 1, CHUNK_SIZE, responseUnpacker,
+                        monitors.newMonitor( ByteCounterMonitor.class, MasterClient214.class ),
+                        monitors.newMonitor( RequestMonitor.class, MasterClient214.class ) ) );
     }
 
     private static Response<Void> voidResponseWithTransactionLogs()

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.ha.cluster;
 
-import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -32,6 +27,11 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
@@ -88,7 +88,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.MASTER;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.SLAVE;
 import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcherTest.neoStoreDataSourceSupplierMock;
@@ -396,7 +395,7 @@ public class HighAvailabilityMemberStateMachineTest
                     }
                 } );
         when( masterClient.toString() ).thenReturn( "TheExpectedMasterClient!" );
-        when( masterClientResolver.instantiate( anyString(), anyInt(), any( Monitors.class ),
+        when( masterClientResolver.instantiate( anyString(), anyInt(), anyString(), any( Monitors.class ),
                 any( StoreId.class ), any( LifeSupport.class ) ) ).thenReturn( masterClient );
 
         final CountDownLatch latch = new CountDownLatch( 2 );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.kernel.ha.cluster;
 
-import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import org.neo4j.backup.OnlineBackupKernelExtension;
 import org.neo4j.cluster.InstanceId;
@@ -215,8 +215,8 @@ public class SwitchToSlaveTest
         when( masterClient.getProtocolVersion() ).thenReturn( MasterClient214.PROTOCOL_VERSION );
 
         MasterClientResolver masterClientResolver = mock( MasterClientResolver.class );
-        when( masterClientResolver.instantiate( anyString(), anyInt(), any( Monitors.class ), any( StoreId.class ),
-                any( LifeSupport.class ) ) ).thenReturn( masterClient );
+        when( masterClientResolver.instantiate( anyString(), anyInt(), anyString(), any( Monitors.class ),
+                any( StoreId.class ), any( LifeSupport.class ) ) ).thenReturn( masterClient );
 
         return spy( new SwitchToSlave( ConsoleLogger.DEV_NULL, configMock(), neoStoreDataSource.getDependencyResolver(),
                 mock( HaIdGeneratorFactory.class ), new DevNullLoggingService(),

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlavesTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlavesTest.java
@@ -19,19 +19,20 @@
  */
 package org.neo4j.kernel.ha.cluster.member;
 
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.cluster.Cluster;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterListener;
+import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher;
 import org.neo4j.kernel.ha.com.master.DefaultSlaveFactory;
@@ -75,7 +76,7 @@ public class HighAvailabilitySlavesTest
         SlaveFactory slaveFactory = mock( SlaveFactory.class );
 
         // when
-        new HighAvailabilitySlaves( clusterMembers, cluster, slaveFactory ).init();
+        new HighAvailabilitySlaves( clusterMembers, cluster, slaveFactory, new HostnamePort( null, 0 ) ).init();
 
         // then
         verify( cluster ).addClusterListener( any( ClusterListener.class ) );
@@ -91,7 +92,8 @@ public class HighAvailabilitySlavesTest
 
         SlaveFactory slaveFactory = mock( SlaveFactory.class );
 
-        HighAvailabilitySlaves slaves = new HighAvailabilitySlaves( clusterMembers, cluster, slaveFactory );
+        HighAvailabilitySlaves slaves = new HighAvailabilitySlaves( clusterMembers, cluster, slaveFactory,
+                new HostnamePort( null, 0 ) );
         slaves.init();
 
         // when
@@ -111,10 +113,11 @@ public class HighAvailabilitySlavesTest
                 new ClusterMember( INSTANCE_ID ).availableAs( SLAVE, HA_URI, StoreId.DEFAULT ) ) );
 
         SlaveFactory slaveFactory = mock( SlaveFactory.class );
-        when( slaveFactory.newSlave( any( LifeSupport.class ), any( ClusterMember.class ) ) )
-                .thenReturn( mock( Slave.class ) );
+        when( slaveFactory.newSlave( any( LifeSupport.class ), any( ClusterMember.class ), any( String.class ),
+                any( Integer.class ) ) ).thenReturn( mock( Slave.class ) );
 
-        HighAvailabilitySlaves slaves = new HighAvailabilitySlaves( clusterMembers, cluster, slaveFactory );
+        HighAvailabilitySlaves slaves = new HighAvailabilitySlaves( clusterMembers, cluster, slaveFactory,
+                new HostnamePort( null, 0 ) );
         slaves.init();
 
         // when
@@ -134,10 +137,11 @@ public class HighAvailabilitySlavesTest
                 new ClusterMember( INSTANCE_ID ).availableAs( SLAVE, HA_URI, StoreId.DEFAULT ) ) );
 
         SlaveFactory slaveFactory = mock( SlaveFactory.class );
-        when( slaveFactory.newSlave( any( LifeSupport.class ), any( ClusterMember.class ) ) )
-                .thenReturn( mock( Slave.class ), mock( Slave.class ) );
+        when( slaveFactory.newSlave( any( LifeSupport.class ), any( ClusterMember.class ), any( String.class ),
+                any( Integer.class ) ) ).thenReturn( mock( Slave.class ), mock( Slave.class ) );
 
-        HighAvailabilitySlaves slaves = new HighAvailabilitySlaves( clusterMembers, cluster, slaveFactory );
+        HighAvailabilitySlaves slaves = new HighAvailabilitySlaves( clusterMembers, cluster, slaveFactory, new
+                HostnamePort( null, 0 ) );
         slaves.init();
 
         ArgumentCaptor<ClusterListener> listener = ArgumentCaptor.forClass( ClusterListener.class );
@@ -159,7 +163,8 @@ public class HighAvailabilitySlavesTest
     {
         // Given
         HighAvailabilitySlaves haSlaves = new HighAvailabilitySlaves( clusterMembersOfSize( 1000 ),
-                mock( Cluster.class ), new DefaultSlaveFactory( DevNullLoggingService.DEV_NULL, new Monitors(), 42 ) );
+                mock( Cluster.class ), new DefaultSlaveFactory( DevNullLoggingService.DEV_NULL, new Monitors(), 42 ),
+                new HostnamePort( null, 0 ) );
 
         // When
         ExecutorService executor = Executors.newFixedThreadPool( 5 );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/slave/MasterClientResolverTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/slave/MasterClientResolverTest.java
@@ -48,7 +48,7 @@ public class MasterClientResolverTest
         {
             life.start();
             MasterClient masterClient1 =
-                    resolver.instantiate( "cluster://localhost", 44, new Monitors(), StoreId.DEFAULT, life );
+                    resolver.instantiate( "cluster://localhost", 44, null, new Monitors(), StoreId.DEFAULT, life );
             assertThat( masterClient1, instanceOf( MasterClient214.class ) );
         }
         finally
@@ -70,7 +70,7 @@ public class MasterClientResolverTest
         {
             life.start();
             MasterClient masterClient2 =
-                    resolver.instantiate( "cluster://localhost", 55, new Monitors(), StoreId.DEFAULT, life );
+                    resolver.instantiate( "cluster://localhost", 55, null, new Monitors(), StoreId.DEFAULT, life );
 
             assertThat( masterClient2, instanceOf( MasterClient210.class ) );
         }


### PR DESCRIPTION
This is a necessary change to make sure we transmit data on the right
path to the destination. Before this, neo4j-ha would not work in case
there were multiple IP addresses on each network interface, since "the
first address" would be picked as the transmission origin.

Also adds more descriptive debug logging around connections.

Only logical changes are in `NetworkSender.java` and `Client.java`, the
rest are just changes to constructors/methods due to the added `origin`
parameter.

~~Not ready for merge until robustness tests have finished.~~

Robustness finished successfully: https://build.neohq.net/viewLog.html?buildId=553194&tab=buildResultsDiv&buildTypeId=JonasHaRequests_HaRobustnessWithMyknocks
