### PR TITLE
Log warnings for unrecognized settings

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -201,7 +201,7 @@ public class Config implements DiagnosticsProvider, Configuration
     private synchronized void replaceSettings( Map<String, String> newSettings )
     {
         Map<String,String> migratedSettings = migrator.apply( newSettings, log );
-        validator.validate( migratedSettings );
+        validator.validate( migratedSettings, log );
         params.clear();
         params.putAll( migratedSettings );
         settingsFunction = new ConfigValues( params );

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationValidator.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.collection.Pair;
+import org.neo4j.logging.Log;
 
 /**
  * Given a set of annotated config classes,
@@ -42,11 +43,25 @@ public class ConfigurationValidator
         this.settings = getSettingsFrom( settingsClasses );
     }
 
-    public void validate( Map<String, String> rawConfig )
+    public void validate( Map<String,String> rawConfig, Log log )
     {
         for ( Setting<?> setting : settings.values() )
         {
             setting.apply( rawConfig::get );
+        }
+
+        // Warn if any of the given setting names does not exist
+        validateSettingNames( rawConfig, log );
+    }
+
+    private void validateSettingNames( Map<String,String> rawConfig, Log log )
+    {
+        for ( String settingName : rawConfig.keySet() )
+        {
+            if ( !settings.containsKey( settingName ) )
+            {
+                log.warn( "The setting '" + settingName + "' is not recognized and will not have any effect." );
+            }
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
@@ -36,7 +36,6 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 import org.neo4j.server.CommunityBootstrapper;
-import org.neo4j.server.ServerCommandLineArgs;
 import org.neo4j.server.ServerTestUtils;
 import org.neo4j.test.SuppressOutput;
 
@@ -44,11 +43,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.neo4j.helpers.ArrayUtil.array;
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.setting;
@@ -211,81 +205,5 @@ public class ConfigLoaderTest
                 is( new File( "foo/bar/auth" ).getAbsoluteFile() ) );
     }
 
-    @Test
-    public void shouldWarnForNonExistingSetting() throws IOException
-    {
-        // given
-        File file = ServerTestUtils.createTempConfigFile( folder.getRoot() );
-        Log mockLog = mock(Log.class);
 
-        try ( BufferedWriter out = new BufferedWriter( new FileWriter( file, true ) ) )
-        {
-            out.write( "this.setting.does.not.exist=value" );
-            out.write( System.lineSeparator() );
-        }
-
-        // when
-        Config config = configLoader.loadConfig( Optional.of( file ), mockLog );
-
-        // then
-        verify( mockLog ).warn( "The setting 'this.setting.does.not.exist' is not recognized and will not have any effect." );
-    }
-
-    @Test
-    public void shouldNotWarnForExistingSetting() throws IOException
-    {
-        // given
-        File file = ServerTestUtils.createTempConfigFile( folder.getRoot() );
-        Log mockLog = mock(Log.class);
-
-        try ( BufferedWriter out = new BufferedWriter( new FileWriter( file, true ) ) )
-        {
-            out.write( GraphDatabaseSettings.logs_directory.name() + "=/tmp/log" );
-            out.write( System.lineSeparator() );
-        }
-
-        // when
-        Config config = configLoader.loadConfig( Optional.of( file ), mockLog );
-
-        // then
-        verify( mockLog, times(0) ).warn( "The setting '" + GraphDatabaseSettings.logs_directory.name() +
-                                          "' is not recognized and will not have any effect." );
-    }
-
-    @Test
-    public void shouldWarnForNonExistingCommandLineSetting() throws IOException
-    {
-        // Given
-        File file = ServerTestUtils.createTempConfigFile( folder.getRoot() );
-        String[] args = array(
-                "-c", "this.setting.does.also.not.exist=value" );
-        ServerCommandLineArgs parsed = ServerCommandLineArgs.parse( args );
-
-        Log mockLog = mock(Log.class);
-
-        // When
-        Config config = configLoader.loadConfig( Optional.of( file ), mockLog, parsed.configOverrides() );
-
-        // then
-        verify( mockLog ).warn( "The setting 'this.setting.does.also.not.exist' is not recognized and will not have any effect." );
-    }
-
-    @Test
-    public void shouldNotWarnForExistingCommandLineSetting() throws IOException
-    {
-        // Given
-        File file = ServerTestUtils.createTempConfigFile( folder.getRoot() );
-        String[] args = array(
-                "-c", ServerSettings.http_logging_enabled.name() + "=true" );
-        ServerCommandLineArgs parsed = ServerCommandLineArgs.parse( args );
-
-        Log mockLog = mock(Log.class);
-
-        // When
-        Config config = configLoader.loadConfig( Optional.of( file ), mockLog, parsed.configOverrides() );
-
-        // then
-        verify( mockLog, times(0) ).warn( "The setting '" + ServerSettings.http_logging_enabled.name() +
-                                          "' is not recognized and will not have any effect." );
-    }
 }


### PR DESCRIPTION
Log a warning if the configuration file or command line contains an
unrecognized setting name.
