### PR TITLE
Procedures fail gracefully with a useful message when used incorrectly

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableProcedure.java
@@ -43,6 +43,7 @@ public interface CallableProcedure
     {
         Key<KernelTransaction> KERNEL_TRANSACTION = Key.key( "KernelTransaction", KernelTransaction.class );
         Key<AccessMode> ACCESS_MODE = Key.key( "AccessMode", AccessMode.class );
+        Key<Thread> THREAD = Key.key( "Thread", Thread.class );
 
         <T> T get( Key<T> key ) throws ProcedureException;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1409,6 +1409,7 @@ public class OperationsFacade implements ReadOperations, DataWriteOperations, Sc
         {
             CallableProcedure.BasicContext ctx = new CallableProcedure.BasicContext();
             ctx.put( CallableProcedure.Context.KERNEL_TRANSACTION, tx );
+            ctx.put( CallableProcedure.Context.THREAD, Thread.currentThread() );
             return procedures.call( ctx, name, input );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDSFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDSFactory.java
@@ -67,8 +67,9 @@ public class ProcedureGDSFactory implements ThrowingFunction<CallableProcedure.C
     public GraphDatabaseService apply( CallableProcedure.Context context ) throws ProcedureException
     {
         KernelTransaction transaction = context.get( CallableProcedure.Context.KERNEL_TRANSACTION );
+        Thread owningThread = context.get( CallableProcedure.Context.THREAD );
         GraphDatabaseFacade facade = new GraphDatabaseFacade();
-        facade.init( new ProcedureGDBFacadeSPI( transaction, queryExecutor, storeDir, resolver,
+        facade.init( new ProcedureGDBFacadeSPI( owningThread, transaction, queryExecutor, storeDir, resolver,
                 AutoIndexing.UNSUPPORTED, storeId, availability, urlValidator ) );
         return facade;
     }


### PR DESCRIPTION
When spawning multiple threads and opening transactions in such
threads the procedure might throw NPE from the ProcedureGDBFacadeSPI
since the wrapped transaction might have been already closed by
another thread.  In order to avoid this situation we added assertion
that check that transaction is not closed in each method of the
procedure SPI.  In such a way we can fail gracefully with an useful
exception for the end user.
