### PR TITLE
Remove leader wait timeout.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
@@ -81,10 +81,6 @@ public class CoreEdgeClusterSettings
     public static final Setting<Long> leader_election_timeout =
             setting( "core_edge.leader_election_timeout", DURATION, "500ms" );
 
-    @Description("Leader wait timeout")
-    public static final Setting<Long> leader_wait_timeout =
-            setting( "core_edge.leader_wait_timeout", DURATION, "30s" );
-
     @Description("The maximum batch size when catching up (in unit of entries)")
     public static final Setting<Integer> catchup_batch_size =
             setting( "core_edge.catchup_batch_size", INTEGER, "64" );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -632,8 +632,6 @@ public class EnterpriseCoreEditionModule
         long electionTimeout = config.get( CoreEdgeClusterSettings.leader_election_timeout );
         long heartbeatInterval = electionTimeout / 3;
 
-        long leaderWaitTimeout = config.get( CoreEdgeClusterSettings.leader_wait_timeout );
-
         Integer expectedClusterSize = config.get( CoreEdgeClusterSettings.expected_core_cluster_size );
 
         CoreMemberSetBuilder memberSetBuilder = new CoreMemberSetBuilder();
@@ -653,7 +651,7 @@ public class EnterpriseCoreEditionModule
         RaftInstance<CoreMember> raftInstance = new RaftInstance<>(
                 myself, termState, voteState, raftLog, raftStateMachine, electionTimeout, heartbeatInterval,
                 raftTimeoutService, loggingRaftInbound,
-                new RaftOutbound( outbound ), leaderWaitTimeout, logProvider,
+                new RaftOutbound( outbound ), logProvider,
                 raftMembershipManager, logShipping, databaseHealthSupplier, monitors );
 
         life.add( new RaftDiscoveryServiceConnector( discoveryService, raftInstance ) );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
@@ -90,7 +90,7 @@ public class RaftInstanceBuilder<MEMBER>
                 clock, member, membershipManager, retryTimeMillis, catchupBatchSize, maxAllowedShippingLag );
 
         return new RaftInstance<>( member, termState, voteState, raftLog, raftStateMachine, electionTimeout,
-                heartbeatInterval, renewableTimeoutService, inbound, outbound, leaderWaitTimeout, logProvider,
+                heartbeatInterval, renewableTimeoutService, inbound, outbound, logProvider,
                 membershipManager, logShipping, databaseHealthSupplier, monitors );
     }
 


### PR DESCRIPTION
It is no longer necessary since the RaftReplicator hides everything leader
from clients and listens to leader switching events.

This was also causing issues since the RaftReplicator was blocking
during startup and timing out on getLeader().
