### PR TITLE
Make store-copying (HA, Backup) work with custom record format configurations

### DIFF
--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -57,6 +57,7 @@ import org.neo4j.logging.NullLogProvider;
 
 import static java.lang.Math.max;
 import static org.neo4j.helpers.Format.bytes;
+import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.record_format;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter.writeLogHeader;
@@ -318,6 +319,7 @@ public class StoreCopyClient
                 .setUserLogProvider( NullLogProvider.getInstance() )
                 .newEmbeddedDatabaseBuilder( tempStore.getAbsoluteFile() )
                 .setConfig( "dbms.backup.enabled", Settings.FALSE )
+                .setConfig( record_format, config.get( record_format ) )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.allow_store_upgrade,


### PR DESCRIPTION
We require that all members of a cluster, and backup clients, are configured with the same record format.
However, there was a problem with store copying, which starts up a temporary embedded database to do recovery of the copied transaction logs.
This embedded database was not told what record format the database as a whole had ben configured with, and thus would fail to start (and fail to recover the copied database) if a non-default format had been configured.

**Note:** It looks like this will have merge conflicts with 3.1.
