### PR TITLE
Nullify fields in TransactionBoundQueryContext on close

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_0/TransactionBoundTokenContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_0/TransactionBoundTokenContext.scala
@@ -24,7 +24,7 @@ import org.neo4j.kernel.api.Statement
 import org.neo4j.cypher.internal.compiler.v2_0.spi.TokenContext
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations
 
-abstract class TransactionBoundTokenContext(statement: Statement) extends TokenContext {
+abstract class TransactionBoundTokenContext(protected var statement: Statement) extends TokenContext {
   def getOptPropertyKeyId(propertyKeyName: String): Option[Int] =
     TokenContext.tryGet[PropertyKeyNotFoundException](getPropertyKeyId(propertyKeyName))
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_1/TransactionBoundQueryContext.scala
@@ -41,7 +41,7 @@ import scala.collection.JavaConverters._
 import scala.collection.{Iterator, mutable}
 
 final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
-                                         var tx: Transaction,
+                                         private var tx: Transaction,
                                          val isTopLevelTx: Boolean,
                                          initialStatement: Statement)
   extends TransactionBoundTokenContext(initialStatement) with QueryContext {
@@ -56,17 +56,21 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   }
 
   def close(success: Boolean) {
-    try {
-      statement.close()
+    if (isOpen) {
+      try {
+        statement.close()
 
-      if (success)
-        tx.success()
-      else
-        tx.failure()
-      tx.close()
-    }
-    finally {
-      open = false
+        if (success)
+          tx.success()
+        else
+          tx.failure()
+        tx.close()
+      }
+      finally {
+        statement = null
+        tx = null
+        open = false
+      }
     }
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_1/TransactionBoundTokenContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_1/TransactionBoundTokenContext.scala
@@ -24,7 +24,7 @@ import org.neo4j.kernel.api.Statement
 import org.neo4j.cypher.internal.compiler.v2_1.spi.TokenContext
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations
 
-abstract class TransactionBoundTokenContext(var statement: Statement) extends TokenContext {
+abstract class TransactionBoundTokenContext(protected var statement: Statement) extends TokenContext {
   def getOptPropertyKeyId(propertyKeyName: String): Option[Int] =
     TokenContext.tryGet[PropertyKeyNotFoundException](getPropertyKeyId(propertyKeyName))
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
@@ -44,7 +44,7 @@ import scala.collection.JavaConverters._
 import scala.collection.{Iterator, mutable}
 
 final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
-                                         var tx: Transaction,
+                                         private var tx: Transaction,
                                          val isTopLevelTx: Boolean,
                                          initialStatement: Statement)(implicit indexSearchMonitor: IndexSearchMonitor)
   extends TransactionBoundTokenContext(initialStatement) with QueryContext {
@@ -65,17 +65,21 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   }
 
   def close(success: Boolean) {
-    try {
-      statement.close()
+    if (isOpen) {
+      try {
+        statement.close()
 
-      if (success)
-        tx.success()
-      else
-        tx.failure()
-      tx.close()
-    }
-    finally {
-      open = false
+        if (success)
+          tx.success()
+        else
+          tx.failure()
+        tx.close()
+      }
+      finally {
+        statement = null
+        tx = null
+        open = false
+      }
     }
   }
 


### PR DESCRIPTION
This is important since transactions might be pooled and so a stale
context might refer to a reused transaction.
