### PR TITLE
Manual copyright fixes

### DIFF
--- a/community/NOTICE.txt
+++ b/community/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/bolt/NOTICE.txt
+++ b/community/bolt/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/codegen/NOTICE.txt
+++ b/community/codegen/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/collections/NOTICE.txt
+++ b/community/collections/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/common/NOTICE.txt
+++ b/community/common/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/consistency-check/NOTICE.txt
+++ b/community/consistency-check/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/csv/NOTICE.txt
+++ b/community/csv/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/cypher/compatibility-suite/NOTICE.txt
+++ b/community/cypher/compatibility-suite/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/cypher/cypher-compiler-3.0/NOTICE.txt
+++ b/community/cypher/cypher-compiler-3.0/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPTable.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPTable.scala
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
-* Copyright (c) 2002-2015 "Neo Technology,"
+* Copyright (c) 2002-2016 "Neo Technology,"
 * Network Engine for Objects in Lund AB [http://neotechnology.com]
 *
 * This file is part of Neo4j.

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPTableTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPTableTest.scala
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Copyright (c) 2002-2015 "Neo Technology,"
+ * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/cypher/cypher/NOTICE.txt
+++ b/community/cypher/cypher/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/cypher/frontend-3.0/NOTICE.txt
+++ b/community/cypher/frontend-3.0/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/dbms/NOTICE.txt
+++ b/community/dbms/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/graph-algo/NOTICE.txt
+++ b/community/graph-algo/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/graph-matching/NOTICE.txt
+++ b/community/graph-matching/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/graphdb-api/NOTICE.txt
+++ b/community/graphdb-api/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/graphviz/NOTICE.txt
+++ b/community/graphviz/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/import-tool/NOTICE.txt
+++ b/community/import-tool/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/io/NOTICE.txt
+++ b/community/io/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/jmx/NOTICE.txt
+++ b/community/jmx/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/kernel/NOTICE.txt
+++ b/community/kernel/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2002-2015 "Neo Technology,"
+  Copyright (c) 2002-2016 "Neo Technology,"
   Network Engine for Objects in Lund AB [http://neotechnology.com]
 
   This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/CacheLayer.java
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
- * Copyright (c) 2002-2015 "Neo Technology,"
+ * Copyright (c) 2002-2016 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/licensecheck-config/NOTICE.txt
+++ b/community/licensecheck-config/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/licensecheck-config/src/main/resources/licensing-requirements-base.xml
+++ b/community/licensecheck-config/src/main/resources/licensing-requirements-base.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/community/licensecheck-config/src/main/resources/licensing-requirements-browser.xml
+++ b/community/licensecheck-config/src/main/resources/licensing-requirements-browser.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/community/licensecheck-config/src/main/resources/licensing-requirements-com.xml
+++ b/community/licensecheck-config/src/main/resources/licensing-requirements-com.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/community/licensecheck-config/src/main/resources/licensing-requirements-installer.xml
+++ b/community/licensecheck-config/src/main/resources/licensing-requirements-installer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/community/licensecheck-config/src/main/resources/licensing-requirements-js.xml
+++ b/community/licensecheck-config/src/main/resources/licensing-requirements-js.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/community/licensecheck-config/src/main/resources/licensing-requirements-oss.xml
+++ b/community/licensecheck-config/src/main/resources/licensing-requirements-oss.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/community/licensecheck-config/src/main/resources/licensing-requirements-win.xml
+++ b/community/licensecheck-config/src/main/resources/licensing-requirements-win.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/community/licensecheck-config/src/main/resources/notice-agpl-prefix.txt
+++ b/community/licensecheck-config/src/main/resources/notice-agpl-prefix.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/licensecheck-config/src/main/resources/notice-gpl-prefix.txt
+++ b/community/licensecheck-config/src/main/resources/notice-gpl-prefix.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/logging/NOTICE.txt
+++ b/community/logging/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/lucene-index-upgrade/NOTICE.txt
+++ b/community/lucene-index-upgrade/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/lucene-index/NOTICE.txt
+++ b/community/lucene-index/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/monitor-logging/NOTICE.txt
+++ b/community/monitor-logging/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/neo4j-community/NOTICE.txt
+++ b/community/neo4j-community/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/neo4j-slf4j/NOTICE.txt
+++ b/community/neo4j-slf4j/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/neo4j/NOTICE.txt
+++ b/community/neo4j/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/primitive-collections/NOTICE.txt
+++ b/community/primitive-collections/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/resource/NOTICE.txt
+++ b/community/resource/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/security/NOTICE.txt
+++ b/community/security/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/server-api/NOTICE.txt
+++ b/community/server-api/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/server-plugin-test/NOTICE.txt
+++ b/community/server-plugin-test/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2002-2015 "Neo Technology,"
+  Copyright (c) 2002-2016 "Neo Technology,"
   Network Engine for Objects in Lund AB [http://neotechnology.com]
 
   This file is part of Neo4j.

--- a/community/shell/NOTICE.txt
+++ b/community/shell/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/udc/NOTICE.txt
+++ b/community/udc/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/community/unsafe/NOTICE.txt
+++ b/community/unsafe/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/NOTICE.txt
+++ b/enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as “Neo Technology”)
    [http://neotechnology.com]
 

--- a/enterprise/backup/NOTICE.txt
+++ b/enterprise/backup/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/cluster/NOTICE.txt
+++ b/enterprise/cluster/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/com/NOTICE.txt
+++ b/enterprise/com/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/core-edge/NOTICE.txt
+++ b/enterprise/core-edge/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/ha/NOTICE.txt
+++ b/enterprise/ha/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/kernel/NOTICE.txt
+++ b/enterprise/kernel/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/management/NOTICE.txt
+++ b/enterprise/management/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/metrics/NOTICE.txt
+++ b/enterprise/metrics/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/query-logging/NOTICE.txt
+++ b/enterprise/query-logging/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/integrationtests/NOTICE.txt
+++ b/integrationtests/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as “Neo Technology”)
    [http://neotechnology.com]
 

--- a/manual/LICENSE.txt
+++ b/manual/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright © 2011-2015 Neo Technology
+Copyright © 2011-2016 Neo Technology
 
 License: Creative Commons 3.0
 

--- a/manual/contents/LICENSE.txt
+++ b/manual/contents/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright © 2011-2015 Neo Technology
+Copyright © 2011-2016 Neo Technology
 
 License: Creative Commons 3.0
 

--- a/manual/contents/assemblies/contents.xml
+++ b/manual/contents/assemblies/contents.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/manual/cypher/NOTICE.txt
+++ b/manual/cypher/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/manual/cypher/cypher-docs/NOTICE.txt
+++ b/manual/cypher/cypher-docs/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/RestartableDatabase.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/tooling/RestartableDatabase.scala
@@ -19,25 +19,6 @@
  */
 package org.neo4j.cypher.docgen.tooling
 
-/*
- * Copyright (c) 2002-2015 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
- *
- * This file is part of Neo4j.
- *
- * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 import org.neo4j.cypher.ExecutionEngineHelper
 import org.neo4j.cypher.internal.ExecutionEngine
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.InternalExecutionResult

--- a/manual/cypher/graphgist/NOTICE.txt
+++ b/manual/cypher/graphgist/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/manual/cypher/refcard-tests/NOTICE.txt
+++ b/manual/cypher/refcard-tests/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/manual/embedded-examples/NOTICE.txt
+++ b/manual/embedded-examples/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/manual/javadocs/NOTICE.txt
+++ b/manual/javadocs/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/manual/manual/LICENSE.txt
+++ b/manual/manual/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright © 2011-2015 Neo Technology
+Copyright © 2011-2016 Neo Technology
 
 License: Creative Commons 3.0
 

--- a/manual/manual/assemblies/manpages-enterprise.xml
+++ b/manual/manual/assemblies/manpages-enterprise.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/manual/manual/assemblies/manpages.xml
+++ b/manual/manual/assemblies/manpages.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/manual/manual/assemblies/upgrade.xml
+++ b/manual/manual/assemblies/upgrade.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2002-2015 "Neo Technology,"
+    Copyright (c) 2002-2016 "Neo Technology,"
     Network Engine for Objects in Lund AB [http://neotechnology.com]
 
     This file is part of Neo4j.

--- a/manual/neo4j-harness-enterprise-test/NOTICE.txt
+++ b/manual/neo4j-harness-enterprise-test/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/manual/neo4j-harness-test/NOTICE.txt
+++ b/manual/neo4j-harness-test/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/manual/server-examples/NOTICE.txt
+++ b/manual/server-examples/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/packaging/NOTICE.txt
+++ b/packaging/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as “Neo Technology”)
    [http://neotechnology.com]
 

--- a/packaging/installer-linux/installer-debian/NOTICE.txt
+++ b/packaging/installer-linux/installer-debian/NOTICE.txt
@@ -1,6 +1,6 @@
 Neo4j
 
-Copyright (c) 2002-2015 "Neo Technology," Network Engine for Objects in Lund AB
+Copyright (c) 2002-2016 "Neo Technology," Network Engine for Objects in Lund AB
    [http://neotechnology.com]
 
 This product includes software developed by "Neo Technology,"

--- a/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
+++ b/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
@@ -13,7 +13,7 @@
 
 # Author: Julian Simpson <julian.simpson@neotechnology.com>
 #
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #

--- a/packaging/installer-linux/installer-debian/src/main/resources/community/debian/copyright
+++ b/packaging/installer-linux/installer-debian/src/main/resources/community/debian/copyright
@@ -6,7 +6,7 @@ Upstream Author:
 
 Copyright: 
 
-    Copyright (c) 2002-2015 "Neo Technology," Network Engine for Objects in Lund AB
+    Copyright (c) 2002-2016 "Neo Technology," Network Engine for Objects in Lund AB
     [http://neotechnology.com]
 
 License:

--- a/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/copyright
+++ b/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/copyright
@@ -6,7 +6,7 @@ Upstream Author:
 
 Copyright: 
 
-    Copyright (c) 2002-2015 "Neo Technology," Network Engine for Objects in Lund AB
+    Copyright (c) 2002-2016 "Neo Technology," Network Engine for Objects in Lund AB
     [http://neotechnology.com]
 
 License:

--- a/packaging/installer-linux/installer-rpm/src/main/resources/init.d/neo4j
+++ b/packaging/installer-linux/installer-rpm/src/main/resources/init.d/neo4j
@@ -17,7 +17,7 @@
 # Description:
 ### END INIT INFO
 
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #

--- a/packaging/neo4j-desktop/NOTICE.txt
+++ b/packaging/neo4j-desktop/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/packaging/neo4j-desktop/neo4j-desktop.install4j
+++ b/packaging/neo4j-desktop/neo4j-desktop.install4j
@@ -139,7 +139,7 @@
                 <boolean>true</boolean>
               </void>
               <void property="versionInfoCopyright">
-                <string>2002-2015 Neo Technology Inc.</string>
+                <string>2002-2016 Neo Technology Inc.</string>
               </void>
               <void property="versionInfoFileDescription">
                 <string>${compiler:sys.fullName}</string>

--- a/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/neo4j-desktop/src/main/distribution/text/community/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/packaging/standalone/NOTICE.txt
+++ b/packaging/standalone/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management.psd1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management.psd1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-KeyValuePairsFromConfFile.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-KeyValuePairsFromConfFile.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jEnv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jEnv.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jSetting.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jSetting.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jStatus.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jStatus.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jWindowsServiceName.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jWindowsServiceName.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Install-Neo4jServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Install-Neo4jServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jAdmin.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jAdmin.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jAdmin_Import.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jAdmin_Import.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jBackup.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jBackup.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jImport.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jImport.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jShell.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jShell.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jUtility.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jUtility.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Neo4j-Management.psm1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Neo4j-Management.psm1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Start-Neo4jServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Start-Neo4jServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Stop-Neo4jServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Stop-Neo4jServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Uninstall-Neo4jServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Uninstall-Neo4jServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2002-2015 "Neo Technology,"
+rem Copyright (c) 2002-2016 "Neo Technology,"
 rem Network Engine for Objects in Lund AB [http://neotechnology.com]
 rem
 rem This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2002-2015 "Neo Technology,"
+rem Copyright (c) 2002-2016 "Neo Technology,"
 rem Network Engine for Objects in Lund AB [http://neotechnology.com]
 rem
 rem This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2002-2015 "Neo Technology,"
+rem Copyright (c) 2002-2016 "Neo Technology,"
 rem Network Engine for Objects in Lund AB [http://neotechnology.com]
 rem
 rem This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2002-2015 "Neo Technology,"
+rem Copyright (c) 2002-2016 "Neo Technology,"
 rem Network Engine for Objects in Lund AB [http://neotechnology.com]
 rem
 rem This file is part of Neo4j.

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j.bat
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-rem Copyright (c) 2002-2015 "Neo Technology,"
+rem Copyright (c) 2002-2016 "Neo Technology,"
 rem Network Engine for Objects in Lund AB [http://neotechnology.com]
 rem
 rem This file is part of Neo4j.

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Install-Neo4jServer.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Install-Neo4jServer.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2015 "Neo Technology,"
+# Copyright (c) 2002-2016 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This file is part of Neo4j.

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/stresstests/NOTICE.txt
+++ b/stresstests/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 

--- a/tools/NOTICE.txt
+++ b/tools/NOTICE.txt
@@ -1,5 +1,5 @@
 Neo4j
-Copyright © 2002-2015 Network Engine for Objects in Lund AB (referred to
+Copyright © 2002-2016 Network Engine for Objects in Lund AB (referred to
 in this notice as "Neo Technology")
    [http://neotechnology.com]
 


### PR DESCRIPTION
I have changed the copyright of files in manual folder to reflect the current year. Please review them and merge.
Also, redundant copyright in RestartableDatabase.scala
The copyright for manuals will be 2016 after this PR. 

Note: I have already signed the CLA.
