### PR TITLE
Resolve configured directories relative to a specific location

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -86,9 +86,8 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
     public static class Settings
     {
         @Description( "Directory for storing certificates to be used by Neo4j for TLS connections" )
-        public static Setting<File> certificates_directory = setting(
-                "dbms.directories.certificates", PATH, "certificates"
-        );
+        public static Setting<File> certificates_directory =
+                pathSetting( "dbms.directories.certificates", "certificates" );
 
         @Internal
         @Description( "Path to the X.509 public certificate to be used by Neo4j for TLS connections" )

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -106,7 +106,9 @@ public class ConsistencyCheckServiceIntegrationTest
         breakNodeStore();
         Date timestamp = new Date();
         ConsistencyCheckService service = new ConsistencyCheckService( timestamp );
-        Config configuration = new Config( settings(), GraphDatabaseSettings.class, ConsistencyCheckSettings.class );
+        Config configuration = new Config(
+                settings( GraphDatabaseSettings.logs_directory.name(), testDirectory.directory().getPath() ),
+                GraphDatabaseSettings.class, ConsistencyCheckSettings.class );
 
         // when
         ConsistencyCheckService.Result result = runFullConsistencyCheck( service, configuration );
@@ -117,25 +119,6 @@ public class ConsistencyCheckServiceIntegrationTest
                 configuration.get( GraphDatabaseSettings.logs_directory ),
                 defaultLogFileName( timestamp ) );
         assertTrue( "Inconsistency report file " + reportFile + " not generated", reportFile.exists() );
-    }
-
-    @Test
-    public void shouldWriteInconsistenciesToLogFileAtSpecifiedLocation() throws Exception
-    {
-        // given
-        breakNodeStore();
-        ConsistencyCheckService service = new ConsistencyCheckService();
-        File specificLogFile = new File( testDirectory.directory(), "specific_logfile.txt" );
-        Config configuration = new Config(
-                settings( GraphDatabaseSettings.logs_directory.name(), specificLogFile.getPath() ),
-                GraphDatabaseSettings.class, ConsistencyCheckSettings.class
-        );
-
-        // when
-        runFullConsistencyCheck( service, configuration );
-
-        // then
-        assertTrue( "Inconsistency report file " + specificLogFile + " not generated", specificLogFile.exists() );
     }
 
     @Test

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceIntegrationTest.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.consistency;
 
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import org.neo4j.consistency.ConsistencyCheckService.Result;
 import org.neo4j.consistency.checking.GraphStoreFixture;
