### PR TITLE
Perform MergeNodeAcceptance through TCK

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
@@ -25,6 +25,7 @@ import org.neo4j.kernel.api.exceptions.schema.UniquePropertyConstraintViolationK
 
 class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
+  // TCK'd
   test("merge node when no nodes exist") {
     // When
     val result = updateWithBothPlannersAndCompatibilityMode("merge (a) return count(*) as n")
@@ -36,6 +37,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1)
   }
 
+  // TCK'd
   test("merge node with label") {
     // When
     val result = updateWithBothPlannersAndCompatibilityMode("merge (a:Label) return labels(a)")
@@ -44,6 +46,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 1)
   }
 
+  // TCK'd
   test("merge node with label add label on create") {
     // When
     val result = updateWithBothPlannersAndCompatibilityMode("merge (a:Label) on create set a:Foo return labels(a)")
@@ -54,6 +57,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 2)
   }
 
+  // TCK'd
   test("merge node with label add property on update") {
     // When
     val result = updateWithBothPlannersAndCompatibilityMode("merge (a:Label) on create set a.prop = 42 return a.prop")
@@ -62,6 +66,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
   }
 
+  // TCK'd
   test("merge node with label when it exists") {
     // Given
     val existingNode = createLabeledNode("Label")
@@ -76,6 +81,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 0)
   }
 
+  // TCK'd
   test("merge node with property when it exists") {
     // Given
     createNode("prop" -> 42)
@@ -88,6 +94,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 0)
   }
 
+  // TCK'd
   test("merge node should create when it doesn't match") {
     // Given
     createNode("prop" -> 42)
@@ -100,6 +107,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
   }
 
+  // TCK'd
   test("merge node with prop and label") {
     // Given
     createLabeledNode(Map("prop" -> 42), "Label")
@@ -112,6 +120,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 0)
   }
 
+  // TCK'd
   test("merge node with prop and label and unique index") {
     // Given
     graph.createConstraint("Label", "prop")
@@ -124,6 +133,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 0)
   }
 
+  // TCK'd
   test("merge node with prop and label and unique index when no match") {
     // Given
     graph.createConstraint("Label", "prop")
@@ -137,6 +147,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
   }
 
+  // TODO: Reflect something like this in the TCK
   test("multiple merges after each other") {
     1 to 100 foreach { prop =>
       val result = updateWithBothPlannersAndCompatibilityMode(s"merge (a:Label {prop: $prop}) return a.prop")
@@ -144,7 +155,8 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     }
   }
 
-  test("merge node with label add label on create when it exists") {
+  // TCK'd
+  test("merge node with label add label on match when it exists") {
     // Given
     createLabeledNode("Label")
 
@@ -156,6 +168,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 0, labelsAdded = 1)
   }
 
+  // TCK'd
   test("merge node with label add property on update when it exists") {
     // Given
     createLabeledNode("Label")
@@ -168,6 +181,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 0)
   }
 
+  // TCK'd
   test("merge node and set property on match") {
     // Given
     createLabeledNode("Label")
@@ -180,18 +194,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, propertiesWritten = 1)
   }
 
-  test("merge node should match properties given ad map") {
-    // Given
-    createLabeledNode(Map("prop" -> 42), "Label")
-
-    // When
-    val result = updateWithBothPlannersAndCompatibilityMode("merge (a:Label {prop:42}) return a.prop")
-
-    // Then
-    assertStats(result, nodesCreated = 0)
-    result.columnAs[Int]("a.prop").toList should equal(List(42))
-  }
-
+  // TCK'd
   test("merge node should create a node with given properties when no match is found") {
     // Given - a node that does not match
     val other = createLabeledNode(Map("prop" -> 666), "Label")
@@ -205,7 +208,8 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     props should equal(List(42))
   }
 
-  test("merge_using_unique_constraint_should_update_existing_node") {
+  // TCK'd
+  test("merge using unique constraint should update existing node") {
     // given
     graph.createConstraint("Person", "id")
     val node = createLabeledNode("Person")
@@ -216,7 +220,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     // when
     val result =
-      executeScalar[Node]("merge (a:Person {id: 23, country: 'Sweden'}) on match set a.name='Emil' return a")
+      executeScalarWithAllPlannersAndCompatibilityMode[Node]("merge (a:Person {id: 23, country: 'Sweden'}) on match set a.name='Emil' return a")
 
     // then
     countNodes() should equal(1)
@@ -227,13 +231,14 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     }
   }
 
