### PR TITLE
Use HighLimit format during checkpoint stress testing

### DIFF
--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
@@ -31,6 +31,7 @@ import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.stresstests.transaction.checkpoint.tracers.TimerTransactionTracer;
 import org.neo4j.kernel.stresstests.transaction.checkpoint.workload.Workload;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
@@ -79,6 +80,7 @@ public class CheckPointingLogRotationStressTesting
         GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
                 .setConfig( GraphDatabaseSettings.pagecache_memory, pageCacheMemory )
                 .setConfig( GraphDatabaseSettings.mapped_memory_page_size, pageSize )
+                .setConfig( GraphDatabaseFacadeFactory.Configuration.record_format, HighLimit.NAME )
                 .setConfig( GraphDatabaseSettings.check_point_interval_time, "1m" )
                 .setConfig( GraphDatabaseFacadeFactory.Configuration.tracer, "timer" )
                 .newGraphDatabase();


### PR DESCRIPTION
Switch checkpoint stress test to use correct enterprise format.
