### PR TITLE
3.0 sys.queryJmx

### DIFF
--- a/community/collections/src/main/java/org/neo4j/collection/RawIterator.java
+++ b/community/collections/src/main/java/org/neo4j/collection/RawIterator.java
@@ -22,6 +22,8 @@ package org.neo4j.collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.neo4j.function.ThrowingSupplier;
+
 /**
  * Just like {@link Iterator}, but with the addition that {@link #hasNext()} and {@link #next()} can
  * be declared to throw a checked exception.
@@ -64,6 +66,22 @@ public interface RawIterator<T,EXCEPTION extends Exception>
                     return values[position++];
                 }
                 throw new NoSuchElementException();
+            }
+        };
+    }
+
+    /**
+     * Create a raw iterator from the provided {@link ThrowingSupplier} - the iterator will end
+     * when the supplier returns null.
+     */
+    static <T, EX extends Exception> RawIterator<T, EX> of( ThrowingSupplier<T, EX> supplier )
+    {
+        return new PrefetchingRawIterator<T,EX>()
+        {
+            @Override
+            protected T fetchNextOrNull() throws EX
+            {
+                return supplier.get();
             }
         };
     }

--- a/community/collections/src/main/java/org/neo4j/collection/RawIterator.java
+++ b/community/collections/src/main/java/org/neo4j/collection/RawIterator.java
@@ -74,7 +74,7 @@ public interface RawIterator<T,EXCEPTION extends Exception>
      * Create a raw iterator from the provided {@link ThrowingSupplier} - the iterator will end
      * when the supplier returns null.
      */
