### PR TITLE
Prevent Bolt connectors from starting for neo4j-shell -path

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -181,6 +181,10 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
         {
             life.add( new NettyServer( scheduler.threadFactory( boltNetworkIO ), connectors ) );
             log.info( "Bolt Server extension loaded." );
+            for ( ProtocolInitializer connector : connectors )
+            {
+                logging.getUserLog( Sessions.class ).info( "Bolt enabled on %s.", connector.address() );
+            }
         }
 
         return life;

--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -177,7 +177,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
                 } )
                 .collect( toList() );
 
-        if ( connectors.size() > 0 )
+        if ( connectors.size() > 0 && !config.get( GraphDatabaseSettings.disconnected ) )
         {
             life.add( new NettyServer( scheduler.threadFactory( boltNetworkIO ), connectors ) );
             log.info( "Bolt Server extension loaded." );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
@@ -30,7 +30,6 @@ import java.util.Set;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
-import org.neo4j.kernel.configuration.Config;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.kernel.configuration.Config;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
@@ -115,6 +116,16 @@ public class GraphDatabaseBuilder
             setConfig( stringStringEntry.getKey(), stringStringEntry.getValue() );
         }
         return this;
+    }
+
+    /**
+     * Retrieve the configured configuration values.
+     *
+     * @return the configured configuration values.
+     */
+    public Config config()
+    {
+        return new Config( config );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseBuilder.java
@@ -119,16 +119,6 @@ public class GraphDatabaseBuilder
     }
 
     /**
-     * Retrieve the configured configuration values.
-     *
-     * @return the configured configuration values.
-     */
-    public Config config()
-    {
-        return new Config( config );
-    }
-
-    /**
      * Load a Properties file from a given file, and add the settings to
      * the builder.
      *

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -92,6 +92,10 @@ public abstract class GraphDatabaseSettings
                  "This mode still requires write access to the directory for lock purposes.")
     public static final Setting<Boolean> read_only = setting( "dbms.read_only", BOOLEAN, FALSE );
 
+    @Title("Disconnected")
+    @Description("Disable all protocol connectors.")
+    public static final Setting<Boolean> disconnected = setting( "dbms.disconnected", BOOLEAN, FALSE );
+
     @Description("Print out the effective Neo4j configuration after startup.")
     @Internal
     public static final Setting<Boolean> dump_configuration = setting("unsupported.dbms.report_configuration", BOOLEAN, FALSE );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -93,8 +93,9 @@ public abstract class GraphDatabaseSettings
     public static final Setting<Boolean> read_only = setting( "dbms.read_only", BOOLEAN, FALSE );
 
     @Title("Disconnected")
+    @Internal
     @Description("Disable all protocol connectors.")
-    public static final Setting<Boolean> disconnected = setting( "dbms.disconnected", BOOLEAN, FALSE );
+    public static final Setting<Boolean> disconnected = setting( "unsupported.dbms.disconnected", BOOLEAN, FALSE );
 
     @Description("Print out the effective Neo4j configuration after startup.")
     @Internal

--- a/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
+++ b/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.logging;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.StringDescription;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,9 +29,15 @@ import java.util.Set;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+
 import static org.apache.commons.lang3.StringEscapeUtils.escapeJava;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.Matchers.any;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
@@ -244,6 +246,7 @@ public class AssertableLogProvider extends AbstractLogProvider<Log>
     private static final Matcher<Level> WARN_LEVEL_MATCHER = equalTo( Level.WARN );
     private static final Matcher<Level> ERROR_LEVEL_MATCHER = equalTo( Level.ERROR );
     private static final Matcher<Level> ANY_LEVEL_MATCHER = any( Level.class );
+    private static final Matcher<String> ANY_MESSAGE_MATCHER = any( String.class );
     private static final Matcher<Object[]> NULL_ARGUMENTS_MATCHER = nullValue( Object[].class );
     private static final Matcher<Object[]> ANY_ARGUMENTS_MATCHER = any( Object[].class );
     private static final Matcher<Throwable> NULL_THROWABLE_MATCHER = nullValue( Throwable.class );
@@ -402,6 +405,14 @@ public class AssertableLogProvider extends AbstractLogProvider<Log>
         public LogMatcher error( Matcher<String> format, Object... arguments )
         {
             return new LogMatcher( contextMatcher, ERROR_LEVEL_MATCHER, format, arrayContaining( ensureMatchers( arguments ) ), NULL_THROWABLE_MATCHER );
+        }
+
+        public LogMatcher any()
+        {
+            return new LogMatcher(
+                    contextMatcher, ANY_LEVEL_MATCHER, ANY_MESSAGE_MATCHER,
+                    anyOf( NULL_ARGUMENTS_MATCHER, ANY_ARGUMENTS_MATCHER ),
+                    anyOf( NULL_THROWABLE_MATCHER, ANY_THROWABLE_MATCHER ) );
         }
 
         @SuppressWarnings( "unchecked" )

--- a/community/shell/pom.xml
+++ b/community/shell/pom.xml
@@ -168,6 +168,19 @@ the relevant Commercial Agreement.
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-bolt</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-logging</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
@@ -30,8 +30,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.shell.Output;
@@ -45,7 +43,6 @@ import org.neo4j.shell.impl.AbstractAppServer;
 import org.neo4j.shell.impl.BashVariableInterpreter.Replacer;
 import org.neo4j.shell.kernel.apps.TransactionProvidingApp;
 
-import static org.neo4j.kernel.configuration.GroupSettingSupport.enumerate;
 import static org.neo4j.shell.Variables.PROMPT_KEY;
 
 /**

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/GraphDatabaseShellServer.java
@@ -206,18 +206,12 @@ public class GraphDatabaseShellServer extends AbstractAppServer
     {
         GraphDatabaseBuilder builder = factory.
                 newEmbeddedDatabaseBuilder( path ).
+                setConfig( GraphDatabaseSettings.disconnected, Boolean.toString( true ) ).
                 setConfig( GraphDatabaseSettings.read_only, Boolean.toString( readOnly ) );
         if ( configFileOrNull != null )
         {
             builder.loadPropertiesFromFile( configFileOrNull );
         }
-        // Explicitly disable all connectors since we're starting an embedded database for the shell client (only!)
-        // This only deals with Bolt since it's the only connector type to start from a kernel extension
-        Config config = builder.config();
-        config.view( enumerate( GraphDatabaseSettings.Connector.class ) )
-                .map( GraphDatabaseSettings.BoltConnector::new )
-                .filter( ( connConfig ) -> config.get( connConfig.enabled ) )
-                .forEach( connector -> builder.setConfig( connector.enabled, Settings.FALSE ) );
         return (GraphDatabaseAPI) builder.newGraphDatabase();
     }
 

--- a/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
+++ b/community/shell/src/test/java/org/neo4j/shell/StartClientTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.shell;
 
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -33,9 +28,17 @@ import java.io.PrintStream;
 import java.io.Serializable;
 import java.rmi.RemoteException;
 
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.bolt.v1.runtime.Sessions;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.shell.impl.AbstractClient;
 import org.neo4j.shell.kernel.GraphDatabaseShellServer;
 import org.neo4j.test.ImpermanentDatabaseRule;
@@ -52,6 +55,8 @@ import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import static org.neo4j.logging.AssertableLogProvider.inLog;
 import static org.neo4j.test.SuppressOutput.suppressAll;
 
 public class StartClientTest
@@ -210,6 +215,32 @@ public class StartClientTest
         assertEquals( 0, err.size() );
         String version = out.toString();
         assertThat( version, startsWith( "Neo4j Community, version " ) );
+    }
+
+    @Test
+    public void shouldNotStartBolt() throws IOException
+    {
+        // Given
+        AssertableLogProvider log = new AssertableLogProvider();
+
+        // When
+        new StartClient( System.out, System.err )
+        {
+            @Override
+            protected GraphDatabaseShellServer getGraphDatabaseShellServer( File path, boolean readOnly, String
+                    configFile ) throws RemoteException
+            {
+                return new GraphDatabaseShellServer(
+                        new GraphDatabaseFactory().setUserLogProvider( log ), path, readOnly, configFile );
+            }
+        }.start( new String[]{
+                        "-c", "RETURN 1;",
+                        "-path", db.getGraphDatabaseAPI().getStoreDir(),
+                        "-config", getClass().getResource( "/config-with-bolt-connector.conf" ).getFile()},
+                mock( CtrlCHandler.class ) );
+
+        // Then
+        log.assertNone( inLog( startsWith( Sessions.class.getPackage().getName() ) ).any() );
     }
 
     private String runAndCaptureOutput( String[] arguments )

--- a/community/shell/src/test/resources/config-with-bolt-connector.conf
+++ b/community/shell/src/test/resources/config-with-bolt-connector.conf
@@ -1,0 +1,8 @@
+#
+# Bolt connector
+#
+dbms.connector.bolt.type=BOLT
+dbms.connector.bolt.enabled=true
+dbms.connector.bolt.tls_level=OPTIONAL
+# To have Bolt accept non-local connections, uncomment this line:
+# dbms.connector.bolt.address=0.0.0.0:7687


### PR DESCRIPTION
This fixes `neo4j-shell -path` by disabling Bolt connectors for the embedded server. A test is included to check that Bolt has not been started (by sniffing the log file) plus a few helpers to enable that test.
