### PR TITLE
More intuitive RecordCursor interface

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
@@ -54,7 +54,7 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
     public StorePropertyCursor init( long firstPropertyId, Lock lock )
     {
         this.lock = lock;
-        propertyStore.placeRecordCursor( firstPropertyId, recordCursor, NORMAL );
+        recordCursor.acquire( firstPropertyId, NORMAL );
         payload.clear();
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -277,7 +277,7 @@ class StorePropertyPayloadCursor
     {
         buffer.clear();
         long startBlockId = PropertyBlock.fetchLong( currentHeader() );
-        try ( Cursor<DynamicRecord> records = store.placeRecordCursor( startBlockId, cursor, NORMAL ) )
+        try ( Cursor<DynamicRecord> records = cursor.acquire( startBlockId, NORMAL ) )
         {
             while ( records.next() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -176,8 +176,8 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
             return;
         }
 
-        try ( Cursor<DynamicRecord> dynamicRecords = dynamicStore.placeRecordCursor( block.getSingleValueLong(),
-                dynamicStore.newRecordCursor( dynamicStore.newRecord() ), NORMAL ) )
+        try ( Cursor<DynamicRecord> dynamicRecords = dynamicStore.newRecordCursor( dynamicStore.newRecord() )
+                .acquire( block.getSingleValueLong(), NORMAL ) )
         {
             while ( dynamicRecords.next() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
@@ -36,19 +36,29 @@ import org.neo4j.kernel.impl.store.record.RecordLoad;
 public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
 {
     /**
-     * Initialize this cursor, placing it at record {@code id} and using the given {@link PageCursor} and
-     * {@link RecordLoad} for loading record data.
+     * Acquires this cursor, placing it at record {@code id} {@link RecordLoad} for loading record data.
      *
-     * @param id record id to start at. Records chains can be followed using
-     * {@link RecordStore#getNextRecordReference(AbstractBaseRecord)}.
+     * @param id record id to start at.
      * @param mode {@link RecordLoad} for loading.
-     * @param pageCursor {@link PageCursor} for the source of the data.
      * @return this record cursor.
      */
-    RecordCursor<R> init( long id, RecordLoad mode, PageCursor pageCursor );
+    RecordCursor<R> acquire( long id, RecordLoad mode );
 
     /**
-     * An additional way of placing this cursor at an arbitrary record id.
+     * Moves to the next record and reads it. If this is the first call since {@link #acquire(long, RecordLoad)}
+     * the record specified in acquire will be read, otherwise the next record in the chain,
+     * {@link RecordStore#getNextRecordReference(AbstractBaseRecord)}.
+     * The read record can be accessed using {@link #get()}.
+     *
+     * @return whether or not that record is in use.
+     */
+    @Override
+    boolean next();
+
+    /**
+     * An additional way of placing this cursor at an arbitrary record id. This is useful when stride,
+     * as opposed to following record chains, is controlled from the outside.
+     * The read record can be accessed using {@link #get()}.
      *
      * @param id record id to place cursor at.
      * @return whether or not that record is in use.
@@ -83,9 +93,9 @@ public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
         }
 
         @Override
-        public RecordCursor<R> init( long id, RecordLoad mode, PageCursor pageCursor )
+        public RecordCursor<R> acquire( long id, RecordLoad mode )
         {
-            actual.init( id, mode, pageCursor );
+            actual.acquire( id, mode );
             return this;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/Scanner.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/Scanner.java
@@ -60,7 +60,7 @@ public class Scanner
             this.filters = filters;
             this.ids = new StoreIdIterator( store, forward );
             this.cursor = store.newRecordCursor( store.newRecord() );
-            store.placeRecordCursor( 0, cursor, RecordLoad.CHECK );
+            cursor.acquire( 0, RecordLoad.CHECK );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreScanAsInputIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreScanAsInputIterable.java
@@ -51,7 +51,7 @@ abstract class StoreScanAsInputIterable<INPUT extends InputEntity,RECORD extends
     @Override
     public InputIterator<INPUT> iterator()
     {
-        store.placeRecordCursor( 0, cursor, CHECK );
+        cursor.acquire( 0, CHECK );
         return new InputIterator.Adapter<INPUT>()
         {
             private final long highId = store.getHighId();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ReadRecordsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ReadRecordsStep.java
@@ -50,7 +50,7 @@ public abstract class ReadRecordsStep<RECORD extends AbstractBaseRecord> extends
     @Override
     public void start( int orderingGuarantees )
     {
-        store.placeRecordCursor( 0, cursor, CHECK );
+        cursor.acquire( 0, CHECK );
         super.start( orderingGuarantees );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
@@ -491,11 +491,10 @@ public class StorePropertyPayloadCursorTest
         DynamicRecord dynamicRecord = new DynamicRecord( 42 );
         dynamicRecord.setData( new byte[]{1, 1, 1, 1, 1} );
         when( recordCursor.get() ).thenReturn( dynamicRecord );
+        when( recordCursor.acquire( anyLong(), any( RecordLoad.class ) ) ).thenReturn( recordCursor );
 
         S store = mock( clazz );
-        when( store.newRecordCursor( any( DynamicRecord.class ) ) ).thenReturn( mock( RecordCursor.class ) );
-        when( store.placeRecordCursor( anyLong(), any( RecordCursor.class ), any( RecordLoad.class ) ) )
-                .thenReturn( recordCursor );
+        when( store.newRecordCursor( any( DynamicRecord.class ) ) ).thenReturn( recordCursor );
 
         return store;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
@@ -619,7 +619,7 @@ public class MetaDataStoreTest
             MetaDataRecord record = store.newRecord();
             try ( RecordCursor<MetaDataRecord> cursor = store.newRecordCursor( record ) )
             {
-                store.placeRecordCursor( 0, cursor, RecordLoad.NORMAL );
+                cursor.acquire( 0, RecordLoad.NORMAL );
                 long highId = store.getHighId();
                 for ( long id = 0; id < highId; id++ )
                 {


### PR DESCRIPTION
by having a #acquire(id,mode) instead of having to do
RecordStore#placeRecordCursor, which also exposed a weird
and public RecordCursor#init method accepting a PageCursor.

So previously:

  RecordCursor<NodeRecord> cursor = store.newRecordCursor(store.newRecord());
  store.placeRecordCursor( 0, cursor, NORMAL );
  ...
  cursor.close();

Now:

  RecordCursor<NodeRecord> cursor =
  store.newRecordCursor(store.newRecord());
  cursor.acquire( 0, NORMAL );
  ...
  cursor.close();

Also added RecordStore#scanAllRecords(visitor) since
DirectRecordStoreMigrator essentially did just that and
CommonAbstractStore already implemented that method.