@@ -54,6 +54,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import static org.neo4j.consistency.ConsistencyCheckService.defaultLogFileName;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.test.Property.property;
@@ -61,7 +62,6 @@ import static org.neo4j.test.Property.set;
 
 public class ConsistencyCheckServiceIntegrationTest
 {
-
     private final GraphStoreFixture fixture = new GraphStoreFixture( getRecordFormatName() )
     {
         @Override
@@ -209,7 +209,6 @@ public class ConsistencyCheckServiceIntegrationTest
         Map<String, String> defaults = new HashMap<>();
         defaults.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
         defaults.put( GraphDatabaseFacadeFactory.Configuration.record_format.name(), getRecordFormatName() );
-        defaults.put( GraphDatabaseSettings.auth_store.name(), testDirectory.file( "auth" ).getAbsolutePath() );
         return stringMap( defaults, strings );
     }
 

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchLongPatternAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchLongPatternAcceptanceTest.scala
@@ -43,7 +43,6 @@ class MatchLongPatternAcceptanceTest extends ExecutionEngineFunSuite with QueryS
   override def databaseConfig() = super.databaseConfig() ++ Map(
     GraphDatabaseSettings.cypher_min_replan_interval -> "0",
     GraphDatabaseSettings.cypher_compiler_tracing -> "true",
-    GraphDatabaseSettings.auth_store -> Files.createTempFile("auth", "").toString,
     GraphDatabaseSettings.pagecache_memory -> "8M"
   )
 

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/GlueSteps.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/GlueSteps.scala
@@ -113,9 +113,6 @@ class GlueSteps extends FunSuiteLike with Matchers with ScalaDsl with EN with Ac
   private def loadConfig(builder: GraphDatabaseBuilder): GraphDatabaseBuilder = {
     val directory: Path = Files.createTempDirectory("tls")
     builder.setConfig(GraphDatabaseSettings.pagecache_memory, "8M")
-    builder.setConfig(GraphDatabaseSettings.auth_store, new File(directory.toFile, "auth").getAbsolutePath)
-    builder.setConfig("dbms.security.tls_key_file", new File(directory.toFile, "key.key").getAbsolutePath)
-    builder.setConfig("dbms.security.tls_certificate_file", new File(directory.toFile, "cert.cert").getAbsolutePath)
     cypherConfig().map { case (s, v) => builder.setConfig(s, v) }
     builder
   }

--- a/community/dbms/src/main/java/org/neo4j/dbms/DatabaseManagementSystemSettings.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/DatabaseManagementSystemSettings.java
@@ -24,20 +24,25 @@ import java.io.File;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.kernel.configuration.Internal;
-import org.neo4j.kernel.configuration.Settings;
+
+import static org.neo4j.kernel.configuration.Settings.PATH;
+import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.derivedSetting;
+import static org.neo4j.kernel.configuration.Settings.pathSetting;
+import static org.neo4j.kernel.configuration.Settings.setting;
 
 public interface DatabaseManagementSystemSettings
 {
     @Description("Name of the database to load")
-    Setting<String> active_database = Settings.setting( "dbms.active_database", Settings.STRING, "graph.db" );
+    Setting<String> active_database = setting( "dbms.active_database", STRING, "graph.db" );
 
     @Description("Path of the data directory. You must not configure more than one Neo4j installation to use the " +
             "same data directory.")
-    Setting<File> data_directory = Settings.setting( "dbms.directories.data", Settings.PATH, "data" );
+    Setting<File> data_directory = pathSetting( "dbms.directories.data", "data" );
 
     @Internal
-    Setting<File> database_path = Settings.derivedSetting( "unsupported.dbms.directories.database",
+    Setting<File> database_path = derivedSetting( "unsupported.dbms.directories.database",
             data_directory, active_database,
             ( data, current ) -> new File( new File( data, "databases" ), current ),
-            Settings.PATH );
+            PATH );
 }

--- a/community/dbms/src/test/java/org/neo4j/dbms/DatabaseManagementSystemSettingsTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/DatabaseManagementSystemSettingsTest.java
@@ -32,12 +32,11 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class DatabaseManagementSystemSettingsTest
 {
-
     @Test
     public void shouldPutDatabaseDirectoriesIntoDataDatabases()
     {
         Config config = new Config( stringMap( DatabaseManagementSystemSettings.data_directory.name(), "the-data-directory" ) );
         assertThat( config.get( DatabaseManagementSystemSettings.database_path ),
-                equalTo( new File( System.getProperty("user.dir") + "/the-data-directory/databases/graph.db" ) ) );
+                equalTo( new File( "the-data-directory/databases/graph.db" ) ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -63,6 +63,7 @@ import static org.neo4j.kernel.configuration.Settings.matches;
 import static org.neo4j.kernel.configuration.Settings.max;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.options;
+import static org.neo4j.kernel.configuration.Settings.pathSetting;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
@@ -73,6 +74,12 @@ public abstract class GraphDatabaseSettings
     @SuppressWarnings("unused") // accessed by reflection
     @Migrator
     private static final ConfigurationMigrator migrator = new GraphDatabaseConfigurationMigrator();
+
+    @Internal
+    @Description("Root relative to which directory settings are resolved. This is set in code and should never be " +
+            "configured explicitly.")
+    public static final Setting<File> neo4j_home =
+            setting( "unsupported.dbms.directories.neo4j_home", PATH, NO_DEFAULT );
 
     @Title("Read only database")
     @Description("Only allow read operations from this Neo4j instance. " +
@@ -164,7 +171,7 @@ public abstract class GraphDatabaseSettings
 
     @Description( "Sets the root directory for file URLs used with the Cypher `LOAD CSV` clause. This must be set to a single "
                   + "directory, restricting access to only those files within that directory and its subdirectories." )
-    public static Setting<File> load_csv_file_url_root = setting( "dbms.directories.import", PATH, NO_DEFAULT );
+    public static Setting<File> load_csv_file_url_root = pathSetting( "dbms.directories.import", NO_DEFAULT );
 
     @Description( "The maximum amount of time to wait for the database to become available, when " +
                   "starting a new transaction." )
@@ -180,7 +187,7 @@ public abstract class GraphDatabaseSettings
 
     @Description("Location of the database plugin directory. Compiled Java JAR files that contain database " +
                  "procedures will be loaded if they are placed in this directory.")
-    public static final Setting<File> plugin_dir = setting("dbms.directories.plugins", PATH, "plugins" );
+    public static final Setting<File> plugin_dir = pathSetting( "dbms.directories.plugins", "plugins" );
 
     @Description( "Threshold for rotation of the debug log." )
     public static final Setting<Long> store_internal_log_rotation_threshold = setting("dbms.logs.debug.rotation.size", BYTES, "20m", min(0L), max( Long.MAX_VALUE ) );
@@ -420,7 +427,7 @@ public abstract class GraphDatabaseSettings
     public static final Setting<Boolean> log_queries = setting("dbms.logs.query.enabled", BOOLEAN, FALSE );
 
     @Description("Path of the logs directory")
-    public static final Setting<File> logs_directory = setting("dbms.directories.logs", PATH, "logs");
+    public static final Setting<File> logs_directory = pathSetting( "dbms.directories.logs", "logs" );
 
     @Internal
     public static final Setting<File> log_queries_filename = derivedSetting("dbms.querylog.filename",
@@ -451,7 +458,8 @@ public abstract class GraphDatabaseSettings
     public static final Setting<Boolean> auth_enabled = setting( "dbms.security.auth_enabled", BOOLEAN, "false" );
 
     @Internal
-    public static final Setting<File> auth_store = setting("unsupported.dbms.security.auth_store.location", PATH, NO_DEFAULT);
+    public static final Setting<File> auth_store =
+            pathSetting( "unsupported.dbms.security.auth_store.location", NO_DEFAULT );
 
     // Bolt Settings
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.factory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -119,6 +120,12 @@ public class PlatformModule
         } );
         life = dependencies.satisfyDependency( createLife() );
         this.graphDatabaseFacade = dependencies.satisfyDependency( graphDatabaseFacade );
+
+        if ( !params.containsKey( GraphDatabaseSettings.neo4j_home.name() ) )
+        {
+            params = new HashMap<>( params );
+            params.put( GraphDatabaseSettings.neo4j_home.name(), providedStoreDir.getAbsolutePath() );
+        }
 
         // SPI - provided services
         config = dependencies.satisfyDependency( new Config( params, getSettingsClasses(

--- a/community/kernel/src/test/java/examples/BatchInsertDocTest.java
+++ b/community/kernel/src/test/java/examples/BatchInsertDocTest.java
@@ -19,19 +19,18 @@
  */
 package examples;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -40,7 +39,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
@@ -93,7 +91,6 @@ public class BatchInsertDocTest
         GraphDatabaseService db =
                 new GraphDatabaseFactory()
                         .newEmbeddedDatabaseBuilder( new File("target/batchinserter-example") )
-                        .setConfig( GraphDatabaseSettings.auth_store, Files.createTempFile("auth", "").toString() )
                         .newGraphDatabase();
         try ( Transaction tx = db.beginTx() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.kernel;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.adversaries.ClassGuardedAdversary;
 import org.neo4j.adversaries.CountingAdversary;
@@ -36,7 +36,6 @@ import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -58,6 +57,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.graphdb.RelationshipType.withName;
 
 public class RecoveryIT
@@ -152,7 +152,6 @@ public class RecoveryIT
         File storeDir = directory.graphDbDir();
         GraphDatabaseService db = AdversarialPageCacheGraphDatabaseFactory.create( fs, adversary )
                 .newEmbeddedDatabaseBuilder( storeDir )
-                .setConfig( GraphDatabaseSettings.auth_store, directory.file( "auth" ).getAbsolutePath() )
                 .newGraphDatabase();
         try
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/docs/SettingsDocumenterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/docs/SettingsDocumenterTest.java
@@ -34,7 +34,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.INTEGER;
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
-import static org.neo4j.kernel.configuration.Settings.PATH;
 import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
@@ -150,7 +149,7 @@ public class SettingsDocumenterTest
             "[cols=\"<1h,<4\"]%n" +
             "|===%n" +
             "|Description a|Public nodefault.%n" +
-            "|Valid values a|public.nodefault is a path%n" +
+            "|Valid values a|public.nodefault is a string%n" +
             "|===%n" +
             "endif::nonhtmloutput[]%n" +
             "%n" +
@@ -160,7 +159,7 @@ public class SettingsDocumenterTest
             "[cols=\"<1h,<4\"]%n" +
             "|===%n" +
             "|Description a|Public nodefault.%n" +
-            "|Valid values a|public.nodefault is a path%n" +
+            "|Valid values a|public.nodefault is a string%n" +
             "|===%n" +
             "endif::nonhtmloutput[]%n%n" ) ));
     }
@@ -243,7 +242,7 @@ public class SettingsDocumenterTest
     public interface SimpleSettings
     {
         @Description("Public nodefault")
-        Setting<File> public_nodefault = setting("public.nodefault", PATH, NO_DEFAULT);
+        Setting<String> public_nodefault = setting( "public.nodefault", STRING, NO_DEFAULT );
 
         @Description("Public with default")
         Setting<Integer> public_with_default = setting("public.default", INTEGER, "1");

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/ProduceUncleanStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/ProduceUncleanStore.java
@@ -19,16 +19,13 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -41,7 +38,7 @@ public class ProduceUncleanStore
         boolean setGraphProperty = args.length > 1 ? Boolean.parseBoolean( args[1] ) : false;
         GraphDatabaseService db = new EmbeddedGraphDatabase(
                 storeDir,
-                stringMap( GraphDatabaseSettings.auth_store.name(), new File(storeDir, "auth").getAbsolutePath()),
+                stringMap(),
                 GraphDatabaseDependencies.newDependencies().userLogProvider( NullLogProvider.getInstance() ) );
         try ( Transaction tx = db.beginTx() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsRotationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsRotationTest.java
@@ -40,11 +40,9 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.CountsVisitor;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
@@ -57,6 +55,7 @@ import org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.TriggerInfo;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.Lifespan;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.AdversarialPageCacheGraphDatabaseFactory;
@@ -202,7 +201,6 @@ public class CountsRotationTest
 
         GraphDatabaseService db = AdversarialPageCacheGraphDatabaseFactory.create( fs, adversary )
                 .newEmbeddedDatabaseBuilder( dir )
-                .setConfig( GraphDatabaseSettings.auth_store, new File( dir, "auth" ).getAbsolutePath() )
                 .newGraphDatabase();
 
         CountDownLatch txStartLatch = new CountDownLatch( 1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/CommitContentionTests.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/CommitContentionTests.java
@@ -19,28 +19,27 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactoryState;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.api.index.RemoveOrphanConstraintIndexesOnStartup;
 import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.test.TargetDirectory;
 
+import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class CommitContentionTests
 {
@@ -184,9 +183,7 @@ public class CommitContentionTests
                     }
                 };
             }
-        }.newFacade( storeLocation.graphDbDir(),
-                stringMap( GraphDatabaseSettings.auth_store.name(), storeLocation.file( "auth" ).getAbsolutePath() ),
-                state.databaseDependencies() );
+        }.newFacade( storeLocation.graphDbDir(), emptyMap(), state.databaseDependencies() );
     }
 
     private void waitForFirstTransactionToStartPushing() throws InterruptedException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/PartialTransactionFailureIT.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.adversaries.ClassGuardedAdversary;
 import org.neo4j.adversaries.CountingAdversary;
@@ -38,7 +38,6 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactoryState;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
 import org.neo4j.kernel.impl.api.scan.InMemoryLabelScanStoreExtension;
 import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
@@ -49,11 +48,13 @@ import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
+import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
 import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 /**
@@ -76,8 +77,7 @@ public class PartialTransactionFailureIT
         adversary.disable();
 
         File storeDir = dir.graphDbDir();
-        final Map<String,String> params = stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m",
-                GraphDatabaseSettings.auth_store.name(), new File(storeDir, "auth").getAbsolutePath() );
+        final Map<String,String> params = stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
         final EmbeddedGraphDatabase db = new TestEmbeddedGraphDatabase( storeDir, params )
         {
             @Override

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -28,7 +28,6 @@ import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.Service;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
 import org.neo4j.kernel.impl.factory.DatabaseInfo;
@@ -37,10 +36,10 @@ import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.SimpleLogService;
+import org.neo4j.kernel.internal.EmbeddedGraphDatabase;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.auth_store;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.kernel.GraphDatabaseDependencies.newDependencies;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
@@ -181,10 +180,6 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
         if ( !result.containsKey( pagecache_memory.name() ) )
         {
             result.put( pagecache_memory.name(), "8M" );
-        }
-        if ( !result.containsKey( auth_store.name() ) )
-        {
-            result.put( auth_store.name(), new File(PATH, "auth").getAbsolutePath() );
         }
         return result;
     }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/Inserter.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/Inserter.java
@@ -21,13 +21,11 @@ package org.neo4j.index.impl.lucene.legacy;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
 
 public class Inserter
@@ -37,7 +35,6 @@ public class Inserter
         File path = new File( args[0] );
         final GraphDatabaseService db = new GraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( path )
-                .setConfig( GraphDatabaseSettings.auth_store, Files.createTempFile("auth", "").toString() )
                 .newGraphDatabase();
         final Index<Node> index = getIndex( db );
         final String[] keys = new String[]{"apoc", "zion", "morpheus"};

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/NonUniqueIndexTests.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/NonUniqueIndexTests.java
@@ -19,21 +19,20 @@
  */
 package org.neo4j.index.impl.lucene.legacy;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.LockSupport;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactoryState;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
 import org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProvider;
@@ -53,8 +52,10 @@ import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.test.TargetDirectory;
 
 import static java.util.Collections.singletonList;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
@@ -112,9 +113,7 @@ public class NonUniqueIndexTests
                     }
                 };
             }
