### PR TITLE
Fix a very rare recursive-table-growth problem in primitive collections

### DIFF
--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/AbstractHopScotchCollection.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/AbstractHopScotchCollection.java
@@ -67,6 +67,12 @@ public abstract class AbstractHopScotchCollection<VALUE> implements PrimitiveCol
     }
 
     @Override
+    public Table<VALUE> getLastTable()
+    {
+        return table;
+    }
+
+    @Override
     public void close()
     {
         table.close();


### PR DESCRIPTION
This fixes #6654

During growing the table underlying a collection, the process of populating the new table could decide that the table needs to grow once more.
If this happened, the outer most table grows (with the smallest table) would end up installing its table last, overwriting the work of any growth caused by table population.
This would result in the table suddenly forgetting an arbitrary number of its entries.
Specifically, this could manifest as very rare permanent self-deadlocks in the Forseti (Enterprise Edition) lock manager.

changelog: Fix for rare permanent self-deadlocks in the Enterprise lock manager [#6654](https://github.com/neo4j/neo4j/issues/6654)
