### PR TITLE
Don't send error reports for common errors

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/Neo4jError.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/Neo4jError.java
@@ -159,6 +159,16 @@ public class Neo4jError
                         "'dbms.memory.heap.max_size' in 'conf/neo4j-wrapper.conf' or if you are running an embedded " +
                         "installation increase the heap by using '-Xmx' command line flag.", cause );
             }
+
+            if (cause instanceof StackOverflowError)
+            {
+                return new Neo4jError( Status.General.OutOfMemoryError,
+                        "There is not enough stack size to perform the current task. This is generally considered to be a " +
+                        "database error, so please contact Neo4j support. You could try increasing the stack size: " +
+                        "for example to set the stack size to 2M, add `dbms.jvm.additional=-Xss2M' to " +
+                        "'conf/neo4j-wrapper.conf' or if you are running an embedded installation just add -Xss2M as " +
+                        "command line flag.", cause );
+            }
         }
 
         // In this case, an error has "slipped out", and we don't have a good way to handle it. This indicates

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/Neo4jError.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/Neo4jError.java
@@ -47,6 +47,11 @@ public class Neo4jError
         this(status, message, null);
     }
 
+    public Neo4jError( Status status, Throwable cause )
+    {
+        this(status, status.code().description(), cause);
+    }
+
     public Status status()
     {
         return status;
@@ -154,20 +159,11 @@ public class Neo4jError
 
             if (cause instanceof OutOfMemoryError)
             {
-                return new Neo4jError( Status.General.OutOfMemoryError,
-                        "There is not enough memory to perform the current task. Please try increasing " +
-                        "'dbms.memory.heap.max_size' in 'conf/neo4j-wrapper.conf' or if you are running an embedded " +
-                        "installation increase the heap by using '-Xmx' command line flag.", cause );
+                return new Neo4jError( Status.General.OutOfMemoryError, cause );
             }
-
             if (cause instanceof StackOverflowError)
             {
-                return new Neo4jError( Status.General.OutOfMemoryError,
-                        "There is not enough stack size to perform the current task. This is generally considered to be a " +
-                        "database error, so please contact Neo4j support. You could try increasing the stack size: " +
-                        "for example to set the stack size to 2M, add `dbms.jvm.additional=-Xss2M' to " +
-                        "'conf/neo4j-wrapper.conf' or if you are running an embedded installation just add -Xss2M as " +
-                        "command line flag.", cause );
+                return new Neo4jError( Status.General.StackOverFlowError, cause );
             }
         }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/Neo4jError.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/Neo4jError.java
@@ -47,11 +47,6 @@ public class Neo4jError
         this(status, message, null);
     }
 
-    public Neo4jError( Status status )
-    {
-        this(status, status.code().description(), null);
-    }
-
     public Status status()
     {
         return status;
@@ -155,6 +150,14 @@ public class Neo4jError
             if ( cause instanceof Status.HasStatus )
             {
                 return new Neo4jError( ((Status.HasStatus) cause).status(), any.getMessage(), any );
+            }
+
+            if (cause instanceof OutOfMemoryError)
+            {
+                return new Neo4jError( Status.General.OutOfMemoryError,
+                        "There is not enough memory to perform the current task. Please try increasing " +
+                        "'dbms.memory.heap.max_size' in 'conf/neo4j-wrapper.conf' or if you are running an embedded " +
+                        "installation increase the heap by using '-Xmx' command line flag.", cause );
             }
         }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
@@ -74,9 +74,11 @@ public class ErrorReporterTest
 
         // Then
         assertThat( error.status(), equalTo( (Status) Status.General.OutOfMemoryError ) );
