### PR TITLE
Fixes initialization and command application of ReplicatedLockTokenStateMachine

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
@@ -177,7 +177,7 @@ public class CoreEdgeClusterSettings
 
     @Description( "RAFT log implementation" )
     public static final Setting<String> raft_log_implementation =
-            setting( "core_edge.raft_log_implementation", STRING, "NAIVE" );
+            setting( "core_edge.raft_log_implementation", STRING, "PHYSICAL" );
 
     @Description( "RAFT log rotation size" )
     public static final Setting<Long> raft_log_rotation_size =
@@ -197,5 +197,5 @@ public class CoreEdgeClusterSettings
 
     @Description("Enable or disable the dump of all network messages pertaining to the RAFT protocol")
     public static final Setting<Boolean> raft_messages_log_enable =
-            setting( "core_edge.raft_messages_log_enable", BOOLEAN, "false");
+            setting( "core_edge.raft_messages_log_enable", BOOLEAN, "true");
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/locks/ReplicatedLockTokenState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/locks/ReplicatedLockTokenState.java
@@ -60,6 +60,15 @@ public class ReplicatedLockTokenState<MEMBER>
         return ordinal;
     }
 
+    @Override
+    public String toString()
+    {
+        return "ReplicatedLockTokenState{" +
+                "currentToken=" + currentToken +
+                ", ordinal=" + ordinal +
+                '}';
+    }
+
     public static class Marshal<MEMBER> implements
             StateMarshal<ReplicatedLockTokenState<MEMBER>>
     {

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/locks/ReplicatedLockTokenStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/locks/ReplicatedLockTokenStateMachine.java
@@ -42,15 +42,15 @@ public class ReplicatedLockTokenStateMachine<MEMBER> implements StateMachine
         this.storage = storage;
         this.state = storage.getInitialState();
         this.pendingLockTokensRequests = pendingLockTokensRequests;
+        this.pendingLockTokensRequests.setCurrentToken( state.get() );
     }
 
     @Override
     public synchronized void applyCommand( ReplicatedContent content, long logIndex )
     {
-        if ( content instanceof ReplicatedLockTokenRequest )
+        if ( content instanceof ReplicatedLockTokenRequest && logIndex > state.ordinal() )
         {
             ReplicatedLockTokenRequest<MEMBER> tokenRequest = (ReplicatedLockTokenRequest<MEMBER>) content;
-
             Optional<PendingLockTokenRequest> future = Optional.ofNullable( pendingLockTokensRequests.retrieve( tokenRequest ) );
             if ( tokenRequest.id() == LockToken.nextCandidateId( currentToken().id() ) )
             {


### PR DESCRIPTION
Initialization of the class required the initial state to also be passed
 to the pending lock token requests, since that's what used to ask for the
 initial token when switching to leader.
Command application is now done in an idempotent fashion through log index
 checking.
