### PR TITLE
Fixes issue with incremental backup failing with invalid high id

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccess.java
@@ -80,6 +80,8 @@ public interface RecordAccess<KEY,RECORD,ADDITIONAL>
         RECORD getBefore();
 
         boolean isChanged();
+
+        boolean isCreated();
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccess.java
@@ -118,6 +118,7 @@ public class DirectRecordAccess<KEY extends Comparable<KEY>,RECORD extends Abstr
         private RECORD record;
         private ADDITIONAL additionalData;
         private boolean changed = false;
+        private final boolean created;
 
         public DirectRecordProxy( KEY key, RECORD record, ADDITIONAL additionalData, boolean created )
         {
@@ -128,6 +129,7 @@ public class DirectRecordAccess<KEY extends Comparable<KEY>,RECORD extends Abstr
             {
                 prepareChange();
             }
+            this.created = created;
         }
 
         @Override
@@ -203,6 +205,12 @@ public class DirectRecordAccess<KEY extends Comparable<KEY>,RECORD extends Abstr
         public boolean isChanged()
         {
             return changed;
+        }
+
+        @Override
+        public boolean isCreated()
+        {
+            return created;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingRecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingRecordAccess.java
@@ -155,5 +155,11 @@ public abstract class BatchingRecordAccess<KEY,RECORD,ADDITIONAL> implements Rec
         {
             return true;
         }
+
+        @Override
+        public boolean isCreated()
+        {
+            return true;
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordProxy.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordProxy.java
@@ -95,4 +95,10 @@ public class TrackingRecordProxy<RECORD, ADDITIONAL> implements RecordProxy<Long
     {
         return changed;
     }
+
+    @Override
+    public boolean isCreated()
+    {
+        return created;
+    }
 }


### PR DESCRIPTION
Special handling of relationship group records could result in creating
 transactions that could result in errors when applied as part of
 external transaction application. This commit fixes the underlying
 cause and adds testing specific to incremental backup to test
 against it.
