### PR TITLE
3.0 bolt ACK_FAILURE

### DIFF
--- a/community/bolt/src/docs/dev/examples.asciidoc
+++ b/community/bolt/src/docs/dev/examples.asciidoc
@@ -175,11 +175,12 @@ Server: SUCCESS { "type": "r" }
 
 ----
 
-=== Error handling
+[[bolt-examples-reset]]
+=== Error handling with RESET
 
 This illustrates how the server behaves when a request fails, and shows how the server ignores incoming messages until a `RESET` message is received.
 
-.Error handling
+.Error handling with RESET
 [source,bolt_exchange]
 ----
 # Handshake
@@ -256,6 +257,112 @@ Server: SUCCESS { "fields": ["num"] }
 
   00 0f b1 70  a1 86 66 69  65 6c 64 73  91 83 6e 75
   6d 00 00
+----
+
+[[bolt-examples-ack-failure]]
+=== Error handling with ACK_FAILURE
+
+This illustrates how to handle errors with `ACK_FAILURE`.
+`ACK_FAILURE` will not roll back transactions or interrupt messages ahead in line.
+Instead, it only clears the error state and moves the session either to `IDLE` or to `IN_TRANSCATION`.
+
+This is helpful, because it means you always have to run "ROLLBACK" to roll back an open transaction.
+For some use cases, that helps minimize complexity, because it cuts down the number of error recovery paths.
+
+.Error handling with ACK_FAILURE
+[source,bolt_exchange]
+----
+# Handshake
+Client: <connect>
+Client: 60 60 B0 17
+Client: 00 00 00 01  00 00 00 00  00 00 00 00  00 00 00 00
+Server: 00 00 00 01
+
+Client: INIT "MyClient/1.0" { "scheme": "basic", "principal": "neo4j", "credentials": "secret"}
+
+  00 40 B1 01  8C 4D 79 43  6C 69 65 6E  74 2F 31 2E
+  30 A3 86 73  63 68 65 6D  65 85 62 61  73 69 63 89
+  70 72 69 6E  63 69 70 61  6C 85 6E 65  6F 34 6A 8B
+  63 72 65 64  65 6E 74 69  61 6C 73 86  73 65 63 72
+  65 74 00 00
+
+Server: SUCCESS {}
+
+  00 03 b1 70  a0 00 00
+
+
+# We explicitly create a transaction
+Client: RUN "BEGIN" {}
+
+  00 09 B2 10  85 42 45 47  49 4E A0 00  00
+
+Client: PULL_ALL
+
+  00 02 B0 3F  00 00
+
+Server: SUCCESS { "fields": [] }
+
+  00 0B B1 70  A1 86 66 69  65 6C 64 73  90 00 00
+
+Server: SUCCESS {}
+
+  00 03 B1 70  A0 00 00
+
+
+# And then send a message with a syntax error
+Client: RUN "This will cause a syntax error" {}
+
+  00 23 b2 10  d0 1e 54 68  69 73 20 77  69 6c 6c 20
+  63 61 75 73  65 20 61 20  73 79 6e 74  61 78 20 65
+  72 72 6f 72  a0 00 00
+
+
+# Server responds with failure
+Server: FAILURE { "code": "Neo.ClientError.Statement.SyntaxError",
+                  "message": "Invalid input 'T': expected <init> (line 1, column 1 (offset: 0))
+                          "This will cause a syntax error"
+                           ^"}
+
+  00 9E B1 7F  A2 84 63 6F  64 65 D0 25  4E 65 6F 2E
+  43 6C 69 65  6E 74 45 72  72 6F 72 2E  53 74 61 74
+  65 6D 65 6E  74 2E 53 79  6E 74 61 78  45 72 72 6F
+  72 87 6D 65  73 73 61 67  65 D0 65 49  6E 76 61 6C
+  69 64 20 69  6E 70 75 74  20 27 54 27  3A 20 65 78
+  70 65 63 74  65 64 20 3C  69 6E 69 74  3E 20 28 6C
+  69 6E 65 20  31 2C 20 63  6F 6C 75 6D  6E 20 31 20
+  28 6F 66 66  73 65 74 3A  20 30 29 29  0A 22 54 68
+  69 73 20 77  69 6C 6C 20  63 61 75 73  65 20 61 20
+  73 79 6E 74  61 78 20 65  72 72 6F 72  22 0A 20 5E
+  00 00
+
+# Further requests are ignored
+Client: PULL_ALL
+
+  00 02 b0 3f 00 00
+
+Server: IGNORED
+
+  00 02 b0 7e 00 00
+
+
+# Until the error is acknowledged
+Client: ACK_FAILURE
+
+  00 02 B0 0E  00 00
+
+Server: SUCCESS {}
+
+  00 03 b1 70  a0 00 00
+
+
+# The transaction remains in place, and can be rolled back
+Client: RUN "ROLLBACK" {}
+
+  00 0C B2 10  88 52 4F 4C  4C 42 41 43  4B A0 00 00
+
+Server: SUCCESS { "fields": [] }
+
+  00 0B B1 70  A1 86 66 69  65 6C 64 73  90 00 00
 ----
 
 === Accessing basic result metadata

--- a/community/bolt/src/docs/dev/messaging.asciidoc
+++ b/community/bolt/src/docs/dev/messaging.asciidoc
@@ -110,41 +110,6 @@ B1 01 8C 4D  79 43 6C 69  65 6E 74 2F  31 2E 30 A3
 |authToken   |An authorization token used to authenticate to the database. The token must contain the keys `scheme`, `principal`, and `credentials`. Example { "scheme": "basic", "principal": "neo4j", "credentials": "secret"}"
 |=======================
 
-[[bolt-message-structs-reset]]
-==== RESET
-
-The `RESET` message is a client message used to return the current session to a "clean" state.
-It will cause the session to `IGNORE` any message it is currently processing, as well as any message before `RESET` that had not yet begun processing.
-This allows `RESET` to abort long-running operations.
-It also means clients must be careful about pipelining `RESET`.
-Only send this if you are not currently waiting for a result from a prior message, or if you want to explicitly abort any prior message.
-
-The following actions are performed by `RESET`:
-
-- force any currently processing message to abort with `IGNORE`
-- force any pending messages that have not yet started processing to be `IGNORED`
-- clear any outstanding `FAILURE` state
-- dispose of any outstanding result records
-- rollback the current transaction (if any)
-
-[source,bolt_message_struct]
-----
-ResetMessage (signature=0x0F) {
-}
-----
-
-.Response
-- `SUCCESS {}` if the session was successfully reset
-- `FAILURE {"code": ..., "message": ...}` if a reset is not currently possible
-
-.Example
-[source,bolt_packstream_type]
-----
-Value: RESET
-
-B0 0F
-----
-
 [[bolt-message-structs-run]]
 ==== RUN
 
@@ -239,6 +204,80 @@ If an unacknowledged failure is pending from a previous exchange, the server wil
 Value: PULL_ALL
 
 B0 3F
+----
+
+[[bolt-message-structs-reset]]
+==== RESET
+
+The `RESET` message is a client message used to return the current session to a "clean" state.
+It will cause the session to `IGNORE` any message it is currently processing, as well as any message before `RESET` that had not yet begun processing.
+This allows `RESET` to abort long-running operations.
+It also means clients must be careful about pipelining `RESET`.
+Only send this if you are not currently waiting for a result from a prior message, or if you want to explicitly abort any prior message.
+
+The following actions are performed by `RESET`:
+
+- force any currently processing message to abort with `IGNORE`
+- force any pending messages that have not yet started processing to be `IGNORED`
+- clear any outstanding `FAILURE` state
+- dispose of any outstanding result records
+- rollback the current transaction (if any)
+
+See <<bolt-examples-reset>> for example usage.
+
+Also, see <<bolt-message-structs-ack-failure>> for a message that only clears `FAILURE` state
+
+
+[source,bolt_message_struct]
+----
+ResetMessage (signature=0x0F) {
+}
+----
+
+.Response
+- `SUCCESS {}` if the session was successfully reset
+- `FAILURE {"code": ..., "message": ...}` if a reset is not currently possible
+
+.Example
+[source,bolt_packstream_type]
+----
+Value: RESET
+
+B0 0F
+----
+
+[[bolt-message-structs-ack-failure]]
+==== ACK_FAILURE
+
+The `ACK_FAILURE` message is a client message used to acknowledge a failure the server has sent.
+It is similar to `RESET`, but it does not roll back open transactions, nor does it interrupt running operations.
+
+This can be a better option than `RESET` in cases where a client wants to explicitly call "ROLLBACK" in case of failure.
+A good example of this is in a shell environment, where an error should cause all subsequent statements to fail until the transaction is rolled back.
+
+The following actions are performed by `ACK_FAILURE`:
+
+- clear any outstanding `FAILURE` state
+- dispose of any outstanding result records
+
+See <<bolt-examples-ack-failure>> for an example.
+
+[source,bolt_message_struct]
+----
+AckFailureMessage (signature=0x0E) {
+}
+----
+
+.Response
+- `SUCCESS {}` if the session was successfully reset
+- `FAILURE {"code": ..., "message": ...}` if a reset is not currently possible
+
+.Example
+[source,bolt_packstream_type]
+----
+Value: ACK_FAILURE
+
+B0 0E
 ----
 
 ==== RECORD

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/MessageHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/MessageHandler.java
@@ -44,6 +44,8 @@ public interface MessageHandler<E extends Exception>
 
     void handleResetMessage() throws E;
 
+    void handleAckFailureMessage() throws E;
+
     class Adapter<E extends Exception> implements MessageHandler<E>
     {
         @Override
@@ -96,6 +98,12 @@ public interface MessageHandler<E extends Exception>
 
         @Override
         public void handleResetMessage() throws E
+        {
+
+        }
+
+        @Override
+        public void handleAckFailureMessage() throws E
         {
 
         }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/message/AckFailureMessage.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/message/AckFailureMessage.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.messaging.message;
+
+import org.neo4j.bolt.v1.messaging.MessageHandler;
+
+public class AckFailureMessage implements Message
+{
+    @Override
+    public <E extends Exception> void dispatch( MessageHandler<E> consumer ) throws E
+    {
+        consumer.handleAckFailureMessage();
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        return !(o == null || getClass() != o.getClass());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return 1;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AckFailureMessage{}";
+    }
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/TransportBridge.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/TransportBridge.java
@@ -84,4 +84,10 @@ public class TransportBridge extends MessageHandler.Adapter<RuntimeException>
     {
         session.reset( null, simpleCallback );
     }
+
+    @Override
+    public void handleAckFailureMessage() throws RuntimeException
+    {
+        session.ackFailure( null, simpleCallback );
+    }
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredSessions.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredSessions.java
@@ -121,7 +121,7 @@ public class MonitoredSessions implements Sessions
         public <A> void ackFailure( A attachment, Callback<Void,A> callback )
         {
             monitor.messageReceived();
-            delegate.reset( attachment, withMonitor( callback ) );
+            delegate.ackFailure( attachment, withMonitor( callback ) );
         }
 
         @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredSessions.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredSessions.java
@@ -118,6 +118,13 @@ public class MonitoredSessions implements Sessions
         }
 
         @Override
+        public <A> void ackFailure( A attachment, Callback<Void,A> callback )
+        {
+            monitor.messageReceived();
+            delegate.reset( attachment, withMonitor( callback ) );
+        }
+
+        @Override
         public void interrupt()
         {
             delegate.interrupt();

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Session.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Session.java
@@ -153,8 +153,32 @@ public interface Session extends AutoCloseable
     <A> void discardAll( A attachment, Callback<Void,A> callback );
 
     /**
+     * Clear any outstanding error condition. This differs from {@link #reset(Object, Callback)} in two
+     * important ways:
+     *
+     * 1) If there was an explicitly created transaction, the session will move back
+     *    to IN_TRANSACTION, rather than IDLE. This allows a more natural flow for client
+     *    side drivers, where explicitly opened transactions always are ended with COMMIT or ROLLBACK,
+     *    even if an error occurs. In all other cases, the session will move to the IDLE state.
+     *
+     * 2) It will not interrupt any ahead-in-line messages.
+     */
+    <A> void ackFailure( A attachment, Callback<Void,A> callback );
+
+
+    /**
      * Reset the session to an IDLE state. This clears any outstanding failure condition, disposes
      * of any outstanding result records and rolls back the current transaction (if any).
+     *
+     * This differs from {@link #reset(Object, Callback)} in that it is more "radical" - it does not
+     * matter what the state of the session is, as long as it is open, reset will move it back to IDLE.
+     *
+     * This is designed to cater to two use cases:
+     *
+     * 1) Rather than create new sessions over and over, drivers can maintain a pool of sessions,
+     *    and reset them before each re-use. Since establishing sessions can be high overhead,
+     *    this is quite helpful.
+     * 2) Kill any stuck or long running operation
      */
     <A> void reset( A attachment, Callback<Void,A> callback );
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReportingSession.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReportingSession.java
@@ -85,6 +85,12 @@ public class ErrorReportingSession implements Session
     }
 
     @Override
+    public <A> void ackFailure( A attachment, Callback<Void,A> callback )
+    {
+        reportError( attachment, callback );
+    }
+
+    @Override
     public <A> void reset( A attachment, Callback<Void,A> callback )
     {
         reportError( attachment, callback );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/concurrent/SessionWorkerFacade.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/concurrent/SessionWorkerFacade.java
@@ -88,6 +88,12 @@ public class SessionWorkerFacade implements Session
     }
 
     @Override
+    public <A> void ackFailure( A attachment, Callback<Void,A> callback )
+    {
+        queue( session -> session.ackFailure( attachment, callback ) );
+    }
+
+    @Override
     public void interrupt()
     {
         worker.interrupt();

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/docs/DocSerialization.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/docs/DocSerialization.java
@@ -170,6 +170,9 @@ public class DocSerialization
                     case "RESET":
                         writer.handleResetMessage();
                         break;
+                    case "ACK_FAILURE":
+                        writer.handleAckFailureMessage();
+                        break;
                     default:
                         throw new RuntimeException( "Unknown value: " + type );
                 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/MessageFormatTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/MessageFormatTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import org.neo4j.bolt.v1.messaging.infrastructure.ValueNode;
 import org.neo4j.bolt.v1.messaging.infrastructure.ValueRelationship;
+import org.neo4j.bolt.v1.messaging.message.AckFailureMessage;
 import org.neo4j.bolt.v1.messaging.message.DiscardAllMessage;
 import org.neo4j.bolt.v1.messaging.message.FailureMessage;
 import org.neo4j.bolt.v1.messaging.message.IgnoredMessage;
@@ -81,6 +82,7 @@ public class MessageFormatTest
         assertSerializes( new FailureMessage( Status.General.UnknownError, "Err" ) );
         assertSerializes( new IgnoredMessage() );
         assertSerializes( new ResetMessage() );
+        assertSerializes( new AckFailureMessage() );
         assertSerializes( new InitMessage( "MyClient/1.0", map("scheme", "basic") ) );
     }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/RecordingMessageHandler.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/RecordingMessageHandler.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.bolt.v1.messaging.message.AckFailureMessage;
 import org.neo4j.bolt.v1.messaging.message.DiscardAllMessage;
 import org.neo4j.bolt.v1.messaging.message.FailureMessage;
 import org.neo4j.bolt.v1.messaging.message.IgnoredMessage;
@@ -92,6 +93,12 @@ public class RecordingMessageHandler implements MessageHandler<RuntimeException>
     public void handleResetMessage() throws RuntimeException
     {
         messages.add( new ResetMessage() );
+    }
+
+    @Override
+    public void handleAckFailureMessage() throws RuntimeException
+    {
+        messages.add( new AckFailureMessage() );
     }
 
     public List<Message> asList()

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredSessionsTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredSessionsTest.java
@@ -171,6 +171,12 @@ public class MonitoredSessionsTest
         }
 
         @Override
+        public <A> void ackFailure( A attachment, Callback<Void,A> callback )
+        {
+            
+        }
+
+        @Override
         public void interrupt()
         {
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionIT.java
@@ -267,7 +267,7 @@ public class SessionIT
         // and send a `ROLLBACK`, because that means that all failures in the
         // transaction, be they client-local or inside neo, can be handled the
         // same way by a driver.
-        Session session = env.newSession();
+        Session session = env.newSession("bolt-test");
         session.init( "TestClient/1.0", emptyMap(), null, null );
 
         session.run( "BEGIN", EMPTY_PARAMS, null, noOp() );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionMatchers.java
@@ -82,6 +82,24 @@ public class SessionMatchers
         };
     }
 
