### PR TITLE
Optimize query planning of "many merges" query

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/PlannerQueryBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/plannerQuery/PlannerQueryBuilder.scala
@@ -57,7 +57,7 @@ case class PlannerQueryBuilder(private val q: PlannerQuery, semanticTable: Seman
     val previousPatternNodes = if (allPlannerQueries.length > 1) {
       val current = allPlannerQueries(allPlannerQueries.length - 2)
       val projectedNodes = current.horizon.exposedSymbols(current.queryGraph).collect {
-        case id@IdName(n) if semanticTable.contains(n) && semanticTable.isNode(n) => id
+        case id@IdName(n) if semanticTable.containsNode(n) => id
       }
       projectedNodes ++ current.queryGraph.allPatternNodes
     } else Set.empty

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/PlannerQuery.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/PlannerQuery.scala
@@ -46,16 +46,6 @@ case class RegularPlannerQuery(queryGraph: QueryGraph = QueryGraph.empty,
     RegularPlannerQuery(queryGraph, horizon, tail)
 }
 
-case class MergePlannerQuery(queryGraph: QueryGraph = QueryGraph.empty,
-                             horizon: QueryHorizon = QueryProjection.empty,
-                             tail: Option[PlannerQuery] = None) extends PlannerQuery {
-  // This is here to stop usage of copy from the outside
-  override protected def copy(queryGraph: QueryGraph = queryGraph,
-                              horizon: QueryHorizon = horizon,
-                              tail: Option[PlannerQuery] = tail) =
-    MergePlannerQuery(queryGraph, horizon, tail)
-}
-
 sealed trait PlannerQuery {
   val queryGraph: QueryGraph
   val horizon: QueryHorizon
@@ -198,13 +188,6 @@ object PlannerQuery {
     val patternRelIds = patternRels.flatMap(_.coveredIds)
     patternNodeIds ++ patternRelIds
   }
-
-  def asMergePlannerQuery(plannerQuery: PlannerQuery) = plannerQuery match {
-    case RegularPlannerQuery(queryGraph, horizon, tail) =>
-      MergePlannerQuery(queryGraph, horizon, tail)
-    case _: MergePlannerQuery =>
-      plannerQuery
-  }
 }
 
 trait CardinalityEstimation {
@@ -218,11 +201,6 @@ object CardinalityEstimation {
   def lift(plannerQuery: PlannerQuery, cardinality: Cardinality) = plannerQuery match {
     case _: RegularPlannerQuery =>
       new RegularPlannerQuery(plannerQuery.queryGraph, plannerQuery.horizon, plannerQuery.tail)
-        with CardinalityEstimation {
-        val estimatedCardinality = cardinality
-      }
-    case _: MergePlannerQuery =>
-      new MergePlannerQuery(plannerQuery.queryGraph, plannerQuery.horizon, plannerQuery.tail)
         with CardinalityEstimation {
         val estimatedCardinality = cardinality
       }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/StatisticsBackedCardinalityModel.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/StatisticsBackedCardinalityModel.scala
@@ -37,9 +37,6 @@ class StatisticsBackedCardinalityModel(queryGraphCardinalityModel: QueryGraphCar
 
         val horizonCardinality = calculateCardinalityForQueryHorizon(graphCardinality, horizon)
         QueryGraphSolverInput(newLabels, horizonCardinality, lazyness)
-
-      case (input, MergePlannerQuery(graph, horizon, _)) =>
-        throw new IllegalStateException("MergePlannerQuery should not exist")
     }
     output.inboundCardinality
   }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/Apply.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/Apply.scala
@@ -27,5 +27,5 @@ case class Apply(left: LogicalPlan, right: LogicalPlan)(val solved: PlannerQuery
   val lhs = Some(left)
   val rhs = Some(right)
 
-  def availableSymbols = left.availableSymbols ++ right.availableSymbols
+  lazy val availableSymbols = left.availableSymbols ++ right.availableSymbols
 }

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/SemanticTable.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/SemanticTable.scala
@@ -52,8 +52,8 @@ class SemanticTable(
       throw new InternalException(s"Did not find any type information for variable $s", e)
   }
 
-  def contains(expr: String): Boolean = types.exists {
-    case (Variable(name), _) => name == expr
+  def containsNode(expr: String): Boolean = types.exists {
+    case (v@Variable(name), _) => name == expr && isNode(v) // NOTE: Profiling showed that checking node type last is better
     case _ => false
   }
 


### PR DESCRIPTION
 E.g. Pokec WQ6 has many many merges. Each merge introduces a new PlannerQuery tail,
 so the chain of planner queries is very long, affecting cost planner performance.
 Based on some profiling of the following smaller optimizations are made:
- Cache availableSymbols of the Apply logical plan
- PlannerQueryBuilder allSeenPatternNodes directly checks SemanticTable containsNode
  
  Also removed dead code: MergePlannerQuery
