### PR TITLE
Cope with differences between conversions to absolute paths on differ…

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/SettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/SettingsTest.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.kernel.configuration;
 
-import org.junit.Test;
-
 import java.io.File;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -46,8 +46,9 @@ public class SettingsTest {
     @Test
     public void doNotModifyAbsolutePaths()
     {
-        File thePath = Settings.PATH.apply( "/some/absolute/path" );
+        File absolutePath = new File( "some/path" ).getAbsoluteFile();
+        File thePath = Settings.PATH.apply( absolutePath.toString() );
 
-        assertEquals( new File( "/some/absolute/path" ), thePath );
+        assertEquals( absolutePath, thePath );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/docs/SettingsDocumenterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/docs/SettingsDocumenterTest.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.kernel.configuration.docs;
 
-import org.junit.Test;
-
 import java.io.File;
+
+import org.junit.Test;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
@@ -31,6 +31,8 @@ import org.neo4j.kernel.configuration.Internal;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.INTEGER;
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.PATH;
@@ -103,8 +105,8 @@ public class SettingsDocumenterTest
             "[cols=\"<1h,<4\"]%n" +
             "|===%n" +
             "|Description a|Public with default.%n" +
-            "|Valid values a|public.default is a path%n" +
-            "|Default value m|" + File.separator + "tmp%n" +
+            "|Valid values a|public.default is an integer%n" +
+            "|Default value m|1%n" +
             "|===%n" +
             "endif::nonhtmloutput[]%n" +
             "%n" +
@@ -114,8 +116,8 @@ public class SettingsDocumenterTest
             "[cols=\"<1h,<4\"]%n" +
             "|===%n" +
             "|Description a|Public with default.%n" +
-            "|Valid values a|public.default is a path%n" +
-            "|Default value m|" + File.separator + "tmp%n" +
+            "|Valid values a|public.default is an integer%n" +
+            "|Default value m|1%n" +
             "|===%n" +
             "endif::nonhtmloutput[]%n" +
             "%n" +
@@ -125,8 +127,8 @@ public class SettingsDocumenterTest
             "[cols=\"<1h,<4\"]%n" +
             "|===%n" +
             "|Description a|Public deprecated.%n" +
-            "|Valid values a|public.deprecated is a path%n" +
-            "|Default value m|" + File.separator + "tmp%n" +
+            "|Valid values a|public.deprecated is a boolean%n" +
+            "|Default value m|false%n" +
             "|Deprecated a|The `public.deprecated` configuration setting has been deprecated.%n" +
             "|===%n" +
             "endif::nonhtmloutput[]%n" +
@@ -137,8 +139,8 @@ public class SettingsDocumenterTest
             "[cols=\"<1h,<4\"]%n" +
             "|===%n" +
             "|Description a|Public deprecated.%n" +
-            "|Valid values a|public.deprecated is a path%n" +
-            "|Default value m|" + File.separator + "tmp%n" +
+            "|Valid values a|public.deprecated is a boolean%n" +
+            "|Default value m|false%n" +
             "|Deprecated a|The `public.deprecated` configuration setting has been deprecated.%n" +
             "|===%n" +
             "endif::nonhtmloutput[]%n" +
@@ -245,15 +247,15 @@ public class SettingsDocumenterTest
         Setting<File> public_nodefault = setting("public.nodefault", PATH, NO_DEFAULT);
 
         @Description("Public with default")
-        Setting<File> public_with_default = setting("public.default", PATH, "/tmp");
+        Setting<Integer> public_with_default = setting("public.default", INTEGER, "1");
 
         @Deprecated
         @Description("Public deprecated")
-        Setting<File> public_deprecated = setting("public.deprecated", PATH, "/tmp");
+        Setting<Boolean> public_deprecated = setting("public.deprecated", BOOLEAN, "false");
 
         @Internal
         @Description("Internal with default")
-        Setting<File> internal_with_default = setting("internal.default", PATH, "/tmp");
+        Setting<String> internal_with_default = setting("internal.default", STRING, "something");
     }
 
     @Group( "group" )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/security/FileURLAccessRuleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/security/FileURLAccessRuleTest.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.kernel.impl.security;
 
-import org.junit.Test;
-
 import java.io.File;
 import java.net.URL;
+
+import org.junit.Test;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.security.URLAccessValidationError;
@@ -84,11 +84,13 @@ public class FileURLAccessRuleTest
     @Test
     public void shouldAdjustURLToWithinImportDirectory() throws Exception
     {
-        final URL url = new File( "/bar/baz.csv" ).toURI().toURL();
+        File importDir = new File( "/var/lib/neo4j/import" ).getAbsoluteFile();
         final Config config = new Config(
-                MapUtil.stringMap( GraphDatabaseSettings.load_csv_file_url_root.name(), "/var/lib/neo4j/import" ) );
+                MapUtil.stringMap( GraphDatabaseSettings.load_csv_file_url_root.name(), importDir.toString() ) );
+
+        final URL url = new File( "/bar/baz.csv" ).toURI().toURL();
         URL accessURL = URLAccessRules.fileAccess().validate( config, url );
-        URL expected = new File( "/var/lib/neo4j/import/bar/baz.csv" ).toURI().toURL();
+        URL expected = new File( importDir, "bar/baz.csv" ).toURI().toURL();
         assertEquals( expected, accessURL );
     }
 }


### PR DESCRIPTION
…ent OSes

The rules about whether a path is absolute are different on Windows and
Linux. Therefore the result of calling File#getAbsolutePath differs. Now
that we convert all FILE settings to absolute paths, we need to do a
better job of insulating ourselves against those differences in our
tests.
