### PR TITLE
Introduces first classes required for Raft log pruning.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigParser.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigParser.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.pruning;
+
+import static org.neo4j.kernel.configuration.Settings.parseLongWithUnit;
+
+public class ThresholdConfigParser
+{
+    public final static class ThresholdConfigValue
+    {
+        public static final ThresholdConfigValue NO_PRUNING = new ThresholdConfigValue( "false", -1 );
+        public final String type;
+        public final long value;
+
+        public ThresholdConfigValue( String type, long value )
+        {
+            this.type = type;
+            this.value = value;
+        }
+    }
+
+    public static ThresholdConfigValue parse( String configValue )
+    {
+        String[] tokens = configValue.split( " " );
+        if ( tokens.length == 0 )
+        {
+            throw new IllegalArgumentException( "Invalid log pruning configuration value '" + configValue + "'" );
+        }
+
+        final String boolOrNumber = tokens[0];
+
+        if ( tokens.length == 1 )
+        {
+            switch ( boolOrNumber )
+            {
+                case "true":
+                    return ThresholdConfigValue.NO_PRUNING;
+                case "false":
+                    return new ThresholdConfigValue( "entries", 1 );
+                default:
+                    throw new IllegalArgumentException( "Invalid log pruning configuration value '" + configValue +
+                            "'. The form is 'all' or '<number><unit> <type>' for example '100k txs' " +
+                            "for the latest 100 000 transactions" );
+            }
+        }
+
+        long thresholdValue = parseLongWithUnit( tokens[0] );
+        String thresholdType = tokens[1];
+
+        return new ThresholdConfigValue( thresholdType, thresholdValue );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -142,6 +142,11 @@ public interface JobScheduler extends Lifecycle
         public static final Group checkPoint = new Group( "CheckPoint", POOLED );
 
         /**
+         * Raft Log pruning
+         */
+        public static final Group raftLogPruning = new Group( "RaftLogPruning", POOLED );
+
+        /**
          * Network IO threads for the Bolt protocol.
          */
         public static final Group boltNetworkIO = new Group( "BoltNetworkIO", NEW_THREAD );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactoryTest.java
@@ -21,29 +21,25 @@ package org.neo4j.kernel.impl.transaction.log.pruning;
 
 import org.junit.Test;
 import org.mockito.Mockito;
-
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.log.pruning.ThresholdConfigParser.ThresholdConfigValue;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.kernel.impl.transaction.log.pruning.LogPruneStrategyFactory.getThresholdByType;
 
 public class LogPruneStrategyFactoryTest
 {
     @Test
     public void testLogPruneThresholdsByType() throws Exception
     {
-        assertThat( getPruneStrategy( "files", "25", "25 files" ), instanceOf( FileCountThreshold.class ) );
-        assertThat( getPruneStrategy( "size", "16G", "16G size" ), instanceOf( FileSizeThreshold.class ) );
-        assertThat( getPruneStrategy( "txs", "4G", "4G txs" ), instanceOf( EntryCountThreshold.class ) );
-        assertThat( getPruneStrategy( "entries", "4G", "4G entries" ), instanceOf( EntryCountThreshold.class ) );
-        assertThat( getPruneStrategy( "hours", "100", "100 hours" ), instanceOf( EntryTimespanThreshold.class ) );
-        assertThat( getPruneStrategy( "days", "100k", "100k days" ),
-                    instanceOf( EntryTimespanThreshold.class) );
-    }
+        FileSystemAbstraction fsa = Mockito.mock( FileSystemAbstraction.class );
 
-    private Threshold getPruneStrategy(String type, String value, String configValue)
-    {
-        FileSystemAbstraction fileSystem = Mockito.mock( FileSystemAbstraction.class );
-        return LogPruneStrategyFactory.getThresholdByType( fileSystem, type, value, configValue );
+        assertThat( getThresholdByType( fsa, new ThresholdConfigValue( "files", 25 ), "" ), instanceOf( FileCountThreshold.class ) );
+        assertThat( getThresholdByType( fsa, new ThresholdConfigValue( "size", 16000 ), "" ), instanceOf( FileSizeThreshold.class ) );
+        assertThat( getThresholdByType( fsa, new ThresholdConfigValue( "txs", 4000 ), "" ), instanceOf( EntryCountThreshold.class ) );
+        assertThat( getThresholdByType( fsa, new ThresholdConfigValue( "entries", 4000 ), "" ), instanceOf( EntryCountThreshold.class ) );
+        assertThat( getThresholdByType( fsa, new ThresholdConfigValue( "hours", 100 ), "" ), instanceOf( EntryTimespanThreshold.class ) );
+        assertThat( getThresholdByType( fsa, new ThresholdConfigValue( "days", 100_000 ), "" ), instanceOf( EntryTimespanThreshold.class) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigValueTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigValueTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.pruning;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class ThresholdConfigValueTest
+{
+    @Test
+    public void shouldParseCorrectly() throws Exception
+    {
+        ThresholdConfigParser.ThresholdConfigValue value = ThresholdConfigParser.parse( "25 files" );
+        assertEquals( "files", value.type );
+        assertEquals( 25, value.value );
+
+        value = ThresholdConfigParser.parse( "4g size" );
+        assertEquals( "size", value.type );
+        assertEquals( 1L << 32, value.value );
+    }
+
+    @Test
+    public void shouldThrowExceptionOnUnknownType() throws Exception
+    {
+        try
+        {
+            ThresholdConfigParser.parse( "more than one spaces is invalid" );
+            fail("Should not parse unknown types");
+        }
+        catch( IllegalArgumentException e )
+        {
+            // good
+        }
+    }
+
+    @Test
+    public void shouldReturnNoPruningForTrue() throws Exception
+    {
+        ThresholdConfigParser.ThresholdConfigValue value = ThresholdConfigParser.parse( "true" );
+        assertSame( ThresholdConfigParser.ThresholdConfigValue.NO_PRUNING, value );
+    }
+
+    @Test
+    public void shouldReturnKeepOneEntryForFalse() throws Exception
+    {
+        ThresholdConfigParser.ThresholdConfigValue value = ThresholdConfigParser.parse( "false" );
+        assertEquals( "entries", value.type );
+        assertEquals( 1, value.value );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/pruning/LogPruner.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/pruning/LogPruner.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.pruning;
+
+import java.io.IOException;
+
+/**
+ * Defines the set of operations needed to execute raft log pruning. Each raft log implementation is expected
+ * to provide its own LogPruner implementation that knows about the log structure on disk. The SPI of these
+ * implementations will be provided with the appropriate configuration options that define the expected pruning
+ * characteristics.
+ */
+public interface LogPruner
+{
+    void prune() throws IOException;
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/pruning/PruningScheduler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/pruning/PruningScheduler.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.pruning;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.raftLogPruning;
+
+import java.io.IOException;
+import java.util.function.BooleanSupplier;
+
+import org.neo4j.function.Predicates;
+import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public class PruningScheduler extends LifecycleAdapter
+{
+    private final LogPruner logPruner;
+    private final JobScheduler scheduler;
+    private final long recurringPeriodMillis;
+    private final Runnable job = new Runnable()
+    {
+        @Override
+        public void run()
+        {
+            try
+            {
+                checkPointing = true;
+                if ( stopped )
+                {
+                    return;
+                }
+                logPruner.prune();
+            }
+            catch ( IOException e )
+            {
+                // no need to reschedule since the check pointer has raised a kernel panic and a shutdown is expected
+                throw new UnderlyingStorageException( e );
+            }
+            finally
+            {
+                checkPointing = false;
+            }
+
+            // reschedule only if it is not stopped
+            if ( !stopped )
+            {
+                handle = scheduler.schedule( raftLogPruning, job, recurringPeriodMillis, MILLISECONDS );
+            }
+        }
+    };
+
+    private volatile JobScheduler.JobHandle handle;
+    private volatile boolean stopped;
+    private volatile boolean checkPointing;
+    private final BooleanSupplier checkPointingCondition = new BooleanSupplier()
+    {
+        @Override
+        public boolean getAsBoolean()
+        {
+            return !checkPointing;
+        }
+    };
+
+    public PruningScheduler( LogPruner logPruner, JobScheduler scheduler, long recurringPeriodMillis )
+    {
+        this.logPruner = logPruner;
+        this.scheduler = scheduler;
+        this.recurringPeriodMillis = recurringPeriodMillis;
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        handle = scheduler.schedule( raftLogPruning, job, recurringPeriodMillis, MILLISECONDS );
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        stopped = true;
+        if ( handle != null )
+        {
+            handle.cancel( false );
+        }
+        Predicates.awaitForever( checkPointingCondition, 100, MILLISECONDS );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/RecoveryProtocol.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/RecoveryProtocol.java
@@ -181,7 +181,6 @@ class RecoveryProtocol
         {
             throw new DamagedLogStorageException( "File versions not strictly monotonic. Expected: %d but found: %d", expectedVersion, fileNameVersion );
         }
-
     }
 
     private void checkVersionMatches( long headerVersion, long fileNameVersion ) throws DamagedLogStorageException

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/pruning/PruningSchedulerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/pruning/PruningSchedulerTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.pruning;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.raftLogPruning;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.neo4j.test.DoubleLatch;
+import org.neo4j.test.OnDemandJobScheduler;
+
+public class PruningSchedulerTest
+{
+    private final LogPruner logPruner = mock( LogPruner.class );
+    private final OnDemandJobScheduler jobScheduler = spy( new OnDemandJobScheduler() );
+
+    @Test
+    public void shouldScheduleTheCheckPointerJobOnStart() throws Throwable
+    {
+        // given
+        PruningScheduler scheduler = new PruningScheduler( logPruner, jobScheduler, 20L );
+
+        assertNull( jobScheduler.getJob() );
+
+        // when
+        scheduler.start();
+
+        // then
+        assertNotNull( jobScheduler.getJob() );
+        verify( jobScheduler, times( 1 ) ).schedule( eq( raftLogPruning ), any( Runnable.class ),
+                eq( 20L ), eq( TimeUnit.MILLISECONDS ) );
+    }
+
+    @Test
+    public void shouldRescheduleTheJobAfterARun() throws Throwable
+    {
+        // given
+        PruningScheduler scheduler = new PruningScheduler( logPruner, jobScheduler, 20L );
+
+        assertNull( jobScheduler.getJob() );
+
+        scheduler.start();
+
+        Runnable scheduledJob = jobScheduler.getJob();
+        assertNotNull( scheduledJob );
+
+        // when
+        jobScheduler.runJob();
+
+        // then
+        verify( jobScheduler, times( 2 ) ).schedule( eq( raftLogPruning ), any( Runnable.class ),
+                eq( 20L ), eq( TimeUnit.MILLISECONDS ) );
+        verify( logPruner, times( 1 ) ).prune();
+        assertEquals( scheduledJob, jobScheduler.getJob() );
+    }
+
+    @Test
+    public void shouldNotRescheduleAJobWhenStopped() throws Throwable
+    {
+        // given
+        PruningScheduler scheduler = new PruningScheduler( logPruner, jobScheduler, 20L );
+
+        assertNull( jobScheduler.getJob() );
+
+        scheduler.start();
+
+        assertNotNull( jobScheduler.getJob() );
+
+        // when
+        scheduler.stop();
+
+        // then
+        assertNull( jobScheduler.getJob() );
+    }
+
+    @Test
+    public void stoppedJobCantBeInvoked() throws Throwable
+    {
+        PruningScheduler scheduler = new PruningScheduler( logPruner, jobScheduler, 10L );
+        scheduler.start();
+        jobScheduler.runJob();
+
+        // verify checkpoint was triggered
+        verify( logPruner ).prune();
+
+        // simulate scheduled run that was triggered just before stop
+        scheduler.stop();
+        scheduler.start();
+        jobScheduler.runJob();
+
+        // logPruner should not be invoked now because job stopped
+        verifyNoMoreInteractions( logPruner );
+    }
+
+    @Test
+    public void shouldWaitOnStopUntilTheRunningCheckpointIsDone() throws Throwable
+    {
+        // given
+        final AtomicReference<Throwable> ex = new AtomicReference<>();
+        final AtomicBoolean stoppedCompleted = new AtomicBoolean();
+        final DoubleLatch checkPointerLatch = new DoubleLatch( 1 );
+        LogPruner logPruner = new LogPruner()
+        {
+            @Override
+            public void prune() throws IOException
+            {
+                checkPointerLatch.start();
+                checkPointerLatch.awaitFinish();
+            }
+        };
+
+        final PruningScheduler scheduler = new PruningScheduler( logPruner, jobScheduler, 20L );
+
+        // when
+        scheduler.start();
+
+        Thread runCheckPointer = new Thread()
+        {
+            @Override
+            public void run()
+            {
+                jobScheduler.runJob();
+            }
+        };
+        runCheckPointer.start();
+
+        checkPointerLatch.awaitStart();
+
+        Thread stopper = new Thread()
+        {
+            @Override
+            public void run()
+            {
+                try
+                {
+                    scheduler.stop();
+                    stoppedCompleted.set( true );
+                }
+                catch ( Throwable throwable )
+                {
+                    ex.set( throwable );
+                }
+            }
+        };
+
+        stopper.start();
+
+        Thread.sleep( 10 );
+
+        // then
+        assertFalse( stoppedCompleted.get() );
+
+        checkPointerLatch.finish();
+        runCheckPointer.join();
+
+        Thread.sleep( 150 );
+
+        assertTrue( stoppedCompleted.get() );
+        stopper.join(); // just in case
+
+        assertNull( ex.get() );
+    }
+}


### PR DESCRIPTION
Kernel specific log pruning config parser is split to allow for other uses to parse
 similarly formatted options without depending on LogFileInformation and other
 tx log specific types.
A log pruning scheduler is introduced for Raft. It is not wired in anywhere, as this
 is still work in progress.
