### PR TITLE
Optimize cost planner unnesting of eagerness

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanWithTail.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/PlanWithTail.scala
@@ -46,12 +46,10 @@ case class PlanWithTail(planEventHorizon: LogicalPlanningFunction2[PlannerQuery,
         val projectedPlan = planEventHorizon(plannerQuery, applyPlan)(applyContext)
         val projectedContext = applyContext.recurse(projectedPlan)
 
-        val completePlan = projectedPlan.endoRewrite(Eagerness.unnestEager)
-
-        this.apply(completePlan, plannerQuery.tail)(projectedContext)
+        this.apply(projectedPlan, plannerQuery.tail)(projectedContext)
 
       case None =>
-        lhs
+        lhs.endoRewrite(Eagerness.unnestEager)
     }
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/DefaultQueryPlannerTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner.logical
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Metrics.QueryGraphSolverInput
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{IdName, LazyMode, LogicalPlan, ProduceResult, Projection}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans._
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, LogicalPlanningTestSupport2, PlannerQuery, QueryGraph, RegularPlannerQuery, RegularQueryProjection, UnionQuery}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
@@ -85,11 +85,8 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     when(plannerQuery.allHints).thenReturn(Set[Hint]())
 
     val lp = {
-      val plan = mock[Projection]
-      when(plan.availableSymbols).thenReturn(Set.empty[IdName])
-      when(plan.solved).thenReturn(plannerQuery)
-      when(plan.leaves).thenReturn(Seq.empty)
-      plan
+      val plan = SingleRow()(plannerQuery)
+      Projection(plan, Map.empty)(plannerQuery)
     }
 
     val context = mock[LogicalPlanningContext]


### PR DESCRIPTION
Only run the rewriter that un-nests eagerness once on the completed
logical plan instead of at every planner query tail.
This improves performance on queries with many MERGE statements, since
every MERGE introduces a new planner query tail.
