### PR TITLE
Proper status code on credentials expired in Bolt.

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
@@ -30,6 +30,7 @@ import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.runtime.StatementMetadata;
 import org.neo4j.bolt.v1.runtime.spi.RecordStream;
 import org.neo4j.bolt.v1.runtime.spi.StatementRunner;
+import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -48,6 +49,7 @@ import org.neo4j.udc.UsageData;
 import static java.lang.String.format;
 import static org.neo4j.kernel.api.KernelTransaction.Type.explicit;
 import static org.neo4j.kernel.api.KernelTransaction.Type.implicit;
+import static org.neo4j.kernel.api.exceptions.Status.Security.CredentialsExpired;
 
 /**
  * State-machine based implementation of {@link Session}. With this approach,
@@ -74,6 +76,7 @@ public class SessionStateMachine implements Session, SessionState
                         {
                             AuthenticationResult authResult = ctx.spi.authenticate( authToken );
                             ctx.accessMode = authResult.getAccessMode();
+                            ctx.credentialsExpired = authResult.credentialsExpired();
                             ctx.result( authResult.credentialsExpired() );
                             ctx.spi.udcRegisterClient( clientName );
                             ctx.setQuerySourceFromClientNameAndPrincipal( clientName, authToken.get( Authentication.PRINCIPAL ) );
@@ -457,6 +460,23 @@ public class SessionStateMachine implements Session, SessionState
 
         State error( SessionStateMachine ctx, Throwable err )
         {
+            if( err instanceof AuthorizationViolationException &&
+                ctx.credentialsExpired )
+            {
+                // TODO: This is *way* too high up the stack to create this message, this should
+                //       happen much further down.
+                return error( ctx, new Neo4jError( CredentialsExpired,
+                        String.format("The credentials you provided were valid, but must be changed before you can " +
+                        "use this instance. If this is the first time you are using Neo4j, this is to " +
+                        "ensure you are not using the default credentials in production. If you are not " +
+                        "using default credentials, you are getting this message because an administrator " +
+                        "requires a password change.%n" +
+                        "Changing your password is easy to do via the Neo4j Browser.%n" +
+                        "If you are connecting via a shell or programmatically via a driver, " +
+                        "just issue a `CALL sys.changePassword('new password')` statement in the current " +
+                        "session, and then restart your driver with the new password configured."),
+                        err ) );
+            }
             return error( ctx, Neo4jError.from( err ) );
         }
 
@@ -542,6 +562,17 @@ public class SessionStateMachine implements Session, SessionState
 
     /** The current session auth state to be used for starting transactions */
     private AccessMode accessMode;
+
+    /**
+     * If the current user has provided valid but needs-to-be-changed credentials,
+     * this flag gets set. This is not awesome - it'd be better to have a special
+     * access mode for this state, that would help disambiguate from being unauthenticated
+     * as well. Did things this way to minimize risk of introducing bugs this late
+     * in the 3.0 cycle. A further note towards adding a special AccessMode is that
+     * we need to set things up to change access mode anyway whenever the user changes
+     * credentials or is upgraded. As it is now, a new session needs to be created.
+     */
+    private boolean credentialsExpired;
 
     /** These are the "external" actions the state machine can take */
     private final SPI spi;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/util/MessageMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/util/MessageMatchers.java
@@ -49,6 +49,7 @@ import org.neo4j.graphdb.Notification;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.util.HexPrinter;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
@@ -180,7 +181,7 @@ public class MessageMatchers
                 assertThat( t, instanceOf( FailureMessage.class ) );
                 FailureMessage msg = (FailureMessage) t;
                 assertThat( msg.status(), equalTo( status ) );
-                assertThat( msg.message(), equalTo( message ) );
+                assertThat( msg.message(), containsString( message ) );
                 return true;
             }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/RecordingCallback.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/RecordingCallback.java
@@ -82,6 +82,12 @@ public class RecordingCallback<V, A> implements Session.Callback<V,A>
         {
             results.add( new StatementSuccess( (StatementMetadata) result ) );
         }
+        else if( result instanceof Boolean )
+        {
+            // TODO: Using Boolean as the payload for init results should be
+            //       changed, since it makes this check really brittle.
+            results.add( new InitSuccess( (Boolean)result ));
+        }
         else
         {
             throw new RuntimeException( "Unknown result type: " + result );
@@ -215,6 +221,27 @@ public class RecordingCallback<V, A> implements Session.Callback<V,A>
         public String toString()
         {
             return "SUCCESS " + meta;
+        }
+    }
+
+    public static class InitSuccess extends Success
+    {
+        private final boolean credentialsExpired;
+
+        public InitSuccess( boolean credentialsExpired )
+        {
+            this.credentialsExpired = credentialsExpired;
+        }
+
+        public boolean credentialsExpired()
+        {
+            return credentialsExpired;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "SUCCESS " + (credentialsExpired ? "(but password change required)" : "");
         }
     }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime.integration;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.bolt.v1.runtime.Session;
