### PR TITLE
Process all property updates from particular node as single update during index population

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
@@ -20,7 +20,7 @@
 package org.neo4j.kernel.api.index;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.impl.api.index.UpdateMode;
@@ -53,7 +53,7 @@ public interface IndexPopulator
      * {@link NodePropertyUpdate#getNodeId()} method and property values will be retrieved using
      * {@link NodePropertyUpdate#getValueAfter()} method.
      */
-    void add( List<NodePropertyUpdate> updates )
+    void add( Collection<NodePropertyUpdate> updates )
             throws IndexEntryConflictException, IOException;
 
     /**
@@ -70,7 +70,7 @@ public interface IndexPopulator
      * Simultaneously as population progresses there might be incoming updates
      * from committing transactions, which needs to be applied as well. This populator will only receive updates
      * for nodes that it already has seen. Updates coming in here must be applied idempotently as the same data
-     * may have been {@link #add(List) added previously}.
+     * may have been {@link #add(Collection) added previously}.
      * Updates can come in two different {@link NodePropertyUpdate#getUpdateMode() modes}.
      * <ol>
      *   <li>{@link UpdateMode#ADDED} means that there's an added property to a node already seen by this
@@ -130,7 +130,7 @@ public interface IndexPopulator
         }
 
         @Override
-        public void add( List<NodePropertyUpdate> updates ) throws IndexEntryConflictException, IOException
+        public void add( Collection<NodePropertyUpdate> updates ) throws IndexEntryConflictException, IOException
         {
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api.index;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -182,12 +183,12 @@ public class BatchingMultipleIndexPopulator extends MultipleIndexPopulator
      * {@link IndexPopulation population}. Flushes all updates if {@link #BATCH_SIZE} is reached.
      *
      * @param population the index population.
-     * @param update the update to add to the batch.
+     * @param updates updates to add to the batch.
      */
-    private void batchUpdate( IndexPopulation population, NodePropertyUpdate update )
+    private void batchUpdate( IndexPopulation population, Collection<NodePropertyUpdate> updates )
     {
         List<NodePropertyUpdate> batch = batchedUpdates.computeIfAbsent( population, key -> newBatch() );
-        batch.add( update );
+        batch.addAll( updates );
         flushIfNeeded( population, batch );
     }
 
@@ -342,9 +343,10 @@ public class BatchingMultipleIndexPopulator extends MultipleIndexPopulator
         }
 
         @Override
-        protected void addApplicable( NodePropertyUpdate update ) throws IOException, IndexEntryConflictException
+        protected void addApplicable( Collection<NodePropertyUpdate> updates ) throws IOException,
+                IndexEntryConflictException
         {
-            batchUpdate( this, update );
+            batchUpdate( this, updates );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -44,7 +44,7 @@ public interface IndexStoreView extends PropertyAccessor
      */
     <FAILURE extends Exception> StoreScan<FAILURE> visitNodes(
             IntPredicate labelIdFilter, IntPredicate propertyKeyIdFilter,
-            Visitor<NodePropertyUpdate, FAILURE> propertyUpdateVisitor,
+            Visitor<NodePropertyUpdates, FAILURE> propertyUpdateVisitor,
             Visitor<NodeLabelUpdate, FAILURE> labelUpdateVisitor );
 
     /**
@@ -93,7 +93,7 @@ public interface IndexStoreView extends PropertyAccessor
 
         @Override
         public <FAILURE extends Exception> StoreScan<FAILURE> visitNodes( IntPredicate labelIdFilter,
-                IntPredicate propertyKeyIdFilter, Visitor<NodePropertyUpdate,FAILURE> propertyUpdateVisitor,
+                IntPredicate propertyKeyIdFilter, Visitor<NodePropertyUpdates,FAILURE> propertyUpdateVisitor,
                 Visitor<NodeLabelUpdate,FAILURE> labelUpdateVisitor )
         {
             return EMPTY_SCAN;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodePropertyUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodePropertyUpdates.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.neo4j.kernel.api.index.NodePropertyUpdate;
+
+import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
+
+/**
+ * Container for all properties updates for one node identified by {@linkplain #nodeId}
+ * Used to group node properties updates and and pass in processing chain, so all updates can be processed together.
+ */
+public class NodePropertyUpdates
+{
+    private Collection<NodePropertyUpdate> propertyUpdates = new ArrayList<>();
+    private long nodeId;
+
+    public NodePropertyUpdates()
+    {
+    }
+
+    public void reset()
+    {
+        propertyUpdates.clear();
+        nodeId = NO_ID;
+    }
+
+    public void initForNodeId( long nodeId )
+    {
+        if ( containsUpdates() )
+        {
+            throw new AssertionError( "Please clear updates fom previous node." );
+        }
+        this.nodeId = nodeId;
+    }
+
+    public long getNodeId()
+    {
+        return nodeId;
+    }
+
+    public void add( NodePropertyUpdate update )
+    {
+        propertyUpdates.add( update );
+    }
+
+    public void add( int propertyKeyId, Object value, long[] labels )
+    {
+        if ( nodeId == NO_ID )
+        {
+            throw new AssertionError( "Please init property updates container for specific node." );
+        }
+        propertyUpdates.add( NodePropertyUpdate.add( nodeId, propertyKeyId, value, labels ) );
+    }
+
+    public boolean containsUpdates()
+    {
+        return !propertyUpdates.isEmpty();
+    }
+
+    public Collection<NodePropertyUpdate> getPropertyUpdates()
+    {
+        return propertyUpdates;
+    }
+
+    public void addAll( Collection<NodePropertyUpdate> propertyUpdates )
+    {
+        this.propertyUpdates.addAll( propertyUpdates );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
@@ -25,10 +25,10 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -215,7 +215,7 @@ public class IndexCRUDIT
         }
 
         @Override
-        public void add( List<NodePropertyUpdate> updates )
+        public void add( Collection<NodePropertyUpdate> updates )
         {
             for ( NodePropertyUpdate update : updates )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -26,10 +26,9 @@ import org.junit.Test;
 import org.mockito.Matchers;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -78,13 +77,13 @@ import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.lang.String.format;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -121,7 +120,7 @@ public class IndexPopulationJobTest
 
         verify( populator ).create();
         verify( populator ).includeSample( update );
-        verify( populator ).add( singletonList( update ) );
+        verify( populator ).add( anyListOf(NodePropertyUpdate.class) );
         verify( populator ).verifyDeferredConstraints( indexStoreView );
         verify( populator ).sampleResult();
         verify( populator ).close( true );
@@ -168,9 +167,8 @@ public class IndexPopulationJobTest
 
         verify( populator ).create();
         verify( populator ).includeSample( update1 );
-        verify( populator ).add( Collections.singletonList( update1 ) );
         verify( populator ).includeSample( update2 );
-        verify( populator ).add( Collections.singletonList( update2 ) );
+        verify( populator, times( 2 ) ).add( anyListOf(NodePropertyUpdate.class ) );
         verify( populator ).verifyDeferredConstraints( indexStoreView );
         verify( populator ).sampleResult();
         verify( populator ).close( true );
@@ -258,7 +256,7 @@ public class IndexPopulationJobTest
         IndexStoreView storeView = mock( IndexStoreView.class );
         ControlledStoreScan storeScan = new ControlledStoreScan();
         when( storeView.visitNodes( any( IntPredicate.class ), any( IntPredicate.class ),
-                Matchers.<Visitor<NodePropertyUpdate,RuntimeException>>any(),
+                Matchers.<Visitor<NodePropertyUpdates,RuntimeException>>any(),
                 Matchers.<Visitor<NodeLabelUpdate,RuntimeException>>any()) )
                 .thenReturn(storeScan );
 
@@ -456,7 +454,7 @@ public class IndexPopulationJobTest
         }
 
         @Override
-        public void add( List<NodePropertyUpdate> updates )
+        public void add( Collection<NodePropertyUpdate> updates )
         {
             for ( NodePropertyUpdate update : updates )
             {
@@ -532,7 +530,7 @@ public class IndexPopulationJobTest
         }
 
         @Override
-        public void add( List<NodePropertyUpdate> updates )
+        public void add( Collection<NodePropertyUpdate> updates )
         {
             for ( NodePropertyUpdate update : updates )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.api.index.inmemory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
@@ -131,7 +131,7 @@ class InMemoryIndex
         }
 
         @Override
-        public void add( List<NodePropertyUpdate> updates ) throws IndexEntryConflictException, IOException
+        public void add( Collection<NodePropertyUpdate> updates ) throws IndexEntryConflictException, IOException
         {
             for ( NodePropertyUpdate update : updates )
             {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
@@ -22,8 +22,8 @@ package org.neo4j.kernel.api.impl.schema.populator;
 import org.apache.lucene.document.Document;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 
 import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
@@ -61,7 +61,7 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
     }
 
     @Override
-    public void add( List<NodePropertyUpdate> updates ) throws IndexEntryConflictException, IOException
+    public void add( Collection<NodePropertyUpdate> updates ) throws IndexEntryConflictException, IOException
     {
         // Lucene documents stored in a ThreadLocal and reused so we can't create an eager collection of documents here
         // That is why we create a lazy Iterator and then Iterable

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -436,7 +436,7 @@ public class SchemaIndexHaIT
         }
 
         @Override
-        public void add( List<NodePropertyUpdate> updates )
+        public void add( Collection<NodePropertyUpdate> updates )
                 throws IndexEntryConflictException, IOException
         {
             delegate.add( updates );


### PR DESCRIPTION
Group all updates from all properties on single node into container that will be processed
in atomic fashion - all of the updates will be processed before check of population queue for current node.
All updates need to be processed as single unit to avoid duplicates in index that can appear
when queue already contains update for current node, but for some other property.
