### PR TITLE
Correctly identify store files when deleting them

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StoreUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StoreUtil.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.util;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 
 import org.neo4j.io.fs.FileUtils;
@@ -45,15 +44,16 @@ public class StoreUtil
             return new File[0];
         }
 
-        return storeDir.listFiles( new FileFilter()
-        {
-            @Override
-            public boolean accept( File file )
+        return storeDir.listFiles(file -> {
+            for ( String directory : new String[] {"metrics", "logs", "certificates"} )
             {
-                return !file.getName().startsWith( "metrics" ) && !file.getName().startsWith( "debug." ) &&
-                       !isBranchedDataRootDirectory( file );
+                if ( file.getName().startsWith( directory ) )
+                {
+                    return false;
+                }
             }
-        } );
+            return !isBranchedDataRootDirectory( file );
+        });
     }
 
     public static File newBranchedDataDir( File storeDir )


### PR DESCRIPTION
When a slave joins an HA cluster it may need to delete its store
files (because they represent a different logical database). The code to
do that is pretty brutal -- it deletes everything in the store dir apart
from some blacklisted files. Now that we keep the logs and other
directories in the store dir when running embedded, we need to update
the blacklist.

This problem was failing the build on Windows (because file locks are
exclusive on that platform), but there was a bug for any platform
running embedded HA.
