### PR TITLE
Increased limits to 58 bits in HighLimit

### DIFF
--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
@@ -34,7 +34,7 @@ import static org.neo4j.kernel.impl.store.format.highlimit.Reference.PAGE_CURSOR
  */
 class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
 {
-    private static final int RECORD_SIZE = 48;
+    private static final int RECORD_SIZE = 64;
 
     protected PropertyRecordFormat()
     {

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitRecordFormatTest.java
@@ -25,7 +25,7 @@ import org.neo4j.kernel.impl.store.format.RecordGenerators;
 
 public class HighLimitRecordFormatTest extends RecordFormatTest
 {
-    private static final RecordGenerators HIGH_LIMITS = new LimitedRecordGenerators( random, 50, 50, 50, 16, NULL );
+    private static final RecordGenerators HIGH_LIMITS = new LimitedRecordGenerators( random, 58, 58, 58, 16, NULL );
 
     public HighLimitRecordFormatTest()
     {


### PR DESCRIPTION
and 64 bytes property record size to align with power of two.
