### PR TITLE
Add limits to number of jetty threads

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -34,6 +34,7 @@ import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Internal;
 import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.server.web.JettyThreadCalculator;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.HTTP;
 import static org.neo4j.kernel.configuration.GroupSettingSupport.enumerate;
@@ -53,6 +54,7 @@ import static org.neo4j.kernel.configuration.Settings.max;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.options;
 import static org.neo4j.kernel.configuration.Settings.pathSetting;
+import static org.neo4j.kernel.configuration.Settings.range;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 @Description("Settings used by the server configuration")
@@ -118,9 +120,11 @@ public interface ServerSettings
                 .findFirst();
     }
 
-    @Description("Number of Neo4j worker threads.")
-    Setting<Integer> webserver_max_threads = setting( "dbms.threads.worker_count",
-            INTEGER, "" + Math.min( Runtime.getRuntime().availableProcessors(), 500 ), min( 1 ) );
+    @Description( "Number of Neo4j worker threads, your OS might enforce a lower limit than the maximum value " +
+            "specified here." )
+    Setting<Integer> webserver_max_threads = setting( "dbms.threads.worker_count", INTEGER,
+            "" + Math.min( Runtime.getRuntime().availableProcessors(), 500 ),
+            range( 1, JettyThreadCalculator.MAX_THREADS ) );
 
     @Description("If execution time limiting is enabled in the database, this configures the maximum request execution time.")
     @Internal

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
@@ -115,7 +115,7 @@ public class Jetty9WebServer implements WebServer
             new HashMap<>();
     private final List<FilterDefinition> filters = new ArrayList<>();
 
-    private int jettyMaxThreads;
+    private int jettyMaxThreads = 1;
     private KeyStoreInformation httpsCertificateInformation = null;
     private final SslSocketConnectorFactory sslSocketFactory;
     private final HttpConnectorFactory connectorFactory;

