### PR TITLE
Add a default configuration for dbms.checkpoint.iops.limit in EE

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -244,15 +244,19 @@ public abstract class GraphDatabaseSettings
                   "for seconds, and 'ms' for milliseconds." )
     public static final Setting<Long> check_point_interval_time = setting( "dbms.checkpoint.interval.time", DURATION, "5m" );
 
-    @Description( "Configures the maximum amount of IO that the background check-point process should consume. " +
-                  "This setting is advisory, and is ignored in Neo4j Community Edition, and is followed to best " +
-                  "effort in Enterprise Edition. The setting is expressed in IOs per second. Restricting the number " +
-                  "of IOPS consumed by the check-point process, will leave more IO bandwidth for things that are " +
-                  "critical for transaction response time, such as appending to the transaction log. This only " +
-                  "matters if both the store files and the transaction logs are placed on the same logical storage " +
-                  "device. If that is the case, then limiting the check-point process to, say, half of the IO " +
-                  "bandwidth of your system is a good place to start.")
-    public static final Setting<Integer> check_point_iops_limit = setting( "dbms.checkpoint.iops.limit", INTEGER, "-1" );
+    @Description( "Limit the number of IOs the background checkpoint process will consume per second. " +
+                  "This setting is advisory, is ignored in Neo4j Community Edition, and is followed to " +
+                  "best effort in Enterprise Edition. " +
+                  "An IO is in this case a 8 KiB (mostly sequential) write. Limiting the write IO in " +
+                  "this way will leave more bandwidth in the IO subsystem to service random-read IOs, " +
+                  "which is important for the response time of queries when the database cannot fit " +
+                  "entirely in memory. The only drawback of this setting is that longer checkpoint times " +
+                  "may lead to slightly longer recovery times in case of a database or system crash. " +
+                  "A lower number means lower IO pressure, and consequently longer checkpoint times. " +
+                  "The configuration can also be commented out to remove the limitation entirely, and " +
+                  "let the checkpointer flush data as fast as the hardware will go. " +
+                  "Set this to -1 to disable the IOPS limit.")
+    public static final Setting<Integer> check_point_iops_limit = setting( "dbms.checkpoint.iops.limit", INTEGER, "1000" );
 
     // Auto Indexing
     @Description("Controls the auto indexing feature for nodes. Setting it to `false` shuts it down, " +

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ConfigurableIOLimiterTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/transaction/log/checkpoint/ConfigurableIOLimiterTest.java
@@ -58,9 +58,24 @@ public class ConfigurableIOLimiterTest
     }
 
     @Test
-    public void mustNotPutLimitOnIOWhenNoLimitIsConfigured() throws Exception
+    public void mustPutDefaultLimitOnIOWhenNoLimitIsConfigured() throws Exception
     {
         createIOLimiter( Config.defaults() );
+
+
+        // Do 100*100 = 10000 IOs real quick, when we're limited to 1000 IOPS.
+        long stamp = IOLimiter.INITIAL_STAMP;
+        repeatedlyCallMaybeLimitIO( limiter, stamp, 100 );
+
+        // This should have led to about 10 seconds of pause, minus the time we spent in the loop.
+        // So let's say 9 seconds - experiments indicate this gives us about a 10x margin.
+        assertThat( pauseNanosCounter.get(), greaterThan( TimeUnit.SECONDS.toNanos( 9 ) ) );
+    }
+
+    @Test
+    public void mustNotPutLimitOnIOWhenConfiguredToBeUnlimited() throws Exception
+    {
+        createIOLimiter( -1 );
         assertUnlimited();
     }
 

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -191,6 +191,8 @@ ha.pull_interval=10
 #dbms.tx_log.rotation.retention_policy=7 days
 
 # Limit the number of IOs the background checkpoint process will consume per second.
+# This setting is advisory, is ignored in Neo4j Community Edition, and is followed to
+# best effort in Enterprise Edition.
 # An IO is in this case a 8 KiB (mostly sequential) write. Limiting the write IO in
 # this way will leave more bandwidth in the IO subsystem to service random-read IOs,
 # which is important for the response time of queries when the database cannot fit
@@ -199,7 +201,8 @@ ha.pull_interval=10
 # A lower number means lower IO pressure, and consequently longer checkpoint times.
 # The configuration can also be commented out to remove the limitation entirely, and
 # let the checkpointer flush data as fast as the hardware will go.
-dbms.checkpoint.iops.limit=1000
+# Set this to -1 to disable the IOPS limit.
+# dbms.checkpoint.iops.limit=1000
 
 # Enable a remote shell server which Neo4j Shell clients can log in to.
 #dbms.shell.enabled=true

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -190,6 +190,17 @@ ha.pull_interval=10
 # Retention policy for transaction logs needed to perform recovery and backups.
 #dbms.tx_log.rotation.retention_policy=7 days
 
+# Limit the number of IOs the background checkpoint process will consume per second.
+# An IO is in this case a 8 KiB (mostly sequential) write. Limiting the write IO in
+# this way will leave more bandwidth in the IO subsystem to service random-read IOs,
+# which is important for the response time of queries when the database cannot fit
+# entirely in memory. The only drawback of this setting is that longer checkpoint times
+# may lead to slightly longer recovery times in case of a database or system crash.
+# A lower number means lower IO pressure, and consequently longer checkpoint times.
+# The configuration can also be commented out to remove the limitation entirely, and
+# let the checkpointer flush data as fast as the hardware will go.
+dbms.checkpoint.iops.limit=1000
+
 # Enable a remote shell server which Neo4j Shell clients can log in to.
 #dbms.shell.enabled=true
 # The network interface IP the shell will listen on (use 0.0.0.0 for all interfaces).


### PR DESCRIPTION
The particular choice of a default value has been shown to improve cluster stability when running on AWS instances with high-IOPS EBS volumes.
