### PR TITLE
Safe percentage reporting of migration step, fix progress monitor for batch import

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitor.java
@@ -58,6 +58,7 @@ public class VisibleMigrationProgressMonitor implements MigrationProgressMonitor
     private class ProgressSection implements Section
     {
         private static final int STRIDE = 10;
+        private static final int HUNDRED = 100;
 
         private long current;
         private int currentPercent;
@@ -67,7 +68,7 @@ public class VisibleMigrationProgressMonitor implements MigrationProgressMonitor
         public void progress( long add )
         {
             current += add;
-            int percent = max == 0 ? 100 : (int) (current*100/max);
+            int percent = max == 0 ? HUNDRED : Math.min( HUNDRED, (int) ((current * HUNDRED) / max) );
             ensurePercentReported( percent );
         }
 
@@ -96,7 +97,7 @@ public class VisibleMigrationProgressMonitor implements MigrationProgressMonitor
         @Override
         public void completed()
         {
-            ensurePercentReported( 100 );
+            ensurePercentReported( HUNDRED );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitorTest.java
@@ -43,12 +43,31 @@ public class VisibleMigrationProgressMonitorTest
         monitor.completed();
 
         // THEN
+        verifySectionReportedCorrectly( logProvider );
+    }
+
+    @Test
+    public void progressNeverReportMoreThenHundredPercent()
+    {
+        AssertableLogProvider logProvider = new AssertableLogProvider();
+        Log log = logProvider.getLog( getClass() );
+        VisibleMigrationProgressMonitor monitor = new VisibleMigrationProgressMonitor( log );
+
+        monitor.started();
+        monitorSection( monitor, "First", 100, 1, 10, 99, 170 );
+        monitor.completed();
+
+        verifySectionReportedCorrectly( logProvider );
+    }
+
+    private void verifySectionReportedCorrectly( AssertableLogProvider logProvider )
+    {
         logProvider.assertContainsMessageContaining( VisibleMigrationProgressMonitor.MESSAGE_STARTED );
         for ( int i = 10; i <= 100; i += 10 )
         {
             logProvider.assertContainsMessageContaining( String.valueOf( i ) + "%" );
         }
-        logProvider.assertNone( logProvider.inLog( VisibleMigrationProgressMonitor.class ).info( containsString( "110%" ) ) );
+        logProvider.assertNone( AssertableLogProvider.inLog( VisibleMigrationProgressMonitor.class ).info( containsString( "110%" ) ) );
         logProvider.assertContainsMessageContaining( VisibleMigrationProgressMonitor.MESSAGE_COMPLETED );
     }
 


### PR DESCRIPTION
Make sure that user will never see more then 100% reported for any migration step.
Update progress reporting of batch import in case of multi-staging execution.
