### PR TITLE
Remove mockito from some tests

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/XForwardFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/XForwardFilterTest.java
@@ -19,19 +19,35 @@
  */
 package org.neo4j.server;
 
+import com.sun.jersey.api.container.ContainerException;
+import com.sun.jersey.api.core.HttpContext;
+import com.sun.jersey.api.core.ResourceConfig;
+import com.sun.jersey.api.core.ResourceContext;
+import com.sun.jersey.core.header.InBoundHeaders;
+import com.sun.jersey.core.spi.component.ioc.IoCComponentProviderFactory;
+import com.sun.jersey.core.util.FeaturesAndProperties;
+import com.sun.jersey.server.impl.inject.ServerInjectableProviderFactory;
+import com.sun.jersey.spi.MessageBodyWorkers;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseWriter;
+import com.sun.jersey.spi.container.ExceptionMapperContext;
+import com.sun.jersey.spi.container.WebApplication;
+import com.sun.jersey.spi.monitoring.DispatchingListener;
+import com.sun.jersey.spi.monitoring.RequestListener;
+import com.sun.jersey.spi.monitoring.ResponseListener;
+import org.junit.Test;
+
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import javax.ws.rs.ext.Providers;
 
-import com.sun.jersey.core.header.InBoundHeaders;
-import com.sun.jersey.spi.container.ContainerRequest;
-import com.sun.jersey.spi.container.WebApplication;
-import org.junit.Test;
 import org.neo4j.server.web.XForwardFilter;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 public class XForwardFilterTest
 {
@@ -49,9 +65,9 @@ public class XForwardFilterTest
         InBoundHeaders headers = new InBoundHeaders();
         headers.add( X_FORWARD_HOST_HEADER_KEY, xForwardHostAndPort );
 
-        ContainerRequest request = new ContainerRequest( mock( WebApplication.class ), "GET",
+        ContainerRequest request = new ContainerRequest( WEB_APPLICATION, "GET",
                 URI.create( "http://iansrobinson.com" ), URI.create( "http://iansrobinson.com/foo/bar" ),
-                headers, mock( InputStream.class ) );
+                headers, INPUT_STREAM );
 
         // when
         ContainerRequest result = filter.filter( request );
@@ -71,9 +87,9 @@ public class XForwardFilterTest
         InBoundHeaders headers = new InBoundHeaders();
         headers.add( X_FORWARD_HOST_HEADER_KEY, xForwardHostAndPort );
 
-        ContainerRequest request = new ContainerRequest( mock( WebApplication.class ), "GET",
+        ContainerRequest request = new ContainerRequest( WEB_APPLICATION, "GET",
                 URI.create( "http://iansrobinson.com" ), URI.create( "http://iansrobinson.com/foo/bar" ),
-                headers, mock( InputStream.class ) );
+                headers, INPUT_STREAM );
 
         // when
         ContainerRequest result = filter.filter( request );
@@ -93,9 +109,9 @@ public class XForwardFilterTest
         InBoundHeaders headers = new InBoundHeaders();
         headers.add( X_FORWARD_PROTO_HEADER_KEY, theProtocol );
 
-        ContainerRequest request = new ContainerRequest( mock( WebApplication.class ), "GET",
+        ContainerRequest request = new ContainerRequest( WEB_APPLICATION, "GET",
                 URI.create( "http://jimwebber.org:1234" ), URI.create( "http://jimwebber.org:1234/foo/bar" ),
-                headers, mock( InputStream.class ) );
+                headers, INPUT_STREAM );
 
         // when
         ContainerRequest result = filter.filter( request );
@@ -115,9 +131,9 @@ public class XForwardFilterTest
         InBoundHeaders headers = new InBoundHeaders();
         headers.add( X_FORWARD_PROTO_HEADER_KEY, theProtocol );
 
-        ContainerRequest request = new ContainerRequest( mock( WebApplication.class ), "GET",
+        ContainerRequest request = new ContainerRequest( WEB_APPLICATION, "GET",
                 URI.create( "http://jimwebber.org:1234" ), URI.create( "http://jimwebber.org:1234/foo/bar" ),
-                headers, mock( InputStream.class ) );
+                headers, INPUT_STREAM );
 
         // when
         ContainerRequest result = filter.filter( request );
@@ -125,4 +141,138 @@ public class XForwardFilterTest
         // then
         assertThat( result.getBaseUri().getScheme(), containsString( theProtocol ) );
     }
