### PR TITLE
Remove dependency on deprecated Clock

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompiler.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0
 
+import java.time.Clock
+
 import org.neo4j.cypher.internal.compiler.v3_0.CompilationPhaseTracer.CompilationPhase.{AST_REWRITE, PARSING, SEMANTIC_CHECK}
 import org.neo4j.cypher.internal.compiler.v3_0.ast.rewriters.{normalizeReturnClauses, normalizeWithClauses}
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.CodeStructure
@@ -34,7 +36,6 @@ import org.neo4j.cypher.internal.frontend.v3_0.ast.Statement
 import org.neo4j.cypher.internal.frontend.v3_0.notification.InternalNotification
 import org.neo4j.cypher.internal.frontend.v3_0.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v3_0.{InputPosition, SemanticTable, inSequence}
-import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseQueryService
 
 trait AstRewritingMonitor {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0
 
+import java.time.Clock
+
 import org.neo4j.cypher.internal.compiler.v3_0.CompilationPhaseTracer.CompilationPhase._
 import org.neo4j.cypher.internal.compiler.v3_0.CompiledPlanBuilder.createTracer
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.profiling.ProfilingTracer
@@ -29,13 +31,12 @@ import org.neo4j.cypher.internal.compiler.v3_0.executionplan.{ExecutionPlan, Gen
 import org.neo4j.cypher.internal.compiler.v3_0.helpers._
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments
-import org.neo4j.cypher.internal.compiler.v3_0.planner.{PeriodicCommit, CantCompileQueryException}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.execution.{PipeExecutionBuilderContext, PipeExecutionPlanBuilder}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
+import org.neo4j.cypher.internal.compiler.v3_0.planner.{CantCompileQueryException, PeriodicCommit}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, PlanContext, QueryContext}
 import org.neo4j.cypher.internal.frontend.v3_0.notification.{InternalNotification, RuntimeUnsupportedNotification}
 import org.neo4j.cypher.internal.frontend.v3_0.{InternalException, InvalidArgumentException, SemanticTable}
-import org.neo4j.helpers.Clock
 
 object RuntimeBuilder {
   def create(runtimeName: Option[RuntimeName], interpretedProducer: InterpretedPlanBuilder,

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGenerator.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGenerator.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_0.codegen
 
 import java.lang.Boolean.getBoolean
+import java.time.Clock
 import java.util
 
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.CodeGenerator.SourceSink
@@ -35,7 +36,6 @@ import org.neo4j.cypher.internal.compiler.v3_0.spi.{InstrumentedGraphStatistics,
 import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionMode, PlannerName, TaskCloser}
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticTable
 import org.neo4j.cypher.internal.frontend.v3_0.helpers.Eagerly
-import org.neo4j.helpers.Clock
 
 class CodeGenerator(val structure: CodeStructure[GeneratedQuery]) {
 
@@ -57,7 +57,7 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery]) {
 
         val fp = planContext.statistics match {
           case igs: InstrumentedGraphStatistics =>
-            Some(PlanFingerprint(clock.currentTimeMillis(), planContext.txIdProvider(), igs.snapshot.freeze))
+            Some(PlanFingerprint(clock.millis(), planContext.txIdProvider(), igs.snapshot.freeze))
           case _ =>
             None
         }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 
+import java.time.Clock
+
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.QueryExecutionTracer
 import org.neo4j.cypher.internal.compiler.v3_0.codegen.profiling.ProfilingTracer
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.ExecutionPlanBuilder.DescriptionProvider
@@ -34,10 +36,7 @@ import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionMode, ProfileMode, _}
 import org.neo4j.cypher.internal.frontend.v3_0.PeriodicCommitInOpenTransactionException
 import org.neo4j.cypher.internal.frontend.v3_0.ast.Statement
 import org.neo4j.cypher.internal.frontend.v3_0.notification.InternalNotification
-import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseQueryService
-
-import scala.annotation.tailrec
 
 
 trait RunnablePlan {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/PlanFingerprint.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/PlanFingerprint.scala
@@ -19,8 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.executionplan
 
+import java.time.Clock
+
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, GraphStatisticsSnapshot}
-import org.neo4j.helpers.Clock
 
 case class PlanFingerprint(creationTimeMillis: Long, txId: Long, snapshot: GraphStatisticsSnapshot)
 
@@ -29,7 +30,7 @@ case class PlanFingerprintReference(clock: Clock, ttl: Long, statsDivergenceThre
 {
   def isStale(lastCommittedTxId: () => Long, statistics: GraphStatistics): Boolean = {
     fingerprint.fold(false) { f =>
-      lazy val currentTimeMillis = clock.currentTimeMillis()
+      lazy val currentTimeMillis = clock.millis()
       lazy val currentTxId = lastCommittedTxId()
 
       check(f.creationTimeMillis + ttl <= currentTimeMillis, {}) &&

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.execution
 
+import java.time.Clock
+
 import org.neo4j.cypher.internal.compiler.v3_0.ast.ResolvedCall
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.commands.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.commands.PatternConverters._
@@ -39,7 +41,6 @@ import org.neo4j.cypher.internal.frontend.v3_0._
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.helpers.Eagerly
 import org.neo4j.graphdb.Relationship
-import org.neo4j.helpers.Clock
 
 import scala.collection.mutable
 
@@ -50,7 +51,7 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors, pipeBuilderFact
 
     val fingerprint = planContext.statistics match {
       case igs: InstrumentedGraphStatistics =>
-        Some(PlanFingerprint(clock.currentTimeMillis(), planContext.txIdProvider(), igs.snapshot.freeze))
+        Some(PlanFingerprint(clock.millis(), planContext.txIdProvider(), igs.snapshot.freeze))
       case _ =>
         None
     }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/PlanFingerprintReferenceTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/PlanFingerprintReferenceTest.scala
@@ -25,7 +25,7 @@ import org.mockito.Mockito.when
 import org.neo4j.cypher.internal.compiler.v3_0.spi.{GraphStatistics, GraphStatisticsSnapshot, NodesWithLabelCardinality}
 import org.neo4j.cypher.internal.frontend.v3_0.LabelId
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
-import org.neo4j.helpers.FakeClock
+import org.neo4j.time.FakeClock
 
 class PlanFingerprintReferenceTest extends CypherFunSuite {
 
@@ -36,7 +36,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
     val clock = new FakeClock
     val stats = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
     clock.forward(2, SECONDS)
 
@@ -52,7 +52,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
     val clock = new FakeClock
     val stats = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
     clock.forward(2, SECONDS)
 
@@ -68,7 +68,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
     val clock = new FakeClock
     val stats = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
     clock.forward(2, SECONDS)
 
@@ -84,7 +84,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
     val clock = new FakeClock
     val stats = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
     clock.forward(500, MILLISECONDS)
 
@@ -100,7 +100,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
     val clock = new FakeClock
     val stats = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
     val reference = PlanFingerprintReference(clock, ttl, threshold, fingerprint)
 
@@ -118,7 +118,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
     val clock = new FakeClock
     val stats = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.currentTimeMillis(), 17, snapshot)
+    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
     val reference = PlanFingerprintReference(clock, ttl, threshold, fingerprint)
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner
 
+import java.time.Clock
+
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0._
@@ -37,7 +39,6 @@ import org.neo4j.cypher.internal.frontend.v3_0._
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.parser.CypherParser
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.{CypherFunSuite, CypherTestSupport}
-import org.neo4j.helpers.Clock
 
 import scala.collection.mutable
 
@@ -166,7 +167,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
       queryPlanner = queryPlanner,
       rewriterSequencer = rewriterSequencer,
       plannerName = None,
-      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.SYSTEM_CLOCK, monitors)),
+      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), monitors)),
       semanticChecker = semanticChecker,
       updateStrategy = None,
       config = config)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilderAcceptanceTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilderAcceptanceTest.scala
