### PR TITLE
Remove last 'underscore' one-character identifier

### DIFF
--- a/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
@@ -390,14 +390,10 @@ public class TestCommunication
         // Given
         final String comExceptionMessage = "The ComException";
 
-        MadeUpCommunicationInterface communication = mock( MadeUpCommunicationInterface.class, new Answer<Response<?>>()
-        {
-            @Override
-            public Response<?> answer( InvocationOnMock _ ) throws ComException
-            {
-                throw new ComException( comExceptionMessage );
-            }
-        } );
+        MadeUpCommunicationInterface communication = mock( MadeUpCommunicationInterface.class,
+                (Answer<Response<?>>) ingored -> {
+                    throw new ComException( comExceptionMessage );
+                } );
 
         ComExceptionHandler handler = mock( ComExceptionHandler.class );
 


### PR DESCRIPTION
Since '_' is reserved identifier in java 9, removed last usage of '_' as java identifier.
Details can be found at https://bugs.openjdk.java.net/browse/JDK-8061549
