### PR TITLE
Fix bit masking issue in Bolt server

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/BoltV1Dechunker.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/BoltV1Dechunker.java
@@ -76,7 +76,7 @@ public class BoltV1Dechunker
                 else
                 {
                     // Only one byte available, read that and wait for the second byte
-                    chunkSize = data.readByte() << 8;
+                    chunkSize = data.readUnsignedByte() << 8;
                     state = State.IN_HEADER;
                 }
                 break;
@@ -84,7 +84,7 @@ public class BoltV1Dechunker
             case IN_HEADER:
             {
                 // First header byte read, now we read the next one
-                chunkSize = (chunkSize | data.readByte()) & 0xFFFF;
+                chunkSize = chunkSize | data.readUnsignedByte();
                 handleHeader();
                 break;
             }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/RecordingByteChannel.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/RecordingByteChannel.java
@@ -26,7 +26,7 @@ import java.nio.channels.WritableByteChannel;
 
 public class RecordingByteChannel implements WritableByteChannel, ReadableByteChannel
 {
-    private final ByteBuffer buffer = ByteBuffer.allocate( 16 * 1024 );
+    private final ByteBuffer buffer = ByteBuffer.allocate( 64 * 1024 );
     private int writePosition = 0;
     private int readPosition = 0;
     private boolean eof;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/BoltV1DechunkerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/BoltV1DechunkerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.transport;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Test;
+
+import org.neo4j.bolt.v1.messaging.RecordingMessageHandler;
+import org.neo4j.bolt.v1.messaging.message.RunMessage;
+import org.neo4j.bolt.v1.messaging.util.MessageMatchers;
+
+import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BoltV1DechunkerTest
+{
+    @Test
+    public void shouldReadMessageWhenTheHeaderIsSplitAcrossChunks() throws Exception
+    {
+        Random random = ThreadLocalRandom.current();
+        for ( int len = 1; len <= 0x8000; len = len << 1 )
+        {
+            // given
+            StringBuilder content = new StringBuilder( len );
+            for ( int i = 0; i < len; i++ )
+            {
+                content.appendCodePoint( 'a' + random.nextInt( 'z' - 'a' ) );
+            }
+            RunMessage run = new RunMessage( content.toString() );
+            byte[] message = MessageMatchers.serialize( run );
+            byte head1 = (byte) (message.length >> 8), head2 = (byte) (message.length & 0xFF);
+            byte[] chunk2 = new byte[message.length + 3];
+            chunk2[0] = head2;
+            System.arraycopy( message, 0, chunk2, 1, message.length );
+
+            RecordingMessageHandler messages = new RecordingMessageHandler();
+            BoltV1Dechunker dechunker = new BoltV1Dechunker( messages, () -> {
+            } );
+
+            // when
+            dechunker.handle( wrappedBuffer( new byte[]{head1} ) );
+            assertTrue( "content length " + len + ": should be waiting for second chunk", messages.asList().isEmpty() );
+            dechunker.handle( wrappedBuffer( chunk2 ) );
+
+            // then
+            assertEquals( "content length " + len + ": should have received message", 1, messages.asList().size() );
+            assertEquals( run, messages.asList().get( 0 ) );
+        }
+    }
+}


### PR DESCRIPTION
When reading split chunk headers the bytes that constitute the header were read as signed bytes. This would cause sign extension which messed up the combination of the bytes. This fix reads the header bytes as unsigned bytes to eliminate this problem.
