### PR TITLE
Enforce consistency when accessing array with non-integer index values

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/CollectionIndexTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/CollectionIndexTest.scala
@@ -55,6 +55,22 @@ class CollectionIndexTest extends CypherFunSuite {
     idx(0) should equal(expectedNull)
   }
 
+  test("should fail when not integer values are passed") {
+    implicit val collection = Literal(Seq(1, 2, 3, 4))
+
+    a [CypherTypeException] should be thrownBy idx(1.0f)
+    a [CypherTypeException] should be thrownBy idx(1.0d)
+    a [CypherTypeException] should be thrownBy idx("bad value")
+  }
+
+  test("should fail when too big values are used to access the array") {
+    implicit val collection = Literal(Seq(1, 2, 3, 4))
+
+    val index = Int.MaxValue + 1L
+
+    an [InvalidArgumentException] should be thrownBy idx(index)
+  }
+
   test("typeWhenCollectionIsAnyTypeIsCollectionOfCTAny") {
     val collection = new FakeExpression(CTAny)
     val symbols = new SymbolTable()
@@ -63,6 +79,6 @@ class CollectionIndexTest extends CypherFunSuite {
     result should equal(CTAny)
   }
 
-  private def idx(value: Int)(implicit collection:Expression) =
+  private def idx(value: Any)(implicit collection:Expression) =
     CollectionIndex(collection, Literal(value))(ctx)(state)
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherTypeAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherTypeAcceptanceTest.scala
@@ -70,4 +70,9 @@ class CypherTypeAcceptanceTest extends ExecutionEngineFunSuite {
 
     result should be(empty)
   }
+
+  test("should be consistent in failing either statically or at runtime when trying to access an array with a non-integer index") {
+    a [SyntaxException] should be thrownBy execute("WITH [1,2,3,4,5] AS array, 3.14 AS idx RETURN array[idx]")
+    a [CypherTypeException] should be thrownBy execute("WITH [1,2,3,4,5] AS array, {idx} AS idx RETURN array[idx]", "idx" -> 3.14d)
+  }
 }


### PR DESCRIPTION
The problem was that when using non integer indexes for accessing
arrays we fail with a semantic exception when the index type is known
in advance of not being an integer (e.g., when using a literal) whilst
we success at run time by coarcing the value to an integer (e.g., when
using parameters).  Such behaviour is confusing and upredictable,
hence this change will make both cases to fail, the first while
semantic checking and the second at runtime.
