### PR TITLE
Increase timeout for test

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
@@ -151,7 +151,7 @@ public class TransactionRepresentationCommitProcessIT
         neoStores.close();
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 15000)
     public void commitDuringContinuousCheckpointing() throws Exception
     {
         // prepare


### PR DESCRIPTION
Test takes 2.9 seconds on my local machine, but consistently runs for
about exactly 5.0 seconds on TeamCity with IBM JDK8. 15s seems like a
reasonable limit.

Graph of some test runs on TC with IBM JDK8 (no wonder the test times out)
![selection_024](https://cloud.githubusercontent.com/assets/223655/14283874/42df7a7c-fb45-11e5-90c3-0379dcf1356d.png)
:
