### PR TITLE
Fix record counting in legacy CC

### DIFF
--- a/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/checking/full/CountsBuilderDecorator.java
+++ b/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/checking/full/CountsBuilderDecorator.java
@@ -39,9 +39,9 @@ import org.neo4j.legacy.consistency.checking.CheckerEngine;
 import org.neo4j.legacy.consistency.checking.ComparativeRecordChecker;
 import org.neo4j.legacy.consistency.checking.OwningRecordCheck;
 import org.neo4j.legacy.consistency.report.ConsistencyReport;
-import org.neo4j.legacy.consistency.report.ConsistencyReporter;
 import org.neo4j.legacy.consistency.report.ConsistencyReport.NodeConsistencyReport;
 import org.neo4j.legacy.consistency.report.ConsistencyReport.RelationshipConsistencyReport;
+import org.neo4j.legacy.consistency.report.ConsistencyReporter;
 import org.neo4j.legacy.consistency.store.DiffRecordAccess;
 import org.neo4j.legacy.consistency.store.RecordAccess;
 import org.neo4j.legacy.consistency.store.synthetic.CountsEntry;
@@ -302,34 +302,6 @@ class CountsBuilderDecorator extends CheckDecorator.Adapter
                                  DiffRecordAccess records )
         {
             inner.checkChange( oldRecord, newRecord, engine, records );
-        }
-    }
-
-    private static class MultiPassAvoidanceCondition<T extends AbstractBaseRecord> implements Predicate<T>
-    {
-        private boolean started = false, done = false;
-
-        @Override
-        public boolean test( T record )
-        {
-            if ( done )
-            {
-                return false;
-            }
-
-            if ( record.getLongId() == 0 )
-            {
-                if ( started )
-                {
-                    done = true;
-                    return false;
-                }
-                else
-                {
-                    started = true;
-                }
-            }
-            return true;
         }
     }
 

--- a/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/checking/full/MultiPassAvoidanceCondition.java
+++ b/community/consistency-check-legacy/src/main/java/org/neo4j/legacy/consistency/checking/full/MultiPassAvoidanceCondition.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.legacy.consistency.checking.full;
+
+import org.neo4j.function.Predicate;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+
+/**
+ * Stateful predicate that accepts record stream only once.
+ * Used to make sure that node and relationship counts are computed only once during multi-pass consistency check.
+ *
+ * @param <T> type of the record.
+ */
+class MultiPassAvoidanceCondition<T extends AbstractBaseRecord> implements Predicate<T>
+{
+    private static final long NO_RECORDS_SEEN = -1;
+
+    private long firstSeenRecordId = NO_RECORDS_SEEN;
+    private boolean singlePassCompleted;
+
+    @Override
+    public boolean test( T record )
+    {
+        if ( singlePassCompleted )
+        {
+            return false;
+        }
+        if ( firstSeenRecordId == record.getLongId() )
+        {
+            singlePassCompleted = true;
+            return false;
+        }
+        if ( firstSeenRecordId == NO_RECORDS_SEEN )
+        {
+            firstSeenRecordId = record.getLongId();
+        }
+        return true;
+    }
+}

--- a/community/consistency-check-legacy/src/test/java/org/neo4j/legacy/consistency/checking/full/MultiPassAvoidanceConditionTest.java
+++ b/community/consistency-check-legacy/src/test/java/org/neo4j/legacy/consistency/checking/full/MultiPassAvoidanceConditionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.legacy.consistency.checking.full;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MultiPassAvoidanceConditionTest
+{
+    @Test
+    public void permitsOnlySinglePass()
+    {
+        MultiPassAvoidanceCondition<NodeRecord> condition = new MultiPassAvoidanceCondition<>();
+
+        assertTrue( condition.test( new NodeRecord( 0 ) ) );
+        assertTrue( condition.test( new NodeRecord( 1 ) ) );
+        assertTrue( condition.test( new NodeRecord( 2 ) ) );
+
+        assertFalse( condition.test( new NodeRecord( 0 ) ) );
+        assertFalse( condition.test( new NodeRecord( 1 ) ) );
+        assertFalse( condition.test( new NodeRecord( 2 ) ) );
+    }
+
+    /**
+     * Checks the case when first record in the store is !inUse and is not delivered to the multi-pass check.
+     */
+    @Test
+    public void permitsOnlySinglePassWhenFirstRecordDoesNotHaveIdZero()
+    {
+        MultiPassAvoidanceCondition<NodeRecord> condition = new MultiPassAvoidanceCondition<>();
+
+        assertTrue( condition.test( new NodeRecord( 1 ) ) );
+        assertTrue( condition.test( new NodeRecord( 2 ) ) );
+        assertTrue( condition.test( new NodeRecord( 3 ) ) );
+
+        assertFalse( condition.test( new NodeRecord( 1 ) ) );
+        assertFalse( condition.test( new NodeRecord( 2 ) ) );
+        assertFalse( condition.test( new NodeRecord( 3 ) ) );
+    }
+}


### PR DESCRIPTION
Consistency check can scan same store multiple times. During first scan over
the node/relationship store counts for nodes/relationships are computed. `MultiPassAvoidanceCondition` is the predicate used to determine if current scan is the very first one.

Currently `MultiPassAvoidanceCondition` relies on the very first record to have
id `0`. However this is not true any more because since 3a88906d2c4da0a91e0525df3623d557054c69cd we skip unused records.

This commit makes `MultiPassAvoidanceCondition` not rely on any specific record id.

**NOTE:** should be a null-merge in 3.0 and further because legacy CC has been removed in 3.0 and new one does not have this issue.
