### PR TITLE
Simplified security status, merging three to two

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
@@ -51,8 +51,8 @@ public class BasicAuthentication implements Authentication
     {
         if ( !SCHEME.equals( authToken.get( SCHEME_KEY ) ) )
         {
-            throw new AuthenticationException( Status.Security.AuthenticationFailed, identifier.get(),
-                    "Authorization token must contain: '" + SCHEME_KEY + " : " + SCHEME + "'" );
+            throw new AuthenticationException( Status.Security.Unauthorized, identifier.get(),
+                    "Authentication token must contain: '" + SCHEME_KEY + " : " + SCHEME + "'" );
         }
 
         String user = safeCast( PRINCIPAL, authToken );
@@ -79,7 +79,7 @@ public class BasicAuthentication implements Authentication
             throw new AuthenticationException( Status.Security.AuthenticationRateLimit, identifier.get() );
         default:
             log.warn( "Failed authentication attempt for '%s'", user);
-            throw new AuthenticationException( Status.Security.AuthenticationFailed, identifier.get() );
+            throw new AuthenticationException( Status.Security.Unauthorized, identifier.get() );
         }
     }
 
@@ -95,11 +95,11 @@ public class BasicAuthentication implements Authentication
             }
             catch ( IOException e )
             {
-                throw new AuthenticationException( Status.Security.AuthenticationFailed, identifier.get(), e.getMessage(), e );
+                throw new AuthenticationException( Status.Security.Unauthorized, identifier.get(), e.getMessage(), e );
             }
             break;
         default:
-            throw new AuthenticationException( Status.Security.AuthenticationFailed, identifier.get() );
+            throw new AuthenticationException( Status.Security.Unauthorized, identifier.get() );
         }
     }
 
@@ -108,7 +108,7 @@ public class BasicAuthentication implements Authentication
         Object value = authToken.get( key );
         if ( value == null || !(value instanceof String) )
         {
-            throw new AuthenticationException( Status.Security.AuthenticationFailed, identifier.get(),
+            throw new AuthenticationException( Status.Security.Unauthorized, identifier.get(),
                     "The value associated with the key `" + key + "` must be a String but was: " +
                     (value == null ? "null" : value.getClass().getSimpleName()));
         }

--- a/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
@@ -75,8 +75,8 @@ public class BasicAuthenticationTest
 
         // Expect
         exception.expect( AuthenticationException.class );
-        exception.expect( hasStatus( Status.Security.AuthenticationFailed ) );
-        exception.expectMessage( "The client provided an incorrect username and/or password." );
+        exception.expect( hasStatus( Status.Security.Unauthorized ) );
+        exception.expectMessage( "The client is unauthorized due to authentication failure." );
 
         // When
         authentication.authenticate( map( "scheme", "basic", "principal", "bob", "credentials", "secret" ) );
@@ -161,8 +161,8 @@ public class BasicAuthenticationTest
 
         // Expect
         exception.expect( AuthenticationException.class );
-        exception.expect( hasStatus( Status.Security.AuthenticationFailed ) );
-        exception.expectMessage( "The client provided an incorrect username and/or password." );
+        exception.expect( hasStatus( Status.Security.Unauthorized ) );
+        exception.expectMessage( "The client is unauthorized due to authentication failure." );
 
         // When
         // When
@@ -180,8 +180,8 @@ public class BasicAuthenticationTest
 
         // Expect
         exception.expect( AuthenticationException.class );
-        exception.expect( hasStatus( Status.Security.AuthenticationFailed ) );
-        exception.expectMessage( "Authorization token must contain: 'scheme : basic'" );
+        exception.expect( hasStatus( Status.Security.Unauthorized ) );
+        exception.expectMessage( "Authentication token must contain: 'scheme : basic'" );
 
         // When
         authentication.authenticate( map( "scheme", "UNKNOWN", "principal", "bob", "credentials", "secret" ) );
@@ -197,7 +197,7 @@ public class BasicAuthenticationTest
 
         // Expect
         exception.expect( AuthenticationException.class );
-        exception.expect( hasStatus( Status.Security.AuthenticationFailed ) );
+        exception.expect( hasStatus( Status.Security.Unauthorized ) );
         exception.expectMessage(
                 "The value associated with the key `principal` must be a String but was: SingletonList" );
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -114,8 +114,8 @@ public class AuthenticationIT
 
         // Then
         assertThat( client, eventuallyRecieves( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyRecieves( msgFailure( Status.Security.AuthenticationFailed,
-                String.format( "The client provided an incorrect username and/or password. (ID:%s)", server.uniqueIdentier()) ) ) );
+        assertThat( client, eventuallyRecieves( msgFailure( Status.Security.Unauthorized,
+                String.format( "The client is unauthorized due to authentication failure. (ID:%s)", server.uniqueIdentier()) ) ) );
     }
 
     @Test
@@ -140,8 +140,8 @@ public class AuthenticationIT
                         init( "TestClient/1.1",
                                 map( "principal", "neo4j", "credentials", "neo4j", "scheme", "basic" ) ) ) );
         assertThat( client, eventuallyRecieves( new byte[]{0, 0, 0, 1} ) );