@@ -19,7 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.planner.execution
 
-import org.mockito.Mockito.{verify, when, atLeastOnce}
+import java.time.Clock
+
+import org.mockito.Mockito.{atLeastOnce, verify, when}
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.commands.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.Literal
 import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.True
@@ -34,7 +36,6 @@ import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_0.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
-import org.neo4j.helpers.Clock
 
 class PipeExecutionPlanBuilderAcceptanceTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
@@ -44,7 +45,7 @@ class PipeExecutionPlanBuilderAcceptanceTest extends CypherFunSuite with Logical
   implicit val pipeBuildContext = newMockedPipeExecutionPlanBuilderContext
   val patternRel = PatternRelationship("r", ("a", "b"), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
 
-  val planBuilder = new PipeExecutionPlanBuilder(Clock.SYSTEM_CLOCK, monitors)
+  val planBuilder = new PipeExecutionPlanBuilder(Clock.systemUTC(), monitors)
 
   def build(f: PlannerQuery with CardinalityEstimation => LogicalPlan): PipeInfo = {
     val logicalPlan = f(solved)

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilderTest.scala
@@ -22,12 +22,11 @@ package org.neo4j.cypher.internal.compiler.v3_0.planner.execution
 import org.neo4j.cypher.internal.compiler.v3_0.Monitors
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.{FakePipe, Pipe, RonjaPipe}
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.Cardinality
-import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{IdName, LogicalPlan}
+import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.compiler.v3_0.planner.{CardinalityEstimation, PlannerQuery}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.PlanContext
-import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
-import org.neo4j.helpers.FakeClock
+import org.neo4j.time.FakeClock
 
 class PipeExecutionPlanBuilderTest extends CypherFunSuite {
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherCompiler.scala
@@ -19,12 +19,13 @@
  */
 package org.neo4j.cypher.internal
 
+import java.time.Clock
+
 import org.neo4j.cypher.internal.compatibility.exceptionHandlerFor3_0
 import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.frontend.v3_0.InputPosition
 import org.neo4j.cypher.{InvalidArgumentException, SyntaxException, _}
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
-import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.KernelAPI
 import org.neo4j.kernel.configuration.Config
@@ -34,7 +35,7 @@ import org.neo4j.logging.{Log, LogProvider}
 object CypherCompiler {
   val DEFAULT_QUERY_CACHE_SIZE: Int = 128
   val DEFAULT_QUERY_PLAN_TTL: Long = 1000 // 1 second
-  val CLOCK = Clock.SYSTEM_CLOCK
+  val CLOCK = Clock.systemUTC()
   val DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD = 0.5
   val DEFAULT_NON_INDEXED_LABEL_WARNING_THRESHOLD = 10000
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PlannerCache.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/PlannerCache.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal
 import org.neo4j.cypher.internal.compatibility.{CompatibilityFor2_3, CompatibilityFor2_3Cost, CompatibilityFor2_3Rule, CompatibilityFor3_0, CompatibilityFor3_0Cost, CompatibilityFor3_0Rule}
 import org.neo4j.cypher.internal.compiler.v3_0.CypherCompilerConfiguration
 import org.neo4j.cypher.{CypherPlanner, CypherRuntime, CypherUpdateStrategy}
+import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.KernelAPI
 import org.neo4j.kernel.monitoring.{Monitors => KernelMonitors}
@@ -39,9 +40,9 @@ class PlannerFactory(graph: GraphDatabaseQueryService, kernelAPI: KernelAPI, ker
   import helpers.wrappersFor2_3._
 
   def create(spec: PlannerSpec_v2_3) =  spec.planner match {
-    case CypherPlanner.rule => CompatibilityFor2_3Rule(graph, as2_3(config), CypherCompiler.CLOCK, kernelMonitors, kernelAPI)
+    case CypherPlanner.rule => CompatibilityFor2_3Rule(graph, as2_3(config), Clock.SYSTEM_CLOCK, kernelMonitors, kernelAPI)
     case _ => CompatibilityFor2_3Cost(graph, as2_3(config),
-      CypherCompiler.CLOCK, kernelMonitors, kernelAPI, log, spec.planner, spec.runtime)
+                                      Clock.SYSTEM_CLOCK, kernelMonitors, kernelAPI, log, spec.planner, spec.runtime)
   }
 
   def create(spec: PlannerSpec_v3_0) =  spec.planner match {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/CompatibilityFor3_0.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compatibility
 
 import java.io.PrintWriter
+import java.time.Clock
 import java.{lang, util}
 
 import org.neo4j.cypher._
@@ -41,7 +42,6 @@ import org.neo4j.cypher.internal.spi.v3_0._
 import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
 import org.neo4j.graphdb.impl.notification.{NotificationCode, NotificationDetail}
 import org.neo4j.graphdb.{InputPosition, Node, Path, QueryExecutionType, Relationship, ResourceIterator}
-import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.KernelAPI
 import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, QuerySession}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher
 
+import java.time.Clock
+
 import org.mockito.Matchers._
 import org.mockito.Mockito.{verify, _}
 import org.neo4j.cypher.internal.compatibility._
@@ -28,7 +30,6 @@ import org.neo4j.cypher.internal.frontend.v3_0.InputPosition
 import org.neo4j.cypher.internal.frontend.v3_0.notification.CartesianProductNotification
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.spi.v3_0.GeneratedQueryStructure
-import org.neo4j.helpers.Clock
 import org.neo4j.logging.NullLog
 
 class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with GraphDatabaseTestSupport {
@@ -112,7 +113,7 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
         errorIfShortestPathFallbackUsedAtRuntime = false,
         nonIndexedLabelWarningThreshold = 10000L
       ),
-      Clock.SYSTEM_CLOCK,
+      Clock.systemUTC(),
       GeneratedQueryStructure,
       new WrappedMonitors3_0(kernelMonitors),
       new StringInfoLogger3_0(NullLog.getInstance),

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_0
 
 import java.io.{File, FileWriter}
 import java.text.NumberFormat
+import java.time.Clock
 import java.util.{Date, Locale}
 
 import org.neo4j.cypher.internal.compatibility.WrappedMonitors3_0
@@ -37,7 +38,6 @@ import org.neo4j.cypher.internal.spi.v3_0.{GeneratedQueryStructure, TransactionB
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QueryStatisticsTestSupport}
 import org.neo4j.graphdb.factory.GraphDatabaseFactory
-import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.impl.query.TransactionalContext
 import org.neo4j.kernel.monitoring.{Monitors => KernelMonitors}
@@ -47,7 +47,7 @@ import scala.xml.Elem
 class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
   val monitorTag = "CompilerComparison"
-  val clock = Clock.SYSTEM_CLOCK
+  val clock = Clock.systemUTC()
   override val config = CypherCompilerConfiguration(
     queryCacheSize = 100,
     statsDivergenceThreshold = 0.5,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0
 
-import java.util.concurrent.TimeUnit
+import java.time.{Clock, Instant, ZoneOffset}
 
 import org.neo4j.cypher.GraphDatabaseTestSupport
 import org.neo4j.cypher.internal.compatibility.{StringInfoLogger3_0, WrappedMonitors3_0}
@@ -30,7 +30,6 @@ import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.spi.v3_0.GeneratedQueryStructure
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
-import org.neo4j.helpers.{Clock, FrozenClock}
 import org.neo4j.logging.AssertableLogProvider.inLog
 import org.neo4j.logging.{AssertableLogProvider, Log, NullLog}
 
@@ -38,7 +37,7 @@ import scala.collection.Map
 
 class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphDatabaseTestSupport {
   def createCompiler(queryCacheSize: Int = 128, statsDivergenceThreshold: Double = 0.5, queryPlanTTL: Long = 1000,
-                     clock: Clock = Clock.SYSTEM_CLOCK, log: Log = NullLog.getInstance) = {
+                     clock: Clock = Clock.systemUTC(), log: Log = NullLog.getInstance) = {
 
     CypherCompilerFactory.costBasedCompiler(
       graph,
@@ -144,7 +143,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
   test("should monitor cache remove") {
     // given
     val counter = new CacheCounter()
-    val clock: Clock = new FrozenClock(1000, TimeUnit.MILLISECONDS)
+    val clock: Clock = Clock.fixed(Instant.ofEpochMilli(1000L), ZoneOffset.UTC)
     val compiler = createCompiler(queryPlanTTL = 0, clock = clock)
     compiler.monitors.addMonitorListener(counter)
     val query: String = "match (n:Person:Dog) return n"
@@ -165,7 +164,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     // given
     val counter = new CacheCounter()
     val logProvider = new AssertableLogProvider()
-    val clock: Clock = new FrozenClock(1000, TimeUnit.MILLISECONDS)
+    val clock: Clock = Clock.fixed(Instant.ofEpochMilli(1000L), ZoneOffset.UTC)
     val compiler = createCompiler(queryPlanTTL = 0, clock = clock, log = logProvider.getLog(getClass))
     compiler.monitors.addMonitorListener(counter)
     val query: String = "match (n:Person:Dog) return n"

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0
 
+import java.time.Clock
 import java.util.concurrent._
 
 import org.junit.Assert._
@@ -45,7 +46,6 @@ import org.neo4j.cypher.internal.frontend.v3_0.{InternalException, Rewriter, Sco
 import org.neo4j.cypher.internal.spi.TransactionalContextWrapper
 import org.neo4j.cypher.internal.spi.v3_0.{GeneratedQueryStructure, TransactionBoundQueryContext}
 import org.neo4j.graphdb.Label.label
-import org.neo4j.helpers.Clock
 import org.neo4j.kernel.api.KernelTransaction
 import org.neo4j.kernel.api.security.AccessMode
 import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker
@@ -70,7 +70,7 @@ class RuleExecutablePlanBuilderTest
     queryPlanner = queryPlanner,
     rewriterSequencer = rewriterSequencer,
     plannerName = None,
-    runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(Clock.SYSTEM_CLOCK, mock[Monitors]), CompiledPlanBuilder(Clock.SYSTEM_CLOCK,GeneratedQueryStructure)),
+    runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), mock[Monitors]), CompiledPlanBuilder(Clock.systemUTC(),GeneratedQueryStructure)),
     semanticChecker = mock[SemanticChecker],
     updateStrategy = None,
     config = config

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGeneratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/CodeGeneratorTest.scala
@@ -19,6 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.codegen
 
+import java.time.Clock
+
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
@@ -37,7 +39,6 @@ import org.neo4j.cypher.internal.frontend.v3_0.{ParameterNotFoundException, Sema
 import org.neo4j.cypher.internal.spi.TransactionalContextWrapper
 import org.neo4j.cypher.internal.spi.v3_0.GeneratedQueryStructure
 import org.neo4j.graphdb.{Direction, Node, Relationship}
-import org.neo4j.helpers.Clock
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.impl.api.RelationshipVisitor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
@@ -842,7 +843,7 @@ class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTestSupport {
   }
 
   private def compile(plan: LogicalPlan) = {
-    generator.generate(plan, newMockedPlanContext, Clock.SYSTEM_CLOCK, semanticTable, CostBasedPlannerName.default)
+    generator.generate(plan, newMockedPlanContext, Clock.systemUTC(), semanticTable, CostBasedPlannerName.default)
   }
 
   private def compileAndExecute(plan: LogicalPlan, params: Map[String, AnyRef] = Map.empty, taskCloser: TaskCloser = new TaskCloser) = {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/ir/CodeGenSugar.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/codegen/ir/CodeGenSugar.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.codegen.ir
 
+import java.time.Clock
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.mockito.Mockito._
@@ -34,7 +35,6 @@ import org.neo4j.cypher.internal.spi.TransactionalContextWrapper
 import org.neo4j.cypher.internal.spi.v3_0.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.spi.v3_0.{GeneratedQueryStructure, TransactionBoundQueryContext}
 import org.neo4j.graphdb.GraphDatabaseService
-import org.neo4j.helpers.Clock
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.security.AccessMode
 import org.neo4j.kernel.api.{KernelTransaction, Statement}
@@ -52,7 +52,7 @@ trait CodeGenSugar extends MockitoSugar {
     val statistics: GraphStatistics = mock[GraphStatistics]
     val context = mock[PlanContext]
     doReturn(statistics).when(context).statistics
-    new CodeGenerator(GeneratedQueryStructure).generate(plan, context, Clock.SYSTEM_CLOCK, semanticTable, CostBasedPlannerName.default)
+    new CodeGenerator(GeneratedQueryStructure).generate(plan, context, Clock.systemUTC(), semanticTable, CostBasedPlannerName.default)
   }
 
   def compileAndExecute(plan: LogicalPlan,


### PR DESCRIPTION
Cypher 3.0 should no longer rely on `org.neo4j.helpers.Clock` and should use
the java 8 Clock instead.
