### PR TITLE
Imporve test failure reporting

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPQueryGraphSolverTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/idp/IDPQueryGraphSolverTest.scala
@@ -27,6 +27,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection.OUTGOING
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+import org.scalatest.exceptions.TestFailedException
 
 import scala.collection.immutable
 import scala.language.reflectiveCalls
@@ -516,7 +517,8 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
           }
           assertMinExpandsAndJoins(plan, Map("expands" -> numberOfPatternRelationships, "joins" -> minJoinsExpected))
         } catch {
-          case e: Exception => fail(s"Failed to plan with config '$solverConfig': ${e.getMessage}")
+          case e: TestFailedException => fail(s"Failed to plan with config '$solverConfig': ${e.getMessage}")
+          case e: Throwable => throw new RuntimeException(s"Failed to plan with config '$solverConfig'", e)
         }
       }
     }


### PR DESCRIPTION
Do not swallow exception stacktraces if are unrelated to test assertions.
