### PR TITLE
Revert "Unconditionally set the auth store location in server"

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ConfigLoader.java
@@ -84,7 +84,7 @@ public class ConfigLoader
         config.ifPresent( ( c ) -> settings.putAll( loadFromFile( log, c ) ) );
         settings.putAll( toMap( configOverrides ) );
         overrideEmbeddedDefaults( settings );
-        addInternalServerSpecificSettings( settings );
+        settings.put( GraphDatabaseSettings.neo4j_home.name(), System.getProperty( "user.dir" ) );
         customizer.accept( settings );
         return settings;
     }
@@ -107,13 +107,10 @@ public class ConfigLoader
     {
         config.putIfAbsent( ShellSettings.remote_shell_enabled.name(), TRUE );
         config.putIfAbsent( GraphDatabaseSettings.auth_enabled.name(), "true" );
-    }
 
-    private static void addInternalServerSpecificSettings( Map<String, String> settings )
-    {
-        settings.put( GraphDatabaseSettings.neo4j_home.name(), System.getProperty( "user.dir" ) );
-        String dataDirectory = settings.getOrDefault( data_directory.name(), data_directory.getDefaultValue() );
-        settings.put( GraphDatabaseSettings.auth_store.name(), new File( dataDirectory, "dbms/auth" ).toString() );
+        String dataDirectory = config.getOrDefault( data_directory.name(), data_directory.getDefaultValue() );
+        config.putIfAbsent( GraphDatabaseSettings.auth_store.name(),
+                new File( dataDirectory, "dbms/auth" ).toString() );
     }
 
     private static Map<String, String> loadFromFile( Log log, File file )

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.server.configuration;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -43,7 +43,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.setting;
@@ -194,7 +193,7 @@ public class ConfigLoaderTest
     }
 
     @Test
-    public void shouldOverwriteAuthStoreLocationIfErroneouslyProvided() throws IOException
+    public void shouldNotOverwriteAuthStoreLocationIfProvided() throws IOException
     {
         Optional<File> configFile = ConfigFileBuilder.builder( folder.getRoot() )
                 .withSetting( DatabaseManagementSystemSettings.data_directory, "the-data-dir" )
@@ -203,7 +202,7 @@ public class ConfigLoaderTest
         Config config = configLoader.loadConfig( configFile, log );
 
         assertThat( config.get( GraphDatabaseSettings.auth_store ),
-                is( new File( "the-data-dir/dbms/auth" ).getAbsoluteFile() ) );
+                is( new File( "foo/bar/auth" ).getAbsoluteFile() ) );
     }
 
 


### PR DESCRIPTION
We have at least one customer who requires the ability to set the
location of the auth file.

This reverts commit e28225459d4d623f2b61c7d98aa4f159b849d6d0.
