### PR TITLE
Fix variable exposure through multiple projections

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/PlannerQueryBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/PlannerQueryBuilder.scala
@@ -36,7 +36,11 @@ case class PlannerQueryBuilder(private val q: PlannerQuery, semanticTable: Seman
     copy(q = q.updateTailOrSelf(_.withHorizon(horizon)))
 
   def withTail(newTail: PlannerQuery): PlannerQueryBuilder = {
-    copy(q = q.updateTailOrSelf(_.withTail(newTail)))
+    copy(q = q.updateTailOrSelf(_.withTail(newTail.amendQueryGraph(_.addArgumentIds(currentlyExposedSymbols.toSeq)))))
+  }
+
+  private def currentlyExposedSymbols: Set[IdName] = {
+    q.lastQueryHorizon.exposedSymbols(q.lastQueryGraph)
   }
 
   def currentlyAvailableVariables: Set[IdName] = {


### PR DESCRIPTION
Variables introduced before multiple projections in update queries would
not be exposed after the projections that introduced empty query graph tails.
This would cause bugs with e.g. `CREATE` creating nodes that were already bound.

The fix is to add all currently available variables as arguments to the
new empty query graph when adding a new tail to the PlannerQueryBuilder.
