### PR TITLE
Change counts store to write -1 as trailer when empty.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/BigEndianByteArrayBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/BigEndianByteArrayBuffer.java
@@ -120,6 +120,26 @@ final class BigEndianByteArrayBuffer implements ReadableBuffer, WritableBuffer
         return true;
     }
 
+    public boolean minusOneAtTheEnd()
+    {
+        for ( int i = 0; i < buffer.length / 2; i++ )
+        {
+            if ( buffer[i] != 0 )
+            {
+                return false;
+            }
+        }
+
+        for ( int i = buffer.length / 2; i < buffer.length; i++)
+        {
+            if ( buffer[i] != -1 )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public void dataFrom( ByteBuffer buffer )
     {
         buffer.get( this.buffer );
@@ -240,11 +260,11 @@ final class BigEndianByteArrayBuffer implements ReadableBuffer, WritableBuffer
         return this;
     }
 
-    public void putIntegerAtEnd( long value ) throws IOException
+    void putIntegerAtEnd( long value ) throws IOException
     {
-        if ( value < 0 )
+        if ( value < -1 )
         {
-            throw new IllegalArgumentException( "Negative values not supported." );
+            throw new IllegalArgumentException( "Negative values different form -1 are not supported." );
         }
         if ( this.size() < 8 )
         {
@@ -261,7 +281,7 @@ final class BigEndianByteArrayBuffer implements ReadableBuffer, WritableBuffer
         }
     }
 
-    public long getIntegerFromEnd()
+    long getIntegerFromEnd()
     {
         long value = 0;
         for ( int i = Math.max( 0, buffer.length - 8 ); i < buffer.length; i++ )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFileFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/KeyValueStoreFileFormat.java
@@ -196,7 +196,7 @@ public abstract class KeyValueStoreFileFormat
             value.clear();
 
             // trailer
-            value.putIntegerAtEnd( dataEntries );
+            value.putIntegerAtEnd( dataEntries == 0 ? -1 : dataEntries );
             if ( !writer.writeHeader( key, value ) )
             {
                 throw new IllegalStateException( "The trailing size header should be valid" );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/MetadataCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/MetadataCollector.java
@@ -148,7 +148,7 @@ abstract class MetadataCollector extends Metadata implements EntryVisitor<BigEnd
             {
                 if ( key.allZeroes() )
                 {
-                    if ( value.allZeroes() )
+                    if ( value.minusOneAtTheEnd() )
                     {
                         collector.state = done;
                         return false;
@@ -181,7 +181,8 @@ abstract class MetadataCollector extends Metadata implements EntryVisitor<BigEnd
             {
                 if ( key.allZeroes() )
                 {
-                    long entries = value.getIntegerFromEnd();
+                    long encodedEntries = value.getIntegerFromEnd();
+                    long entries = encodedEntries == -1 ? 0 : encodedEntries;
                     if ( entries != collector.data )
                     {
                         collector.state = in_error;


### PR DESCRIPTION
We use -1 rather than 0 to signify no entries in the counts store.
Using 0 is a poor choice since the pagecache by default zeros
out a blank page, making it impossible to determine if there are
zero entries or if the system failed before writing any values.