-        assertThat( client, eventuallyRecieves( msgFailure( Status.Security.AuthenticationFailed,
-                String.format( "The client provided an incorrect username and/or password. (ID:%s)", server.uniqueIdentier()) ) ) );
+        assertThat( client, eventuallyRecieves( msgFailure( Status.Security.Unauthorized,
+                String.format( "The client is unauthorized due to authentication failure. (ID:%s)", server.uniqueIdentier()) ) ) );
 
         // But the new password works fine
         reconnect();

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -313,13 +313,12 @@ public interface Status
     enum Security implements Status
     {
         // client
-        AuthenticationFailed( ClientError, "The client provided an incorrect username and/or password." ),
         CredentialsExpired( ClientError, "The credentials have expired and need to be updated." ),
-        AuthorizationFailed( ClientError, "The client does not have privileges to perform the operation requested." ),
+        Unauthorized( ClientError, "The client is unauthorized due to authentication failure." ),
         AuthenticationRateLimit( ClientError, "The client has provided incorrect authentication details too many times in a row." ),
         ModifiedConcurrently( TransientError, "The user was modified concurrently to this request." ),
         EncryptionRequired( ClientError, "A TLS encrypted connection is required." ),
-        AccessViolation( ClientError, "An attempt was made to perform an unauthorized action." );
+        Forbidden( ClientError, "An attempt was made to perform an unauthorized action." );
 
         private final Code code;
 

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationViolationException.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/security/AuthorizationViolationException.java
@@ -28,7 +28,7 @@ import org.neo4j.kernel.api.exceptions.Status;
  */
 public class AuthorizationViolationException extends RuntimeException implements Status.HasStatus
 {
-    private final Status statusCode = Status.Security.AccessViolation;
+    private final Status statusCode = Status.Security.Forbidden;
 
     public AuthorizationViolationException( String msg )
     {

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationFilter.java
@@ -147,19 +147,19 @@ public class AuthorizationFilter implements Filter
     private static final ThrowingConsumer<HttpServletResponse, IOException> noHeader =
             error(  401,
                     map( "errors", singletonList( map(
-                            "code", Status.Security.AuthorizationFailed.code().serialize(),
-                            "message", "No authorization header supplied." ) ) ) );
+                            "code", Status.Security.Unauthorized.code().serialize(),
+                            "message", "No authentication header supplied." ) ) ) );
 
     private static final ThrowingConsumer<HttpServletResponse, IOException> badHeader =
             error(  400,
                     map( "errors", singletonList( map(
                             "code", Status.Request.InvalidFormat.code().serialize(),
-                            "message", "Invalid Authorization header." ) ) ) );
+                            "message", "Invalid authentication header." ) ) ) );
 
     private static final ThrowingConsumer<HttpServletResponse, IOException> invalidCredential =
             error(  401,
                     map( "errors", singletonList( map(
-                            "code", Status.Security.AuthorizationFailed.code().serialize(),
+                            "code", Status.Security.Unauthorized.code().serialize(),
                             "message", "Invalid username or password." ) ) ) );
 
     private static final ThrowingConsumer<HttpServletResponse, IOException> tooManyAttempts =
