### PR TITLE
Rename the old dbms.querylog.filename setting to mark it as internal

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -464,7 +464,7 @@ public abstract class GraphDatabaseSettings
     public static final Setting<File> logs_directory = pathSetting( "dbms.directories.logs", "logs" );
 
     @Internal
-    public static final Setting<File> log_queries_filename = derivedSetting("dbms.querylog.filename",
+    public static final Setting<File> log_queries_filename = derivedSetting("dbms.logs.query.path",
             logs_directory,
             ( logs ) -> new File( logs, "query.log" ),
             PATH );


### PR DESCRIPTION
This setting has been removed from the product surface. It's now an
internal, derived setting and should have been renamed to reflect that.

This fixes a bug where someone who used the query log and had customized
the name of the log file, but had not correctly migrated their
configuration, would end up with a server which would not start.