-        }.newFacade( directory.graphDbDir(), stringMap( GraphDatabaseSettings.auth_store.name(),
-                directory.file( "auth" ).getAbsolutePath()),
-                graphDatabaseFactoryState.databaseDependencies() );
+        }.newFacade( directory.graphDbDir(), stringMap(), graphDatabaseFactoryState.databaseDependencies() );
     }
 
     private static Neo4jJobScheduler newSlowJobScheduler()

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/ServerControls.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.util.Optional;
 
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.config.Configuration;
 
 /**
  * Control panel for a Neo4j test instance.
@@ -47,4 +48,7 @@ public interface ServerControls extends AutoCloseable
 
     /** Access the {@link org.neo4j.graphdb.GraphDatabaseService} used by the server */
     GraphDatabaseService graph();
+
+    /** Returns the server's configuration */
+    Configuration config();
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.util.Optional;
 
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.config.Configuration;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.HostnamePort;
@@ -107,5 +108,11 @@ public class InProcessServerControls implements ServerControls
     public GraphDatabaseService graph()
     {
         return server.getDatabase().getGraph();
+    }
+
+    @Override
+    public Configuration config()
+    {
+        return server.getConfig();
     }
 }

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/junit/Neo4jRule.java
@@ -19,15 +19,16 @@
  */
 package org.neo4j.harness.junit;
 
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-
 import java.io.File;
 import java.net.URI;
 import java.util.function.Function;
 
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.config.Configuration;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.harness.TestServerBuilder;
@@ -175,5 +176,9 @@ public class Neo4jRule implements TestRule, TestServerBuilder
 
     public GraphDatabaseService getGraphDatabaseService() {
         return controls.graph();
+    }
+
+    public Configuration getConfig() {
+        return controls.config();
     }
 }

