### PR TITLE
Determine maximum number of bits for record ID based on current store format

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -83,7 +83,6 @@ import org.neo4j.kernel.impl.coreapi.schema.SchemaImpl;
 import org.neo4j.kernel.impl.query.QueryEngineProvider;
 import org.neo4j.kernel.impl.query.QuerySession;
 import org.neo4j.kernel.impl.store.StoreId;
-import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.traversal.BidirectionalTraversalDescriptionImpl;
 import org.neo4j.kernel.impl.traversal.MonoDirectionalTraversalDescription;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -100,12 +99,8 @@ import static org.neo4j.kernel.impl.api.operations.KeyReadOperations.NO_SUCH_PRO
  * implementation, this provides users with
  * a clean facade to interact with the database.
  */
-public class GraphDatabaseFacade
-        implements GraphDatabaseAPI
+public class GraphDatabaseFacade implements GraphDatabaseAPI
 {
-    private static final long MAX_NODE_ID = IdType.NODE.getMaxValue();
-    private static final long MAX_RELATIONSHIP_ID = IdType.RELATIONSHIP.getMaxValue();
-
     private Schema schema;
     private IndexManager indexManager;
     private NodeProxy.NodeActions nodeActions;
@@ -256,7 +251,7 @@ public class GraphDatabaseFacade
     @Override
     public Node getNodeById( long id )
     {
-        if ( id < 0 || id > MAX_NODE_ID )
+        if ( id < 0 )
         {
             throw new NotFoundException( format( "Node %d not found", id ),
                     new EntityNotFoundException( EntityType.NODE, id ) );
@@ -276,7 +271,7 @@ public class GraphDatabaseFacade
     @Override
     public Relationship getRelationshipById( long id )
     {
-        if ( id < 0 || id > MAX_RELATIONSHIP_ID )
+        if ( id < 0 )
         {
             throw new NotFoundException( format( "Relationship %d not found", id ),
                     new EntityNotFoundException( EntityType.RELATIONSHIP, id ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
@@ -80,21 +80,8 @@ public abstract class AbstractDynamicStore extends ComposableRecordStore<Dynamic
             String storeVersion )
     {
         super( fileName, conf, idType, idGeneratorFactory, pageCache, logProvider, typeDescriptor,
-                recordFormat,
-                storeVersion,
-                new IntStoreHeaderFormat( dataSizeFromConfiguration + recordFormat.getRecordHeaderSize() )
-                {
-                    @Override
-                    public void writeHeader( PageCursor cursor )
-                    {
-                        if ( defaultValue < 1 || defaultValue > 0xFFFF )
-                        {
-                            throw new IllegalArgumentException(
-                                    "Illegal block size[" + defaultValue + "], limit is 65535" );
-                        }
-                        super.writeHeader( cursor );
-                    }
-                } );
+                recordFormat, new DynamicStoreHeaderFormat( dataSizeFromConfiguration, recordFormat ),
+                storeVersion );
     }
 
     public static void allocateRecordsFromBytes(
@@ -235,5 +222,24 @@ public abstract class AbstractDynamicStore extends ComposableRecordStore<Dynamic
         }
 
         return readFullByteArrayFromHeavyRecords( records, propertyType );
+    }
+
+    private static class DynamicStoreHeaderFormat extends IntStoreHeaderFormat
+    {
+        DynamicStoreHeaderFormat( int dataSizeFromConfiguration, RecordFormat<DynamicRecord> recordFormat )
+        {
+            super( dataSizeFromConfiguration + recordFormat.getRecordHeaderSize() );
+        }
+
+        @Override
+        public void writeHeader( PageCursor cursor )
+        {
+            if ( defaultValue < 1 || defaultValue > 0xFFFF )
+            {
+                throw new IllegalArgumentException(
+                        "Illegal block size[" + defaultValue + "], limit is 65535" );
+            }
+            super.writeHeader( cursor );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -71,6 +71,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord>
     protected final Log log;
     protected PagedFile storeFile;
     protected final String storeVersion;
+    protected final RecordFormat<RECORD> recordFormat;
     private IdGenerator idGenerator;
     private boolean storeOk = true;
     private Throwable causeOfStoreNotOk;
@@ -100,6 +101,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord>
             PageCache pageCache,
             LogProvider logProvider,
             String typeDescriptor,
+            RecordFormat<RECORD> recordFormat,
             String storeVersion )
     {
         this.storageFileName = fileName;
@@ -108,6 +110,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord>
         this.pageCache = pageCache;
         this.idType = idType;
         this.typeDescriptor = typeDescriptor;
+        this.recordFormat = recordFormat;
         this.storeVersion = storeVersion;
         this.log = logProvider.getLog( getClass() );
     }
@@ -627,7 +630,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord>
      */
     protected IdGenerator openIdGenerator( File fileName, int grabSize )
     {
-        return idGeneratorFactory.open( fileName, grabSize, getIdType(), scanForHighId() );
+        return idGeneratorFactory.open( fileName, grabSize, getIdType(), scanForHighId(), recordFormat.getMaxId() );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ComposableRecordStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ComposableRecordStore.java
@@ -35,18 +35,15 @@ import org.neo4j.logging.LogProvider;
 public class ComposableRecordStore<RECORD extends AbstractBaseRecord, HEADER extends StoreHeader>
         extends CommonAbstractStore<RECORD>
 {
-    protected final RecordFormat<RECORD> recordFormat;
     protected final StoreHeaderFormat<HEADER> storeHeaderFormat;
     protected HEADER storeHeader;
 
     public ComposableRecordStore( File fileName, Config configuration, IdType idType,
             IdGeneratorFactory idGeneratorFactory, PageCache pageCache, LogProvider logProvider, String typeDescriptor,
-            RecordFormat<RECORD> recordFormat, String storeVersion,
-            StoreHeaderFormat<HEADER> storeHeaderFormat )
+            RecordFormat<RECORD> recordFormat, StoreHeaderFormat<HEADER> storeHeaderFormat, String storeVersion )
     {
         super( fileName, configuration, idType, idGeneratorFactory, pageCache, logProvider, typeDescriptor,
-                storeVersion );
-        this.recordFormat = recordFormat;
+                recordFormat, storeVersion );
         this.storeHeaderFormat = storeHeaderFormat;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
@@ -29,6 +29,7 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.store.format.RecordFormat;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.NeoStoreActualRecord;
@@ -135,12 +136,11 @@ public class MetaDataStore extends CommonAbstractStore<NeoStoreActualRecord>
     private final CappedLogger transactionCloseWaitLogger;
 
     MetaDataStore( File fileName, Config conf,
-                   IdGeneratorFactory idGeneratorFactory,
-                   PageCache pageCache, LogProvider logProvider,
-                   String storeVersion )
+            IdGeneratorFactory idGeneratorFactory,
+            PageCache pageCache, LogProvider logProvider, RecordFormat<NeoStoreActualRecord> recordFormat, String storeVersion )
     {
         super( fileName, conf, IdType.NEOSTORE_BLOCK, idGeneratorFactory, pageCache, logProvider,
-                TYPE_DESCRIPTOR, storeVersion );
+                TYPE_DESCRIPTOR, recordFormat, storeVersion );
         this.transactionCloseWaitLogger = new CappedLogger( logProvider.getLog( MetaDataStore.class ) );
         transactionCloseWaitLogger.setTimeLimit( 30, SECONDS, Clock.SYSTEM_CLOCK );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.counts.ReadOnlyCountsTracker;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.lowlimit.NoRecordFormat;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.kvstore.DataInitializer;
@@ -580,7 +581,7 @@ public class NeoStores implements AutoCloseable
     CommonAbstractStore createMetadataStore()
     {
         return initialize( new MetaDataStore( neoStoreFileName, config, idGeneratorFactory, pageCache, logProvider,
-                recordFormats.storeVersion() ) );
+                new NoRecordFormat<>(), recordFormats.storeVersion() ) );
     }
 
     public void registerDiagnostics( DiagnosticsManager diagnosticsManager )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
@@ -74,7 +74,7 @@ public class NodeStore extends ComposableRecordStore<NodeRecord,NoStoreHeader>
             RecordFormats recordFormats)
     {
         super( fileName, config, IdType.NODE, idGeneratorFactory, pageCache, logProvider, TYPE_DESCRIPTOR,
-                recordFormats.node(), recordFormats.storeVersion(), NO_STORE_HEADER_FORMAT );
+                recordFormats.node(), NO_STORE_HEADER_FORMAT, recordFormats.storeVersion() );
         this.dynamicLabelStore = dynamicLabelStore;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -75,7 +75,7 @@ public class PropertyStore extends ComposableRecordStore<PropertyRecord,NoStoreH
             RecordFormats recordFormats)
     {
         super( fileName, configuration, IdType.PROPERTY, idGeneratorFactory, pageCache, logProvider, TYPE_DESCRIPTOR,
-                recordFormats.property(), recordFormats.storeVersion(), NO_STORE_HEADER_FORMAT );
+                recordFormats.property(), NO_STORE_HEADER_FORMAT, recordFormats.storeVersion() );
         this.stringStore = stringPropertyStore;
         this.propertyKeyTokenStore = propertyKeyTokenStore;
         this.arrayStore = arrayPropertyStore;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipGroupStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipGroupStore.java
@@ -45,7 +45,7 @@ public class RelationshipGroupStore extends ComposableRecordStore<RelationshipGr
     {
         super( fileName, config, IdType.RELATIONSHIP_GROUP, idGeneratorFactory, pageCache,
                 logProvider, TYPE_DESCRIPTOR, recordFormat,
-                storeVersion, new IntStoreHeaderFormat( config.get( GraphDatabaseSettings.dense_node_threshold ) ) );
+                new IntStoreHeaderFormat( config.get( GraphDatabaseSettings.dense_node_threshold ) ), storeVersion );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RelationshipStore.java
@@ -47,8 +47,9 @@ public class RelationshipStore extends ComposableRecordStore<RelationshipRecord,
             RecordFormats recordFormats)
     {
         super( fileName, configuration, IdType.RELATIONSHIP, idGeneratorFactory,
-                pageCache, logProvider, TYPE_DESCRIPTOR, recordFormats.relationship(), recordFormats.storeVersion(),
-                NO_STORE_HEADER_FORMAT );
+                pageCache, logProvider, TYPE_DESCRIPTOR, recordFormats.relationship(), NO_STORE_HEADER_FORMAT,
+                recordFormats.storeVersion()
+        );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/TokenStore.java
@@ -65,7 +65,7 @@ public abstract class TokenStore<RECORD extends TokenRecord,TOKEN extends Token>
             String storeVersion )
     {
         super( file, configuration, idType, idGeneratorFactory, pageCache, logProvider, typeDescriptor,
-                recordFormat, storeVersion, NO_STORE_HEADER_FORMAT );
+                recordFormat, NO_STORE_HEADER_FORMAT, storeVersion );
         this.nameStore = nameStore;
         this.tokenFactory = tokenFactory;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormat.java
