### PR TITLE
Fix computing effects in DeleteEntityAction

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/DeleteEntityAction.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/mutation/DeleteEntityAction.scala
@@ -70,6 +70,7 @@ case class DeleteEntityAction(elementToDelete: Expression)
       case _: RelationshipType => Effects(DeletesRelationship, WritesRelationships, WritesAnyRelationshipProperty)
       case _: PathType         => Effects(DeletesRelationship, WritesRelationships, WritesAnyRelationshipProperty,
                                           DeletesNode, WritesNodes, WritesAnyLabel, WritesAnyNodeProperty)
+      case _                   => Effects((AllWriteEffects | Effects(DeletesNode, DeletesRelationship)).effectsSet)
     }
     case _ => Effects((AllWriteEffects | Effects(DeletesNode, DeletesRelationship)).effectsSet)
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ForeachAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ForeachAcceptanceTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher
 
-class ForeachAcceptanceTest extends ExecutionEngineFunSuite {
+class ForeachAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport {
 
   test("nested foreach") {
     // given
@@ -70,5 +70,23 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite {
     result.head.get("e.foo") should equal(Some("e_bar"))
     result.head.get("i.foo") should equal(Some("i_bar"))
     result.head.get("p.foo") should equal(Some("p_bar"))
+  }
+
+
+  test("Foreach and delete should work together without breaking on unknown identifier types") {
+    // given
+    val node = createLabeledNode("Label")
+    relate(node, createNode())
+
+    val query =
+      """MATCH (n: Label)
+        |OPTIONAL MATCH (n)-[rel]->()
+        |FOREACH (r IN CASE WHEN rel IS NOT NULL THEN [rel] ELSE [] END | DELETE r )""".stripMargin
+
+    // when
+    val result = execute(query)
+
+    // then
+    assertStats(result, relationshipsDeleted = 1)
   }
 }


### PR DESCRIPTION
The code was assuming wrongly that the type of the entity to be delete
was always known at compilation time. Of course this is not true in
some cases. So the fix simply conservatly assume the worst case
scenario when typing info are not available at compilation time.