@@ -172,7 +172,7 @@ public class AuthorizationFilter implements Filter
     {
         return error( 403,
                 map( "errors", singletonList( map(
-                        "code", Status.Security.AuthorizationFailed.code().serialize(),
+                        "code", Status.Security.Forbidden.code().serialize(),
                         "message", String.format("Unauthorized access violation: %s.", message ) ) ) ) );
     }
 
@@ -181,7 +181,7 @@ public class AuthorizationFilter implements Filter
         URI path = UriBuilder.fromUri( baseURL ).path( format( "/user/%s/password", username ) ).build();
         return error( 403,
                 map( "errors", singletonList( map(
-                        "code", Status.Security.AuthorizationFailed.code().serialize(),
+                        "code", Status.Security.Forbidden.code().serialize(),
                         "message", "User is required to change their password." ) ), "password_change", path.toString() ) );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
@@ -132,8 +132,8 @@ public class AuthorizationFilterTest
         verify( servletResponse ).setStatus( 401 );
         verify( servletResponse ).addHeader( HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"Neo4j\"" );
         verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
-        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError" +".Security.AuthorizationFailed\"" ) );
-        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"message\" : \"No authorization header supplied.\"" ) );
+        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError" +".Security.Unauthorized\"" ) );
+        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"message\" : \"No authentication header supplied.\"" ) );
     }
 
     @Test
@@ -153,7 +153,7 @@ public class AuthorizationFilterTest
         verify( servletResponse ).setStatus( 400 );
         verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
         assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Request.InvalidFormat\"" ) );
-        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"message\" : \"Invalid Authorization header.\"" ) );
+        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"message\" : \"Invalid authentication header.\"" ) );
     }
 
     @Test
@@ -178,7 +178,7 @@ public class AuthorizationFilterTest
         );
         verify( servletResponse ).setStatus( 401 );
         verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
-        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Security.AuthorizationFailed\"" ) );
+        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Security.Unauthorized\"" ) );
         assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"message\" : \"Invalid username or password.\"" ) );
     }
 
@@ -221,7 +221,7 @@ public class AuthorizationFilterTest
         verify( servletResponse ).setStatus( 403 );
         verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
         assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"password_change\" : \"http://bar.baz:7474/user/foo/password\"" ) );
-        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Security.AuthorizationFailed\"" ) );
+        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError.Security.Forbidden\"" ) );
         assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"message\" : \"User is required to change their password.\"" ) );
     }
 
@@ -282,7 +282,7 @@ public class AuthorizationFilterTest
         verify( servletResponse ).setStatus( 401 );
         verify( servletResponse ).addHeader( HttpHeaders.WWW_AUTHENTICATE, "None" );
         verify( servletResponse ).addHeader( HttpHeaders.CONTENT_TYPE, "application/json; charset=UTF-8" );
-        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError" +".Security.AuthorizationFailed\"" ) );
-        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"message\" : \"No authorization header supplied.\"" ) );
+        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"code\" : \"Neo.ClientError" +".Security.Unauthorized\"" ) );
+        assertThat( outputStream.toString( StandardCharsets.UTF_8.name() ), containsString( "\"message\" : \"No authentication header supplied.\"" ) );
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/AuthenticationDocIT.java
@@ -80,8 +80,8 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
         // Then
         JsonNode data = JsonHelper.jsonNode( response.entity() );
         JsonNode firstError = data.get( "errors" ).get( 0 );
-        assertThat( firstError.get( "code" ).asText(), equalTo( "Neo.ClientError.Security.AuthorizationFailed" ) );
-        assertThat( firstError.get( "message" ).asText(), equalTo( "No authorization header supplied." ) );
+        assertThat( firstError.get( "code" ).asText(), equalTo( "Neo.ClientError.Security.Unauthorized" ) );
+        assertThat( firstError.get( "message" ).asText(), equalTo( "No authentication header supplied." ) );
     }
 
     @Test
@@ -129,7 +129,7 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
         // Then
         JsonNode data = JsonHelper.jsonNode( response.entity() );
         JsonNode firstError = data.get( "errors" ).get( 0 );
