### PR TITLE
Safe freeing of aggressively reused ids

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/IdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/IdGeneratorFactory.java
@@ -35,4 +35,32 @@ public interface IdGeneratorFactory
     void create( File filename, long highId, boolean throwIfFileExists );
 
     IdGenerator get( IdType idType );
+
+    public class Delegate implements IdGeneratorFactory
+    {
+        private final IdGeneratorFactory delegate;
+
+        public Delegate( IdGeneratorFactory delegate )
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public IdGenerator open( File filename, int grabSize, IdType idType, long highId )
+        {
+            return delegate.open( filename, grabSize, idType, highId );
+        }
+
+        @Override
+        public void create( File filename, long highId, boolean throwIfFileExists )
+        {
+            delegate.create( filename, highId, throwIfFileExists );
+        }
+
+        @Override
+        public IdGenerator get( IdType idType )
+        {
+            return delegate.get( idType );
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.neo4j.collection.pool.LinkedQueuePool;
 import org.neo4j.collection.pool.MarshlandPool;
 import org.neo4j.function.Factory;
+import org.neo4j.function.Supplier;
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.helpers.Clock;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -62,7 +63,9 @@ import static java.util.Collections.newSetFromMap;
  * for enumerating all running transactions. During normal operation, acquiring new transactions and enumerating live
  * ones requires no synchronization (although the live list is not guaranteed to be exact).
  */
-public class KernelTransactions extends LifecycleAdapter implements Factory<KernelTransaction>
+public class KernelTransactions extends LifecycleAdapter
+        implements Factory<KernelTransaction>, // For providing KernelTransaction instances
+        Supplier<KernelTransactionsSnapshot>   // For providing KernelTransactionSnapshots
 {
     // Transaction dependencies
 
@@ -248,5 +251,11 @@ public class KernelTransactions extends LifecycleAdapter implements Factory<Kern
         {
             throw new DatabaseShutdownException();
         }
+    }
+
+    @Override
+    public KernelTransactionsSnapshot get()
+    {
+        return new KernelTransactionsSnapshot( allTransactions );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionsSnapshot.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionsSnapshot.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import java.util.Set;
+
+/**
+ * An instance of this class can get a snapshot of all currently running transactions and be able to tell
+ * later if all transactions which were running when it was constructed have closed.
+ *
+ * Creating a snapshot creates a list and one additional book keeping object per open transaction.
+ * No thread doing normal transaction work should create snapshots, only threads that monitor transactions.
+ */
+public class KernelTransactionsSnapshot
+{
+    private Tx relevantTransactions;
+
+    public KernelTransactionsSnapshot( Set<KernelTransactionImplementation> allTransactions )
+    {
+        Tx head = null;
+        for ( KernelTransactionImplementation tx : allTransactions )
+        {
+            if ( tx.isOpen() )
+            {
+                Tx current = new Tx( tx, tx.getReuseCount() );
+                if ( head != null )
+                {
+                    current.next = head;
+                    head = current;
+                }
+                else
+                {
+                    head = current;
+                }
+            }
+        }
+        relevantTransactions = head;
+    }
+
+    public boolean allClosed()
+    {
+        while ( relevantTransactions != null )
+        {
+            if ( !relevantTransactions.haveClosed() )
+            {
+                // At least one transaction hasn't closed yet
+                return false;
+            }
+
+            // This transaction has been closed, unlink so we don't have to check it the next time
+            relevantTransactions = relevantTransactions.next;
+        }
+
+        // All transactions have been closed
+        return true;
+    }
+
+    private static class Tx
+    {
+        private final KernelTransactionImplementation transaction;
+        private final int reuseCount;
+        private Tx next;
+
+        Tx( KernelTransactionImplementation tx, int reuseCount )
+        {
+            this.transaction = tx;
+            this.reuseCount = reuseCount;
+        }
+
+        boolean haveClosed()
+        {
+            return transaction.getReuseCount() != reuseCount;
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -201,7 +201,7 @@ public class DataSourceModule
                 platformModule.monitors.newMonitor( PhysicalLogFile.Monitor.class ),
                 editionModule.headerInformationFactory, startupStatistics, nodeManager, guard, indexStore,
                 editionModule.commitProcessFactory, pageCache, editionModule.constraintSemantics,
-                platformModule.monitors, platformModule.tracers ) );
+                platformModule.monitors, platformModule.tracers, editionModule.idGeneratorFactory ) );
         dataSourceManager.register( neoStoreDataSource );
 
         life.add( new MonitorGc( config, logging.getInternalLog( MonitorGc.class ) ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGenerator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.id;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.function.Predicate;
+import org.neo4j.function.Supplier;
+import org.neo4j.kernel.impl.api.KernelTransactionsSnapshot;
+
+class BufferingIdGenerator extends IdGenerator.Delegate
+{
+    private DelayedBuffer<KernelTransactionsSnapshot> buffer;
+
+    public BufferingIdGenerator( IdGenerator delegate )
+    {
+        super( delegate );
+    }
+
+    void initialize( Supplier<KernelTransactionsSnapshot> boundaries )
+    {
+        buffer = new DelayedBuffer<>( boundaries, new Predicate<KernelTransactionsSnapshot>()
+        {
+            @Override
+            public boolean test( KernelTransactionsSnapshot snapshot )
+            {
+                return snapshot.allClosed();
+            }
+        }, 10_000, new Consumer<long[]>()
+        {
+            @Override
+            public void accept( long[] freedIds )
+            {
+                for ( long id : freedIds )
+                {
+                    actualFreeId( id );
+                }
+            }
+        } );
+    }
+
+    private void actualFreeId( long id )
+    {
+        super.freeId( id );
+    }
+
+    @Override
+    public void freeId( long id )
+    {
+        buffer.offer( id );
+    }
+
+    void maintenance()
+    {
+        buffer.maintenance();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.id;
+
+import java.io.File;
+import org.neo4j.function.Supplier;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.api.KernelTransactionsSnapshot;
+
+/**
+ * Wraps {@link IdGenerator} for those that have {@link IdType#allowAggressiveReuse() aggressive id reuse}
+ * so that ids can be {@link IdGenerator#freeId(long) freed} at safe points in time, after all transactions
+ * which were active at the time of freeing, have been closed.
+ */
+public class BufferingIdGeneratorFactory extends IdGeneratorFactory.Delegate
+{
+    private final BufferingIdGenerator[/*IdType#ordinal as key*/] overriddenIdGenerators =
+            new BufferingIdGenerator[IdType.values().length];
+    private Supplier<KernelTransactionsSnapshot> boundaries;
+
+    public BufferingIdGeneratorFactory( IdGeneratorFactory delegate )
+    {
+        super( delegate );
+    }
+
+    public void initialize( Supplier<KernelTransactionsSnapshot> boundaries )
+    {
+        this.boundaries = boundaries;
+        for ( BufferingIdGenerator generator : overriddenIdGenerators )
+        {
+            if ( generator != null )
+            {
+                generator.initialize( boundaries );
+            }
+        }
+    }
+
+    @Override
+    public IdGenerator open( File filename, int grabSize, IdType idType, long highId )
+    {
+        IdGenerator generator = super.open( filename, grabSize, idType, highId );
+        if ( idType.allowAggressiveReuse() )
+        {
+            BufferingIdGenerator bufferingGenerator = new BufferingIdGenerator( generator );
+
+            // If shutdown was CLEAN
+            // BufferingIdGeneratorFactory has lifecycle:
+            //   - Construct
+            //   - open (all store files)
+            //   - initialize
+            //
+            // If Shutdown was UNCLEAN
+            // BufferingIdGeneratorFactory has lifecycle:
+            //   - Construct
+            //   - open (all store files) will fail
+            //   - initialize (with all generators being null)
+            //   - recovery is performed
+            //   - open (all store files) again
+            //   - initialize will NOT be called again so...
+            //   - call initialize on generators after open
+            //   = that is why this if-statement is here
+            if ( boundaries != null )
+            {
+                bufferingGenerator.initialize( boundaries );
+            }
+            overriddenIdGenerators[idType.ordinal()] = bufferingGenerator;
+            generator = bufferingGenerator;
+        }
+        return generator;
+    }
+
+    @Override
+    public IdGenerator get( IdType idType )
+    {
+        IdGenerator generator = overriddenIdGenerators[idType.ordinal()];
+        return generator != null ? generator : super.get( idType );
+    }
+
+    public void maintenance()
+    {
+        for ( BufferingIdGenerator generator : overriddenIdGenerators )
+        {
+            if ( generator != null )
+            {
+                generator.maintenance();
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DelayedBuffer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DelayedBuffer.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.id;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.function.Predicate;
+import org.neo4j.function.Supplier;
+
+import static java.util.Arrays.copyOf;
+
+/**
+ * Buffer of {@code long} values which can be held until a safe threshold is crossed, at which point
+ * they are released onto a {@link Consumer}. These values are held in chunk and each chunk knows
+ * which threshold is considered safe. Regular {@link #maintenance()} is required to be called externally
+ * for values to be released.
+ *
+ * This class is thread-safe for concurrent requests, but only a single thread should be responsible for
+ * calling {@link #maintenance()}.
+ */
+public class DelayedBuffer<T>
+{
+    private static class Chunk<T>
+    {
+        private final T threshold;
+        private final long[] values;
+
+        Chunk( T threshold, long[] values )
+        {
+            this.threshold = threshold;
+            this.values = values;
+        }
+    }
+
+    private final Supplier<T> thresholdSupplier;
+    private final Predicate<T> safeThreshold;
+    private final Consumer<long[]> chunkConsumer;
+    private final Deque<Chunk> chunks = new LinkedList<>();
+    private final int chunkSize;
+
+    private final long[] chunk;
+    private int chunkCursor;
+
+    public DelayedBuffer( Supplier<T> thresholdSupplier, Predicate<T> safeThreshold, int chunkSize,
+            Consumer<long[]> chunkConsumer )
+    {
+        this.thresholdSupplier = thresholdSupplier;
+        this.safeThreshold = safeThreshold;
+        this.chunkSize = chunkSize;
+        this.chunkConsumer = chunkConsumer;
+        this.chunk = new long[chunkSize];
+    }
+
+    /**
+     * Should be called every now and then to check for safe thresholds of buffered chunks and potentially
+     * release them onto the {@link Consumer}.
+     */
+    public void maintenance()
+    {
+        synchronized ( this )
+        {
+            flush();
+        }
+
+        if ( !chunks.isEmpty() )
+        {
+            synchronized ( chunks )
+            {
+                // Potentially hand over chunks to the consumer
+                while ( !chunks.isEmpty() )
+                {
+                    Chunk<T> candidate = chunks.peek();
+                    if ( safeThreshold.test( candidate.threshold ) )
+                    {
+                        chunkConsumer.accept( candidate.values );
+                        chunks.remove();
+                    }
+                    else
+                    {
+                        // The chunks are ordered by chunkThreshold, so we know that no more chunks will qualify anyway
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Must be called under synchronized on this
+    private void flush()
+    {
+        if ( chunkCursor > 0 )
+        {
+            synchronized ( chunks )
+            {
+                Chunk<T> chunkToAdd = new Chunk<>( thresholdSupplier.get(), copyOf( chunk, chunkCursor ) );
+                chunks.offer( chunkToAdd );
+            }
+            chunkCursor = 0;
+        }
+    }
+
+    /**
+     * Offers a value to this buffer. This value will at a later point be part of a buffered chunk,
+     * released by a call to {@link #maintenance()} when the safe threshold for the chunk, which is determined
+     * when the chunk is full or otherwise queued.
+     */
+    public synchronized void offer( long value )
+    {
+        chunk[chunkCursor++] = value;
+        if ( chunkCursor == chunkSize )
+        {
+            flush();
+        }
+    }
+
+    /**
+     * Closes this buffer, releasing all {@link #offer(long)} values into the {@link Consumer}.
+     *
+     * This class is typically not used in a scenario suitable for try-with-resource
+     * and so having it implement AutoCloseable would be more annoying
+     */
+    public synchronized void close()
+    {
+        flush();
+        while ( !chunks.isEmpty() )
+        {
+            chunkConsumer.accept( chunks.poll().values );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGenerator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGenerator.java
@@ -44,4 +44,74 @@ public interface IdGenerator extends IdSequence
      * middle will still leave the file marked as dirty so it will be deleted on the next open call.
      */
     void delete();
+
+    class Delegate implements IdGenerator
+    {
+        private final IdGenerator delegate;
+
+        public Delegate( IdGenerator delegate )
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public long nextId()
+        {
+            return delegate.nextId();
+        }
+
+        @Override
+        public IdRange nextIdBatch( int size )
+        {
+            return delegate.nextIdBatch( size );
+        }
+
+        @Override
+        public void setHighId( long id )
+        {
+            delegate.setHighId( id );
+        }
+
+        @Override
+        public long getHighId()
+        {
+            return delegate.getHighId();
+        }
+
+        @Override
+        public long getHighestPossibleIdInUse()
+        {
+            return delegate.getHighestPossibleIdInUse();
+        }
+
+        @Override
+        public void freeId( long id )
+        {
+            delegate.freeId( id );
+        }
+
+        @Override
+        public void close()
+        {
+            delegate.close();
+        }
+
+        @Override
+        public long getNumberOfIdsInUse()
+        {
+            return delegate.getNumberOfIdsInUse();
+        }
+
+        @Override
+        public long getDefragCount()
+        {
+            return delegate.getDefragCount();
+        }
+
+        @Override
+        public void delete()
+        {
+            delegate.delete();
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -145,6 +145,11 @@ public interface JobScheduler extends Lifecycle
          * Network IO threads for the Bolt protocol.
          */
         public static final Group boltNetworkIO = new Group( "BoltNetworkIO", NEW_THREAD );
+
+        /**
+         * Storage maintenance.
+         */
+        public static Group storageMaintenance = new Group( "StorageMaintenance", POOLED );
     }
 
     interface JobHandle

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/AbstractNeo4jTestCase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/AbstractNeo4jTestCase.java
@@ -39,7 +39,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.reflect.Field;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -50,10 +49,11 @@ import org.neo4j.kernel.GraphDatabaseAPI;
 import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.IdType;
 import org.neo4j.kernel.impl.core.NodeManager;
-import org.neo4j.kernel.impl.store.AbstractDynamicStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.transaction.state.NeoStoresSupplier;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -283,31 +283,31 @@ public abstract class AbstractNeo4jTestCase
 
     protected long propertyRecordsInUse()
     {
-        return propertyStore().getNumberOfIdsInUse();
+        return numberOfRecordsInUse( propertyStore() );
+    }
+
+    public static <RECORD extends AbstractBaseRecord> int numberOfRecordsInUse( RecordStore<RECORD> store )
+    {
+        int inUse = 0;
+        for ( long id = store.getNumberOfReservedLowIds(); id < store.getHighId(); id++ )
+        {
+            RECORD record = store.forceGetRecord( id );
+            if ( record.inUse() )
+            {
+                inUse++;
+            }
+        }
+        return inUse;
     }
 
     protected long dynamicStringRecordsInUse()
     {
-        return dynamicRecordsInUse( "stringPropertyStore" );
+        return numberOfRecordsInUse( propertyStore().getStringStore() );
     }
 
     protected long dynamicArrayRecordsInUse()
     {
-        return dynamicRecordsInUse( "arrayPropertyStore" );
-    }
-
-    private long dynamicRecordsInUse( String fieldName )
-    {
-        try
-        {
-            Field storeField = PropertyStore.class.getDeclaredField( fieldName );
-            storeField.setAccessible( true );
-            return ((AbstractDynamicStore) storeField.get( propertyStore() )).getNumberOfIdsInUse();
-        }
-        catch ( Exception e )
-        {
-            throw new RuntimeException( e );
-        }
+        return numberOfRecordsInUse( propertyStore().getArrayStore() );
     }
 
     protected PropertyStore propertyStore()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.api;
+package org.neo4j.kernel.impl.api;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +28,7 @@ import java.util.Collection;
 
 import org.neo4j.collection.pool.Pool;
 import org.neo4j.helpers.FakeClock;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
@@ -410,6 +411,21 @@ public class KernelTransactionImplementationTest
 
         // THEN
         verify( locks ).newClient();
+    }
+
+    @Test
+    public void shouldIncrementReuseCounterOnReuse() throws Exception
+    {
+        // GIVEN
+        KernelTransactionImplementation transaction = newTransaction();
+        int reuseCount = transaction.getReuseCount();
+
+        // WHEN
+        transaction.close();
+        transaction.initialize( 1 );
+
+        // THEN
+        assertEquals( reuseCount + 1, transaction.getReuseCount() );
     }
 
     private final NeoStores neoStores = mock( NeoStores.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -23,6 +23,10 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.api.store.ProcedureCache;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
@@ -47,16 +51,23 @@ import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
 import org.neo4j.logging.NullLog;
+import org.neo4j.test.Race;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+
 import static org.neo4j.helpers.collection.IteratorUtil.asSet;
 import static org.neo4j.helpers.collection.IteratorUtil.asUniqueSet;
 
@@ -122,6 +133,116 @@ public class KernelTransactionsTest
         byte[] additionalHeader = transactionRepresentation[0].additionalHeader();
         assertNotNull( additionalHeader );
         assertTrue( additionalHeader.length > 0 );
+    }
+
+    @Test
+    public void shouldReuseClosedTransactionObjects() throws Exception
+    {
+        // GIVEN
+        KernelTransactions transactions = newKernelTransactions();
+        KernelTransaction a = transactions.newInstance();
+
+        // WHEN
+        a.close();
+        KernelTransaction b = transactions.newInstance();
+
+        // THEN
+        assertSame( a, b );
+    }
+
+    @Test
+    public void shouldTellWhenTransactionsFromSnapshotHaveBeenClosed() throws Exception
+    {
+        // GIVEN
+        KernelTransactions transactions = newKernelTransactions();
+        KernelTransaction a = transactions.newInstance();
+        KernelTransaction b = transactions.newInstance();
+        KernelTransaction c = transactions.newInstance();
+        KernelTransactionsSnapshot snapshot = transactions.get();
+        assertFalse( snapshot.allClosed() );
+
+        // WHEN a gets closed
+        a.close();
+        assertFalse( snapshot.allClosed() );
+
+        // WHEN c gets closed and (test knowing too much) that instance getting reused in another transaction "d".
+        c.close();
+        KernelTransaction d = transactions.newInstance();
+        assertFalse( snapshot.allClosed() );
+
+        // WHEN b finally gets closed
+        b.close();
+        assertTrue( snapshot.allClosed() );
+    }
+
+    @Test
+    public void shouldBeAbleToSnapshotDuringHeavyLoad() throws Throwable
+    {
+        // GIVEN
+        final KernelTransactions transactions = newKernelTransactions();
+        Race race = new Race();
+        final int threads = 50;
+        final AtomicBoolean end = new AtomicBoolean();
+        final AtomicReferenceArray<KernelTransactionsSnapshot> snapshots = new AtomicReferenceArray<>( threads );
+
+        // Representing "transaction" threads
+        for ( int i = 0; i < threads; i++ )
+        {
+            final int threadIndex = i;
+            race.addContestant( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    ThreadLocalRandom random = ThreadLocalRandom.current();
+                    while ( !end.get() )
+                    {
+                        try ( KernelTransaction transaction = transactions.newInstance() )
+                        {
+                            parkNanos( MILLISECONDS.toNanos( random.nextInt( 3 ) ) );
+                            if ( snapshots.get( threadIndex ) == null )
+                            {
+                                snapshots.set( threadIndex, transactions.get() );
+                                parkNanos( MILLISECONDS.toNanos( random.nextInt( 3 ) ) );
+                            }
+                        }
+                        catch ( TransactionFailureException e )
+                        {
+                            throw new RuntimeException( e );
+                        }
+                    }
+                }
+            } );
+        }
+
+        // Just checks snapshots
+        race.addContestant( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                ThreadLocalRandom random = ThreadLocalRandom.current();
+                int snapshotsLeft = 1_000;
+                while ( snapshotsLeft > 0 )
+                {
+                    int threadIndex = random.nextInt( threads );
+                    KernelTransactionsSnapshot snapshot = snapshots.get( threadIndex );
+                    if ( snapshot != null && snapshot.allClosed() )
+                    {
+                        snapshotsLeft--;
+                        snapshots.set( threadIndex, null );
+                    }
+                }
+
+                // End condition of this test can be described as:
+                //   when 1000 snapshots have been seen as closed.
+                // setting this boolean to true will have all other threads end as well so that race.go() will end
+                end.set( true );
+            }
+        } );
+
+        // WHEN
+        race.go();
     }
 
     private static KernelTransactions newKernelTransactions()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShortStringProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestShortStringProperties.java
@@ -29,7 +29,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.kernel.NeoStoreDataSource;
-import org.neo4j.kernel.impl.store.AbstractDynamicStore;
+import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.TestShortString;
 import org.neo4j.test.DatabaseRule;
@@ -228,19 +228,12 @@ public class TestShortStringProperties extends TestShortString
 
     private long propertyRecordsInUse()
     {
-        return propertyStore().getNumberOfIdsInUse();
+        return AbstractNeo4jTestCase.numberOfRecordsInUse( propertyStore() );
     }
 
     private long dynamicRecordsInUse()
     {
-        try
-        {
-            return ( (AbstractDynamicStore) storeField.get( propertyStore() ) ).getNumberOfIdsInUse();
-        }
-        catch ( Exception e )
-        {
-            throw new RuntimeException( e );
-        }
+        return AbstractNeo4jTestCase.numberOfRecordsInUse( propertyStore().getStringStore() );
     }
 
     private PropertyStore propertyStore()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestPropertyBlocks.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestPropertyBlocks.java
@@ -861,7 +861,6 @@ public class TestPropertyBlocks extends AbstractNeo4jTestCase
                 getIdGenerator( IdType.PROPERTY ).getNumberOfIdsInUse() );
         node.delete();
         commit();
-        assertEquals( "All property records should be freed", propcount,
-                getIdGenerator( IdType.PROPERTY ).getNumberOfIdsInUse() );
+        assertEquals( "All property records should be freed", propcount, propertyRecordsInUse() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactoryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.id;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import org.neo4j.function.Supplier;
+import org.neo4j.kernel.IdGeneratorFactory;
+import org.neo4j.kernel.IdType;
+import org.neo4j.kernel.impl.api.KernelTransactionsSnapshot;
+import org.neo4j.test.EphemeralFileSystemRule;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class BufferingIdGeneratorFactoryTest
+{
+    @Rule
+    public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
+
+    @Test
+    public void shouldDelayFreeingOfAggressivelyReusedIds() throws Exception
+    {
+        // GIVEN
+        MockedIdGeneratorFactory actual = new MockedIdGeneratorFactory();
+        BufferingIdGeneratorFactory bufferingIdGeneratorFactory = new BufferingIdGeneratorFactory( actual );
+        ControllableSnapshotSupplier boundaries = new ControllableSnapshotSupplier();
+        IdGenerator idGenerator = bufferingIdGeneratorFactory.open(
+                new File( "doesnt-matter" ), 10, IdType.STRING_BLOCK, 0 );
+        bufferingIdGeneratorFactory.initialize( boundaries );
+
+        // WHEN
+        idGenerator.freeId( 7 );
+        verifyNoMoreInteractions( actual.get( IdType.STRING_BLOCK ) );
+
+        // after some maintenance and transaction still not closed
+        bufferingIdGeneratorFactory.maintenance();
+        verifyNoMoreInteractions( actual.get( IdType.STRING_BLOCK ) );
+
+        // although after transactions have all closed
+        boundaries.setMostRecentlyReturnedSnapshotToAllClosed();
+        bufferingIdGeneratorFactory.maintenance();
+
+        // THEN
+        verify( actual.get( IdType.STRING_BLOCK ) ).freeId( 7 );
+    }
+
+    private static class ControllableSnapshotSupplier implements Supplier<KernelTransactionsSnapshot>
+    {
+        KernelTransactionsSnapshot mostRecentlyReturned;
+
+        @Override
+        public KernelTransactionsSnapshot get()
+        {
+            return mostRecentlyReturned = mock( KernelTransactionsSnapshot.class );
+        }
+
+        void setMostRecentlyReturnedSnapshotToAllClosed()
+        {
+            when( mostRecentlyReturned.allClosed() ).thenReturn( true );
+        }
+    }
+
+    private static class MockedIdGeneratorFactory implements IdGeneratorFactory
+    {
+        private final IdGenerator[] generators = new IdGenerator[IdType.values().length];
+
+        @Override
+        public IdGenerator open( File filename, int grabSize, IdType idType, long highId )
+        {
+            return generators[idType.ordinal()] = mock( IdGenerator.class );
+        }
+
+        @Override
+        public void create( File filename, long highId, boolean throwIfFileExists )
+        {
+        }
+
+        @Override
+        public IdGenerator get( IdType idType )
+        {
+            return generators[idType.ordinal()];
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/DelayedBufferTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/DelayedBufferTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.id;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
+
+import org.neo4j.function.Consumer;
+import org.neo4j.function.Predicate;
+import org.neo4j.function.Supplier;
+import org.neo4j.helpers.Clock;
+import org.neo4j.test.Race;
+import static java.util.concurrent.ThreadLocalRandom.current;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+
+import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToInt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class DelayedBufferTest
+{
+    @Test
+    public void shouldHandleTheWholeWorkloadShebang() throws Throwable
+    {
+        // GIVEN
+        final int size = 1_000;
+        final long bufferTime = 3;
+        VerifyingConsumer consumer = new VerifyingConsumer( size );
+        final Clock clock = Clock.SYSTEM_CLOCK;
+        Supplier<Long> chunkThreshold = new Supplier<Long>()
+        {
+            @Override
+            public Long get()
+            {
+                return clock.currentTimeMillis();
+            }
+        };
+        Predicate<Long> safeThreshold = new Predicate<Long>()
+        {
+            @Override
+            public boolean test( Long time )
+            {
+                return clock.currentTimeMillis() - bufferTime >= time;
+            }
+        };
+        final DelayedBuffer<Long> buffer = new DelayedBuffer<>( chunkThreshold, safeThreshold, 10, consumer );
+        MaintenanceThread maintenance = new MaintenanceThread( buffer, 5 );
+        Race adders = new Race();
+        final int numberOfAdders = 20;
+        final byte[] offeredIds = new byte[size];
+        for ( int i = 0; i < numberOfAdders; i++ )
+        {
+            final int finalI = i;
+            adders.addContestant( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    for ( int j = 0; j < size; j++ )
+                    {
+                        if ( j % numberOfAdders == finalI )
+                        {
+                            buffer.offer( j );
+                            offeredIds[j] = 1;
+                            parkNanos( MILLISECONDS.toNanos( current().nextInt( 2 ) ) );
+                        }
+                    }
+                }
+            } );
+        }
+
+        // WHEN (multi-threadded) offering of ids
+        adders.go();
+        // ... ensuring the test is sane itself (did we really offer all these IDs?)
+        for ( int i = 0; i < size; i++ )
+        {
+            assertEquals( "ID " + i, (byte) 1, offeredIds[i] );
+        }
+        maintenance.halt();
+        buffer.close();
+
+        // THEN
+        consumer.assertHaveOnlySeenRange( 0, size-1 );
+    }
+
+    @Test
+    public void shouldNotReleaseValuesUntilCrossedThreshold() throws Exception
+    {
+        // GIVEN
+        VerifyingConsumer consumer = new VerifyingConsumer( 30 );
+        final AtomicLong txOpened = new AtomicLong();
+        final AtomicLong txClosed = new AtomicLong();
+        Supplier<Long> chunkThreshold = new Supplier<Long>()
+        {
+            @Override
+            public Long get()
+            {
+                return txOpened.get();
+            }
+        };
+        Predicate<Long> safeThreshold = new Predicate<Long>()
+        {
+            @Override
+            public boolean test( Long value )
+            {
+                return txClosed.get() >= value;
+            }
+        };
+        DelayedBuffer<Long> buffer = new DelayedBuffer<>( chunkThreshold, safeThreshold, 100, consumer );
+
+        // Transaction spans like these:
+        //    1 |-1--------2-------3---|
+        //    2   |4--5---------|
+        //    3       |---------6----|
+        //    4        |7--8-|
+        //    5          |--------9-------10-|
+        //    6                  |--11----|
+        //    7                    |-12---13---14--|
+        // TIME|1-2-3-4-5-6-7-8-9-a-b-c-d-e-f-g-h-i-j|
+        //  POI     ^   ^     ^         ^     ^     ^
+        //          A   B     C         D     E     F
+
+        // A
+        txOpened.incrementAndGet(); // <-- TX 1
+        buffer.offer( 1 );
+        txOpened.incrementAndGet(); // <-- TX 2
+        buffer.offer( 4 );
+        buffer.maintenance();
+        assertEquals( 0, consumer.chunksAccepted() );
+
+        // B
+        buffer.offer( 5 );
+        txOpened.incrementAndGet(); // <-- TX 3
+        txOpened.incrementAndGet(); // <-- TX 4
+        buffer.offer( 7 );
+        buffer.maintenance();
+        assertEquals( 0, consumer.chunksAccepted() );
+
+        // C
+        txOpened.incrementAndGet(); // <-- TX 5
+        buffer.offer( 2 );
+        buffer.offer( 8 );
+        // TX 4 closes, but TXs with lower ids are still open
+        buffer.maintenance();
+        assertEquals( 0, consumer.chunksAccepted() );
+
+        // D
+        // TX 2 closes, but TXs with lower ids are still open
+        buffer.offer( 6 );
+        txOpened.incrementAndGet(); // <-- TX 6
+        buffer.offer( 9 );
+        buffer.offer( 3 );
+        txOpened.incrementAndGet(); // <-- TX 7
+        buffer.offer( 11 );
+        // TX 3 closes, but TXs with lower ids are still open
+        buffer.offer( 12 );
+        txClosed.set( 4 ); // since 1-4 have now all closed
+        buffer.maintenance();
+        consumer.assertHaveOnlySeen( 1, 4, 5, 7 );
+
+        // E
+        buffer.offer( 10 );
+        // TX 6 closes, but TXs with lower ids are still open
+        buffer.offer( 13 );
+        txClosed.set( 6 ); // since 1-6 have now all closed
+        buffer.maintenance();
+        consumer.assertHaveOnlySeen( 1, 2, 4, 5, 7, 8 );
+
+        // F
+        buffer.offer( 14 );
+        txClosed.set( 7 ); // since 1-7 have now all closed
+        buffer.maintenance();
+        consumer.assertHaveOnlySeen( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 );
+    }
+
+    private static class MaintenanceThread extends Thread
+    {
+        private final DelayedBuffer buffer;
+        private final long nanoInterval;
+        private volatile boolean end;
+
+        MaintenanceThread( DelayedBuffer buffer, long nanoInterval )
+        {
+            this.buffer = buffer;
+            this.nanoInterval = nanoInterval;
+            start();
+        }
+
+        @Override
+        public void run()
+        {
+            while ( !end )
+            {
+                buffer.maintenance();
+                LockSupport.parkNanos( nanoInterval );
+            }
+        }
+
+        void halt() throws InterruptedException
+        {
+            end = true;
+            while ( isAlive() )
+            {
+                Thread.sleep( 1 );
+            }
+        }
+    }
+
+    private static class VerifyingConsumer implements Consumer<long[]>
+    {
+        private final boolean[] seenIds;
+        private int chunkCount;
+
+        public VerifyingConsumer( int size )
+        {
+            seenIds = new boolean[size];
+        }
+
+        void assertHaveOnlySeenRange( long low, long high )
+        {
+            long[] values = new long[(int) (high - low + 1)];
+            for ( long id = low, i = 0; id <= high; id++, i++ )
+            {
+                values[(int) i] = id;
+            }
+            assertHaveOnlySeen( values );
+        }
+
+        @Override
+        public void accept( long[] chunk )
+        {
+            chunkCount++;
+            for ( long id : chunk )
+            {
+                assertFalse( seenIds[safeCastLongToInt( id )] );
+                seenIds[safeCastLongToInt( id )] = true;
+            }
+        }
+
+        void assertHaveOnlySeen( long... values )
+        {
+            for ( int i = 0, vi = 0; i < seenIds.length && vi < values.length; i++ )
+            {
+                boolean expectedToBeSeen = values[vi] == i;
+                if ( expectedToBeSeen && !seenIds[i] )
+                {
+                    fail( "Expected to have seen " + i + ", but hasn't" );
+                }
+                else if ( !expectedToBeSeen && seenIds[i] )
+                {
+                    fail( "Expected to NOT have seen " + i + ", but have" );
+                }
+
+                if ( expectedToBeSeen )
+                {
+                    vi++;
+                }
+            }
+        }
+
+        int chunksAccepted()
+        {
+            return chunkCount;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -78,7 +78,8 @@ public class NeoStoreDataSourceRule extends ExternalResource
         final Config config = new Config( stringMap( additionalConfig ),
                 GraphDatabaseSettings.class );
 
-        StoreFactory sf = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs ), pageCache, fs,
+        DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
+        StoreFactory sf = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs,
                 NullLogProvider.getInstance() );
 
         Locks locks = mock( Locks.class );
@@ -93,7 +94,8 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 mock( PhysicalLogFile.Monitor.class ), TransactionHeaderInformationFactory.DEFAULT,
                 new StartupStatisticsProvider(), mock( NodeManager.class ), null, null,
                 new CommunityCommitProcessFactory(), mock( PageCache.class ),
-                mock( ConstraintSemantics.class), new Monitors(), new Tracers( "null", NullLog.getInstance() ) );
+                mock( ConstraintSemantics.class), new Monitors(), new Tracers( "null", NullLog.getInstance() ),
+                idGeneratorFactory );
 
         return dataSource;
     }


### PR DESCRIPTION
By using tracking of open transaction. This hooks in as a decorating BufferingIdGeneratorFactory
where the buffering of ids are managed, even exposing means of running maintenance which
can check and release the buffered freed ids at safe points in time. There's an added maintenance
job in JobScheduler which every now and then tests buffered ids if they are safe to free,
by looking at their respective transaction snapshots.

Tracking of transactions works by getting a snapshot of currently active
KernelTransactionImplementation instances. Snapshots can be asked whether or not all
transactions have been closed. KTI got an additional field for tracking how many
times it has been reused. This in conjunction with checking if transaction is open or not
can determine whether or not transaction have been closed.

Buffering of ids can be disabled with a feature toggle:
-Dorg.neo4j.kernel.NeoStoreDataSource.safeIdBuffering=false