-  test("merge_using_unique_constraint_should_create_missing_node") {
+  // TCK'd
+  test("merge using unique constraint should create missing node") {
     // given
     graph.createConstraint("Person", "id")
 
     // when
     val result =
-      executeScalar[Node]("merge (a:Person {id: 23, country: 'Sweden'}) on create set a.name='Emil' return a")
+      executeScalarWithAllPlannersAndCompatibilityMode[Node]("merge (a:Person {id: 23, country: 'Sweden'}) on create set a.name='Emil' return a")
 
     // then
     countNodes() should equal(1)
@@ -244,7 +249,8 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     }
   }
 
-  test("should_match_on_merge_using_multiple_unique_indexes_if_only_found_single_node_for_both_indexes") {
+  // TCK'd
+  test("should match on merge using multiple unique indexes if only found single node for both indexes") {
     // given
     graph.createConstraint("Person", "id")
     graph.createConstraint("Person", "mail")
@@ -253,7 +259,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     // when
     val result =
-      executeScalar[Node]("merge (a:Person {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
+      executeScalarWithAllPlannersAndCompatibilityMode[Node]("merge (a:Person {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
 
     // then
     countNodes() should equal(1)
@@ -264,7 +270,8 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     }
   }
 
-  test("should_match_on_merge_using_multiple_unique_indexes_and_labels_if_only_found_single_node_for_both_indexes") {
+  // TCK'd
+  test("should match on merge using multiple unique indexes and labels if only found single node for both indexes") {
     // given
     graph.createConstraint("Person", "id")
     graph.createConstraint("User", "mail")
@@ -273,7 +280,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     // when
     val result =
-      executeScalar[Node]("merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
+      executeScalarWithAllPlannersAndCompatibilityMode[Node]("merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
 
     // then
     countNodes() should equal(1)
@@ -284,7 +291,8 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     }
   }
 
-  test("should_match_on_merge_using_multiple_unique_indexes_using_same_key_if_only_found_single_node_for_both_indexes") {
+  // TCK'd
+  test("should match on merge using multiple unique indexes using same key if only found single node for both indexes") {
     // given
     graph.createConstraint("Person", "id")
     graph.createConstraint("User", "id")
@@ -293,7 +301,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     // when
     val result =
-      executeScalar[Node]("merge (a:Person:User {id: 23}) on match set a.country='Sweden' return a")
+      executeScalarWithAllPlannersAndCompatibilityMode[Node]("merge (a:Person:User {id: 23}) on match set a.country='Sweden' return a")
 
     // then
     countNodes() should equal(1)
@@ -303,6 +311,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     }
   }
 
+  // TCK'd
   test("should fail on merge using multiple unique indexes using same key if found different nodes") {
     // given
     graph.createConstraint("Person", "id")
@@ -312,18 +321,21 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     createLabeledNode(Map("id" -> 23), "User")
 
     // when + then
-    intercept[MergeConstraintConflictException](executeWithCostPlannerOnly("merge (a:Person:User {id: 23}) return a.id"))
+    a [MergeConstraintConflictException] should be thrownBy {
+      updateWithBothPlannersAndCompatibilityMode("merge (a:Person:User {id: 23}) return a.id")
+    }
     countNodes() should equal(2)
   }
 
-  test("should_create_on_merge_using_multiple_unique_indexes_if_found_no_nodes") {
+  // TCK'd
+  test("should create on merge using multiple unique indexes if found no nodes") {
     // given
     graph.createConstraint("Person", "id")
     graph.createConstraint("Person", "mail")
 
     // when
     val result =
-      executeScalar[Node]("merge (a:Person {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a")
+      executeScalarWithAllPlannersAndCompatibilityMode[Node]("merge (a:Person {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a")
 
     // then
     countNodes() should equal(1)
@@ -335,14 +347,15 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     }
   }
 
-  test("should_create_on_merge_using_multiple_unique_indexes_and_labels_if_found_no_nodes") {
+  // TCK'd
+  test("should create on merge using multiple unique indexes and labels if found no nodes") {
     // given
     graph.createConstraint("Person", "id")
     graph.createConstraint("User", "mail")
 
     // when
     val result =
-      executeScalar[Node]("merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a")
+      executeScalarWithAllPlannersAndCompatibilityMode[Node]("merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a")
 
     // then
     countNodes() should equal(1)
@@ -354,6 +367,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     }
   }
 
+  // TCK'd
   test("should fail on merge using multiple unique indexes if found different nodes") {
     // given
     graph.createConstraint("Person", "id")
@@ -362,13 +376,14 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     createLabeledNode(Map("id" -> 23), "Person")
     createLabeledNode(Map("mail" -> "emil@neo.com"), "Person")
 
-    val error = intercept[MergeConstraintConflictException](executeWithCostPlannerOnly("merge (a:Person {id: 23, mail: 'emil@neo.com'}) return a"))
+    val error = intercept[MergeConstraintConflictException](updateWithBothPlannersAndCompatibilityMode("merge (a:Person {id: 23, mail: 'emil@neo.com'}) return a"))
 
-    error.getMessage contains "Merge did not find a matching node and can not create a new node due to conflicts with existing unique nodes. The conflicting constraints are on: :Person.id and :Person.mail"
+    error.getMessage should include("Merge did not find a matching node and can not create a new node due to conflicts with existing unique nodes. The conflicting constraints are on: :Person.id and :Person.mail")
 
     countNodes() should equal(2)
   }
 
+//   TCK'd
   test("should fail on merge using multiple unique indexes if it found a node matching single property only") {
     // given
     graph.createConstraint("Person", "id")
@@ -377,14 +392,14 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     createLabeledNode(Map("id" -> 23), "Person")
 
     // when + then
-    val error = intercept[MergeConstraintConflictException](executeWithCostPlannerOnly("merge (a:Person {id: 23, mail: 'emil@neo.com'}) return a"))
+    val error = intercept[MergeConstraintConflictException](updateWithBothPlannersAndCompatibilityMode("merge (a:Person {id: 23, mail: 'emil@neo.com'}) return a"))
 
-    error.getMessage contains "Merge did not find a matching node and can not create a new node due to conflicts with both existing and missing unique nodes. The conflicting constraints are on: :Person.id and :Person.mail"
+    error.getMessage should include("Merge did not find a matching node and can not create a new node due to conflicts with both existing and missing unique nodes. The conflicting constraints are on: :Person.id and :Person.mail")
 
     countNodes() should equal(1)
   }
 
-  //TODO rule planner fails on this
+  // TCK'd
   test("should fail on merge using multiple unique indexes if it found a node matching single property only flipped order") {
     // given
     graph.createConstraint("Person", "id")
@@ -392,14 +407,16 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
 
     createLabeledNode(Map("mail" -> "emil@neo.com"), "Person")
 
+    // Rule planner in 2.3 has a bug that makes it throw an incorrect exception for this case, so no compatibilityMode here
     // when + then
-    val error = intercept[MergeConstraintConflictException](executeWithCostPlannerOnly("merge (a:Person {id: 23, mail: 'emil@neo.com'}) return a"))
+    val error = intercept[MergeConstraintConflictException](updateWithBothPlanners("merge (a:Person {id: 23, mail: 'emil@neo.com'}) return a"))
 
-    error.getMessage contains "Merge did not find a matching node and can not create a new node due to conflicts with both existing and missing unique nodes. The conflicting constraints are on: :Person.id and :Person.mail"
+    error.getMessage should include("Merge did not find a matching node and can not create a new node due to conflicts with both existing and missing unique nodes. The conflicting constraints are on: :Person.id and :Person.mail")
 
     countNodes() should equal(1)
   }
 
+  // TCK'd
   test("should fail on merge using multiple unique indexes and labels if found different nodes") {
     // given
     graph.createConstraint("Person", "id")
@@ -409,24 +426,26 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     createLabeledNode(Map("mail" -> "emil@neo.com"), "User")
 
     // when
-    val error = intercept[MergeConstraintConflictException](executeWithCostPlannerOnly("merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) return a"))
+    val error = intercept[MergeConstraintConflictException](updateWithBothPlannersAndCompatibilityMode("merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) return a"))
 
-    error.getMessage contains "Merge did not find a matching node and can not create a new node due to conflicts with existing unique nodes. The conflicting constraints are on: :Person.id and :User.mail"
+    error.getMessage should include("Merge did not find a matching node and can not create a new node due to conflicts with existing unique nodes. The conflicting constraints are on: :Person.id and :User.mail")
 
     // then
     countNodes() should equal(2)
   }
 
-  test("should_handle_running_merge_inside_a_foreach_loop") {
+  // TCK'd
+  test("should handle running merge inside a foreach loop") {
     // given an empty database
 
     // when
-    val result = updateWithBothPlanners("foreach(x in [1,2,3] | merge ({property: x}))")
+    val result = updateWithBothPlannersAndCompatibilityMode("foreach(x in [1,2,3] | merge ({property: x}))")
 
     // then
     assertStats(result, nodesCreated = 3, propertiesWritten = 3)
   }
 
+  // TCK'd
   test("unrelated nodes with same property should not clash") {
     // given
     graph.createConstraint("Person", "id")
@@ -438,6 +457,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     // then does not throw
   }
 
+  // TCK'd
   test("works fine with index") {
     // given
     updateWithBothPlannersAndCompatibilityMode("create index on :Person(name)")
@@ -449,6 +469,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
   }
 
+  // TCK'd
   test("works with index and constraint") {
     // given
     updateWithBothPlannersAndCompatibilityMode("create index on :Person(name)")
@@ -461,6 +482,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 2)
   }
 
+  // TCK'd
   test("works with indexed and unindexed property") {
     // given
     updateWithBothPlannersAndCompatibilityMode("create index on :Person(name)")
@@ -472,6 +494,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 2)
   }
 
+  // TCK'd
   test("works with two indexed properties") {
     // given
     updateWithBothPlannersAndCompatibilityMode("create index on :Person(name)")
@@ -484,6 +507,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 2)
   }
 
+  // TCK'd
   test("works with property repeated in literal map in set") {
     // given
     graph.createConstraint("Person","ssn")
@@ -496,6 +520,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 3)
   }
 
+  // TCK'd
   test("works with property in map that gets set") {
     // given
     graph.createConstraint("Person","ssn")
@@ -509,10 +534,12 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 3)
   }
 
