### PR TITLE
Make sure /var/run/neo4j exists

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j
+++ b/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j
@@ -35,7 +35,8 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 NAME=neo4j
 DAEMON=/usr/bin/$NAME
-PIDFILE=/var/run/${NAME}/neo4j.pid
+PIDDIR=/var/run/${NAME}
+PIDFILE=${PIDDIR}/neo4j.pid
 SCRIPTNAME=/etc/init.d/$NAME-service
 
 [ -x "$DAEMON" ] || exit 0
@@ -46,6 +47,9 @@ SCRIPTNAME=/etc/init.d/$NAME-service
 
 do_start()
 {
+  [ -d "${PIDDIR}" ] || mkdir -p "${PIDDIR}"
+  chown "${NEO_USER}:" "${PIDDIR}"
+
   start-stop-daemon --chuid ${NEO_USER} --start --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON -- start
 }
 


### PR DESCRIPTION
If /var/run is a tmpfs, we need to make sure the dir is created on each
startup.

Fixes #7086
