### PR TITLE
Fixes an issue where human friendly memory config couldn't be parsed

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 
-import static java.lang.Long.parseLong;
 import static java.lang.Math.min;
 
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_threshold;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.io.ByteUnit.mebiBytes;
 
 /**
@@ -37,6 +37,7 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
      * database directory of the imported database, i.e. <into>/bad.log.
      */
     String BAD_FILE_NAME = "bad.log";
+    long MAX_PAGE_CACHE_MEMORY = mebiBytes( 240 );
 
     /**
      * @return number of relationships threshold for considering a node dense.
@@ -59,16 +60,15 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
         @Override
         public long pageCacheMemory()
         {
-            long upperBound = parseLong( GraphDatabaseSettings.pagecache_memory.getDefaultValue() );
             // Get the upper bound of what we can get from the default config calculation
             // We even want to limit amount of memory a bit more since we don't need very much during import
-            return min( mebiBytes( 240 ), upperBound );
+            return min( MAX_PAGE_CACHE_MEMORY, new Config().get( pagecache_memory ) );
         }
 
         @Override
         public int denseNodeThreshold()
         {
-            return Integer.parseInt( GraphDatabaseSettings.dense_node_threshold.getDefaultValue() );
+            return Integer.parseInt( dense_node_threshold.getDefaultValue() );
         }
     }
 
@@ -96,13 +96,13 @@ public interface Configuration extends org.neo4j.unsafe.impl.batchimport.staging
         @Override
         public long pageCacheMemory()
         {
-            return defaults.pageCacheMemory();
+            return min( MAX_PAGE_CACHE_MEMORY, config.get( pagecache_memory ) );
         }
 
         @Override
         public int denseNodeThreshold()
         {
-            return config.get( GraphDatabaseSettings.dense_node_threshold );
+            return config.get( dense_node_threshold );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ConfigurationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ConfigurationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.configuration.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.String.valueOf;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.configuration.Config.parseLongWithUnit;
+import static org.neo4j.unsafe.impl.batchimport.Configuration.MAX_PAGE_CACHE_MEMORY;
+
+public class ConfigurationTest
+{
+    @Test
+    public void shouldOverrideBigPageCacheMemorySettingContainingUnit() throws Exception
+    {
+        // GIVEN
+        Config dbConfig = new Config( stringMap( pagecache_memory.name(), "2g" ) );
+        Configuration config = new Configuration.Overridden( dbConfig );
+
+        // WHEN
+        long memory = config.pageCacheMemory();
+
+        // THEN
+        assertEquals( MAX_PAGE_CACHE_MEMORY, memory );
+    }
+
+    @Test
+    public void shouldOverrideSmallPageCacheMemorySettingContainingUnit() throws Exception
+    {
+        // GIVEN
+        long overridden = parseLongWithUnit( "10m" );
+        Config dbConfig = new Config( stringMap( pagecache_memory.name(), valueOf( overridden ) ) );
+        Configuration config = new Configuration.Overridden( dbConfig );
+
+        // WHEN
+        long memory = config.pageCacheMemory();
+
+        // THEN
+        assertEquals( overridden, memory );
+    }
+
+    @Test
+    public void shouldParseDefaultPageCacheMemorySetting() throws Exception
+    {
+        // GIVEN
+        Configuration config = Configuration.DEFAULT;
+
+        // WHEN
+        long memory = config.pageCacheMemory();
+
+        // THEN
+        assertTrue( within( memory, new Config().get( pagecache_memory ), MAX_PAGE_CACHE_MEMORY ) );
+    }
+
+    private boolean within( long value, long firstBound, long otherBound )
+    {
+        return value >= min( firstBound, otherBound ) && value <= max( firstBound, otherBound );
+    }
+}


### PR DESCRIPTION
in the ParallelBatchImporter configuration. This would break on some
builds which didn't have means of figuring out machine memory availability
and default to something like "2g".
