### PR TITLE
Uses RecordCursor in RecordStore.Scanner

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
@@ -39,7 +39,7 @@ import org.neo4j.helpers.collection.BoundedIterable;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.store.RecordStore;
-import org.neo4j.kernel.impl.store.RecordStore.Scanner;
+import org.neo4j.kernel.impl.store.Scanner;
 import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.store.StoreAccess;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
@@ -22,11 +22,13 @@ package org.neo4j.consistency.checking.full;
 import java.io.IOException;
 import java.util.Iterator;
 
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.BoundedIterable;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 
-import static org.neo4j.consistency.checking.full.CloningRecordIterable.cloned;
+import static org.neo4j.consistency.checking.full.CloningRecordIterator.cloned;
 import static org.neo4j.kernel.impl.store.RecordStore.Scanner.scan;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.FORCE;
 
@@ -34,6 +36,7 @@ public class IterableStore<RECORD extends AbstractBaseRecord> implements Bounded
 {
     private final RecordStore<RECORD> store;
     private final boolean forward;
+    private ResourceIterator<RECORD> iterator;
 
     public IterableStore( RecordStore<RECORD> store, boolean forward )
     {
@@ -50,12 +53,24 @@ public class IterableStore<RECORD extends AbstractBaseRecord> implements Bounded
     @Override
     public void close() throws IOException
     {
+        closeIterator();
+    }
+
+    private void closeIterator()
+    {
+        if ( iterator != null )
+        {
+            iterator.close();
+            iterator = null;
+        }
     }
 
     @Override
     public Iterator<RECORD> iterator()
     {
-        return cloned( scan( store, forward ) ).iterator();
+        closeIterator();
+        ResourceIterable<RECORD> iterable = scan( store, forward );
+        return cloned( iterator = iterable.iterator() );
     }
 
     public void warmUpCache()

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/IterableStore.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 
 import static org.neo4j.consistency.checking.full.CloningRecordIterator.cloned;
-import static org.neo4j.kernel.impl.store.RecordStore.Scanner.scan;
+import static org.neo4j.kernel.impl.store.Scanner.scan;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.FORCE;
 
 public class IterableStore<RECORD extends AbstractBaseRecord> implements BoundedIterable<RECORD>

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ParallelRecordScanner.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ParallelRecordScanner.java
@@ -51,6 +51,6 @@ public class ParallelRecordScanner<RECORD> extends RecordScanner<RECORD>
 
         QueueDistributor<RECORD> distributor = distribution.distributor( recordsPerCPU, numberOfThreads );
         distributeRecords( numberOfThreads, getClass().getSimpleName() + "-" + name,
-                DEFAULT_QUEUE_SIZE, store, progress, processor, distributor );
+                DEFAULT_QUEUE_SIZE, store.iterator(), progress, processor, distributor );
     }
 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordDistributor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordDistributor.java
@@ -37,13 +37,12 @@ public class RecordDistributor
             int numberOfThreads,
             String workerNames,
             int queueSize,
