### PR TITLE
Update documentation with simplified powershell scripts

### DIFF
--- a/community/import-tool/src/docs/ops/import-tool.asciidoc
+++ b/community/import-tool/src/docs/ops/import-tool.asciidoc
@@ -91,7 +91,9 @@ Under Unix/Linux/OSX, the command is named `neo4j-import`. Depending on the inst
 
 === Windows
 
-For help with running the import tool using Windows PowerShell, see <<powershell>>.
+Under Windows, used by executing `bin\neo4j-import` from inside the installation directory.
+
+For help with running the import tool under Windows, see the reference in <<powershell-windows,Windows>>.
 
 [[import-tool-options]]
 === Options

--- a/community/server/src/docs/man/neo4j-admin.1.asciidoc
+++ b/community/server/src/docs/man/neo4j-admin.1.asciidoc
@@ -16,7 +16,7 @@ Neo4j is a graph database, perfect for working with highly connected data.
 The `neo4j` command is used to control the Neo4j Server.
 
 The preferred way to install Neo4j on Linux systems is by using prebuilt installation packages.
-For information regarding Windows, see http://neo4j.com/docs/stable/powershell.html.
+For information regarding Windows, see http://neo4j.com/docs/stable/server-installation.html#windows-install.
 
 [[neo4j-admin-manpage-commands]]
 == COMMANDS

--- a/community/server/src/docs/man/neo4j.1.asciidoc
+++ b/community/server/src/docs/man/neo4j.1.asciidoc
@@ -16,7 +16,8 @@ Neo4j is a graph database, perfect for working with highly connected data.
 The `neo4j` command is used to control the Neo4j Server.
 
 The preferred way to install Neo4j on Linux systems is by using prebuilt installation packages.
-For information regarding Windows, see http://neo4j.com/docs/stable/powershell.html.
+
+For information regarding Windows, see http://neo4j.com/docs/stable/server-installation.html#windows-install.
 
 [[neo4j-manpage-commands]]
 == COMMANDS
@@ -35,6 +36,14 @@ For information regarding Windows, see http://neo4j.com/docs/stable/powershell.h
 
 *status*::
   Current running state of the server.
+
+.Windows-specific commands
+
+*install-service*::
+  Installs the server as Windows service
+
+*uninstall-service*::
+  Uninstalls the Windows service
 
 [[neo4j-manpage-files]]
 == FILES

--- a/community/server/src/docs/ops/powershell.asciidoc
+++ b/community/server/src/docs/ops/powershell.asciidoc
@@ -3,7 +3,6 @@
 
 The Neo4j PowerShell module allows administrators to:
 
-* audit and set Neo4j configuration settings,
 * install, start and stop Neo4j Windows® Services
 * and start tools, such as `Neo4j Shell` and `Neo4j Import`.
 
@@ -14,6 +13,21 @@ The PowerShell module is installed as part of the http://neo4j.com/download/[ZIP
 
 * Requires PowerShell v2.0 or above.
 * Supported on either 32 or 64 bit operating systems.
+
+[[powershell-windows]]
+== Managing Neo4j on Windows
+
+On Windows it is sometimes necessary to _Unblock_ a downloaded zip file before you can import its contents as a module. If you right-click on the zip file and choose "Properties" you will get a dialog. Bottom-right on that dialog you will find an "Unblock" button. Click that. Then you should be able to import the module.
+
+Running scripts has to be enabled on the system.
+This can for example be achieved by executing the following from an elevated PowerShell prompt:
+[source,powershell]
+----
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned
+----
+For more information see https://technet.microsoft.com/en-us/library/hh847748.aspx[About execution policies].
+
+The powershell module will display a warning if it detects that you do not have administrative rights.
 
 [[powershell-module-import]]
 == How do I import the module?
@@ -28,30 +42,14 @@ Import-Module C:\Neo4j\bin\Neo4j-Management.psd1
 
 This will add the module to the current session.
 
-[NOTE]
---
-On Windows it is sometimes necessary to _Unblock_ a downloaded zip file before you can import its contents as a module. If you right-click on the zip file and choose "Properties" you will get a dialog. Bottom-right on that dialog you will find an "Unblock" button. Click that. Then you should be able to import the module.
---
-
-[NOTE]
---
-Running scripts has to be enabled on the system.
-This can for example be achieved by executing the following from an elevated PowerShell prompt:
-[source,powershell]
-----
-Set-ExecutionPolicy -ExecutionPolicy RemoteSigned
-----
-For more information see http://go.microsoft.com/fwlink/?LinkID=135[About execution policies].
---
-
 Once the module has been imported you can start an interactive console version of a Neo4j Server like this:
 
 [source,powershell]
 ----
-'C:\Neo4j' | Start-Neo4jServer -Console -Wait
+Invoke-Neo4j console
 ----
 
-To stop the server, issue `ctrl-c` in the console window that was created by the command.
+To stop the server, issue `Ctrl-C` in the console window that was created by the command.
 
 [[powershell-help]]
 == How do I get help about the module?
@@ -67,161 +65,62 @@ The output should be similar to the following:
 
 [source]
 ----