@@ -95,5 +95,11 @@ public abstract class BaseRecordFormat<RECORD extends AbstractBaseRecord> implem
     public int hashCode()
     {
         return getClass().hashCode();
+
+    }
+
+    protected long getMaxId(int bits)
+    {
+        return (1L << bits) - 1;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/InternalRecordFormatSelector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/InternalRecordFormatSelector.java
@@ -33,7 +33,6 @@ import org.neo4j.kernel.impl.store.format.lowlimit.LowLimitV2_3;
 import org.neo4j.kernel.impl.store.format.lowlimit.LowLimitV3_0;
 
 import static java.util.Arrays.asList;
-
 import static org.neo4j.helpers.collection.Iterables.concat;
 import static org.neo4j.helpers.collection.Iterables.map;
 
@@ -75,19 +74,19 @@ public class InternalRecordFormatSelector
                 // We specified config to select this format specifically and we found it
                 return candidate.newInstance();
             }
-            else if ( key.equals( "" ) )
+            else if ( "".equals( key ) )
             {
                 // No specific config, just return the first format we found from service loading
                 return loggedSelection( candidate.newInstance(), candidateId, logging );
             }
         }
 
-        if ( key.equals( COMMUNITY_KEY ) )
+        if ( COMMUNITY_KEY.equals( key ) )
         {
             // We specified config to select the community format
             return FALLBACK;
         }
