### PR TITLE
Disallow general expression for identify node/rels in a property expression

### DIFF
--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/Expressions.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/parser/Expressions.scala
@@ -175,7 +175,7 @@ trait Expressions extends Parser
   def parenthesizedExpression: Rule1[ast.Expression] = "(" ~~ Expression ~~ ")"
 
   def PropertyExpression: Rule1[ast.Property] = rule {
-    Expression1 ~ oneOrMore(WS ~ PropertyLookup)
+    Variable ~ oneOrMore(WS ~ PropertyLookup)
   }
 
   private def PropertyLookup: ReductionRule1[ast.Expression, ast.Property] = rule("'.'") {


### PR DESCRIPTION
Only plain variables are allowed in such cases, i.e., writing `n.prop`
is allowed whilst `(CASE WHEN true THEN n END).prop` is not.

This simplifies the language, improves readability and keeps the same
language expressivity, indeed the second case above can be rewritten
as `WITH (CASE WHEN true THEN n END) as x ... x.prop ...`
