### PR TITLE
6 minutes faster server enterprise tests

### DIFF
--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneClusterClientIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneClusterClientIT.java
@@ -28,6 +28,7 @@ import org.junit.rules.TestRule;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.AccessibleObject;
 import java.net.URI;
 import java.nio.file.Files;
@@ -286,8 +287,16 @@ public class StandaloneClusterClientIT
         {
             if ( process != null )
             {
-                kill( process );
-                process.waitFor();
+                // Tell it to leave the cluster and shut down now
+                try ( OutputStream inputToOtherProcess = process.getOutputStream() )
+                {
+                    inputToOtherProcess.write( 0 );
+                    inputToOtherProcess.flush();
+                }
+                if ( !process.waitFor( 10, SECONDS ) )
+                {
+                    kill( process );
+                }
             }
             if ( handler != null )
             {

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneClusterClientTestProxy.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/StandaloneClusterClientTestProxy.java
@@ -21,6 +21,8 @@ package org.neo4j.server.enterprise;
 
 import java.io.IOException;
 
+import static org.neo4j.server.enterprise.StandaloneClusterClient.getConfig;
+
 public class StandaloneClusterClientTestProxy
 {
     public static final String START_SIGNAL = "starting";
@@ -29,8 +31,11 @@ public class StandaloneClusterClientTestProxy
     {
         // This sysout will be intercepted by the parent process and will trigger
         // a start of a timeout. The whole reason for this class to be here is to
-        // split awaiting for the process to start and actually awaiting the cluster client to start. 
+        // split awaiting for the process to start and actually awaiting the cluster client to start.
         System.out.println( START_SIGNAL );
-        StandaloneClusterClient.main( args );
+        try ( StandaloneClusterClient client = new StandaloneClusterClient( getConfig( args ) ) )
+        {
+            System.in.read();
+        }
     }
 }


### PR DESCRIPTION
by properly shutting down the standalone cluster client as to not
wait for the semaphore for 60 seconds for shutting down, for every one of
the 6 tests in StandaloneClusterClientIT
