### PR TITLE
Fix bug in rule planner pattern matcher

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/PatternGraphBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/executionplan/builders/PatternGraphBuilder.scala
@@ -33,7 +33,7 @@ trait PatternGraphBuilder {
       return new PatternGraph(Map.empty, Map.empty, Seq.empty, Seq.empty)
 
     val patternNodeMap: mutable.Map[String, PatternNode] = scala.collection.mutable.Map()
-    val patternRelMap: mutable.Map[String, PatternRelationship] = scala.collection.mutable.Map()
+    val patternRelMap: mutable.Map[String, Seq[PatternRelationship]] = scala.collection.mutable.Map()
 
     def takeOnPattern(x: Pattern): Boolean = {
       x match {
@@ -49,14 +49,24 @@ trait PatternGraphBuilder {
       val relName = r.relName
       val leftNode: PatternNode = patternNodeMap.getOrElseUpdate(left.name, new PatternNode(left))
       val rightNode: PatternNode = patternNodeMap.getOrElseUpdate(right.name, new PatternNode(right))
-      patternRelMap(relName) = leftNode.relateTo(relName, rightNode, r)
+      val maybeSetOfPatternRel =  patternRelMap.get(relName)
+      val newPatternRel = leftNode.relateTo(relName, rightNode, r)
+      if (maybeSetOfPatternRel.isDefined)
+        patternRelMap(relName) = maybeSetOfPatternRel.get :+ newPatternRel
+      else
+        patternRelMap(relName) = Seq(newPatternRel)
       true
     }
 
     def takeOnVarLengthRel(r: VarLengthRelatedTo) = {
       val startNode: PatternNode = patternNodeMap.getOrElseUpdate(r.left.name, new PatternNode(r.left))
       val endNode: PatternNode = patternNodeMap.getOrElseUpdate(r.right.name, new PatternNode(r.right))
-      patternRelMap(r.pathName) = startNode.relateViaVariableLengthPathTo(r.pathName, endNode, r.minHops, r.maxHops, r.relTypes, r.direction, r.relIterator, r.properties)
+      val maybeSetOfPatternRel =  patternRelMap.get(r.pathName)
+      val newPatternRel = startNode.relateViaVariableLengthPathTo(r.pathName, endNode, r.minHops, r.maxHops, r.relTypes, r.direction, r.relIterator, r.properties)
+      if (maybeSetOfPatternRel.isDefined)
+        patternRelMap(r.pathName) = maybeSetOfPatternRel.get :+ newPatternRel
+      else
+        patternRelMap(r.pathName) = Seq(newPatternRel)
       true
     }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/MatchingContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/MatchingContext.scala
@@ -39,7 +39,7 @@ class MatchingContext(boundIdentifiers: SymbolTable,
   val builder: MatcherBuilder = decideWhichMatcherToUse()
 
   private def identifiers: immutable.Map[String, CypherType] =
-    patternGraph.patternRels.values.flatMap(p => p.identifiers2).toMap
+    patternGraph.patternRels.values.flatMap(p => p.flatMap(_.identifiers2)).toMap
 
   lazy val symbols = {
     val ids = identifiers

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/MatchingPair.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/MatchingPair.scala
@@ -29,8 +29,9 @@ case class MatchingPair(patternElement: PatternElement, entity: Any) {
 
   override def toString = patternElement.key + "=" + entity
 
-  def matchesBoundEntity(boundNodes: Map[String, MatchingPair]): Boolean = boundNodes.get(patternElement.key) match {
-    case Some(pinnedNode) => (entity, pinnedNode.entity) match {
+  def matchesBoundEntity(boundNodes: Map[String, Set[MatchingPair]]): Boolean = boundNodes.get(patternElement.key)
+  match {
+    case Some(pinnedNodeSet) => pinnedNodeSet.forall(pinnedNode => (entity, pinnedNode.entity) match {
       case (a: Node, b: Node)                                                       => a == b
       case (a: SingleGraphRelationship, b: Relationship)                            => a.rel == b
       case (a: Relationship, b: SingleGraphRelationship)                            => a == b.rel
@@ -38,7 +39,7 @@ case class MatchingPair(patternElement: PatternElement, entity: Any) {
       case (a: VariableLengthGraphRelationship, b)                                  => false
       case (a, b: VariableLengthGraphRelationship)                                  => false
 
-    }
+    })
     case None             => true
   }
 

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/PatternGraph.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/PatternGraph.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.compiler.v2_2.PatternException
 import org.neo4j.cypher.internal.compiler.v2_2.commands.Pattern
 
 case class PatternGraph(patternNodes: Map[String, PatternNode],
-                        patternRels: Map[String, PatternRelationship],
+                        patternRels: Map[String, Seq[PatternRelationship]],
                         boundElements: Seq[String],
                         patternsContained: Seq[Pattern]) {
 
@@ -38,23 +38,6 @@ case class PatternGraph(patternNodes: Map[String, PatternNode],
   lazy val hasBoundRelationships: Boolean = boundElements.exists(patternRels.keys.toSeq.contains)
   lazy val hasVarLengthPaths: Boolean = patternRels.values.exists(_.isInstanceOf[VariableLengthPatternRelationship])
 
-  def extractGraphFromPaths(relationshipsNotInDoubleOptionalPaths: Iterable[PatternRelationship], boundPoints: Seq[String]): PatternGraph = {
-    val oldNodes = relationshipsNotInDoubleOptionalPaths.flatMap(p => Seq(p.startNode, p.endNode)).toSeq.distinct
-
-    val newNodes = oldNodes.map(patternNode => patternNode.key ->
-      new PatternNode(patternNode.key, patternNode.labels, patternNode.properties)).toMap
-
-    val newRelationships = relationshipsNotInDoubleOptionalPaths.map {
-      case pr: VariableLengthPatternRelationship => ???
-      case pr: PatternRelationship               =>
-        val s = newNodes(pr.startNode.key)
-        val e = newNodes(pr.endNode.key)
-        pr.key -> s.relateTo(pr.key, e, pr.relTypes, pr.dir)
-    }.toMap
-
-    new PatternGraph(newNodes, newRelationships, boundPoints, Seq.empty /* This is only used for plan building and is not needed here */)
-  }
-
   def apply(key: String) = patternGraph(key)
 
   def get(key: String) = patternGraph.get(key)
@@ -64,8 +47,8 @@ case class PatternGraph(patternNodes: Map[String, PatternNode],
   def keySet = patternGraph.keySet
 
   private def validatePattern(patternNodes: Map[String, PatternNode],
-                              patternRels: Map[String, PatternRelationship]):
-  (Map[String, PatternElement], Boolean) = {
+                              patternRels: Map[String, Seq[PatternRelationship]]):
+  (Map[String, Seq[PatternElement]], Boolean) = {
 
     if (isEmpty)
       return (Map(), false)
@@ -75,10 +58,11 @@ case class PatternGraph(patternNodes: Map[String, PatternNode],
       throw new PatternException("Some identifiers are used as both relationships and nodes: " + overlaps.mkString(", "))
     }
 
-    val elementsMap: Map[String, PatternElement] = (patternNodes.values ++ patternRels.values).map(x => (x.key -> x)).toMap
-    val allElements = elementsMap.values.toSeq
+    val elementsMap: Map[String, Seq[PatternElement]] = (patternNodes.values.map(Seq[PatternElement](_)) ++
+      patternRels.values.asInstanceOf[Iterable[Seq[PatternElement]]]).map(x => x.head.key -> x).toMap
+    val allElements = elementsMap.values.flatMap(_.toSeq).toSeq
 
-    val boundPattern: Seq[PatternElement] = boundElements.flatMap(i => elementsMap.get(i))
+    val boundPattern: Seq[PatternElement] = boundElements.flatMap(i => elementsMap.get(i)).flatMap(_.toSeq)
 
     val hasLoops = checkIfWeHaveLoops(boundPattern, allElements)
 
@@ -115,9 +99,9 @@ case class PatternGraph(patternNodes: Map[String, PatternNode],
   override def toString = if(patternRels.isEmpty && patternNodes.isEmpty) {
       "[EMPTY PATTERN]"
   } else {
-      patternRels.map(tuple=> {
-        val r = tuple._2
-        "(%s)-['%s']-(%s)".format(r.startNode.key, r, r.endNode.key)
+      patternRels.flatMap(tuple => {
+        val patternRels = tuple._2
+        patternRels.map(r => "(%s)-['%s']-(%s)".format(r.startNode.key, r, r.endNode.key))
       }).mkString(",")
   }
 }

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/PatternMatchingBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/PatternMatchingBuilder.scala
@@ -31,18 +31,18 @@ class PatternMatchingBuilder(patternGraph: PatternGraph,
                              identifiersInClause: Set[String]) extends MatcherBuilder {
   def getMatches(sourceRow: ExecutionContext, state:QueryState): Traversable[ExecutionContext] = {
     val bindings: Map[String, Any] = sourceRow.filter(_._2.isInstanceOf[PropertyContainer])
-    val boundPairs: Map[String, MatchingPair] = extractBoundMatchingPairs(bindings)
+    val boundPairs: Map[String, Set[MatchingPair]] = extractBoundMatchingPairs(bindings)
 
     val undirectedBoundRelationships: Iterable[PatternRelationship] = bindings.keys.
       filter(z => patternGraph.contains(z)).
-      filter(patternGraph(_).isInstanceOf[PatternRelationship]).
-      map(patternGraph(_).asInstanceOf[PatternRelationship]).
+      filter(patternGraph(_).exists(_.isInstanceOf[PatternRelationship])).
+      flatMap(patternGraph(_).asInstanceOf[Seq[PatternRelationship]]).
       filter(_.dir == Direction.BOTH)
 
     val mandatoryPattern: Traversable[ExecutionContext] = if (undirectedBoundRelationships.isEmpty) {
       createPatternMatcher(boundPairs, includeOptionals = false, sourceRow, state)
     } else {
-      val boundRels: Seq[Map[String, MatchingPair]] = createListOfBoundRelationshipsWithHangingNodes(undirectedBoundRelationships, bindings)
+      val boundRels = createListOfBoundRelationshipsWithHangingNodes(undirectedBoundRelationships, bindings)
 
       boundRels.
         flatMap(relMap => createPatternMatcher(relMap ++ boundPairs, includeOptionals = false, sourceRow, state))
@@ -51,18 +51,20 @@ class PatternMatchingBuilder(patternGraph: PatternGraph,
     mandatoryPattern
   }
 
-  private def createListOfBoundRelationshipsWithHangingNodes(undirectedBoundRelationships: Iterable[PatternRelationship], bindings: Map[String, Any]): Seq[Map[String, MatchingPair]] = {
+  private def createListOfBoundRelationshipsWithHangingNodes(undirectedBoundRelationships:
+                                                             Iterable[PatternRelationship], bindings: Map[String,
+    Any]): Seq[Map[String, Set[MatchingPair]]] = {
     val toList = undirectedBoundRelationships.map(patternRel => {
       val rel = bindings(patternRel.key).asInstanceOf[Relationship]
-      val x = patternRel.key -> MatchingPair(patternRel, rel)
+      val x = patternRel.key -> Set(MatchingPair(patternRel, rel))
 
       // Outputs the first direction of the pattern relationship
-      val a1 = patternRel.startNode.key -> MatchingPair(patternRel.startNode, rel.getStartNode)
-      val a2 = patternRel.endNode.key -> MatchingPair(patternRel.endNode, rel.getEndNode)
+      val a1 = patternRel.startNode.key -> Set(MatchingPair(patternRel.startNode, rel.getStartNode))
+      val a2 = patternRel.endNode.key -> Set(MatchingPair(patternRel.endNode, rel.getEndNode))
 
       // Outputs the second direction of the pattern relationship
-      val b1 = patternRel.startNode.key -> MatchingPair(patternRel.startNode, rel.getEndNode)
-      val b2 = patternRel.endNode.key -> MatchingPair(patternRel.endNode, rel.getStartNode)
+      val b1 = patternRel.startNode.key -> Set(MatchingPair(patternRel.startNode, rel.getEndNode))
+      val b2 = patternRel.endNode.key -> Set(MatchingPair(patternRel.endNode, rel.getStartNode))
 
       Seq(Map(x, a1, a2), Map(x, b1, b2))
     }).toList
@@ -77,35 +79,36 @@ class PatternMatchingBuilder(patternGraph: PatternGraph,
         result.flatMap(r => element.map(e => e :: r))
     ).toSeq
 
-  private def createPatternMatcher(boundPairs: Map[String, MatchingPair], includeOptionals: Boolean, source: ExecutionContext, state:QueryState): Traversable[ExecutionContext] =
+  private def createPatternMatcher(boundPairs: Map[String, Set[MatchingPair]], includeOptionals: Boolean, source: ExecutionContext, state:QueryState): Traversable[ExecutionContext] =
       new PatternMatcher(boundPairs, predicates, source, state, identifiersInClause)
 
-  private def extractBoundMatchingPairs(bindings: Map[String, Any]): Map[String, MatchingPair] = bindings.flatMap {
-    case (key, node: Node) if patternGraph.contains(key)        => Seq(key -> MatchingPair(patternGraph(key), node))
+  private def extractBoundMatchingPairs(bindings: Map[String, Any]): Map[String, Set[MatchingPair]] = bindings.flatMap {
+    case (key, node: Node) if patternGraph.contains(key) =>
+      Seq(key -> patternGraph(key).map(pNode => MatchingPair(pNode, node)).toSet)
     case (key, rel: Relationship) if patternGraph.contains(key) =>
-      val pRel = patternGraph(key).asInstanceOf[PatternRelationship]
+      val patternRels = patternGraph(key).asInstanceOf[Seq[PatternRelationship]]
+      patternRels.flatMap(pRel => {
+        def extractMatchingPairs(startNode: PatternNode, endNode: PatternNode): Seq[(String, Set[MatchingPair])] = {
+          val t1 = startNode.key -> Set(MatchingPair(startNode, rel.getStartNode))
+          val t2 = endNode.key -> Set(MatchingPair(endNode, rel.getEndNode))
+          val t3 = pRel.key -> Set(MatchingPair(pRel, rel))
 
-      def extractMatchingPairs(startNode: PatternNode, endNode: PatternNode): Seq[(String, MatchingPair)] = {
-        val t1 = startNode.key -> MatchingPair(startNode, rel.getStartNode)
-        val t2 = endNode.key -> MatchingPair(endNode, rel.getEndNode)
-        val t3 = pRel.key -> MatchingPair(pRel, rel)
+          // Check that found end nodes correspond to what is already in scope
+          if (bindings.get(t1._1).forall(_ == t1._2.head.entity) &&
+              bindings.get(t2._1).forall(_ == t2._2.head.entity))
+            Seq(t1, t2, t3)
+          else
+            Seq.empty[(String, Set[MatchingPair])]
+        }
 
-        // Check that found end nodes correspond to what is already in scope
-        if (bindings.get(t1._1).forall(_ == t1._2.entity) &&
-            bindings.get(t2._1).forall(_ == t2._2.entity))
-          Seq(t1, t2, t3)
-        else
-          Seq.empty
-      }
-
-      pRel.dir match {
-        case Direction.OUTGOING                            => extractMatchingPairs(pRel.startNode, pRel.endNode)
-        case Direction.INCOMING                            => extractMatchingPairs(pRel.endNode, pRel.startNode)
-        case Direction.BOTH if bindings.contains(pRel.key) => Seq(pRel.key -> MatchingPair(pRel, rel))
-        case Direction.BOTH                                => Seq.empty
-      }
-
-    case (key, _) => Nil
+        pRel.dir match {
+          case Direction.OUTGOING => extractMatchingPairs(pRel.startNode, pRel.endNode)
+          case Direction.INCOMING => extractMatchingPairs(pRel.endNode, pRel.startNode)
+          case Direction.BOTH if bindings.contains(pRel.key) => Seq(pRel.key -> Set(MatchingPair(pRel, rel)))
+          case Direction.BOTH => Seq.empty[(String, Set[MatchingPair])]
+        }
+      })
+    case (key, _) => Seq(key -> Set.empty[MatchingPair])
   }
 
   def name = "PatternMatcher"

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/SimplePatternMatcherBuilder.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/matching/SimplePatternMatcherBuilder.scala
@@ -27,7 +27,7 @@ import org.neo4j.graphdb.{DynamicRelationshipType, Node, Relationship}
 import org.neo4j.graphmatching.{PatternMatch, PatternMatcher => SimplePatternMatcher, PatternNode => SimplePatternNode, PatternRelationship => SimplePatternRelationship}
 
 import scala.collection.JavaConverters._
-import scala.collection.{Map, immutable}
+import scala.collection.{Map, Set, immutable}
 
 class SimplePatternMatcherBuilder(pattern: PatternGraph,
                                   predicates: Seq[Predicate],
@@ -42,8 +42,8 @@ class SimplePatternMatcherBuilder(pattern: PatternGraph,
     }
   }
 
-  def createPatternRels(patternNodes:immutable.Map[String, SimplePatternNode]):immutable.Map[String, SimplePatternRelationship]  = pattern.patternRels.map {
-    case (key, pr) =>
+  def createPatternRels(patternNodes: immutable.Map[String, SimplePatternNode]): immutable.Map[String, SimplePatternRelationship] = pattern.patternRels.flatMap {
+    case (key, prs) => prs.map(pr => {
       val start = patternNodes(pr.startNode.key)
       val end = patternNodes(pr.endNode.key)
 
@@ -58,6 +58,7 @@ class SimplePatternMatcherBuilder(pattern: PatternGraph,
       patternRel.setLabel(pr.key)
 
       key -> patternRel
+    })
   }
 
   def setAssociations(sourceRow: Map[String, Any]): (immutable.Map[String, SimplePatternNode], immutable.Map[String, SimplePatternRelationship]) = {
@@ -128,11 +129,11 @@ class SimplePatternMatcherBuilder(pattern: PatternGraph,
 
 object SimplePatternMatcherBuilder {
   def canHandle(graph: PatternGraph): Boolean = {
-    val a = !graph.patternRels.values.exists(pr => pr.isInstanceOf[VariableLengthPatternRelationship] || pr.startNode == pr.endNode || pr.relTypes.size > 1)
+    val a = !graph.patternRels.values.exists(_.forall(pr => pr.isInstanceOf[VariableLengthPatternRelationship] || pr.startNode == pr.endNode || pr.relTypes.size > 1))
     val b = !graph.patternRels.keys.exists(graph.boundElements.contains)
-    val c = !graph.patternNodes.values.exists(pn => pn.relationships.isEmpty )
+    val c = !graph.patternNodes.values.exists(pn => pn.relationships.isEmpty)
     val d = !graph.patternNodes.values.exists(node => node.labels.nonEmpty || node.properties.nonEmpty)
-    val e = !graph.patternRels.values.exists(rel => rel.properties.nonEmpty)
+    val e = !graph.patternRels.values.exists(_.forall(rel => rel.properties.nonEmpty))
     a && b && c && d && e
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcQueries.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/LdbcQueries.scala
@@ -1462,6 +1462,48 @@ object LdbcQueries {
       Map("weight" -> 3.0, "pathNodeIds" -> List(0, 1, 2, 4, 6, 5)))
   }
 
-  val LDBC_QUERIES = Seq(Query1, Query2, Query3, Query4, Query5, Query6, Query7, Query8,
-    Query9, Query10, Query11, Query12, Query13, Query14)
+  object Query14_v2 extends LdbcQuery {
+
+    val name = "LDBC Query 14 v2"
+
+    val createQuery = Query14.createQuery
+
+    def createParams = Map.empty
+
+    val query = """MATCH path = allShortestPaths((person1:Person {id:{1}})-[:KNOWS*0..]-(person2:Person {id:{2}}))
+                  |RETURN
+                  |extract(n IN nodes(path) | n.id) AS pathNodeIds,
+                  |reduce(weight=0.0, r IN rels(path) |
+                  |           weight +
+                  |           length(()-[r]->()<-[:COMMENT_HAS_CREATOR]-(:Comment)-[:REPLY_OF_POST]->(:Post)-[:POST_HAS_CREATOR]->()-[r]->())*1.0 +
+                  |           length(()<-[r]-()<-[:COMMENT_HAS_CREATOR]-(:Comment)-[:REPLY_OF_POST]->(:Post)-[:POST_HAS_CREATOR]->()<-[r]-())*1.0 +
+                  |           length(()<-[r]-()-[:COMMENT_HAS_CREATOR]-(:Comment)-[:REPLY_OF_COMMENT]-(:Comment)-[:COMMENT_HAS_CREATOR]-()<-[r]-())*0.5
+                  |) AS weight
+                  |ORDER BY weight DESC""".stripMargin
+
+    def params = Map("1" -> 0, "2" -> 5)
+
+    def expectedResult = List(
+      Map("weight" -> 5.5, "pathNodeIds" -> List(0, 1, 7, 4, 8, 5)),
+      Map("weight" -> 4.5, "pathNodeIds" -> List(0, 1, 7, 4, 6, 5)),
+      Map("weight" -> 4.0, "pathNodeIds" -> List(0, 1, 2, 4, 8, 5)),
+      Map("weight" -> 3.0, "pathNodeIds" -> List(0, 1, 2, 4, 6, 5)))
+  }
+
+  val LDBC_QUERIES = Seq(
+    Query1,
+    Query2,
+    Query3,
+    Query4,
+    Query5,
+    Query6,
+    Query7,
+    Query8,
+    Query9,
+    Query10,
+    Query11,
+    Query12,
+    Query13,
+    Query14,
+    Query14_v2)
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ShortestPathAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ShortestPathAcceptanceTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher
 
 import org.neo4j.graphdb.Node
-import org.neo4j.helpers.collection.IteratorUtil
+
 import scala.collection.JavaConverters._
 
 class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
@@ -237,5 +237,122 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     ))
 
     result.close()
+  }
+
+  test("should work with path expression with 2 repeating bound relationships") {
+    createLdbc14Model()
+
+    // This is a simplified version of ldbc q14
+    val query =
+      """MATCH path = allShortestPaths((person1:Person {id:0})-[:KNOWS*0..]-(person2:Person {id:5}))
+        |RETURN
+        | reduce(weight=0.0, r IN rels(path) |
+        |            weight +
+        |            length(()-[r]->()<-[:COMMENT_HAS_CREATOR]-(:Comment)-[:REPLY_OF_POST]->(:Post)-[:POST_HAS_CREATOR]->()-[r]->())*1.0
+        | ) AS weight
+        |ORDER BY weight DESC""".stripMargin
+
+    val result = executeWithAllPlanners(query)
+
+    // Four shortest path with the same weight
+    result.toList should equal(List(Map("weight" -> 2.0), Map("weight" -> 2.0), Map("weight" -> 2.0), Map("weight" -> 2.0)))
+  }
+
+  test("should work with path expression with multiple repeating bound relationships") {
+    createLdbc14Model()
+
+    // This is a simplified version of ldbc q14 with intentional redundant pattern part duplication
+    val query =
+      """MATCH path = allShortestPaths((person1:Person {id:0})-[:KNOWS*0..]-(person2:Person {id:5}))
+        |RETURN
+        | reduce(weight=0.0, r IN rels(path) |
+        |            weight +
+        |            length((:Comment)-[:COMMENT_HAS_CREATOR]->()<-[r]-()-[r]->()<-[:COMMENT_HAS_CREATOR]-(:Comment)-[:REPLY_OF_POST]->(:Post)-[:POST_HAS_CREATOR]->()-[r]->()<-[r]-())*1.0
+        | ) AS weight
+        |ORDER BY weight DESC""".stripMargin
+
+    val result = executeWithAllPlanners(query)
+
+    // Four shortest path with the same weight
+    result.toList should equal(List(Map("weight" -> 2.0), Map("weight" -> 2.0), Map("weight" -> 2.0), Map("weight" -> 2.0)))
+  }
+
+  private def createLdbc14Model(): Unit = {
+    def createPersonNode( id: Int ) = createLabeledNode(Map("id" -> id), "Person")
+
+    def createCommentNode( id: Int ) = createLabeledNode(Map("id" -> id, "creationDate" -> 1), "Comment")
+
+    def createPostNode( id: Int) =  createLabeledNode(Map("id" -> id, "creationDate" -> 1), "Post")
+
+    val p0: Node = createPersonNode(0)
+    val p1: Node = createPersonNode(1)
+    val p2: Node = createPersonNode(2)
+    val p3: Node = createPersonNode(3)
+    val p4: Node = createPersonNode(4)
+    val p5: Node = createPersonNode(5)
+    val p6: Node = createPersonNode(6)
+    val p7: Node = createPersonNode(7)
+    val p8: Node = createPersonNode(8)
+    val p9: Node = createPersonNode(9)
+
+    val p0Post1 = createPostNode(0)
+    val p1Post1 = createPostNode(1)
+    val p3Post1 = createPostNode(2)
+    val p5Post1 = createPostNode(3)
+    val p6Post1 = createPostNode(4)
+    val p7Post1 = createPostNode(5)
+    val p0Comment1 = createCommentNode(6)
+    val p1Comment1 = createCommentNode(7)
+    val p1Comment2 = createCommentNode(8)
+    val p4Comment1 = createCommentNode(9)
+    val p4Comment2 = createCommentNode(10)
+    val p5Comment1 = createCommentNode(11)
+    val p5Comment2 = createCommentNode(12)
+    val p7Comment1 = createCommentNode(13)
+    val p8Comment1 = createCommentNode(14)
+    val p8Comment2 = createCommentNode(15)
+
+    relate(p0, p1, "KNOWS")
+    relate(p1, p3, "KNOWS")
+    relate(p3, p2, "KNOWS")
+    relate(p4, p7, "KNOWS")
+    relate(p4, p8, "KNOWS")
+    relate(p4, p6, "KNOWS")
+
+    relate(p4, p2, "KNOWS")
+    relate(p5, p6, "KNOWS")
+    relate(p5, p8, "KNOWS")
+    relate(p2, p1, "KNOWS")
+    relate(p7, p1, "KNOWS")
+
+    relate(p0Post1, p0, "POST_HAS_CREATOR")
+    relate(p3Post1, p3, "POST_HAS_CREATOR")
+    relate(p1Post1, p1, "POST_HAS_CREATOR")
+    relate(p5Post1, p5, "POST_HAS_CREATOR")
+    relate(p6Post1, p6, "POST_HAS_CREATOR")
+    relate(p7Post1, p7, "POST_HAS_CREATOR")
+
+    relate(p0Comment1, p0, "COMMENT_HAS_CREATOR")
+    relate(p1Comment1, p1, "COMMENT_HAS_CREATOR")
+    relate(p1Comment2, p1, "COMMENT_HAS_CREATOR")
+    relate(p4Comment1, p4, "COMMENT_HAS_CREATOR")
+    relate(p4Comment2, p4, "COMMENT_HAS_CREATOR")
+    relate(p5Comment1, p5, "COMMENT_HAS_CREATOR")
+    relate(p5Comment2, p5, "COMMENT_HAS_CREATOR")
+    relate(p7Comment1, p7, "COMMENT_HAS_CREATOR")
+    relate(p8Comment1, p8, "COMMENT_HAS_CREATOR")
+    relate(p8Comment2, p8, "COMMENT_HAS_CREATOR")
+
+    relate(p0Comment1, p1Post1, "REPLY_OF_POST")
+    relate(p1Comment1, p0Post1, "REPLY_OF_POST")
+    relate(p1Comment2, p0Post1, "REPLY_OF_POST")
+    relate(p4Comment1, p3Post1, "REPLY_OF_POST")
+    relate(p4Comment2, p7Post1, "REPLY_OF_POST")
+    relate(p5Comment1, p5Post1, "REPLY_OF_POST")
+    relate(p8Comment1, p6Post1, "REPLY_OF_POST")
+
+    relate(p7Comment1, p4Comment2, "REPLY_OF_COMMENT")
+    relate(p8Comment2, p4Comment1, "REPLY_OF_COMMENT")
+    relate(p5Comment2, p8Comment2, "REPLY_OF_COMMENT")
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/PipeLazynessTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v2_2/PipeLazynessTest.scala
@@ -118,7 +118,7 @@ class PipeLazynessTest extends GraphDatabaseFunSuite with QueryStateTestSupport 
     val rel = x.relateTo("r", y, Seq.empty, Direction.OUTGOING)
 
     val patternNodes = Map("x" -> x, "y" -> y)
-    val patternRels = Map("r" -> rel)
+    val patternRels = Map("r" -> Seq(rel))
     val graph = new PatternGraph(patternNodes, patternRels, Seq("x"), Seq.empty)
     val pipe = new MatchPipe(src, Seq(), graph, Set("x", "r", "y"))
     (pipe, iter)


### PR DESCRIPTION
Previously, when a bound relationship occured multiple times in a pattern with
unnamed start/end nodes, only one pair of unnamed nodes would be bound in
the execution context, resulting in an exception when accessing a path result.

This fixes a newer implementation of LDBC Q14.
