### PR TITLE
Fix incorrect counts for relationships with direction BOTH

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -276,4 +276,15 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
     executeWithAllPlanners("unwind range(1000000,2000000) as i with i limit 3000 return sum(i)").toList should equal(
       List(Map("sum(i)" -> 3004498500L)))
   }
+
+  test("should count correctly in case of loops") {
+    val node = createNode()
+    relate(node, node)
+
+    val list = executeWithAllPlanners("MATCH ()-[r]-() RETURN id(r) as r").columnAs[Long]("r").toList
+    val result = executeWithAllPlanners("MATCH ()-[r]-() RETURN count(r) as c").columnAs[Long]("c").next()
+
+    list should equal(Seq(0))
+    result should equal(1)
+  }
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
@@ -262,7 +262,7 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest extends ExecutionEngineF
 
   test("counts relationships with type, any direction and labeled source node without using count store") {
     // Given
-    withRelationshipsModel(
+    withRelationshipsModel(expectedLogicalPlan = "AllNodesScan",
 
       // When
       query = "MATCH (:User)-[r:KNOWS]-() RETURN count(r)", f = { result =>
@@ -275,7 +275,7 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest extends ExecutionEngineF
 
   test("counts relationships with type, any direction and labeled destination node without using count store") {
     // Given
-    withRelationshipsModel(
+    withRelationshipsModel(expectedLogicalPlan = "NodeByLabelScan",
 
       // When
       query = "MATCH ()-[r:KNOWS]-(:User) RETURN count(r)", f = { result =>
@@ -288,7 +288,7 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest extends ExecutionEngineF
 
   test("counts relationships with type, any direction and no labeled nodes without using count store") {
     // Given
-    withRelationshipsModel(
+    withRelationshipsModel(expectedLogicalPlan = "AllNodesScan",
 
       // When
       query = "MATCH ()-[r:KNOWS]-() RETURN count(r)", f = { result =>
@@ -701,5 +701,4 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest extends ExecutionEngineF
     private def matchResultMsg(negated: Boolean, result: InternalPlanDescription) =
       s"$operationName ${if (negated) "" else "not"} found in plan description\n $result"
   }
-
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/InternalPlanDescription.scala
@@ -115,8 +115,7 @@ object InternalPlanDescription {
                                 direction: SemanticDirection, varLength: Boolean = false) extends Argument
     case class CountNodesExpression(ident: String, label: Option[LazyLabel]) extends Argument
     case class CountRelationshipsExpression(ident: String, startLabel: Option[LazyLabel],
-                                            typeNames: LazyTypes, endLabel: Option[LazyLabel],
-                                            bothDirections: Boolean) extends Argument
+                                            typeNames: LazyTypes, endLabel: Option[LazyLabel]) extends Argument
     case class SourceCode(className: String, sourceCode: String) extends Argument {
       override def name = className
     }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -65,12 +65,11 @@ object PlanDescriptionArgumentSerializer {
       case CountNodesExpression(ident, label) =>
         val node = label.map(l => ":" + l.name).mkString
         s"count( ($node) )" + (if (ident.startsWith(" ")) "" else s" AS $ident")
-      case CountRelationshipsExpression(ident, startLabel, LazyTypes(typeNames), endLabel, bothDirections) =>
+      case CountRelationshipsExpression(ident, startLabel, LazyTypes(typeNames), endLabel) =>
         val start = startLabel.map(l => ":" + l.name).mkString
         val end = endLabel.map(l => ":" + l.name).mkString
         val types = typeNames.mkString(":", "|:", "")
-        val dirArrow = if (bothDirections) "" else ">"
-        s"count( ($start)-[$types]-$dirArrow($end) )" + (if (ident.unnamed) "" else s" AS $ident")
+        s"count( ($start)-[$types]->($end) )" + (if (ident.unnamed) "" else s" AS $ident")
       case Signature(procedureName, args, results) =>
         val argString = args.mkString(", ")
         val resultString = results.map { case (name, typ) => s"$name :: $typ" }.mkString(", ")

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -178,8 +178,8 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
     case NodeCountFromCountStore(IdName(id), label, _) =>
       NodeCountFromCountStorePipe(id, label.map(LazyLabel.apply))()
 
-    case RelationshipCountFromCountStore(IdName(id), startLabel, typeNames, endLabel, bothDirections, _) =>
-      RelationshipCountFromCountStorePipe(id, startLabel.map(LazyLabel.apply), typeNames, endLabel.map(LazyLabel.apply), bothDirections)()
+    case RelationshipCountFromCountStore(IdName(id), startLabel, typeNames, endLabel, _) =>
+      RelationshipCountFromCountStorePipe(id, startLabel.map(LazyLabel.apply), typeNames, endLabel.map(LazyLabel.apply))()
 
     case NodeByLabelScan(IdName(id), label, _) =>
       NodeByLabelScanPipe(id, LazyLabel(label))()

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/RelationshipCountFromCountStore.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/plans/RelationshipCountFromCountStore.scala
@@ -24,9 +24,8 @@ import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, P
 import org.neo4j.cypher.internal.frontend.v3_0.ast.LabelName
 
 case class RelationshipCountFromCountStore(idName: IdName, startLabel: Option[LabelName],
-                                           typeNames: LazyTypes, endLabel: Option[LabelName], bothDirections: Boolean,
-                                           argumentIds: Set[IdName])
-                                            (val solved: PlannerQuery with CardinalityEstimation)
+                                           typeNames: LazyTypes, endLabel: Option[LabelName], argumentIds: Set[IdName])
+                                          (val solved: PlannerQuery with CardinalityEstimation)
   extends LogicalLeafPlan {
 
   def availableSymbols = Set(idName)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/LogicalPlanProducer.scala
@@ -397,11 +397,10 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends Colle
   }
 
   def planCountStoreRelationshipAggregation(query: PlannerQuery, idName: IdName, startLabel: Option[LabelName],
-                                            typeNames: LazyTypes, endLabel: Option[LabelName], bothDirections: Boolean,
-                                            argumentIds: Set[IdName])
+                                            typeNames: LazyTypes, endLabel: Option[LabelName], argumentIds: Set[IdName])
                                            (implicit context: LogicalPlanningContext) = {
     val solved: PlannerQuery = RegularPlannerQuery(query.queryGraph, query.horizon)
-    RelationshipCountFromCountStore(idName, startLabel, typeNames, endLabel, bothDirections, argumentIds)(solved)
+    RelationshipCountFromCountStore(idName, startLabel, typeNames, endLabel, argumentIds)(solved)
   }
 
   def planSkip(inner: LogicalPlan, count: Expression)(implicit context: LogicalPlanningContext) = {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlanner.scala
@@ -103,14 +103,12 @@ case object countStorePlanner {
       case PatternRelationship(relId, (startNodeId, endNodeId), direction, types, SimplePatternLength)
         if variableName.forall(_ == relId.name) && noWrongPredicates(Set(startNodeId, endNodeId), selections) =>
 
-        def planRelAggr(fromLabel: Option[LabelName], toLabel: Option[LabelName], bothDirections: Boolean = false) =
-          Some(context.logicalPlanProducer.planCountStoreRelationshipAggregation(query, IdName(columnName), fromLabel, LazyTypes(types.map(_.name)), toLabel, bothDirections, argumentIds)(context))
+        def planRelAggr(fromLabel: Option[LabelName], toLabel: Option[LabelName]) =
+          Some(context.logicalPlanProducer.planCountStoreRelationshipAggregation(query, IdName(columnName), fromLabel, LazyTypes(types.map(_.name)), toLabel, argumentIds)(context))
 
         (findLabel(startNodeId, selections), direction, findLabel(endNodeId, selections)) match {
-          case (None,       BOTH,     None) => planRelAggr(None, None, bothDirections = true)
-          case (None,       BOTH,     endLabel) => planRelAggr(endLabel, None, bothDirections = true)
-          case (startLabel, BOTH,     None) => planRelAggr(None, startLabel, bothDirections = true)
-          case (None,       _,        None) => planRelAggr(None, None)
+          case (None,       OUTGOING, None) => planRelAggr(None, None)
+          case (None,       INCOMING, None) => planRelAggr(None, None)
           case (None,       OUTGOING, endLabel) => planRelAggr(None, endLabel)
           case (startLabel, OUTGOING, None) => planRelAggr(startLabel, None)
           case (None,       INCOMING, endLabel) => planRelAggr(endLabel, None)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/RelationshipCountFromCountStorePipeTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/RelationshipCountFromCountStorePipeTest.scala
@@ -31,7 +31,7 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
   implicit val monitor = mock[PipeMonitor]
 
   test("should return a count for relationships without a type or any labels") {
-    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes.empty, None, bothDirections = false)()
+    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes.empty, None)()
 
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].relationshipCountByCountStore(WILDCARD, WILDCARD, WILDCARD)).thenReturn(42L).getMock[QueryContext]
@@ -43,7 +43,7 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
     implicit val table = new SemanticTable()
     table.resolvedRelTypeNames.put("X", RelTypeId(22))
 
-    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Seq(RelTypeName("X")(pos))), None, bothDirections = false)()
+    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Seq(RelTypeName("X")(pos))), None)()
 
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].relationshipCountByCountStore(WILDCARD, 22, WILDCARD)).thenReturn(42L).getMock[QueryContext]
@@ -56,7 +56,7 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
     table.resolvedRelTypeNames.put("X", RelTypeId(22))
     table.resolvedLabelIds.put("A", LabelId(12))
 
-    val pipe = RelationshipCountFromCountStorePipe("count(r)", Some(LazyLabel(LabelName("A") _)), LazyTypes(Seq(RelTypeName("X")(pos))), None, bothDirections = false)()
+    val pipe = RelationshipCountFromCountStorePipe("count(r)", Some(LazyLabel(LabelName("A") _)), LazyTypes(Seq(RelTypeName("X")(pos))), None)()
 
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].relationshipCountByCountStore(12, 22, WILDCARD)).thenReturn(42L).getMock[QueryContext]
@@ -64,25 +64,10 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
     pipe.createResults(queryState).map(_("count(r)")).toSet should equal(Set(42L))
   }
 
