### PR TITLE
Fix filename conflict in documentation examples

### DIFF
--- a/community/import-tool/src/docs/ops/import-tool.asciidoc
+++ b/community/import-tool/src/docs/ops/import-tool.asciidoc
@@ -396,22 +396,22 @@ The type for properties specified in nodes and relationships files is defined in
 The following example creates a small graph containing one actor and one movie connected by an `ACTED_IN` relationship.
 There is a `roles` property on the relationship which contains an array of the characters played by the actor in a movie.
 
-.movies10.csv
+.movies7.csv
 [source]
 ----
-include::movies10.csv[]
+include::movies7.csv[]
 ----
 
-.actors10.csv
+.actors7.csv
 [source]
 ----
-include::actors10.csv[]
+include::actors7.csv[]
 ----
 
-.roles10.csv
+.roles7.csv
 [source]
 ----
-include::roles10.csv[]
+include::roles7.csv[]
 ----
 
 The arguments to `neo4j-import` would be the following:
@@ -435,25 +435,25 @@ Those data sets can define id spaces where identifiers are unique within their r
 
 For example if movies and people both use sequential identifiers then we would define `Movie` and `Actor` id spaces.
 
-.movies7.csv
+.movies8.csv
 [source]
 ----
-include::movies7.csv[]
+include::movies8.csv[]
 ----
 
-.actors7.csv
+.actors8.csv
 [source]
 ----
-include::actors7.csv[]
+include::actors8.csv[]
 ----
 
 We also need to reference the appropriate id space in our relationships file so it knows which nodes to connect
 together:
 
-.roles7.csv
+.roles8.csv
 [source]
 ----
-include::roles7.csv[]
+include::roles8.csv[]
 ----
 
 The command line arguments would remain the same as before:

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolDocIT.java
@@ -434,7 +434,7 @@ public class ImportToolDocIT
     public void idSpaces() throws FileNotFoundException
     {
         // GIVEN
-        File movies = file( "ops", "movies7.csv" );
+        File movies = file( "ops", "movies8.csv" );
         try (PrintStream out = new PrintStream( movies ))
         {
             out.println( "movieId:ID(Movie),title,year:int,:LABEL" );
@@ -443,7 +443,7 @@ public class ImportToolDocIT
             out.println( "3,\"The Matrix Revolutions\",2003,Movie;Sequel" );
         }
 
-        File actors = file( "ops", "actors7.csv" );
+        File actors = file( "ops", "actors8.csv" );
         try (PrintStream out = new PrintStream( actors ))
         {
             out.println( "personId:ID(Actor),name,:LABEL" );
@@ -452,7 +452,7 @@ public class ImportToolDocIT
             out.println( "3,\"Carrie-Anne Moss\",Actor" );
         }
 
-        File roles = file( "ops", "roles7.csv" );
+        File roles = file( "ops", "roles8.csv" );
         try ( PrintStream out = new PrintStream( roles ) )
         {
             out.println( ":START_ID(Actor),role,:END_ID(Movie)" );
@@ -582,21 +582,21 @@ public class ImportToolDocIT
     public void propertyTypes() throws FileNotFoundException
     {
         // GIVEN
-        File movies = file( "ops", "movies10.csv" );
+        File movies = file( "ops", "movies7.csv" );
         try (PrintStream out = new PrintStream( movies ))
         {
             out.println( "movieId:ID,title,year:int,:LABEL" );
             out.println( "tt0099892,\"Joe Versus the Volcano\",1990,Movie" );
         }
 
-        File actors = file( "ops", "actors10.csv" );
+        File actors = file( "ops", "actors7.csv" );
         try (PrintStream out = new PrintStream( actors ))
         {
             out.println( "personId:ID,name,:LABEL" );
             out.println( "meg,\"Meg Ryan\",Actor" );
         }
 
-        File roles = file( "ops", "roles10.csv" );
+        File roles = file( "ops", "roles7.csv" );
         try (PrintStream out = new PrintStream( roles ))
         {
             out.println( ":START_ID,roles:string[],:END_ID,:TYPE" );


### PR DESCRIPTION
Two examples used the same filename causing one example in the manual to refer to the wrong filecontents.
I reordered the filenames so they're incrementing in the same way they appear in the docs.
