### PR TITLE
Always migrate using batch importer.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
@@ -76,8 +76,14 @@ public class StoreFactory
 
     public StoreFactory( FileSystemAbstraction fileSystem, File storeDir, PageCache pageCache, LogProvider logProvider )
     {
+        this( fileSystem, storeDir, pageCache, logProvider, InternalRecordFormatSelector.select() );
+    }
+
+    public StoreFactory( FileSystemAbstraction fileSystem, File storeDir, PageCache pageCache, LogProvider
+            logProvider, RecordFormats recordFormats )
+    {
         this( storeDir, Config.defaults(), new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem,
-                logProvider );
+                logProvider, recordFormats );
     }
 
     public StoreFactory( File storeDir, Config config,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationParticipant.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationParticipant.java
@@ -70,9 +70,10 @@ public interface StoreMigrationParticipant
 
      * @param storeDir directory the store directory of the to move the migrated files to.
      * @param versionToMigrateFrom the version we have migrated from
+     * @param versionToMigrateTo
      * @throws IOException if unable to move one or more files.
      */
-    void rebuildCounts( File storeDir, String versionToMigrateFrom ) throws IOException;
+    void rebuildCounts( File storeDir, String versionToMigrateFrom, String versionToMigrateTo ) throws IOException;
 
     /**
      * Delete any file from {@code migrationDir} produced during migration.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -215,7 +215,7 @@ public class StoreUpgrader
         {
             for ( StoreMigrationParticipant participant : participants )
             {
-                participant.rebuildCounts( storeDirectory, versionToMigrateFrom );
+                participant.rebuildCounts( storeDirectory, versionToMigrateFrom, upgradableDatabase.currentVersion() );
             }
         }
         catch ( IOException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/propertydeduplication/PropertyDeduplicator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/propertydeduplication/PropertyDeduplicator.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.SchemaStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.Record;
@@ -53,16 +54,18 @@ public class PropertyDeduplicator
     private final File workingDir;
     private final PageCache pageCache;
     private final SchemaIndexProvider schemaIndexProvider;
+    private final RecordFormats recordFormats;
     private final PrimitiveIntObjectMap<Long> seenPropertyKeys;
     private final PrimitiveIntObjectMap<DuplicateCluster> localDuplicateClusters;
 
     public PropertyDeduplicator( FileSystemAbstraction fileSystem, File workingDir, PageCache pageCache,
-                                 SchemaIndexProvider schemaIndexProvider )
+                                 SchemaIndexProvider schemaIndexProvider, RecordFormats recordFormats )
     {
         this.fileSystem = fileSystem;
         this.workingDir = workingDir;
         this.pageCache = pageCache;
         this.schemaIndexProvider = schemaIndexProvider;
+        this.recordFormats = recordFormats;
 
         seenPropertyKeys = Primitive.intObjectMap();
         localDuplicateClusters = Primitive.intObjectMap();
@@ -71,7 +74,7 @@ public class PropertyDeduplicator
     public void deduplicateProperties() throws IOException
     {
         final StoreFactory storeFactory =
-                new StoreFactory( fileSystem, workingDir, pageCache, NullLogProvider.getInstance() );
+                new StoreFactory( fileSystem, workingDir, pageCache, NullLogProvider.getInstance(), recordFormats );
         try ( NeoStores neoStores = storeFactory.openNeoStores( StoreType.PROPERTY, StoreType
                 .NODE, StoreType.SCHEMA) )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/AbstractStoreMigrationParticipant.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/AbstractStoreMigrationParticipant.java
@@ -53,7 +53,7 @@ public class AbstractStoreMigrationParticipant implements StoreMigrationParticip
     }
 
     @Override
-    public void rebuildCounts( File storeDir, String versionToMigrateFrom ) throws IOException
+    public void rebuildCounts( File storeDir, String versionToMigrateFrom, String versionToMigrateTo ) throws IOException
     {
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -92,7 +93,6 @@ import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
-import static org.neo4j.helpers.collection.Iterables.iterable;
 import static org.neo4j.kernel.impl.store.MetaDataStore.DEFAULT_NAME;
 import static org.neo4j.kernel.impl.store.format.Capability.VERSION_TRAILERS;
 import static org.neo4j.kernel.impl.store.format.InternalRecordFormatSelector.fromVersion;
@@ -419,10 +419,17 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
         // that dynamic record store over before doing the "batch import".
         //   Copying this file just as-is assumes that the format hasn't change. If that happens we're in
         // a different situation, where we first need to migrate this file.
+
+        // The token stores also need to be migrated because we use those as-is and ask for their high ids
+        // when using the importer in the store migration scenario.
+        StoreFile[] storesFilesToMigrate = {
+                StoreFile.LABEL_TOKEN_STORE, StoreFile.LABEL_TOKEN_NAMES_STORE,
+                StoreFile.PROPERTY_KEY_TOKEN_STORE, StoreFile.PROPERTY_KEY_TOKEN_NAMES_STORE,
+                StoreFile.RELATIONSHIP_TYPE_TOKEN_STORE, StoreFile.RELATIONSHIP_TYPE_TOKEN_NAMES_STORE,
+                StoreFile.NODE_LABEL_STORE};
         if ( newFormat.dynamic().equals( oldFormat.dynamic() ) )
         {
-            Iterable<StoreFile> storeFiles = iterable( StoreFile.NODE_LABEL_STORE );
-            StoreFile.fileOperation( COPY, fileSystem, storeDir, migrationDir, storeFiles,
+            StoreFile.fileOperation( COPY, fileSystem, storeDir, migrationDir, Arrays.asList(storesFilesToMigrate),
                     true, // OK if it's not there (1.9)
                     ExistingTargetStrategy.FAIL, StoreFileType.values() );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/AdditionalInitialIds.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/AdditionalInitialIds.java
@@ -37,12 +37,6 @@ import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
  */
 public interface AdditionalInitialIds
 {
-    int highLabelTokenId();
-
-    int highRelationshipTypeTokenId();
-
-    int highPropertyKeyTokenId();
-
     long lastCommittedTransactionId();
 
     long lastCommittedTransactionChecksum();
@@ -56,24 +50,6 @@ public interface AdditionalInitialIds
      */
     AdditionalInitialIds EMPTY = new AdditionalInitialIds()
     {
-        @Override
-        public int highRelationshipTypeTokenId()
-        {
-            return 0;
-        }
-
-        @Override
-        public int highPropertyKeyTokenId()
-        {
-            return 0;
-        }
-
-        @Override
-        public int highLabelTokenId()
-        {
-            return 0;
-        }
-
         @Override
         public long lastCommittedTransactionId()
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -126,11 +126,11 @@ public class BatchingNeoStores implements AutoCloseable
                 initialIds.lastCommittedTransactionId(), initialIds.lastCommittedTransactionChecksum(),
                 initialIds.lastCommittedTransactionLogVersion(), initialIds.lastCommittedTransactionLogByteOffset() );
         this.propertyKeyRepository = new BatchingPropertyKeyTokenRepository(
-                neoStores.getPropertyKeyTokenStore(), initialIds.highPropertyKeyTokenId() );
+                neoStores.getPropertyKeyTokenStore() );
         this.labelRepository = new BatchingLabelTokenRepository(
-                neoStores.getLabelTokenStore(), initialIds.highLabelTokenId() );
+                neoStores.getLabelTokenStore() );
         this.relationshipTypeRepository = new BatchingRelationshipTypeTokenRepository(
-                neoStores.getRelationshipTypeTokenStore(), initialIds.highRelationshipTypeTokenId() );
+                neoStores.getRelationshipTypeTokenStore() );
 
         // Initialize kernel extensions
         Dependencies dependencies = new Dependencies();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepository.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+
 import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.store.TokenStore;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