-        if ( key.equals( "" ) )
+        if ( "".equals( key ) )
         {
             // No specific config, just return the community fallback
             return loggedSelection( FALLBACK, COMMUNITY_KEY, logging );
@@ -105,7 +104,7 @@ public class InternalRecordFormatSelector
 
     public static RecordFormats fromVersion( String storeVersion )
     {
-        Iterable<RecordFormats> additionalFormats = map( factory -> factory.newInstance(),
+        Iterable<RecordFormats> additionalFormats = map( Factory::newInstance,
                 loadAdditionalFormats() );
         for ( RecordFormats format : concat( KNOWN_FORMATS, additionalFormats ) )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormat.java
@@ -143,4 +143,10 @@ public interface RecordFormat<RECORD extends AbstractBaseRecord>
      */
     @Override
     int hashCode();
+
+    /**
+     * Maximum number that can be used to as id in specified format
+     * @return maximum possible id
+     */
+    long getMaxId();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/DynamicRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/DynamicRecordFormat.java
@@ -142,4 +142,10 @@ public class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRe
     {
         return record.getNextBlock();
     }
+
+    @Override
+    public long getMaxId()
+    {
+        return getMaxId( LowLimitFormatSettings.DYNAMIC_RECORD_MAXIMUM_ID_BITS );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/LabelTokenRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/LabelTokenRecordFormat.java
@@ -33,4 +33,10 @@ public class LabelTokenRecordFormat extends TokenRecordFormat<LabelTokenRecord>
     {
         return new LabelTokenRecord( -1 );
     }
+
+    @Override
+    public long getMaxId()
+    {
+        return getMaxId( LowLimitFormatSettings.LABEL_TOKEN_MAXIMUM_ID_BITS );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/LowLimitFormatSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/LowLimitFormatSettings.java
@@ -17,15 +17,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.store.id;
+package org.neo4j.kernel.impl.store.format.lowlimit;
 
-import java.io.File;
-
-public interface IdGeneratorFactory
+/**
+ * Common low limit format settings.
+ */
+final class LowLimitFormatSettings
 {
-    IdGenerator open( File filename, int grabSize, IdType idType, long highId, long maxId );
+    static final int NODE_RECORD_MAXIMUM_ID_BITS = 35;
+    static final int RELATIONSHIP_MAXIMUM_ID_BITS = 35;
+    static final int PROPERTY_RECORD_MAXIMUM_ID_BITS = 36;
+    static final int DYNAMIC_RECORD_MAXIMUM_ID_BITS = 36;
+    static final int LABEL_TOKEN_MAXIMUM_ID_BITS = 32;
+    static final int PROPERTY_TOKEN_MAXIMUM_ID_BITS = 32;
+    static final int RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS = 16;
+    static final int RELATIONSHIP_GROUP_MAXIMUM_ID_BITS = 35;
 
-    void create( File filename, long highId, boolean throwIfFileExists );
-
-    IdGenerator get( IdType idType );
+    private LowLimitFormatSettings()
+    {
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/LowLimitV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/LowLimitV2_0.java
@@ -51,7 +51,6 @@ public class LowLimitV2_0 extends BaseRecordFormats
     @Override
     public RecordFormat<RelationshipRecord> relationship()
     {
-        // Yes, uses the same relationship record format as 1.9
         return new RelationshipRecordFormatV2_0();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/NoRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/NoRecordFormat.java
@@ -78,4 +78,10 @@ public class NoRecordFormat<RECORD extends AbstractBaseRecord> implements Record
     {
         return Record.NULL_REFERENCE.intValue();
     }
+
+    @Override
+    public long getMaxId()
+    {
+        return 0;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/NodeRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/NodeRecordFormat.java
@@ -46,6 +46,11 @@ public class NodeRecordFormat extends BaseOneByteHeaderRecordFormat<NodeRecord>
     }
 
     @Override
+    public long getMaxId()
+    {
+        return getMaxId( LowLimitFormatSettings.NODE_RECORD_MAXIMUM_ID_BITS );
+    }
+
     public void read( NodeRecord record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
             throws IOException
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/NodeRecordFormatV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/NodeRecordFormatV2_0.java
@@ -40,6 +40,11 @@ class NodeRecordFormatV2_0 extends BaseOneByteHeaderRecordFormat<NodeRecord>
     }
 
     @Override
+    public long getMaxId()
+    {
+        return LowLimitFormatSettings.NODE_RECORD_MAXIMUM_ID_BITS;
+    }
+
     public void read( NodeRecord record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
             throws IOException
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/PropertyKeyTokenRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/PropertyKeyTokenRecordFormat.java
@@ -49,4 +49,10 @@ public class PropertyKeyTokenRecordFormat extends TokenRecordFormat<PropertyKeyT
         cursor.putInt( record.getPropertyCount() );
         cursor.putInt( record.getNameId() );
     }
+
+    @Override
+    public long getMaxId()
+    {
+        return getMaxId( LowLimitFormatSettings.PROPERTY_TOKEN_MAXIMUM_ID_BITS );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/PropertyRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/PropertyRecordFormat.java
@@ -37,7 +37,7 @@ public class PropertyRecordFormat extends BaseRecordFormat<PropertyRecord>
             + 4/*next*/
             + 4/*prev*/
             + DEFAULT_PAYLOAD_SIZE /*property blocks*/;
-         // = 41
+    // = 41
 
     public PropertyRecordFormat()
     {
@@ -133,6 +133,12 @@ public class PropertyRecordFormat extends BaseRecordFormat<PropertyRecord>
     public long getNextRecordReference( PropertyRecord record )
     {
         return record.getNextProp();
+    }
+
+    @Override
+    public long getMaxId()
+    {
+        return getMaxId( LowLimitFormatSettings.PROPERTY_RECORD_MAXIMUM_ID_BITS );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/RelationshipGroupRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/RelationshipGroupRecordFormat.java
@@ -126,4 +126,10 @@ public class RelationshipGroupRecordFormat extends BaseOneByteHeaderRecordFormat
     {
         return record.getNext();
     }
+
+    @Override
+    public long getMaxId()
+    {
+        return getMaxId( LowLimitFormatSettings.RELATIONSHIP_GROUP_MAXIMUM_ID_BITS );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/RelationshipRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/RelationshipRecordFormat.java
@@ -49,6 +49,12 @@ public class RelationshipRecordFormat extends BaseOneByteHeaderRecordFormat<Rela
     }
 
     @Override
+    public long getMaxId()
+    {
+        return getMaxId( LowLimitFormatSettings.RELATIONSHIP_MAXIMUM_ID_BITS );
+    }
+
+
     public void read( RelationshipRecord record, PageCursor cursor, RecordLoad mode, int recordSize,
             PagedFile storeFile ) throws IOException
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/RelationshipRecordFormatV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/RelationshipRecordFormatV2_0.java
@@ -99,4 +99,10 @@ class RelationshipRecordFormatV2_0 extends BaseOneByteHeaderRecordFormat<Relatio
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public long getMaxId()
+    {
+        return LowLimitFormatSettings.RELATIONSHIP_MAXIMUM_ID_BITS;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/RelationshipTypeTokenRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/lowlimit/RelationshipTypeTokenRecordFormat.java
@@ -33,4 +33,10 @@ public class RelationshipTypeTokenRecordFormat extends TokenRecordFormat<Relatio
     {
         return new RelationshipTypeTokenRecord( -1 );
     }
+
+    @Override
+    public long getMaxId()
+    {
+        return getMaxId( LowLimitFormatSettings.RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DefaultIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DefaultIdGeneratorFactory.java
@@ -36,12 +36,10 @@ public class DefaultIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId )
+    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
     {
-        long maxValue = idType.getMaxValue();
         boolean aggressiveReuse = idType.allowAggressiveReuse();
-        IdGenerator generator = instantiate( fs, fileName, grabSize, maxValue,
-                aggressiveReuse, highId );
+        IdGenerator generator = instantiate( fs, fileName, grabSize, maxId, aggressiveReuse, highId );
         generators.put( idType, generator );
         return generator;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdType.java
@@ -21,39 +21,28 @@ package org.neo4j.kernel.impl.store.id;
 
 public enum IdType
 {
-    NODE( 35, false ),
-    RELATIONSHIP( 35, false ),
-    PROPERTY( 36, true ),
-    STRING_BLOCK( 36, true ),
-    ARRAY_BLOCK( 36, true ),
+    NODE( false ),
+    RELATIONSHIP( false ),
+    PROPERTY( true ),
+    STRING_BLOCK( true ),
+    ARRAY_BLOCK( true ),
     PROPERTY_KEY_TOKEN( false ),
     PROPERTY_KEY_TOKEN_NAME( false ),
-    RELATIONSHIP_TYPE_TOKEN( 16, false ),
+    RELATIONSHIP_TYPE_TOKEN( false ),
     RELATIONSHIP_TYPE_TOKEN_NAME( false ),
     LABEL_TOKEN( false ),
     LABEL_TOKEN_NAME( false ),
     NEOSTORE_BLOCK( false ),
-    SCHEMA( 35, false ),
-    NODE_LABELS( 35, true ),
-    RELATIONSHIP_GROUP( 35, false );
+    SCHEMA( false ),
+    NODE_LABELS( true ),
+    RELATIONSHIP_GROUP( false );
 
-    private final long max;
     private final boolean allowAggressiveReuse;
+
 
     IdType( boolean allowAggressiveReuse )
     {
-        this( 32, allowAggressiveReuse );
-    }
-
-    IdType( int bits, boolean allowAggressiveReuse )
-    {
         this.allowAggressiveReuse = allowAggressiveReuse;
-        this.max = (long)Math.pow( 2, bits )-1;
-    }
-
-    public long getMaxValue()
-    {
-        return this.max;
     }
 
     public boolean allowAggressiveReuse()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/ReadOnlyIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/ReadOnlyIdGeneratorFactory.java
@@ -32,7 +32,7 @@ public class ReadOnlyIdGeneratorFactory implements IdGeneratorFactory
     private final Map<IdType,IdGenerator> idGenerators = new HashMap<>();
 
     @Override
-    public IdGenerator open( File filename, int grabSize, IdType idType, long highId )
+    public IdGenerator open( File filename, int grabSize, IdType idType, long highId, long maxId )
     {
         IdGenerator generator = new ReadOnlyIdGenerator( highId );
         idGenerators.put( idType, generator );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingIdGeneratorFactory.java
@@ -46,7 +46,7 @@ public class BatchingIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId )
+    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
     {
         IdGenerator generator = idGenerators.get( idType );
         if ( generator == null )

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -35,10 +35,8 @@ import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseDependencies;
-import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
-import org.neo4j.kernel.impl.store.id.IdType;
-import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
 import org.neo4j.kernel.impl.factory.CommunityEditionModule;
 import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
 import org.neo4j.kernel.impl.factory.EditionModule;
@@ -47,6 +45,8 @@ import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.storageengine.api.LabelItem;
 import org.neo4j.storageengine.api.NodeItem;
 import org.neo4j.storageengine.api.PropertyItem;
@@ -587,7 +587,7 @@ public class LabelsAcceptanceTest
         final EphemeralIdGenerator.Factory idFactory = new EphemeralIdGenerator.Factory()
         {
             @Override
-            public IdGenerator open( File fileName, int grabSize, IdType idType, long highId )
+            public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
             {
                 if ( idType == IdType.LABEL_TOKEN )
                 {
@@ -607,7 +607,7 @@ public class LabelsAcceptanceTest
                     }
                     return generator;
                 }
-                return super.open( fileName, grabSize, idType, Long.MAX_VALUE );
+                return super.open( fileName, grabSize, idType, Long.MAX_VALUE, Long.MAX_VALUE );
             }
         };
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingIdGeneratorFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingIdGeneratorFactory.java
@@ -44,7 +44,7 @@ public class JumpingIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId )
+    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
     {
         return get( idType );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.core;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import org.neo4j.graphdb.Node;
@@ -35,7 +34,6 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.graphdb.RelationshipType.withName;
 
 public class RelationshipProxyTest extends PropertyContainerProxyTest
@@ -57,22 +55,10 @@ public class RelationshipProxyTest extends PropertyContainerProxyTest
     {
         // GIVEN
         RelationshipActions actions = mock( RelationshipActions.class );
-        when( actions.newNodeProxy( anyLong() ) ).then( new Answer<Node>()
-        {
-            @Override
-            public Node answer( InvocationOnMock invocation ) throws Throwable
-            {
-                return nodeWithId( (Long) invocation.getArguments()[0] );
-            }
-        } );
-        when( actions.getRelationshipTypeById( anyInt() ) ).then( new Answer<RelationshipType>()
-        {
-            @Override
-            public RelationshipType answer( InvocationOnMock invocation ) throws Throwable
-            {
-                return new RelationshipTypeToken( "whatever", (Integer) invocation.getArguments()[0] );
-            }
-        } );
+        when( actions.newNodeProxy( anyLong() ) ).then(
+                (Answer<Node>) invocation -> nodeWithId( (Long) invocation.getArguments()[0] ) );
+        when( actions.getRelationshipTypeById( anyInt() ) ).then(
+                (Answer<RelationshipType>) invocation -> new RelationshipTypeToken( "whatever", (Integer) invocation.getArguments()[0] ) );
 
         long[] ids = new long[]{
                 1437589437,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
@@ -44,7 +44,6 @@ import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.ImpermanentDatabaseRule;
@@ -100,14 +99,10 @@ public class TestTransactionEvents
         { /* Good */
         }
 
-        assertTrue( handler1 == db.registerTransactionEventHandler(
-                handler1 ) );
-        assertTrue( handler2 == db.registerTransactionEventHandler(
-                handler2 ) );
-        assertTrue( handler1 == db.unregisterTransactionEventHandler(
-                handler1 ) );
-        assertTrue( handler2 == db.unregisterTransactionEventHandler(
-                handler2 ) );
+        assertTrue( handler1 == db.registerTransactionEventHandler( handler1 ) );
+        assertTrue( handler2 == db.registerTransactionEventHandler( handler2 ) );
+        assertTrue( handler1 == db.unregisterTransactionEventHandler( handler1 ) );
+        assertTrue( handler2 == db.unregisterTransactionEventHandler( handler2 ) );
 
         db.registerTransactionEventHandler( handler1 );
         try ( Transaction tx = db.beginTx() )
@@ -376,9 +371,9 @@ public class TestTransactionEvents
             node2 = db.createNode();
             rel = node1.createRelationshipTo( node2, RelTypes.TXEVENT );
             node1.setProperty( "test1", "stringvalue" );
-            node1.setProperty( "test2", 1l );
+            node1.setProperty( "test2", 1L );
             rel.setProperty( "test1", "stringvalue" );
-            rel.setProperty( "test2", 1l );
+            rel.setProperty( "test2", 1L );
             rel.setProperty( "test3", new int[] { 1, 2, 3 } );
             tx.success();
         }
@@ -386,7 +381,6 @@ public class TestTransactionEvents
         db.registerTransactionEventHandler( handler );
         try ( Transaction tx = db.beginTx() )
         {
-            GraphDatabaseAPI dbApi = dbRule.getGraphDatabaseAPI();
             rel.delete();
             node1.delete();
             node2.delete();
@@ -394,8 +388,8 @@ public class TestTransactionEvents
         }
         assertEquals( "stringvalue", handler.nodeProps.get( "test1" ) );
         assertEquals( "stringvalue", handler.relProps.get( "test1" ) );
-        assertEquals( 1l , handler.nodeProps.get( "test2" ) );
-        assertEquals( 1l , handler.relProps.get( "test2" ) );
+        assertEquals( 1L, handler.nodeProps.get( "test2" ) );
+        assertEquals( 1L, handler.relProps.get( "test2" ) );
         int[] intArray = (int[]) handler.relProps.get( "test3" );
         assertEquals( 3, intArray.length );
         assertEquals( 1, intArray[0] );
@@ -461,7 +455,7 @@ public class TestTransactionEvents
         }
     }
 
-    private static enum RelTypes implements RelationshipType
+    private enum RelTypes implements RelationshipType
     {
         TXEVENT
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.store;
 
 import org.junit.Test;
 import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,6 +29,7 @@ import java.io.IOException;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.kernel.impl.store.format.RecordFormat;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.configuration.Config;
@@ -63,9 +65,10 @@ public class CommonAbstractStoreTest
         when( pageCache.map( eq( storeFile ), anyInt() ) ).thenReturn( storePagedFile );
         IdGenerator idGenerator = mock(
                 IdGenerator.class );
-        when( idGeneratorFactory.open( any( File.class ), anyInt(), eq( idType ), anyInt() ) )
+        when( idGeneratorFactory.open( any( File.class ), anyInt(), eq( idType ), anyInt(), anyInt() ) )
                 .thenReturn( idGenerator );
-        CommonAbstractStore store = new TheStore( storeFile, config, idType, idGeneratorFactory, pageCache, LOG );
+        RecordFormat recordFormat = Mockito.mock( RecordFormat.class );
+        CommonAbstractStore store = new TheStore( storeFile, config, idType, idGeneratorFactory, pageCache, LOG, recordFormat );
         store.initialise( false );
 
         // this is needed to forget all interaction with the mocks during the construction of the store
@@ -84,9 +87,10 @@ public class CommonAbstractStoreTest
     private static class TheStore extends CommonAbstractStore
     {
         public TheStore( File fileName, Config configuration, IdType idType, IdGeneratorFactory idGeneratorFactory,
-                PageCache pageCache, LogProvider logProvider )
+                PageCache pageCache, LogProvider logProvider, RecordFormat recordFormat )
         {
-            super( fileName, configuration, idType, idGeneratorFactory, pageCache, logProvider, "TheType", "v1" );
+            super( fileName, configuration, idType, idGeneratorFactory, pageCache, logProvider, "TheType",
+                    recordFormat, "v1" );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -41,10 +42,17 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
-import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
+import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.lowlimit.LowLimitV3_0;
+import org.neo4j.kernel.impl.store.format.lowlimit.NodeRecordFormat;
+import org.neo4j.kernel.impl.store.format.lowlimit.PropertyKeyTokenRecordFormat;
+import org.neo4j.kernel.impl.store.format.lowlimit.PropertyRecordFormat;
+import org.neo4j.kernel.impl.store.format.lowlimit.RelationshipRecordFormat;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -55,7 +63,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.graphdb.RelationshipType.withName;
 import static org.neo4j.helpers.collection.IteratorUtil.lastOrNull;
 import static org.neo4j.io.fs.FileUtils.deleteRecursively;
@@ -499,12 +506,13 @@ public class IdGeneratorTest
     {
         try
         {
+            PropertyKeyTokenRecordFormat recordFormat = new PropertyKeyTokenRecordFormat();
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
             IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1,
-                    IdType.PROPERTY_KEY_TOKEN.getMaxValue(), false, 0 );
-            idGenerator.setHighId( IdType.PROPERTY_KEY_TOKEN.getMaxValue() - 1 );
+                    recordFormat.getMaxId(), false, 0 );
+            idGenerator.setHighId( recordFormat.getMaxId() - 1 );
             long id = idGenerator.nextId();
-            assertEquals( IdType.PROPERTY_KEY_TOKEN.getMaxValue() - 1, id );
+            assertEquals( recordFormat.getMaxId() - 1, id );
             idGenerator.freeId( id );
             try
             {
@@ -515,10 +523,10 @@ public class IdGeneratorTest
             { // good, capacity exceeded
             }
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, IdType.PROPERTY_KEY_TOKEN.getMaxValue(), false, 0 );
-            assertEquals( IdType.PROPERTY_KEY_TOKEN.getMaxValue() + 1, idGenerator.getHighId() );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, recordFormat.getMaxId(), false, 0 );
+            assertEquals( recordFormat.getMaxId() + 1, idGenerator.getHighId() );
             id = idGenerator.nextId();
-            assertEquals( IdType.PROPERTY_KEY_TOKEN.getMaxValue() - 1, id );
+            assertEquals( recordFormat.getMaxId() - 1, id );
             try
             {
                 idGenerator.nextId();
@@ -541,31 +549,36 @@ public class IdGeneratorTest
     @Test
     public void makeSureIdCapacityCannotBeExceeded() throws Exception
     {
-        for ( IdType type : IdType.values() )
+        RecordFormats formats = LowLimitV3_0.RECORD_FORMATS;
+        List<RecordFormat<? extends AbstractBaseRecord>> recordFormats = Arrays.asList( formats.node(),
+                formats.dynamic(),
+                formats.labelToken(),
+                formats.property(),
+                formats.propertyKeyToken(),
+                formats.relationship(),
+                formats.relationshipGroup(),
+                formats.relationshipTypeToken() );
+
+        for ( RecordFormat format : recordFormats )
         {
-            makeSureIdCapacityCannotBeExceeded( type );
+            makeSureIdCapacityCannotBeExceeded( format );
         }
     }
 
-    private void makeSureIdCapacityCannotBeExceeded( IdType type )
+    private void makeSureIdCapacityCannotBeExceeded( RecordFormat format )
     {
         deleteIdGeneratorFile();
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        long maxValue = type.getMaxValue();
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, maxValue, false, 0 );
+        long maxValue = format.getMaxId();
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, maxValue - 1, false, 0 );
         long id = maxValue - 2;
         idGenerator.setHighId( id );
         assertEquals( id, idGenerator.nextId() );
         assertEquals( id + 1, idGenerator.nextId() );
-        if ( maxValue != (long) Math.pow( 2, 32 ) - 1 )
-        {
-            // This is for the special -1 value
-            assertEquals( id + 2, idGenerator.nextId() );
-        }
         try
         {
             idGenerator.nextId();
-            fail( "Id capacity shouldn't be able to be exceeded for " + type );
+            fail( "Id capacity shouldn't be able to be exceeded for " + format );
         }
         catch ( StoreFailureException e )
         { // Good
@@ -576,16 +589,16 @@ public class IdGeneratorTest
     @Test
     public void makeSureMagicMinusOneIsNotReturnedFromNodeIdGenerator() throws Exception
     {
-        makeSureMagicMinusOneIsSkipped( IdType.NODE );
-        makeSureMagicMinusOneIsSkipped( IdType.RELATIONSHIP );
-        makeSureMagicMinusOneIsSkipped( IdType.PROPERTY );
+        makeSureMagicMinusOneIsSkipped( new NodeRecordFormat() );
+        makeSureMagicMinusOneIsSkipped( new RelationshipRecordFormat() );
+        makeSureMagicMinusOneIsSkipped( new PropertyRecordFormat());
     }
 
-    private void makeSureMagicMinusOneIsSkipped( IdType type )
+    private void makeSureMagicMinusOneIsSkipped( RecordFormat format )
     {
         deleteIdGeneratorFile();
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, type.getMaxValue(), false, 0 );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, format.getMaxId(), false, 0 );
         long id = (long) Math.pow( 2, 32 ) - 3;
         idGenerator.setHighId( id );
         assertEquals( id, idGenerator.nextId() );
@@ -601,7 +614,7 @@ public class IdGeneratorTest
     public void makeSureMagicMinusOneCannotBeReturnedEvenIfFreed() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, IdType.NODE.getMaxValue(), false, 0 );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, 0 );
         long magicMinusOne = (long) Math.pow( 2, 32 ) - 1;
         idGenerator.setHighId( magicMinusOne );
         assertEquals( magicMinusOne + 1, idGenerator.nextId() );
@@ -609,7 +622,7 @@ public class IdGeneratorTest
         idGenerator.freeId( magicMinusOne );
         closeIdGenerator( idGenerator );
 
-        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, IdType.NODE.getMaxValue(), false, 0 );
+        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, 0 );
         assertEquals( magicMinusOne - 1, idGenerator.nextId() );
         assertEquals( magicMinusOne + 2, idGenerator.nextId() );
         closeIdGenerator( idGenerator );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
@@ -215,7 +215,7 @@ public class NodeStoreTest
         // When & then
         assertTrue( store.isInUse( exists ) );
         assertFalse( store.isInUse( deleted ) );
-        assertFalse( store.isInUse( IdType.NODE.getMaxValue() ) );
+        assertFalse( store.isInUse( nodeStore.recordFormat.getMaxId() ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/UpgradeStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/UpgradeStoreIT.java
@@ -416,7 +416,7 @@ public class UpgradeStoreIT
         }
 
         @Override
-        public IdGenerator open( File fileName, int grabSize, IdType idType, long highId )
+        public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
         {
             IdGenerator generator = new IdGeneratorImpl( fs, fileName, grabSize, Long.MAX_VALUE, false, highId );
             generators.put( idType, generator );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
@@ -198,6 +198,12 @@ public class PrepareTrackingRecordFormats implements RecordFormats
         }
 
         @Override
+        public long getMaxId()
+        {
+            return actual.getMaxId();
+        }
+
+        @Override
         public boolean equals( Object otherFormat )
         {
             return actual.equals( otherFormat );

--- a/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralIdGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralIdGenerator.java
@@ -39,7 +39,7 @@ public class EphemeralIdGenerator implements IdGenerator
         protected final Map<IdType, IdGenerator> generators = new EnumMap<>( IdType.class );
 
         @Override
-        public IdGenerator open( File fileName, int grabSize, IdType idType, long highId )
+        public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
         {
             IdGenerator generator = generators.get( idType );
             if ( generator == null )

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
@@ -140,7 +140,7 @@ public class DefaultUdcInformationCollectorTest
         }
 
         @Override
-        public IdGenerator open( File fileName, int grabSize, IdType idType, long highId )
+        public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
         {
             return get( idType );
         }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertClassicStoreCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertClassicStoreCommand.java
@@ -136,7 +136,8 @@ public class ConvertClassicStoreCommand
 
     private long getHighId( File coreDir, DefaultIdGeneratorFactory factory, IdType idType, String store )
     {
-        IdGenerator idGenerator = factory.open( new File( coreDir, idFile( store ) ), idType.getGrabSize(), idType, -1 );
+        IdGenerator idGenerator = factory.open( new File( coreDir, idFile( store ) ), idType.getGrabSize(), idType,
+                -1, Long.MAX_VALUE );
         long highId = idGenerator.getHighId();
         idGenerator.close();
         return highId;

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdGeneratorFactory.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdGeneratorFactory.java
@@ -48,7 +48,7 @@ public class ReplicatedIdGeneratorFactory extends LifecycleAdapter implements Id
     }
 
     @Override
-    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId )
+    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
     {
         SwitchableRaftIdGenerator previous = generators.remove( idType );
         if ( previous != null )
@@ -56,10 +56,8 @@ public class ReplicatedIdGeneratorFactory extends LifecycleAdapter implements Id
             previous.close();
         }
 
-        long maxValue = idType.getMaxValue();
         boolean aggressiveReuse = idType.allowAggressiveReuse();
-        IdGenerator initialIdGenerator =
-                new IdGeneratorImpl( fs, fileName, grabSize, maxValue, aggressiveReuse, highId );
+        IdGenerator initialIdGenerator = new IdGeneratorImpl( fs, fileName, grabSize, maxId, aggressiveReuse, highId );
         SwitchableRaftIdGenerator switchableIdGenerator =
                 new SwitchableRaftIdGenerator( initialIdGenerator, idType, idRangeAcquirer, logProvider );
         if ( replicatedMode )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
@@ -29,6 +29,7 @@ import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
 import org.neo4j.graphdb.TransientTransactionFailureException;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
@@ -165,7 +166,7 @@ public class HaIdGeneratorFactoryTest
         File idFile = new File( "my.id" );
         // ... opening an id generator as master
         fac.create( idFile, 10, true );
-        IdGenerator idGenerator = fac.open( idFile, 10, IdType.NODE, 10 );
+        IdGenerator idGenerator = fac.open( idFile, 10, IdType.NODE, 10, HighLimit.RECORD_FORMATS.node().getMaxId() );
         assertTrue( fs.fileExists( idFile ) );
         idGenerator.close();
 
@@ -186,7 +187,7 @@ public class HaIdGeneratorFactoryTest
         fac.create( idFile, 10, true );
 
         // WHEN
-        IdGenerator idGenerator = fac.open( idFile, 10, IdType.NODE, 10 );
+        IdGenerator idGenerator = fac.open( idFile, 10, IdType.NODE, 10, HighLimit.RECORD_FORMATS.node().getMaxId() );
 
         // THEN
         assertFalse( "Id file should've been deleted by now", fs.fileExists( idFile ) );
@@ -226,7 +227,7 @@ public class HaIdGeneratorFactoryTest
     private IdGenerator switchToSlave()
     {
         fac.switchToSlave();
-        IdGenerator gen = fac.open( new File( "someFile" ), 10, IdType.NODE, 1 );
+        IdGenerator gen = fac.open( new File( "someFile" ), 10, IdType.NODE, 1, HighLimit.RECORD_FORMATS.node().getMaxId() );
         masterDelegate.setDelegate( master );
         return gen;
     }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
@@ -89,6 +89,11 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
     }
 
     @Override
+    public long getMaxId()
+    {
+        return getMaxId( HighLimit.DEFAULT_MAXIMUM_BITS_PER_ID );
+    }
+
     public void read( RECORD record, PageCursor primaryCursor, RecordLoad mode, int recordSize, PagedFile storeFile )
             throws IOException
     {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
@@ -99,4 +99,10 @@ class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRecord>
     {
         return record.getNextBlock();
     }
+
+    @Override
+    public long getMaxId()
+    {
+        return getMaxId( HighLimit.DEFAULT_MAXIMUM_BITS_PER_ID );
+    }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -42,6 +42,11 @@ import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
  */
 public class HighLimit extends BaseRecordFormats
 {
+    /**
+     * Default maximum number of bits that can be used to represent id
+     */
+    static final int DEFAULT_MAXIMUM_BITS_PER_ID = 50;
+
     public static final RecordFormats RECORD_FORMATS = new HighLimit();
     // Enterprise.HighLimit.Zero
     public static final String STORE_VERSION = "vE.H.0";

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
@@ -120,4 +120,10 @@ import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toRelative;
     {
         return record.getNextProp();
     }
+
+    @Override
+    public long getMaxId()
+    {
+        return getMaxId( HighLimit.DEFAULT_MAXIMUM_BITS_PER_ID );
+    }
 }


### PR DESCRIPTION
Remove hardcoded number of bits for each particular id type;
use current store format to determine allowable max id for each particular record type
