### PR TITLE
Optimize Cypher aggregation memory usage

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ExecutionContext.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/ExecutionContext.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v2_2
 
-import mutation.UpdateAction
-import pipes.MutableMaps
-import collection.{immutable, Iterator}
-import collection.mutable.{Queue, Map => MutableMap}
+import org.neo4j.cypher.internal.compiler.v2_2.pipes.MutableMaps
+
+import scala.collection.mutable.{Map => MutableMap}
+import scala.collection.{Iterator, immutable}
 
 object ExecutionContext {
   def empty = new ExecutionContext()
@@ -30,8 +30,7 @@ object ExecutionContext {
   def from(x: (String, Any)*) = new ExecutionContext().newWith(x)
 }
 
-case class ExecutionContext(m: MutableMap[String, Any] = MutableMaps.empty,
-                            mutationCommands: Queue[UpdateAction] = Queue.empty)
+case class ExecutionContext(m: MutableMap[String, Any] = MutableMaps.empty)
   extends MutableMap[String, Any] {
 
   def get(key: String): Option[Any] = m.get(key)

--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EagerAggregationPipe.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/pipes/EagerAggregationPipe.scala
@@ -50,12 +50,12 @@ case class EagerAggregationPipe(source: Pipe, keyExpressions: Set[String], aggre
     state.decorator.registerParentPipe(this)
 
     // This is the temporary storage used while the aggregation is going on
-    val result = MutableMap[NiceHasher, (ExecutionContext, Seq[AggregationFunction])]()
+    val result = MutableMap[NiceHasher, Seq[AggregationFunction]]()
     val keyNames: Seq[String] = keyExpressions.toSeq
-    val aggregationNames: Seq[String] = aggregations.map(_._1).toSeq
+    val aggregationNames: Seq[String] = aggregations.keys.toSeq
     val mapSize = keyNames.size + aggregationNames.size
 
-    def createResults(key: NiceHasher, aggregator: scala.Seq[AggregationFunction], ctx: ExecutionContext): ExecutionContext = {
+    def createResults(key: NiceHasher, aggregator: scala.Seq[AggregationFunction]): ExecutionContext = {
       val newMap = MutableMaps.create(mapSize)
 
       //add key values
@@ -64,7 +64,7 @@ case class EagerAggregationPipe(source: Pipe, keyExpressions: Set[String], aggre
       //add aggregated values
       (aggregationNames zip aggregator.map(_.result)).foreach(newMap += _)
 
-      ctx.newFromMutableMap(newMap)
+      ExecutionContext(newMap)
     }
 
     def createEmptyResult(params: Map[String, Any]): Iterator[ExecutionContext] = {
@@ -78,8 +78,10 @@ case class EagerAggregationPipe(source: Pipe, keyExpressions: Set[String], aggre
 
     input.foreach(ctx => {
       val groupValues: NiceHasher = new NiceHasher(keyNames.map(ctx))
-      val aggregateFunctions: Seq[AggregationFunction] = aggregations.map(_._2.createAggregationFunction).toSeq
-      val (_, functions) = result.getOrElseUpdate(groupValues, (ctx, aggregateFunctions))
+      val functions = result.getOrElseUpdate(groupValues, {
+        val aggregateFunctions: Seq[AggregationFunction] = aggregations.map(_._2.createAggregationFunction).toSeq
+        aggregateFunctions
+      })
       functions.foreach(func => func(ctx)(state))
     })
 
@@ -87,7 +89,7 @@ case class EagerAggregationPipe(source: Pipe, keyExpressions: Set[String], aggre
       createEmptyResult(state.params)
     } else {
       result.map {
-        case (key, (ctx, aggregator)) => createResults(key, aggregator, ctx)
+        case (key, aggregator) => createResults(key, aggregator)
       }.toIterator
     }
   }


### PR DESCRIPTION
- Do not store ExecutionContext in every hash table entry in
  EagerAggregationPipe. (It was not used for anything).
- Only create aggregation functions when a new hash table entry is inserted.
- Remove unused member in ExecutionContext
- Fix warning

The high memory consumption of eager aggregation causes some queries to require very large heaps to be able to run. We should do what we can to improve this. This is a simple and fairly safe first step.
