### PR TITLE
Print null JSON elements to maintain index parity

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/Neo4jJsonCodec.java
@@ -200,10 +200,7 @@ public class Neo4jJsonCodec extends ObjectMapper
         }
         else if ( value instanceof Path )
         {
-            for ( PropertyContainer element : ((Path) value) )
-            {
-                writeMeta( out, element );
-            }
+            writeMetaPath( out, (Path) value );
         }
         else if ( value instanceof Iterable )
         {
@@ -219,6 +216,26 @@ public class Neo4jJsonCodec extends ObjectMapper
             {
                 writeMeta( out, map.get( key ) );
             }
+        }
+        else
+        {
+            out.writeNull();
+        }
+    }
+
+    private void writeMetaPath( JsonGenerator out, Path value ) throws IOException
+    {
+        out.writeStartArray();
+        try
+        {
+            for ( PropertyContainer element : value )
+            {
+                writeMeta( out, element );
+            }
+        }
+        finally
+        {
+            out.writeEndArray();
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -136,7 +136,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         // then
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"commit\":\"commit/uri/1\",\"results\":[{\"columns\":[\"column1\",\"column2\"]," +
-                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}],\"errors\":[]}", result );
+                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}],\"errors\":[]}", result );
     }
 
     @Test
@@ -157,7 +157,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         // then
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"results\":[{\"columns\":[\"column1\",\"column2\"]," +
-                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}],\"errors\":[]}", result );
+                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}],\"errors\":[]}", result );
     }
 
     @Test
@@ -180,7 +180,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         // then
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"commit\":\"commit/uri/1\",\"results\":[{\"columns\":[\"column1\",\"column2\"]," +
-                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}]," +
+                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}]," +
                       "\"errors\":[{\"code\":\"Neo.ClientError.Request.InvalidFormat\",\"message\":\"cause1\"}]}",
                       result );
     }
@@ -204,7 +204,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         // then
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"results\":[{\"columns\":[\"column1\",\"column2\"]," +
-                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}]," +
+                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}]," +
                       "\"errors\":[{\"code\":\"Neo.ClientError.Request.InvalidFormat\",\"message\":\"cause1\"}]}",
                       result );
     }
@@ -280,7 +280,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         // then
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"results\":[{\"columns\":[\"column1\",\"column2\"]," +
-                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]},{\"row\":[\"value3\",\"value4\"],\"meta\":[]}]}]," +
+                      "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]},{\"row\":[\"value3\",\"value4\"],\"meta\":[null,null]}]}]," +
                       "\"errors\":[]}", result );
     }
 
@@ -306,8 +306,8 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         // then
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"results\":[" +
-                      "{\"columns\":[\"column1\",\"column2\"],\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}," +
-                      "{\"columns\":[\"column3\",\"column4\"],\"data\":[{\"row\":[\"value3\",\"value4\"],\"meta\":[]}]}]," +
+                      "{\"columns\":[\"column1\",\"column2\"],\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}," +
+                      "{\"columns\":[\"column3\",\"column4\"],\"data\":[{\"row\":[\"value3\",\"value4\"],\"meta\":[null,null]}]}]," +
                       "\"errors\":[]}", result );
     }
 
@@ -363,7 +363,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"results\":[{\"columns\":[\"nested\"]," +
                       "\"data\":[{\"row\":[{\"edge\":{\"baz\":\"quux\"},\"node\":{\"foo\":12},\"path\":[{\"foo\":12},{\"baz\":\"quux\"},{\"bar\":false}]}]," +
-                      "\"meta\":[{\"id\":1,\"type\":\"relationship\",\"deleted\":false},{\"id\":1,\"type\":\"node\",\"deleted\":false},{\"id\":1,\"type\":\"node\",\"deleted\":false},{\"id\":1,\"type\":\"relationship\",\"deleted\":false},{\"id\":2,\"type\":\"node\",\"deleted\":false}]}]}]," +
+                      "\"meta\":[{\"id\":1,\"type\":\"relationship\",\"deleted\":false},{\"id\":1,\"type\":\"node\",\"deleted\":false},[{\"id\":1,\"type\":\"node\",\"deleted\":false},{\"id\":1,\"type\":\"relationship\",\"deleted\":false},{\"id\":2,\"type\":\"node\",\"deleted\":false}]]}]}]," +
                       "\"errors\":[]}", result );
     }
 
