### PR TITLE
Fixes issue where CC would process some unused records

### DIFF
--- a/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/checking/full/IterableStore.java
+++ b/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/checking/full/IterableStore.java
@@ -26,7 +26,6 @@ import org.neo4j.kernel.api.direct.BoundedIterable;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 
-import static org.neo4j.kernel.impl.store.RecordStore.IN_USE;
 import static org.neo4j.kernel.impl.store.RecordStore.Scanner.scan;
 
 public class IterableStore<RECORD extends AbstractBaseRecord> implements BoundedIterable<RECORD>
@@ -52,6 +51,6 @@ public class IterableStore<RECORD extends AbstractBaseRecord> implements Bounded
     @Override
     public Iterator<RECORD> iterator()
     {
-        return scan( store, IN_USE ).iterator();
+        return scan( store ).iterator();
     }
 }

--- a/community/consistency-check-legacy/src/test/java/org/neo4j/legacy/consistency/checking/full/StoreProcessorTest.java
+++ b/community/consistency-check-legacy/src/test/java/org/neo4j/legacy/consistency/checking/full/StoreProcessorTest.java
@@ -72,7 +72,7 @@ public class StoreProcessorTest
             public NodeRecord answer( InvocationOnMock invocation ) throws Throwable
             {
                 processor.stop();
-                return new NodeRecord( 0, false, 0, 0 );
+                return new NodeRecord( 2, true, false, 0, 0, 0 );
             }
         } );
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
@@ -103,7 +103,8 @@ public class ConsistencyCheckTasks
             tasks.add( create( CheckStage.Stage2_RS_Labels.name(), nativeStores.getRelationshipStore(),
                     processor, ROUND_ROBIN ) );
             //NodeStore pass - just cache nextRel and inUse
