### PR TITLE
Revert introduction of warnings for unrecognized configuration

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -201,7 +201,7 @@ public class Config implements DiagnosticsProvider, Configuration
     private synchronized void replaceSettings( Map<String, String> newSettings )
     {
         Map<String,String> migratedSettings = migrator.apply( newSettings, log );
-        validator.validate( migratedSettings, log );
+        validator.validate( migratedSettings );
         params.clear();
         params.putAll( migratedSettings );
         settingsFunction = new ConfigValues( params );

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConfigurationValidator.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.collection.Pair;
-import org.neo4j.logging.Log;
 
 /**
  * Given a set of annotated config classes,
@@ -43,25 +42,11 @@ public class ConfigurationValidator
         this.settings = getSettingsFrom( settingsClasses );
     }
 
-    public void validate( Map<String,String> rawConfig, Log log )
+    public void validate( Map<String, String> rawConfig )
     {
         for ( Setting<?> setting : settings.values() )
         {
             setting.apply( rawConfig::get );
-        }
-
-        // Warn if any of the given setting names does not exist
-        validateSettingNames( rawConfig, log );
-    }
-
-    private void validateSettingNames( Map<String,String> rawConfig, Log log )
-    {
-        for ( String settingName : rawConfig.keySet() )
-        {
-            if ( !settings.containsKey( settingName ) )
-            {
-                log.warn( "The setting '" + settingName + "' is not recognized and will not have any effect." );
-            }
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -28,16 +28,12 @@ import java.util.Map;
 import org.neo4j.graphdb.config.Configuration;
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
-import org.neo4j.logging.Log;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.INTEGER;
@@ -92,34 +88,6 @@ public class ConfigTest
 
         // Then
         assertThat( config.get( MyMigratingSettings.newer ), is( "hello!" ) );
-    }
-
-    @Test
-    public void shouldWarnForUnrecognizedSettingNames()
-    {
-        // Given
-        Log mockLog = mock( Log.class );
-
-        // When
-        Config config = new Config( stringMap( "unrecognized", "hello!" ), MySettingsWithDefaults.class );
-        config.setLogger( mockLog );
-
-        // Then
-        verify( mockLog ).warn( "The setting 'unrecognized' is not recognized and will not have any effect." );
-    }
-
-    @Test
-    public void shouldNotWarnForMigratedSettingNames()
-    {
-        // Given
-        Log mockLog = mock( Log.class );
-
-        // When
-        Config config = new Config( stringMap( "old", "hello!" ), MyMigratingSettings.class );
-        config.setLogger( mockLog );
-
-        // Then
-        verify( mockLog, times(0) ).warn( "The setting 'old' is not recognized and will not have any effect." );
     }
 
     @Test(expected = InvalidSettingException.class)


### PR DESCRIPTION
The design of this had problems which meant that we issued warnings for
valid configuration and duplicated the warnings between the
console/neo4j.log and debug.log. We don't have time to fix these for
3.0, so we've decided to pull out the feature rather than ship something
misleading and worrying for users.

This reverts commit 5956c71fc4f31fbe117fbe47d69e607be43392cc.
This reverts commit b25931241a8f0babf69f609e9f50466259c7c3d6.

Conflicts:
    community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
