### PR TITLE
Fix bug in org.neo4j.kernel.impl.util.Bits.numberToString()

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Bits.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Bits.java
@@ -187,12 +187,12 @@ public final class Bits implements Cloneable
         builder.append( "[" );
         for ( int i = 8 * numberOfBytes - 1; i >= 0; i-- )
         {
+            boolean isSet = (value & (1L << i)) != 0;
+            builder.append( isSet ? "1" : "0" );
             if ( i > 0 && i % 8 == 0 )
             {
                 builder.append( "," );
             }
-            boolean isSet = (value & (1L << i)) != 0;
-            builder.append( isSet ? "1" : "0" );
         }
         builder.append( "]" );
         return builder;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestBits.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/TestBits.java
@@ -23,7 +23,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.junit.Test;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import static org.neo4j.kernel.impl.util.Bits.bits;
 
@@ -97,4 +99,13 @@ public class TestBits
         assertEquals( 123456789L, bits.getLong());
 
     }
+
+    @Test
+    public void numberToStringSeparatesAfter8Bits()
+    {
+        StringBuilder builder = new StringBuilder();
+        Bits.numberToString(builder, 0b11111111, 2);
+        assertThat(builder.toString(), is("[00000000,11111111]"));
+    }
+
 }


### PR DESCRIPTION
The `Bits.numberToString(StringBuilder, long, int)` method is supposed to pretty-print bits containted in a `long` value. It does that by separating every eight bits with a comma. This comma gets inserted too early.

See the test in my first commit. It pretty-prints `0b11111111` as two bytes long, but fails without the fix from the second commit:

> java.lang.AssertionError:
> Expected: is "[00000000,11111111]"
>     but: was "[0000000,011111111]"
