### PR TITLE
Add extra byte to BaseHighLimitRecordFormat header.

### DIFF
--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -48,8 +48,8 @@ public class HighLimit extends BaseRecordFormats
     static final int DEFAULT_MAXIMUM_BITS_PER_ID = 50;
 
     public static final RecordFormats RECORD_FORMATS = new HighLimit();
-    // Enterprise.HighLimit.Zero
-    public static final String STORE_VERSION = "vE.H.0";
+    // Enterprise.HighLimit.One
+    public static final String STORE_VERSION = "vE.H.1";
     public static final String NAME = "high_limit";
 
     public HighLimit()

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
@@ -31,12 +31,12 @@ import org.neo4j.kernel.impl.store.record.Record;
  * V: variable between 3B-8B
  *
  * Record format:
- * 1B   header
+ * 2B   header
  * VB   first relationship
  * VB   first property
  * 5B   labels
  *
- * => 12B-22B
+ * => 13B-23B
  */
 class NodeRecordFormat extends BaseHighLimitRecordFormat<NodeRecord>
 {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
  * V: variable between 3B-8B
  *
  * Record format:
- * 1B   header
+ * 2B   header
  * 2B   relationship type
  * VB   first outgoing relationships
  * VB   first incoming relationships
@@ -38,7 +38,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
  * VB   owning node
  * VB   next relationship group record
  *
- * => 18B-43B
+ * => 19B-44B
  */
 class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<RelationshipGroupRecord>
 {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
@@ -33,7 +33,7 @@ import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toRelative;
  * V: variable between 3B-8B
  *
  * Record format:
- * 1B   header
+ * 2B   header
  * 2B   relationship type
  * VB   first property
  * VB   start node
@@ -43,7 +43,7 @@ import static org.neo4j.kernel.impl.store.format.highlimit.Reference.toRelative;
  * VB   end node chain previous relationship
  * VB   end node chain next relationship
  *
- * => 24B-59B
+ * => 25B-60B
  */
 class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRecord>
 {

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.StubPageCursor;
+import org.neo4j.kernel.impl.store.IntStoreHeader;
+import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+
+import static org.junit.Assert.assertEquals;
+
+public class BaseHighLimitRecordFormatTest
+{
+    StubPageCursor pageCursor;
+
+    @Before
+    public void setUp()
+    {
+        pageCursor = new StubPageCursor( 0, 8192 );
+    }
+    @Test
+    public void secondHeaderByteEmptyTest() throws IOException
+    {
+        //GIVEN
+        RecordFormat<NodeRecord> nodeRecordFormat = HighLimit.RECORD_FORMATS.node();
+        NodeRecord nodeRecord = new NodeRecord( 1 );
+        nodeRecord.setInUse( true );
+        nodeRecord.setNextRel( Integer.MAX_VALUE );
+        nodeRecord.setNextProp( Integer.MAX_VALUE );
+        IntStoreHeader intStoreHeader = new IntStoreHeader( 42 );
+        int recordSize = nodeRecordFormat.getRecordSize( intStoreHeader);
+        nodeRecordFormat.write( nodeRecord, pageCursor, recordSize, null);
+
+        //WHEN
+        pageCursor.setOffset( 0 );
+        byte firstHeaderByte = pageCursor.getByte();
+        byte secondHeaderByte = pageCursor.getByte();
+
+        //THEN
+        assertEquals((byte) 0 , secondHeaderByte);
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
@@ -40,6 +40,7 @@ public class BaseHighLimitRecordFormatTest
     {
         pageCursor = new StubPageCursor( 0, 8192 );
     }
+
     @Test
     public void secondHeaderByteEmptyTest() throws IOException
     {
@@ -50,8 +51,8 @@ public class BaseHighLimitRecordFormatTest
         nodeRecord.setNextRel( Integer.MAX_VALUE );
         nodeRecord.setNextProp( Integer.MAX_VALUE );
         IntStoreHeader intStoreHeader = new IntStoreHeader( 42 );
-        int recordSize = nodeRecordFormat.getRecordSize( intStoreHeader);
-        nodeRecordFormat.write( nodeRecord, pageCursor, recordSize, null);
+        int recordSize = nodeRecordFormat.getRecordSize( intStoreHeader );
+        nodeRecordFormat.write( nodeRecord, pageCursor, recordSize, null );
 
         //WHEN
         pageCursor.setOffset( 0 );
@@ -59,6 +60,6 @@ public class BaseHighLimitRecordFormatTest
         byte secondHeaderByte = pageCursor.getByte();
 
         //THEN
-        assertEquals((byte) 0 , secondHeaderByte);
+        assertEquals( (byte) 0, secondHeaderByte );
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
@@ -42,7 +42,7 @@ public class HighLimitWithSmallRecords extends HighLimit
      */
     private static final int NODE_RECORD_SIZE = (NodeRecordFormat.RECORD_SIZE / 2) + 1;
     private static final int RELATIONSHIP_RECORD_SIZE = (RelationshipRecordFormat.RECORD_SIZE / 2) + 1;
-    private static final int RELATIONSHIP_GROUP_RECORD_SIZE = (RelationshipGroupRecordFormat.RECORD_SIZE / 2) + 1;
+    private static final int RELATIONSHIP_GROUP_RECORD_SIZE  = (RelationshipGroupRecordFormat.RECORD_SIZE / 2) + 1;
 
     private HighLimitWithSmallRecords()
     {
@@ -60,8 +60,8 @@ public class HighLimitWithSmallRecords extends HighLimit
 
     public static boolean isEnabled()
     {
-        String toggleValue = FeatureToggles.getString( InternalRecordFormatSelector.class,
-                InternalRecordFormatSelector.FORMAT_TOGGLE_NAME, "" );
+        String toggleValue = FeatureToggles
+                .getString( InternalRecordFormatSelector.class, InternalRecordFormatSelector.FORMAT_TOGGLE_NAME, "" );
         return NAME.equals( toggleValue );
     }
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
@@ -35,9 +35,14 @@ public class HighLimitWithSmallRecords extends HighLimit
     public static final String NAME = "high_limit_with_small_records";
     public static final RecordFormats RECORD_FORMATS = new HighLimitWithSmallRecords();
 
-    private static final int NODE_RECORD_SIZE = NodeRecordFormat.RECORD_SIZE / 2;
-    private static final int RELATIONSHIP_RECORD_SIZE = RelationshipRecordFormat.RECORD_SIZE / 2;
-    private static final int RELATIONSHIP_GROUP_RECORD_SIZE = RelationshipGroupRecordFormat.RECORD_SIZE / 2;
+    /**
+     * We've added an extra byte to the header {@link BaseHighLimitRecordFormat}
+     * This causes problems with splitting across values in this small records high limits format used in tests.
+     * The +1 to the following 3 record sizes will cause it to not split across a value.
+     */
+    private static final int NODE_RECORD_SIZE = (NodeRecordFormat.RECORD_SIZE / 2) + 1;
+    private static final int RELATIONSHIP_RECORD_SIZE = (RelationshipRecordFormat.RECORD_SIZE / 2) + 1;
+    private static final int RELATIONSHIP_GROUP_RECORD_SIZE = (RelationshipGroupRecordFormat.RECORD_SIZE / 2) + 1;
 
     private HighLimitWithSmallRecords()
     {


### PR DESCRIPTION
In the future if we want to add extra bits to the header,
we would have to rewrite all the records to account for this.
By reserving this space now, we give ourselves the ability to
start using those bits in the future without migrating.
