### PR TITLE
Fix the logic around isolating aggregations

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/IterableExpressions.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/IterableExpressions.scala
@@ -227,9 +227,9 @@ case class ReduceExpression(scope: ReduceScope, init: Expression, collection: Ex
       expression.semanticCheck(SemanticContext.Simple)
     } chain expression.expectType(init.types, AccumulatorExpressionTypeMismatchMessageGenerator) chain
     this.specifyType(s => init.types(s) leastUpperBounds expression.types(s)) chain
-    failIfAggregrating
+    failIfAggregating
 
-  protected def failIfAggregrating: Option[SemanticError] =
+  protected def failIfAggregating: Option[SemanticError] =
     if (expression.containsAggregate) {
       val message = "Can't use aggregating expressions inside of expressions executing over collections"
       Some(SemanticError(message, expression.position))

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/isolateAggregation.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ast/rewriters/isolateAggregation.scala
@@ -51,29 +51,23 @@ case object isolateAggregation extends Rewriter {
     case q@SingleQuery(clauses) =>
 
       val newClauses = clauses.flatMap {
-        case clause if !clauseNeedingWork(clause) => Some(clause)
+        case clause if !clauseNeedingWork(clause) => Seq(clause)
         case clause =>
-          val originalExpressions = getExpressions(clause)
-
-          val expressionsToGoToWith: Set[Expression] = iterateUntilConverged {
+          val (withAggregations, others) = getExpressions(clause).partition(hasAggregateButIsNotAggregate(_))
+          val expressionsToGoToWith: Set[Expression] = others ++ iterateUntilConverged {
             (expressions: Set[Expression]) => expressions.flatMap {
               case e if hasAggregateButIsNotAggregate(e) =>
                 e match {
                   case ReduceExpression(_, init, coll) => Seq(init, coll)
-                  case FilterExpression(_, expr)       => Some(expr)
-                  case ExtractExpression(_, expr)      => Some(expr)
-                  case ListComprehension(_, expr)      => Some(expr)
+                  case FilterExpression(_, expr)       => Seq(expr)
+                  case ExtractExpression(_, expr)      => Seq(expr)
+                  case ListComprehension(_, expr)      => Seq(expr)
                   case _                               => e.arguments
                 }
-
-              case e =>
-                Some(e)
-
+              case e => Seq(e)
             }
-          }(originalExpressions).filter {
-            //Constant expressions should never be isolated
-            case ConstantExpression(_) => false
-            case expr => true
+          }(withAggregations).filter {
+            expr => IsAggregate(expr) || expr.dependencies.nonEmpty
           }
 
           val withReturnItems: Set[ReturnItem] = expressionsToGoToWith.map {


### PR DESCRIPTION
The previous code was extracting alongside aggregations also "constant
expression" which are not based on any identifier/variable.  This
behaviour was problematic since Cypher defines implicitly grouping
keys, hence the extracted "constant expressions" were erroneously part
of the implicit grouping key and messing up the aggregation result.

The isolate aggregation code has been change to only extract
aggregating functions/subfunctions ans only expression which uses
identifiers/variables in scope.  In such a way the implicit grouping
key is defined by expressions depending on identifiers/variables in
scope rather than constants which is more likely what the user
intended.