-        assertThat( firstError.get( "code" ).asText(), equalTo( "Neo.ClientError.Security.AuthorizationFailed" ) );
+        assertThat( firstError.get( "code" ).asText(), equalTo( "Neo.ClientError.Security.Unauthorized" ) );
         assertThat( firstError.get( "message" ).asText(), equalTo( "Invalid username or password." ) );
     }
 
@@ -155,7 +155,7 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
         // Then
         JsonNode data = JsonHelper.jsonNode( response.entity() );
         JsonNode firstError = data.get( "errors" ).get( 0 );
-        assertThat( firstError.get( "code" ).asText(), equalTo( "Neo.ClientError.Security.AuthorizationFailed" ) );
+        assertThat( firstError.get( "code" ).asText(), equalTo( "Neo.ClientError.Security.Forbidden" ) );
         assertThat( firstError.get( "message" ).asText(), equalTo( "User is required to change their password." ) );
         assertThat( data.get( "password_change" ).asText(), equalTo( passwordURL( "neo4j" ) ) );
     }
@@ -188,7 +188,7 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
         // Then
         assertThat( response.status(), equalTo( 400 ) );
         assertThat( response.get( "errors" ).get( 0 ).get( "code" ).asText(), equalTo( "Neo.ClientError.Request.InvalidFormat" ) );
-        assertThat( response.get( "errors" ).get( 0 ).get( "message" ).asText(), equalTo( "Invalid Authorization header." ) );
+        assertThat( response.get( "errors" ).get( 0 ).get( "message" ).asText(), equalTo( "Invalid authentication header." ) );
     }
 
     @Test
@@ -286,20 +286,20 @@ public class AuthenticationDocIT extends ExclusiveServerTestBase
         // When no header
         HTTP.Response response = HTTP.request( method, server.baseUri().resolve( path ).toString(), payload );
         assertThat(response.status(), equalTo(401));
-        assertThat(response.get("errors").get(0).get("code").asText(), equalTo("Neo.ClientError.Security.AuthorizationFailed"));
-        assertThat(response.get("errors").get(0).get("message").asText(), equalTo("No authorization header supplied."));
+        assertThat(response.get("errors").get(0).get("code").asText(), equalTo("Neo.ClientError.Security.Unauthorized"));
+        assertThat(response.get("errors").get(0).get("message").asText(), equalTo("No authentication header supplied."));
         assertThat(response.header( HttpHeaders.WWW_AUTHENTICATE ), equalTo("Basic realm=\"Neo4j\""));
 
         // When malformed header
         response = HTTP.withHeaders( HttpHeaders.AUTHORIZATION, "This makes no sense" ).request( method, server.baseUri().resolve( path ).toString(), payload );
         assertThat(response.status(), equalTo(400));
         assertThat(response.get("errors").get(0).get("code").asText(), equalTo("Neo.ClientError.Request.InvalidFormat"));
-        assertThat(response.get("errors").get(0).get( "message" ).asText(), equalTo("Invalid Authorization header."));
+        assertThat(response.get("errors").get(0).get( "message" ).asText(), equalTo("Invalid authentication header."));
 
         // When invalid credential
         response = HTTP.withHeaders( HttpHeaders.AUTHORIZATION, challengeResponse( "neo4j", "incorrect" ) ).request( method, server.baseUri().resolve( path ).toString(), payload );
         assertThat(response.status(), equalTo(401));
-        assertThat(response.get("errors").get(0).get("code").asText(), equalTo("Neo.ClientError.Security.AuthorizationFailed"));
+        assertThat(response.get("errors").get(0).get("code").asText(), equalTo("Neo.ClientError.Security.Unauthorized"));
         assertThat(response.get("errors").get(0).get("message").asText(), equalTo("Invalid username or password."));
         assertThat(response.header(HttpHeaders.WWW_AUTHENTICATE ), equalTo("Basic realm=\"Neo4j\""));
 


### PR DESCRIPTION
The design is based on the HTTP status codes 401 and 403, and the names for the status fields taken from HTTP documentation. This is assuming that being aligned with HTTP will minimize confusion over meaning.