+  // TCK'd
   test("should work when finding multiple elements") {
     assertStats(updateWithBothPlannersAndCompatibilityMode( "CREATE (:X) CREATE (:X) MERGE (:X)"), nodesCreated = 2, labelsAdded = 2)
   }
 
+  // TCK'd
   test("merge should handle argument properly") {
     createNode("x" -> 42)
     createNode("x" -> "not42")
@@ -524,7 +551,8 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
   }
 
-  ignore("merge should handle arguments properly with only write clauses") {
+  // TCK'd
+  test("merge should handle arguments properly with only write clauses") {
     val query = "CREATE (a {p: 1}) MERGE (b {v: a.p})"
 
     val result = updateWithBothPlannersAndCompatibilityMode(query)
@@ -532,6 +560,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 2, propertiesWritten = 2)
   }
 
+  // TCK'd
   test("should be able to merge using property from match") {
     createLabeledNode(Map("name" -> "A", "bornIn" -> "New York"), "Person")
     createLabeledNode(Map("name" -> "B", "bornIn" -> "Ohio"), "Person")
@@ -547,6 +576,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 3, propertiesWritten = 3, labelsAdded = 3)
   }
 
+  // TCK'd
   test("should be able to merge using property from match with index") {
     graph.createIndex("City", "name")
 
@@ -564,6 +594,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 3, propertiesWritten = 3, labelsAdded = 3)
   }
 