-            tasks.add( new CacheTask.CacheNextRel( CheckStage.Stage3_NS_NextRel, cacheAccess, Scanner.scan( nativeStores.getNodeStore() ) ) );
+            tasks.add( new CacheTask.CacheNextRel( CheckStage.Stage3_NS_NextRel, cacheAccess,
+                    Scanner.scan( nativeStores.getNodeStore() ) ) );
             //RelationshipStore pass - check nodes inUse, FirstInFirst, FirstInSecond using cached info
             processor = multiPass.processor( CheckStage.Stage4_RS_NextRel, NODES );
             multiPass.reDecorateRelationship( processor, RelationshipRecordCheck.relationshipRecordCheckBackwardPass(

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
@@ -27,8 +27,6 @@ import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.RecordStore.Scanner;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 
-import static org.neo4j.kernel.impl.store.RecordStore.IN_USE;
-
 public class IterableStore<RECORD extends AbstractBaseRecord> implements BoundedIterable<RECORD>
 {
     private final RecordStore<RECORD> store;
@@ -54,7 +52,7 @@ public class IterableStore<RECORD extends AbstractBaseRecord> implements Bounded
     @Override
     public Iterator<RECORD> iterator()
     {
-        return Scanner.scan( store, forward, IN_USE ).iterator();
+        return Scanner.scan( store, forward ).iterator();
     }
 
     public void warmUpCache()

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/QueueDistribution.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/QueueDistribution.java
@@ -20,6 +20,7 @@
 package org.neo4j.consistency.checking.full;
 
 import org.neo4j.consistency.checking.full.RecordDistributor.RecordConsumer;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
 /**
@@ -112,7 +113,8 @@ public interface QueueDistribution
             }
             catch ( ArrayIndexOutOfBoundsException e )
             {
-                throw e;
+                throw Exceptions.withMessage( e, e.getMessage() + ", recordsPerCPU:" + recordsPerCpu +
+                        ", relationship:" + relationship );
             }
         }
     }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessorTask.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessorTask.java
@@ -90,8 +90,7 @@ public class StoreProcessorTask<R extends AbstractBaseRecord> extends Consistenc
                 }
                 long recordsPerCPU = RecordDistributor.calculateRecodsPerCpu( highId, numberOfThreads );
                 QueueDistributor<R> distributor = distribution.distributor( recordsPerCPU, numberOfThreads );
-                processor.applyFilteredParallel( store, progressListener, numberOfThreads, recordsPerCPU,
-                        distributor );
+                processor.applyFilteredParallel( store, progressListener, numberOfThreads, recordsPerCPU, distributor );
             }
             else
             {

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -41,11 +41,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.consistency.RecordType;
 import org.neo4j.consistency.checking.GraphStoreFixture;
+import org.neo4j.consistency.checking.GraphStoreFixture.IdGenerator;
+import org.neo4j.consistency.checking.GraphStoreFixture.TransactionDataBuilder;
 import org.neo4j.consistency.report.ConsistencyReport;
 import org.neo4j.consistency.report.ConsistencyReporter;
 import org.neo4j.consistency.report.ConsistencySummaryStatistics;
@@ -1930,6 +1933,41 @@ public class FullCheckIntegrationTest
 
         createUniquenessConstraintRule( labelId, propertyKeyId );
         createNodePropertyExistenceConstraint( labelId, propertyKeyId );
+
+        // When
+        ConsistencySummaryStatistics stats = check();
+
+        // Then
+        assertTrue( stats.isConsistent() );
+    }
+
+    @Test
+    public void shouldManageUnusedRecordsWithWeirdDataIn() throws Exception
+    {
+        // Given
+        final AtomicLong id = new AtomicLong();
+        fixture.apply( new GraphStoreFixture.Transaction()
+        {
+            @Override
+            protected void transactionData( TransactionDataBuilder tx, IdGenerator next )
+            {
+                id.set( next.relationship() );
+                RelationshipRecord relationship = new RelationshipRecord( id.get() );
+                relationship.setFirstNode( -1 );
+                relationship.setSecondNode( -1 );
+                relationship.setInUse( true );
+                tx.create( relationship );
+            }
+        } );
+        fixture.apply( new GraphStoreFixture.Transaction()
+        {
+            @Override
+            protected void transactionData( TransactionDataBuilder tx, IdGenerator next )
+            {
+                RelationshipRecord relationship = new RelationshipRecord( id.get() );
+                tx.delete( relationship );
+            }
+        } );
 
         // When
         ConsistencySummaryStatistics stats = check();

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTest.java
@@ -75,7 +75,7 @@ public class StoreProcessorTest
             public NodeRecord answer( InvocationOnMock invocation ) throws Throwable
             {
                 processor.stop();
-                return new NodeRecord( 0, false, 0, 0 );
+                return new NodeRecord( 2, true, false, 0, 0, 0 );
             }
         } );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordStore.java
@@ -71,15 +71,6 @@ public interface RecordStore<R extends AbstractBaseRecord> extends IdSequence
 
     int getNumberOfReservedLowIds();
 
-    Predicate<AbstractBaseRecord> IN_USE = new Predicate<AbstractBaseRecord>()
-    {
-        @Override
-        public boolean test( AbstractBaseRecord item )
-        {
-            return item.inUse();
-        }
-    };
-
     class Delegator<R extends AbstractBaseRecord> implements RecordStore<R>
     {
         private final RecordStore<R> actual;
@@ -287,14 +278,17 @@ public interface RecordStore<R extends AbstractBaseRecord> extends IdSequence
                             while ( ids.hasNext() )
                             {
                                 R record = store.forceGetRecord( ids.next() );
-                                for ( Predicate<? super R> filter : filters )
+                                if ( record.inUse() )
                                 {
-                                    if ( !filter.test( record ) )
+                                    for ( Predicate<? super R> filter : filters )
                                     {
-                                        continue scan;
+                                        if ( !filter.test( record ) )
+                                        {
+                                            continue scan;
+                                        }
                                     }
+                                    return record;
                                 }
-                                return record;
                             }
                             return null;
                         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
@@ -247,7 +247,7 @@ public class StoreAccess
     protected <FAILURE extends Exception> void apply( RecordStore.Processor<FAILURE> processor, RecordStore<?> store )
             throws FAILURE
     {
-        processor.applyFiltered( store, RecordStore.IN_USE );
+        processor.applyFiltered( store );
     }
 
     public synchronized void close()

--- a/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/generator/DataGenerator.java
+++ b/enterprise/enterprise-performance-tests/src/main/java/org/neo4j/perftest/enterprise/generator/DataGenerator.java
@@ -137,7 +137,7 @@ public class DataGenerator
             if ( configuration.get( report_stats ) )
             {
                 PropertyStats stats = new PropertyStats();
-                stats.applyFiltered( stores.getPropertyStore(), RecordStore.IN_USE );
+                stats.applyFiltered( stores.getPropertyStore() );
                 // TODO please pass in the PrintStream as an argument
                 System.out.println( stats );
             }


### PR DESCRIPTION
but where the processing code assumed used records. This would be a
problem, first and foremost, in RelationshipNodesQueueDistributor where
the decision about where to send a record for processing might end up
with an invalid thread id to send to.
