### PR TITLE
Expanded upon the workings of shortestPath and how it is planned

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -112,12 +112,21 @@ public abstract class GraphDatabaseSettings
             + "If true, then non-conformance will result in an error, otherwise only a warning is generated." )
     public static final Setting<Boolean> cypher_hints_error = setting( "cypher.hints_error", BOOLEAN, FALSE );
 
-    @Description( "If set to true it will disable the shortest path fallback. That means that no full path enumeration" +
-                  "will be performed in case shortest path algorithms cannot be used. This might happen in case of" +
-                  "existential predicates on the path, e.g., when searching for the shortest path containing a node" +
-                  "with property 'name=Emil'. The problem is that graph algorithms work only on universal predicates," +
-                  "e.g., when searching for the shortest where all nodes have label 'Person'.  Note that disabling " +
-                  "shortest path fallback (i.e., setting this property to true) might cause errors at runtime." )
+    @Description( "This setting is associated with performance optimization. Set this to `true` in situations where " +
+                  "it is preferable to have any queries using the 'shortestPath' function terminate as soon as " +
+                  "possible with no answer, rather than potentially running for a long time attempting to find an " +
+                  "answer (even if there is no path to be found). " +
+                  "For most queries, the 'shortestPath' algorithm will return the correct answer very quickly. However " +
+                  "there are some cases where it is possible that the fast bidirectional breadth-first search " +
+                  "algorithm will find no results even if they exist. This can happen when the predicates in the " +
+                  "`WHERE` clause applied to 'shortestPath' cannot be applied to each step of the traversal, and can " +
+                  "only be applied to the entire path. When the query planner detects these special cases, it will " +
+                  "plan to perform an exhaustive depth-first search if the fast algorithm finds no paths. However, " +
+                  "the exhaustive search may be orders of magnitude slower than the fast algorithm. If it is critical " +
+                  "that queries terminate as soon as possible, it is recommended that this option be set to `true`, " +
+                  "which means that Neo4j will never consider using the exhaustive search for shortestPath queries. " +
+                  "However, please note that if no paths are found, an error will be thrown at run time, which will " +
+                  "need to be handled by the application." )
     public static final Setting<Boolean> forbid_exhaustive_shortestpath = setting(
             "cypher.forbid_exhaustive_shortestpath", BOOLEAN, FALSE );
 

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShortestPathPlanningTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/ShortestPathPlanningTest.scala
@@ -34,33 +34,43 @@ class ShortestPathPlanningTest extends DocumentingTest {
         |       (rob:Person {name: 'Rob Reiner'}),
         |
         |       (wallStreet:Movie {title: 'Wall Street'}),
-        |       (charlie)-[:ACTED_IN {role: "Bud Fox"}]->(wallStreet),
-        |       (martin)-[:ACTED_IN {role: "Carl Fox"}]->(wallStreet),
-        |       (michael)-[:ACTED_IN {role: "Gordon Gekko"}]->(wallStreet),
+        |       (charlie)-[:ACTED_IN {role: 'Bud Fox'}]->(wallStreet),
+        |       (martin)-[:ACTED_IN {role: 'Carl Fox'}]->(wallStreet),
+        |       (michael)-[:ACTED_IN {role: 'Gordon Gekko'}]->(wallStreet),
         |       (oliver)-[:DIRECTED]->(wallStreet),
         |
         |       (thePresident:Movie {title: 'The American President'}),
-        |       (martin)-[:ACTED_IN {role: "A.J. MacInerney"}]->(thePresident),
-        |       (michael)-[:ACTED_IN {role: "President Andrew Shepherd"}]->(thePresident),
+        |       (martin)-[:ACTED_IN {role: 'A.J. MacInerney'}]->(thePresident),
+        |       (michael)-[:ACTED_IN {role: 'President Andrew Shepherd'}]->(thePresident),
         |       (rob)-[:DIRECTED]->(thePresident)""",
         "CREATE INDEX ON :Person(name)"
     )
     synopsis("Shortest path finding in Cypher and how it is planned.")
     p("""Planning shortest paths in Cypher can lead to different query plans depending on the predicates that need
         |to be evaluated. Internally, Neo4j will use a fast bidirectional breadth-first search algorithm if the
-        |predicates can be evaluated whilst searching for the path. If the predicates need to inspect the whole path
-        |before deciding on whether it is valid or not, this fast algorithm cannot be used, and Neo4j will fall back to
-        |a slower exhaustive search for the path. The difference between these two can be in the order of magnitude,
-        |so it is important to ensure that the fast approach is used for time critical queries.""")
+        |predicates can be evaluated whilst searching for the path. Therefore, this fast algorithm will always
+        |be certain to return the right answer when there are universal predicates on the path; for example, when
+        |searching for the shortest path where all nodes have the `Person` label, or where there are no nodes with
+        |a `name` property.""".stripMargin)
+    p("""If the predicates need to inspect the whole path before deciding on whether it is valid or not, this fast
+        |algorithm cannot be relied on to find the shortest path, and Neo4j may have to resort to using a slower
+        |exhaustive depth-first search algorithm to find the path. This means that query plans for shortest path
+        |queries with non-universal predicates will include a fallback to running the exhaustive search to find
+        |the path should the fast algorithm not succeed. For example, depending on the data, an answer to a shortest
+        |path query with existential predicates -- such as the requirement that at least one node contains the property
+        |`name='Charlie Sheen'` -- may not be able to be found by the fast algorithm. In this case, Neo4j will fall back to using
+        |the exhaustive search to enumerate all paths and potentially return an answer.""".stripMargin)
+    p("""The running times of these two algorithms may differ by orders of magnitude, so it is important to ensure
+        |that the fast approach is used for time-critical queries.""".stripMargin)
     p("""When the exhaustive search is planned, it is still only executed when the fast algorithm fails to find any
         |matching paths. The fast algorithm is always executed first, since it is possible that it can find a valid
-        |path even though that could not be guaranteed at planning time.""")
+        |path even though that could not be guaranteed at planning time.""".stripMargin)
     section("Shortest path with fast algorithm") {
       query(
-        """MATCH (ms:Person {name:"Martin Sheen"} ),
-          |      (cs:Person {name:"Charlie Sheen"}),
-          |      p = shortestPath( (ms)-[rels*]-(cs) )
-          |WHERE ALL(r in rels WHERE type(r) = "ACTED_IN")
+        """MATCH (ms:Person {name:'Martin Sheen'} ),
+          |      (cs:Person {name:'Charlie Sheen'}),
+          |      p = shortestPath( (ms)-[rels:ACTED_IN*]-(cs) )
+          |WHERE ALL(r in rels WHERE exists(r.role))
           |RETURN p""", assertShortestPathLength) {
         p(
           """This query can be evaluated with the fast algorithm -- there are no predicates that need to see the whole
@@ -69,25 +79,46 @@ class ShortestPathPlanningTest extends DocumentingTest {
       }
     }
     section("Shortest path with additional predicate checks on the paths") {
-      p("""Predicates used in the `WHERE` clause that apply to the shortest path pattern are evaluated before deciding
-           |what the shortest matching path is. """)
-      query(
-        """MATCH (cs:Person {name:"Charlie Sheen"}),
-          |      (ms:Person {name:"Martin Sheen"}),
-          |      p = shortestPath( (cs)-[*]-(ms) )
-          |WHERE length(p) > 1
-          |RETURN p""", assertShortestPathLength) {
+      section("Consider using the exhaustive search as a fallback") {
         p(
-          """This query, in contrast with the one above, needs to check that the whole path follows the predicate
-            |before we know if it is valid or not, and so the query plan will also include the fall back to the slower
-            |exhaustive search algorithm""")
-        profileExecutionPlan()
+          """Predicates used in the `WHERE` clause that apply to the shortest path pattern are evaluated before deciding
+            |what the shortest matching path is. """)
+        query(
+          """MATCH (cs:Person {name:'Charlie Sheen'}),
+            |      (ms:Person {name:'Martin Sheen'}),
+            |      p = shortestPath( (cs)-[*]-(ms) )
+            |WHERE length(p) > 1
+            |RETURN p""", assertShortestPathLength) {
+          p(
+            """This query, in contrast with the one above, needs to check that the whole path follows the predicate
+              |before we know if it is valid or not, and so the query plan will also include the fallback to the slower
+              |exhaustive search algorithm""")
+          profileExecutionPlan()
+        }
+        p(
+          """The way the bigger exhaustive query plan works is by using `Apply`/`Optional` to ensure that when the
+            |fast algorithm does not find any results, a `NULL` result is generated instead of simply stopping the result
+            |stream.
+            |On top of this, the planner will issue an `AntiConditionalApply`, which will run the exhaustive search
+            |if the path variable is pointing to `NULL` instead of a path.""")
       }
-      p("""The way the bigger exhaustive query plan works is by using +Apply+/+Optional+ to ensure that when the
-          |fast algorithm does not find any results, a `NULL` result is generated instead of simply stopping the result
-          |stream.
-          |On top of this, the planner will issue an `AntiConditionalApply`, which will run the exhaustive search
-          |if the path variable is pointing to `NULL` instead of a path.""")
+      section("Prevent the exhaustive search from being used as a fallback") {
+        query(
+          """MATCH (cs:Person {name:'Charlie Sheen'}),
+            |      (ms:Person {name:'Martin Sheen'}),
+            |      p = shortestPath( (cs)-[*]-(ms) )
+            |WITH p
+            |WHERE length(p) > 1
+            |RETURN p""", assertShortestPathLength) {
+          p(
+            """This query, just like the one above, needs to check that the whole path follows the predicate
+              |before we know if it is valid or not. However, the inclusion of the `WITH` clause means that the query
+              |plan will not include the fallback to the slower exhaustive search algorithm. Instead, any
+              |paths found by the fast algorithm will subsequently be filtered, which may result in no answers
+              | being returned.""")
+          profileExecutionPlan()
+        }
+      }
     }
   }.build()
 


### PR DESCRIPTION
- Made the Configuration Settings text for the cypher.forbid_exhaustive_shortestpath setting more comprehensive
- Described how shortestPath works in a lot more detail in terms of how it is planned, which algorithms work in which cases, and how the predicates affect these
- Added another query example showing how to avoid falling back to the slow exhaustive search