+  // TCK'd
   test("should be able to use properties from match in ON CREATE") {
     createLabeledNode(Map("bornIn" -> "New York"), "Person")
     createLabeledNode(Map("bornIn" -> "Ohio"), "Person")
@@ -575,6 +606,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
   }
 
+  // TCK'd
   test("should be able to use properties from match in ON MATCH") {
     createLabeledNode(Map("bornIn" -> "New York"), "Person")
     createLabeledNode(Map("bornIn" -> "Ohio"), "Person")
@@ -585,6 +617,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
   }
 
+  // TCK'd
   test("should be able to use properties from match in ON MATCH and ON CREATE") {
     createLabeledNode(Map("bornIn" -> "New York"), "Person")
     createLabeledNode(Map("bornIn" -> "Ohio"), "Person")
@@ -596,6 +629,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     executeWithAllPlannersAndCompatibilityMode("MATCH (n:City) WHERE NOT exists(n.name) RETURN n").toList shouldBe empty
   }
 
+  // TCK'd
   test("should be able to set labels on match") {
     createNode()
 
@@ -605,6 +639,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, labelsAdded = 1)
   }
 
+  // TCK'd
   test("should be able to set labels on match and on create") {
     createNode()
     createNode()
@@ -618,32 +653,39 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     executeScalarWithAllPlannersAndCompatibilityMode[Int]("MATCH (a:M2) RETURN count(a)") should equal(1)
   }
 