-        assertThat( error.message(), equalTo(   "There is not enough memory to perform the current task. Please try increasing " +
-                                                             "'dbms.memory.heap.max_size' in 'conf/neo4j-wrapper.conf' or if you are running an embedded " +
-                                                             "installation increase the heap by using '-Xmx' command line flag." ));
+        assertThat( error.message(),
+                equalTo(  "There is not enough memory to perform the current task. Please try increasing " +
+                          "'dbms.memory.heap.max_size' in the process wrapper configuration (normally in 'conf/neo4j-wrapper" +
+                          ".conf' or, if you are using Neo4j Desktop, found through the user interface) or if you are running an embedded " +
+                          "installation increase the heap by using '-Xmx' command line flag, and then restart the database." ) );
         provider.assertNoLoggingOccurred();
     }
 
@@ -95,12 +97,14 @@ public class ErrorReporterTest
         reporter.report( error );
 
         // Then
-        assertThat( error.status(), equalTo( (Status) Status.General.OutOfMemoryError ) );
-        assertThat( error.message(), equalTo(  "There is not enough stack size to perform the current task. This is generally considered to be a " +
-                                                            "database error, so please contact Neo4j support. You could try increasing the stack size: " +
-                                                            "for example to set the stack size to 2M, add `dbms.jvm.additional=-Xss2M' to " +
-                                                            "'conf/neo4j-wrapper.conf' or if you are running an embedded installation just add -Xss2M as " +
-                                                            "command line flag." ));
+        assertThat( error.status(), equalTo( (Status) Status.General.StackOverFlowError ) );
+        assertThat( error.message(), equalTo(
+                "There is not enough stack size to perform the current task. This is generally considered to be a " +
+                "database error, so please contact Neo4j support. You could try increasing the stack size: " +
+                "for example to set the stack size to 2M, add `dbms.jvm.additional=-Xss2M' to " +
+                "in the process wrapper configuration (normally in 'conf/neo4j-wrapper.conf' or, if you are using " +
+                "Neo4j Desktop, found through the user interface) or if you are running an embedded installation " +
+                "just add -Xss2M as command line flag." ) );
         provider.assertNoLoggingOccurred();
     }
 }

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -423,7 +423,19 @@ public interface Status
         UnknownError( DatabaseError,
                 "An unknown error occurred." ),
         OutOfMemoryError( TransientError,
-                "There is not enough memory to perform the current task." ),
+                "There is not enough memory to perform the current task. Please try increasing " +
+                "'dbms.memory.heap.max_size' in the process wrapper configuration (normally in 'conf/neo4j-wrapper" +
+                ".conf' or, if you are using Neo4j Desktop, found through the user interface) or if you are running an embedded " +
+                "installation increase the heap by using '-Xmx' command line flag, and then restart the database." ),
+        StackOverFlowError( TransientError,
+                "There is not enough stack size to perform the current task. This is generally considered to be a " +
+                "database error, so please contact Neo4j support. You could try increasing the stack size: " +
+                "for example to set the stack size to 2M, add `dbms.jvm.additional=-Xss2M' to " +
+                "in the process wrapper configuration (normally in 'conf/neo4j-wrapper.conf' or, if you are using " +
+                "Neo4j Desktop, found through the user interface) or if you are running an embedded installation " +
+                "just add -Xss2M as command line flag." ),
+
+
 
         // transient errors
         DatabaseUnavailable( TransientError,

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -422,6 +422,8 @@ public interface Status
                 "A malformed schema rule was encountered. Please contact your support representative." ),
         UnknownError( DatabaseError,
                 "An unknown error occurred." ),
+        OutOfMemoryError( TransientError,
+                "There is not enough memory to perform the current task." ),
 
         // transient errors
         DatabaseUnavailable( TransientError,
@@ -519,20 +521,8 @@ public interface Status
 
             Code code = (Code) o;
 
-            if ( !category.equals( code.category ) )
-            {
-                return false;
-            }
-            if ( classification != code.classification )
-            {
-                return false;
-            }
-            if ( !title.equals( code.title ) )
-            {
-                return false;
-            }
-
-            return true;
+            return category.equals( code.category ) && classification == code.classification &&
+                   title.equals( code.title );
         }
 
         @Override


### PR DESCRIPTION
`OutOfMemoryError` and `StackOverflowError` does not need to be sent via the error reporter. 
Instead provide better error messages that describes how to get rid of the errors.