-            Iterable<RECORD> records,
+            Iterator<RECORD> records,
             final ProgressListener progress,
             RecordProcessor<RECORD> processor,
             QueueDistributor<RECORD> idDistributor )
     {
-        Iterator<RECORD> iterator = records.iterator();
-        if ( !iterator.hasNext() )
+        if ( !records.hasNext() )
         {
             return;
         }
@@ -71,12 +70,12 @@ public class RecordDistributor
 
         try
         {
-            while ( iterator.hasNext() )
+            while ( records.hasNext() )
             {
                 try
                 {
                     // Put records into the queues using the queue distributor. Each Worker will pull and process.
-                    RECORD record = iterator.next();
+                    RECORD record = records.next();
                     idDistributor.distribute( record, recordConsumer );
                     progress.add( 1 );
                 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessor.java
@@ -47,7 +47,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 import static org.neo4j.consistency.checking.cache.DefaultCacheAccess.DEFAULT_QUEUE_SIZE;
 import static org.neo4j.consistency.checking.full.CloningRecordIterator.cloned;
 import static org.neo4j.consistency.checking.full.RecordDistributor.distributeRecords;
-import static org.neo4j.kernel.impl.store.RecordStore.Scanner.scan;
+import static org.neo4j.kernel.impl.store.Scanner.scan;
 
 /**
  * Full check works by spawning StoreProcessorTasks that call StoreProcessor. StoreProcessor.applyFiltered()

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/StoreProcessorTest.java
@@ -19,49 +19,52 @@
  */
 package org.neo4j.consistency.checking.full;
 
+import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-
 import org.neo4j.consistency.checking.CheckDecorator;
+import org.neo4j.consistency.checking.RecordCheck;
 import org.neo4j.consistency.checking.cache.CacheAccess;
 import org.neo4j.consistency.report.ConsistencyReport;
+import org.neo4j.kernel.impl.store.RecordCursor;
 import org.neo4j.kernel.impl.store.RecordStore;
-import org.neo4j.kernel.impl.store.RecordStoreUtil.NewNodeRecordAnswer;
-import org.neo4j.kernel.impl.store.RecordStoreUtil.ReadNodeAnswer;
+import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
-import org.neo4j.kernel.impl.store.record.RecordLoad;
+import org.neo4j.test.NeoStoresRule;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class StoreProcessorTest
 {
+    @Rule
+    public final NeoStoresRule stores = new NeoStoresRule( getClass(), StoreType.NODE, StoreType.NODE_LABEL );
+
     @SuppressWarnings( "unchecked" )
     @Test
     public void shouldProcessAllTheRecordsInAStore() throws Exception
     {
         // given
+        RecordStore<NodeRecord> nodeStore = stores.open().getNodeStore();
+        ConsistencyReport.Reporter reporter = mock( ConsistencyReport.Reporter.class );
         StoreProcessor processor = new StoreProcessor( CheckDecorator.NONE,
-                mock( ConsistencyReport.Reporter.class ), Stage.SEQUENTIAL_FORWARD, CacheAccess.EMPTY );
-        RecordStore<NodeRecord> recordStore = mock( RecordStore.class );
-        when( recordStore.newRecord() ).thenAnswer( new NewNodeRecordAnswer() );
-        when( recordStore.getHighId() ).thenReturn( 3L );
-        when( recordStore.getRecord( anyLong(), any( NodeRecord.class ), any( RecordLoad.class ) ) )
-                .thenAnswer( new ReadNodeAnswer( false, 0, 0 ) );
+                reporter, Stage.SEQUENTIAL_FORWARD, CacheAccess.EMPTY );
+        nodeStore.updateRecord( node( 0, false, 0, 0 ) );
+        nodeStore.updateRecord( node( 1, false, 0, 0 ) );
+        nodeStore.updateRecord( node( 2, false, 0, 0 ) );
+        nodeStore.setHighestPossibleIdInUse( 2 );
 
         // when
-        processor.applyFiltered( recordStore );
+        processor.applyFiltered( nodeStore );
 
         // then
-        verify( recordStore ).getRecord( eq( 0L ), any( NodeRecord.class ), any( RecordLoad.class ) );
-        verify( recordStore ).getRecord( eq( 1L ), any( NodeRecord.class ), any( RecordLoad.class ) );
-        verify( recordStore ).getRecord( eq( 2L ), any( NodeRecord.class ), any( RecordLoad.class ) );
-        verify( recordStore, never() ).getRecord( eq( 3L ), any( NodeRecord.class ), any( RecordLoad.class ) );
+        verify( reporter, times( 3 ) ).forNode( any( NodeRecord.class ), any( RecordCheck.class ) );
+    }
+
+    private NodeRecord node( long id, boolean dense, long nextRel, long nextProp )
+    {
+        return new NodeRecord( id ).initialize( true, nextProp, dense, nextRel, 0 );
     }
 
     @SuppressWarnings( "unchecked" )
@@ -69,33 +72,39 @@ public class StoreProcessorTest
     public void shouldStopProcessingRecordsWhenSignalledToStop() throws Exception
     {
         // given
-        final StoreProcessor processor = new StoreProcessor( CheckDecorator.NONE,
-                mock( ConsistencyReport.Reporter.class ), Stage.SEQUENTIAL_FORWARD, CacheAccess.EMPTY );
-        RecordStore<NodeRecord> recordStore = mock( RecordStore.class );
-        when( recordStore.newRecord() ).thenAnswer( new NewNodeRecordAnswer() );
-        when( recordStore.getHighId() ).thenReturn( 4L );
-        when( recordStore.getRecord( eq( 0L ), any( NodeRecord.class ), any( RecordLoad.class ) ) )
-                .thenAnswer( new ReadNodeAnswer( false, 0, 0 ) );
-        when( recordStore.getRecord( eq( 1L ), any( NodeRecord.class ), any( RecordLoad.class ) ) )
-                .thenAnswer( new ReadNodeAnswer( false, 0, 0 ) );
-        when( recordStore.getRecord( eq( 2L ), any( NodeRecord.class ), any( RecordLoad.class ) ) ).thenAnswer(
-                new ReadNodeAnswer( false, 0, 0 )
+        ConsistencyReport.Reporter reporter = mock( ConsistencyReport.Reporter.class );
+        StoreProcessor processor = new StoreProcessor( CheckDecorator.NONE,
+                reporter, Stage.SEQUENTIAL_FORWARD, CacheAccess.EMPTY );
+        RecordStore<NodeRecord> nodeStore = new RecordStore.Delegator<NodeRecord>( stores.open().getNodeStore() )
+        {
+            @Override
+            public RecordCursor<NodeRecord> newRecordCursor( NodeRecord record )
+            {
+                return new RecordCursor.Delegator<NodeRecord>( super.newRecordCursor( record ) )
                 {
                     @Override
-                    public NodeRecord answer( InvocationOnMock invocation ) throws Throwable
+                    public boolean next( long id )
                     {
-                        processor.stop();
-                        return super.answer( invocation );
+                        if ( id == 3 )
+                        {
+                            processor.stop();
+                        }
+                        return super.next( id );
                     }
-                } );
+                };
+            }
+        };
+        nodeStore.updateRecord( node( 0, false, 0, 0 ) );
+        nodeStore.updateRecord( node( 1, false, 0, 0 ) );
+        nodeStore.updateRecord( node( 2, false, 0, 0 ) );
+        nodeStore.updateRecord( node( 3, false, 0, 0 ) );
+        nodeStore.updateRecord( node( 4, false, 0, 0 ) );
+        nodeStore.setHighestPossibleIdInUse( 4 );
 
         // when
-        processor.applyFiltered( recordStore );
+        processor.applyFiltered( nodeStore );
 
         // then
-        verify( recordStore ).getRecord( eq( 0L ), any( NodeRecord.class ), any( RecordLoad.class ) );
-        verify( recordStore ).getRecord( eq( 1L ), any( NodeRecord.class ), any( RecordLoad.class ) );
-        verify( recordStore ).getRecord( eq( 2L ), any( NodeRecord.class ), any( RecordLoad.class ) );
-        verify( recordStore, never() ).getRecord( eq( 3L ), any( NodeRecord.class ), any( RecordLoad.class ) );
+        verify( reporter, times( 3 ) ).forNode( any( NodeRecord.class ), any( RecordCheck.class ) );
     }
 }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/store/RecordAccessStub.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/store/RecordAccessStub.java
@@ -61,6 +61,8 @@ import static org.mockito.Mockito.mock;
 
 import static java.util.Collections.singletonMap;
 
+import static org.neo4j.helpers.collection.IteratorUtil.resourceIterable;
+
 public class RecordAccessStub implements RecordAccess
 {
     public static final int SCHEMA_RECORD_TYPE = 255;
@@ -212,14 +214,14 @@ public class RecordAccessStub implements RecordAccess
     public void populateCache()
     {
         CacheTask action = new CacheTask.CacheNextRel( CheckStage.Stage3_NS_NextRel, cacheAccess,
-                new IterableWrapper<NodeRecord,Delta<NodeRecord>>( nodes.values() )
+                resourceIterable( new IterableWrapper<NodeRecord,Delta<NodeRecord>>( nodes.values() )
         {
             @Override
             protected NodeRecord underlyingObjectToObject( Delta<NodeRecord> node )
             {
                 return node.newRecord;
             }
-        } );
+        } ) );
         action.run();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
@@ -54,4 +54,45 @@ public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
      * @return whether or not that record is in use.
      */
     boolean next( long id );
+
+    class Delegator<R extends AbstractBaseRecord> implements RecordCursor<R>
+    {
+        private final RecordCursor<R> actual;
+
+        public Delegator( RecordCursor<R> actual )
+        {
+            this.actual = actual;
+        }
+
+        @Override
+        public R get()
+        {
+            return actual.get();
+        }
+
+        @Override
+        public boolean next()
+        {
+            return actual.next();
+        }
+
+        @Override
+        public void close()
+        {
+            actual.close();
+        }
+
+        @Override
+        public RecordCursor<R> init( long id, RecordLoad mode, PageCursor pageCursor )
+        {
+            actual.init( id, mode, pageCursor );
+            return this;
+        }
+
+        @Override
+        public boolean next( long id )
+        {
+            return actual.next( id );
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/Scanner.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/Scanner.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store;
+
+import java.util.function.Predicate;
+
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.PrefetchingResourceIterator;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+
+/**
+ * Scans all used records in a store, returned {@link ResourceIterable} must be properly used such that
+ * its {@link ResourceIterable#iterator() resource iterators} are {@link ResourceIterator#close() closed}
+ * after use.
+ */
+public class Scanner
+{
+    @SafeVarargs
+    public static <R extends AbstractBaseRecord> ResourceIterable<R> scan( final RecordStore<R> store,
+            final Predicate<? super R>... filters )
+    {
+        return scan( store, true, filters );
+    }
+
+    @SafeVarargs
+    public static <R extends AbstractBaseRecord> ResourceIterable<R> scan( final RecordStore<R> store,
+            final boolean forward, final Predicate<? super R>... filters )
+    {
+        return () -> new Scan<>( store, forward, filters );
+    }
+
+    private static class Scan<R extends AbstractBaseRecord> extends PrefetchingResourceIterator<R>
+    {
+        private final PrimitiveLongIterator ids;
+        private final RecordCursor<R> cursor;
+        private final Predicate<? super R>[] filters;
+
+        public Scan( RecordStore<R> store, boolean forward, final Predicate<? super R>... filters )
+        {
+            this.filters = filters;
+            this.ids = new StoreIdIterator( store, forward );
+            this.cursor = store.newRecordCursor( store.newRecord() );
+            store.placeRecordCursor( 0, cursor, RecordLoad.CHECK );
+        }
+
+        @Override
+        protected R fetchNextOrNull()
+        {
+            while ( ids.hasNext() )
+            {
+                if ( cursor.next( ids.next() ) )
+                {
+                    R record = cursor.get();
+                    if ( passesFilters( record ) )
+                    {
+                        return record;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private boolean passesFilters( R record )
+        {
+            for ( Predicate<? super R> filter : filters )
+            {
+                if ( !filter.test( record ) )
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public void close()
+        {
+            cursor.close();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
@@ -51,10 +52,12 @@ public class NeoStoresRule extends ExternalResource
     private EphemeralFileSystemAbstraction efs;
     private PageCache pageCache;
     private StoreFactory storeFactory;
+    private final StoreType[] stores;
 
-    public NeoStoresRule( Class<?> testClass )
+    public NeoStoresRule( Class<?> testClass, StoreType... stores )
     {
         this.testClass = testClass;
+        this.stores = stores;
     }
 
     public NeoStores open( String... config )
@@ -81,7 +84,9 @@ public class NeoStoresRule extends ExternalResource
         Config configuration = new Config( stringMap( config ) );
         storeFactory = new StoreFactory( storeDir, configuration, new DefaultIdGeneratorFactory( fs ),
                 pageCache, fs, NullLogProvider.getInstance(), format );
-        return neoStores = storeFactory.openAllNeoStores( true );
+        return neoStores = stores.length == 0
+                ? storeFactory.openAllNeoStores( true )
+                : storeFactory.openNeoStores( true, stores );
     }
 
     @Override


### PR DESCRIPTION
instead of doing getRecord each time, benefit is one open PageCursor
and not repinning page for every record.
