### PR TITLE
Set the nofile ulimit if the appropriate environment variable is set.

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j
+++ b/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j
@@ -54,8 +54,16 @@ do_stop()
   $DAEMON stop
 }
 
+do_ulimit()
+{
+  if [ -n "${NEO4J_ULIMIT_NOFILE}" ]; then
+    ulimit -n "${NEO4J_ULIMIT_NOFILE}"
+  fi
+}
+
 case "$1" in
   start)
+    do_ulimit
     do_start
     ;;
   stop)


### PR DESCRIPTION
```
$ sudo apt install ./neo4j_3.0.0.SNAPSHOT_all.deb
...
$ sudo service neo4j stop
$ echo "NEO4J_ULIMIT_NOFILE=40000" |sudo tee /etc/default/neo4j
$ sudo service neo4j start
$ journalctl -n 10 -t neo4j
-- Logs begin at tis 2016-04-12 16:34:44 CEST, end at tor 2016-04-14 15:05:53 CEST. --
apr 14 15:02:41 swirl neo4j[11713]: Starting Neo4j.
apr 14 15:02:41 swirl neo4j[11713]: WARNING: Max 1024 open files allowed, minimum of 40000 recommended. See the Neo4j manual.
apr 14 15:02:41 swirl neo4j[11713]: Started neo4j (pid 11768). By default, it is available at http://localhost:7474/
apr 14 15:02:41 swirl neo4j[11713]: There may be a short delay until the server is ready.
apr 14 15:02:41 swirl neo4j[11713]: See /var/log/neo4j/neo4j.log for current status.
apr 14 15:05:07 swirl neo4j[12165]: Stopping Neo4j.. stopped
apr 14 15:05:37 swirl neo4j[12279]: Starting Neo4j.
apr 14 15:05:37 swirl neo4j[12279]: Started neo4j (pid 12334). By default, it is available at http://localhost:7474/
apr 14 15:05:37 swirl neo4j[12279]: There may be a short delay until the server is ready.
apr 14 15:05:37 swirl neo4j[12279]: See /var/log/neo4j/neo4j.log for current status.
```