+import org.neo4j.kernel.api.exceptions.Status;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.failedWith;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.recorded;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.successButRequiresPasswordChange;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class SessionAuthIT
+{
+    @Rule
+    public TestSessions env = new TestSessions().withAuthEnabled( true );
+
+    @Test
+    public void shouldGiveCredentialsExpiredStatusOnExpiredCredentials() throws Throwable
+    {
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "neo4j" ), null, recorder );
+        session.run( "CREATE ()", map(), null, recorder );
+
+        // then
+        assertThat(  recorder, recorded(
+            successButRequiresPasswordChange(),
+            failedWith( Status.Security.CredentialsExpired )));
+    }
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionIT.java
@@ -398,7 +398,6 @@ public class SessionIT
 
         // Then
         assertThat( ((Record) stream[0]).fields()[0], equalTo( (Object) 1L ) );
-
     }
 
     private String createLocalIrisData( Session session ) throws IOException, InterruptedException

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionMatchers.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionMatchers.java
@@ -48,6 +48,25 @@ public class SessionMatchers
         };
     }
 
+    public static Matcher<RecordingCallback.Call> successButRequiresPasswordChange()
+    {
+        return new TypeSafeMatcher<RecordingCallback.Call>()
+        {
+            @Override
+            protected boolean matchesSafely( RecordingCallback.Call item )
+            {
+                return item instanceof RecordingCallback.InitSuccess
+                       && ((RecordingCallback.InitSuccess) item).credentialsExpired();
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( "SUCCESS (but password change required)" );
+            }
+        };
+    }
+
     public static Matcher<RecordingCallback.Call> streamContaining( final Matcher<?>... values )
     {
         return new TypeSafeMatcher<RecordingCallback.Call>()

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TestSessions.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TestSessions.java
@@ -52,6 +52,7 @@ public class TestSessions implements TestRule, Sessions
     private Sessions actual;
     private LinkedList<Session> startedSessions = new LinkedList<>();
     private final LifeSupport life = new LifeSupport();
+    private boolean authEnabled = false;
 
     @Override
     public Statement apply( final Statement base, Description description )
@@ -62,7 +63,7 @@ public class TestSessions implements TestRule, Sessions
             public void evaluate() throws Throwable
             {
                 Map<Setting<?>,String> config = new HashMap<>();
-                config.put( GraphDatabaseSettings.auth_enabled, "false" );
+                config.put( GraphDatabaseSettings.auth_enabled, Boolean.toString( authEnabled ) );
                 gdb = (GraphDatabaseFacade) new TestGraphDatabaseFactory().newImpermanentDatabase( config );
                 Neo4jJobScheduler scheduler = life.add( new Neo4jJobScheduler() );
                 DependencyResolver resolver = gdb.getDependencyResolver();
@@ -103,6 +104,12 @@ public class TestSessions implements TestRule, Sessions
         Session session = actual.newSession( connectionDescriptor, isEncrypted );
         startedSessions.add( session );
         return session;
+    }
+
+    public TestSessions withAuthEnabled( boolean authEnabled )
+    {
+        this.authEnabled = authEnabled;
+        return this;
     }
 
     public URL putTmpFile( String prefix, String suffix, String contents ) throws IOException

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
@@ -219,6 +219,7 @@ public class ResetFuzzTest
         {
             return null;
         }
+
     }
 
     /**

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -222,8 +222,8 @@ public class AuthenticationIT
                 pullAll() ) );
 
         // Then
-        assertThat( client, eventuallyRecieves( msgFailure( Status.Security.Forbidden,
-                "Read operations are not allowed for `NONE` transactions." ) ) );
+        assertThat( client, eventuallyRecieves( msgFailure( Status.Security.CredentialsExpired,
+                "The credentials you provided were valid, but must be changed before you can use this instance." ) ) );
     }
 
     @Before


### PR DESCRIPTION
This gives an identifiable error when statements fail due to
expired credentials. However, it is done as a patch layer in SSM,
rather than down the stack where the authentication fails.

I chose to do it this way to avoid introducing bugs in the lower
layers of auth stuff this late in the 3.0 cycle. However, we should
move more knowledge about the state of authentication down the stack
such that the message we patch over in SSM now can be generated at the
source down in kernel instead. One way to do that would be to introduce
a special AccessMode for authenticated_but_needs_credential_change.

In any case, this should resolve the current problem in the Browser.
