### PR TITLE
Remove the command prompt functionality from Neo4j Desktop

### DIFF
--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/ui/SettingsDialog.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/ui/SettingsDialog.java
@@ -52,7 +52,6 @@ class SettingsDialog extends JDialog
         this.model = model;
 
         getContentPane().add( withSpacingBorder( withBoxLayout( BoxLayout.Y_AXIS, createPanel(
-                createCommandPromptPanel( createCommandPromptButton() ),
                 createEditDatabaseConfigPanel( createEditDatabaseConfigurationButton() ),
                 createEditVmOptionsPanel( createEditVmOptionsButton() ),
                 createExtensionsPanel( createOpenPluginsDirectoryButton() ),


### PR DESCRIPTION
This is broken by changes elsewhere. It is as yet undecided whether the
problems will be fixed and the functionality reinstated or whether it is
removed permanently in favour of using the tarball or zip for advanced
functionality like Neo4j Shell; therefore this is a minimal change,
leaving unused code which will be cleaned up later.
