### PR TITLE
Modulo function cannot only use doubles

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/ModuloTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/ModuloTest.scala
@@ -30,18 +30,18 @@ class ModuloTest extends InfixExpressionTestBase(Modulo(_, _)(DummyPosition(0)))
   // 1.1 % 1 => 0.1
   // 1.1 % 1.1 => 0.0
 
-  test("shouldHandleAllSpecializations") {
+  test("should handle all specializations") {
     testValidTypes(CTInteger, CTInteger)(CTInteger)
     testValidTypes(CTInteger, CTFloat)(CTFloat)
     testValidTypes(CTFloat, CTInteger)(CTFloat)
     testValidTypes(CTFloat, CTFloat)(CTFloat)
   }
 
-  test("shouldHandleCombinedSpecializations") {
+  test("should handle combined specializations") {
     testValidTypes(CTFloat | CTInteger, CTFloat | CTInteger)(CTFloat | CTInteger)
   }
 
-  test("shouldFailTypeCheckWhenAddingIncompatible") {
+  test("should fail type check when adding incompatible") {
     testInvalidApplication(CTInteger, CTBoolean)(
       "Type mismatch: expected Float or Integer but was Boolean"
     )

--- a/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/ModuloTest.scala
+++ b/community/cypher/cypher-compiler-2.2/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/commands/expressions/ModuloTest.scala
@@ -19,19 +19,21 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2.commands.expressions
 
-case class Modulo(a: Expression, b: Expression) extends Arithmetics(a, b) {
-  def calc(a: Number, b: Number): Any = (a, b) match {
-    case (l1: java.lang.Double, _) => l1 % b.doubleValue()
-    case (_, l2: java.lang.Double) => a.doubleValue() % l2
-    case (l1: java.lang.Float, _) => l1 % b.floatValue()
-    case (_, l2: java.lang.Float) => a.floatValue() % l2
+import org.neo4j.cypher.internal.commons.CypherFunSuite
 
-    //no floating point values, then we treat everything else as longs
-    case _ => a.longValue() % b.longValue()
+class ModuloTest extends CypherFunSuite {
+
+  test("should handle large integers") {
+    // Given
+    val modulo = Modulo(mock[Expression], mock[Expression])
+
+    modulo.calc(16000000000000001L, 16000) should equal (1L)
   }
 
+  test("should handle large integers and floating point values") {
+    // Given
+    val modulo = Modulo(mock[Expression], mock[Expression])
 
-  def rewrite(f: (Expression) => Expression) = f(Modulo(a.rewrite(f), b.rewrite(f)))
-
-  def symbolTableDependencies = a.symbolTableDependencies ++ b.symbolTableDependencies
+    modulo.calc(16000000000000001L, 16000d) should equal (0.0)
+  }
 }


### PR DESCRIPTION
By turning everything into doubles precision will be lost and we will
end up with invalid results a lot of the time.
