### PR TITLE
Fixes an issue with adding to dynamic label records

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeRecordCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/NodeRecordCheckTest.java
@@ -222,7 +222,7 @@ public class NodeRecordCheckTest
     {
         // given
         NodeRecord node = inUse( new NodeRecord( 42, false, NONE, NONE ) );
-        new InlineNodeLabels( node.getLabelField(), node ).add( 1, null, null );
+        new InlineNodeLabels( node ).add( 1, null, null );
         LabelTokenRecord labelRecordNotInUse = notInUse( new LabelTokenRecord( 1 ) );
 
         add( labelRecordNotInUse );
@@ -272,7 +272,7 @@ public class NodeRecordCheckTest
     {
         // given
         NodeRecord node = inUse( new NodeRecord( 42, false, NONE, NONE ) );
-        new InlineNodeLabels( node.getLabelField(), node ).put( new long[]{1, 2, 1}, null, null );
+        new InlineNodeLabels( node ).put( new long[]{1, 2, 1}, null, null );
         LabelTokenRecord label1 = inUse( new LabelTokenRecord( 1 ) );
         LabelTokenRecord label2 = inUse( new LabelTokenRecord( 2 ) );
 
@@ -322,7 +322,7 @@ public class NodeRecordCheckTest
         // given
         final NodeRecord node = inUse( new NodeRecord( 42, false, NONE, NONE ) );
         // We need to do this override so we can put the labels unsorted, since InlineNodeLabels always sorts on insert
-        new InlineNodeLabels( node.getLabelField(), node )
+        new InlineNodeLabels( node )
         {
             @Override
             public Collection<DynamicRecord> put( long[] labelIds, NodeStore nodeStore, DynamicRecordAllocator
@@ -353,7 +353,7 @@ public class NodeRecordCheckTest
         // given
         final NodeRecord node = inUse( new NodeRecord( 42, false, NONE, NONE ) );
         // We need to do this override so we can put the labels unsorted, since InlineNodeLabels always sorts on insert
-        new InlineNodeLabels( node.getLabelField(), node )
+        new InlineNodeLabels( node )
         {
             @Override
             public Collection<DynamicRecord> put( long[] labelIds, NodeStore nodeStore, DynamicRecordAllocator

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheckTest.java
@@ -129,7 +129,7 @@ public class NodeInUseWithCorrectLabelsCheckTest
 
     private NodeRecord withInlineLabels( NodeRecord nodeRecord, long... labelIds )
     {
-        new InlineNodeLabels( nodeRecord.getLabelField(), nodeRecord ).put( labelIds, null, null );
+        new InlineNodeLabels( nodeRecord ).put( labelIds, null, null );
         return nodeRecord;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
@@ -124,9 +124,10 @@ public class DynamicNodeLabels implements NodeLabels
     public Collection<DynamicRecord> add( long labelId, NodeStore nodeStore, DynamicRecordAllocator allocator )
     {
         nodeStore.ensureHeavy( node, firstDynamicLabelRecordId( labelField ) );
-        Collection<DynamicRecord> existingRecords = node.getDynamicLabelRecords();
-        long[] existingLabelIds = getDynamicLabelsArray( existingRecords, nodeStore.getDynamicLabelStore() );
+        long[] existingLabelIds = getDynamicLabelsArray( node.getUsedDynamicLabelRecords(),
+                nodeStore.getDynamicLabelStore() );
         long[] newLabelIds = LabelIdArray.concatAndSort( existingLabelIds, labelId );
+        Collection<DynamicRecord> existingRecords = node.getDynamicLabelRecords();
         Collection<DynamicRecord> changedDynamicRecords =
                 allocateRecordsForDynamicLabels( node.getId(), newLabelIds, existingRecords.iterator(), allocator );
         node.setLabelField( dynamicPointer( changedDynamicRecords ), changedDynamicRecords );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
@@ -41,12 +41,10 @@ import static org.neo4j.kernel.impl.store.PropertyType.ARRAY;
 
 public class DynamicNodeLabels implements NodeLabels
 {
-    private final long labelField;
     private final NodeRecord node;
 
-    public DynamicNodeLabels( long labelField, NodeRecord node )
+    public DynamicNodeLabels( NodeRecord node )
     {
-        this.labelField = labelField;
         this.node = node;
     }
 
@@ -123,7 +121,7 @@ public class DynamicNodeLabels implements NodeLabels
     @Override
     public Collection<DynamicRecord> add( long labelId, NodeStore nodeStore, DynamicRecordAllocator allocator )
     {
-        nodeStore.ensureHeavy( node, firstDynamicLabelRecordId( labelField ) );
+        nodeStore.ensureHeavy( node, firstDynamicLabelRecordId( node.getLabelField() ) );
         long[] existingLabelIds = getDynamicLabelsArray( node.getUsedDynamicLabelRecords(),
                 nodeStore.getDynamicLabelStore() );
         long[] newLabelIds = LabelIdArray.concatAndSort( existingLabelIds, labelId );
@@ -137,7 +135,7 @@ public class DynamicNodeLabels implements NodeLabels
     @Override
     public Collection<DynamicRecord> remove( long labelId, NodeStore nodeStore )
     {
-        nodeStore.ensureHeavy( node, firstDynamicLabelRecordId( labelField ) );
+        nodeStore.ensureHeavy( node, firstDynamicLabelRecordId( node.getLabelField() ) );
         long[] existingLabelIds = getDynamicLabelsArray( node.getUsedDynamicLabelRecords(),
                 nodeStore.getDynamicLabelStore() );
         long[] newLabelIds = filter( existingLabelIds, labelId );
@@ -167,7 +165,7 @@ public class DynamicNodeLabels implements NodeLabels
 
     public long getFirstDynamicRecordId()
     {
-        return firstDynamicLabelRecordId( labelField );
+        return firstDynamicLabelRecordId( node.getLabelField() );
     }
 
     public static long dynamicPointer( Collection<DynamicRecord> newRecords )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InlineNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/InlineNodeLabels.java
@@ -39,12 +39,10 @@ import static org.neo4j.kernel.impl.util.Bits.bitsFromLongs;
 public class InlineNodeLabels implements NodeLabels
 {
     private static final int LABEL_BITS = 36;
-    private final long labelField;
     private final NodeRecord node;
 
-    public InlineNodeLabels( long labelField, NodeRecord node )
+    public InlineNodeLabels( NodeRecord node )
     {
-        this.labelField = labelField;
         this.node = node;
     }
 
@@ -62,7 +60,7 @@ public class InlineNodeLabels implements NodeLabels
     @Override
     public long[] getIfLoaded()
     {
-        return parseInlined( labelField );
+        return parseInlined( node.getLabelField() );
     }
 
     @Override
@@ -86,8 +84,8 @@ public class InlineNodeLabels implements NodeLabels
     @Override
     public Collection<DynamicRecord> add( long labelId, NodeStore nodeStore, DynamicRecordAllocator allocator )
     {
-        long[] augmentedLabelIds = labelCount( labelField ) == 0 ? new long[]{labelId} :
-                                   concatAndSort( parseInlined( labelField ), labelId );
+        long[] augmentedLabelIds = labelCount( node.getLabelField() ) == 0 ? new long[]{labelId} :
+                                   concatAndSort( parseInlined( node.getLabelField() ), labelId );
 
         return putSorted( node, augmentedLabelIds, nodeStore, allocator );
     }
@@ -95,7 +93,7 @@ public class InlineNodeLabels implements NodeLabels
     @Override
     public Collection<DynamicRecord> remove( long labelId, NodeStore nodeStore )
     {
-        long[] newLabelIds = filter( parseInlined( labelField ), labelId );
+        long[] newLabelIds = filter( parseInlined( node.getLabelField() ), labelId );
         boolean inlined = tryInlineInNodeRecord( node, newLabelIds, node.getDynamicLabelRecords() );
         assert inlined;
         return Collections.emptyList();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabelsField.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabelsField.java
@@ -43,8 +43,8 @@ public class NodeLabelsField
     {
         long labelField = node.getLabelField();
         return fieldPointsToDynamicRecordOfLabels( labelField )
-                ? new DynamicNodeLabels( labelField, node )
-                : new InlineNodeLabels( labelField, node );
+                ? new DynamicNodeLabels( node )
+                : new InlineNodeLabels( node );
     }
 
     public static long[] get( NodeRecord node, NodeStore nodeStore )


### PR DESCRIPTION
issue was that dynamic label record which was marked as unused,
while still kept in the list in the NodeRecord since we want to know
about it when updating the node store, was mistakedly included when
reading before adding a new label to that node. This would have
the last id for that node duplicated. This was "fine", but would
have the next removal let the last (now a duplicate) label id be 0.
This would have these consequences:
- If the label 0 would be the only one left then that node would
  be seen as having the label with id 0, which in reality never
  was added to it.
- If the label 0 was one out of many then it would not be observed
  on that node since the label id 0 would sit last in the list of
  label ids and label ids are found by binary search and so it would
  be missed. However counts updates would think that the node had
  this label and would update counts incorrectly.

This commit adds a randomized test which catches this issue as well
as potentially other issues.