-    static <T, EX extends Exception> RawIterator<T, EX> of( ThrowingSupplier<T, EX> supplier )
+    static <T, EX extends Exception> RawIterator<T, EX> from( ThrowingSupplier<T, EX> supplier )
     {
         return new PrefetchingRawIterator<T,EX>()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.builtinprocs;
 
+import java.lang.management.ManagementFactory;
+
 import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -52,6 +54,7 @@ public class BuiltInProcedures implements ThrowingConsumer<Procedures, Procedure
         // functionality - eg. things that apply across databases.
         procs.register( new ListProceduresProcedure( procedureName( "sys", "procedures" ) ) );
         procs.register( new ListComponentsProcedure( procedureName( "sys", "components" ), neo4jVersion ) );
+        procs.register( new JmxQueryProcedure( procedureName( "sys", "queryJmx" ), ManagementFactory.getPlatformMBeanServer() ) );
 
         // These are 'sys.auth'-namespaced procedures; these deal with authentication and authorization-oriented operations
         procs.register( new AlterUserPasswordProcedure( procedureName( "sys", "changePassword" ) ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedure.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.builtinprocs;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.management.JMException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.RuntimeMBeanException;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.TabularData;
+
+import org.neo4j.collection.RawIterator;
+import org.neo4j.helpers.collection.Pair;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.ProcedureSignature;
+
+import static java.util.Arrays.asList;
+import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.helpers.collection.Pair.pair;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
+
+public class JmxQueryProcedure extends CallableProcedure.BasicProcedure
+{
+    private final MBeanServer jmxServer;
+
+    public JmxQueryProcedure( ProcedureSignature.ProcedureName name, MBeanServer jmxServer )
+    {
+        super( procedureSignature( name )
+                .in( "query", Neo4jTypes.NTString )
+                .out( "name", Neo4jTypes.NTString )
+                .out( "description", Neo4jTypes.NTString )
+                .out( "attributes", Neo4jTypes.NTMap )
+                .build() );
+        this.jmxServer = jmxServer;
+    }
+
+    @Override
+    public RawIterator<Object[], ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+    {
+        String query = input[0].toString();
+        try
+        {
+            // Find all beans that match the query name pattern
+            Iterator<ObjectName> names = jmxServer.queryNames( new ObjectName( query ), null ).iterator();
+
+            // Then convert them to a Neo4j type system representation
+            return RawIterator.of( () -> {
+                if( !names.hasNext() )
+                {
+                    return null;
+                }
+
+                ObjectName name = names.next();
+                try
+                {
+                    MBeanInfo beanInfo = jmxServer.getMBeanInfo( name );
+                    return new Object[]{
+                            name.getCanonicalName(),
+                            beanInfo.getDescription(),
+                            toNeo4jValue( name, beanInfo.getAttributes() ) };
+                }
+                catch ( JMException e )
+                {
+                    throw new ProcedureException( Status.General.UnknownError,
+                            e, "JMX error while accessing `%s`, please report this. Message was: %s",
+                            name, e.getMessage() );
+                }
+            });
+        }
+        catch ( MalformedObjectNameException e )
+        {
+            throw new ProcedureException( Status.Procedure.ProcedureCallFailed,
+                  "'%s' is an invalid JMX name pattern. Valid queries should use" +
+                  "the syntax outlined in the javax.management.ObjectName API documentation." +
+                  "For instance, try 'org.neo4j:*' to find all JMX beans of the 'org.neo4j' " +
+                  "domain, or '*:*' to find every JMX bean.", query );
+        }
+    }
+
+    private Map<String,Object> toNeo4jValue( ObjectName name, MBeanAttributeInfo[] attributes )
+            throws JMException
+    {
+        HashMap<String,Object> out = new HashMap<>();
+        for ( MBeanAttributeInfo attribute : attributes )
+        {
+            if( attribute.isReadable() )
+            {
+                out.put( attribute.getName(), toNeo4jValue( name, attribute ) );
+            }
+        }
+        return out;
+    }
+
+    private Map<String,Object> toNeo4jValue( ObjectName name, MBeanAttributeInfo attribute )
+            throws JMException
+    {
+        Object value;
+        try
+        {
+            value = toNeo4jValue( jmxServer.getAttribute( name, attribute.getName() ) );
+        }
+        catch( RuntimeMBeanException e )
+        {
+            if( e.getCause() != null && e.getCause() instanceof UnsupportedOperationException )
+            {
+                // We include the name and description of this attribute still - but the value of it is
+                // unknown. We do this rather than rethrow the exception, because several MBeans built into
+                // the JVM will throw exception on attribute access depending on their runtime state, even
+                // if the attribute is marked as readable. Notably the GC beans do this.
+                value = null;
+            }
+            else
+            {
+                throw e;
+            }
+        }
+        return map(
+            "description", attribute.getDescription(),
+            "value", value
+        );
+    }
+
+    private Object toNeo4jValue( Object attributeValue )
+    {
+        // These branches as per {@link javax.management.openmbean.OpenType#ALLOWED_CLASSNAMES_LIST}
+        if( isSimpleType( attributeValue ) )
+        {
+            return attributeValue;
+        }
+        else if( attributeValue.getClass().isArray() )
+        {
+            if( isSimpleType( attributeValue.getClass().getComponentType() ) )
+            {
+                return attributeValue;
+            }
+            else
+            {
+                return toNeo4jValue((Object[])attributeValue);
+            }
+        }
+        else if( attributeValue instanceof CompositeData )
+        {
+            return toNeo4jValue( (CompositeData)attributeValue );
+        }
+        else if( attributeValue instanceof ObjectName )
+        {
+            return ((ObjectName) attributeValue).getCanonicalName();
+        }
+        else if( attributeValue instanceof TabularData )
+        {
+            return toNeo4jValue( (Map<?,?>) attributeValue );
+        }
+        else if( attributeValue instanceof Date )
+        {
+            return ((Date) attributeValue).getTime();
+        }
+        else
+        {
+            // Don't convert objects that are not OpenType values
+            return null;
+        }
+    }
+
+    private Map<String,Object> toNeo4jValue( Map<?,?> attributeValue )
+    {
+        // Build a new map with the same keys, but each value passed
+        // through `toNeo4jValue`
+        return attributeValue.entrySet().stream()
+            .map( (e) -> pair(
+                e.getKey().toString(),
+                toNeo4jValue( e.getValue() )) )
+            .collect( Collectors.toMap( Pair::first, Pair::other ) );
+    }
+
+    private List<Object> toNeo4jValue( Object[] array )
+    {
+        return asList(array).stream().map( this::toNeo4jValue ).collect( Collectors.toList() );
+    }
+
+    private Map<String, Object> toNeo4jValue( CompositeData composite )
+    {
+        HashMap<String,Object> properties = new HashMap<>();
+        for ( String key : composite.getCompositeType().keySet() )
+        {
+            properties.put( key, toNeo4jValue(composite.get( key )) );
+        }
+
+        return map(
+            "description", composite.getCompositeType().getDescription(),
+            "properties", properties
+        );
+    }
+
+    private boolean isSimpleType( Object value )
+    {
+        return value == null || isSimpleType( value.getClass() );
+    }
+
+    private boolean isSimpleType( Class<?> cls )
+    {
+        return String.class.isAssignableFrom( cls ) ||
+               Number.class.isAssignableFrom( cls ) ||
+               Boolean.class.isAssignableFrom( cls ) ||
+               cls.isPrimitive();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedure.java
@@ -73,7 +73,7 @@ public class JmxQueryProcedure extends CallableProcedure.BasicProcedure
             Iterator<ObjectName> names = jmxServer.queryNames( new ObjectName( query ), null ).iterator();
 
             // Then convert them to a Neo4j type system representation
-            return RawIterator.of( () -> {
+            return RawIterator.from( () -> {
                 if( !names.hasNext() )
                 {
                     return null;

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -165,7 +165,8 @@ public class BuiltInProceduresTest
             record( "db.relationshipTypes", "db.relationshipTypes() :: (relationshipType :: STRING?)" ),
             record( "sys.changePassword", "sys.changePassword(password :: STRING?) :: ()" ),
             record( "sys.components", "sys.components() :: (name :: STRING?, versions :: LIST? OF STRING?)" ),
-            record( "sys.procedures", "sys.procedures() :: (name :: STRING?, signature :: STRING?)" )
+            record( "sys.procedures", "sys.procedures() :: (name :: STRING?, signature :: STRING?)" ),
+            record( "sys.queryJmx", "sys.queryJmx(query :: STRING?) :: (name :: STRING?, description :: STRING?, attributes :: MAP?)")
         ) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/JmxQueryProcedureTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.builtinprocs;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.RuntimeMBeanException;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+
+import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.proc.ProcedureSignature;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.Iterators.asList;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class JmxQueryProcedureTest
+{
+
+    private MBeanServer jmxServer;
+    private ObjectName beanName;
+    private String attributeName;
+
+    @Test
+    public void shouldHandleBasicMBean() throws Throwable
+    {
+        // given
+        when( jmxServer.getAttribute( beanName, "name" ) ).thenReturn( "Hello, world!" );
+        JmxQueryProcedure procedure = new JmxQueryProcedure( ProcedureSignature.procedureName( "bob" ), jmxServer );
+
+        // when
+        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"} );
+
+        // then
+        assertThat( asList( result ), contains(
+            equalTo( new Object[]{
+                    "org.neo4j:chevyMakesTheTruck=bobMcCoshMakesTheDifference",
+                    "This is a description",
+                    map( attributeName, map(
+                        "description", "This is the attribute desc.",
+                        "value", "Hello, world!"
+                    ) )
+            } ) ) );
+    }
+
+    @Test
+    public void shouldHandleMBeanThatThrowsOnGetAttribute() throws Throwable
+    {
+        // given some JVM MBeans do not allow accessing their attributes, despite marking
+        // then as readable
+        when( jmxServer.getAttribute( beanName, "name" ) )
+            // We throw the exact combo thrown by JVM MBeans here, so that any other exception will bubble up,
+            // and we can make an informed decision about swallowing more exception on an as-needed basis.
+            .thenThrow( new RuntimeMBeanException(
+                    new UnsupportedOperationException( "Haha, screw discoverable services!" ) ) );
+
+        JmxQueryProcedure procedure = new JmxQueryProcedure( ProcedureSignature.procedureName( "bob" ), jmxServer );
+
+        // when
+        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"} );
+
+        // then
+        assertThat( asList( result ), contains(
+                equalTo( new Object[]{
+                        "org.neo4j:chevyMakesTheTruck=bobMcCoshMakesTheDifference",
+                        "This is a description",
+                        map( attributeName, map(
+                            "description", "This is the attribute desc.",
+                            "value", null
+                        ) )
+                } ) ) );
+    }
+
+
+    @Test
+    public void shouldHandleCompositeAttributes() throws Throwable
+    {
+        // given
+        ObjectName beanName = new ObjectName( "org.neo4j:chevyMakesTheTruck=bobMcCoshMakesTheDifference" );
+        when( jmxServer.queryNames( new ObjectName( "*:*" ), null ) )
+                .thenReturn( asSet( beanName ) );
+        when( jmxServer.getMBeanInfo( beanName ) )
+                .thenReturn( new MBeanInfo(
+                        "org.neo4j.SomeMBean",
+                        "This is a description",
+                        new MBeanAttributeInfo[]{
+                                new MBeanAttributeInfo( "name", "differenceMaker", "Who makes the difference?",
+                                        true, false, false )
+                        },
+                        null, null, null ) );
+        when( jmxServer.getAttribute( beanName, "name" ) ).thenReturn(
+                new CompositeDataSupport( new CompositeType(
+                        "myComposite",
+                        "Composite description",
+                        new String[]{"key1", "key2"},
+                        new String[]{"Can't be empty", "Also can't be empty"},
+                        new OpenType<?>[]{SimpleType.STRING, SimpleType.INTEGER} ), map(
+                    "key1", "Hello",
+                    "key2", 123
+                ) ) );
+
+        JmxQueryProcedure procedure = new JmxQueryProcedure( ProcedureSignature.procedureName( "bob" ), jmxServer );
+
+        // when
+        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"} );
+
+        // then
+        assertThat( asList( result ), contains(
+                equalTo( new Object[]{
+                    "org.neo4j:chevyMakesTheTruck=bobMcCoshMakesTheDifference",
+                    "This is a description",
+                    map( attributeName, map(
+                            "description", "Who makes the difference?",
+                            "value", map(
+                                "description", "Composite description",
+                                "properties", map(
+                                        "key1", "Hello",
+                                        "key2", 123 ) ) ) ) } ) ) );
+    }
+
+    @Test
+    public void shouldConvertAllStandardBeansWithoutError() throws Throwable
+    {
+        // given
+        MBeanServer jmxServer = ManagementFactory.getPlatformMBeanServer();
+
+        JmxQueryProcedure procedure = new JmxQueryProcedure( ProcedureSignature.procedureName( "bob" ), jmxServer );
+
+        // when
+        RawIterator<Object[],ProcedureException> result = procedure.apply( null, new Object[]{"*:*"} );
+
+        // then we verify that we respond with the expected number of beans without error
+        //      .. we don't assert more than this, this is more of a smoke test to ensure
+        //      that independent of platform, we never throw exceptions even when converting every
+        //      single MBean into Neo4j types, and we always get the correct number of MBeans out.
+        assertThat( asList( result ).size(), equalTo( jmxServer.getMBeanCount() ));
+    }
+
+    @Before
+    public void setup() throws Throwable
+    {
+        jmxServer = mock( MBeanServer.class );
+        beanName = new ObjectName( "org.neo4j:chevyMakesTheTruck=bobMcCoshMakesTheDifference" );
+        attributeName = "name";
+
+        when( jmxServer.queryNames( new ObjectName( "*:*" ), null ) )
+                .thenReturn( asSet( beanName ) );
+        when( jmxServer.getMBeanInfo( beanName ) )
+                .thenReturn( new MBeanInfo(
+                    "org.neo4j.SomeMBean",
+                    "This is a description",
+                    new MBeanAttributeInfo[]{
+                            new MBeanAttributeInfo( attributeName, "someType", "This is the attribute desc.",
+                                    true, false, false )
+                    },
+                    null, null, null ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltinProceduresIT.java
@@ -160,10 +160,11 @@ public class BuiltinProceduresIT extends KernelIntegrationTest
                 equalTo( new Object[]{"db.indexes", "db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)"} ),
                 equalTo( new Object[]{"db.propertyKeys", "db.propertyKeys() :: (propertyKey :: STRING?)"}),
                 equalTo( new Object[]{"db.labels", "db.labels() :: (label :: STRING?)"} ),
+                equalTo( new Object[]{"db.relationshipTypes", "db.relationshipTypes() :: (relationshipType :: STRING?)"}),
                 equalTo( new Object[]{"sys.procedures", "sys.procedures() :: (name :: STRING?, signature :: STRING?)"} ),
                 equalTo( new Object[]{"sys.components", "sys.components() :: (name :: STRING?, versions :: LIST? OF STRING?)"} ),
-                equalTo( new Object[]{"db.relationshipTypes", "db.relationshipTypes() :: (relationshipType :: STRING?)"}),
-                equalTo( new Object[]{"sys.changePassword", "sys.changePassword(password :: STRING?) :: ()"})
+                equalTo( new Object[]{"sys.changePassword", "sys.changePassword(password :: STRING?) :: ()"}),
+                equalTo( new Object[]{"sys.queryJmx", "sys.queryJmx(query :: STRING?) :: (name :: STRING?, description :: STRING?, attributes :: MAP?)"})
         ));
     }
 

--- a/manual/embedded-examples/src/docs/dev/procedures.asciidoc
+++ b/manual/embedded-examples/src/docs/dev/procedures.asciidoc
@@ -70,10 +70,14 @@ Neo4j comes with a handful of pre-packaged procedures ready to be used:
 [options="header", cols="m,m,d"]
 |===
 | Procedure name        | Command to invoke procedure | What it does
-| ListProcedures        | CALL db.procedures()        | List all procedures in the database.
 | ListLabels            | CALL db.labels()            | List all labels in the database.
 | ListRelationshipTypes | CALL db.relationshipTypes() | List all relationship types in the database.
 | ListPropertyKeys      | CALL db.propertyKeys()      | List all property keys in the database.
+| ListIndexes           | CALL db.indexes()           | List all indexes in the database.
+| ListConstraints       | CALL db.constraints()       | List all constraints in the database.
+| ListProcedures        | CALL sys.procedures()       | List all procedures in the DBMS.
+| ListComponents        | CALL sys.components()       | List DBMS components and their versions.
+| QueryJmx              | CALL sys.queryJmx(query)    | Query JMX management data by domain and name. For instance, "org.neo4j:*".
 |===
 
 


### PR DESCRIPTION
Late to the game - this had fallen between chairs as a requirement for the browser to work with only Bolt. The change is designed to be minimal, not touching any classes outside the procedure, beyond adding a small utility method, and is tested both with pointed unit tests and a smoke test that ensures that the full JMX Bean "space" can be retrieved without error.

```
CALL sys.queryJmx("*:*");
```
