### PR TITLE
Include error reference in both user and debug logs.

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/MessageProcessingCallback.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/MessageProcessingCallback.java
@@ -34,19 +34,18 @@ public class MessageProcessingCallback<T> extends Session.Callback.Adapter<T,Voi
     public static void publishError( MessageHandler<IOException> out, Neo4jError error )
             throws IOException
     {
-        if ( error.status().code().classification().publishable() )
+        if ( error.status().code().classification().refersToLog() )
         {
-            // If publishable, we forward the message as-is to the user.
-            out.handleFailureMessage( error.status(), error.message() );
-        }
-        else
-        {
-            // If not publishable, we only return an error reference to the user. This must
-            // be cross-referenced with the log files for full error detail. This feature
-            // exists to improve security so that sensitive information is not leaked.
+            // If not intended for client, we only return an error reference. This must
+            // be cross-referenced with the log files for full error detail.
             out.handleFailureMessage( error.status(), String.format(
                     "An unexpected failure occurred, see details in the database " +
                     "logs, reference number %s.", error.reference() ) );
+        }
+        else
+        {
+            // If intended for client, we forward the message as-is.
+            out.handleFailureMessage( error.status(), error.message() );
         }
     }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporterTest.java
@@ -19,110 +19,114 @@
  */
 package org.neo4j.bolt.v1.runtime.internal;
 
