### PR TITLE
Handling of unused records in property chain  

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -278,7 +278,7 @@ class StorePropertyPayloadCursor
     {
         buffer.clear();
         long startBlockId = PropertyBlock.fetchLong( currentHeader() );
-        try ( GenericCursor<DynamicRecord> records = store.getRecordsCursor( startBlockId, true, cursor ) )
+        try ( GenericCursor<DynamicRecord> records = store.getRecordsCursor( startBlockId, cursor ) )
         {
             while ( records.next() )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -87,6 +87,7 @@ class StorePropertyPayloadCursor
 
     private final long[] data = new long[MAX_NUMBER_OF_PAYLOAD_LONG_ARRAY];
     private int position = INITIAL_POSITION;
+    private boolean exhausted;
 
     StorePropertyPayloadCursor( DynamicStringStore stringStore, DynamicArrayStore arrayStore )
     {
@@ -105,6 +106,7 @@ class StorePropertyPayloadCursor
     void clear()
     {
         position = INITIAL_POSITION;
+        exhausted = false;
         buffer = cachedBuffer;
         // Array of data should be filled with '0' because it is possible to call next() without calling init().
         // In such case 'false' should be returned, which might not be the case if there is stale data in the buffer.
@@ -113,6 +115,11 @@ class StorePropertyPayloadCursor
 
     boolean next()
     {
+        if ( exhausted )
+        {
+            return false;
+        }
+
         if ( position == INITIAL_POSITION )
         {
             position = 0;
@@ -121,11 +128,13 @@ class StorePropertyPayloadCursor
         {
             position += currentBlocksUsed();
         }
-        if ( position >= data.length )
+
+        if ( position >= data.length || type() == null )
         {
+            exhausted = true;
             return false;
         }
-        return type() != null;
+        return true;
     }
 
     PropertyType type()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/AbstractDynamicStore.java
@@ -67,15 +67,9 @@ import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_LOCK;
 public abstract class AbstractDynamicStore extends CommonAbstractStore implements RecordStore<DynamicRecord>,
         DynamicBlockSize, DynamicRecordAllocator
 {
-    public static final byte[] NO_DATA = new byte[0];
+    private static final byte[] NO_DATA = new byte[0];
     // (in_use+next high)(1 byte)+nr_of_bytes(3 bytes)+next_block(int)
     public static final int BLOCK_HEADER_SIZE = 1 + 3 + 4; // = 8
-
-    // Return signals for the readRecordHeader() method:
-    private static int hasDataSignal = 0;
-    private static int hasNoDataSignal = 1;
-    private static int notInUseSignal = 2;
-    private static int illegalSizeSignal = 3;
 
     private final int blockSizeFromConfiguration;
     private int blockSize;
@@ -393,12 +387,12 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
             while ( blockId != noNextBlock && cursor.next( pageIdForRecord( blockId ) ) )
             {
                 DynamicRecord record = new DynamicRecord( blockId );
-                int headerReadResult;
+                HeaderReadResult headerReadResult;
                 do
                 {
                     cursor.setOffset( offsetForId( blockId ) );
                     headerReadResult = readRecordHeader( cursor, record, false );
-                    if ( headerReadResult == hasDataSignal && readBothHeaderAndData )
+                    if ( headerReadResult == HeaderReadResult.DATA && readBothHeaderAndData )
                     {
                         readRecordData( cursor, record );
                     }
@@ -423,20 +417,17 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
         return new DynamicRecordCursor();
     }
 
-    public DynamicRecordCursor getRecordsCursor( final long startBlockId,
-            final boolean readBothHeaderAndData )
+    DynamicRecordCursor getRecordsCursor( long startBlockId )
     {
-        return getRecordsCursor( startBlockId, readBothHeaderAndData, newDynamicRecordCursor() );
+        return getRecordsCursor( startBlockId, newDynamicRecordCursor() );
     }
 
-    public DynamicRecordCursor getRecordsCursor( final long startBlockId,
-            final boolean readBothHeaderAndData, DynamicRecordCursor dynamicRecordCursor )
+    public DynamicRecordCursor getRecordsCursor( long startBlockId, DynamicRecordCursor dynamicRecordCursor )
     {
         try
         {
-            final PageCursor cursor = storeFile.io( 0, PF_SHARED_LOCK );
-
-            dynamicRecordCursor.init( startBlockId, cursor, readBothHeaderAndData );
+            PageCursor cursor = storeFile.io( 0, PF_SHARED_LOCK );
+            dynamicRecordCursor.init( startBlockId, cursor );
             return dynamicRecordCursor;
         }
         catch ( IOException e )
@@ -445,17 +436,17 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
         }
     }
 
-    private void checkForInUse( int headerReadResult, DynamicRecord record )
+    private void checkForInUse( HeaderReadResult headerReadResult, DynamicRecord record )
     {
-        if ( headerReadResult == notInUseSignal )
+        if ( headerReadResult == HeaderReadResult.NOT_IN_USE )
         {
-            throw new InvalidRecordException( "DynamicRecord Not in use, blockId[" + record.getId() + "]" );
+            throw new InvalidRecordException( "DynamicRecord not in use, blockId[" + record.getId() + "]" );
         }
     }
 
-    private void checkForIllegalSize( int headerReadResult, DynamicRecord record )
+    private void checkForIllegalSize( HeaderReadResult headerReadResult, DynamicRecord record )
     {
-        if ( headerReadResult == illegalSizeSignal )
+        if ( headerReadResult == HeaderReadResult.ILLEGAL_SIZE )
         {
             int dataSize = getBlockSize() - AbstractDynamicStore.BLOCK_HEADER_SIZE;
             throw new InvalidRecordException( "Next block set[" + record.getNextBlock()
@@ -467,7 +458,7 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     /**
      * Reads data from the cursor into the given record, and returns one of the signals specified above.
      */
-    private int readRecordHeader( PageCursor cursor, DynamicRecord record, boolean force )
+    private HeaderReadResult readRecordHeader( PageCursor cursor, DynamicRecord record, boolean force )
     {
         /*
          * First 4b
@@ -484,7 +475,7 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
         boolean inUse = highNibbleInMaskedInteger == Record.IN_USE.intValue();
         if ( !inUse && !force )
         {
-            return notInUseSignal;
+            return HeaderReadResult.NOT_IN_USE;
         }
         int dataSize = getBlockSize() - AbstractDynamicStore.BLOCK_HEADER_SIZE;
 
@@ -508,10 +499,10 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
             hasDataToRead = false;
             if ( !force )
             {
-                return illegalSizeSignal;
+                return HeaderReadResult.ILLEGAL_SIZE;
             }
         }
-        return hasDataToRead ? hasDataSignal : hasNoDataSignal;
+        return hasDataToRead ? HeaderReadResult.DATA : HeaderReadResult.NO_DATA;
     }
 
     private void readRecordData( PageCursor cursor, DynamicRecord record )
@@ -566,7 +557,7 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
         long pageId = pageIdForRecord( id );
         try ( PageCursor cursor = storeFile.io( pageId, PF_SHARED_LOCK ) )
         {
-            int headerReadResult = notInUseSignal;
+            HeaderReadResult headerReadResult = HeaderReadResult.NOT_IN_USE;
             if ( cursor.next() )
             {
                 int offset = offsetForId( record.getId() );
@@ -574,7 +565,7 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
                 {
                     cursor.setOffset( offset );
                     headerReadResult = readRecordHeader( cursor, record, false );
-                    if ( headerReadResult == hasDataSignal )
+                    if ( headerReadResult == HeaderReadResult.DATA )
                     {
                         readRecordData( cursor, record );
                     }
@@ -602,12 +593,12 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
             if ( cursor.next() )
             {
                 int offset = offsetForId( record.getId() );
-                int headerReadResult;
+                HeaderReadResult headerReadResult;
                 do
                 {
                     cursor.setOffset( offset );
                     headerReadResult = readRecordHeader( cursor, record, true );
-                    if ( headerReadResult == hasDataSignal )
+                    if ( headerReadResult == HeaderReadResult.DATA )
                     {
                         readRecordData( cursor, record );
                     }
@@ -656,16 +647,14 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
     public class DynamicRecordCursor extends GenericCursor<DynamicRecord>
     {
         private PageCursor cursor;
-        private boolean readBothHeaderAndData;
         long blockId;
         int noNextBlock;
 
         private final DynamicRecord record = new DynamicRecord( blockId );
 
-        public void init( long startBlockId, PageCursor cursor, boolean readBothHeaderAndData )
+        public void init( long startBlockId, PageCursor cursor )
         {
             this.cursor = cursor;
-            this.readBothHeaderAndData = readBothHeaderAndData;
             blockId = startBlockId;
             noNextBlock = Record.NO_NEXT_BLOCK.intValue();
         }
@@ -679,19 +668,18 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
                 {
                     record.setId( blockId );
 
-                    int headerReadResult;
+                    HeaderReadResult headerReadResult;
                     do
                     {
                         cursor.setOffset( offsetForId( blockId ) );
-                        headerReadResult = readRecordHeader( cursor, record, false );
-                        if ( headerReadResult == hasDataSignal && readBothHeaderAndData )
+                        headerReadResult = readRecordHeader( cursor, record, true );
+                        if ( headerReadResult == HeaderReadResult.DATA )
                         {
                             readRecordData( cursor, record );
                         }
                     }
                     while ( cursor.shouldRetry() );
 
-                    checkForInUse( headerReadResult, record );
                     checkForIllegalSize( headerReadResult, record );
                     current = record;
                     blockId = record.getNextBlock();
@@ -714,5 +702,10 @@ public abstract class AbstractDynamicStore extends CommonAbstractStore implement
             cursor.close();
             cursor = null;
         }
+    }
+
+    private enum HeaderReadResult
+    {
+        DATA, NO_DATA, NOT_IN_USE, ILLEGAL_SIZE
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
@@ -49,7 +49,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -489,7 +488,7 @@ public class StorePropertyPayloadCursorTest
 
         S store = mock( clazz );
         when( store.newDynamicRecordCursor() ).thenReturn( mock( AbstractDynamicStore.DynamicRecordCursor.class ) );
-        when( store.getRecordsCursor( anyLong(), anyBoolean(), any( AbstractDynamicStore.DynamicRecordCursor.class ) ) )
+        when( store.getRecordsCursor( anyLong(), any( AbstractDynamicStore.DynamicRecordCursor.class ) ) )
                 .thenReturn( recordCursor );
 
         return store;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
@@ -84,8 +84,8 @@ public class StorePropertyPayloadCursorTest
             // Given
             StorePropertyPayloadCursor cursor = newCursor( 1, 2, 3L );
 
-            cursor.next();
-            cursor.next();
+            assertTrue( cursor.next() );
+            assertTrue( cursor.next() );
 
             // When
             cursor.clear();
@@ -100,9 +100,9 @@ public class StorePropertyPayloadCursorTest
             // Given
             StorePropertyPayloadCursor cursor = newCursor( 1, 2, 3 );
 
-            cursor.next();
-            cursor.next();
-            cursor.next();
+            assertTrue( cursor.next() );
+            assertTrue( cursor.next() );
+            assertTrue( cursor.next() );
 
             // When
             cursor.clear();
@@ -131,7 +131,7 @@ public class StorePropertyPayloadCursorTest
             StorePropertyPayloadCursor cursor = newCursor();
 
             // When
-            cursor.next();
+            assertFalse( cursor.next() );
 
             // Then
             // next() on an empty cursor works just fine
@@ -161,6 +161,18 @@ public class StorePropertyPayloadCursorTest
             verify( dynamicStringStore ).newDynamicRecordCursor();
             verify( dynamicArrayStore ).newDynamicRecordCursor();
         }
+
+        @Test
+        public void nextMultipleInvocations()
+        {
+            StorePropertyPayloadCursor cursor = newCursor();
+
+            assertFalse( cursor.next() );
+            assertFalse( cursor.next() );
+            assertFalse( cursor.next() );
+            assertFalse( cursor.next() );
+        }
+
     }
 
     @RunWith( Parameterized.class )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.core;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 
 import java.util.UUID;
@@ -27,15 +29,20 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.IteratorUtil;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.neo4j.helpers.NamedThreadFactory.named;
@@ -73,6 +80,78 @@ public class NodeProxyTest extends PropertyContainerProxyTest
         catch ( NotFoundException exception )
         {
             assertThat( exception.getMessage(), containsString( PROPERTY_KEY ) );
+        }
+    }
+
+    @Test
+    public void createDropNodeLongStringProperty()
+    {
+        Label markerLabel = DynamicLabel.label( "marker" );
+        String testPropertyKey = "testProperty";
+        String propertyValue = RandomStringUtils.randomAscii( 255 );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode( markerLabel );
+            node.setProperty( testPropertyKey, propertyValue );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = IteratorUtil.single( db.findNodes( markerLabel ) );
+            assertEquals( propertyValue, node.getProperty( testPropertyKey ) );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = IteratorUtil.single( db.findNodes( markerLabel ) );
+            node.removeProperty( testPropertyKey );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = IteratorUtil.single( db.findNodes( markerLabel ) );
+            assertFalse( node.hasProperty( testPropertyKey ) );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void createDropNodeLongArrayProperty()
+    {
+        Label markerLabel = DynamicLabel.label( "marker" );
+        String testPropertyKey = "testProperty";
+        byte[] propertyValue = RandomUtils.nextBytes( 1024 );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode( markerLabel );
+            node.setProperty( testPropertyKey, propertyValue );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = IteratorUtil.single( db.findNodes( markerLabel ) );
+            assertArrayEquals( propertyValue, (byte[]) node.getProperty( testPropertyKey ) );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = IteratorUtil.single( db.findNodes( markerLabel ) );
+            node.removeProperty( testPropertyKey );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = IteratorUtil.single( db.findNodes( markerLabel ) );
+            assertFalse( node.hasProperty( testPropertyKey ) );
+            tx.success();
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
@@ -19,16 +19,24 @@
  */
 package org.neo4j.kernel.impl.core;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.neo4j.graphdb.DynamicLabel;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.core.RelationshipProxy.RelationshipActions;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -99,6 +107,82 @@ public class RelationshipProxyTest extends PropertyContainerProxyTest
             int type = types[i];
             verifyIds( actions, id, nodeId1, type, nodeId2 );
             verifyIds( actions, id, nodeId2, type, nodeId1 );
+        }
+    }
+
+    @Test
+    public void createDropRelationshipLongStringProperty()
+    {
+        Label markerLabel = DynamicLabel.label( "marker" );
+        String testPropertyKey = "testProperty";
+        String propertyValue = RandomStringUtils.randomAscii( 255 );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node start = db.createNode( markerLabel );
+            Node end = db.createNode( markerLabel );
+            Relationship relationship = start.createRelationshipTo( end, withName( "type" ) );
+            relationship.setProperty( testPropertyKey, propertyValue );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship relationship = db.getRelationshipById( 0 );
+            assertEquals( propertyValue, relationship.getProperty( testPropertyKey ) );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship relationship = db.getRelationshipById( 0 );
+            relationship.removeProperty( testPropertyKey );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship relationship = db.getRelationshipById( 0 );
+            assertFalse( relationship.hasProperty( testPropertyKey ) );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void createDropRelationshipLongArrayProperty()
+    {
+        Label markerLabel = DynamicLabel.label( "marker" );
+        String testPropertyKey = "testProperty";
+        byte[] propertyValue = RandomUtils.nextBytes( 1024 );
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node start = db.createNode( markerLabel );
+            Node end = db.createNode( markerLabel );
+            Relationship relationship = start.createRelationshipTo( end, withName( "type" ) );
+            relationship.setProperty( testPropertyKey, propertyValue );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship relationship = db.getRelationshipById( 0 );
+            assertArrayEquals( propertyValue, (byte[]) relationship.getProperty( testPropertyKey ) );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship relationship = db.getRelationshipById( 0 );
+            relationship.removeProperty( testPropertyKey );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship relationship = db.getRelationshipById( 0 );
+            assertFalse( relationship.hasProperty( testPropertyKey ) );
+            tx.success();
         }
     }
 


### PR DESCRIPTION
- Skip unused property records when reading chain
  
  To be able to increase property read throughput our reads should be more
  tolerant to concurrent updates of the same property chains. One of the
  steps - skip already removed properties.
  To do that store property cursor will skip unused records and will read and
  build chain of only used records. Exception that record is not in used will not
  be thrown anymore.
- Read unused dynamic records when reading chain
  
  Without short-lived locks reading of property records and corresponding dynamic
  records is not atomic. First, property record is read and only then
  corresponding dynamic records are read. This might result in reading
  inconsistent property values under concurrent load.
  This commit allows reading of unused dynamic records and their data when they
  are reachable from the chain.

Co-authored-by: @MishaDemianenko
