### PR TITLE
Fixed eagerness with deletes followed by reads

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/Effects.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/Effects.scala
@@ -134,6 +134,8 @@ case object ReadsNodes extends ReadEffect {
 
 case object WritesNodes extends WriteEffect
 
+case object DeletesNode extends WriteEffect
+
 case class ReadsNodeProperty(propertyName: String) extends ReadEffect {
   override def toString = s"${super.toString} '$propertyName'"
 
@@ -179,6 +181,8 @@ case object ReadsRelationships extends ReadEffect {
 }
 
 case object WritesRelationships extends WriteEffect
+
+case object DeletesRelationship extends WriteEffect
 
 case class ReadsRelationshipProperty(propertyName: String) extends ReadEffect {
   override def toString = s"${super.toString} '$propertyName'"

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/DeleteEntityAction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/DeleteEntityAction.scala
@@ -66,10 +66,11 @@ case class DeleteEntityAction(elementToDelete: Expression)
 
   def localEffects(symbols: SymbolTable) = elementToDelete match {
     case i: Identifier => symbols.identifiers(i.entityName) match {
-      case _: NodeType         => Effects(WritesNodes, WritesAnyLabel, WritesAnyNodeProperty)
-      case _: RelationshipType => Effects(WritesRelationships, WritesAnyRelationshipProperty)
-      case _                   => Effects()
+      case _: NodeType         => Effects(DeletesNode, WritesNodes, WritesAnyLabel, WritesAnyNodeProperty)
+      case _: RelationshipType => Effects(DeletesRelationship, WritesRelationships, WritesAnyRelationshipProperty)
+      case _: PathType         => Effects(DeletesRelationship, WritesRelationships, WritesAnyRelationshipProperty,
+                                          DeletesNode, WritesNodes, WritesAnyLabel, WritesAnyNodeProperty)
     }
-    case _ => AllWriteEffects
+    case _ => Effects((AllWriteEffects | Effects(DeletesNode, DeletesRelationship)).effectsSet)
   }
 }


### PR DESCRIPTION
This fixes the bug in 2.2 only. The fix for 2.3 and 3.0 is in different PR's, so be sure to null forward merge. See https://github.com/neo4j/neo4j/pull/6564
