### PR TITLE
Make constraint violations uniform to the TCK

### DIFF
--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
@@ -129,22 +129,21 @@ class CypherTCKSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
   }
 
   private def checkError(result: Try[Result], status: String, phase: String, detail: String): Unit = {
+    val statusType = if (status == "ConstraintValidationFailed") "Schema" else "Statement"
     result match {
       case Failure(e: QueryExecutionException) =>
-        s"Neo.ClientError.Statement.$status" should equal(e.getStatusCode)
+        s"Neo.ClientError.$statusType.$status" should equal(e.getStatusCode)
 
-        if (e.getMessage.matches("Expected .+ to be a java.lang.String, but it was a .+")) {
+        if (e.getMessage.matches("Expected .+ to be a java.lang.String, but it was a .+"))
           detail should equal("MapElementAccessByNonString")
-        }
-        else if (e.getMessage.matches("Expected .+ to be a java.lang.Number, but it was a .+")) {
+        else if (e.getMessage.matches("Expected .+ to be a java.lang.Number, but it was a .+"))
           detail should equal("ListElementAccessByNonInteger")
-        }
-        else if (e.getMessage.matches(".+ is not a collection or a map. Element access is only possible by performing a collection lookup using an integer index, or by performing a map lookup using a string key .+")) {
+        else if (e.getMessage.matches(".+ is not a collection or a map. Element access is only possible by performing a collection lookup using an integer index, or by performing a map lookup using a string key .+"))
           detail should equal("InvalidElementAccess")
-        }
-        else if (e.getMessage.matches(".+ can not create a new node due to conflicts with( both)? existing( and missing)? unique nodes.*")) {
+        else if (e.getMessage.matches(".+ can not create a new node due to conflicts with( both)? existing( and missing)? unique nodes.*"))
           detail should equal("CreateBlockedByConstraint")
-        }
+        else if (e.getMessage.matches("Node [0-9]+ already exists with label .+ and property \".+\"=\\[.+\\]"))
+          detail should equal("CreateBlockedByConstraint")
         else fail(s"Unknown runtime error: $e")
 
       case Failure(e) =>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -122,7 +122,7 @@ class InvalidSemanticsException(message: String, cause: Throwable) extends Cyphe
 }
 
 class MergeConstraintConflictException(message: String, cause: Throwable) extends CypherException(message, cause) {
-  val status = Status.Statement.ConstraintVerificationFailed
+  val status = Status.Schema.ConstraintValidationFailed
   def this(message: String) = this(message, null)
 }
 


### PR DESCRIPTION
We handle constraint violations differently depending on whether only a
single constraint, or multiple constraints, are being violated. In the
case of multiple constraints, Cypher throws exception, effectively
enforcing the constraints on the transaction state. In the case of a
single constraint, Cypher relies on the kernel to throw exception.

This commit makes sure that both types of violations get the same
`Status`, while still having different exceptions and messages. Fixing
the latter is simple in the rule planner, but harder in the cost
planner, thus deferred.
