### PR TITLE
[3.0-RC1] Fix powershell management scripts to support non default lib dir

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1
@@ -153,6 +153,7 @@ Function Get-Java
     # Shell arguments for the Neo4jServer and Arbiter classes
     if ($PsCmdlet.ParameterSetName -eq 'ServerInvoke')
     {
+      $NeoLibDir = Join-Path -Path $Neo4jServer.Home -ChildPath $Neo4jServer.LibDir
       $serverMainClass = ''
       if ($Neo4jServer.ServerType -eq 'Enterprise') { $serverMainClass = 'org.neo4j.server.enterprise.EnterpriseEntryPoint' }
       if ($Neo4jServer.ServerType -eq 'Community') { $serverMainClass = 'org.neo4j.server.CommunityEntryPoint' }
@@ -161,7 +162,7 @@ Function Get-Java
       if ($serverMainClass -eq '') { Write-Error "Unable to determine the Server Main Class from the server information"; return $null }
 
       # Build the Java command line
-      $ClassPath="$($Neo4jServer.Home)/lib/*;$($Neo4jServer.Home)/plugins/*"
+      $ClassPath="$($NeoLibDir)/*;$($Neo4jServer.Home)/plugins/*"
       $ShellArgs = @("-cp `"$($ClassPath)`""`
                     ,'-server' `
                     ,'-Dlog4j.configuration=file:conf/log4j.properties' `
@@ -208,10 +209,11 @@ Function Get-Java
     # Shell arguments for the utility classes e.g. Import, Shell
     if ($PsCmdlet.ParameterSetName -eq 'UtilityInvoke')
     {
+      $NeoLibDir = Join-Path -Path $Neo4jServer.Home -ChildPath $Neo4jServer.LibDir
       # Generate the commandline args
       $ClassPath = ''
       # Enumerate all JARS in the lib directory and add to the class path
-      Get-ChildItem -Path (Join-Path  -Path $Neo4jServer.Home -ChildPath 'lib') | Where-Object { $_.Extension -eq '.jar'} | % {
+      Get-ChildItem -Path $NeoLibDir | Where-Object { $_.Extension -eq '.jar'} | % {
         $ClassPath += "`"$($_.FullName)`";"
       }
       # Enumerate all JARS in the bin directory and add to the class path

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
@@ -113,7 +113,7 @@ Function Get-Neo4jPrunsrv
           '--StdOutput=logs\neo4j.log',
           '--StdError=logs\neo4j-error.log',
           '--LogPrefix=neo4j-service',
-          '--Classpath=lib/*;plugins/*',
+          "`"--Classpath=$($Neo4jServer.LibDir)/*;plugins/*`"",
           "`"--JvmOptions=$($JvmOptions -join ';')`"",
           '--Startup=auto'
         )

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4j.ps1
@@ -74,9 +74,11 @@ Function Invoke-Neo4j
       
       $thisServer = Get-Neo4jServer -Neo4jHome $Neo4jHome -ErrorAction Stop
       if ($thisServer -eq $null) { throw "Unable to determine the Neo4j Server installation information" }
-      Write-Verbose "Neo4j Server Type is '$($thisServer.ServerType)'"
-      Write-Verbose "Neo4j Version is '$($thisServer.ServerVersion)'"
-      Write-Verbose "Neo4j Database Mode is '$($thisServer.DatabaseMode)'"
+      # Verbose output of the Neo4j server properties
+      Get-Member -InputObject $thisServer -MemberType NoteProperty | ForEach-Object {
+        $value = $thisServer."$($_.Name)"
+        Write-Verbose "Neo4j $($_.Name) is '$($value)'"
+      }
 
       # Check if we have administrative rights; If the current user's token contains the Administrators Group SID (S-1-5-32-544)
       if (-not [bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jAdmin.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jAdmin.ps1
@@ -75,9 +75,11 @@ Function Invoke-Neo4jAdmin
       
       $thisServer = Get-Neo4jServer -Neo4jHome $Neo4jHome -ErrorAction Stop
       if ($thisServer -eq $null) { throw "Unable to determine the Neo4j Server installation information" }
-      Write-Verbose "Neo4j Server Type is '$($thisServer.ServerType)'"
-      Write-Verbose "Neo4j Version is '$($thisServer.ServerVersion)'"
-      Write-Verbose "Neo4j Database Mode is '$($thisServer.DatabaseMode)'"
+      # Verbose output of the Neo4j server properties
+      Get-Member -InputObject $thisServer -MemberType NoteProperty | ForEach-Object {
+        $value = $thisServer."$($_.Name)"
+        Write-Verbose "Neo4j $($_.Name) is '$($value)'"
+      }
 
       # Check if we have administrative rights; If the current user's token contains the Administrators Group SID (S-1-5-32-544)
       if (-not [bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jUtility.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jUtility.ps1
@@ -69,9 +69,11 @@ Function Invoke-Neo4jUtility
     
     $thisServer = Get-Neo4jServer -Neo4jHome $Neo4jHome -ErrorAction Stop
     if ($thisServer -eq $null) { throw "Unable to determine the Neo4j Server installation information" }
-    Write-Verbose "Neo4j Server Type is '$($thisServer.ServerType)'"
-    Write-Verbose "Neo4j Version is '$($thisServer.ServerVersion)'"
-    Write-Verbose "Neo4j Database Mode is '$($thisServer.DatabaseMode)'"
+    # Verbose output of the Neo4j server properties
+    Get-Member -InputObject $thisServer -MemberType NoteProperty | ForEach-Object {
+      $value = $thisServer."$($_.Name)"
+      Write-Verbose "Neo4j $($_.Name) is '$($value)'"
+    }
 
     # Check if we have administrative rights; If the current user's token contains the Administrators Group SID (S-1-5-32-544)
     if (-not [bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {

--- a/packaging/standalone/src/tests/Neo4j-Management/Common.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/Common.ps1
@@ -31,21 +31,25 @@ Function global:New-InvalidNeo4jInstall($ServerType = 'Enterprise', $ServerVersi
   return $serverObject
 }
 
-Function global:New-MockNeo4jInstall($IncludeFiles = $true, $ServerType = 'Community', $ServerVersion = '0.0', $DatabaseMode = '', $WindowsService = $global:mockServiceName) {
+Function global:New-MockNeo4jInstall($IncludeFiles = $true, $ServerType = 'Community', $ServerVersion = '0.0', $DatabaseMode = '', $WindowsService = $global:mockServiceName, $Lib = '') {
   # Creates a skeleton directory and file structure of a Neo4j Installation
+  $customLib = ($Lib -ne '')
+  if ($Lib -eq '') { $Lib = 'lib' }
   $RootDir = $global:mockNeo4jHome
+  $LibDir = "$($RootDir)\$($Lib)"
+
   New-Item $RootDir -ItemType Directory | Out-Null
-  New-Item "$RootDir\lib" -ItemType Directory | Out-Null
+  New-Item $LibDir -ItemType Directory | Out-Null
   New-Item "$RootDir\bin" -ItemType Directory | Out-Null
   New-Item "$RootDir\bin\tools" -ItemType Directory | Out-Null
   New-Item "$RootDir\conf" -ItemType Directory | Out-Null
   
   if ($IncludeFiles) {
-    'TempFile' | Out-File -FilePath "$RootDir\lib\neo4j-server-$($ServerVersion).jar"
-    if ($ServerType -eq 'Enterprise') { 'TempFile' | Out-File -FilePath "$RootDir\lib\neo4j-server-enterprise-$($ServerVersion).jar" }
+    'TempFile' | Out-File -FilePath "$LibDir\neo4j-server-$($ServerVersion).jar"
+    if ($ServerType -eq 'Enterprise') { 'TempFile' | Out-File -FilePath "$LibDir\neo4j-server-enterprise-$($ServerVersion).jar" }
 
     # Additional Jars
-    'TempFile' | Out-File -FilePath "$RootDir\lib\lib1.jar"
+    'TempFile' | Out-File -FilePath "$LibDir\lib1.jar"
     'TempFile' | Out-File -FilePath "$RootDir\bin\bin1.jar"
     
     # Procrun service files
@@ -56,6 +60,9 @@ Function global:New-MockNeo4jInstall($IncludeFiles = $true, $ServerType = 'Commu
     $neoConf = ''
     if ($DatabaseMode -ne '') {
       $neoConf += "dbms.mode=$DatabaseMode`n`r"
+    }    
+    if ($customLib) {
+      $neoConf += "dbms.directories.lib=$Lib`n`r"
     }    
     $neoConf | Out-File -FilePath "$RootDir\conf\neo4j.conf"
 
@@ -71,6 +78,7 @@ Function global:New-MockNeo4jInstall($IncludeFiles = $true, $ServerType = 'Commu
     'ServerVersion' = $ServerVersion;
     'ServerType' = $ServerType;
     'DatabaseMode' = $DatabaseMode;
+    'LibDir' = $Lib;
   })
   return $serverObject
 }

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
@@ -169,7 +169,8 @@ InModuleScope Neo4j-Management {
 
     # Utility Invoke
     Context "Utility Invoke" {
-      $serverObject = global:New-MockNeo4jInstall -ServerVersion '99.99' -ServerType 'Community'
+      $mockLib = 'mock_lib'
+      $serverObject = global:New-MockNeo4jInstall -ServerVersion '99.99' -ServerType 'Community' -Lib $mockLib
 
       $result = Get-Java -ForUtility -StartingClass 'someclass' -Neo4jServer $serverObject -ErrorAction Stop
       $resultArgs = ($result.args -join ' ')
@@ -178,7 +179,7 @@ InModuleScope Neo4j-Management {
         $resultArgs | Should Match ([regex]::Escape('\bin\bin1.jar"'))
       }
       It "should have jars from lib" {
-        $resultArgs | Should Match ([regex]::Escape('\lib\lib1.jar"'))
+        $resultArgs | Should Match ([regex]::Escape('\' + $mockLib + '\lib1.jar"'))
       }
       It "should have correct Starting Class" {
         $resultArgs | Should Match ([regex]::Escape(' someclass'))

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
@@ -55,7 +55,8 @@ InModuleScope Neo4j-Management {
     }
 
     Context "PRUNSRV arguments" {
-      $serverObject = global:New-MockNeo4jInstall
+      $mockLib = 'mock_lib'
+      $serverObject = global:New-MockNeo4jInstall -Lib $mockLib
 
       It "return //IS/xxx argument on service install" {
         $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $serverObject -ForServerInstall
@@ -73,6 +74,12 @@ InModuleScope Neo4j-Management {
         $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $serverObject -ForConsole
 
         $prunsrv.args -join ' ' | Should Match ([regex]::Escape("//TS//$($global:mockServiceName)"))
+      }
+
+      It "return configured lib ClassPath for service install" {
+        $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $serverObject -ForServerInstall
+
+        $prunsrv.args -join ' ' | Should Match ([regex]::Escape("--ClassPath=$($mockLib)/*"))
       }
     }
 

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jServer.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jServer.Tests.ps1
@@ -109,5 +109,16 @@ InModuleScope Neo4j-Management {
          $neoServer.ConfDir | Should Be 'TestDrive:\neo4j-conf'
       }
     }
+
+    Context "Valid install with non-default directories" {
+      $mockLib = 'mock_lib'
+      $mockServer = global:New-MockNeo4jInstall -ServerType 'Community' -ServerVersion '99.99' -Lib $mockLib
+
+      $neoServer = Get-Neo4jServer -Neo4jHome $mockServer.Home -ErrorAction Stop
+  
+      It "detects lib dir" {
+        $neoServer.LibDir | Should Be $mockLib
+      }
+    }
   }
 }


### PR DESCRIPTION
Previously, the powershell module did not support having a non-default
lib directory (dbms.directories.lib). This PR;
- Modifies the powershell based management scripts to detect and use a non default lib directory (dbms.directories.lib)
- Modifies the verbose logging of Neo4j server properties to reduce the effort to add further properties to the Neo4jServer object
- Adds mocks and test examples for a non-default lib dir
