### PR TITLE
Fix sampling of lucene index size

### DIFF
--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneIndexAccessorReaderTest.java
@@ -87,6 +87,7 @@ public class LuceneIndexAccessorReaderTest
                 new Term( "string", "aaa" ),
                 new Term( "string", "ccc" )
         );
+        when(reader.numDocs() ).thenReturn( 3 );
 
         // When
         final DoubleLongRegister output = Registers.newDoubleLongRegister();
@@ -108,6 +109,7 @@ public class LuceneIndexAccessorReaderTest
                 new Term( NODE_ID_KEY, "aaa" ), // <- this should be ignored
                 new Term( "string", "bbb" )
         );
+        when(reader.numDocs() ).thenReturn( 1 );
 
         // When
 

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexSamplingIntegrationTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexSamplingIntegrationTest.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory;
 import org.neo4j.kernel.impl.store.counts.keys.IndexSampleKey;
+import org.neo4j.kernel.impl.store.counts.keys.IndexStatisticsKey;
 import org.neo4j.register.Register.DoubleLongRegister;
 import org.neo4j.register.Registers;
 import org.neo4j.test.TargetDirectory;
@@ -58,6 +59,7 @@ public class IndexSamplingIntegrationTest
     public void shouldSampleNotUniqueIndex() throws Throwable
     {
         GraphDatabaseService db = null;
+        long deletedNodes = 0;
         try
         {
             // Given
@@ -82,6 +84,17 @@ public class IndexSamplingIntegrationTest
                     db.createNode( label ).setProperty( property, names[i % names.length] );
                     tx.success();
                 }
+
+            }
+
+            try ( Transaction tx = db.beginTx() )
+            {
+                for ( int i = 0; i < (nodes / 10) ; i++ )
+                {
+                    db.findNodes( label, property, names[i % names.length] ).next().delete();
+                    deletedNodes++;
+                    tx.success();
+                }
             }
         }
         finally
@@ -96,15 +109,23 @@ public class IndexSamplingIntegrationTest
         triggerIndexResamplingOnNextStartup();
 
         // Then
+
+        // sampling will consider also the delete nodes till the next lucene compaction
         DoubleLongRegister register = fetchIndexSamplingValues( db );
         assertEquals( names.length, register.readFirst() );
         assertEquals( nodes, register.readSecond() );
+
+        // but the deleted nodes should not be considered in the index size value
+        DoubleLongRegister indexSizeRegister = fetchIndexSizeValues( db );
+        assertEquals( 0, indexSizeRegister.readFirst() );
+        assertEquals( nodes - deletedNodes, indexSizeRegister.readSecond() );
     }
 
     @Test
     public void shouldSampleUniqueIndex() throws Throwable
     {
         GraphDatabaseService db = null;
+        long deletedNodes = 0;
         try
         {
             // Given
@@ -123,6 +144,19 @@ public class IndexSamplingIntegrationTest
                     tx.success();
                 }
             }
+
+            try ( Transaction tx = db.beginTx() )
+            {
+                for ( int i = 0; i < nodes; i++ )
+                {
+                    if ( i % 10 == 0 )
+                    {
+                        deletedNodes++;
+                        db.findNode( label, property, "" + i ).delete();
+                        tx.success();
+                    }
+                }
+            }
         }
         finally
         {
@@ -136,9 +170,13 @@ public class IndexSamplingIntegrationTest
         triggerIndexResamplingOnNextStartup();
 
         // Then
-        DoubleLongRegister register = fetchIndexSamplingValues( db );
-        assertEquals( nodes, register.readFirst() );
-        assertEquals( nodes, register.readSecond() );
+        DoubleLongRegister indexSampleRegister = fetchIndexSamplingValues( db );
+        assertEquals( nodes - deletedNodes, indexSampleRegister.readFirst() );
+        assertEquals( nodes - deletedNodes, indexSampleRegister.readSecond() );
+
+        DoubleLongRegister indexSizeRegister = fetchIndexSizeValues( db );
+        assertEquals( 0, indexSizeRegister.readFirst() );
+        assertEquals( nodes - deletedNodes, indexSizeRegister.readSecond() );
     }
 
     private DoubleLongRegister fetchIndexSamplingValues( GraphDatabaseService db )
@@ -151,6 +189,27 @@ public class IndexSamplingIntegrationTest
             GraphDatabaseAPI api = (GraphDatabaseAPI) db;
             CountsTracker countsTracker = api.getDependencyResolver().resolveDependency( NeoStore.class ).getCounts();
             IndexSampleKey key = CountsKeyFactory.indexSampleKey( 0, 0 ); // cheating a bit...
+            return countsTracker.get( key, Registers.newDoubleLongRegister() );
+        }
+        finally
+        {
+            if ( db != null )
+            {
+                db.shutdown();
+            }
+        }
+    }
+
+    private DoubleLongRegister fetchIndexSizeValues( GraphDatabaseService db )
+    {
+        try
+        {
+            // Then
+            db = new TestGraphDatabaseFactory().newEmbeddedDatabase( testDirectory.graphDbDir().getAbsolutePath() );
+            @SuppressWarnings( "deprecation" )
+            GraphDatabaseAPI api = (GraphDatabaseAPI) db;
+            CountsTracker countsTracker = api.getDependencyResolver().resolveDependency( NeoStore.class ).getCounts();
+            IndexStatisticsKey key = CountsKeyFactory.indexStatisticsKey( 0, 0 ); // cheating a bit...
             return countsTracker.get( key, Registers.newDoubleLongRegister() );
         }
         finally


### PR DESCRIPTION
Since when we iterate over all the terms in the lucene index, lucene
will return also the term that has been deleted and not in use anymore
untill the next index compaction.  This is not a huge problem per se
for computing index selectivity, but we were using this skewed numbers
also for the index size.  This commit will fix the index size to be
computed correctly by asking lucene the number of documents present in
the index.
