### PR TITLE
Doc auto generated certificate will not work for diff protocols on diff interfaces

### DIFF
--- a/community/server/src/docs/ops/security.asciidoc
+++ b/community/server/src/docs/ops/security.asciidoc
@@ -51,6 +51,10 @@ The Neo4j server includes built in support for SSL encrypted communication over 
 The first time the server starts, it automatically generates a self-signed SSL certificate and a private key.
 Because the certificate is self signed, it is not safe to rely on for production use, instead, you should provide your own key and certificate for the server to use.
 
+[CAUTION]
+Using autogeneration of self-signed SSL certificates will not work if the Neo4j server has been configured with multiple connectors that do not bind to the same IP address.
+If you need to use multiple IP addresses, please configure certificates manually and consider using multi-host or wildcard certificates instead.
+
 To provide your own key and certificate put them in the <<file-locations, _certificates_>> directory.
 The files must be named _neo4j.key_ and _neo4j.cert_.
 The location of the directory can be configured by setting _dbms.directories.certificates_ in <<file-locations, _neo4j.conf_>>.

--- a/community/server/src/docs/ops/security.asciidoc
+++ b/community/server/src/docs/ops/security.asciidoc
@@ -52,8 +52,8 @@ The first time the server starts, it automatically generates a self-signed SSL c
 Because the certificate is self signed, it is not safe to rely on for production use, instead, you should provide your own key and certificate for the server to use.
 
 [CAUTION]
-Using autogeneration of self-signed SSL certificates will not work if the Neo4j server has been configured with multiple connectors that do not bind to the same IP address.
-If you need to use multiple IP addresses, please configure certificates manually and consider using multi-host or wildcard certificates instead.
+Using auto-generation of self-signed SSL certificates will not work if the Neo4j server has been configured with multiple connectors that bind to different IP addresses.
+If you need to use multiple IP addresses, please configure certificates manually and use multi-host or wildcard certificates instead.
 
 To provide your own key and certificate put them in the <<file-locations, _certificates_>> directory.
 The files must be named _neo4j.key_ and _neo4j.cert_.

--- a/manual/contents/src/operations/configuration-reference.asciidoc
+++ b/manual/contents/src/operations/configuration-reference.asciidoc
@@ -17,8 +17,8 @@ Each connector has a unique key to identify it, denoted `(bolt-connector-key)` i
 include::{importdir}/neo4j-config-docs-docs-jar/ops/configuration-bolt-connector-attributes.asciidoc[]
 
 [CAUTION]
-Using autogeneration of self-signed SSL certificates will not work if the Neo4j server has been configured with multiple connectors that do not bind to the same IP address.
-If you need to use multiple IP addresses, please configure certificates manually and consider using multi-host or wildcard certificates instead.
+Using auto-generation of self-signed SSL certificates will not work if the Neo4j server has been configured with multiple connectors that bind to different IP addresses.
+If you need to use multiple IP addresses, please configure certificates manually and use multi-host or wildcard certificates instead.
 
 == Configuring HTTP Connectors
 
@@ -31,5 +31,5 @@ Each connector has a unique key to identify it, denoted `(http-connector-key)` i
 include::{importdir}/neo4j-config-docs-docs-jar/ops/configuration-http-connector-attributes.asciidoc[]
 
 [CAUTION]
-Using autogeneration of self-signed SSL certificates will not work if the Neo4j server has been configured with multiple connectors that do not bind to the same IP address.
-If you need to use multiple IP addresses, please configure certificates manually and consider using multi-host or wildcard certificates instead.
+Using auto-generation of self-signed SSL certificates will not work if the Neo4j server has been configured with multiple connectors that bind to different IP addresses.
+If you need to use multiple IP addresses, please configure certificates manually and use multi-host or wildcard certificates instead.

--- a/manual/contents/src/operations/configuration-reference.asciidoc
+++ b/manual/contents/src/operations/configuration-reference.asciidoc
@@ -16,6 +16,9 @@ Each connector has a unique key to identify it, denoted `(bolt-connector-key)` i
 
 include::{importdir}/neo4j-config-docs-docs-jar/ops/configuration-bolt-connector-attributes.asciidoc[]
 
+[CAUTION]
+Using autogeneration of self-signed SSL certificates will not work if the Neo4j server has been configured with multiple connectors that do not bind to the same IP address.
+If you need to use multiple IP addresses, please configure certificates manually and consider using multi-host or wildcard certificates instead.
 
 == Configuring HTTP Connectors
 
@@ -26,3 +29,7 @@ There must be exactly one HTTP connector and zero or one HTTPS connectors config
 Each connector has a unique key to identify it, denoted `(http-connector-key)` in the listing below.
 
 include::{importdir}/neo4j-config-docs-docs-jar/ops/configuration-http-connector-attributes.asciidoc[]
+
+[CAUTION]
+Using autogeneration of self-signed SSL certificates will not work if the Neo4j server has been configured with multiple connectors that do not bind to the same IP address.
+If you need to use multiple IP addresses, please configure certificates manually and consider using multi-host or wildcard certificates instead.


### PR DESCRIPTION
Document that if configuring different protocols on different interfaces that auto-generated certificates will not work

Document recommended workaround to use multi-host or wildcard certificate instead