-
+  // TCK'd
   test("should support updates while merging") {
-    (0 to 2) foreach(x =>
-      (0 to 2) foreach( y=>
+    (0 until 3) foreach(x =>
+      (0 until 3) foreach( y=>
         createNode("x"->x, "y"->y)
         ))
 
     // when
-    updateWithBothPlannersAndCompatibilityMode(
+    val result = updateWithBothPlannersAndCompatibilityMode(
       "MATCH (foo) WITH foo.x AS x, foo.y AS y " +
         "MERGE (c:N {x: x, y: y+1}) " +
         "MERGE (a:N {x: x, y: y}) " +
         "MERGE (b:N {x: x+1, y: y})  " +
-        "RETURN x, y;").toList
+        "RETURN x, y;")
+
+    assertStats(result, nodesCreated = 15, labelsAdded = 15, propertiesWritten = 30)
+    result.toList should equal(List(Map("x" -> 0, "y" -> 0), Map("x" -> 0, "y" -> 1),
+                                    Map("x" -> 0, "y" -> 2), Map("x" -> 1, "y" -> 0),
+                                    Map("x" -> 1, "y" -> 1), Map("x" -> 1, "y" -> 2),
+                                    Map("x" -> 2, "y" -> 0), Map("x" -> 2, "y" -> 1),
+                                    Map("x" -> 2, "y" -> 2)))
   }
 
-
-
-  test("merge_inside_foreach_should_see_variables_introduced_by_update_actions_outside_foreach") {
+  // TCK'd
+  test("merge inside foreach should see variables introduced by update actions outside foreach") {
     // when
-    val result = updateWithBothPlanners("CREATE (a {name: 'Start'}) FOREACH(x in [1,2,3] | MERGE (a)-[:X]->({id: x})) RETURN a.name")
+    val result = updateWithBothPlannersAndCompatibilityMode("CREATE (a {name: 'Start'}) FOREACH(x in [1,2,3] | MERGE (a)-[:X]->({id: x})) RETURN a.name")
 
     // then
     assertStats(result, nodesCreated = 4, relationshipsCreated = 3, propertiesWritten = 4)
   }
 
+  // TCK'd
   test("merge must properly handle multiple labels") {
     createLabeledNode(Map("prop" -> 42), "L", "A")
 
@@ -653,6 +695,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     result.toList should equal(List(Map("labels" -> List("L", "B"))))
   }
 
+  // TCK'd
   test("merge with an index must properly handle multiple labels") {
     graph.createIndex("L", "prop")
     createLabeledNode(Map("prop" -> 42), "L", "A")
@@ -663,6 +706,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     result.toList should equal(List(Map("labels" -> List("L", "B"))))
   }
 
+  // TODO half done - discussing in dragons channel
   test("merge with uniqueness constraints must properly handle multiple labels") {
     graph.createConstraint("L", "prop")
     val node = createLabeledNode(Map("prop" -> 42), "L", "A")
@@ -673,6 +717,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     result.getMessage should equal(s"""Node ${node.getId} already exists with label L and property "prop"=[42]""")
   }
 
+  // TCK'd
   test("merge followed by multiple creates") {
     val query =
       """MERGE (t:T {id:42})
@@ -685,6 +730,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     assertStats(result, nodesCreated = 2, labelsAdded = 2, relationshipsCreated = 1, propertiesWritten = 1)
   }
 
+  // TCK'd
   test("unwind combined with merge") {
     val query = "UNWIND [1,2,3,4] AS int MERGE (n {id: int}) RETURN count(*)"
     val result = updateWithBothPlannersAndCompatibilityMode(query)
@@ -693,6 +739,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     result.toList should equal(List(Map("count(*)" -> 4)))
   }
 
+  // TCK'd
   test("merges should not be able to match on deleted nodes") {
     // GIVEN
     val node1 = createLabeledNode(Map("value" -> 1), "A")
@@ -709,7 +756,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val result = updateWithBothPlannersAndCompatibilityMode(query)
 
     // THEN
-    result.toList should not contain Map("a2" -> node1)
-    result.toList should not contain Map("a2" -> node2)
+    result.toList should equal(List(Map("a2.value" -> null), Map("a2.value" -> null)))
+    assertStats(result, nodesCreated = 1, nodesDeleted = 2, labelsAdded = 1)
   }
 }

--- a/community/cypher/compatibility-suite/pom.xml
+++ b/community/cypher/compatibility-suite/pom.xml
@@ -50,6 +50,20 @@
     <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>neo4j-releases-repository</id>
+      <name>Neo4j Maven 2 releases repository</name>
+      <url>http://m2.neo4j.org/content/repositories/releases/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+  </repositories>
+
   <build>
     <plugins>
       <plugin>
@@ -75,20 +89,7 @@
     <dependency>
       <groupId>org.opencypher</groupId>
       <artifactId>tck</artifactId>
-      <version>1.0-SNAPSHOT</version>
-    </dependency>
-
-    <!-- cucumber -->
-
-    <dependency>
-      <groupId>info.cukes</groupId>
-      <artifactId>cucumber-scala_2.11</artifactId>
-      <version>1.2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>info.cukes</groupId>
-      <artifactId>cucumber-junit</artifactId>
-      <version>1.2.4</version>
+      <version>1.2016-04-05</version>
     </dependency>
 
     <!-- JSON -->
@@ -188,9 +189,8 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-io</artifactId>
-      <version>${project.version}</version>
       <type>test-jar</type>
-      <scope>compile</scope>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/community/cypher/compatibility-suite/src/main/scala/cypher/feature/reporting/CypherResultReporter.scala
+++ b/community/cypher/compatibility-suite/src/main/scala/cypher/feature/reporting/CypherResultReporter.scala
@@ -47,7 +47,8 @@ class CypherResultReporter(producer: OutputProducer, jsonWriter: PrintStream, ch
 
   private var query: String = null
   private var status: String = Result.PASSED
-  private val queryPattern: Regex = TCKStepDefinitions.EXECUTING_QUERY.r
+  private val shortQuery: Regex = TCKStepDefinitions.EXECUTING_QUERY.r
+  private val docStringQuery: Regex = TCKStepDefinitions.EXECUTING_LONG_QUERY.r
 
   override def done(): Unit = {
     jsonWriter.println(producer.dump())
@@ -63,7 +64,8 @@ class CypherResultReporter(producer: OutputProducer, jsonWriter: PrintStream, ch
   override def step(step: Step) {
     if (step.getKeyword.trim == "When") {
       step.getName match {
-        case queryPattern(q) => query = q
+        case shortQuery(q) => query = q
+        case docStringQuery() => query = step.getDocString.getValue
       }
     }
   }

--- a/community/cypher/compatibility-suite/src/main/scala/cypher/feature/reporting/OutputProducer.scala
+++ b/community/cypher/compatibility-suite/src/main/scala/cypher/feature/reporting/OutputProducer.scala
@@ -58,7 +58,7 @@ class JsonProducer(tagger: QueryTagger[String]) extends OutputProducer {
         }
     }
     val withZeros = QueryTags.all.foldLeft(tagCounts) {
-      case (map, tag) => if (map.contains(tag.name)) map else map + ((tag.name, 0))
+      case (map, tag) => if (map.contains(tag.toString)) map else map + ((tag.toString, 0))
     }
 
     sortByValue(withZeros).asJava

--- a/community/cypher/compatibility-suite/src/test/java/cypher/FeatureSuiteTest.java
+++ b/community/cypher/compatibility-suite/src/test/java/cypher/FeatureSuiteTest.java
@@ -36,7 +36,8 @@ public class FeatureSuiteTest
                     "cypher.cucumber.db.DatabaseConfigProvider:/cypher/db/config/rule.json"
             },
             glue = { "classpath:cypher/feature/steps" },
-            features = { "target/features" }
+            features = { "target/features" },
+            strict = true
     )
     public static class RuleInterpreted
     {
@@ -52,7 +53,8 @@ public class FeatureSuiteTest
                     "cypher.cucumber.db.DatabaseConfigProvider:/cypher/db/config/cost-interpreted.json",
             },
             glue = { "classpath:cypher/feature/steps" },
-            features = { "target/features" }
+            features = { "target/features" },
+            strict = true
     )
     public static class CostInterpreted
     {

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/QueryTagger.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/QueryTagger.scala
@@ -161,6 +161,8 @@ case object DeleteTag extends QueryTag("delete")
 case object SetTag extends QueryTag("set")
 case object RemoveTag extends QueryTag("remove")
 case object MergeTag extends QueryTag("merge")
+case object OnMatchTag extends QueryTag("on-match")
+case object OnCreateTag extends QueryTag("on-create")
 case object CreateUniqueTag extends QueryTag("create-unique")
 case object ForeachTag extends QueryTag("foreach")
 
@@ -231,7 +233,10 @@ object QueryTagger extends QueryTagger[String] {
           case u: Delete => Set(DeleteTag)
           case u: SetClause => Set(SetTag)
           case u: Remove => Set(RemoveTag)
-          case u: Merge => Set(MergeTag)
+          case u: Merge => Set(MergeTag) ++ u.actions.map {
+            case _: OnCreate => OnCreateTag
+            case _: OnMatch => OnMatchTag
+          }
           case u: CreateUnique => Set(CreateUniqueTag)
           case u: Foreach => Set(ForeachTag)
           case _ => Set.empty[QueryTag]

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/MergeNodeAction.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/MergeNodeAction.scala
@@ -128,10 +128,10 @@ case class MergeNodeAction(variable: String,
             if (firstId != otherId) {
               throw new MergeConstraintConflictException(s"Merge did not find a matching node and can not create a new node due to conflicts with existing unique nodes. The conflicting constraints are on: $firstProducer and $producer")
             }
-          case None =>
-            if (first.isDefined) {
-              throw new MergeConstraintConflictException(s"Merge did not find a matching node and can not create a new node due to conflicts with both existing and missing unique nodes. The conflicting constraints are on: $firstProducer and $producer")
-            }
+          case Some(other) if first.isEmpty =>
+            throw new MergeConstraintConflictException(s"Merge did not find a matching node and can not create a new node due to conflicts with both existing and missing unique nodes. The conflicting constraints are on: $firstProducer and $producer")
+          case None if first.isDefined =>
+            throw new MergeConstraintConflictException(s"Merge did not find a matching node and can not create a new node due to conflicts with both existing and missing unique nodes. The conflicting constraints are on: $firstProducer and $producer")
           case _ =>
         }
       }

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/QueryTaggerTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/QueryTaggerTest.scala
@@ -157,6 +157,16 @@ class QueryTaggerTest extends CypherFunSuite {
     QueryTagger("MERGE ()-[r:T]->()") should contain(MergeTag)
   }
 
+  test(queryTag(OnMatchTag)) {
+    QueryTagger("MERGE (n) ON MATCH SET n:Foo") should contain(OnMatchTag)
+    QueryTagger("MERGE ()-[r:T]->() ON MATCH SET r.prop = 0") should contain(OnMatchTag)
+  }
+
+  test(queryTag(OnCreateTag)) {
+    QueryTagger("MERGE (n) ON CREATE SET n:Foo") should contain(OnCreateTag)
+    QueryTagger("MERGE ()-[r:T]->() ON CREATE SET r.prop = 0") should contain(OnCreateTag)
+  }
+
   test(queryTag(CreateUniqueTag)) {
     QueryTagger("CREATE UNIQUE ()") should contain(CreateUniqueTag)
     QueryTagger("CREATE UNIQUE ()-[r:T]->()") should contain(CreateUniqueTag)


### PR DESCRIPTION
Fixes a rule planner inconsistency, where it would not throw the same exception depending on which constraint was violated by a `MERGE` creation.
Also removes the snapshot dependency on `openCypher`.
