### PR TITLE
Configure `neo4j_home` to outside store dir

### DIFF
--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -1278,6 +1278,8 @@ public class ClusterManager
                 builder.setConfig( ClusterSettings.cluster_server, "0.0.0.0:" + clusterPort );
                 builder.setConfig( HaSettings.ha_server, clusterUri.getHost() + ":" + haPort );
                 builder.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE );
+                builder.setConfig( GraphDatabaseSettings.neo4j_home,
+                        new File( parent, "miscForServer" + serverId ).getAbsolutePath() );
                 for ( Map.Entry<String,IntFunction<String>> conf : commonConfig.entrySet() )
                 {
                     builder.setConfig( conf.getKey(), conf.getValue().apply( serverId.toIntegerIndex() ) );


### PR DESCRIPTION
In embedded HA setups (common for our build/test environments), there
are issues when starting a cluster if the `logs` directory is placed
inside of the store directory. This commit configures the `logs`
directory to be within a sibling `misc` directory to the store dir.
