### PR TITLE
Deleting a node/relationship should never fail

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/DeleteConcurrencyIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/DeleteConcurrencyIT.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import java.io.{PrintWriter, StringWriter}
+
+class DeleteConcurrencyIT extends ExecutionEngineFunSuite {
+
+  test("should not fail if a node has been already deleted by another transaction") {
+    graph.inTx {
+      execute("CREATE (n:person)")
+    }
+
+    val threads: List[MyThread] = (0 until 2).map { ignored =>
+      new MyThread(() => {
+        execute(s"MATCH (root) WHERE ID(root) = 0 DELETE root").toList
+      })
+    }.toList
+
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+
+    import scala.language.reflectiveCalls
+    val errors = threads.collect {
+      case t if t.exception != null => t.exception
+    }
+
+    withClue(prettyPrintErrors(errors)) {
+      errors shouldBe empty
+    }
+  }
+
+  test("should not fail if a relationship has been already deleted by another transaction") {
+    graph.inTx {
+      execute("CREATE (:person)-[:FRIEND]->(:person)")
+    }
+
+    val threads: List[MyThread] = (0 until 2).map { ignored =>
+      new MyThread(() => {
+        execute(s"MATCH ()-[r:FRIEND]->() WHERE ID(r) = 0 DELETE r").toList
+      })
+    }.toList
+
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+
+    import scala.language.reflectiveCalls
+    val errors = threads.collect {
+      case t if t.exception != null => t.exception
+    }
+
+    withClue(prettyPrintErrors(errors)) {
+      errors shouldBe empty
+    }
+  }
+
+  private def prettyPrintErrors(errors: Seq[Throwable]): String = {
+    val stringWriter = new StringWriter()
+    val writer = new PrintWriter(stringWriter)
+    errors.foreach { e => e.printStackTrace(writer); writer.println() }
+    stringWriter.toString
+  }
+
+  private class MyThread(f: () => Unit) extends Thread {
+    private var ex: Throwable = null
+
+    def exception: Throwable = ex
+
+    override def run() {
+      try {
+        graph.inTx { f() }
+      } catch {
+        case ex: Throwable => this.ex = ex
+      }
+    }
+  }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LockingStatementOperations.java
@@ -54,11 +54,11 @@ import static java.lang.Math.min;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.schemaResource;
 
 public class LockingStatementOperations implements
-    EntityWriteOperations,
-    SchemaReadOperations,
-    SchemaWriteOperations,
-    SchemaStateOperations,
-    LockOperations
+        EntityWriteOperations,
+        SchemaReadOperations,
+        SchemaWriteOperations,
+        SchemaStateOperations,
+        LockOperations
 {
     private final EntityReadOperations entityReadDelegate;
     private final EntityWriteOperations entityWriteDelegate;
@@ -131,7 +131,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public <K, V> V schemaStateGetOrCreate( KernelStatement state, K key, Function<K, V> creator )
+    public <K, V> V schemaStateGetOrCreate( KernelStatement state, K key, Function<K,V> creator )
     {
         state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
         return schemaStateDelegate.schemaStateGetOrCreate( state, key, creator );
@@ -173,21 +173,24 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public InternalIndexState indexGetState( KernelStatement state, IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public InternalIndexState indexGetState( KernelStatement state, IndexDescriptor descriptor )
+            throws IndexNotFoundKernelException
     {
         state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
         return schemaReadDelegate.indexGetState( state, descriptor );
     }
 
     @Override
-    public double indexUniqueValuesPercentage( KernelStatement state, IndexDescriptor descriptor ) throws IndexNotFoundKernelException
+    public double indexUniqueValuesPercentage( KernelStatement state, IndexDescriptor descriptor )
+            throws IndexNotFoundKernelException
     {
         state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
         return schemaReadDelegate.indexUniqueValuesPercentage( state, descriptor );
     }
 
     @Override
-    public Long indexGetOwningUniquenessConstraintId( KernelStatement state, IndexDescriptor index ) throws SchemaRuleNotFoundException
+    public Long indexGetOwningUniquenessConstraintId( KernelStatement state, IndexDescriptor index )
+            throws SchemaRuleNotFoundException
     {
         state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
         return schemaReadDelegate.indexGetOwningUniquenessConstraintId( state, index );
@@ -248,11 +251,12 @@ public class LockingStatementOperations implements
                 {
                     lockRelationshipNodes( state, startNode, endNode );
                 }
-            });
+            } );
         }
         catch ( EntityNotFoundException e )
         {
-            throw new IllegalStateException( "Unable to delete relationship[" + relationshipId+ "] since it is already deleted." );
+            throw new IllegalStateException(
+                    "Unable to delete relationship[" + relationshipId + "] since it is already deleted." );
         }
         state.locks().acquireExclusive( ResourceTypes.RELATIONSHIP, relationshipId );
         entityWriteDelegate.relationshipDelete( state, relationshipId );
@@ -277,7 +281,8 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public Iterator<UniquenessConstraint> constraintsGetForLabelAndPropertyKey( KernelStatement state, int labelId, int propertyKeyId )
+    public Iterator<UniquenessConstraint> constraintsGetForLabelAndPropertyKey( KernelStatement state, int labelId,
+            int propertyKeyId )
     {
         state.locks().acquireShared( ResourceTypes.SCHEMA, schemaResource() );
         return schemaReadDelegate.constraintsGetForLabelAndPropertyKey( state, labelId, propertyKeyId );
@@ -371,7 +376,7 @@ public class LockingStatementOperations implements
     }
 
     @Override
-    public void acquireShared(KernelStatement state, Locks.ResourceType resourceType, long[] resourceId )
+    public void acquireShared( KernelStatement state, Locks.ResourceType resourceType, long[] resourceId )
     {
         state.locks().acquireShared( resourceType, resourceId );
     }


### PR DESCRIPTION
The problem was that when trying to delete a node/relationship from a
transaction, it could fail if another transaction deleted already the
node/relationship.  This commit will simply ignore the exception and
continue since the deleting a node/relationship should be an
idempotent operation.
