### PR TITLE
Add AuthManager login with auth token map

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
@@ -62,17 +62,17 @@ public class BasicAuthentication implements Authentication
         String password = safeCast( CREDENTIALS, authToken );
         if ( authToken.containsKey( NEW_CREDENTIALS ) )
         {
-            return update( user, password, safeCast( NEW_CREDENTIALS, authToken ) );
+            return update( user, password, safeCast( NEW_CREDENTIALS, authToken ), authToken );
         }
         else
         {
-            return authenticate( user, password );
+            return authenticate( user, password, authToken );
         }
     }
 
-    private AuthenticationResult authenticate( String user, String password ) throws AuthenticationException
+    private AuthenticationResult authenticate( String user, String password, Map<String,Object> authToken ) throws AuthenticationException
     {
-        authSubject = authManager.login( user, password );
+        authSubject = authManager.login( user, password, authToken );
         boolean credentialsExpired = false;
         switch ( authSubject.getAuthenticationResult() )
         {
@@ -90,9 +90,10 @@ public class BasicAuthentication implements Authentication
         return new BasicAuthenticationResult( authSubject, credentialsExpired );
     }
 
-    private AuthenticationResult update( String user, String password, String newPassword ) throws AuthenticationException
+    private AuthenticationResult update( String user, String password, String newPassword,
+            Map<String,Object> authToken ) throws AuthenticationException
     {
-        authSubject = authManager.login( user, password );
+        authSubject = authManager.login( user, password, authToken );
         switch ( authSubject.getAuthenticationResult() )
         {
         case SUCCESS:

--- a/community/security/src/main/java/org/neo4j/server/security/auth/AuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/AuthManager.java
@@ -20,6 +20,7 @@
 package org.neo4j.server.security.auth;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.neo4j.server.security.auth.exception.IllegalUsernameException;
 
@@ -43,6 +44,15 @@ public interface AuthManager
      * @return An AuthSubject representing the newly logged-in user
      */
     AuthSubject login( String username, String password );
+
+    /**
+     * Log in using the provided username and password
+     * @param username The name of the user
+     * @param password The password of the user
+     * @param authToken A map containing all principals and credentials
+     * @return An AuthSubject representing the newly logged-in user
+     */
+    AuthSubject login( String username, String password, Map<String, Object> authToken );
 
     /**
      * Create a new user with the provided credentials.
@@ -136,6 +146,12 @@ public interface AuthManager
                     return "";
                 }
             };
+        }
+
+        @Override
+        public AuthSubject login( String username, String password, Map<String,Object> authToken )
+        {
+            return login( username, password );
         }
 
         @Override

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -21,6 +21,7 @@ package org.neo4j.server.security.auth;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.util.Map;
 
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
@@ -87,6 +88,12 @@ public class BasicAuthManager extends LifecycleAdapter implements AuthManager
             }
         }
         return new BasicAuthSubject( this, user, result );
+    }
+
+    @Override
+    public AuthSubject login( String username, String password, Map<String,Object> authToken )
+    {
+        return login( username, password );
     }
 
     @Override


### PR DESCRIPTION
- Add an addition login method to the AuthManager interface that takes a
  general auth token Map<String, Object>
- Make Bolt BasicAuthentication also pass its auth token on login
