### PR TITLE
Fix pom and license issue in cypher compatibility suite

### DIFF
--- a/community/cypher/compatibility-suite/LICENSES.txt
+++ b/community/cypher/compatibility-suite/LICENSES.txt
@@ -10,6 +10,7 @@ Apache Software License, Version 2.0
   casbah-commons
   casbah-core
   casbah-query
+  ConcurrentLinkedHashMap
   Cucumber-JVM Repackaged Dependencies
   Joda convert
   Joda-Time

--- a/community/cypher/compatibility-suite/NOTICE.txt
+++ b/community/cypher/compatibility-suite/NOTICE.txt
@@ -33,6 +33,7 @@ Apache Software License, Version 2.0
   casbah-commons
   casbah-core
   casbah-query
+  ConcurrentLinkedHashMap
   Cucumber-JVM Repackaged Dependencies
   Joda convert
   Joda-Time

--- a/community/cypher/compatibility-suite/pom.xml
+++ b/community/cypher/compatibility-suite/pom.xml
@@ -52,7 +52,6 @@
 
   <build>
     <plugins>
-
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
@@ -173,10 +172,8 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher</artifactId>
-      <type>test-jar</type>
+      <artifactId>neo4j-cypher-compiler-3.1</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- neo4j testing -->
@@ -187,6 +184,7 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-io</artifactId>
@@ -195,50 +193,12 @@
       <scope>compile</scope>
     </dependency>
 
-
-    <!-- neo4j-cypher -->
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-compiler-3.1</artifactId>
+      <artifactId>neo4j-cypher</artifactId>
+      <type>test-jar</type>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.neo4j</groupId>
-          <artifactId>neo4j-kernel</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.neo4j</groupId>
-          <artifactId>neo4j-lucene-index</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.neo4j</groupId>
-          <artifactId>neo4j-graph-matching</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.neo4j</groupId>
-          <artifactId>neo4j-graph-algo</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-        </exclusion>
-        <exclusion>
-          <artifactId>scala-reflect</artifactId>
-          <groupId>org.scala-lang</groupId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.parboiled</groupId>
-          <artifactId>parboiled-scala_2.11</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sf.opencsv</groupId>
-          <artifactId>opencsv</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-          <artifactId>concurrentlinkedhashmap-lru</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>test</scope>
     </dependency>
 
     <!-- other -->


### PR DESCRIPTION
Initially issue observed locally while building the full project with maven 3.3.1. Module `neo4j-cypher-compatibility-suite` refused to build because `parboiled-core` and `parboiled-scala` were not present in the generated `LICENSES.txt` and `NOTICE.txt` files. However build was successful on build agents which use maven 3.0.5. This tuned out to be a maven issue https://issues.apache.org/jira/browse/MNG-5188 which caused transitive dependencies `parboiled-core` and `parboiled-scala` to be incorrectly promoted from test scope to compile scope. Issue was fixed in maven 3.1.0.

This PR fixes described build problem by removing all exclusions from compile time dependency `neo4j-cypher-compiler-3.1`. Now all it's transitive dependencies have compiled scope and are listed in licence files.
