### PR TITLE
Revert change in NiceHasher causing regression

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NiceHasher.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/NiceHasher.scala
@@ -64,14 +64,14 @@ object NiceHasherValue {
     case x: Array[AnyRef] => java.util.Arrays.deepHashCode(x)
     case null => 0
     case x: List[_] => seqHashFun(x)
-    case x: Map[_, _] => seqHashFun(x.keySet ++ x.values)
+    case x: Map[_, _] => x.keySet.hashCode() * 31 + seqHashFun(x.values)
     case x => x.hashCode()
   }
 
   def comparableValuesFun(y: Any): Any = y match {
     case x: Array[_] => x.deep
     case x: List[_] => x.map(comparableValuesFun)
-    case x: Map[_, _] => (x.keys ++ x.values).map(comparableValuesFun)
+    case x: Map[_, _] => x.keys.toSeq ++ x.values.map(comparableValuesFun)
     case x => x
   }
 


### PR DESCRIPTION
Profiling showed that how the sets of keys and values are combined for
Map values in NiceHasher has a performance impact on some queries,
e.g. Cypher benchmark Levelstory Q10. The regression was introduced by
a commit to fix warnings 799925074feddfde1db8e1737ad19679223aec97.
This only changes the additional code with an impact and does not
affect the warning.
