### PR TITLE
Include the plugins and conf directories in the classpath

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
@@ -39,7 +39,7 @@ setup_environment() {
 }
 
 build_classpath() {
-  CLASSPATH="${NEO4J_LIB}/*:${NEO4J_PLUGINS}/*"
+  CLASSPATH="${NEO4J_PLUGINS}:${NEO4J_CONF}:${NEO4J_LIB}/*:${NEO4J_PLUGINS}/*"
 }
 
 detect_os() {

--- a/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
+++ b/packaging/standalone/src/tests/shell-scripts/test-java-arguments.sh
@@ -39,9 +39,9 @@ for run_command in run_console run_daemon; do
     test_expect_java_arg '-Dfile.encoding=UTF-8'
   "
 
-  test_expect_success "should construct the classpath" "
+  test_expect_success "should construct the classpath and include plugins and conf dirs so that plugins can load config files from the classpath and developers can override plugin classes" "
     ${run_command} &&
-    test_expect_java_arg '-cp lib/*:plugins/*'
+    test_expect_java_arg '-cp plugins:conf:lib/*:plugins/*'
   "
 
   test_expect_success "classpath elements should be configurable" "
@@ -49,7 +49,7 @@ for run_command in run_console run_daemon; do
     set_config 'dbms.directories.lib' 'some-other-lib' neo4j.conf &&
     set_config 'dbms.directories.plugins' 'some-other-plugins' neo4j.conf &&
     ${run_command} &&
-    test_expect_java_arg '-cp some-other-lib/*:some-other-plugins/*'
+    test_expect_java_arg '-cp some-other-plugins:conf:some-other-lib/*:some-other-plugins/*'
   "
 
   test_expect_success "should set gc log location when gc log is enabled" "


### PR DESCRIPTION
This is for the benefit of plugin and procedure writers.
- Including the directories gives people the option of storing
  configuration files in those directories and loading them from the
  classpath. That means that they don't have to mess around with
  filesystem paths and don't have to embed config in their jar files.
- We put them at the start of the classpath so that when developing a
  plugin or procedure it's easy to drop a single class into the
  directory to override what is found in a jar later in the classpath.