--- a/community/neo4j/src/test/java/ConcurrentChangesOnEntitiesTest.java
+++ b/community/neo4j/src/test/java/ConcurrentChangesOnEntitiesTest.java
@@ -18,14 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
@@ -36,7 +36,6 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.FormattedLogProvider;
@@ -59,7 +58,6 @@ public class ConcurrentChangesOnEntitiesTest
     {
         db = new GraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() )
-                .setConfig( GraphDatabaseSettings.auth_store, testDirectory.file( "auth" ).getAbsolutePath() )
                 .newGraphDatabase();
     }
 

--- a/community/neo4j/src/test/java/org/neo4j/index/ReadIndexWritesUnderConcurrentLoadStressIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/ReadIndexWritesUnderConcurrentLoadStressIT.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.index;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import java.io.File;
 import java.text.DecimalFormat;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -38,6 +38,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 
 import static java.lang.String.format;
+
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -61,7 +62,6 @@ public class ReadIndexWritesUnderConcurrentLoadStressIT
         GraphDatabaseService db = new GraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( dbDir )
                 .setConfig( GraphDatabaseSettings.pagecache_memory, "2000M" )
-                .setConfig( GraphDatabaseSettings.auth_store, temporaryFolder.newFile().getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.logical_log_rotation_threshold, "500M" )
                 .newGraphDatabase();
 

--- a/community/neo4j/src/test/java/recovery/UniquenessRecoveryTest.java
+++ b/community/neo4j/src/test/java/recovery/UniquenessRecoveryTest.java
@@ -19,11 +19,6 @@
  */
 package recovery;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -34,6 +29,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
 import org.neo4j.graphdb.ConstraintViolationException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -41,7 +41,6 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.helpers.collection.Iterables;
@@ -51,9 +50,11 @@ import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
 
 import static java.lang.Boolean.getBoolean;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeNotNull;
+
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.test.SuppressOutput.suppress;
 import static org.neo4j.test.TargetDirectory.testDirForTest;
@@ -291,10 +292,7 @@ public class UniquenessRecoveryTest
 
     private static GraphDatabaseService graphdb( File path )
     {
-        return new GraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( path )
-                .setConfig( GraphDatabaseSettings.auth_store, new File(path, "auth").getAbsolutePath() )
-                .newGraphDatabase();
+        return new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( path ).newGraphDatabase();
     }
 
     private static void flushPageCache( GraphDatabaseService db )

--- a/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
+++ b/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
@@ -19,10 +19,6 @@
  */
 package schema;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -31,6 +27,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.ConsistencyCheckService.Result;
@@ -76,8 +76,10 @@ import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.helpers.progress.ProgressMonitorFactory.NONE;
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
@@ -178,7 +180,6 @@ public class MultipleIndexPopulationStressIT
         final GraphDatabaseService db = new GraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( directory.graphDbDir() )
                 .setConfig( GraphDatabaseSettings.pagecache_memory, "8m" )
-                .setConfig( GraphDatabaseSettings.auth_store, directory.file( "auth" ).getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.multi_threaded_schema_index_population_enabled, multiThreaded + "" )
                 .newGraphDatabase();
         try
@@ -216,7 +217,6 @@ public class MultipleIndexPopulationStressIT
         GraphDatabaseService db = new GraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( directory.graphDbDir() )
                 .setConfig( GraphDatabaseSettings.pagecache_memory, "8m" )
-                .setConfig( GraphDatabaseSettings.auth_store, directory.file( "auth" ).getAbsolutePath() )
                 .newGraphDatabase();
         try ( Transaction tx = db.beginTx() )
         {

--- a/community/server/src/main/java/org/neo4j/server/CommunityBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityBootstrapper.java
@@ -19,8 +19,8 @@
  */
 package org.neo4j.server;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -44,7 +44,7 @@ public class CommunityBootstrapper extends ServerBootstrapper
     }
 
     @Override
-    protected Iterable<Class<?>> settingsClasses( HashMap<String, String> settings )
+    protected Iterable<Class<?>> settingsClasses( Map<String, String> settings )
     {
         return settingsClasses;
     }

--- a/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
@@ -21,7 +21,7 @@ package org.neo4j.server;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -138,7 +138,7 @@ public abstract class ServerBootstrapper implements Bootstrapper
     protected abstract NeoServer createNeoServer( Config config, GraphDatabaseDependencies dependencies,
                                                   LogProvider userLogProvider );
 