@@ -47,11 +48,11 @@ public abstract class BatchingTokenRepository<RECORD extends TokenRecord, TOKEN 
     private final TokenStore<RECORD, TOKEN> store;
     private int highId;
 
-    public BatchingTokenRepository( TokenStore<RECORD,TOKEN> store, int highId )
+    public BatchingTokenRepository( TokenStore<RECORD,TOKEN> store )
     {
         this.store = store;
         // TODO read the store into the repository, i.e. into existing?
-        this.highId = highId;
+        this.highId = (int)store.getHighId();
     }
 
     public int getOrCreateId( String name )
@@ -158,9 +159,9 @@ public abstract class BatchingTokenRepository<RECORD extends TokenRecord, TOKEN 
 
     public static class BatchingPropertyKeyTokenRepository extends BatchingTokenRepository<PropertyKeyTokenRecord, Token>
     {
-        public BatchingPropertyKeyTokenRepository( TokenStore<PropertyKeyTokenRecord, Token> store, int highId )
+        public BatchingPropertyKeyTokenRepository( TokenStore<PropertyKeyTokenRecord, Token> store )
         {
-            super( store, highId );
+            super( store );
         }
 
         @Override
@@ -191,7 +192,7 @@ public abstract class BatchingTokenRepository<RECORD extends TokenRecord, TOKEN 
             else if ( key instanceof Integer )
             {
                 // A raw token id was supplied, just use it
-                return ((Integer)key).intValue();
+                return (Integer) key;
             }
             throw new IllegalArgumentException( "Expected either a String or Integer for property key, but was '" +
                     key + "'" + ", " + key.getClass() );
@@ -200,9 +201,9 @@ public abstract class BatchingTokenRepository<RECORD extends TokenRecord, TOKEN 
 
     public static class BatchingLabelTokenRepository extends BatchingTokenRepository<LabelTokenRecord, Token>
     {
-        public BatchingLabelTokenRepository( TokenStore<LabelTokenRecord, Token> store, int highId )
+        public BatchingLabelTokenRepository( TokenStore<LabelTokenRecord, Token> store )
         {
-            super( store, highId );
+            super( store );
         }
 
         @Override
@@ -216,9 +217,9 @@ public abstract class BatchingTokenRepository<RECORD extends TokenRecord, TOKEN 
             extends BatchingTokenRepository<RelationshipTypeTokenRecord,RelationshipTypeToken>
     {
         public BatchingRelationshipTypeTokenRepository( TokenStore<RelationshipTypeTokenRecord,
-                RelationshipTypeToken> store, int highId )
+                RelationshipTypeToken> store )
         {
-            super( store, highId );
+            super( store );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -54,7 +54,6 @@ import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TargetDirectory.TestDirectory;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.kernel.impl.storemigration.participant.StoreMigrator.readLastTxLogPosition;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_LOG_BYTE_OFFSET;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_LOG_VERSION;
@@ -150,7 +149,7 @@ public class StoreMigratorTest
         // WHEN simulating resuming the migration
         progressMonitor = new SilentMigrationProgressMonitor();
         migrator = new StoreMigrator( fs, pageCache, Config.empty(), logService, schemaIndexProvider );
-        migrator.rebuildCounts( storeDirectory, versionToMigrateFrom );
+        migrator.rebuildCounts( storeDirectory, versionToMigrateFrom, upgradableDatabase.currentVersion() );
 
         // THEN starting the new store should be successful
         StoreFactory storeFactory =

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/NodeEncoderStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/NodeEncoderStepTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
-
 import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators.fromInput;
@@ -47,7 +46,7 @@ public class NodeEncoderStepTest
 {
     private final StageControl control = mock( StageControl.class );
     private final TokenStore<LabelTokenRecord,Token> tokenStore = mock( TokenStore.class );
-    private final BatchingLabelTokenRepository tokenRepository = new BatchingLabelTokenRepository( tokenStore, 0 );
+    private final BatchingLabelTokenRepository tokenRepository = new BatchingLabelTokenRepository( tokenStore );
     private final NodeStore nodeStore = mock( NodeStore.class );
     private final CapturingSender sender = new CapturingSender();
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/PropertyEncoderStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/PropertyEncoderStepTest.java
@@ -44,7 +44,6 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-
 import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT;
 
 public class PropertyEncoderStepTest
@@ -78,7 +77,7 @@ public class PropertyEncoderStepTest
         // GIVEN
         StageControl control = mock( StageControl.class );
         BatchingPropertyKeyTokenRepository tokens =
-                new BatchingPropertyKeyTokenRepository( neoStores.getPropertyKeyTokenStore(), 0 );
+                new BatchingPropertyKeyTokenRepository( neoStores.getPropertyKeyTokenStore() );
         Step<Batch<InputNode,NodeRecord>> step =
                 new PropertyEncoderStep<>( control, DEFAULT, tokens, neoStores.getPropertyStore() );
         @SuppressWarnings( "rawtypes" )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepositoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepositoryTest.java
@@ -33,7 +33,7 @@ public class BatchingTokenRepositoryTest
     public void shouldDedupLabelIds() throws Exception
     {
         // GIVEN
-        BatchingLabelTokenRepository repo = new BatchingLabelTokenRepository( null, 0 );
+        BatchingLabelTokenRepository repo = new BatchingLabelTokenRepository( null );
 
         // WHEN
         long[] ids = repo.getOrCreateIds( new String[] {"One", "Two", "One"} );
@@ -46,7 +46,7 @@ public class BatchingTokenRepositoryTest
     public void shouldSortLabelIds() throws Exception
     {
         // GIVEN
-        BatchingLabelTokenRepository repo = new BatchingLabelTokenRepository( null, 0 );
+        BatchingLabelTokenRepository repo = new BatchingLabelTokenRepository( null );
         long[] expected = new long[] {
                 repo.getOrCreateId( "One" ),
                 repo.getOrCreateId( "Two" ),

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepositoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepositoryTest.java
@@ -22,10 +22,12 @@ package org.neo4j.unsafe.impl.batchimport.store;
 import org.junit.Test;
 
 import org.neo4j.kernel.impl.store.NodeLabelsField;
+import org.neo4j.kernel.impl.store.TokenStore;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingTokenRepository.BatchingLabelTokenRepository;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class BatchingTokenRepositoryTest
 {
@@ -33,7 +35,8 @@ public class BatchingTokenRepositoryTest
     public void shouldDedupLabelIds() throws Exception
     {
         // GIVEN
-        BatchingLabelTokenRepository repo = new BatchingLabelTokenRepository( null );
+        @SuppressWarnings( "unchecked" )
+        BatchingLabelTokenRepository repo = new BatchingLabelTokenRepository( mock( TokenStore.class ) );
 
         // WHEN
         long[] ids = repo.getOrCreateIds( new String[] {"One", "Two", "One"} );
@@ -46,7 +49,8 @@ public class BatchingTokenRepositoryTest
     public void shouldSortLabelIds() throws Exception
     {
         // GIVEN
-        BatchingLabelTokenRepository repo = new BatchingLabelTokenRepository( null );
+        @SuppressWarnings( "unchecked" )
+        BatchingLabelTokenRepository repo = new BatchingLabelTokenRepository( mock( TokenStore.class ) );
         long[] expected = new long[] {
                 repo.getOrCreateId( "One" ),
                 repo.getOrCreateId( "Two" ),


### PR DESCRIPTION
Migration times did not seem to improve by doing a direct migration.
 However we still use the direct migration for migrating token stores.
