### PR TITLE
Lock compatibility suite executes during mvn test

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/CommunityLocksTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/CommunityLocksTest.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.locking.community;
 import org.neo4j.kernel.impl.locking.LockingCompatibilityTestSuite;
 import org.neo4j.kernel.impl.locking.Locks;
 
-public class CommunityLocksCompatibility extends LockingCompatibilityTestSuite
+public class CommunityLocksTest extends LockingCompatibilityTestSuite
 {
     @Override
     protected Locks createLockManager()

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLocksTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLocksTest.java
@@ -23,11 +23,11 @@ import org.neo4j.kernel.impl.locking.LockingCompatibilityTestSuite;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 
-public class ForsetiLocksCompatibility extends LockingCompatibilityTestSuite
+public class ForsetiLocksTest extends LockingCompatibilityTestSuite
 {
     @Override
     protected Locks createLockManager()
     {
-        return new ForsetiLockManager( ResourceTypes.values());
+        return new ForsetiLockManager( ResourceTypes.values() );
     }
 }


### PR DESCRIPTION
Current naming of lock compatibility suite implementations makes them invisible to surefire and failsafe.
This commit makes community and forseti tests run during test phase.
