### PR TITLE
Add progress monitor to DirectRecordStoreMigrator

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/SilentMigrationProgressMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/SilentMigrationProgressMonitor.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.impl.storemigration.monitoring;
 
 public class SilentMigrationProgressMonitor implements MigrationProgressMonitor
 {
-    private static final Section SECTION = new Section()
+    public static final Section NO_OP_SECTION = new Section()
     {
         @Override
         public void progress( long add )
@@ -47,7 +47,7 @@ public class SilentMigrationProgressMonitor implements MigrationProgressMonitor
     @Override
     public Section startSection( String name )
     {
-        return SECTION;
+        return NO_OP_SECTION;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -71,6 +71,7 @@ import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.storemigration.legacylogs.LegacyLogs;
 import org.neo4j.kernel.impl.storemigration.legacystore.v21.propertydeduplication.PropertyDeduplicator;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.storemigration.monitoring.SilentMigrationProgressMonitor;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
@@ -95,7 +96,6 @@ import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
-
 import static org.neo4j.helpers.collection.Iterables.iterable;
 import static org.neo4j.kernel.impl.store.MetaDataStore.DEFAULT_NAME;
 import static org.neo4j.kernel.impl.store.StoreType.META_DATA;
@@ -162,7 +162,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
             if ( newFormat.hasSameCapabilities( oldFormat, CapabilityType.FORMAT ) )
             {
                 // Do direct migration
-                migrateWithDirectMigration( storeDir, migrationDir, oldFormat, newFormat );
+                migrateWithDirectMigration( storeDir, migrationDir, oldFormat, newFormat, progressMonitor );
             }
             else
             {
@@ -185,14 +185,14 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
     }
 
     private void migrateWithDirectMigration( File storeDir, File migrationDir,
-            RecordFormats oldFormat, RecordFormats newFormat )
+            RecordFormats oldFormat, RecordFormats newFormat, MigrationProgressMonitor.Section progressMonitor )
     {
         DirectRecordStoreMigrator migrator = new DirectRecordStoreMigrator( pageCache, fileSystem, config );
         StoreType[] stores = stream( StoreType.values() )
                 // Not interested in migrating MetaData store.
                 .filter( type -> type != META_DATA )
                 .toArray( StoreType[]::new );
-        migrator.migrate( storeDir, oldFormat, migrationDir, newFormat, stores );
+        migrator.migrate( storeDir, oldFormat, migrationDir, newFormat, progressMonitor, stores );
     }
 
     private void writeLastTxChecksum( File migrationDir, long lastTxChecksum ) throws IOException
@@ -450,16 +450,18 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
         {
             // Migrate all token stores, schema store and dynamic node label ids, keeping their ids intact
             DirectRecordStoreMigrator migrator = new DirectRecordStoreMigrator( pageCache, fileSystem, config );
-            migrator.migrate( storeDir, oldFormat, migrationDir, newFormat,
-                    new StoreType[] {
-                        StoreType.LABEL_TOKEN, StoreType.LABEL_TOKEN_NAME,
-                        StoreType.PROPERTY_KEY_TOKEN, StoreType.PROPERTY_KEY_TOKEN_NAME,
-                        StoreType.RELATIONSHIP_TYPE_TOKEN, StoreType.RELATIONSHIP_TYPE_TOKEN_NAME,
-                        StoreType.NODE_LABEL,
-                        StoreType.SCHEMA },
-                    new StoreType[] {
-                        StoreType.NODE,
-                    } );
+
+            StoreType[] storesToMigrate = {
+                    StoreType.LABEL_TOKEN, StoreType.LABEL_TOKEN_NAME,
+                    StoreType.PROPERTY_KEY_TOKEN, StoreType.PROPERTY_KEY_TOKEN_NAME,
+                    StoreType.RELATIONSHIP_TYPE_TOKEN, StoreType.RELATIONSHIP_TYPE_TOKEN_NAME,
+                    StoreType.NODE_LABEL,
+                    StoreType.SCHEMA};
+
+            // Migrate these stores silently because they are usually very small
+            MigrationProgressMonitor.Section section = SilentMigrationProgressMonitor.NO_OP_SECTION;
+
+            migrator.migrate( storeDir, oldFormat, migrationDir, newFormat, section, storesToMigrate, StoreType.NODE );
         }
     }
 


### PR DESCRIPTION
`DirectRecordStoreMigrator` is used to migrate between versions that have same store format capabilities. It migrates records for corresponding stores sequentially.

Currently it only prints progress in one go when the migration is completed.

This commit adds progress tracking so that `DirectRecordStoreMigrator` outputs dots while doing it's job. Percentage is calculated based on the numbers of migrated stores. It would me more precise to do this based on sum of all `highIds` but there is a high risk of long overflow.