+
+    //Mocking WebApplication leads to flakyness on ibm-jdk, hence
+    //we use a manual mock instead
+    private final static WebApplication WEB_APPLICATION = new WebApplication()
+    {
+        @Override
+        public boolean isInitiated()
+        {
+            return false;
+        }
+
+        @Override
+        public void initiate( ResourceConfig resourceConfig ) throws IllegalArgumentException, ContainerException
+        {
+
+        }
+
+        @Override
+        public void initiate( ResourceConfig resourceConfig, IoCComponentProviderFactory ioCComponentProviderFactory )
+                throws IllegalArgumentException, ContainerException
+        {
+
+        }
+
+        @SuppressWarnings( "CloneDoesntCallSuperClone" )
+        @Override
+        public WebApplication clone()
+        {
+            return null;
+        }
+
+        @Override
+        public FeaturesAndProperties getFeaturesAndProperties()
+        {
+            return null;
+        }
+
+        @Override
+        public Providers getProviders()
+        {
+            return null;
+        }
+
+        @Override
+        public ResourceContext getResourceContext()
+        {
+            return null;
+        }
+
+        @Override
+        public MessageBodyWorkers getMessageBodyWorkers()
+        {
+            return null;
+        }
+
+        @Override
+        public ExceptionMapperContext getExceptionMapperContext()
+        {
+            return null;
+        }
+
+        @Override
+        public HttpContext getThreadLocalHttpContext()
+        {
+            return null;
+        }
+
+        @Override
+        public ServerInjectableProviderFactory getServerInjectableProviderFactory()
+        {
+            return null;
+        }
+
+        @Override
+        public RequestListener getRequestListener()
+        {
+            return null;
+        }
+
+        @Override
+        public DispatchingListener getDispatchingListener()
+        {
+            return null;
+        }
+
+        @Override
+        public ResponseListener getResponseListener()
+        {
+            return null;
+        }
+
+        @Override
+        public void handleRequest( ContainerRequest containerRequest, ContainerResponseWriter containerResponseWriter )
+                throws IOException
+        {
+
+        }
+
+        @Override
+        public void handleRequest( ContainerRequest containerRequest, ContainerResponse containerResponse )
+                throws IOException
+        {
+
+        }
+
+        @Override
+        public void destroy()
+        {
+
+        }
+
+        @Override
+        public boolean isTracingEnabled()
+        {
+            return false;
+        }
+
+        @Override
+        public void trace( String s )
+        {
+
+        }
+    };
+
+    //Using mockito to mock arguments to ContainerRequest leads to flakyness
+    //on ibm jdk, hence the manual mocks
+    private final static InputStream INPUT_STREAM = new InputStream()
+    {
+        @Override
+        public int read() throws IOException
+        {
+            return 0;
+        }
+    };
 }

--- a/community/server/src/test/java/org/neo4j/server/database/TestLifecycleManagedDatabase.java
+++ b/community/server/src/test/java/org/neo4j/server/database/TestLifecycleManagedDatabase.java
@@ -33,7 +33,6 @@ import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.StoreLockException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
-import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.ImpermanentDatabaseRule;
 import org.neo4j.test.SuppressOutput;
@@ -41,9 +40,6 @@ import org.neo4j.test.SuppressOutput;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 import static org.neo4j.server.ServerTestUtils.createTempDir;
@@ -70,9 +66,7 @@ public class TestLifecycleManagedDatabase
     {
         dataDirectory = createTempDir();
 
-        dbFactory = mock( LifecycleManagingDatabase.GraphFactory.class );
-        when(dbFactory.newGraphDatabase( any( Config.class ), any( GraphDatabaseFacadeFactory.Dependencies.class ) ))
-                .thenReturn( (GraphDatabaseFacade) dbRule.getGraphDatabaseAPI() );
+        dbFactory = createGraphFactory();
         dbConfig = new Config(stringMap( DatabaseManagementSystemSettings.data_directory.name(), dataDirectory.getAbsolutePath() ) );
         theDatabase = newDatabase();
     }
@@ -149,5 +143,10 @@ public class TestLifecycleManagedDatabase
     {
         theDatabase.start();
         assertThat( theDatabase.getLocation(), is( dbConfig.get( DatabaseManagementSystemSettings.database_path ).getAbsolutePath() ) );
+    }
+
+    private LifecycleManagingDatabase.GraphFactory createGraphFactory()
+    {
+        return ( config, dependencies ) -> (GraphDatabaseFacade) dbRule.getGraphDatabaseAPI();
     }
 }


### PR DESCRIPTION
In some instances using mockito mocks seems to lead to flakyness on ibm jdk.
Rewrite tests to use explicit mocking instead.