--- a/community/server/src/main/java/org/neo4j/server/web/JettyThreadCalculator.java
+++ b/community/server/src/main/java/org/neo4j/server/web/JettyThreadCalculator.java
@@ -21,6 +21,9 @@ package org.neo4j.server.web;
 
 public class JettyThreadCalculator
 {
+    // Any higher and maxCapacity will overflow
+    public static final int MAX_THREADS = 44738;
+
     private int acceptors;
     private int selectors;
     private int minThreads;
@@ -29,8 +32,19 @@ public class JettyThreadCalculator
 
     public JettyThreadCalculator( int jettyMaxThreads )
     {
+        if ( jettyMaxThreads < 1 )
+        {
+            throw new IllegalArgumentException( "Max threads can't be less than 1" );
+        }
+        else if ( jettyMaxThreads > MAX_THREADS )
+        {
+            throw new IllegalArgumentException( String.format( "Max threads can't exceed %d", MAX_THREADS ) );
+        }
+        // transactionThreads = N / 5
         int transactionThreads = jettyMaxThreads / 5;
+        // acceptors = N / 15
         acceptors = Math.max( 1, transactionThreads / 3 );
+        // selectors = N * 2 / 15
         selectors = Math.max( 1, transactionThreads - acceptors );
         if ( jettyMaxThreads < 4 )
         {
@@ -53,8 +67,14 @@ public class JettyThreadCalculator
             acceptors = Math.max( 2, transactionThreads / 3 );
             selectors = Math.max( 3, transactionThreads - acceptors );
         }
+        // minThreads = N / 5 + 2 * N / 5
+        // max safe value for this = 5 / 3 * INT.MAX = INT.MAX
         minThreads = Math.max( 2, transactionThreads ) + (acceptors + selectors) * 2;
+        // maxThreads = N + N / 5
+        // max Safe value for this = 6 / 5 * INT.MAX = INT.MAX
         maxThreads = Math.max( (jettyMaxThreads - selectors - acceptors), 8 ) + (acceptors + selectors) * 2;
+        // maxCapacity = (N - N / 5) * 60_000
+        // max safe value = 44738
         maxCapacity = (maxThreads - (selectors + acceptors) * 2) * 1000 * 60; // threads * 1000 req/s * 60 s
     }
 

--- a/community/server/src/test/java/org/neo4j/server/web/JettyThreadCalculatorTest.java
+++ b/community/server/src/test/java/org/neo4j/server/web/JettyThreadCalculatorTest.java
@@ -20,39 +20,78 @@
 package org.neo4j.server.web;
 
 import org.junit.Test;
+
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.neo4j.server.web.JettyThreadCalculator.MAX_THREADS;
 
 public class JettyThreadCalculatorTest
 {
     @Test
     public void shouldHaveCorrectAmountOfThreads()
     {
-        JettyThreadCalculator jtc = new JettyThreadCalculator(1);
-        assertEquals("Wrong acceptor value for 1 core", 1, jtc.getAcceptors());
-        assertEquals("Wrong selector value for 1 core", 1, jtc.getSelectors());
-        assertEquals("Wrong maxThreads value for 1 core", 12, jtc.getMaxThreads());
-        assertEquals("Wrong minThreads value for 1 core", 6, jtc.getMinThreads());
-        assertEquals("Wrong capacity value for 1 core", 480000, jtc.getMaxCapacity());
+        JettyThreadCalculator jtc = new JettyThreadCalculator( 1 );
+        assertEquals( "Wrong acceptor value for 1 core", 1, jtc.getAcceptors() );
+        assertEquals( "Wrong selector value for 1 core", 1, jtc.getSelectors() );
+        assertEquals( "Wrong maxThreads value for 1 core", 12, jtc.getMaxThreads() );
+        assertEquals( "Wrong minThreads value for 1 core", 6, jtc.getMinThreads() );
+        assertEquals( "Wrong capacity value for 1 core", 480000, jtc.getMaxCapacity() );
 
-        jtc = new JettyThreadCalculator(4);
-        assertEquals("Wrong acceptor value for 4 cores", 1, jtc.getAcceptors());
-        assertEquals("Wrong selector value for 4 cores", 2, jtc.getSelectors());
-        assertEquals("Wrong maxThreads value for 4 cores", 14, jtc.getMaxThreads());
-        assertEquals("Wrong minThreads value for 4 cores", 8, jtc.getMinThreads());
-        assertEquals("Wrong capacity value for 4 cores", 480000, jtc.getMaxCapacity());
+        jtc = new JettyThreadCalculator( 4 );
+        assertEquals( "Wrong acceptor value for 4 cores", 1, jtc.getAcceptors() );
+        assertEquals( "Wrong selector value for 4 cores", 2, jtc.getSelectors() );
+        assertEquals( "Wrong maxThreads value for 4 cores", 14, jtc.getMaxThreads() );
+        assertEquals( "Wrong minThreads value for 4 cores", 8, jtc.getMinThreads() );
+        assertEquals( "Wrong capacity value for 4 cores", 480000, jtc.getMaxCapacity() );
 
-        jtc = new JettyThreadCalculator(16);
-        assertEquals("Wrong acceptor value for 16 cores", 2, jtc.getAcceptors());
-        assertEquals("Wrong selector value for 16 cores", 3, jtc.getSelectors());
-        assertEquals("Wrong maxThreads value for 16 cores", 21, jtc.getMaxThreads());
-        assertEquals("Wrong minThreads value for 16 cores", 14, jtc.getMinThreads());
-        assertEquals("Wrong capacity value for 16 cores", 660000, jtc.getMaxCapacity());
+        jtc = new JettyThreadCalculator( 16 );
+        assertEquals( "Wrong acceptor value for 16 cores", 2, jtc.getAcceptors() );
+        assertEquals( "Wrong selector value for 16 cores", 3, jtc.getSelectors() );
+        assertEquals( "Wrong maxThreads value for 16 cores", 21, jtc.getMaxThreads() );
+        assertEquals( "Wrong minThreads value for 16 cores", 14, jtc.getMinThreads() );
+        assertEquals( "Wrong capacity value for 16 cores", 660000, jtc.getMaxCapacity() );
 
-        jtc = new JettyThreadCalculator(64);
-        assertEquals("Wrong acceptor value for 64 cores", 4, jtc.getAcceptors());
-        assertEquals("Wrong selector value for 64 cores", 8, jtc.getSelectors());
-        assertEquals("Wrong maxThreads value for 64 cores", 76, jtc.getMaxThreads());
-        assertEquals("Wrong minThreads value for 64 cores", 36, jtc.getMinThreads());
-        assertEquals("Wrong capacity value for 64 cores", 3120000, jtc.getMaxCapacity());
+        jtc = new JettyThreadCalculator( 64 );
+        assertEquals( "Wrong acceptor value for 64 cores", 4, jtc.getAcceptors() );
+        assertEquals( "Wrong selector value for 64 cores", 8, jtc.getSelectors() );
+        assertEquals( "Wrong maxThreads value for 64 cores", 76, jtc.getMaxThreads() );
+        assertEquals( "Wrong minThreads value for 64 cores", 36, jtc.getMinThreads() );
+        assertEquals( "Wrong capacity value for 64 cores", 3120000, jtc.getMaxCapacity() );
+
+        jtc = new JettyThreadCalculator( MAX_THREADS );
+        assertEquals( "Wrong acceptor value for max cores", 2982, jtc.getAcceptors() );
+        assertEquals( "Wrong selector value for max cores", 5965, jtc.getSelectors() );
+        assertEquals( "Wrong maxThreads value for max cores", 53685, jtc.getMaxThreads() );
+        assertEquals( "Wrong minThreads value for max cores", 26841, jtc.getMinThreads() );
+        assertEquals( "Wrong capacity value for max cores", 2147460000, jtc.getMaxCapacity() );
+    }
+
+    @Test
+    public void shouldNotAllowLessThanOneThread()
+    {
+        try
+        {
+            new JettyThreadCalculator( 0 );
+            fail( "Should not succeed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            assertEquals( "Max threads can't be less than 1", e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldNotAllowMoreThanMaxValue()
+    {
+        try
+        {
+            new JettyThreadCalculator( MAX_THREADS + 1 );
+            fail( "Should not succeed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            assertEquals( String.format( "Max threads can't exceed %d", MAX_THREADS ), e.getMessage() );
+        }
     }
 }


### PR DESCRIPTION
Also updates the relevant setting and docstring. The actual maximum
value is platform (and memory) dependent, but the current limit
indicates when our code will overflow so is a hard limit.

We should refrain from specifying a lower max value IMO since someone
might want to run it on a huge machine capable of many many threads.

To find out your machine's limit, you can run this script:

`groovysh maxthreads.groovy`

``` groovy
count = 0;
while(true){
  count++;
  println(count);
  new Thread(
    new Runnable(){
      public void run() {
        try {
          Thread.sleep(10000000);
        } catch(InterruptedException e) { }
      }
    }).start();
}
```

You can also mess with the limit by tweaking your limits. See what
`ulimit -u` reports. Then set some other value: `ulimit -u XXX` and the
max thread number should have changed.