-    protected abstract Iterable<Class<?>> settingsClasses( HashMap<String, String> settings );
+    protected abstract Iterable<Class<?>> settingsClasses( Map<String, String> settings );
 
     private static LogProvider setupLogging()
     {

--- a/community/server/src/main/java/org/neo4j/server/ServerCommandLineArgs.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerCommandLineArgs.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.collection.Pair;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.util.Converters;
 import org.neo4j.server.configuration.ConfigLoader;
 
@@ -67,7 +66,7 @@ public class ServerCommandLineArgs
     public Optional<File> configFile()
     {
         return Optional.ofNullable( args.get( CONFIG_DIR_ARG ) )
-                .map( (dirPath) -> new File( Settings.PATH.apply( dirPath ), ConfigLoader.DEFAULT_CONFIG_FILE_NAME ) );
+                .map( (dirPath) -> new File( dirPath, ConfigLoader.DEFAULT_CONFIG_FILE_NAME ) );
     }
 
     private static Pair<String, String>[] parseConfigOverrides( Args arguments )

--- a/community/server/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
@@ -84,7 +84,7 @@ public class ConfigLoader
         config.ifPresent( ( c ) -> settings.putAll( loadFromFile( log, c ) ) );
         settings.putAll( toMap( configOverrides ) );
         overrideEmbeddedDefaults( settings );
-        settings.put( GraphDatabaseSettings.neo4j_home.name(), System.getProperty( "user.dir" ) );
+        addInternalServerSpecificSettings( settings );
         customizer.accept( settings );
         return settings;
     }
@@ -107,10 +107,13 @@ public class ConfigLoader
     {
         config.putIfAbsent( ShellSettings.remote_shell_enabled.name(), TRUE );
         config.putIfAbsent( GraphDatabaseSettings.auth_enabled.name(), "true" );
+    }
 
-        String dataDirectory = config.getOrDefault( data_directory.name(), data_directory.getDefaultValue() );
-        config.putIfAbsent( GraphDatabaseSettings.auth_store.name(),
-                new File( dataDirectory, "dbms/auth" ).toString() );
+    private static void addInternalServerSpecificSettings( Map<String, String> settings )
+    {
+        settings.put( GraphDatabaseSettings.neo4j_home.name(), System.getProperty( "user.dir" ) );
+        String dataDirectory = settings.getOrDefault( data_directory.name(), data_directory.getDefaultValue() );
+        settings.put( GraphDatabaseSettings.auth_store.name(), new File( dataDirectory, "dbms/auth" ).toString() );
     }
 
     private static Map<String, String> loadFromFile( Log log, File file )

--- a/community/server/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
@@ -103,10 +103,9 @@ public class ConfigLoader
      * TODO: This means docs will say defaults are something other than what they are in the server. Better
      * make embedded the special case and set the defaults to be what the server will have.
      */
-    private static void overrideEmbeddedDefaults( HashMap<String, String> config )
+    private static void overrideEmbeddedDefaults( Map<String, String> config )
     {
         config.putIfAbsent( ShellSettings.remote_shell_enabled.name(), TRUE );
-        config.putIfAbsent( GraphDatabaseSettings.logs_directory.name(), "logs" );
         config.putIfAbsent( GraphDatabaseSettings.auth_enabled.name(), "true" );
 
         String dataDirectory = config.getOrDefault( data_directory.name(), data_directory.getDefaultValue() );

--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -46,13 +46,13 @@ import static org.neo4j.kernel.configuration.Settings.HOSTNAME_PORT;
 import static org.neo4j.kernel.configuration.Settings.INTEGER;
 import static org.neo4j.kernel.configuration.Settings.NORMALIZED_RELATIVE_URI;
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
-import static org.neo4j.kernel.configuration.Settings.PATH;
 import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
 import static org.neo4j.kernel.configuration.Settings.max;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.options;
+import static org.neo4j.kernel.configuration.Settings.pathSetting;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 @Description("Settings used by the server configuration")
@@ -212,11 +212,11 @@ public interface ServerSettings
 
     @SuppressWarnings("unused") // used only in the startup scripts
     @Description("Path of the run directory")
-    Setting<File> run_directory = setting("dbms.directories.run", PATH, "run");
+    Setting<File> run_directory = pathSetting( "dbms.directories.run", "run" );
 
     @SuppressWarnings("unused") // used only in the startup scripts
     @Description("Path of the lib directory")
-    Setting<File> lib_directory = setting("dbms.directories.lib", PATH, "lib");
+    Setting<File> lib_directory = pathSetting( "dbms.directories.lib", "lib" );
 
     @Description("Timeout for idle transactions.")
     Setting<Long> transaction_timeout = setting( "dbms.transaction_timeout", DURATION, "60s" );

--- a/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
@@ -40,7 +40,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.auth_store;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.forced_kernel_id;
 import static org.neo4j.helpers.collection.MapUtil.store;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
@@ -82,7 +81,6 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
         // When
         int resultCode = ServerBootstrapper.start( bootstrapper,
                 "-c", configOption( data_directory, tempDir.getRoot().getAbsolutePath() ),
-                "-c", configOption( auth_store, tempDir.newFile().getAbsolutePath() ),
                 "-c", configOption( tls_certificate_file,
                         new File( tempDir.getRoot(), "cert.cert" ).getAbsolutePath() ),
                 "-c", configOption( tls_key_file, new File( tempDir.getRoot(), "key.key" ).getAbsolutePath() ),

--- a/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertThat;
 
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.forced_kernel_id;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logs_directory;
 import static org.neo4j.helpers.collection.MapUtil.store;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.server.configuration.ServerSettings.tls_certificate_file;
@@ -81,6 +82,7 @@ public abstract class BaseBootstrapperTest extends ExclusiveServerTestBase
         // When
         int resultCode = ServerBootstrapper.start( bootstrapper,
                 "-c", configOption( data_directory, tempDir.getRoot().getAbsolutePath() ),
+                "-c", configOption( logs_directory, tempDir.getRoot().getAbsolutePath() ),
                 "-c", configOption( tls_certificate_file,
                         new File( tempDir.getRoot(), "cert.cert" ).getAbsolutePath() ),
                 "-c", configOption( tls_key_file, new File( tempDir.getRoot(), "key.key" ).getAbsolutePath() ),

--- a/community/server/src/test/java/org/neo4j/server/ServerCommandLineArgsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerCommandLineArgsTest.java
@@ -46,9 +46,7 @@ public class ServerCommandLineArgsTest
     @Test
     public void shouldResolveConfigFileRelativeToWorkingDirectory() throws Exception
     {
-        Optional<File> expectedFile = Optional.of( new File(
-                new File( System.getProperty( "user.dir" ) ),
-                "some-dir/" + ConfigLoader.DEFAULT_CONFIG_FILE_NAME ) );
+        Optional<File> expectedFile = Optional.of( new File( "some-dir", ConfigLoader.DEFAULT_CONFIG_FILE_NAME ) );
         assertEquals( expectedFile, parse( "--config-dir", "some-dir" ).configFile() );
         assertEquals( expectedFile, parse( "--config-dir=some-dir" ).configFile() );
     }

--- a/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -36,6 +35,7 @@ import java.util.Random;
 
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.server.configuration.ServerSettings;
 
 public class ServerTestUtils
@@ -87,6 +87,7 @@ public class ServerTestUtils
     public static void addDefaultRelativeProperties( Map<String,String> properties, File temporaryFolder )
     {
         addRelativeProperty( temporaryFolder, properties, DatabaseManagementSystemSettings.data_directory );
+        addRelativeProperty( temporaryFolder, properties, GraphDatabaseSettings.logs_directory );
         addRelativeProperty( temporaryFolder, properties, ServerSettings.certificates_directory );
     }
 

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.server.configuration;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -43,6 +43,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.setting;
@@ -193,7 +194,7 @@ public class ConfigLoaderTest
     }
 
     @Test
-    public void shouldNotOverwriteAuthStoreLocationIfProvided() throws IOException
+    public void shouldOverwriteAuthStoreLocationIfErroneouslyProvided() throws IOException
     {
         Optional<File> configFile = ConfigFileBuilder.builder( folder.getRoot() )
                 .withSetting( DatabaseManagementSystemSettings.data_directory, "the-data-dir" )
@@ -202,7 +203,7 @@ public class ConfigLoaderTest
         Config config = configLoader.loadConfig( configFile, log );
 
         assertThat( config.get( GraphDatabaseSettings.auth_store ),
-                is( new File( "foo/bar/auth" ).getAbsoluteFile() ) );
+                is( new File( "the-data-dir/dbms/auth" ).getAbsoluteFile() ) );
     }
 
 

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -188,9 +188,7 @@ public class CommunityServerBuilder
         }
 
         properties.put( GraphDatabaseSettings.auth_enabled.name(), "false" );
