### PR TITLE
Clarified purpose of TransactionType->TransactionWriteState

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -99,7 +99,7 @@ public class KernelStatement implements TxStateHolder, Statement
             throw new AuthorizationViolationException(
                     String.format( "Write operations are not allowed for `%s` transactions.", transaction.mode().name() ) );
         }
-        transaction.upgradeToDataTransaction();
+        transaction.upgradeToDataWrites();
         return facade;
     }
 
@@ -112,7 +112,7 @@ public class KernelStatement implements TxStateHolder, Statement
             throw new AuthorizationViolationException(
                     String.format( "Schema operations are not allowed for `%s` transactions.", transaction.mode().name() ) );
         }
-        transaction.upgradeToSchemaTransaction();
+        transaction.upgradeToSchemaWrites();
         return facade;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -72,6 +72,14 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
      *   - the #release() method releases resources acquired in #initialize() or during the transaction's life time
      */
 
+    /**
+     * It is not allowed for the same transaction to perform database writes as well as schema writes.
+     * This enum tracks the current write state of the transaction, allowing it to transition from
+     * no writes (NONE) to data writes (DATA) or schema writes (SCHEMA), but it cannot transition between
+     * DATA and SCHEMA without throwing an InvalidTransactionTypeKernelException. Note that this behavior
+     * is orthogonal to the AccessMode which manages what the transaction or statement is allowed to do
+     * based on authorization.
+     */
     private enum TransactionWriteState
     {
         NONE,
@@ -126,12 +134,12 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     // whereas others, such as timestamp or txId when transaction starts, even locks, needs to be set in #initialize().
     private TransactionState txState;
     private LegacyIndexTransactionState legacyIndexTransactionState;
-    private TransactionWriteState writeState; // Tracks current state of transaction, which will upgrade to WRITE or SCHEMA mode when necessary
+    private TransactionWriteState writeState;
     private TransactionHooks.TransactionHooksState hooksState;
     private final KernelStatement currentStatement;
     private final StorageStatement storageStatement;
     private CloseListener closeListener;
-    private AccessMode accessMode; // Defines whether a transaction/statement is allowed to perform read, write or schema commands
+    private AccessMode accessMode;
     private Locks.Client locks;
     private boolean beforeHookInvoked;
     private boolean closing, closed;


### PR DESCRIPTION
It was easy to confuse the TransactionType and AccessMode, especially since both had a READ value. However, these two enums have very different purposes, and should not be entagled or confused. This PR changes the name of the enum and the methods to further clarify the purpose and make it more different to AccessMode.
