### PR TITLE
Update token name/id caching order during creation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingTokenHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/DelegatingTokenHolder.java
@@ -86,8 +86,13 @@ public abstract class DelegatingTokenHolder<TOKEN extends Token> extends Lifecyc
         }
     }
 
-    private synchronized int createToken( String name )
-            throws KernelException
+    /**
+     * Create and put new token in cache.
+     * @param name token name
+     * @return newly created token id
+     * @throws KernelException
+     */
+    private synchronized int createToken( String name ) throws KernelException
     {
         Integer id = tokenCache.getId( name );
         if ( id != null )

--- a/community/kernel/src/test/java/org/neo4j/kernel/TokenCreationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/TokenCreationIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import com.google.common.collect.Sets;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.RepeatRule;
+
+/**
+ * Token creation should be able to handle cases of concurrent token creation
+ * with different/same names. Short random interval (1-3) give a high chances of same token name in this test.
+ * <p>
+ * Newly created token should be visible only when token cache already have both mappings:
+ * "name -> id" and "id -> name" populated.
+ * Otherwise attempt to retrieve labels from newly created node can fail.
+ */
+public class TokenCreationIT
+{
+    @Rule
+    public final EmbeddedDatabaseRule databaseRule = new EmbeddedDatabaseRule();
+
+    private volatile boolean stop = false;
+
+    @Test
+    @RepeatRule.Repeat( times = 5 )
+    public void concurrentLabelTokenCreation() throws InterruptedException
+    {
+        int concurrentWorkers = 10;
+        CountDownLatch latch = new CountDownLatch( concurrentWorkers );
+        for ( int i = 0; i < concurrentWorkers; i++ )
+        {
+            new LabelCreator( databaseRule, latch ).start();
+        }
+        LockSupport.parkNanos( TimeUnit.MILLISECONDS.toNanos( 500 ) );
+        stop = true;
+        latch.await();
+    }
+
+    public Label[] getLabels()
+    {
+        int randomLabelValue = ThreadLocalRandom.current().nextInt( 2 ) + 1;
+        Label[] labels = new Label[randomLabelValue];
+        for ( int i = 0; i < labels.length; i++ )
+        {
+            labels[i] = Label.label( RandomStringUtils.randomAscii( randomLabelValue ) );
+        }
+        return labels;
+    }
+
+    private class LabelCreator extends Thread
+    {
+        private final GraphDatabaseService database;
+        private final CountDownLatch createLatch;
+
+        public LabelCreator( GraphDatabaseService database, CountDownLatch createLatch )
+        {
+            this.database = database;
+            this.createLatch = createLatch;
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                while ( !stop )
+                {
+
+                    try ( Transaction transaction = database.beginTx() )
+                    {
+                        Label[] createdLabels = getLabels();
+                        Node node = database.createNode( createdLabels );
+                        Iterable<Label> nodeLabels = node.getLabels();
+                        Assert.assertEquals( Sets.newHashSet( createdLabels ), Sets.newHashSet( nodeLabels ) );
+                        transaction.success();
+                    }
+                    catch ( Exception e )
+                    {
+                        stop = true;
+                        throw e;
+                    }
+                }
+            }
+            finally
+            {
+                createLatch.countDown();
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/InMemoryTokenCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/InMemoryTokenCacheTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class InMemoryTokenCacheTest
+{
+    private static final String INBOUND2_TYPE = "inbound2";
+    private static final String INBOUND1_TYPE = "inbound1";
+    @Rule
+    public ExpectedException expectedEcxeption = ExpectedException.none();
+
+    @Test
+    public void addTokenWithDuplicatedNotAllowed()
+    {
+        InMemoryTokenCache<RelationshipTypeToken> tokenCache = createTokenCache();
+        tokenCache.put( new RelationshipTypeToken( INBOUND1_TYPE, 1 ) );
+        tokenCache.put( new RelationshipTypeToken( INBOUND2_TYPE, 2 ) );
+
+        expectedEcxeption.expect( NonUniqueTokenException.class );
+        expectedEcxeption.expectMessage( "The testType \"inbound1\" is not unique" );
+
+        tokenCache.put( new RelationshipTypeToken( INBOUND1_TYPE, 3 ) );
+    }
+
+    @Test
+    public void keepOriginalTokenWhenAddDuplicate()
+    {
+        InMemoryTokenCache<RelationshipTypeToken> tokenCache = createTokenCache();
+        tokenCache.put( new RelationshipTypeToken( INBOUND1_TYPE, 1 ) );
+        tokenCache.put( new RelationshipTypeToken( INBOUND2_TYPE, 2 ) );
+
+        tryToAddDuplicate( tokenCache );
+
+        assertEquals( 1, tokenCache.getId( INBOUND1_TYPE ).intValue() );
+        assertEquals( 2, tokenCache.getId( INBOUND2_TYPE ).intValue() );
+        assertNull( tokenCache.getToken( 3 ) );
+    }
+
+    private InMemoryTokenCache<RelationshipTypeToken> createTokenCache()
+    {
+        return new InMemoryTokenCache<>( "testType" );
+    }
+
+    private void tryToAddDuplicate( InMemoryTokenCache<RelationshipTypeToken> tokenCache )
+    {
+        try
+        {
+            tokenCache.put( new RelationshipTypeToken( INBOUND1_TYPE, 3 ) );
+        }
+        catch ( NonUniqueTokenException ignored )
+        {
+        }
+    }
+
+}


### PR DESCRIPTION
Update order in which newly created token will be cached.
First idToToken map will be updated and then nameToId.
This will prevent cases when nameToId  already updated without corresponding token in idToToken map.
Reverse case is not possible since newly created token id is not exposed anywhere yet.
