### PR TITLE
Show parameters in query logging

### DIFF
--- a/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/helpers/JavaCompatibility.scala
+++ b/community/cypher/cypher-compiler-2.2/src/main/scala/org/neo4j/cypher/internal/compiler/v2_2/helpers/JavaCompatibility.scala
@@ -17,20 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.query;
+package org.neo4j.cypher.internal.compiler.v2_2.helpers
 
-import java.util.Map;
+import java.util
 
-/**
- * The current (December 2014) usage of this interface expects the {@code end*} methods to be idempotent.
- * That is, once either of them have been invoked with a particular session as parameter, invoking either
- * of them with the same session parameter should do nothing.
- */
-public interface QueryExecutionMonitor
-{
-    void startQueryExecution( QuerySession session, String query, Map<String,Object> parameters );
+import scala.collection.JavaConverters._
 
-    void endFailure( QuerySession session, Throwable failure );
+object JavaCompatibility {
 
-    void endSuccess( QuerySession session );
+  def asJavaCompatible(value: Any): Any = value match {
+    case seq: Seq[_] => seq.map(asJavaCompatible).asJava
+    case map: Map[_, _] => Eagerly.immutableMapValues(map, asJavaCompatible).asJava
+    case x => x
+  }
+
+  def asJavaMap[S, T](map: Map[S, T]): util.Map[S, AnyRef] = Eagerly.immutableMapValues(map, asJavaCompatible).asJava.asInstanceOf[util.Map[S, AnyRef]]
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/ExecutionEngine.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher
 import java.util.{Map => JavaMap}
 
 import org.neo4j.cypher.internal.compiler.v2_2._
+import org.neo4j.cypher.internal.compiler.v2_2.helpers.JavaCompatibility.asJavaMap
 import org.neo4j.cypher.internal.compiler.v2_2.helpers.LRUCache
 import org.neo4j.cypher.internal.compiler.v2_2.parser.ParserMonitor
 import org.neo4j.cypher.internal.compiler.v2_2.prettifier.Prettifier
@@ -82,7 +83,7 @@ class ExecutionEngine(graph: GraphDatabaseService, logger: StringLogger = String
 
   @throws(classOf[SyntaxException])
   def profile(query: String, params: Map[String, Any], session: QuerySession): ExtendedExecutionResult = {
-    executionMonitor.startQueryExecution(session, query)
+    executionMonitor.startQueryExecution(session, query, asJavaMap(params))
 
     val (preparedPlanExecution, txInfo) = planQuery(query)
     preparedPlanExecution.profile(graphAPI, txInfo, params, session)
@@ -108,7 +109,7 @@ class ExecutionEngine(graph: GraphDatabaseService, logger: StringLogger = String
 
   @throws(classOf[SyntaxException])
   def execute(query: String, params: Map[String, Any], session: QuerySession): ExtendedExecutionResult = {
-    executionMonitor.startQueryExecution(session, query)
+    executionMonitor.startQueryExecution(session, query, asJavaMap(params))
     val (preparedPlanExecution, txInfo) = planQuery(query)
     preparedPlanExecution.execute(graphAPI, txInfo, params, session)
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor2_2.scala
@@ -257,11 +257,20 @@ case class ExecutionResultWrapperFor2_2(inner: InternalExecutionResult, planner:
     )
   }
 
-  def close() = exceptionHandlerFor2_2.runSafely{ inner.close() }
+  def close() = exceptionHandlerFor2_2.runSafely {
+    endQueryExecution()
+    inner.close()
+  }
 
   def next() = exceptionHandlerFor2_2.runSafely{ inner.next() }
 
-  def hasNext = exceptionHandlerFor2_2.runSafely{ inner.hasNext }
+  def hasNext = exceptionHandlerFor2_2.runSafely {
+    val next = inner.hasNext
+    if (!next) {
+      endQueryExecution()
+    }
+    next
+  }
 
   def convert(i: InternalPlanDescription): ExtendedPlanDescription = exceptionHandlerFor2_2.runSafely {
     CompatibilityPlanDescription(i, CypherVersion.v2_2, planner)

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher
 
+import java.util.Collections
+
 import org.neo4j.cypher.internal.commons.CypherFunSuite
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.GraphDatabaseAPI
@@ -41,7 +43,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     engine.execute("RETURN 42", Map.empty[String, Any], session)
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42", Collections.emptyMap())
     verify(monitor, never()).endSuccess(session)
   }
 
@@ -61,7 +63,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     }
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -77,7 +79,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CREATE()", Map.empty[String, Any], session).javaIterator
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CREATE()")
+    verify(monitor, times(1)).startQueryExecution(session, "CREATE()", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -93,7 +95,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
 
     //then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]", Collections.emptyMap())
     while (result.hasNext) {
       verify(monitor, never).endSuccess(session)
       result.next()
@@ -123,7 +125,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("RETURN 42", Map.empty[String, Any], session).javaIterator.close()
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -148,7 +150,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     }
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endFailure(session, throwable)
   }
 
@@ -164,7 +166,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.profile("RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
 
     //then
-    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]")
+    verify(monitor, times(1)).startQueryExecution(session, "RETURN [1, 2, 3, 4, 5]", Collections.emptyMap())
     while (result.hasNext) {
       verify(monitor, never).endSuccess(session)
       result.next()
@@ -184,7 +186,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.profile("CYPHER 2.1 RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
 
     //then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 RETURN [1, 2, 3, 4, 5]")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 RETURN [1, 2, 3, 4, 5]", Collections.emptyMap())
     while (result.hasNext) {
       verify(monitor, never).endSuccess(session)
       result.next()
@@ -204,7 +206,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CYPHER 2.1 RETURN 42", Map.empty[String, Any], session).javaIterator.close()
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -229,7 +231,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     }
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endFailure(session, throwable)
   }
 
@@ -245,7 +247,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CYPHER 2.1 CREATE()", Map.empty[String, Any], session).javaIterator
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 CREATE()")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.1 CREATE()", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -261,7 +263,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.profile("CYPHER 2.0 RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
 
     //then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 RETURN [1, 2, 3, 4, 5]")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 RETURN [1, 2, 3, 4, 5]", Collections.emptyMap())
     while (result.hasNext) {
       verify(monitor, never).endSuccess(session)
       result.next()
@@ -281,7 +283,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CYPHER 2.0 RETURN 42", Map.empty[String, Any], session).javaIterator.close()
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -306,7 +308,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     }
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endFailure(session, throwable)
   }
 
@@ -322,7 +324,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CYPHER 2.0 CREATE()", Map.empty[String, Any], session).javaIterator
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 CREATE()")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 2.0 CREATE()", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -338,7 +340,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.profile("CYPHER 1.9 CREATE() RETURN [1, 2, 3, 4, 5]", Map.empty[String, Any], session).javaIterator
 
     //then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE() RETURN [1, 2, 3, 4, 5]")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE() RETURN [1, 2, 3, 4, 5]", Collections.emptyMap())
     while (result.hasNext) {
       verify(monitor, never).endSuccess(session)
       result.next()
@@ -358,7 +360,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CYPHER 1.9 CREATE() RETURN 42", Map.empty[String, Any], session).javaIterator.close()
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE() RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE() RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 
@@ -383,7 +385,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     }
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE() RETURN 42")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE() RETURN 42", Collections.emptyMap())
     verify(monitor, times(1)).endFailure(session, throwable)
   }
 
@@ -399,7 +401,7 @@ class QueryExecutionMonitorTest extends CypherFunSuite {
     val result = engine.execute("CYPHER 1.9 CREATE()", Map.empty[String, Any], session).javaIterator
 
     // then
-    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE()")
+    verify(monitor, times(1)).startQueryExecution(session, "CYPHER 1.9 CREATE()", Collections.emptyMap())
     verify(monitor, times(1)).endSuccess(session)
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryStatisticsTestSupport.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher
 
+import java.util
+
 import org.neo4j.cypher.internal.compatibility.ExecutionResultWrapperFor2_2
 import org.neo4j.cypher.internal.compiler.v2_2.PlannerName
 import org.neo4j.cypher.internal.compiler.v2_2.executionplan.InternalExecutionResult
@@ -35,7 +37,7 @@ trait QueryStatisticsTestSupport {
 
     def apply(actual: InternalExecutionResult) {
       implicit val monitor = new QueryExecutionMonitor {
-        override def startQueryExecution(session: QuerySession, query: String){}
+        override def startQueryExecution(session: QuerySession, query: String, parameters: util.Map[String, AnyRef]){}
 
         override def endSuccess(session: QuerySession){}
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -399,6 +399,9 @@ public abstract class GraphDatabaseSettings
     @Description( "Log executed queries that takes longer than the configured threshold." )
     public static final Setting<Boolean> log_queries = setting("dbms.querylog.enabled", BOOLEAN, FALSE );
 
+    @Description( "Log parameters for executed queries that took longer than the configured threshold." )
+    public static final Setting<Boolean> log_queries_parameter_logging_enabled = setting( "dbms.querylog.parameter_logging_enabled", BOOLEAN, TRUE );
+
     @Description( "The file where queries will be recorded." )
     public static final Setting<File> log_queries_filename = setting("dbms.querylog.filename", PATH, NO_DEFAULT );
 

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -19,17 +19,22 @@
  */
 package org.neo4j.kernel.impl.query;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Settings;
@@ -37,6 +42,7 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
+import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -64,14 +70,63 @@ public class QueryLoggerIT
         final File logFilename = new File( testDirectory.graphDbDir(), "queries.log" );
         GraphDatabaseService database = databaseBuilder.setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.log_queries_filename, logFilename.getPath() )
+                .setConfig( GraphDatabaseSettings.log_queries_parameter_logging_enabled, Settings.FALSE )
                 .newGraphDatabase();
 
         executeQueryAndShutdown( database );
 
         List<String> logLines = readAllLines( logFilename );
         assertEquals( 1, logLines.size() );
-        assertThat( logLines.get( 0 ), Matchers.endsWith( String.format( " ms: %s - %s",
+        assertThat( logLines.get( 0 ), endsWith( String.format( " ms: %s - %s",
                 QueryEngineProvider.embeddedSession(), QUERY ) ) );
+    }
+
+    @Test
+    public void shouldLogParametersWhenNestedMap() throws Exception
+    {
+        File logFilename = new File( testDirectory.graphDbDir(), "queries.log" );
+        GraphDatabaseService database = databaseBuilder.setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.log_queries_filename, logFilename.getPath() )
+                .setConfig( GraphDatabaseSettings.log_queries_parameter_logging_enabled, Settings.TRUE )
+                .newGraphDatabase();
+
+        Map<String,Object> props = new LinkedHashMap<>(); // to be sure about ordering in the last assertion
+        props.put( "name", "Roland" );
+        props.put( "position", "Gunslinger" );
+        props.put( "followers", Arrays.asList( "Jake", "Eddie", "Susannah" ) );
+
+        Map<String,Object> params = new HashMap<>();
+        params.put( "props", props );
+
+        String query = "CREATE ({props})";
+        executeQueryAndShutdown( database, query, params );
+
+        List<String> logLines = readAllLines( logFilename );
+        assertEquals( 1, logLines.size() );
+        assertThat( logLines.get( 0 ), endsWith( String.format(
+                " ms: %s - %s - {props: {name: Roland, position: Gunslinger, followers: [Jake, Eddie, Susannah]}}",
+                QueryEngineProvider.embeddedSession(), query ) ) );
+    }
+
+    @Test
+    public void shouldLogParametersWhenList() throws Exception
+    {
+        File logFilename = new File( testDirectory.graphDbDir(), "queries.log" );
+        GraphDatabaseService database = databaseBuilder.setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.log_queries_filename, logFilename.getPath() )
+                .setConfig( GraphDatabaseSettings.log_queries_parameter_logging_enabled, Settings.TRUE )
+                .newGraphDatabase();
+
+        Map<String,Object> params = new HashMap<>();
+        params.put( "ids", Arrays.asList( 0, 1, 2 ) );
+        String query = "MATCH (n) WHERE id(n) in {ids} RETURN n.name";
+        executeQueryAndShutdown( database, query, params );
+
+        List<String> logLines = readAllLines( logFilename );
+        assertEquals( 1, logLines.size() );
+        assertThat( logLines.get( 0 ), endsWith( String.format(
+                " ms: %s - %s - {ids: [0, 1, 2]}",
+                QueryEngineProvider.embeddedSession(), query ) ) );
     }
 
     @Test
@@ -153,6 +208,13 @@ public class QueryLoggerIT
     private void executeQueryAndShutdown( GraphDatabaseService database )
     {
         database.execute( QUERY );
+        database.shutdown();
+    }
+
+    private void executeQueryAndShutdown( GraphDatabaseService database, String query, Map<String,Object> params )
+    {
+        Result execute = database.execute( query, params );
+        execute.close();
         database.shutdown();
     }
 

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
@@ -22,9 +22,14 @@ package org.neo4j.kernel.impl.query;
 import org.junit.Test;
 import org.mockito.InOrder;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.function.Factory;
+import org.neo4j.helpers.Clock;
 import org.neo4j.helpers.FakeClock;
 import org.neo4j.kernel.impl.query.QueryLoggerKernelExtension.QueryLogger;
 import org.neo4j.kernel.impl.util.StringLogger;
@@ -44,11 +49,11 @@ public class QueryLoggerTest
         StringLogger logger = mock( StringLogger.class );
         QuerySession session = session( "{the session}" );
         FakeClock clock = new FakeClock();
-        QueryLogger queryLogger = new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/ );
+        QueryLogger queryLogger = queryLoggerWithoutParams( logger, clock );
         queryLogger.init();
 
         // when
-        queryLogger.startQueryExecution( session, "MATCH (n) RETURN n" );
+        queryLogger.startQueryExecution( session, "MATCH (n) RETURN n", Collections.<String,Object>emptyMap() );
         clock.forward( 11, TimeUnit.MILLISECONDS );
         queryLogger.endSuccess( session );
 
@@ -63,11 +68,11 @@ public class QueryLoggerTest
         StringLogger logger = mock( StringLogger.class );
         QuerySession session = session( "{the session}" );
         FakeClock clock = new FakeClock();
-        QueryLogger queryLogger = new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/ );
+        QueryLogger queryLogger = queryLoggerWithoutParams( logger, clock );
         queryLogger.init();
 
         // when
-        queryLogger.startQueryExecution( session, "MATCH (n) RETURN n" );
+        queryLogger.startQueryExecution( session, "MATCH (n) RETURN n", Collections.<String,Object>emptyMap() );
         clock.forward( 9, TimeUnit.MILLISECONDS );
         queryLogger.endSuccess( session );
 
@@ -84,15 +89,15 @@ public class QueryLoggerTest
         QuerySession session2 = session( "{session two}" );
         QuerySession session3 = session( "{session three}" );
         FakeClock clock = new FakeClock();
-        QueryLogger queryLogger = new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/ );
+        QueryLogger queryLogger = queryLoggerWithoutParams( logger, clock );
         queryLogger.init();
 
         // when
-        queryLogger.startQueryExecution( session1, "MATCH (a) RETURN a" );
+        queryLogger.startQueryExecution( session1, "MATCH (a) RETURN a", Collections.<String,Object>emptyMap() );
         clock.forward( 1, TimeUnit.MILLISECONDS );
-        queryLogger.startQueryExecution( session2, "MATCH (b) RETURN b" );
+        queryLogger.startQueryExecution( session2, "MATCH (b) RETURN b", Collections.<String,Object>emptyMap() );
         clock.forward( 1, TimeUnit.MILLISECONDS );
-        queryLogger.startQueryExecution( session3, "MATCH (c) RETURN c" );
+        queryLogger.startQueryExecution( session3, "MATCH (c) RETURN c", Collections.<String,Object>emptyMap() );
         clock.forward( 7, TimeUnit.MILLISECONDS );
         queryLogger.endSuccess( session3 );
         clock.forward( 7, TimeUnit.MILLISECONDS );
@@ -114,17 +119,73 @@ public class QueryLoggerTest
         StringLogger logger = mock( StringLogger.class );
         QuerySession session = session( "{the session}" );
         FakeClock clock = new FakeClock();
-        QueryLogger queryLogger = new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/ );
+        QueryLogger queryLogger = queryLoggerWithoutParams( logger, clock );
         queryLogger.init();
         RuntimeException failure = new RuntimeException();
 
         // when
-        queryLogger.startQueryExecution( session, "MATCH (n) RETURN n" );
+        queryLogger.startQueryExecution( session, "MATCH (n) RETURN n", Collections.<String,Object>emptyMap() );
         clock.forward( 1, TimeUnit.MILLISECONDS );
         queryLogger.endFailure( session, failure );
 
         // then
         verify( logger ).error( "FAILURE 1 ms: {the session} - MATCH (n) RETURN n", failure );
+    }
+
+    @Test
+    public void shouldLogQueryParameters() throws Exception
+    {
+        // given
+        StringLogger logger = mock( StringLogger.class );
+        QuerySession session = session( "{the session}" );
+        FakeClock clock = new FakeClock();
+        QueryLogger queryLogger = queryLoggerWithParams( logger, clock );
+        queryLogger.init();
+
+        // when
+        Map<String,Object> params = new HashMap<>();
+        params.put( "ages", Arrays.asList( 41, 42, 43 ) );
+        queryLogger.startQueryExecution( session, "MATCH (n) WHERE n.age IN {ages} RETURN n", params );
+        clock.forward( 11, TimeUnit.MILLISECONDS );
+        queryLogger.endSuccess( session );
+
+        // then
+        verify( logger ).info(
+                "SUCCESS 11 ms: {the session} - MATCH (n) WHERE n.age IN {ages} RETURN n - {ages: [41, 42, 43]}" );
+    }
+
+    @Test
+    public void shouldLogQueryParametersOnFailure() throws Exception
+    {
+        // given
+        StringLogger logger = mock( StringLogger.class );
+        QuerySession session = session( "{the session}" );
+        FakeClock clock = new FakeClock();
+        QueryLogger queryLogger = queryLoggerWithParams( logger, clock );
+        queryLogger.init();
+        RuntimeException failure = new RuntimeException();
+
+        // when
+        Map<String,Object> params = new HashMap<>();
+        params.put( "ages", Arrays.asList( 41, 42, 43 ) );
+        queryLogger.startQueryExecution( session, "MATCH (n) WHERE n.age IN {ages} RETURN n", params );
+        clock.forward( 1, TimeUnit.MILLISECONDS );
+        queryLogger.endFailure( session, failure );
+
+        // then
+        verify( logger ).error(
+                "FAILURE 1 ms: {the session} - MATCH (n) WHERE n.age IN {ages} RETURN n - {ages: [41, 42, 43]}",
+                failure );
+    }
+
+    private static QueryLogger queryLoggerWithoutParams( StringLogger logger, Clock clock )
+    {
+        return new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/, false );
+    }
+
+    private static QueryLogger queryLoggerWithParams( StringLogger logger, Clock clock )
+    {
+        return new QueryLogger( clock, new LoggerFactory( logger ), 10/*ms*/, true );
     }
 
     private static QuerySession session( final String data )


### PR DESCRIPTION
When logging slow queries we now also display the parameters that was used for the specific case.

This commit **backports** 24f867e2a8da3677c9b1f947ec428798d7e93473. Additional setting `dbms.querylog.parameter_logging_enabled` is added to enable/disable logging of query parameters.

**Note:** this functionality already exists in 3.0 and 3.1 so only the setting part should be forward merged. I can do it myself when PR passes the review.