@@ -385,7 +385,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         String result = output.toString( UTF_8.name() );
         assertEquals( "{\"results\":[{\"columns\":[\"path\"]," +
                       "\"data\":[{\"row\":[[{\"key1\":\"value1\"},{\"key2\":\"value2\"},{\"key3\":\"value3\"}]]," +
-                      "\"meta\":[{\"id\":1,\"type\":\"node\",\"deleted\":false},{\"id\":1,\"type\":\"relationship\",\"deleted\":false},{\"id\":2,\"type\":\"node\",\"deleted\":false}]}]}]," +
+                      "\"meta\":[[{\"id\":1,\"type\":\"node\",\"deleted\":false},{\"id\":1,\"type\":\"relationship\",\"deleted\":false},{\"id\":2,\"type\":\"node\",\"deleted\":false}]]}]}]," +
                       "\"errors\":[]}", result );
     }
 
@@ -420,7 +420,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         // then
         String result = output.toString( UTF_8.name() );
         assertEquals(
-                "{\"results\":[{\"columns\":[\"column1\",\"column2\"],\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}]," +
+                "{\"results\":[{\"columns\":[\"column1\",\"column2\"],\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}]," +
                 "\"errors\":[{\"code\":\"Neo.DatabaseError.Statement.ExecutionFailure\",\"message\":\"Stuff went wrong!\",\"stackTrace\":***}]}",
                 replaceStackTrace( result, "***" ) );
     }
@@ -457,7 +457,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         // then
         String result = output.toString( UTF_8.name() );
         assertEquals(
-                "{\"results\":[{\"columns\":[\"column1\",\"column2\"],\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}]," +
+                "{\"results\":[{\"columns\":[\"column1\",\"column2\"],\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}]," +
                 "\"errors\":[{\"code\":\"Neo.DatabaseError.Statement.ExecutionFailure\",\"message\":\"Stuff went wrong!\"," +
                 "\"stackTrace\":***}]}",
                 replaceStackTrace( result, "***" ) );
@@ -813,7 +813,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
 
         assertEquals(
                 "{\"commit\":\"commit/uri/1\",\"results\":[{\"columns\":[\"column1\",\"column2\"]," +
-                        "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}],\"notifications\":[{\"code\":\"Neo" +
+                        "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}],\"notifications\":[{\"code\":\"Neo" +
                         ".ClientNotification.Statement.CartesianProduct\",\"severity\":\"WARNING\",\"title\":\"This " +
                         "query builds a cartesian product between disconnected patterns.\",\"description\":\"If a " +
                         "part of a query contains multiple disconnected patterns, this will build a cartesian product" +
@@ -847,7 +847,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
 
         assertEquals(
                 "{\"commit\":\"commit/uri/1\",\"results\":[{\"columns\":[\"column1\",\"column2\"]," +
-                        "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}],\"errors\":[]}", result );
+                        "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}],\"errors\":[]}", result );
     }
 
     @Test
@@ -875,7 +875,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
 
         assertEquals(
                 "{\"commit\":\"commit/uri/1\",\"results\":[{\"columns\":[\"column1\",\"column2\"]," +
-                        "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[]}]}],\"notifications\":[{\"code\":\"Neo" +
+                        "\"data\":[{\"row\":[\"value1\",\"value2\"],\"meta\":[null,null]}]}],\"notifications\":[{\"code\":\"Neo" +
                         ".ClientNotification.Statement.CartesianProduct\",\"severity\":\"WARNING\",\"title\":\"This " +
                         "query builds a cartesian product between disconnected patterns.\",\"description\":\"If a " +
                         "part of a query contains multiple disconnected patterns, this will build a cartesian product" +

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
@@ -46,6 +46,7 @@ import static org.neo4j.server.rest.transactional.integration.TransactionMatcher
 import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.restContainsDeletedEntities;
 import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.restContainsNoDeletedEntities;
 import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.rowContainsDeletedEntities;
+import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.rowContainsDeletedEntitiesInPath;
 import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.rowContainsNoDeletedEntities;
 import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
@@ -496,7 +497,7 @@ public class QueryResultsSerializationTest extends AbstractRestFunctionalTestBas
                 queryAsJsonRow( "MATCH p=(s)-[r:R]->(e) DELETE p RETURN p" ) );
 
         assertThat( commit, containsNoErrors() );
-        assertThat( commit, rowContainsDeletedEntities( 2, 1 ) );
+        assertThat( commit, rowContainsDeletedEntitiesInPath( 2, 1 ) );
         assertThat( commit.status(), equalTo( 200 ) );
         assertThat( nodesInDatabase(), equalTo( 0L ) );
     }
@@ -512,7 +513,7 @@ public class QueryResultsSerializationTest extends AbstractRestFunctionalTestBas
                 queryAsJsonRow( "MATCH p=(s)-[r:R]->(e) DELETE s,r RETURN p" ) );
 
         assertThat( commit, containsNoErrors() );
