### PR TITLE
Make sure reserved ID is skipped in batch importer

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ReadNodeRecordsStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ReadNodeRecordsStepTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReadNodeRecordsStepTest
+{
+    @Test
+    public void reservedIdIsSkipped()
+    {
+        long highId = 5;
+        int batchSize = (int) highId;
+        NodeStore store = StoreWithReservedId.newNodeStoreMock( highId );
+        when( store.getHighId() ).thenReturn( highId );
+
+        ReadNodeRecordsStep step = new ReadNodeRecordsStep( mock( StageControl.class ), Configuration.DEFAULT, store );
+
+        Object batch = step.nextBatchOrNull( 0, batchSize );
+
+        assertNotNull( batch );
+
+        NodeRecord[] records = (NodeRecord[]) batch;
+        boolean hasRecordWithReservedId = Stream.of( records ).anyMatch( recordWithReservedId() );
+        assertFalse( "Batch contains record with reserved id " + Arrays.toString( records ), hasRecordWithReservedId );
+    }
+
+    private static Predicate<NodeRecord> recordWithReservedId()
+    {
+        return record -> record.getId() == IdGeneratorImpl.INTEGER_MINUS_ONE;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ReadRelationshipRecordsBackwardsStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ReadRelationshipRecordsBackwardsStepTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.neo4j.kernel.impl.store.RelationshipStore;
+import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReadRelationshipRecordsBackwardsStepTest
+{
+    @Test
+    public void reservedIdIsSkipped()
+    {
+        long highId = 5;
+        int batchSize = (int) highId;
+        RelationshipStore store = StoreWithReservedId.newRelationshipStoreMock( highId );
+        when( store.getHighId() ).thenReturn( highId );
+
+        ReadRelationshipRecordsBackwardsStep step = new ReadRelationshipRecordsBackwardsStep(
+                mock( StageControl.class ), Configuration.DEFAULT, store );
+
+        Object batch = step.nextBatchOrNull( 0, batchSize );
+
+        assertNotNull( batch );
+
+        RelationshipRecord[] records = (RelationshipRecord[]) batch;
+        boolean hasRecordWithReservedId = Stream.of( records ).anyMatch( recordWithReservedId() );
+        assertFalse( "Batch contains record with reserved id " + Arrays.toString( records ), hasRecordWithReservedId );
+    }
+
+    private static Predicate<RelationshipRecord> recordWithReservedId()
+    {
+        return record -> record.getId() == IdGeneratorImpl.INTEGER_MINUS_ONE;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStageTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.junit.Test;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.impl.store.RelationshipStore;
+import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitors;
+import org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class RelationshipLinkbackStageTest
+{
+    @Test
+    public void reservedIdIsSkipped() throws Exception
+    {
+        long highId = 5;
+        RelationshipStore store = StoreWithReservedId.newRelationshipStoreMock( highId );
+        RelationshipLinkbackStage stage = new RelationshipLinkbackStage( Configuration.DEFAULT, store, newCache() );
+
+        ExecutionSupervisors.superviseExecution( ExecutionMonitors.invisible(), Configuration.DEFAULT, stage );
+
+        verify( store, never() ).updateRecord( new RelationshipRecord( IdGeneratorImpl.INTEGER_MINUS_ONE ) );
+    }
+
+    private static NodeRelationshipCache newCache()
+    {
+        int denseNodeThreshold = Integer.parseInt( GraphDatabaseSettings.dense_node_threshold.getDefaultValue() );
+        return new NodeRelationshipCache( NumberArrayFactory.HEAP, denseNodeThreshold );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/StoreWithReservedId.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/StoreWithReservedId.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.RelationshipStore;
+import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class StoreWithReservedId
+{
+    private StoreWithReservedId()
+    {
+    }
+
+    /**
+     * Create new {@link NodeStore} mock with {@link RecordCursor} that returns record with
+     * reserved id - {@link IdGeneratorImpl#INTEGER_MINUS_ONE}.
+     *
+     * @param highId the highId for the store mock
+     * @return new {@link NodeStore} mock
+     */
+    public static NodeStore newNodeStoreMock( long highId )
+    {
+        return newStoreMock( NodeStore.class, new NodeRecord( -1 ), highId );
+    }
+
+    /**
+     * Create new {@link RelationshipStore} mock with {@link RecordCursor} that returns record with
+     * reserved id - {@link IdGeneratorImpl#INTEGER_MINUS_ONE}.
+     *
+     * @param highId the highId for the store mock
+     * @return new {@link RelationshipStore} mock
+     */
+    public static RelationshipStore newRelationshipStoreMock( long highId )
+    {
+        return newStoreMock( RelationshipStore.class, new RelationshipRecord( -1 ), highId );
+    }
+
+    private static <R extends AbstractBaseRecord, S extends RecordStore<R>> S newStoreMock( Class<S> storeClass,
+            R record, long highId )
+    {
+        S store = mock( storeClass );
+        when( store.getHighId() ).thenReturn( highId );
+
+        when( store.newRecord() ).thenReturn( record );
+
+        RecordCursor<R> cursor = newReservedIdReturningRecordCursor( highId, record );
+        when( store.newRecordCursor( any() ) ).thenReturn( cursor );
+
+        return store;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static <R extends AbstractBaseRecord> RecordCursor<R> newReservedIdReturningRecordCursor( long highId,
+            R record )
+    {
+        RecordCursor<R> cursor = mock( RecordCursor.class );
+        when( cursor.next( anyInt() ) ).thenAnswer( invocation -> {
+            long id = (long) invocation.getArguments()[0];
+            long realId = (id == highId - 1) ? IdGeneratorImpl.INTEGER_MINUS_ONE : id;
+            record.setId( realId );
+            return true;
+        } );
+        return cursor;
+    }
+}


### PR DESCRIPTION
Parallel batch importer assigns/tracks record ids using it's own id sequence. Sequence is aware of the special reserved id `IdGeneratorImpl.INTEGER_MINUS_ONE`. However, PBI also reads batches of records directly from the store using raw ids. This code was not aware of the reserved id and tried to read and write records with such id. Doing this caused exceptions from the store layer.

This commit makes sure records with reserved ids are never returned as part of a PBI's records batch. As a safety, measure it also makes sure record with reserved id is never written to the store.