+import java.util.UUID;
+
 import org.junit.Test;
 
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.logging.AssertableLogProvider;
-import org.neo4j.logging.Log;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Matchers.contains;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ErrorReporterTest
 {
     @Test
-    public void shouldLogFullMessageInDebugLogAndHelpfulPointerInUserLog() throws Exception
+    public void clientErrorShouldNotLog() throws Exception
     {
         // given
-        Log userLog = mock( Log.class );
-        Log internalLog = mock( Log.class );
-        ErrorReporter reporter = new ErrorReporter( userLog, internalLog );
+        AssertableLogProvider userLog = new AssertableLogProvider();
+        AssertableLogProvider internalLog = new AssertableLogProvider();
+        ErrorReporter reporter =
+                new ErrorReporter( userLog.getLog( "userLog" ), internalLog.getLog( "internalLog" ) );
 
-        Throwable cause = new Throwable( "Hello World" );
-        Neo4jError error = Neo4jError.from( cause );
+
+        Status.Code code = mock( Status.Code.class );
+        Neo4jError error = new Neo4jError( () -> code, "Should not be logged" );
+        when( code.classification() ).thenReturn( Status.Classification.ClientError );
 
         // when
         reporter.report( error );
 
         // then
-        verify( userLog ).error( "Client triggered an unexpected error: Hello World. See debug.log for more details." );
-        verify( internalLog ).error( contains( "java.lang.Throwable: Hello World" ) );
+
+        userLog.assertNoLoggingOccurred();
+        internalLog.assertNoLoggingOccurred();
     }
 
     @Test
-    public void shouldReportUnknownErrorsInUserLog()
+    public void clientNotificationShouldNotLog() throws Exception
     {
-        // Given
-        AssertableLogProvider provider = new AssertableLogProvider();
+        // given
+        AssertableLogProvider userLog = new AssertableLogProvider();
+        AssertableLogProvider internalLog = new AssertableLogProvider();
         ErrorReporter reporter =
-                new ErrorReporter( provider.getLog( "userLog" ), provider.getLog( "internalLog" ) );
+                new ErrorReporter( userLog.getLog( "userLog" ), internalLog.getLog( "internalLog" ) );
 
-        Throwable cause = new Throwable( "This is not an error we know how to handle." );
-        Neo4jError error = Neo4jError.from( cause );
 
-        // When
+        Status.Code code = mock( Status.Code.class );
+        Neo4jError error = new Neo4jError( () -> code, "Should not be logged" );
+        when( code.classification() ).thenReturn( Status.Classification.ClientNotification );
+
+        // when
         reporter.report( error );
 
-        // Then
-        assertThat( error.status(), equalTo( (Status) Status.General.UnknownError ) );
-        provider.assertContainsMessageContaining( error.cause().getMessage() );
+        // then
+
+        userLog.assertNoLoggingOccurred();
+        internalLog.assertNoLoggingOccurred();
+    }
+
+
+    @Test
+    public void databaseErrorShouldLogFullMessageInDebugLogAndHelpfulPointerInUserLog() throws Exception
+    {
+        // given
+        AssertableLogProvider userLog = new AssertableLogProvider();
+        AssertableLogProvider internalLog = new AssertableLogProvider();
+        ErrorReporter reporter =
+                new ErrorReporter( userLog.getLog( "userLog" ), internalLog.getLog( "internalLog" ) );
+
+        Status.Code code = mock( Status.Code.class );
+        Neo4jError error = new Neo4jError( () -> code, "Database error" );
+        when( code.classification() ).thenReturn( Status.Classification.DatabaseError );
+        UUID reference = error.reference();
+
+        // when
+        reporter.report( error );
+
+        // then
+        userLog.assertContainsLogCallContaining( "Client triggered an unexpected error" );
+        userLog.assertContainsLogCallContaining( reference.toString() );
+        userLog.assertContainsLogCallContaining( "Database error" );
+
+        internalLog.assertContainsLogCallContaining( reference.toString() );
+        internalLog.assertContainsLogCallContaining( "Database error" );
     }
 
     @Test
-    public void shouldNotReportOOMErrorsInUserLog()
+    public void transientErrorShouldLogFullMessageInDebugLogAndHelpfulPointerInUserLog() throws Exception
     {
-        // Given
-        AssertableLogProvider provider = new AssertableLogProvider();
+        // given
+        AssertableLogProvider userLog = new AssertableLogProvider();
+        AssertableLogProvider internalLog = new AssertableLogProvider();
         ErrorReporter reporter =
-                new ErrorReporter( provider.getLog( "userLog" ), provider.getLog( "internalLog" ) );
+                new ErrorReporter( userLog.getLog( "userLog" ), internalLog.getLog( "internalLog" ) );
 
-        Throwable cause = new OutOfMemoryError( "memory is fading" );
-        Neo4jError error = Neo4jError.from( cause );
+        Status.Code code = mock( Status.Code.class );
+        Neo4jError error = new Neo4jError( () -> code, "Transient error" );
+        when( code.classification() ).thenReturn( Status.Classification.TransientError );
+        UUID reference = error.reference();
 
-        // When
+        // when
         reporter.report( error );
 
-        // Then
-        assertThat( error.status(), equalTo( (Status) Status.General.OutOfMemoryError ) );
-        assertThat( error.message(),
-                equalTo( "There is not enough memory to perform the current task. Please try increasing " +
-                        "'dbms.memory.heap.max_size' in the process wrapper configuration (normally in " +
-                        "'conf/neo4j-wrapper" +
-                        ".conf' or, if you are using Neo4j Desktop, found through the user interface) or if you are " +
-                        "running an embedded " +
-                        "installation increase the heap by using '-Xmx' command line flag, and then restart the " +
-                        "database." ) );
-        provider.assertContainsMessageContaining( cause.getClass().getName() );
-    }
+        // then
+        userLog.assertContainsLogCallContaining( "Client triggered an unexpected error" );
+        userLog.assertContainsLogCallContaining( reference.toString() );
+        userLog.assertContainsLogCallContaining( "Transient error" );
 
-    @Test
-    public void shouldReportStackOverflowErrorsInInternalLog()
-    {
-        // Given
-        AssertableLogProvider provider = new AssertableLogProvider();
-        ErrorReporter reporter =
-                new ErrorReporter( provider.getLog( "userLog" ), provider.getLog( "internalLog" ) );
-
-        Throwable cause = new StackOverflowError( "some rewriter is probably not tail recursive" );
-        Neo4jError error = Neo4jError.from( cause );
-
-        // When
-        reporter.report( error );
-
-        // Then
-        assertThat( error.status(), equalTo( (Status) Status.General.StackOverFlowError ) );
-        assertThat( error.message(), equalTo(
-                "There is not enough stack size to perform the current task. This is generally considered to be a " +
-                        "database error, so please contact Neo4j support. You could try increasing the stack size: " +
-                        "for example to set the stack size to 2M, add `dbms.jvm.additional=-Xss2M' to " +
-                        "in the process wrapper configuration (normally in 'conf/neo4j-wrapper.conf' or, if you are " +
-                        "using " +
-                        "Neo4j Desktop, found through the user interface) or if you are running an embedded " +
-                        "installation " +
-                        "just add -Xss2M as command line flag." ) );
-        provider.assertContainsMessageContaining( cause.getClass().getName() );
+        internalLog.assertContainsLogCallContaining( reference.toString() );
+        internalLog.assertContainsLogCallContaining( "Transient error" );
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/Neo4jErrorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/Neo4jErrorTest.java
@@ -25,9 +25,22 @@ import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.api.exceptions.Status;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Neo4jErrorTest
 {
+    @Test
+    public void shouldAssignUnknownStatusToUnpredictedException()
+    {
+        // Given
+        Throwable cause = new Throwable( "This is not an error we know how to handle." );
+        Neo4jError error = Neo4jError.from( cause );
+
+        // Then
+        assertThat( error.status(), equalTo( (Status) Status.General.UnknownError ) );
+    }
+
     @Test
     public void shouldConvertDeadlockException() throws Throwable
     {


### PR DESCRIPTION
The unique reference allows the user to locate a detailed stack trace
that corresponds to a briefer messages in the user log, and to the short
message sent back to the client.
