### PR TITLE
Auth store should be in data/ by default

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
@@ -96,8 +96,10 @@ public class ConfigLoader
         config.putIfAbsent( ShellSettings.remote_shell_enabled.name(), TRUE );
         config.putIfAbsent( GraphDatabaseSettings.logs_directory.name(), "logs" );
         config.putIfAbsent( GraphDatabaseSettings.auth_enabled.name(), "true" );
+
+        String dataDirectory = config.getOrDefault( data_directory.name(), data_directory.getDefaultValue() );
         config.putIfAbsent( GraphDatabaseSettings.auth_store.name(),
-                new File( config.get( data_directory.name() ), "dbms/auth" ).toString() );
+                new File( dataDirectory, "dbms/auth" ).toString() );
     }
 
     private static Map<String, String> loadFromFile( Log log, File file )

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
@@ -138,7 +138,7 @@ public class ConfigLoaderTest
         Optional<File> configFile = ConfigFileBuilder.builder( folder.getRoot() )
                 .withNameValue( ServerSettings.third_party_packages.name(),
                         "org.neo4j.extension.extension1=/extension1,org.neo4j.extension.extension2=/extension2," +
-                                "org.neo4j.extension.extension3=/extension3" )
+                        "org.neo4j.extension.extension3=/extension3" )
                 .build();
 
         // when
@@ -165,6 +165,19 @@ public class ConfigLoaderTest
 
         // Then
         assertNotNull( config );
+    }
+
+    @Test
+    public void shouldDefaultToCorrectValueForAuthStoreLocation() throws IOException
+    {
+        Optional<File> configFile = ConfigFileBuilder
+                .builder( folder.getRoot() )
+                .withoutSetting( DatabaseManagementSystemSettings.data_directory )
+                .build();
+        Config config = configLoader.loadConfig( configFile, log );
+
+        assertThat( config.get( GraphDatabaseSettings.auth_store ),
+                is( new File( "data/dbms/auth" ).getAbsoluteFile() ) );
     }
 
     @Test


### PR DESCRIPTION
When user has not explicitly configured `dbms.directories.data` we should put
the auth store in the default `data` directory instead of putting it directly under root.
