### PR TITLE
Make ExpandIntoPipe deterministic

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExpandIntoPipe.scala
@@ -104,16 +104,24 @@ case class ExpandIntoPipe(source: Pipe,
         return Iterator.empty
       }
 
-      relIterator(query, fromNode, toNode, fromDegree < toDegree, relTypes, relCache)
+      relIterator(query, fromNode, toNode, preserveDirection = fromDegree < toDegree, relTypes, relCache)
     }
     // iterate from a non-dense node
     else if (toNodeIsDense)
       relIterator(query, fromNode, toNode, preserveDirection = true, relTypes, relCache)
     else if (fromNodeIsDense)
       relIterator(query, fromNode, toNode, preserveDirection = false, relTypes, relCache)
-    //both nodes are non-dense, choose a random starting point
+    //both nodes are non-dense, choose a starting point by alternating from and to nodes
     else
-      relIterator(query, fromNode, toNode, ThreadLocalRandom.current().nextBoolean(), relTypes, relCache)
+      relIterator(query, fromNode, toNode, preserveDirection = alternate(), relTypes, relCache)
+  }
+
+  private var alternateState = false
+
+  private def alternate(): Boolean = {
+    val result = !alternateState
+    alternateState = result
+    result
   }
 
   private def relIterator(query: QueryContext, fromNode: Node,  toNode: Node, preserveDirection: Boolean,


### PR DESCRIPTION
If we rely on non-deterministic behaviour it is hard to debug and
benchmark since results are unpredictable and non systematically
reproducible.
