### PR TITLE
Make membership waiter block until leader commit is available before executing the catchup algorithm

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/Sleeper.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/Sleeper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+public interface Sleeper
+{
+    void sleep( long millis );
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ThreadSleeper.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/catchup/ThreadSleeper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.catchup;
+
+public class ThreadSleeper implements Sleeper
+{
+    @Override
+    public void sleep( long millis )
+    {
+        try
+        {
+            Thread.sleep( millis );
+        }
+        catch ( InterruptedException ignored )
+        {
+            // ignore me
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/LeaderCommitWaiter.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/membership/LeaderCommitWaiter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.membership;
+
+import org.neo4j.coreedge.catchup.Sleeper;
+import org.neo4j.coreedge.raft.state.ReadableRaftState;
+
+public class LeaderCommitWaiter<MEMBER>
+{
+    private Sleeper sleeper;
+
+    public LeaderCommitWaiter( Sleeper sleeper )
+    {
+        this.sleeper = sleeper;
+    }
+
+    public void waitMore()
+    {
+        sleeper.sleep( 100 );
+    }
+
+    public boolean keepWaiting( ReadableRaftState<MEMBER> raftState )
+    {
+        return raftState.leaderCommit() == -1;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -47,8 +47,10 @@ import org.neo4j.coreedge.raft.log.NaiveDurableRaftLog;
 import org.neo4j.coreedge.raft.log.PhysicalRaftLog;
 import org.neo4j.coreedge.raft.log.RaftLog;
 import org.neo4j.coreedge.raft.membership.CoreMemberSetBuilder;
+import org.neo4j.coreedge.raft.membership.LeaderCommitWaiter;
 import org.neo4j.coreedge.raft.membership.MembershipWaiter;
 import org.neo4j.coreedge.raft.membership.RaftMembershipManager;
+import org.neo4j.coreedge.catchup.ThreadSleeper;
 import org.neo4j.coreedge.raft.net.CoreReplicatedContentMarshal;
 import org.neo4j.coreedge.raft.net.LoggingInbound;
 import org.neo4j.coreedge.raft.net.LoggingOutbound;
@@ -315,7 +317,8 @@ public class EnterpriseCoreEditionModule
 
         long electionTimeout = config.get( CoreEdgeClusterSettings.leader_election_timeout );
         MembershipWaiter<CoreMember> membershipWaiter =
-                new MembershipWaiter<>( myself, platformModule.jobScheduler, electionTimeout * 4, logProvider );
+                new MembershipWaiter<>( myself, platformModule.jobScheduler, electionTimeout * 4, logProvider,
+                        new LeaderCommitWaiter<>( new ThreadSleeper() ) );
 
         ReplicatedIdGeneratorFactory replicatedIdGeneratorFactory =
                 createIdGeneratorFactory( fileSystem, idRangeAcquirer, logProvider );


### PR DESCRIPTION
At the moment we unnecessarily wait for up to 2 rounds because
in the first round of catchup the leader commit is nearly always
-1 since we go into this code path before the RAFT machinery is
up and running.

This commit introduces a job which blocks waiting for the leader
commit to be -1. The code in MembershipWaiter#waitUntilCaughtUpMember
relies on MembershipWaiterLifecycle to timeout if the leader commit
is never discovered.