-CommandType     Name                          Version    Source
------------     ----                          -------    ------
-Function        Get-Neo4jHome                 2.3.0      Neo4j-Management
-Function        Get-Neo4jServer               2.3.0      Neo4j-Management
-Function        Get-Neo4jSetting              2.3.0      Neo4j-Management
-Function        Initialize-Neo4jHACluster     2.3.0      Neo4j-Management
-Function        Initialize-Neo4jServer        2.3.0      Neo4j-Management
-Function        Install-Neo4jServer           2.3.0      Neo4j-Management
-Function        Remove-Neo4jSetting           2.3.0      Neo4j-Management
-Function        Restart-Neo4jServer           2.3.0      Neo4j-Management
-Function        Set-Neo4jSetting              2.3.0      Neo4j-Management
-Function        Start-Neo4jBackup             2.3.0      Neo4j-Management
-Function        Start-Neo4jImport             2.3.0      Neo4j-Management
-Function        Start-Neo4jServer             2.3.0      Neo4j-Management
-Function        Start-Neo4jShell              2.3.0      Neo4j-Management
-Function        Stop-Neo4jServer              2.3.0      Neo4j-Management
-Function        Uninstall-Neo4jServer         2.3.0      Neo4j-Management
+CommandType     Name                                Version    Source
+-----------     ----                                -------    ------
+Function        Invoke-Neo4j                        3.0.0      Neo4j-Management
+Function        Invoke-Neo4jAdmin                   3.0.0      Neo4j-Management
+Function        Invoke-Neo4jBackup                  3.0.0      Neo4j-Management
+Function        Invoke-Neo4jImport                  3.0.0      Neo4j-Management
+Function        Invoke-Neo4jShell                   3.0.0      Neo4j-Management
 ----
 
 The module also supports the standard PowerShell help commands.
 
 [source,powershell]
 ----
-Get-Help Initialize-Neo4jServer
+Get-Help Invoke-Neo4j
 ----
 
 To see examples for a command, do like this:
 
+[source,powershell]
 ----
-Get-Help Initialize-Neo4jServer -examples
+Get-Help Invoke-Neo4j -examples
 ----
 
-[[powershell-basic-examples]]
-== Basic Examples
+[[powershell-examples]]
+== Example usage
 
-* Retrieve basic information about the Neo4j Server e.g. Version and Edition.
+* List of available commands:
 +
 [source,powershell]
 ----
-Get-Neo4jServer C:\Neo4j
+Invoke-Neo4j
 ----
 
-* Retrieve all of the settings of a Neo4j Server and display in a nice table
+* Current status of the Neo4j service:
 +
 [source,powershell]
 ----
-'C:\Neo4j' | Get-Neo4jSetting | `
-Select ConfigurationFile, Name, Value | `
-Format-Table
+Invoke-Neo4j status
 ----
 
-* The module uses the pipeline so you can export the settings, modify or filter them.
-  For example, only show settings with the value of `True`:
+* Install the service with verbose output:
 +
 [source,powershell]
 ----
