### PR TITLE
Wrong version of dpkg in Pre-Depends.

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
@@ -8,7 +8,7 @@ Homepage: http://neo4j.org/
 
 Package: neo4j
 Architecture: all
-Pre-Depends: dpkg (>= 1.17.14)
+Pre-Depends: dpkg (>= 1.15.7.2)
 Depends: ${misc:Depends}, bash, daemon, adduser, psmisc, lsb-base, java8-runtime | j2re1.8
 Conflicts: 
 Replaces: neo4j-enterprise, neo4j-advanced

--- a/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
@@ -8,7 +8,7 @@ Homepage: http://neo4j.org/
 
 Package: neo4j-enterprise
 Architecture: all
-Pre-Depends: dpkg (>= 1.17.14)
+Pre-Depends: dpkg (>= 1.15.7.2)
 Depends: ${misc:Depends}, bash, daemon, adduser, psmisc, lsb-base, java8-runtime | j2re1.8
 Conflicts: 
 Replaces: neo4j, neo4j-advanced


### PR DESCRIPTION
Since we don't use the symlink helpers, we can depend on an older version. The newest version is not available in Ubuntu 14.04 LTS, and so should not be used.

See `dpkg-maintscript-helper(1)` for details.
