### PR TITLE
Removing Base64 encoding for stack traces.

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporter.java
@@ -24,11 +24,9 @@ import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.Log;
 
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * Report received exceptions into the appropriate log (console or debug) and format exception stack traces in debug.log
- * humanely.
+ * Report received exceptions into the appropriate log (console or debug) and delivery stacktraces to debug.log.
  */
 class ErrorReporter
 {
@@ -57,21 +55,14 @@ class ErrorReporter
                     error.cause().getMessage() ) );
         }
 
-        if(somethingToLog(error))
+        if ( somethingToLog( error ) )
         {
-            debugLog.error( formatFixedWidth( error.cause() ) );
+            debugLog.error( Exceptions.stringify( error.cause() ) );
         }
     }
 
     private boolean somethingToLog( Neo4jError error )
     {
         return error != null && error.cause() != null;
-    }
-
-    private String formatFixedWidth( Throwable cause )
-    {
-        // replaceAll call inserts a line break every 100 characters
-        return new String( Exceptions.stringify( cause ).getBytes( UTF_8 ) )
-                .replaceAll( "(.{100})", "$1" + System.lineSeparator() );
     }
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/StandardStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/StandardStateMachineSPI.java
@@ -59,7 +59,7 @@ class StandardStateMachineSPI implements SessionStateMachine.SPI
         this.statementRunner = statementRunner;
         this.txBridge = txBridge;
         this.featureUsage = usageData.get( UsageDataKeys.features );
-        this.errorReporter = new ErrorReporter( logging, this.usageData );
+        this.errorReporter = new ErrorReporter( logging );
         this.log = logging.getInternalLog( SessionStateMachine.class );
         this.authentication = authentication;
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
@@ -99,7 +99,7 @@ public class ErrorReporterTest
     }
 
     @Test
