### PR TITLE
Core Edge conversion tool should be able to convert a store with

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertClassicStoreCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertClassicStoreCommand.java
@@ -26,6 +26,8 @@ import org.neo4j.coreedge.raft.replication.tx.LogIndexTxHeaderEncoding;
 import org.neo4j.coreedge.raft.state.DurableStateStorageImporter;
 import org.neo4j.coreedge.raft.state.id_allocation.IdAllocationState;
 import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
@@ -67,10 +69,12 @@ import static org.neo4j.kernel.impl.store.id.IdType.STRING_BLOCK;
 public class ConvertClassicStoreCommand
 {
     private File databaseDir;
+    private String recordFormat;
 
-    public ConvertClassicStoreCommand( File databaseDir )
+    public ConvertClassicStoreCommand( File databaseDir, String recordFormat )
     {
         this.databaseDir = databaseDir;
+        this.recordFormat = recordFormat;
     }
 
     public void execute() throws Throwable
@@ -81,7 +85,11 @@ public class ConvertClassicStoreCommand
 
     private void appendNullTransactionLogEntryToSetRaftIndexToMinusOne( File dbDir) throws TransactionFailureException
     {
-        GraphDatabaseAPI db = (GraphDatabaseAPI) new EnterpriseGraphDatabaseFactory().newEmbeddedDatabase( dbDir );
+
+        GraphDatabaseBuilder builder = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabaseBuilder( dbDir )
+                .setConfig( GraphDatabaseSettings.record_format, recordFormat );
+
+        GraphDatabaseAPI db = (GraphDatabaseAPI) builder.newGraphDatabase();
 
         TransactionCommitProcess commitProcess = db.getDependencyResolver().resolveDependency( TransactionCommitProcess.class );
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertNonCoreEdgeStoreCli.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertNonCoreEdgeStoreCli.java
@@ -24,6 +24,7 @@ import java.io.PrintStream;
 
 import org.neo4j.dbms.ConfigFactory;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.ArrayUtil;
 import org.neo4j.helpers.Strings;
@@ -50,7 +51,10 @@ public class ConvertNonCoreEdgeStoreCli
         Config config = ConfigFactory.readFrom( new File( configPath, "neo4j.conf" ) )
                 .with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) );
 
-        new ConvertClassicStoreCommand( config.get( DatabaseManagementSystemSettings.database_path ) ).execute();
+        new ConvertClassicStoreCommand(
+                config.get( DatabaseManagementSystemSettings.database_path ),
+                config.get( GraphDatabaseSettings.record_format ))
+                .execute();
     }
 
     private static void printUsage( PrintStream out )


### PR DESCRIPTION
high_limit record format

We do this by respecting the `GraphDatabaseFacadeFactory.Configuration.record_format`
property when opening a database over the store.

Very similar change to: https://github.com/neo4j/neo4j/commit/4f05a4f0de6d26f0e75498f6a33132014bf4dbd1