-        assertThat( commit, rowContainsDeletedEntities( 1, 1 ) );
+        assertThat( commit, rowContainsDeletedEntitiesInPath( 1, 1 ) );
         assertThat( commit.status(), equalTo( 200 ) );
         assertThat( nodesInDatabase(), equalTo( 1L ) );
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/RowFormatMetaFieldTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/RowFormatMetaFieldTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.transactional.integration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.server.rest.AbstractRestFunctionalTestBase;
+import org.neo4j.server.rest.domain.JsonParseException;
+import org.neo4j.test.server.HTTP;
+import org.neo4j.test.server.HTTP.Response;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.containsNoErrors;
+import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.matches;
+import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.rowContainsAMetaListAtIndex;
+import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.rowContainsMetaNodesAtIndex;
+import static org.neo4j.server.rest.transactional.integration.TransactionMatchers.rowContainsMetaRelsAtIndex;
+import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
+
+public class RowFormatMetaFieldTest extends AbstractRestFunctionalTestBase
+{
+    private final HTTP.Builder http = HTTP.withBaseUri( "http://localhost:7474" );
+
+    private String commitResource;
+
+    @Before
+    public void setUp()
+    {
+        // begin
+        Response begin = http.POST( "/db/data/transaction" );
+
+        assertThat( begin.status(), equalTo( 201 ) );
+        assertHasTxLocation( begin );
+        try
+        {
+            commitResource = begin.stringFromContent( "commit" );
+        }
+        catch ( JsonParseException e )
+        {
+            fail( "Exception caught when setting up test: " + e.getMessage() );
+        }
+        assertThat( commitResource, equalTo( begin.location() + "/commit" ) );
+    }
+
+    @After
+    public void tearDown()
+    {
+        // empty the database
+        graphdb().execute( "MATCH (n) DETACH DELETE n" );
+    }
+
+    @Test
+    public void metaFieldShouldGetCorrectIndex()
+    {
+        // given
+        graphdb().execute( "CREATE (:Start)-[:R]->(:End)" );
+
+        // execute and commit
+        Response commit = http.POST( commitResource,
+                queryAsJsonRow( "MATCH (s:Start)-[r:R]->(e:End) RETURN s, r, 1, e" ) );
+
+        assertThat( commit, containsNoErrors() );
+        assertThat( commit, rowContainsMetaNodesAtIndex( 0, 3 ) );
+        assertThat( commit, rowContainsMetaRelsAtIndex( 1 ) );
+        assertThat( commit.status(), equalTo( 200 ) );
+    }
+
+    @Test
+    public void metaFieldShouldGivePathInfoInList()
+    {
+        // given
+        graphdb().execute( "CREATE (:Start)-[:R]->(:End)" );
+
+        // execute and commit
+        Response commit = http.POST( commitResource,
+                queryAsJsonRow( "MATCH p=(s)-[r:R]->(e) RETURN p" ) );
+
+        assertThat( commit, containsNoErrors() );
+        assertThat( commit, rowContainsAMetaListAtIndex( 0 ) );
+        assertThat( commit.status(), equalTo( 200 ) );
+    }
+
+    @Test
+    public void metaFieldShouldPutPathListAtCorrectIndex()
+    {
+        // given
+        graphdb().execute( "CREATE (:Start)-[:R]->(:End)" );
+
+        // execute and commit
+        Response commit = http.POST( commitResource,
+                queryAsJsonRow( "MATCH p=(s)-[r:R]->(e) RETURN 10, p" ) );
+
+        assertThat( commit, containsNoErrors() );
+        assertThat( commit, rowContainsAMetaListAtIndex( 1 ) );
+        assertThat( commit.status(), equalTo( 200 ) );
+    }
+
+    private HTTP.RawPayload queryAsJsonRow( String query )
+    {
+        return quotedJson( "{ 'statements': [ { 'statement': '" + query + "', 'resultDataContents': [ 'row' ] } ] }" );
+    }
+
+    private void assertHasTxLocation( Response begin )
+    {
+        assertThat( begin.location(), matches( "http://localhost:\\d+/db/data/transaction/\\d+" ) );
+    }
+}


### PR DESCRIPTION
The 'row' format has a 'meta' field containing information about
returned nodes and relationships, in particular whether or not these
have been deleted in the same transaction. This commit makes sure that
the index in the 'row' field of the returned entity is the same as the
index in the 'meta' field, by putting null fields in between, for types
that are not graph elements (nodes, relationships, paths).

Additionally, a returned path consists of several nodes and
relationships, and will now print a list in its meta entries, with the
meta information on the nodes and relationships that make up the path.
