### PR TITLE
Set the nofile ulimit if the appropriate environment variable is set.

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
+++ b/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
@@ -83,12 +83,20 @@ do_stop()
 	return "$RETVAL"
 }
 
+do_ulimit()
+{
+  if [ -n "${NEO4J_ULIMIT_NOFILE}" ]; then
+    ulimit -n "${NEO4J_ULIMIT_NOFILE}"
+  fi
+}
+
 # Ensure that the NEO_USER is set to a useful default.
 [ -n "${NEO_USER}" ] || NEO_USER=$NAME
 
 case "$1" in
   start)
 	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_ulimit
 	do_start
 	case "$?" in
 		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;


### PR DESCRIPTION
Ported #6937 from @srbaker  to 2.2

Fixes #6613
Fixes #5849

changelog: [packaging] Added ability to set max number of open files in `/etc/default/neo4j` (default behavior remains unchanged)
