### PR TITLE
Fix how the check on the file page size in PageCache.map interacts with PageCacheOpenOptions.ANY_PAGE_SIZE

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -280,12 +280,6 @@ public class MuninnPageCache implements PageCache
                     "Cannot map files with a filePageSize (" + filePageSize + ") that is greater than the " +
                     "cachePageSize (" + cachePageSize + ")" );
         }
-        if ( filePageSize < Long.BYTES )
-        {
-            throw new IllegalArgumentException(
-                    "Cannot map files with a filePageSize (" + filePageSize + ") that is less than " +
-                    Long.BYTES + " bytes" );
-        }
         boolean createIfNotExists = false;
         boolean truncateExisting = false;
         boolean deleteOnClose = false;
@@ -358,6 +352,13 @@ public class MuninnPageCache implements PageCache
                 return pagedFile;
             }
             current = current.next;
+        }
+
+        if ( filePageSize < Long.BYTES )
+        {
+            throw new IllegalArgumentException(
+                    "Cannot map files with a filePageSize (" + filePageSize + ") that is less than " +
+                    Long.BYTES + " bytes" );
         }
 
         // there was no existing mapping

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/CompositePageCursorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/CompositePageCursorTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.test.ByteArrayMatcher.byteArray;
 
-//@RunWith( Theories.class )
 public class CompositePageCursorTest
 {
     private static final int PAGE_SIZE = 16;


### PR DESCRIPTION
Our block device integration needs to map files without specifying a page size.
Recent commits added a check which required that the file page size be at least 8 bytes long, but this unfortunately broke our block device integration code.
This changes the behaviour of this check, to only apply when we actually need the file page size to make sense.