-        properties.put( GraphDatabaseSettings.auth_store.name(), new File(temporaryFolder, "auth").getAbsolutePath() );
         properties.put( ServerSettings.certificates_directory.name(), new File(temporaryFolder, "certificates").getAbsolutePath() );
-        properties.put( GraphDatabaseSettings.auth_store.name(), new File(temporaryFolder, "auth").getAbsolutePath() );
         properties.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
 
         for ( Object key : arbitraryProperties.keySet() )

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -189,6 +189,7 @@ public class CommunityServerBuilder
 
         properties.put( GraphDatabaseSettings.auth_enabled.name(), "false" );
         properties.put( ServerSettings.certificates_directory.name(), new File(temporaryFolder, "certificates").getAbsolutePath() );
+        properties.put( GraphDatabaseSettings.logs_directory.name(), new File(temporaryFolder, "logs").getAbsolutePath() );
         properties.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
 
         for ( Object key : arbitraryProperties.keySet() )

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -26,6 +26,7 @@ import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.configuration.Settings;
 
+import static org.neo4j.kernel.configuration.Settings.pathSetting;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
@@ -98,7 +99,7 @@ public class MetricsSettings
     public static Setting<Boolean> csvEnabled = setting( "metrics.csv.enabled", Settings.BOOLEAN, Settings.FALSE );
     @Description( "The target location of the CSV files: a path to a directory wherein a CSV file per reported " +
                   "field  will be written." )
-    public static Setting<File> csvPath = setting( "dbms.directories.metrics", Settings.PATH, "metrics" );
+    public static Setting<File> csvPath = pathSetting( "dbms.directories.metrics", "metrics" );
 
     @Description( "The reporting interval for the CSV files. That is, how often new rows with numbers are appended to " +
                   "the CSV files." )

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/BoltMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/BoltMetricsIT.java
@@ -19,15 +19,14 @@
  */
 package org.neo4j.metrics;
 
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.util.concurrent.TimeUnit;
-
-import org.neo4j.bolt.BoltKernelExtension;
 import org.neo4j.bolt.v1.messaging.message.Messages;
 import org.neo4j.bolt.v1.transport.socket.client.Connection;
 import org.neo4j.bolt.v1.transport.socket.client.SocketConnection;
@@ -39,6 +38,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
 import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.acceptedVersions;
 import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.chunk;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
@@ -63,8 +63,6 @@ public class BoltMetricsIT
                 .newImpermanentDatabaseBuilder()
                 .setConfig( boltConnector( "0" ).enabled, "true" )
                 .setConfig( GraphDatabaseSettings.auth_enabled, "false" )
-                .setConfig( BoltKernelExtension.Settings.certificates_directory,
-                        BoltKernelExtension.Settings.certificates_directory.getDefaultValue().toString())
                 .setConfig( MetricsSettings.boltMessagesEnabled, "true" )
                 .setConfig( MetricsSettings.csvEnabled, "true" )
                 .setConfig( MetricsSettings.csvPath, metricsFolder.getAbsolutePath() )

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
@@ -73,7 +73,6 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
         final Config config = dependencies.config();
         boolean queryLogEnabled = config.get( GraphDatabaseSettings.log_queries );
         final File queryLogFile = config.get( GraphDatabaseSettings.log_queries_filename );
