### PR TITLE
Include unique indexes in procedure

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StandaloneProcedureCallAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StandaloneProcedureCallAcceptanceTest.scala
@@ -284,7 +284,7 @@ class StandaloneProcedureCallAcceptanceTest extends ProcedureCallAcceptanceTest 
     registerDummyInOutProcedure(Neo4jTypes.NTString, Neo4jTypes.NTNumber)
 
     // Then
-    an [SyntaxException] shouldBe thrownBy(execute("CALL my.first.proc('ten')"))
+    a [SyntaxException] shouldBe thrownBy(execute("CALL my.first.proc('ten')"))
   }
 
   test("should fail if too many arguments") {
@@ -292,7 +292,7 @@ class StandaloneProcedureCallAcceptanceTest extends ProcedureCallAcceptanceTest 
     registerDummyInOutProcedure(Neo4jTypes.NTString, Neo4jTypes.NTNumber)
 
     // Then
-    an [SyntaxException] shouldBe thrownBy(execute("CALL my.first.proc('ten', 10, 42)"))
+    a [SyntaxException] shouldBe thrownBy(execute("CALL my.first.proc('ten', 10, 42)"))
   }
 
   test("should fail if implicit argument is missing") {
@@ -327,6 +327,6 @@ class StandaloneProcedureCallAcceptanceTest extends ProcedureCallAcceptanceTest 
 
     // Then
     result.toList should equal(
-      List(Map("description" -> "INDEX ON :A(prop)", "state" -> "ONLINE")))
+      List(Map("description" -> "INDEX ON :A(prop)", "state" -> "ONLINE", "unique" -> false)))
   }
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StandaloneProcedureCallAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/StandaloneProcedureCallAcceptanceTest.scala
@@ -327,6 +327,6 @@ class StandaloneProcedureCallAcceptanceTest extends ProcedureCallAcceptanceTest 
 
     // Then
     result.toList should equal(
-      List(Map("description" -> "INDEX ON :A(prop)", "state" -> "ONLINE", "unique" -> false)))
+      List(Map("description" -> "INDEX ON :A(prop)", "state" -> "online", "type" -> "node_label_property")))
   }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -31,13 +31,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.neo4j.helpers.collection.Iterators;
-import org.neo4j.kernel.api.dbms.DbmsOperations;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.constraints.NodePropertyExistenceConstraint;
 import org.neo4j.kernel.api.constraints.PropertyConstraint;
 import org.neo4j.kernel.api.constraints.UniquenessConstraint;
+import org.neo4j.kernel.api.dbms.DbmsOperations;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.InternalIndexState;
@@ -46,8 +46,8 @@ import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.storageengine.api.Token;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyIterator;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -57,6 +57,8 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.api.proc.CallableProcedure.Context.KERNEL_TRANSACTION;
+import static org.neo4j.kernel.builtinprocs.ListIndexesProcedure.IndexType.NODE_LABEL_PROPERTY;
+import static org.neo4j.kernel.builtinprocs.ListIndexesProcedure.IndexType.NODE_UNIQUE_PROPERTY;
 
 public class BuiltInProceduresTest
 {
@@ -84,7 +86,7 @@ public class BuiltInProceduresTest
 
         List<Object[]> call = call( "db.indexes" );
         assertThat( call,
-            contains( record( "INDEX ON :User(name)", "ONLINE", false ) ) );
+            contains( record( "INDEX ON :User(name)", "online", NODE_LABEL_PROPERTY.typeName() ) ) );
     }
 
     @Test
@@ -95,7 +97,7 @@ public class BuiltInProceduresTest
 
         // When/Then
         assertThat( call( "db.indexes" ),
-                contains( record( "INDEX ON :User(name)", "ONLINE", true ) ) );
+                contains( record( "INDEX ON :User(name)", "online", NODE_UNIQUE_PROPERTY.typeName() ) ) );
     }
 
     @Test
@@ -157,7 +159,7 @@ public class BuiltInProceduresTest
         // When/Then
         assertThat( call( "sys.procedures" ), contains(
             record( "db.constraints", "db.constraints() :: (description :: STRING?)" ),
-            record( "db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, unique :: BOOLEAN?)" ),
+            record( "db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)" ),
             record( "db.labels", "db.labels() :: (label :: STRING?)" ),
             record( "db.propertyKeys", "db.propertyKeys() :: (propertyKey :: STRING?)" ),
             record( "db.relationshipTypes", "db.relationshipTypes() :: (relationshipType :: STRING?)" ),
@@ -172,7 +174,7 @@ public class BuiltInProceduresTest
     {
         // When/Then
         assertThat( call( "sys.components" ), contains(
-            record( "Neo4j Kernel", asList( "1.3.37" ) )
+            record( "Neo4j Kernel", singletonList( "1.3.37" ) )
         ) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.security.AccessMode;
+import org.neo4j.kernel.builtinprocs.ListIndexesProcedure;
 import org.neo4j.server.security.auth.AuthSubject;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -156,7 +157,7 @@ public class BuiltinProceduresIT extends KernelIntegrationTest
         // Then
         assertThat( asList( stream ), containsInAnyOrder(
                 equalTo( new Object[]{"db.constraints", "db.constraints() :: (description :: STRING?)"} ),
-                equalTo( new Object[]{"db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, unique :: BOOLEAN?)"} ),
+                equalTo( new Object[]{"db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)"} ),
                 equalTo( new Object[]{"db.propertyKeys", "db.propertyKeys() :: (propertyKey :: STRING?)"}),
                 equalTo( new Object[]{"db.labels", "db.labels() :: (label :: STRING?)"} ),
                 equalTo( new Object[]{"sys.procedures", "sys.procedures() :: (name :: STRING?, signature :: STRING?)"} ),
@@ -248,8 +249,10 @@ public class BuiltinProceduresIT extends KernelIntegrationTest
                 readOperationsInNewTransaction().procedureCallRead( procedureName( "db", "indexes" ), new Object[0] );
 
         // Then
-        assertThat( stream.next(), equalTo( new Object[]{"INDEX ON :Age(foo)", "ONLINE", true} ) );
-        assertThat( stream.next(), equalTo( new Object[]{"INDEX ON :Person(foo)", "ONLINE", false} ) );
+        assertThat( stream.next(), equalTo( new Object[]{"INDEX ON :Age(foo)", "online",
+                ListIndexesProcedure.IndexType.NODE_UNIQUE_PROPERTY.typeName()} ) );
+        assertThat( stream.next(), equalTo( new Object[]{"INDEX ON :Person(foo)", "online",
+                ListIndexesProcedure.IndexType.NODE_LABEL_PROPERTY.typeName()} ) );
     }
 
     @Test


### PR DESCRIPTION
Console `:schema` command also lists unique indexes so procedure should do the same.
