### PR TITLE
Display correct offset on parser errors

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/SyntaxExceptionCreator.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/SyntaxExceptionCreator.scala
@@ -19,9 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2
 
-class SyntaxExceptionCreator(queryText: String, preParserOffset: Option[InputPosition]) extends ((String, InputPosition) => CypherException) {
+class SyntaxExceptionCreator(rawQuery: Option[RawQuery]) extends ((String, InputPosition) => CypherException) {
+  def this(rawQuery: RawQuery) = this(Some(rawQuery))
+
   override def apply(message: String, position: InputPosition): CypherException = {
-    val adjustedPosition = position.withOffset(preParserOffset)
-    new SyntaxException(s"$message ($adjustedPosition)", queryText, adjustedPosition.offset)
+    val adjustedPosition = position.withOffset(rawQuery.map(_.pos))
+    new SyntaxException(s"$message ($adjustedPosition)", rawQuery.map(_.rawStatement).getOrElse(""), adjustedPosition.offset)
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Base.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/Base.scala
@@ -112,7 +112,7 @@ trait Base extends Parser {
     ) memoMismatches) ~~> (_.reduce(_ + '`' + _))
   }
 
-  def parseOrThrow[T](input: String, initialOffset: Option[InputPosition], rule: Rule1[Seq[T]], monitor: Option[ParserMonitor[T]]): T = {
+  def parseOrThrow[T](input: String, rawQuery: Option[RawQuery], rule: Rule1[Seq[T]], monitor: Option[ParserMonitor[T]]): T = {
     monitor.foreach(_.startParsing(input))
     val parsingResults = ReportingParseRunner(rule).run(input)
     parsingResults.result match {
@@ -139,8 +139,8 @@ trait Base extends Parser {
           }
 
           val bufferPosition = BufferPosition(error.getInputBuffer, error.getStartIndex)
-          val position = bufferPosition.withOffset(initialOffset)
-          throw new SyntaxException(s"$message ($position)", input, position.offset)
+          val position = bufferPosition.withOffset(rawQuery.map(_.pos))
+          throw new SyntaxException(s"$message ($position)", rawQuery.map(_.rawStatement).getOrElse(input), position.offset)
         }
 
         throw new ThisShouldNotHappenError("cleishm", "Parsing failed but no parse errors were provided")

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParser.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/parser/CypherParser.scala
@@ -30,8 +30,8 @@ class CypherParser(monitor: ParserMonitor[ast.Statement]) extends Parser
 
 
   @throws(classOf[SyntaxException])
-  def parse(queryText: String, offset: Option[InputPosition] = None): ast.Statement =
-    parseOrThrow(queryText, offset, CypherParser.Statements, Some(monitor))
+  def parse(queryText: String, rawQuery: Option[RawQuery] = None): ast.Statement =
+    parseOrThrow(queryText, rawQuery, CypherParser.Statements, Some(monitor))
 }
 
 object CypherParser extends Parser with Statement with Expressions {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -44,7 +44,7 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
 
   def buildPlannerQuery(query: String, cleanStatement: Boolean = true): UnionQuery = {
     val ast = parser.parse(query.replace("\r\n", "\n"))
-    val mkException = new SyntaxExceptionCreator(query, Some(pos))
+    val mkException = new SyntaxExceptionCreator(RawQuery(query, pos))
     val cleanedStatement: Statement =
       if (cleanStatement)
         ast.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ExpandStarTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ExpandStarTest.scala
@@ -106,7 +106,7 @@ class ExpandStarTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   private def assertRewrite(originalQuery: String, expectedQuery: String) {
-    val mkException = new SyntaxExceptionCreator(originalQuery, Some(pos))
+    val mkException = new SyntaxExceptionCreator(RawQuery(originalQuery, pos))
     val original = parser.parse(originalQuery).endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
     val expected = parser.parse(expectedQuery).endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/InlineProjectionsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/InlineProjectionsTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.planner.{AstRewritingTestSupport, CantHandleQueryException}
-import org.neo4j.cypher.internal.compiler.v2_2.{SyntaxExceptionCreator, SemanticState, inSequence}
+import org.neo4j.cypher.internal.compiler.v2_2.{RawQuery, SemanticState, SyntaxExceptionCreator, inSequence}
 import org.neo4j.helpers.Platforms
 
 class InlineProjectionsTest extends CypherFunSuite with AstRewritingTestSupport {
@@ -404,7 +404,7 @@ class InlineProjectionsTest extends CypherFunSuite with AstRewritingTestSupport 
 
   private def ast(queryText: String) = {
     val parsed = parser.parse(queryText)
-    val mkException = new SyntaxExceptionCreator(queryText, Some(pos))
+    val mkException = new SyntaxExceptionCreator(RawQuery(queryText,pos))
     val normalized = parsed.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
     val checkResult = normalized.semanticCheck(SemanticState.clean)
     normalized.endoRewrite(inSequence(expandStar(checkResult.state)))

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/IsolateAggregationTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/IsolateAggregationTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.ast.AstConstructionTestSupport
-import org.neo4j.cypher.internal.compiler.v2_2.{SyntaxExceptionCreator, inSequence}
+import org.neo4j.cypher.internal.compiler.v2_2.{RawQuery, SyntaxExceptionCreator, inSequence}
 
 class IsolateAggregationTest extends CypherFunSuite with RewriteTest with AstConstructionTestSupport {
   val rewriterUnderTest = isolateAggregation
@@ -151,7 +151,7 @@ class IsolateAggregationTest extends CypherFunSuite with RewriteTest with AstCon
   }
 
   override protected def parseForRewriting(queryText: String) = {
-    val mkException = new SyntaxExceptionCreator(queryText, Some(pos))
+    val mkException = new SyntaxExceptionCreator(RawQuery(queryText, pos))
     super.parseForRewriting(queryText).endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NamespacerTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NamespacerTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2._
-import org.neo4j.cypher.internal.compiler.v2_2.ast.{AstConstructionTestSupport, ASTAnnotationMap, Identifier, Statement}
+import org.neo4j.cypher.internal.compiler.v2_2.ast.{ASTAnnotationMap, AstConstructionTestSupport, Identifier, Statement}
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.StatementHelper._
 import org.neo4j.cypher.internal.compiler.v2_2.parser.ParserFixture.parser
 import org.neo4j.cypher.internal.compiler.v2_2.planner.SemanticTable
@@ -128,7 +128,7 @@ class NamespacerTest extends CypherFunSuite with AstConstructionTestSupport {
 
   private def parseAndRewrite(queryText: String): Statement = {
     val parsedAst = parser.parse(queryText)
-    val mkException = new SyntaxExceptionCreator(queryText, Some(pos))
+    val mkException = new SyntaxExceptionCreator(RawQuery(queryText, pos))
     val cleanedAst = parsedAst.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
     val (rewrittenAst, _, _) = astRewriter.rewrite(queryText, cleanedAst, cleanedAst.semanticState)
     rewrittenAst

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NormalizeReturnClausesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NormalizeReturnClausesTest.scala
@@ -22,10 +22,9 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
-import org.neo4j.cypher.internal.compiler.v2_2.symbols._
 
 class NormalizeReturnClausesTest extends CypherFunSuite with RewriteTest with AstConstructionTestSupport {
-  val mkException = new SyntaxExceptionCreator("<Query>", Some(pos))
+  val mkException = new SyntaxExceptionCreator(RawQuery("<Query>", pos))
   val rewriterUnderTest: Rewriter = normalizeReturnClauses(mkException)
 
   test("alias RETURN clause items") {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NormalizeWithClausesTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/NormalizeWithClausesTest.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v2_2._
 import org.neo4j.cypher.internal.compiler.v2_2.ast.AstConstructionTestSupport
 
 class NormalizeWithClausesTest extends CypherFunSuite with RewriteTest with AstConstructionTestSupport {
-  val mkException = new SyntaxExceptionCreator("<Query>", Some(pos))
+  val mkException = new SyntaxExceptionCreator(RawQuery("<Query>", pos))
   val rewriterUnderTest: Rewriter = normalizeWithClauses(mkException)
 
   test("ensure identifiers are aliased") {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ProjectFreshSortExpressionsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ProjectFreshSortExpressionsTest.scala
@@ -198,7 +198,7 @@ class ProjectFreshSortExpressionsTest extends CypherFunSuite with RewriteTest wi
 
   private def ast(queryText: String) = {
     val parsed = parseForRewriting(queryText)
-    val mkException = new SyntaxExceptionCreator(queryText, Some(pos))
+    val mkException = new SyntaxExceptionCreator(RawQuery(queryText, pos))
     val normalized = parsed.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
     val checkResult = normalized.semanticCheck(SemanticState.clean)
     normalized.endoRewrite(inSequence(expandStar(checkResult.state)))

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ProjectNamedPathsTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/ProjectNamedPathsTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v2_2.ast.rewriters
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v2_2.ast._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.AstRewritingTestSupport
-import org.neo4j.cypher.internal.compiler.v2_2.{SemanticState, SyntaxExceptionCreator, inSequence}
+import org.neo4j.cypher.internal.compiler.v2_2.{RawQuery, SemanticState, SyntaxExceptionCreator, inSequence}
 import org.neo4j.graphdb.Direction
 
 class ProjectNamedPathsTest extends CypherFunSuite with AstRewritingTestSupport {
@@ -31,7 +31,7 @@ class ProjectNamedPathsTest extends CypherFunSuite with AstRewritingTestSupport 
 
   private def ast(queryText: String) = {
     val parsed = parser.parse(queryText)
-    val mkException = new SyntaxExceptionCreator(queryText, Some(pos))
+    val mkException = new SyntaxExceptionCreator(RawQuery(queryText, pos))
     val normalized = parsed.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
     val checkResult = normalized.semanticCheck(SemanticState.clean)
     normalized.endoRewrite(inSequence(expandStar(checkResult.state)))

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/RewriteTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/RewriteTest.scala
@@ -34,7 +34,7 @@ trait RewriteTest {
   protected def assertRewrite(originalQuery: String, expectedQuery: String) {
     val original = parseForRewriting(originalQuery)
     val expected = parseForRewriting(expectedQuery)
-    val mkException = new SyntaxExceptionCreator(originalQuery, Some(DummyPosition(0)))
+    val mkException = new SyntaxExceptionCreator(RawQuery(originalQuery, DummyPosition(0)))
     semanticChecker.check(originalQuery, original, mkException)
 
     val result = rewrite(original)

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport.scala
@@ -28,12 +28,12 @@ import org.neo4j.cypher.internal.compiler.v2_2.parser.{CypherParser, ParserMonit
 import org.neo4j.cypher.internal.compiler.v2_2.planner.execution.PipeExecutionBuilderContext
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical._
-import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.greedy.{GreedyPlanTable, expandsOrJoins, expandsOnly, GreedyQueryGraphSolver}
+import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.greedy.{GreedyPlanTable, GreedyQueryGraphSolver, expandsOnly, expandsOrJoins}
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.plans.rewriter.LogicalPlanRewriter
 import org.neo4j.cypher.internal.compiler.v2_2.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v2_2.spi.{GraphStatistics, PlanContext}
-import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.{ValidatingRewriterStepSequencer, RewriterStepSequencer}
+import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.graphdb.Direction
 import org.neo4j.helpers.Clock
 
@@ -161,7 +161,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
 
   def produceLogicalPlan(queryText: String)(implicit planner: CostBasedPipeBuilder, planContext: PlanContext): LogicalPlan = {
     val parsedStatement = parser.parse(queryText)
-    val mkException = new SyntaxExceptionCreator(queryText, Some(pos))
+    val mkException = new SyntaxExceptionCreator(RawQuery(queryText, pos))
     val semanticState = semanticChecker.check(queryText, parsedStatement, mkException)
     val (rewrittenStatement, _, postConditions) = astRewriter.rewrite(queryText, parsedStatement, semanticState)
     CostBasedPipeBuilder.rewriteStatement(rewrittenStatement, semanticState.scopeTree, SemanticTable(types = semanticState.typeTable), rewriterSequencer, semanticChecker, postConditions, monitors.newMonitor[AstRewritingMonitor]()) match {

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/LogicalPlanningTestSupport2.scala
@@ -147,7 +147,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
     def planFor(queryString: String): SemanticPlan = {
       val parsedStatement = parser.parse(queryString)
-      val mkException = new SyntaxExceptionCreator(queryString, Some(pos))
+      val mkException = new SyntaxExceptionCreator(RawQuery(queryString, pos))
       val cleanedStatement: Statement = parsedStatement.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
       val semanticState = semanticChecker.check(queryString, cleanedStatement, mkException)
       val (rewrittenStatement, _, postConditions) = astRewriter.rewrite(queryString, cleanedStatement, semanticState)
@@ -168,7 +168,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
 
     def getLogicalPlanFor(queryString: String): (LogicalPlan, SemanticTable) = {
       val parsedStatement = parser.parse(queryString)
-      val mkException = new SyntaxExceptionCreator(queryString, Some(pos))
+      val mkException = new SyntaxExceptionCreator(RawQuery(queryString, pos))
       val semanticState = semanticChecker.check(queryString, parsedStatement, mkException)
       val (rewrittenStatement, _, postConditions) = astRewriter.rewrite(queryString, parsedStatement, semanticState)
 

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryGraphProducer.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/planner/logical/QueryGraphProducer.scala
@@ -34,7 +34,7 @@ trait QueryGraphProducer extends MockitoSugar {
   def producePlannerQueryForPattern(query: String): (PlannerQuery, SemanticTable) = {
     val q = query + " RETURN 1 AS Result"
     val ast = parser.parse(q)
-    val mkException = new SyntaxExceptionCreator(query, Some(pos))
+    val mkException = new SyntaxExceptionCreator(RawQuery(query, pos))
     val semanticChecker = new SemanticChecker(mock[SemanticCheckMonitor])
     val cleanedStatement: Statement = ast.endoRewrite(inSequence(normalizeReturnClauses(mkException), normalizeWithClauses(mkException)))
     val semanticState = semanticChecker.check(query, cleanedStatement, mkException)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -154,7 +154,7 @@ trait CompatibilityFor2_2 {
   implicit val indexSearchMonitor = kernelMonitors.newMonitor(classOf[IndexSearchMonitor])
 
   def produceParsedQuery(statementAsText: String, rawStatement: String, offset: InputPosition) = new ParsedQuery {
-    val preparedQueryForV_2_2 = Try(compiler.prepareQuery(statementAsText, rawStatement, Some(offset)))
+    val preparedQueryForV_2_2 = Try(compiler.prepareQuery(statementAsText, Some(RawQuery(rawStatement,offset))))
 
     def isPeriodicCommit = preparedQueryForV_2_2.map(_.isPeriodicCommit).getOrElse(false)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -20,7 +20,8 @@
 package org.neo4j.cypher
 
 import org.neo4j.graphdb.QueryExecutionException
-import collection.JavaConverters._
+
+import scala.collection.JavaConverters._
 
 class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
 
@@ -545,6 +546,11 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
     executeAndEnsureError("MATCH m, n RETURN m, n, o LIMIT 25",
       "o not defined (line 1, column 25 (offset: 24))")
 
+  }
+
+  test("position should be correct when using cypher options on general syntax exceptions") {
+    executeAndEnsureError("CYPHER planner=cost REXTURN 1",
+                          "Invalid input 'X': expected 'm/M' or 't/T' (line 1, column 23 (offset: 22))")
   }
 
   def executeAndEnsureError(query: String, expected: String) {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -152,7 +152,7 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
 
   def plan(query: String): (Double, Double) = {
     val compiler = createCurrentCompiler
-    val (prepareTime, preparedQuery) = measure(compiler.prepareQuery(query, query))
+    val (prepareTime, preparedQuery) = measure(compiler.prepareQuery(query, None))
     val (planTime, _) = graph.inTx {
       measure(compiler.executionPlanBuilder.build(planContext, preparedQuery))
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -21,7 +21,8 @@ package org.neo4j.cypher.internal.compiler.v2_2
 
 import org.neo4j.cypher.GraphDatabaseTestSupport
 import org.neo4j.cypher.internal.commons.CypherFunSuite
-import org.neo4j.cypher.internal.compatibility.{WrappedMonitors, StringInfoLogger}
+import org.neo4j.cypher.internal.compatibility.{StringInfoLogger, WrappedMonitors}
+import org.neo4j.cypher.internal.compiler.v2_2.ast.Statement
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.ExecutionPlan
 import org.neo4j.cypher.internal.compiler.v2_2.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
@@ -29,7 +30,6 @@ import org.neo4j.helpers.{Clock, FrozenClock}
 import org.neo4j.kernel.impl.util.StringLogger.DEV_NULL
 import org.neo4j.kernel.impl.util.TestLogger.LogCall
 import org.neo4j.kernel.impl.util.{StringLogger, TestLogger}
-import org.neo4j.cypher.internal.compiler.v2_2.ast.Statement
 
 import scala.collection.Map
 
@@ -147,7 +147,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     val compiler = createCompiler(queryPlanTTL = 0, clock = clock, logger = logger)
     compiler.monitors.addMonitorListener(counter)
     val query: String = "match (n:Person:Dog) return n"
-    val statement = compiler.prepareQuery(query, query).statement
+    val statement = compiler.prepareQuery(query, None).statement
 
     createLabeledNode("Dog")
     (0 until 50).foreach { _ => createLabeledNode("Person") }


### PR DESCRIPTION
On general syntax exception or parser errors, i.e. those that do not originate
from semantic checking we must keep track of the original statement (including
pre-parser options) in order to always correctly show the offset in the error.
