### PR TITLE
Documentation fix to remove the url that is not working in repository overview

### DIFF
--- a/RepositoryOverview.asciidoc
+++ b/RepositoryOverview.asciidoc
@@ -199,7 +199,7 @@ More information about the maven conventions can be found http://maven.apache.or
 
 Finally, each module can have documentation.
 This documentation is located in the `src/docs` folder,
-which is organized as described http://neo4j.com/docs/milestone/community-docs.html#_file_structure_in_emphasis_docs_jar_emphasis[here].
+which is organized as described http://neo4j.com/docs/milestone/resources.html[here].
 These documentation files can be incorporated into http://neo4j.com/docs/milestone/index.html[the manual]
 by including them in the neo4j-manual component.
 


### PR DESCRIPTION
I have removed the link relating to the organization of docs in RepositoryOverview.asciidoc that was not working and have replaced it with the most relevant documentation available that addresses this.

Please have a look at this PR and merge it if things seem alright. If you any new links need to be added to this, please mention it here.
