### PR TITLE
Separate checkpoint triggers for backup and store copy

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/SimpleTriggerInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/SimpleTriggerInfo.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.transaction.log.checkpoint;
 
+import java.util.Objects;
+
 /**
  * Simple implementation of a trigger info taking in construction the name/description of what triggered the check point
  * and offering the possibility to be enriched with a single optional extra description.
@@ -47,5 +49,27 @@ public class SimpleTriggerInfo implements TriggerInfo
         assert description != null;
         assert this.description == null;
         this.description = description;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        SimpleTriggerInfo that = (SimpleTriggerInfo) o;
+        return Objects.equals( triggerName, that.triggerName ) &&
+               Objects.equals( description, that.description );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( triggerName, description );
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
@@ -36,6 +36,8 @@ import static org.neo4j.com.RequestContext.anonymous;
 
 class BackupImpl implements TheBackupInterface
 {
+    static final String FULL_BACKUP_CHECKPOINT_TRIGGER = "full backup";
+
     private final StoreCopyServer storeCopyServer;
     private final ResponsePacker incrementalResponsePacker;
     private final LogicalTransactionStore logicalTransactionStore;
@@ -60,7 +62,8 @@ class BackupImpl implements TheBackupInterface
     {
         try ( StoreWriter storeWriter = writer )
         {
-            RequestContext copyStartContext = storeCopyServer.flushStoresAndStreamStoreFiles( storeWriter, forensics );
+            RequestContext copyStartContext = storeCopyServer.flushStoresAndStreamStoreFiles(
+                    FULL_BACKUP_CHECKPOINT_TRIGGER, storeWriter, forensics );
             ResponsePacker responsePacker = new StoreCopyResponsePacker( logicalTransactionStore,
                     transactionIdStore, logFileInformation, storeId,
                     copyStartContext.lastAppliedTransaction() + 1, storeCopyServer.monitor() ); // mandatory transaction id

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupImplTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupImplTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import org.junit.Test;
+
+import org.neo4j.com.RequestContext;
+import org.neo4j.com.storecopy.StoreCopyServer;
+import org.neo4j.com.storecopy.StoreWriter;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BackupImplTest
+{
+    @Test
+    public void flushStoreFilesWithCorrectCheckpointTriggerName()
+    {
+        StoreCopyServer storeCopyServer = mock( StoreCopyServer.class );
+        when( storeCopyServer.flushStoresAndStreamStoreFiles( anyString(), any(), anyBoolean() ) )
+                .thenReturn( RequestContext.EMPTY );
+
+        BackupImpl backup = new BackupImpl( storeCopyServer, new Monitors(), mock( LogicalTransactionStore.class ),
+                mock( TransactionIdStore.class ), mock( LogFileInformation.class ), () -> StoreId.DEFAULT );
+
+        backup.fullBackup( mock( StoreWriter.class ), false ).close();
+
+        verify( storeCopyServer ).flushStoresAndStreamStoreFiles(
+                eq( BackupImpl.FULL_BACKUP_CHECKPOINT_TRIGGER ), any(), eq( false ) );
+    }
+}

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyServer.java
@@ -130,14 +130,20 @@ public class StoreCopyServer
     }
 
     /**
+     * Trigger store flush (checkpoint) and write {@link NeoStoreDataSource#listStoreFiles(boolean) store files} to the
+     * given {@link StoreWriter}.
+     *
+     * @param triggerName name of the component asks for store files.
+     * @param writer store writer to write files to.
+     * @param includeLogs <code>true</code> if transaction logs should be copied, <code>false</code> otherwise.
      * @return a {@link RequestContext} specifying at which point the store copy started.
      */
