### PR TITLE
Improve detection of occupied ports in ClusterManager.

### DIFF
--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestFailover.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestFailover.java
@@ -34,7 +34,6 @@ import org.neo4j.test.LoggerRule;
 import org.neo4j.test.TargetDirectory;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.kernel.impl.ha.ClusterManager.clusterOfSize;
 
 @RunWith( Parameterized.class )
 public class TestFailover


### PR DESCRIPTION
We now test binding to wildcard and localhost as well as actually
connecting to anyone that might be listening on localhost. This should
eliminate most issues in testing, but ymmv.
