### PR TITLE
Update forseti client to use volatile locks indicator flag, monitor try locks acquisition.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/CloseCompatibility.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import org.neo4j.kernel.impl.locking.Locks.Client;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.NODE;
 
@@ -106,5 +107,18 @@ public class CloseCompatibility extends LockingCompatibilityTestSuite.Compatibil
         clientA.close();
         Assert.assertFalse( clientA.trySharedLock( NODE, 1l ) );
         Assert.assertFalse( clientA.tryExclusiveLock( NODE, 1l ) );
+    }
+
+    @Test
+    public void releaseTryLocksOnClose() {
+        assertTrue( clientA.trySharedLock( ResourceTypes.NODE, 1L ) );
+        assertTrue( clientB.tryExclusiveLock( ResourceTypes.NODE, 2L ) );
+
+        clientA.close();
+        clientB.close();
+
+        LockCountVisitor lockCountVisitor = new LockCountVisitor();
+        locks.accept( lockCountVisitor );
+        Assert.assertEquals( 0, lockCountVisitor.getLockCount() );
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
@@ -101,7 +101,7 @@ public class ForsetiClient implements Locks.Client
      */
     private final ExclusiveLock myExclusiveLock = new ExclusiveLock( this );
 
-    private boolean hasLocks;
+    private volatile boolean hasLocks;
 
     public ForsetiClient( int id,
                           ConcurrentMap<Long,ForsetiLockManager.Lock>[] lockMaps,
@@ -308,6 +308,7 @@ public class ForsetiClient implements Locks.Client
     @Override
     public boolean tryExclusiveLock( ResourceType resourceType, long resourceId )
     {
+        hasLocks = true;
         // increment number of active clients if we can't do so we are closed so exiting
         if ( !stateHolder.incrementActiveClients() )
         {
@@ -363,6 +364,7 @@ public class ForsetiClient implements Locks.Client
     @Override
     public boolean trySharedLock( ResourceType resourceType, long resourceId )
     {
+        hasLocks = true;
         // increment number of active clients if we can't do so we are closed so exiting
         if ( !stateHolder.incrementActiveClients() )
         {


### PR DESCRIPTION
Since it's possible that client will be closed by reaper thread we need this flag to be volatile.
Also we need to track invocations of tryExclusiveLock and trySharedLock to not miss those locks on release.