-    public RequestContext flushStoresAndStreamStoreFiles( StoreWriter writer, boolean includeLogs )
+    public RequestContext flushStoresAndStreamStoreFiles( String triggerName, StoreWriter writer, boolean includeLogs )
     {
         try
         {
             monitor.startTryCheckPoint();
-            long lastAppliedTransaction = checkPointer.tryCheckPoint( new SimpleTriggerInfo( "store copy" ) );
+            long lastAppliedTransaction = checkPointer.tryCheckPoint( new SimpleTriggerInfo( triggerName ) );
             monitor.finishTryCheckPoint();
             ByteBuffer temporaryBuffer = ByteBuffer.allocateDirect( (int) ByteUnit.mebiBytes( 1 ) );
 

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -335,7 +335,7 @@ public class StoreCopyClientTest
 
                     RequestContext requestContext = new StoreCopyServer( neoStoreDataSource,
                             checkPointer, fs, originalDir, new Monitors().newMonitor( StoreCopyServer.Monitor.class ) )
-                            .flushStoresAndStreamStoreFiles( writer, false );
+                            .flushStoresAndStreamStoreFiles( "test", writer, false );
 
                     final StoreId storeId = original.getDependencyResolver().resolveDependency( RecordStorageEngine.class )
                     .testAccessNeoStores().getMetaDataStore().getStoreId();

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPI.java
@@ -28,9 +28,6 @@ import org.neo4j.com.storecopy.ResponsePacker;
 import org.neo4j.com.storecopy.StoreCopyServer;
 import org.neo4j.com.storecopy.StoreWriter;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
-import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.ha.TransactionChecksumLookup;
@@ -43,17 +40,22 @@ import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 
 public class DefaultMasterImplSPI implements MasterImpl.SPI
 {
     private static final int ID_GRAB_SIZE = 1000;
+    static final String STORE_COPY_CHECKPOINT_TRIGGER = "store copy";
+
     private final GraphDatabaseAPI graphDb;
     private final TransactionChecksumLookup txChecksumLookup;
     private final FileSystemAbstraction fileSystem;
@@ -157,7 +159,7 @@ public class DefaultMasterImplSPI implements MasterImpl.SPI
     {
         StoreCopyServer streamer = new StoreCopyServer( neoStoreDataSource,
                 checkPointer, fileSystem, storeDir, monitors.newMonitor( StoreCopyServer.Monitor.class ) );
-        return streamer.flushStoresAndStreamStoreFiles( writer, false );
+        return streamer.flushStoresAndStreamStoreFiles( STORE_COPY_CHECKPOINT_TRIGGER, writer, false );
     }
 
     @Override

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultMasterImplSPITest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.cluster;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.com.storecopy.StoreWriter;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.impl.api.TransactionCommitProcess;
+import org.neo4j.kernel.impl.core.LabelTokenHolder;
+import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
+import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
+import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.TriggerInfo;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DefaultMasterImplSPITest
+{
+    @Test
+    public void flushStoreFilesWithCorrectCheckpointTriggerName() throws IOException
+    {
+        CheckPointer checkPointer = mock( CheckPointer.class );
+
+        NeoStoreDataSource dataSource = mock( NeoStoreDataSource.class );
+        when( dataSource.listStoreFiles( anyBoolean() ) ).thenReturn( Iterators.emptyIterator() );
+
+        DefaultMasterImplSPI master = new DefaultMasterImplSPI( mock( GraphDatabaseAPI.class, RETURNS_MOCKS ),
+                mock( FileSystemAbstraction.class ), new Monitors(), mock( LabelTokenHolder.class ),
+                mock( PropertyKeyTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ),
+                mock( IdGeneratorFactory.class ), mock( TransactionCommitProcess.class ), checkPointer,
+                mock( TransactionIdStore.class ), mock( LogicalTransactionStore.class ),
+                dataSource );
+
+        master.flushStoresAndStreamStoreFiles( mock( StoreWriter.class ) );
+
+        TriggerInfo expectedTriggerInfo = new SimpleTriggerInfo( DefaultMasterImplSPI.STORE_COPY_CHECKPOINT_TRIGGER );
+        verify( checkPointer ).tryCheckPoint( expectedTriggerInfo );
+    }
+}


### PR DESCRIPTION
Currently full backup and store copy use same checkpoint trigger name - 'store copy'. This results in slightly confusing log messages that do not differentiate between backup and store copy.

This PR makes full backup and store copy use different trigger names.
