### PR TITLE
Exclude only exact matches of exclusion list directories

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StoreUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StoreUtil.java
@@ -45,7 +45,7 @@ public class StoreUtil
         }
 
         return storeDir.listFiles(file -> {
-            for ( String directory : new String[] {"metrics", "certificates"} )
+            for ( String directory : new String[] {"metrics", "logs", "certificates"} )
             {
                 if ( file.getName().startsWith( directory ) )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StoreUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/StoreUtil.java
@@ -47,7 +47,7 @@ public class StoreUtil
         return storeDir.listFiles(file -> {
             for ( String directory : new String[] {"metrics", "logs", "certificates"} )
             {
-                if ( file.getName().startsWith( directory ) )
+                if ( file.getName().equals( directory ) )
                 {
                     return false;
                 }


### PR DESCRIPTION
This also reverts the quick-fix removal of `logs` from the exclusion list of things to _not_ delete when cleaning store directory.
