### PR TITLE
Packer should not fail on deleted entities

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -34,7 +34,6 @@ import org.neo4j.bolt.v1.packstream.PackStream;
 import org.neo4j.bolt.v1.packstream.PackType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
-import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.kernel.api.exceptions.Status;
 
@@ -198,28 +197,13 @@ public class Neo4jPack
             }
         }
 
-        public void packRawMap( Map<String, Object> map ) throws IOException
+        public void packRawMap( Map<String,Object> map ) throws IOException
         {
             packMapHeader( map.size() );
-            if ( map.size() > 0 )
+            for ( Map.Entry<String,Object> entry : map.entrySet() )
             {
-                for ( Map.Entry<String, Object> entry : map.entrySet() )
-                {
-                    pack( entry.getKey() );
-                    pack( entry.getValue() );
-                }
-            }
-        }
-
-        // TODO: combine these
-        public void packProperties( PropertyContainer entity ) throws IOException
-        {
-            Map<String, Object> props = entity.getAllProperties();
-            packMapHeader( props.size() );
-            for ( Map.Entry<String, Object> property : props.entrySet() )
-            {
-                pack( property.getKey() );
-                pack( property.getValue() );
+                pack( entry.getKey() );
+                pack( entry.getValue() );
             }
         }
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
@@ -31,11 +31,17 @@ import java.util.Map;
 import org.neo4j.bolt.v1.packstream.PackedInputArray;
 import org.neo4j.bolt.v1.packstream.PackedOutputArray;
 import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Path;
+import org.neo4j.kernel.impl.util.HexPrinter;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.neo4j.bolt.v1.messaging.example.Nodes.ALICE;
 import static org.neo4j.bolt.v1.messaging.example.Paths.ALL_PATHS;
 import static org.neo4j.bolt.v1.messaging.example.Relationships.ALICE_KNOWS_BOB;
@@ -121,6 +127,28 @@ public class Neo4jPackTest
 
         // When
         unpacked( output.bytes() );
+    }
+
+    @Test
+    public void shouldHandleDeletedNodesGracefully() throws IOException
+    {
+        // Given
+        Node node = mock(Node.class);
+        when(node.getId()).thenReturn( 42L );
+        doThrow( NotFoundException.class ).when(node).getAllProperties(  );
+        doThrow( NotFoundException.class ).when(node).getLabels(  );
+
+        // When
+        byte[] packed = packed( node );
+
+        // Then
+        //Node (signature=0x4E)
+        //{
+        //    id: 42 (0x2A)
+        //    labels: [] (90)
+        //    props: {} (A0)
+        //}
+        assertThat(HexPrinter.hex( packed ), equalTo("B3 4E 2A 90 A0"));
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserDocIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserDocIT.java
@@ -92,14 +92,9 @@ public class PagedTraverserDocIT extends ExclusiveServerTestBase
                 .withClock( clock )
                 .build();
 
-        suppressAll().call( new Callable<Void>()
-        {
-            @Override
-            public Void call() throws Exception
-            {
-                server.start();
-                return null;
-            }
+        suppressAll().call( (Callable<Void>) () -> {
+            server.start();
+            return null;
         } );
         functionalTestHelper = new FunctionalTestHelper( server );
     }
@@ -113,14 +108,9 @@ public class PagedTraverserDocIT extends ExclusiveServerTestBase
     @AfterClass
     public static void stopServer() throws Exception
     {
-        suppressAll().call( new Callable<Void>()
-        {
-            @Override
-            public Void call() throws Exception
-            {
-                server.stop();
-                return null;
-            }
+        suppressAll().call( (Callable<Void>) () -> {
+            server.stop();
+            return null;
         } );
     }
 


### PR DESCRIPTION
When returning deleted entitities such as in `CREATE (a) DELETE a RETURN a`
we should still be able to pack and return the deleted entity to the user. Note
that in the other APIs we currently also mark the entity as deleted, this PR does not
add that to BOLT but that will come at a later stage.