-    public void shouldNotReportStackOverflowErrorsInUserLogButShouldInInternalLog()
+    public void shouldReportStackOverflowErrorsInInternalLog()
     {
         // Given
         AssertableLogProvider provider = new AssertableLogProvider();

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
@@ -19,28 +19,46 @@
  */
 package org.neo4j.bolt.v1.runtime.internal;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import org.neo4j.kernel.api.exceptions.Status;
-import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.AssertableLogProvider;
-import org.neo4j.udc.UsageData;
+import org.neo4j.logging.Log;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.contains;
 import static org.mockito.Mockito.mock;
-import static org.neo4j.logging.AssertableLogProvider.inLog;
+import static org.mockito.Mockito.verify;
 
 public class ErrorReporterTest
 {
     @Test
-    public void shouldReportUnknownErrors()
+    public void shouldLogFullMessageInDebugLogAndHelpfulPointerInUserLog() throws Exception
+    {
+        // given
+        Log userLog = mock( Log.class );
+        Log internalLog = mock( Log.class );
+        ErrorReporter reporter = new ErrorReporter( userLog, internalLog );
+
+        Throwable cause = new Throwable( "Hello World" );
+        Neo4jError error = Neo4jError.from( cause );
+
+        // when
+        reporter.report( error );
+
+        // then
+        verify( userLog ).error( "Client triggered an unexpected error: Hello World. See debug.log for more details." );
+        verify( internalLog ).error( contains( "java.lang.Throwable: Hello World" ) );
+    }
+
+    @Test
+    public void shouldReportUnknownErrorsInUserLog()
     {
         // Given
         AssertableLogProvider provider = new AssertableLogProvider();
         ErrorReporter reporter =
-                new ErrorReporter( provider.getLog( "userlog" ), new UsageData( mock( JobScheduler.class ) ) );
+                new ErrorReporter( provider.getLog( "userLog" ), provider.getLog( "internalLog" ) );
 
         Throwable cause = new Throwable( "This is not an error we know how to handle." );
         Neo4jError error = Neo4jError.from( cause );
@@ -50,21 +68,16 @@ public class ErrorReporterTest
 
         // Then
         assertThat( error.status(), equalTo( (Status) Status.General.UnknownError ) );
-        provider.assertExactly(
-                inLog( "userlog" )
-                        .error( CoreMatchers.both( CoreMatchers.containsString( "START OF REPORT" ) )
-                                .and( CoreMatchers.containsString( "END OF REPORT" ) ) ) );
-        provider.assertExactly(
-                inLog( "userlog" ).error( CoreMatchers.containsString( error.reference().toString() ) ) );
+        provider.assertContainsMessageContaining( error.cause().getMessage() );
     }
 
     @Test
-    public void shouldNotReportOOMErrors()
+    public void shouldNotReportOOMErrorsInUserLog()
     {
         // Given
         AssertableLogProvider provider = new AssertableLogProvider();
         ErrorReporter reporter =
-                new ErrorReporter( provider.getLog( "userlog" ), new UsageData( mock( JobScheduler.class ) ) );
+                new ErrorReporter( provider.getLog( "userLog" ), provider.getLog( "internalLog" ) );
 
         Throwable cause = new OutOfMemoryError( "memory is fading" );
         Neo4jError error = Neo4jError.from( cause );
@@ -75,20 +88,23 @@ public class ErrorReporterTest
         // Then
         assertThat( error.status(), equalTo( (Status) Status.General.OutOfMemoryError ) );
         assertThat( error.message(),
-                equalTo(  "There is not enough memory to perform the current task. Please try increasing " +
-                          "'dbms.memory.heap.max_size' in the process wrapper configuration (normally in 'conf/neo4j-wrapper" +
-                          ".conf' or, if you are using Neo4j Desktop, found through the user interface) or if you are running an embedded " +
-                          "installation increase the heap by using '-Xmx' command line flag, and then restart the database." ) );
-        provider.assertNoLoggingOccurred();
+                equalTo( "There is not enough memory to perform the current task. Please try increasing " +
+                        "'dbms.memory.heap.max_size' in the process wrapper configuration (normally in " +
+                        "'conf/neo4j-wrapper" +
+                        ".conf' or, if you are using Neo4j Desktop, found through the user interface) or if you are " +
+                        "running an embedded " +
+                        "installation increase the heap by using '-Xmx' command line flag, and then restart the " +
+                        "database." ) );
+        provider.assertContainsMessageContaining( cause.getClass().getName() );
     }
 
     @Test
-    public void shouldNotReportStackOverflowErrors()
+    public void shouldNotReportStackOverflowErrorsInUserLogButShouldInInternalLog()
     {
         // Given
         AssertableLogProvider provider = new AssertableLogProvider();
         ErrorReporter reporter =
-                new ErrorReporter( provider.getLog( "userlog" ), new UsageData( mock( JobScheduler.class ) ) );
+                new ErrorReporter( provider.getLog( "userLog" ), provider.getLog( "internalLog" ) );
 
         Throwable cause = new StackOverflowError( "some rewriter is probably not tail recursive" );
         Neo4jError error = Neo4jError.from( cause );
@@ -100,11 +116,13 @@ public class ErrorReporterTest
         assertThat( error.status(), equalTo( (Status) Status.General.StackOverFlowError ) );
         assertThat( error.message(), equalTo(
                 "There is not enough stack size to perform the current task. This is generally considered to be a " +
-                "database error, so please contact Neo4j support. You could try increasing the stack size: " +
-                "for example to set the stack size to 2M, add `dbms.jvm.additional=-Xss2M' to " +
-                "in the process wrapper configuration (normally in 'conf/neo4j-wrapper.conf' or, if you are using " +
-                "Neo4j Desktop, found through the user interface) or if you are running an embedded installation " +
-                "just add -Xss2M as command line flag." ) );
-        provider.assertNoLoggingOccurred();
+                        "database error, so please contact Neo4j support. You could try increasing the stack size: " +
+                        "for example to set the stack size to 2M, add `dbms.jvm.additional=-Xss2M' to " +
+                        "in the process wrapper configuration (normally in 'conf/neo4j-wrapper.conf' or, if you are " +
+                        "using " +
+                        "Neo4j Desktop, found through the user interface) or if you are running an embedded " +
+                        "installation " +
+                        "just add -Xss2M as command line flag." ) );
+        provider.assertContainsMessageContaining( cause.getClass().getName() );
     }
 }


### PR DESCRIPTION
Publishable errors now have a short description entry in the user log, and
a full entry including stacktrace in the internal log.

 Non-publishable errors go directly to the internal log.
