### PR TITLE
ImportTool now prints neo4j version

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -403,6 +403,7 @@ public class ImportTool
     private static void printOverview( File storeDir, Collection<Option<File[]>> nodesFiles,
             Collection<Option<File[]>> relationshipsFiles )
     {
+        System.out.println( "Neo4j version: " + Version.getKernel().getReleaseVersion() );
         System.out.println( "Importing the contents of these files into " + storeDir + ":" );
         printInputFiles( "Nodes", nodesFiles );
         printInputFiles( "Relationships", relationshipsFiles );


### PR DESCRIPTION
When importing a database, the version number of neo4j (including git branch) is printed.
This will help when user copy-paste output for support cases.

changelog: [import tool] Added print of Neo4j version 
