### PR TITLE
Use count store for all capitalizations of `count(*)`

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
@@ -39,6 +39,19 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest extends ExecutionEngineF
     })
   }
 
+  test("capitalized COUNTS nodes using count store") {
+    // Given
+    withModel(
+
+      // When
+      query = "MATCH (n) RETURN COUNT(n)", f = { result =>
+
+        // Then
+        result.columnAs("COUNT(n)").toSet[Int] should equal(Set(2))
+
+      })
+  }
+
   test("counts nodes using count store with count(*)") {
     // Given
     withModel(

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionAcceptanceTest.scala
@@ -439,13 +439,26 @@ class PatternExpressionAcceptanceTest extends ExecutionEngineFunSuite with Match
     result should be (empty)
   }
 
-  test("match (n:X) where EXISTS(n.prop) return n, EXISTS( (n)--() ) AS b") {
+  test("match (n:X) return n, EXISTS( (n)--() ) AS b") {
     val n1 = createLabeledNode(Map("prop" -> 42), "X")
     val n2 = createLabeledNode(Map("prop" -> 42), "X")
 
     relate(n1, createNode())
 
     val result = executeWithAllPlanners("match (n:X) return n, EXISTS( (n)--() ) AS b")
+
+    result.toList should equal(List(
+      Map("n" -> n1, "b" -> true),
+      Map("n" -> n2, "b" -> false)))
+  }
+
+  test("match (n:X) return n, exists( (n)--() ) AS b, not uppercase") {
+    val n1 = createLabeledNode(Map("prop" -> 42), "X")
+    val n2 = createLabeledNode(Map("prop" -> 42), "X")
+
+    relate(n1, createNode())
+
+    val result = executeWithAllPlanners("match (n:X) return n, exists( (n)--() ) AS b")
 
     result.toList should equal(List(
       Map("n" -> n1, "b" -> true),

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/simpleExpressionEvaluator.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/simpleExpressionEvaluator.scala
@@ -38,8 +38,8 @@ object simpleExpressionEvaluator {
 
   def isNonDeterministic(expr: Expression): Boolean =
     expr.inputs.exists {
-      case (FunctionInvocation(FunctionName(Rand.name), _, _), _) => true
-      case (FunctionInvocation(FunctionName(Timestamp.name), _, _), _) => true
+      case (func@FunctionInvocation(_, _, _), _) if func.function contains Rand => true
+      case (func@FunctionInvocation(_, _, _), _) if func.function contains Timestamp => true
       case _ => false
     }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/PatternExpressionSolver.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/PatternExpressionSolver.scala
@@ -208,7 +208,7 @@ case class CollectionSubQueryExpressionSolver[T <: Expression](namer: T => (T, M
     }
     topDown(inner, stopper = {
       case _: ScopeExpression | _: CaseExpression => true
-      case _@FunctionInvocation(FunctionName(name), _, _) => name == Exists.name
+      case f:FunctionInvocation => f.function contains Exists
       case _ => false
     })
   }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlanner.scala
@@ -54,7 +54,7 @@ case object countStorePlanner {
                                         argumentIds: Set[IdName], selections: Selections)(implicit context: LogicalPlanningContext): Option[LogicalPlan] =
     exp match {
       case // COUNT(<id>)
-        FunctionInvocation(FunctionName("count"), false, Vector(Variable(variableName))) =>
+        func@FunctionInvocation(_, false, Vector(Variable(variableName))) if func.function contains functions.Count =>
         trySolveNodeAggregation(query, columnName, Some(variableName), patternRelationships, patternNodes, argumentIds, selections)
 
       case // COUNT(*)
@@ -62,7 +62,8 @@ case object countStorePlanner {
         trySolveNodeAggregation(query, columnName, None, patternRelationships, patternNodes, argumentIds, selections)
 
       case // COUNT(n.prop)
-        FunctionInvocation(FunctionName("count"), false, Vector(Property(Variable(variableName), PropertyKeyName(propKeyName)))) =>
+        func@FunctionInvocation(_, false, Vector(Property(Variable(variableName), PropertyKeyName(propKeyName))))
+        if func.function contains functions.Count =>
         val labelCheck: Option[LabelName] => (Option[LogicalPlan] => Option[LogicalPlan]) = {
             case None => _ => None
             case Some(LabelName(labelName)) => (plan: Option[LogicalPlan]) => plan.filter(_ => context.planContext.hasPropertyExistenceConstraint(labelName, propKeyName))

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/planShortestPaths.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/planShortestPaths.scala
@@ -21,14 +21,14 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps
 
 import org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters.projectNamedPaths
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.FreshIdNameGenerator
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Ascending, LogicalPlanningContext}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.idp.expandSolverStep
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{IdName, LogicalPlan, ShortestPathPattern, _}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.{Ascending, LogicalPlanningContext}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{Predicate, QueryGraph}
+import org.neo4j.cypher.internal.frontend.v3_0.ast._
+import org.neo4j.cypher.internal.frontend.v3_0.ast.functions.{Length, Nodes}
 import org.neo4j.cypher.internal.frontend.v3_0.notification.ExhaustiveShortestPathForbiddenNotification
 import org.neo4j.cypher.internal.frontend.v3_0.{ExhaustiveShortestPathForbiddenException, InternalException}
-import org.neo4j.cypher.internal.frontend.v3_0.ast._
-import org.neo4j.cypher.internal.frontend.v3_0.ast.functions.Length
 
 case object planShortestPaths {
 
@@ -46,8 +46,8 @@ case object planShortestPaths {
 
     val (safePredicates, needFallbackPredicates) = predicates.partition {
       // TODO: Once we support node predicates we should enable all NONE and ALL predicates as safe predicates
-      case NoneIterablePredicate(_, FunctionInvocation(FunctionName("nodes"), _, _)) => false
-      case AllIterablePredicate(_, FunctionInvocation(FunctionName("nodes"), _, _)) => false
+      case NoneIterablePredicate(_, f@FunctionInvocation(_, _, _)) if f.function contains Nodes => false
+      case AllIterablePredicate(_, f@FunctionInvocation(_, _, _)) if f.function contains Nodes => false
       case NoneIterablePredicate(FilterScope(_, Some(innerPredicate)), _) if doesNotDependOnFullPath(innerPredicate) => true
       case AllIterablePredicate(FilterScope(_, Some(innerPredicate)), _) if doesNotDependOnFullPath(innerPredicate) => true
       case _ => false

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/simpleExpressionEvaluatorTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/simpleExpressionEvaluatorTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.helpers
+
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.simpleExpressionEvaluator.isNonDeterministic
+import org.neo4j.cypher.internal.frontend.v3_0.DummyPosition
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{FunctionName, FunctionInvocation}
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+
+class SimpleExpressionEvaluatorTest extends CypherFunSuite {
+  private val pos = DummyPosition(-1)
+
+  test("isNonDeterministic should not care about capitalization") {
+    isNonDeterministic(
+      FunctionInvocation(FunctionName("ranD")(pos), distinct = false, IndexedSeq.empty)(pos)) shouldBe true
+    isNonDeterministic(
+      FunctionInvocation(FunctionName("Timestamp")(pos), distinct = false, IndexedSeq.empty)(pos)) shouldBe true
+  }
+}


### PR DESCRIPTION
Since we allow `COUNT(*)`, `cOuNt(*)` etc we should also be able to use
the count store for all these variants.

fixes #6716 

Also fixed similar casing issue on other places. 