-        final File logsDirectory = config.get( GraphDatabaseSettings.logs_directory );
         final FileSystemAbstraction fileSystem = dependencies.fileSystem();
         final JobScheduler jobScheduler = dependencies.jobScheduler();
         final Monitors monitoring = dependencies.monitoring();

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.server.enterprise;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.helpers.collection.Iterables;
@@ -44,7 +44,7 @@ public class EnterpriseBootstrapper extends CommunityBootstrapper
     }
 
     @Override
-    protected Iterable<Class<?>> settingsClasses( HashMap<String, String> settings )
+    protected Iterable<Class<?>> settingsClasses( Map<String, String> settings )
     {
         if ( isHAMode( settings ) )
         {
@@ -58,7 +58,7 @@ public class EnterpriseBootstrapper extends CommunityBootstrapper
         }
     }
 
-    private boolean isHAMode( HashMap<String, String> settings )
+    private boolean isHAMode( Map<String, String> settings )
     {
         return new Config( settings, EnterpriseServerSettings.class ).get( mode ).equals( "HA" );
     }

--- a/enterprise/server-enterprise/src/test/java/TxBench.java
+++ b/enterprise/server-enterprise/src/test/java/TxBench.java
@@ -34,9 +34,7 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.server.configuration.ServerSettings;
 
 public class TxBench
 {
@@ -60,12 +58,7 @@ public class TxBench
         {
             FileUtils.deleteRecursively( path );
         }
-        db = new GraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( path )
-                .setConfig( GraphDatabaseSettings.auth_store, new File(path, "auth").getAbsolutePath() )
-                .setConfig( ServerSettings.tls_certificate_file, new File(path, "cert.pem").getAbsolutePath() )
-                .setConfig( ServerSettings.tls_key_file, new File(path, "key.pem").getAbsolutePath() )
-                .newGraphDatabase();
+        db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( path ).newGraphDatabase();
         try( Transaction tx = db.beginTx() )
         {
             db.execute( "CREATE INDEX ON :User(name)" );

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ArbiterBootstrapperIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ArbiterBootstrapperIT.java
@@ -44,6 +44,7 @@ import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.cluster.protocol.cluster.ClusterListener.Adapter;
 import org.neo4j.cluster.protocol.election.ServerIdElectionCredentialsProvider;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.util.Dependencies;
@@ -177,6 +178,7 @@ public class ArbiterBootstrapperIT
 
     private File writeConfig( Map<String, String> config ) throws IOException
     {
+        config.put( GraphDatabaseSettings.logs_directory.name(), directory.getPath() );
         File configFile = new File( directory, ConfigLoader.DEFAULT_CONFIG_FILE_NAME );
         store( config, configFile );
         return directory;

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ArbiterBootstrapperIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/ArbiterBootstrapperIT.java
@@ -24,9 +24,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.AccessibleObject;
 import java.net.URI;
-import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -46,7 +44,6 @@ import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterListener;
 import org.neo4j.cluster.protocol.cluster.ClusterListener.Adapter;
 import org.neo4j.cluster.protocol.election.ServerIdElectionCredentialsProvider;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.util.Dependencies;
@@ -187,9 +184,7 @@ public class ArbiterBootstrapperIT
 
     private void startAndAssertJoined( Integer expectedAssignedPort, Map<String, String> config ) throws Exception
     {
-        Map<String, String> localCopy = new HashMap<>( config );
-        localCopy.put( GraphDatabaseSettings.auth_store.name(), Files.createTempFile( "auth", "" ).toString() );
-        File configDir = writeConfig( localCopy );
+        File configDir = writeConfig( config );
         CountDownLatch latch = new CountDownLatch( 1 );
         AtomicInteger port = new AtomicInteger();
         clients[0].addClusterListener( joinAwaitingListener( latch, port ) );

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
@@ -33,10 +33,9 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logs_directory;
 import static org.neo4j.server.ServerTestUtils.getRelativePath;
 import static org.neo4j.server.configuration.ServerSettings.certificates_directory;
-import static org.neo4j.server.configuration.ServerSettings.tls_certificate_file;
-import static org.neo4j.server.configuration.ServerSettings.tls_key_file;
 import static org.neo4j.test.Assert.assertEventually;
 
 public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
@@ -69,6 +68,7 @@ public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
         int resultCode = ServerBootstrapper.start( bootstrapper,
                 "-c", configOption( EnterpriseServerSettings.mode, "SINGLE" ),
                 "-c", configOption( data_directory, getRelativePath( folder.getRoot(), data_directory ) ),
+                "-c", configOption( logs_directory, tempDir.getRoot().getAbsolutePath() ),
                 "-c", configOption( certificates_directory, getRelativePath( folder.getRoot(), certificates_directory ) ),
                 "-c", "dbms.connector.1.type=HTTP",
                 "-c", "dbms.connector.1.enabled=true" );
@@ -87,6 +87,7 @@ public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
                 "-c", configOption( ClusterSettings.server_id, "1" ),
                 "-c", configOption( ClusterSettings.initial_hosts, "127.0.0.1:5001" ),
                 "-c", configOption( data_directory, getRelativePath( folder.getRoot(), data_directory ) ),
+                "-c", configOption( logs_directory, tempDir.getRoot().getAbsolutePath() ),
                 "-c", configOption( certificates_directory, getRelativePath( folder.getRoot(), certificates_directory ) ),
                 "-c", "dbms.connector.1.type=HTTP",
                 "-c", "dbms.connector.1.enabled=true" );

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/jmx/ServerManagementTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/jmx/ServerManagementTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.NullLog;
@@ -40,6 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.helpers.collection.Pair.pair;
 
 public class ServerManagementTest
 {
@@ -63,7 +65,9 @@ public class ServerManagementTest
                         .server()
                         .withDefaultDatabaseTuning()
                         .usingDataDir( dataDirectory1 )
-                        .createConfigFiles(), NullLog.getInstance() );
+                        .createConfigFiles(), NullLog.getInstance(),
+                pair( GraphDatabaseSettings.logs_directory.name(), baseDir.directory( "logs" ).getPath() )
+                );
 
         // When
         NeoServer server = cleanup.add( new EnterpriseNeoServer( config, graphDbDependencies(), NullLogProvider

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -176,6 +176,7 @@ public class StoreUpgradeIntegrationTest
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
             builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             builder.setConfig( GraphDatabaseFacadeFactory.Configuration.record_format, HighLimit.NAME );
+            builder.setConfig( GraphDatabaseSettings.logs_directory, testDir.directory( "logs" ).getAbsolutePath() );
             GraphDatabaseService db = builder.newGraphDatabase();
             try
             {
@@ -203,6 +204,7 @@ public class StoreUpgradeIntegrationTest
             Properties props = new Properties();
             props.putAll( ServerTestUtils.getDefaultRelativeProperties() );
             props.setProperty( DatabaseManagementSystemSettings.data_directory.name(), rootDir.getAbsolutePath() );
+            props.setProperty( GraphDatabaseSettings.logs_directory.name(), rootDir.getAbsolutePath() );
             props.setProperty( GraphDatabaseSettings.allow_store_upgrade.name(), "true" );
             props.setProperty( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
             props.setProperty( GraphDatabaseFacadeFactory.Configuration.record_format.name(), HighLimit.NAME );
@@ -238,6 +240,7 @@ public class StoreUpgradeIntegrationTest
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
             builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             builder.setConfig( GraphDatabaseFacadeFactory.Configuration.record_format, HighLimit.NAME );
+            builder.setConfig( GraphDatabaseSettings.logs_directory, testDir.directory( "logs" ).getAbsolutePath() );
             GraphDatabaseService db = builder.newGraphDatabase();
             try
             {

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
@@ -34,9 +34,7 @@ import org.neo4j.server.configuration.ConfigLoader;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.configuration.ServerSettings.HttpConnector;
 
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
 import static org.neo4j.helpers.collection.Pair.pair;
-import static org.neo4j.server.configuration.ServerSettings.certificates_directory;
 
 public class DesktopConfigurator
 {
@@ -58,8 +56,6 @@ public class DesktopConfigurator
                 Optional.of( installation.getConfigurationsFile() ),
                 FormattedLog.toOutputStream( System.out ),
                 (settings) -> settings.put( GraphDatabaseSettings.neo4j_home.name(), dbDir.getAbsolutePath() ),
-                pair( data_directory.name(), new File( dbDir, "./data" ).getAbsolutePath() ),
-                pair( certificates_directory.name(), new File( dbDir, "./certificates" ).getAbsolutePath() ),
                 pair( DatabaseManagementSystemSettings.database_path.name(), dbDir.getAbsolutePath() ) );
     }
 

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DesktopConfigurator.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.desktop.config.Installation;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.FormattedLog;
@@ -34,8 +35,8 @@ import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.configuration.ServerSettings.HttpConnector;
 
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
-import static org.neo4j.server.configuration.ServerSettings.certificates_directory;
 import static org.neo4j.helpers.collection.Pair.pair;
+import static org.neo4j.server.configuration.ServerSettings.certificates_directory;
 
 public class DesktopConfigurator
 {
@@ -56,8 +57,7 @@ public class DesktopConfigurator
         config = new ConfigLoader( CommunityBootstrapper.settingsClasses).loadConfig(
                 Optional.of( installation.getConfigurationsFile() ),
                 FormattedLog.toOutputStream( System.out ),
-
-                /** Desktop-specific config overrides */
+                (settings) -> settings.put( GraphDatabaseSettings.neo4j_home.name(), dbDir.getAbsolutePath() ),
                 pair( data_directory.name(), new File( dbDir, "./data" ).getAbsolutePath() ),
                 pair( certificates_directory.name(), new File( dbDir, "./certificates" ).getAbsolutePath() ),
                 pair( DatabaseManagementSystemSettings.database_path.name(), dbDir.getAbsolutePath() ) );

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.conf
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.conf
@@ -2,6 +2,11 @@
 # Server configuration
 #***************************************************************
 
+# This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or uncomment it to
+# allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`
+# section of the manual for details.
+dbms.directories.import=import
+
 # Require (or disable the requirement of) auth to access Neo4j
 dbms.security.auth_enabled=true
 

--- a/packaging/neo4j-desktop/src/test/java/org/neo4j/desktop/runtime/DatabaseActionsTest.java
+++ b/packaging/neo4j-desktop/src/test/java/org/neo4j/desktop/runtime/DatabaseActionsTest.java
@@ -47,7 +47,7 @@ public class DatabaseActionsTest
     private File configFile;
 
     @Test
-    public void shouldCreateMessagesLogInWorkingDirectory() throws Exception
+    public void shouldCreateMessagesLogBelowStoreDir() throws Exception
     {
         // Given
         Installation installation = mock( Installation.class );
@@ -63,7 +63,7 @@ public class DatabaseActionsTest
             databaseActions.start();
 
             // Then
-            File logFile = new File( new File( System.getProperty("user.dir"), "logs" ), "debug.log" );
+            File logFile = new File( new File( storeDir, "logs" ), "debug.log" );
             assertTrue( logFile.exists() );
         }
         finally

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -6,9 +6,10 @@
 #dbms.directories.data=data
 #dbms.directories.plugins=plugins
 
-# Uncomment this line to resolve import files relative to a directory. See the
-# `LOAD CSV` section of the manual for details.
-#dbms.directories.import=import
+# This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or uncomment it to
+# allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`
+# section of the manual for details.
+dbms.directories.import=import
 
 # The name of the database to mount
 #dbms.active_database=graph.db

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -6,9 +6,10 @@
 #dbms.directories.data=data
 #dbms.directories.plugins=plugins
 
-# Uncomment this line to resolve import files relative to a directory. See the
-# `LOAD CSV` section of the manual for details.
-#dbms.directories.import=import
+# This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or uncomment it to
+# allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`
+# section of the manual for details.
+dbms.directories.import=import
 
 # The name of the database to mount
 #dbms.active_database=graph.db


### PR DESCRIPTION
Previously we resolved relative to the working directory which made it
hard to manipulate this in tests and may have been unexpected for
embedded users. Now we use a specific location, provided by the internal
unsupported.dbms.directories.neo4j_home setting.

neo4j_home is set to the working directory for server, but the database
directory when running embedded or in the desktop application.
