### PR TITLE
Intersection of relationships ids assigned by batch importer and store id generator for secondary unit

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStage.java
@@ -21,6 +21,7 @@ package org.neo4j.unsafe.impl.batchimport;
 
 import java.io.IOException;
 
+import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
@@ -36,7 +37,7 @@ import org.neo4j.unsafe.impl.batchimport.staging.Stage;
 public class CalculateDenseNodesStage extends Stage
 {
     public CalculateDenseNodesStage( Configuration config, InputIterable<InputRelationship> relationships,
-            NodeRelationshipCache cache, IdMapper idMapper,
+            RelationshipStore relationshipStore, NodeRelationshipCache cache, IdMapper idMapper,
             Collector badCollector, InputCache inputCache ) throws IOException
     {
         super( "Calculate dense nodes", config );
@@ -47,6 +48,7 @@ public class CalculateDenseNodesStage extends Stage
             add( new InputEntityCacherStep<>( control(), config, inputCache.cacheRelationships() ) );
         }
         add( new RelationshipPreparationStep( control(), config, idMapper ) );
+        add( new CalculateRelationshipsStep( control(), config, relationshipStore ) );
         add( new CalculateDenseNodePrepareStep( control(), config, badCollector ) );
         add( new CalculateDenseNodesStep( control(), config, cache ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateRelationshipsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateRelationshipsStep.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RelationshipStore;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
+import org.neo4j.unsafe.impl.batchimport.staging.ProcessorStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+public class CalculateRelationshipsStep extends ProcessorStep<Batch<InputRelationship,RelationshipRecord>>
+{
+    private final RelationshipStore relationshipStore;
+    private long numberOfRelationships;
+    private long maxSpecific;
+
+    public CalculateRelationshipsStep( StageControl control, Configuration config, RelationshipStore relationshipStore )
+    {
+        super( control, "RelationshipCalculator", config, 1 );
+        this.relationshipStore = relationshipStore;
+    }
+
+    @Override
+    protected void process( Batch<InputRelationship,RelationshipRecord> batch, BatchSender sender ) throws Throwable
+    {
+        int batchSize = batch.input.length;
+        InputRelationship inputRelationship = batch.input[batchSize - 1];
+
+        if ( inputRelationship.hasSpecificId() )
+        {
+            maxSpecific = Math.max( inputRelationship.specificId(), maxSpecific );
+        }
+        else
+        {
+            numberOfRelationships += batchSize;
+        }
+        sender.send( batch );
+    }
+
+    @Override
+    protected void done()
+    {
+        long highestId = relationshipStore.getHighId() + numberOfRelationships;
+        relationshipStore.setHighestPossibleIdInUse( Math.max( highestId, maxSpecific ) );
+        super.done();
+    }
+}


### PR DESCRIPTION
In case if relationship record over exceed size of single unit in high limit format, it will be expanded into secondary unit.
Id for secondary unit will be generated by store id generator.

In case if we are in the middle on batch import store id generator is out of sync with actual ids in a store, since id's for new records are assigned by batch import itself.

This situation will cause store corruptions since same id will be assigned to multiple records.
To prevent this we will calculate number of relationships that batch import will try to create and reserve those ids in store generator by shifting its high id.
