### PR TITLE
Don't go back to IDLE after INTERRUPT if error occurred

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
@@ -43,11 +43,11 @@ import org.neo4j.bolt.v1.runtime.integration.RecordingCallback;
 import org.neo4j.bolt.v1.runtime.internal.concurrent.ThreadedSessions;
 import org.neo4j.bolt.v1.runtime.spi.RecordStream;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.lifecycle.LifeSupport;
@@ -58,7 +58,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.recorded;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.success;
-import static org.neo4j.bolt.v1.runtime.internal.SessionStateMachine.State.IDLE;
+import static org.neo4j.bolt.v1.runtime.internal.SessionStateMachine.State.ERROR;
 import static org.neo4j.helpers.collection.MapUtil.map;
 
 public class ResetFuzzTest
@@ -122,7 +122,7 @@ public class ResetFuzzTest
         try
         {
             assertThat( recorder, recorded( success() ) );
-            assertThat( ssm.state(), equalTo( IDLE ) );
+            assertThat( ssm.state(), equalTo( ERROR ) );
             assertThat( liveTransactions.get(), equalTo( 0L ));
         }
         catch( AssertionError e )

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineResetTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineResetTest.java
@@ -47,6 +47,7 @@ public class SessionStateMachineResetTest
         // Then
         ssm.run( "hello", map(), null, recorder );
         ssm.reset( null, recorder );
+        ssm.ackFailure( noOp(), noOp() );
         ssm.run( "hello", map(), null, recorder );
         assertThat( recorder, recorded(
             ignored(),
@@ -70,6 +71,7 @@ public class SessionStateMachineResetTest
         // Then
         ssm.run( "hello", map(), null, recorder );
         ssm.reset( null, recorder );
+        ssm.ackFailure( noOp(), noOp() );
         ssm.run( "hello", map(), null, recorder );
         assertThat( recorder, recorded(
                 ignored(),
@@ -81,7 +83,7 @@ public class SessionStateMachineResetTest
 
         // But when
         ssm.reset( null, recorder );
-
+        ssm.ackFailure( noOp(), noOp() );
         // Then
         ssm.run( "hello", map(), null, recorder );
         assertThat( recorder, recorded(


### PR DESCRIPTION
If we get an interrupt that kills the current transaction, that will likely
lead to an error being reported back to the client. The client will then
respond with an `ACK_FAILURE`. This means that we should not go back to IDLE
after receiving the `RESET` in these cases.