-  test("should return a count for relationships with a type and start label and un-directed relationship") {
-    implicit val table = new SemanticTable()
-    table.resolvedRelTypeNames.put("X", RelTypeId(22))
-    table.resolvedLabelIds.put("A", LabelId(12))
-
-    val pipe = RelationshipCountFromCountStorePipe("count(r)", Some(LazyLabel(LabelName("A") _)), LazyTypes(Seq(RelTypeName("X")(pos))), None, bothDirections = true)()
-
-    val mockedContext: QueryContext = mock[QueryContext]
-    when(mockedContext.relationshipCountByCountStore(12, 22, WILDCARD)).thenReturn(42L)
-    when(mockedContext.relationshipCountByCountStore(WILDCARD, 22, 12)).thenReturn(38L)
-    val queryState = QueryStateHelper.emptyWith(query = mockedContext)
-
-    pipe.createResults(queryState).map(_("count(r)")).toSet should equal(Set(80L))
-  }
-
   test("should return zero if rel-type is missing") {
     implicit val table = new SemanticTable()
 
-    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Seq("X")), Some(LazyLabel(LabelName("A") _)), bothDirections = false)()
+    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Seq("X")), Some(LazyLabel(LabelName("A") _)))()
 
     val mockedContext: QueryContext = mock[QueryContext]
     // try to guarantee that the mock won't be the reason for the exception

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/countStorePlannerTest.scala
@@ -85,7 +85,7 @@ class countStorePlannerTest extends CypherFunSuite with LogicalPlanningTestSuppo
   test("should plan a count for rel count with no direction") {
     val plannerQuery = producePlannerQuery("MATCH ()-[r]-()", "r")
 
-    countStorePlanner(plannerQuery) should beCountPlanFor("r")
+    countStorePlanner(plannerQuery) should notBeCountPlan
   }
 
   test("should plan a count for rel count with no type") {
@@ -115,7 +115,7 @@ class countStorePlannerTest extends CypherFunSuite with LogicalPlanningTestSuppo
   test("should not plan a count for rel count with type but no direction") {
     val plannerQuery = producePlannerQuery("MATCH ()-[r:X]-()", "r")
 
-    countStorePlanner(plannerQuery) should beCountPlanFor("r")
+    countStorePlanner(plannerQuery) should notBeCountPlan
   }
 
   test("should plan a count for rel count with rel type") {
@@ -160,7 +160,7 @@ class countStorePlannerTest extends CypherFunSuite with LogicalPlanningTestSuppo
           plan match {
             case Some(NodeCountFromCountStore(IdName(countId), _, _)) if countId == s"count($variable)" =>
               true
-            case Some(RelationshipCountFromCountStore(IdName(countId), _, _, _, _, _)) if countId == s"count($variable)" =>
+            case Some(RelationshipCountFromCountStore(IdName(countId), _, _, _, _)) if countId == s"count($variable)" =>
               true
             case _ =>
               false


### PR DESCRIPTION
The previous counts store based implementation was simply summing the
count for outgoing relationships with the count for incoming
relationships.  This is not correct since we count twice all the
relationships that same node as source and target. This commit will
remove the counts store shortcuts for such cases.  We could
reintroduce the counts store based implementation when we'll start
counting loop relationships on nodes as well.
