### PR TITLE
Allow synthetic fields in procedures.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/FieldInjections.java
@@ -89,6 +89,11 @@ public class FieldInjections
         {
             for ( Field field : currentClass.getDeclaredFields() )
             {
+                //ignore synthetic fields
+                if (field.isSynthetic())
+                {
+                    continue;
+                }
                 if ( Modifier.isStatic( field.getModifiers() ) )
                 {
                     if( field.isAnnotationPresent( Context.class ))


### PR DESCRIPTION
Compilers may generate synthetic fields in some scenarios, such as
Groovy metaclasses. The procedure loader should not throw error when
these are encountered.