+    public static Matcher<? super RecordingCallback.Call> failed()
+    {
+        return new TypeSafeMatcher<RecordingCallback.Call>()
+        {
+            @Override
+            protected boolean matchesSafely( RecordingCallback.Call item )
+            {
+                return item.error() != null;
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( "Failed" );
+            }
+        };
+    }
+
     public static Matcher<? super RecordingCallback.Call> failedWith( final Status expected )
     {
         return new TypeSafeMatcher<RecordingCallback.Call>()

--- a/tools/src/main/java/org/neo4j/tools/boltalyzer/BoltMessageDescriber.java
+++ b/tools/src/main/java/org/neo4j/tools/boltalyzer/BoltMessageDescriber.java
@@ -57,6 +57,12 @@ public class BoltMessageDescriber implements MessageHandler<RuntimeException>
     }
 
     @Override
+    public void handleAckFailureMessage() throws RuntimeException
+    {
+        messages.add( "ACK_FAILURE" );
+    }
+
+    @Override
     public void handleRecordMessage( Record item ) throws RuntimeException
     {
         messages.add( "RECORD" );


### PR DESCRIPTION
This re-introduces ACK_FAILURE, as a milder alternative to `RESET`. RESET serves a brilliant purpose in making session re-use easy, but it complicates error management in drivers and poses a severe danger in that it makes it very hard for clients to keep track of if there is an open transaction or not. This can in turn lead to dangerous situations where a client thinks it is working within a transaction, but it is actually issuing individual auto-committing statements.

Hence, `ACK_FAILURE` is useful during "regular" application flow, because it will not roll back open transactions, while `RESET` is useful for session pooling and for interrupting long-running operations.
