### PR TITLE
Fixed eagerness on reads after deletes

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/Effects.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/Effects.scala
@@ -159,6 +159,8 @@ object WritesNodesWithLabels {
 
 case class WritesNodesWithLabels(labels: Set[String]) extends WritesNodes
 
+case object DeletesNode extends WritesNodes
+
 trait ReadsNodeProperty extends ReadEffect
 
 case class ReadsGivenNodeProperty(propertyName: String) extends ReadsNodeProperty {
@@ -188,6 +190,8 @@ case object ReadsRelationships extends ReadEffect {
 }
 
 case object WritesRelationships extends WriteEffect
+
+case object DeletesRelationship extends WriteEffect
 
 trait ReadsRelationshipProperty extends ReadEffect
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/addEagernessIfNecessary.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/addEagernessIfNecessary.scala
@@ -27,8 +27,7 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
     val relsInterfere = from.contains(ReadsRelationships) && to.contains(WritesRelationships)
 
     val readWriteInterfereNodes = nodesWriteInterference(from, to)
-    val readWriteInterfereRelationships = from.contains(WritesRelationships) && to.contains(WritesRelationships) &&
-      to.contains(ReadsRelationships)
+    val readWriteInterfereRelationships = relsWriteInterference(from, to)
 
     nodesInterfere || relsInterfere || readWriteInterfereNodes || readWriteInterfereRelationships ||
       nodePropertiesInterfere(from, to) || relationshipPropertiesInterfere(from, to)
@@ -47,6 +46,11 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
     toPipe.dup(sources.toList)
   }
 
+  private def relsWriteInterference(from: Effects, to: Effects) = {
+    from.contains(WritesRelationships) && to.contains(WritesRelationships) && to.contains(ReadsRelationships) ||
+    from.contains(DeletesRelationship) && to.contains(ReadsRelationships)
+  }
+
   private def nodesWriteInterference(from: Effects, to: Effects) = {
     val fromWrites = from.effectsSet.collect {
       case writes: WritesNodes => writes
@@ -58,7 +62,11 @@ object addEagernessIfNecessary extends (Pipe => Pipe) {
     val toWrites = to.effectsSet.collect {
       case writes: WritesNodes => writes
     }
+    val fromDeletes = from.effectsSet.collect {
+      case deletes@DeletesNode => deletes
+    }
     (fromWrites.contains(WritesAnyNode) && toWrites.nonEmpty && toReads.nonEmpty) ||
+    (fromDeletes.nonEmpty && toReads.nonEmpty) ||
     (fromWrites.nonEmpty && toWrites.nonEmpty && toReads.contains(ReadsAllNodes)) ||
       (nodeLabelOverlap(toReads, fromWrites) && toWrites.nonEmpty)
   }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/DeleteEntityAction.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/mutation/DeleteEntityAction.scala
@@ -73,10 +73,10 @@ case class DeleteEntityAction(elementToDelete: Expression, forced: Boolean)
 
   def localEffects(symbols: SymbolTable) = elementToDelete match {
     case i: Identifier => symbols.identifiers(i.entityName) match {
-      case _: NodeType         => Effects(WritesAnyNode, WritesAnyNodeProperty)
-      case _: RelationshipType => Effects(WritesRelationships, WritesAnyRelationshipProperty)
-      case _: PathType         => Effects(WritesRelationships, WritesAnyRelationshipProperty, WritesAnyNode, WritesAnyNodeProperty)
+      case _: NodeType         => Effects(DeletesNode, WritesAnyNode, WritesAnyNodeProperty)
+      case _: RelationshipType => Effects(DeletesRelationship, WritesRelationships, WritesAnyRelationshipProperty)
+      case _: PathType         => Effects(DeletesNode, DeletesRelationship, WritesRelationships, WritesAnyRelationshipProperty, WritesAnyNode, WritesAnyNodeProperty)
     }
-    case _ => AllWriteEffects
+    case _ => Effects((AllWriteEffects | Effects(DeletesNode, DeletesRelationship)).effectsSet)
   }
 }


### PR DESCRIPTION
This fix is related to similar fixes in 3.0 at https://github.com/neo4j/neo4j/pull/6549. For that reason, do a null forward merge of this one, so 3.0 does not get this fix, but only the one in https://github.com/neo4j/neo4j/pull/6549.