-'C:\Neo4j' | Get-Neo4jSetting | `
-Where { $_.Value -eq 'True' } | `
-Select ConfigurationFile, Name, Value | `
-Format-Table
+Invoke-Neo4j install-service -Verbose
 ----
 
-* Quickly configure a Neo4j Server from saved settings in a CSV file.
+* Available commands for administrative tasks:
 +
 [source,powershell]
 ----
-Import-CSV -Path 'C:\Neo4jSettings.CSV' | Set-Neo4jSetting -Force
-----
-
-[[powershell-advanced-examples]]
-== Advanced examples
-
-* You can quickly configure and start an interactive console version of a Neo4j Server like this:
-+
-[source,powershell]
-----
-'C:\Neo4j' | `
-Initialize-Neo4jServer -ListenOnIPAddress 127.0.0.1 -PassThru | `
-Start-Neo4jServer -Console -Wait
-----
-+
-To stop the server, issue `ctrl-c` in the console window that was created by the command.
-
-* You can quickly configure and start a Service version of a Neo4j Server.
-+
-NOTE: The following must be executed from an elevated PowerShell prompt, where the Neo4j module has been imported into the session.
-+
-[source,powershell]
-----
-'C:\Neo4j' | `
-Initialize-Neo4jServer -ListenOnIPAddress 127.0.0.1 -PassThru | `
-Install-Neo4jServer -PassThru | `
-Start-Neo4jServer
-----
-+
-To stop the server do this:
-+
-[source,powershell]
-----
-'C:\Neo4j' | Stop-Neo4jServer
-----
-
-* Create a three node cluster on the local computer.
-  This example assumes three installations of the Enterprise version of Neo4j installed at `C:\Neo4j-1`,`C:\Neo4j-2` and `C:\Neo4j-3`.
-+
-[source,powershell]
-----
-'C:\Neo4j-1' |
-Initialize-Neo4jServer `
- -ListenOnIPAddress 127.0.0.1 `
- -HTTPPort 7474 `
- -OnlineBackupServer '127.0.0.1:6362' `
- -PassThru |
-Initialize-Neo4jHACluster `
- -ServerID 1 `
- -InitialHosts '127.0.0.1:5001' `
- -ClusterServer '127.0.0.1:5001' `
- -HAServer '127.0.0.1:6001' `
- -PassThru |
-Start-Neo4jServer -Console
-
-'C:\Neo4j-2' |
-Initialize-Neo4jServer `
- -ListenOnIPAddress 127.0.0.1 `
- -HTTPPort 7475 `
- -OnlineBackupServer '127.0.0.1:6363' `
- -PassThru |
-Initialize-Neo4jHACluster `
- -ServerID 2 `
- -InitialHosts '127.0.0.1:5001' `
- -ClusterServer '127.0.0.1:5002' `
- -HAServer '127.0.0.1:6002' `
- -DisallowClusterInit `
- -PassThru |
-Start-Neo4jServer -Console
-
-'C:\Neo4j-3' |
-Initialize-Neo4jServer `
- -ListenOnIPAddress 127.0.0.1 `
- -HTTPPort 7476 `
- -OnlineBackupServer '127.0.0.1:6364' `
- -PassThru |
-Initialize-Neo4jHACluster `
- -ServerID 3 `
- -InitialHosts '127.0.0.1:5001' `
- -ClusterServer '127.0.0.1:5003' `
- -HAServer '127.0.0.1:6003' `
- -DisallowClusterInit `
- -PassThru |
-Start-Neo4jServer -Console
+Invoke-Neo4jAdmin
 ----
 
 [[powershell-common-parameters]]
 == Common PowerShell parameters
 
-The module commands support the common PowerShell parameters of `Verbose`, `Debug`, `WhatIf` etc.
-
+The module commands support the common PowerShell parameter of `Verbose`.
 

--- a/community/server/src/docs/ops/server-installation.asciidoc
+++ b/community/server/src/docs/ops/server-installation.asciidoc
@@ -60,8 +60,9 @@ If you see this error simply install Neo4j into a different location.
 1. Download the latest release from http://neo4j.com/download/.
    * Select the appropriate Zip distribution.
 2. Right-click the downloaded file, click Extract All.
-   * Refer to the top-level extracted directory as: +NEO4J_HOME+
-3. Consult <<powershell>> for how to start or install Neo4j.
+3. Change directory to top-level extracted directory.
+   * Run `bin/neo4j console`
+4. Stop the server by typing Ctrl-C in the console.
 
 [NOTE]
 Some users have reported problems on Windows when using the ZoneAlarm firewall.

--- a/community/shell/src/docs/dev/shell.asciidoc
+++ b/community/shell/src/docs/dev/shell.asciidoc
@@ -13,12 +13,17 @@ This guide will show you how to get it going!
 
 When used together with a Neo4j server, simply issue the following at the command line:
 
+.Linux
 [source,shell]
 ----
 ./bin/neo4j-shell
 ----
 
-For help with running shell using Windows PowerShell, see <<powershell>>.
+.Windows
+[source,powershell]
+----
+bin/neo4j-shell
+----
 
 For the full list of options, see the reference in the <<shell-manpage,Shell manual page>>.
 
@@ -26,6 +31,8 @@ To connect to a running Neo4j database, use <<read-only-mode>> for local databas
 and see <<shell-enabling-remote>> for remote databases.
 
 You need to make sure that the shell jar file is on the classpath when you start up your Neo4j instance.
+
+For help with running shell using Windows, see the reference in <<powershell-windows,Windows>>.
 
 [[shell-enabling-remote]]
 === Enabling the shell server

--- a/enterprise/backup/src/docs/man/neo4j-backup.1.asciidoc
+++ b/enterprise/backup/src/docs/man/neo4j-backup.1.asciidoc
@@ -18,7 +18,7 @@ The first backup must be a full backup, after that incremental backups can be pe
 
 The source(s) are given as host:port pairs, the target is a filesystem location.
 
-For information regarding Windows, see http://neo4j.com/docs/stable/powershell.html.
+For help regarding Windows, see the reference in <<powershell-windows,Windows>>.
 
 == BACKUP TYPE
 

--- a/manual/contents/src/reference/deprecations.asciidoc
+++ b/manual/contents/src/reference/deprecations.asciidoc
@@ -14,7 +14,3 @@ See link:javadocs/deprecated-list.html[Deprecated list in Javadoc].
 
 Graph Matching::
 The graph-matching component will be removed in future releases.
-
-Windows scripts::
-The `.bat` files used to operate the database and tools on Windows are being phased out and will be removed in future releases, in favor of modern, equivalent PowerShell scripts.
-For more information, see <<powershell>>.


### PR DESCRIPTION
This commit updates the Neo4j documentation for the simplified powershell
scripts which were introduced in https://github.com/neo4j/neo4j/commit/fd6351310feabd9682742a3974938ad5c1738c1c
- The Windows batch files were created to be almost mirrors of the linux
  management scripts, unifying the administrative experience.
- Removed noticed about bat file deprectation
- Help text is valid for both Linux and Windows, and links modified for
  help that is Windows specific.
