### PR TITLE
Update sum loop, split sum and zeroing in SequenceLockStressIT

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -162,16 +163,16 @@ public class SequenceLockStressIT
                     }
                     for ( int[] record : data )
                     {
-                        for ( int i = 0; i < record.length; i++ )
+                        for ( int value : record  )
                         {
-                            sumB += record[i];
-                            record[i] = 0;
+                            sumB += value;
                         }
+                        Arrays.fill(record, 0);
                     }
                     lock.unlockExclusive();
                     if ( sumA != sumB )
                     {
-                        throw new AssertionError( "Inconsistent exclusive lock" );
+                        throw new AssertionError( "Inconsistent exclusive lock. 'Sum A' = " + sumA + ", 'Sum B' = " + sumB );
                     }
                 }
             }


### PR DESCRIPTION
 It looks like IBM JDK JIT mistakenly reorder/brakes sumB loop in some rare cases and every second observed value in array is zeroed before accumulation.
 In those cases sumB will always be half of sumA.

 For example in case when all values in data array are 1 sequences of observed values of sumB and record[i] values:
 sumB: 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12... so on
 record[i]: 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1... so on.
 While making copies of record array still preserve expected values.

 Going through fixed issues list shows strained relationship between loops and JIT.
 Potential fixes usually are -Xjit:disableIdiomRecognition or code update.

 Add some details in error message.
