### PR TITLE
Update powershell scripts to emit exit codes instead of exit

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
@@ -69,7 +69,7 @@ Function Invoke-Neo4j
       if ( ($Neo4jHome -eq $null) -or (-not (Test-Path -Path $Neo4jHome)) ) {
         $Neo4jHome = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
       }
-      if ($Neo4jHome -eq $null) { throw "Could not determine the Neo4j home Directory.  Set the NEO4J_HOME environment variable and retry" }
+      if ($Neo4jHome -eq $null) { throw "Could not determine the Neo4j home Directory.  Set the NEO4J_HOME environment variable and retry" }  
       Write-Verbose "Neo4j Root is '$Neo4jHome'"
       
       $thisServer = Get-Neo4jServer -Neo4jHome $Neo4jHome -ErrorAction Stop
@@ -87,50 +87,50 @@ Function Invoke-Neo4j
       {
         "" {
           Write-Host "Usage: neo4j { console | start | stop | restart | status | install-service | uninstall-service } < -Verbose >"
-          Exit 1
+          Return 1
         }
         "console" {
           Write-Verbose "Console command specified"
-          Exit (Start-Neo4jServer -Console -Neo4jServer $thisServer -ErrorAction Stop)
+          Return [int](Start-Neo4jServer -Console -Neo4jServer $thisServer -ErrorAction Stop)
         }
         "start" {
           Write-Verbose "Start command specified"
-          Exit (Start-Neo4jServer -Service -Neo4jServer $thisServer -ErrorAction Stop)
+          Return [int](Start-Neo4jServer -Service -Neo4jServer $thisServer -ErrorAction Stop)
         }
         "stop" {
           Write-Verbose "Stop command specified"
-          Exit (Stop-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
+          Return [int](Stop-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
         }
         "restart" {
           Write-Verbose "Restart command specified"
           
           $result = (Stop-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
-          if ($result -ne 0) { Exit $result}
-          Exit (Start-Neo4jServer -Service -Neo4jServer $thisServer -ErrorAction Stop)
+          if ($result -ne 0) { Return $result}
+          Return (Start-Neo4jServer -Service -Neo4jServer $thisServer -ErrorAction Stop)
         }
         "status" {
           Write-Verbose "Status command specified"
-          Exit (Get-Neo4jStatus -Neo4jServer $thisServer -ErrorAction Stop)
+          Return [int](Get-Neo4jStatus -Neo4jServer $thisServer -ErrorAction Stop)
         }
         "install-service" {
           Write-Verbose "Install command specified"
-          Exit (Install-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
+          Return [int](Install-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
         }
         "uninstall-service" {
           Write-Verbose "Uninstall command specified"
-          Exit (Uninstall-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
+          Return [int](Uninstall-Neo4jServer -Neo4jServer $thisServer -ErrorAction Stop)
         }
         default {
           Write-Host "Unknown command $Command"
-          Exit 255
+          Return 255
         }
       }
       # Should not get here!
-      Exit 2
+      Return 2
     }
     catch {
-      $_
-      Exit 1
+      Write-Error $_
+      Return 1
     }
   }
   

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jAdmin.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jAdmin.ps1
@@ -118,23 +118,23 @@ neo4j-admin help
 
     Display this help text.
 "@)
-          Exit 0
+          Return 0
         }
         "import" {
           Write-Verbose "Import command specified"
-          Exit (Invoke-Neo4jAdmin_Import -CommandArgs $ArgsHash -Neo4jServer $thisServer -ErrorAction Stop)
+          Return  [int](Invoke-Neo4jAdmin_Import -CommandArgs $ArgsHash -Neo4jServer $thisServer -ErrorAction Stop)
         }
         default {
           Write-Host "Unknown command $Command"
-          Exit 255
+          Return 255
         }
       }
       # Should not get here!
-      Exit 2
+      Return 2
     }
     catch {
-      $_
-      Exit 1
+      Write-Error $_
+      Return 1
     }
   }
   

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jBackup.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jBackup.ps1
@@ -51,11 +51,11 @@ Function Invoke-Neo4jBackup
   Process
   {
     try {
-      Exit (Invoke-Neo4jUtility -Command 'Backup' -CommandArgs $CommandArgs -ErrorAction 'Stop')      
+      Return [int](Invoke-Neo4jUtility -Command 'Backup' -CommandArgs $CommandArgs -ErrorAction 'Stop')      
     }
     catch {
-      $_
-      Exit 1
+      Write-Error $_
+      Return 1
     }
   }
   

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jImport.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jImport.ps1
@@ -51,11 +51,11 @@ Function Invoke-Neo4jImport
   Process
   {
     try {
-      Exit (Invoke-Neo4jUtility -Command 'Import' -CommandArgs $CommandArgs -ErrorAction 'Stop')      
+      Return [int](Invoke-Neo4jUtility -Command 'Import' -CommandArgs $CommandArgs -ErrorAction 'Stop')      
     }
     catch {
-      $_
-      Exit 1
+      Write-Error $_
+      Return 1
     }
   }
   

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jShell.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jShell.ps1
@@ -51,11 +51,11 @@ Function Invoke-Neo4jShell
   Process
   {
     try {
-      Exit (Invoke-Neo4jUtility -Command 'Shell' -CommandArgs $CommandArgs -ErrorAction 'Stop')      
+      Return [int](Invoke-Neo4jUtility -Command 'Shell' -CommandArgs $CommandArgs -ErrorAction 'Stop')      
     }
     catch {
-      $_
-      Exit 1
+      Write-Error $_
+      Return 1
     }
   }
   

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin.bat
@@ -19,5 +19,5 @@ rem along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 SETLOCAL
 
-Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "Import-Module '%~dp0Neo4j-Management.psd1'; Invoke-Neo4jAdmin %*"
+Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "Import-Module '%~dp0Neo4j-Management.psd1'; Exit (Invoke-Neo4jAdmin %*)"
 EXIT /B %ERRORLEVEL%

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup.bat
@@ -19,5 +19,5 @@ rem along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 SETLOCAL
 
-Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "Import-Module '%~dp0Neo4j-Management.psd1'; Invoke-Neo4jBackup %*"
+Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "Import-Module '%~dp0Neo4j-Management.psd1'; Exit (Invoke-Neo4jBackup %*)"
 EXIT /B %ERRORLEVEL%

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import.bat
@@ -19,5 +19,5 @@ rem along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 SETLOCAL
 
-Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "Import-Module '%~dp0Neo4j-Management.psd1'; Invoke-Neo4jImport %*"
+Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "Import-Module '%~dp0Neo4j-Management.psd1'; Exit (Invoke-Neo4jImport %*)"
 EXIT /B %ERRORLEVEL%

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell.bat
@@ -19,5 +19,5 @@ rem along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 SETLOCAL
 
-Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "Import-Module '%~dp0Neo4j-Management.psd1'; Invoke-Neo4jShell %*"
+Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "Import-Module '%~dp0Neo4j-Management.psd1'; Exit (Invoke-Neo4jShell %*)"
 EXIT /B %ERRORLEVEL%

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j.bat
@@ -19,5 +19,5 @@ rem along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 SETLOCAL
 
-Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "try { Unblock-File -Path '%~dp0Neo4j-Management\*.*' -ErrorAction 'SilentlyContinue' } catch {};Import-Module '%~dp0Neo4j-Management.psd1'; Invoke-Neo4j %*"
+Powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command "try { Unblock-File -Path '%~dp0Neo4j-Management\*.*' -ErrorAction 'SilentlyContinue' } catch {};Import-Module '%~dp0Neo4j-Management.psd1'; Exit (Invoke-Neo4j %*)"
 EXIT /B %ERRORLEVEL%


### PR DESCRIPTION
It was found that running the powershell module would prematurely exit
the shell e.g. Running Invoke-Neo4j would exit the current powershell
session.  This was due to the Exit statements being in the powershell
helpers.  This commit moves the Exit statements to the helper BAT files
and changes the powershell entry functions to return an exit code
