### PR TITLE
Keep open page cursors

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeLabelReader.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeLabelReader.java
@@ -110,7 +110,7 @@ public class NodeLabelReader
             }
             return LabelChainWalker.labelIds( recordList );
         }
-        return NodeLabelsField.get( nodeRecord, null );
+        return InlineNodeLabels.get( nodeRecord );
     }
 
     public static Set<Long> getListOfLabels( long labelField )

--- a/community/io/src/main/java/org/neo4j/io/IOUtils.java
+++ b/community/io/src/main/java/org/neo4j/io/IOUtils.java
@@ -20,6 +20,7 @@
 package org.neo4j.io;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.util.Collection;
 
 /**
@@ -75,32 +76,7 @@ public final class IOUtils
     @SafeVarargs
     public static <T extends AutoCloseable> void closeAll( T... closeables ) throws IOException
     {
-        Exception closeException = null;
-        for ( T closeable : closeables )
-        {
-            if ( closeable != null )
-            {
-                try
-                {
-                    closeable.close();
-                }
-                catch ( Exception e )
-                {
-                    if ( closeException == null )
-                    {
-                        closeException = e;
-                    }
-                    else
-                    {
-                        closeException.addSuppressed( e );
-                    }
-                }
-            }
-        }
-        if ( closeException != null )
-        {
-            throw new IOException( "Exception closing multiple resources", closeException );
-        }
+        closeAll( IOException.class, closeables );
     }
 
     /**
@@ -118,6 +94,65 @@ public final class IOUtils
         }
         catch ( IOException ignored )
         {
+        }
+    }
+
+    /**
+     * Close all given closeables and if something goes wrong throw exception of the given type.
+     * Exception class should have a public constructor that accepts {@link String} and {@link Throwable} like
+     * {@link RuntimeException#RuntimeException(String, Throwable)}
+     *
+     * @param throwableClass exception type to throw in case of failure
+     * @param closeables the closeables to close
+     * @param <T> the type of closeable
+     * @param <E> the type of exception
+     * @throws E when any {@link AutoCloseable#close()} throws exception
+     */
+    @SafeVarargs
+    public static <T extends AutoCloseable, E extends Throwable> void closeAll( Class<E> throwableClass,
+            T... closeables ) throws E
+    {
+        Throwable closeThrowable = null;
+        for ( T closeable : closeables )
+        {
+            if ( closeable != null )
+            {
+                try
+                {
+                    closeable.close();
+                }
+                catch ( Throwable t )
+                {
+                    if ( closeThrowable == null )
+                    {
+                        closeThrowable = t;
+                    }
+                    else
+                    {
+                        closeThrowable.addSuppressed( t );
+                    }
+                }
+            }
+        }
+        if ( closeThrowable != null )
+        {
+            throw newThrowable( throwableClass, "Exception closing multiple resources", closeThrowable );
+        }
+    }
+
+    private static <E extends Throwable> E newThrowable( Class<E> throwableClass, String message, Throwable cause )
+    {
+        try
+        {
+            Constructor<E> constructor = throwableClass.getConstructor( String.class, Throwable.class );
+            return constructor.newInstance( message, cause );
+        }
+        catch ( Throwable t )
+        {
+            RuntimeException runtimeException = new RuntimeException(
+                    "Unable to create exception to throw. Original message: " + message, t );
+            runtimeException.addSuppressed( cause );
+            throw runtimeException;
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -186,7 +186,8 @@ public class KernelStatement implements TxStateHolder, Statement
 
     private void cleanupResources()
     {
-        storeStatement.close();
+        storeStatement.release();
+        // closing is done by KTI
     }
 
     public StorageStatement getStoreStatement()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -605,4 +605,9 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     {
         return "KernelTransaction[" + this.locks.getLockSessionId() + "]";
     }
+
+    public void dispose()
+    {
+        storageStatement.close();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -158,6 +158,7 @@ public class KernelTransactions extends LifecycleAdapter
         protected void dispose( KernelTransactionImplementation tx )
         {
             allTransactions.remove( tx );
+            tx.dispose();
             super.dispose( tx );
         }
     };

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
@@ -108,9 +108,8 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
             @Override
             protected StoreNodeRelationshipCursor create()
             {
-                return new StoreNodeRelationshipCursor( relationshipStore.newRecord(), neoStores,
-                        relationshipGroupStore.newRecord(), storeStatement, this, lockService,
-                        cursors );
+                return new StoreNodeRelationshipCursor( relationshipStore.newRecord(),
+                        relationshipGroupStore.newRecord(), this, lockService, cursors );
             }
         };
         singlePropertyCursor = new InstanceCache<StoreSinglePropertyCursor>()
@@ -118,8 +117,8 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
             @Override
             protected StoreSinglePropertyCursor create()
             {
-                return new StoreSinglePropertyCursor( cursors.property(),
-                        cursors.propertyString(), cursors.propertyArray(), this );
+                return new StoreSinglePropertyCursor( cursors.property(), cursors.propertyString(),
+                        cursors.propertyArray(), this );
             }
         };
         allPropertyCursor = new InstanceCache<StorePropertyCursor>()
@@ -127,8 +126,8 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
             @Override
             protected StorePropertyCursor create()
             {
-                return new StorePropertyCursor( cursors.property(),
-                        cursors.propertyString(), cursors.propertyArray(), allPropertyCursor );
+                return new StorePropertyCursor( cursors.property(), cursors.propertyString(), cursors.propertyArray(),
+                        allPropertyCursor );
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
@@ -32,7 +32,6 @@ import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.NeoStores;
-import org.neo4j.kernel.impl.store.NodeLabelsField;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.RecordStore;
@@ -92,7 +91,7 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
             @Override
             protected StoreLabelCursor create()
             {
-                return new StoreLabelCursor( this );
+                return new StoreLabelCursor( cursors.label(), this );
             }
         };
         singleLabelCursor = new InstanceCache<StoreSingleLabelCursor>()
@@ -100,7 +99,7 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
             @Override
             protected StoreSingleLabelCursor create()
             {
-                return new StoreSingleLabelCursor( this );
+                return new StoreSingleLabelCursor( cursors.label(), this );
             }
         };
         nodeRelationshipCursor = new InstanceCache<StoreNodeRelationshipCursor>()
@@ -147,13 +146,13 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
     @Override
     public Cursor<LabelItem> labels()
     {
-        return labelCursor.get().init( NodeLabelsField.get( nodeRecord, nodeStore ) );
+        return labelCursor.get().init( nodeRecord );
     }
 
     @Override
     public Cursor<LabelItem> label( int labelId )
     {
-        return singleLabelCursor.get().init( NodeLabelsField.get( nodeRecord, nodeStore ), labelId );
+        return singleLabelCursor.get().init( nodeRecord, labelId );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractNodeCursor.java
@@ -116,8 +116,7 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
             @Override
             protected StoreSinglePropertyCursor create()
             {
-                return new StoreSinglePropertyCursor( cursors.property(), cursors.propertyString(),
-                        cursors.propertyArray(), this );
+                return new StoreSinglePropertyCursor( cursors, this );
             }
         };
         allPropertyCursor = new InstanceCache<StorePropertyCursor>()
@@ -125,8 +124,7 @@ public abstract class StoreAbstractNodeCursor extends NodeItemHelper implements 
             @Override
             protected StorePropertyCursor create()
             {
-                return new StorePropertyCursor( cursors.property(), cursors.propertyString(), cursors.propertyArray(),
-                        allPropertyCursor );
+                return new StorePropertyCursor( cursors, allPropertyCursor );
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
@@ -23,13 +23,9 @@ import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.api.cursor.EntityItemHelper;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordCursor;
 import org.neo4j.kernel.impl.store.RecordCursors;
-import org.neo4j.kernel.impl.store.RecordStore;
-import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.record.Record;
-import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.util.InstanceCache;
 import org.neo4j.storageengine.api.PropertyItem;
@@ -45,25 +41,18 @@ public abstract class StoreAbstractRelationshipCursor extends EntityItemHelper
         implements Cursor<RelationshipItem>, RelationshipItem
 {
     protected final RelationshipRecord relationshipRecord;
-    protected final RelationshipStore relationshipStore;
-    protected final RecordStore<RelationshipGroupRecord> relationshipGroupStore;
     protected final RecordCursor<RelationshipRecord> relationshipRecordCursor;
     private final LockService lockService;
-    protected StoreStatement storeStatement;
 
-    private InstanceCache<StoreSinglePropertyCursor> singlePropertyCursor;
-    private InstanceCache<StorePropertyCursor> allPropertyCursor;
+    private final InstanceCache<StoreSinglePropertyCursor> singlePropertyCursor;
+    private final InstanceCache<StorePropertyCursor> allPropertyCursor;
 
-    public StoreAbstractRelationshipCursor( RelationshipRecord relationshipRecord, final NeoStores neoStores,
-            StoreStatement storeStatement, LockService lockService, RecordCursors cursors )
+    public StoreAbstractRelationshipCursor( RelationshipRecord relationshipRecord, LockService lockService,
+            RecordCursors cursors )
     {
         this.lockService = lockService;
         this.relationshipRecordCursor = cursors.relationship();
-        this.relationshipStore = neoStores.getRelationshipStore();
-        this.relationshipGroupStore = neoStores.getRelationshipGroupStore();
         this.relationshipRecord = relationshipRecord;
-
-        this.storeStatement = storeStatement;
 
         singlePropertyCursor = new InstanceCache<StoreSinglePropertyCursor>()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreAbstractRelationshipCursor.java
@@ -59,8 +59,7 @@ public abstract class StoreAbstractRelationshipCursor extends EntityItemHelper
             @Override
             protected StoreSinglePropertyCursor create()
             {
-                return new StoreSinglePropertyCursor( cursors.property(),
-                        cursors.propertyString(), cursors.propertyArray(), this );
+                return new StoreSinglePropertyCursor( cursors, this );
             }
         };
         allPropertyCursor = new InstanceCache<StorePropertyCursor>()
@@ -68,8 +67,7 @@ public abstract class StoreAbstractRelationshipCursor extends EntityItemHelper
             @Override
             protected StorePropertyCursor create()
             {
-                return new StorePropertyCursor( cursors.property(),
-                        cursors.propertyString(), cursors.propertyArray(), this );
+                return new StorePropertyCursor( cursors, this );
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorNodeCursor.java
@@ -25,8 +25,8 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Resource;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
-
 import static org.neo4j.kernel.impl.store.record.RecordLoad.CHECK;
 
 /**
@@ -42,9 +42,10 @@ public class StoreIteratorNodeCursor extends StoreAbstractNodeCursor
             NeoStores neoStores,
             StoreStatement storeStatement,
             Consumer<StoreIteratorNodeCursor> instanceCache,
-            LockService lockService )
+            LockService lockService,
+            RecordCursors cursors )
     {
-        super( nodeRecord, neoStores, storeStatement, lockService );
+        super( nodeRecord, neoStores, storeStatement, lockService, cursors );
         this.instanceCache = instanceCache;
     }
 
@@ -59,7 +60,7 @@ public class StoreIteratorNodeCursor extends StoreAbstractNodeCursor
     {
         while ( iterator != null && iterator.hasNext() )
         {
-            if ( nodeStore.getRecord( iterator.next(), nodeRecord, CHECK ).inUse() )
+            if ( cursors.node().next( iterator.next(), nodeRecord, CHECK ) )
             {
                 return true;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
@@ -23,6 +23,7 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Resource;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.util.InstanceCache;
 
@@ -39,9 +40,9 @@ public class StoreIteratorRelationshipCursor extends StoreAbstractRelationshipCu
     public StoreIteratorRelationshipCursor( RelationshipRecord relationshipRecord,
             NeoStores neoStores,
             StoreStatement storeStatement, InstanceCache<StoreIteratorRelationshipCursor> instanceCache,
-            LockService lockService )
+            LockService lockService, RecordCursors cursors )
     {
-        super( relationshipRecord, neoStores, storeStatement, lockService );
+        super( relationshipRecord, neoStores, storeStatement, lockService, cursors );
         this.instanceCache = instanceCache;
     }
 
@@ -56,7 +57,7 @@ public class StoreIteratorRelationshipCursor extends StoreAbstractRelationshipCu
     {
         while ( iterator != null && iterator.hasNext() )
         {
-            if ( relationshipStore.getRecord( iterator.next(), relationshipRecord, CHECK ).inUse() )
+            if ( relationshipRecordCursor.next( iterator.next(), relationshipRecord, CHECK ) )
             {
                 return true;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.api.store;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Resource;
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.util.InstanceCache;
@@ -38,11 +37,10 @@ public class StoreIteratorRelationshipCursor extends StoreAbstractRelationshipCu
     private final InstanceCache<StoreIteratorRelationshipCursor> instanceCache;
 
     public StoreIteratorRelationshipCursor( RelationshipRecord relationshipRecord,
-            NeoStores neoStores,
-            StoreStatement storeStatement, InstanceCache<StoreIteratorRelationshipCursor> instanceCache,
+            InstanceCache<StoreIteratorRelationshipCursor> instanceCache,
             LockService lockService, RecordCursors cursors )
     {
-        super( relationshipRecord, neoStores, storeStatement, lockService, cursors );
+        super( relationshipRecord, lockService, cursors );
         this.instanceCache = instanceCache;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreLabelCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreLabelCursor.java
@@ -22,6 +22,10 @@ package org.neo4j.kernel.impl.api.store;
 import java.util.function.Consumer;
 
 import org.neo4j.cursor.Cursor;
+import org.neo4j.kernel.impl.store.NodeLabelsField;
+import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.storageengine.api.LabelItem;
 
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.safeCastLongToInt;
@@ -34,17 +38,20 @@ public class StoreLabelCursor implements Cursor<LabelItem>, LabelItem
     private long[] labels;
     private int index;
     private int currentLabel;
+
+    private final RecordCursor<DynamicRecord> dynamicLabelRecordCursor;
     private final Consumer<StoreLabelCursor> instanceCache;
 
-    public StoreLabelCursor( Consumer<StoreLabelCursor> instanceCache )
+    public StoreLabelCursor( RecordCursor<DynamicRecord> dynamicLabelRecordCursor,
+            Consumer<StoreLabelCursor> instanceCache )
     {
+        this.dynamicLabelRecordCursor = dynamicLabelRecordCursor;
         this.instanceCache = instanceCache;
     }
 
-    public StoreLabelCursor init( long[] labels )
+    public StoreLabelCursor init( NodeRecord nodeRecord )
     {
-        this.labels = labels;
-        index = 0;
+        this.labels = NodeLabelsField.get( nodeRecord, dynamicLabelRecordCursor );
         return this;
     }
 
@@ -77,6 +84,14 @@ public class StoreLabelCursor implements Cursor<LabelItem>, LabelItem
     @Override
     public void close()
     {
+        // this cursor is pooled so it is better to clear it's state here
+        clearState();
         instanceCache.accept( this );
+    }
+
+    private void clearState()
+    {
+        labels = null;
+        index = 0;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreLabelCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreLabelCursor.java
@@ -34,7 +34,7 @@ public class StoreLabelCursor implements Cursor<LabelItem>, LabelItem
     private long[] labels;
     private int index;
     private int currentLabel;
-    private Consumer<StoreLabelCursor> instanceCache;
+    private final Consumer<StoreLabelCursor> instanceCache;
 
     public StoreLabelCursor( Consumer<StoreLabelCursor> instanceCache )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
@@ -23,7 +23,6 @@ import java.util.function.Consumer;
 
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
@@ -53,14 +52,12 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
     private final RecordCursors cursors;
 
     public StoreNodeRelationshipCursor( RelationshipRecord relationshipRecord,
-            NeoStores neoStores,
             RelationshipGroupRecord groupRecord,
-            StoreStatement storeStatement,
             Consumer<StoreNodeRelationshipCursor> instanceCache,
             LockService lockService,
             RecordCursors cursors )
     {
-        super( relationshipRecord, neoStores, storeStatement, lockService, cursors );
+        super( relationshipRecord, lockService, cursors );
         this.groupRecord = groupRecord;
         this.instanceCache = instanceCache;
         this.cursors = cursors;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.store.RecordCursor;
-import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.storageengine.api.PropertyItem;
@@ -42,15 +42,11 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
 
     private Lock lock;
 
-    public StorePropertyCursor(
-            RecordCursor<PropertyRecord> recordCursor,
-            RecordCursor<DynamicRecord> stringRecordCursor,
-            RecordCursor<DynamicRecord> arrayRecordCursor,
-            Consumer<StorePropertyCursor> instanceCache )
+    public StorePropertyCursor( RecordCursors cursors, Consumer<StorePropertyCursor> instanceCache )
     {
         this.instanceCache = instanceCache;
-        this.payload = new StorePropertyPayloadCursor( stringRecordCursor, arrayRecordCursor );
-        this.recordCursor = recordCursor;
+        this.payload = new StorePropertyPayloadCursor( cursors.propertyString(), cursors.propertyArray() );
+        this.recordCursor = cursors.property();
     }
 
     public StorePropertyCursor init( long firstPropertyId, Lock lock )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
@@ -23,8 +23,8 @@ import java.util.function.Consumer;
 
 import org.neo4j.cursor.Cursor;
 import org.neo4j.kernel.impl.locking.Lock;
-import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.storageengine.api.PropertyItem;
@@ -42,17 +42,21 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
 
     private Lock lock;
 
-    public StorePropertyCursor( PropertyStore propertyStore, Consumer<StorePropertyCursor> instanceCache )
+    public StorePropertyCursor(
+            RecordCursor<PropertyRecord> recordCursor,
+            RecordCursor<DynamicRecord> stringRecordCursor,
+            RecordCursor<DynamicRecord> arrayRecordCursor,
+            Consumer<StorePropertyCursor> instanceCache )
     {
         this.instanceCache = instanceCache;
-        this.payload = new StorePropertyPayloadCursor( propertyStore.getStringStore(), propertyStore.getArrayStore() );
-        this.recordCursor = propertyStore.newRecordCursor( propertyStore.newRecord() );
+        this.payload = new StorePropertyPayloadCursor( stringRecordCursor, arrayRecordCursor );
+        this.recordCursor = recordCursor;
     }
 
     public StorePropertyCursor init( long firstPropertyId, Lock lock )
     {
         this.lock = lock;
-        recordCursor.acquire( firstPropertyId, FORCE );
+        recordCursor.placeAt( firstPropertyId, FORCE );
         payload.clear();
         return this;
     }
@@ -115,7 +119,6 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
         {
             payload.clear();
             instanceCache.accept( this );
-            recordCursor.close();
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleLabelCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleLabelCursor.java
@@ -21,6 +21,9 @@ package org.neo4j.kernel.impl.api.store;
 
 import java.util.function.Consumer;
 
+import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.util.InstanceCache;
 
 /**
@@ -30,14 +33,15 @@ public class StoreSingleLabelCursor extends StoreLabelCursor
 {
     private int labelId;
 
-    public StoreSingleLabelCursor( InstanceCache<StoreSingleLabelCursor> instanceCache )
+    public StoreSingleLabelCursor( RecordCursor<DynamicRecord> dynamicLabelRecordCursor,
+            InstanceCache<StoreSingleLabelCursor> instanceCache )
     {
-        super( (Consumer) instanceCache );
+        super( dynamicLabelRecordCursor, (Consumer) instanceCache );
     }
 
-    public StoreSingleLabelCursor init( long[] labels, int labelId )
+    public StoreSingleLabelCursor init( NodeRecord nodeRecord, int labelId )
     {
-        super.init( labels );
+        super.init( nodeRecord );
         this.labelId = labelId;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
@@ -24,8 +24,8 @@ import java.util.function.Consumer;
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
-
 import static org.neo4j.kernel.impl.store.record.RecordLoad.CHECK;
 
 /**
@@ -40,9 +40,10 @@ public class StoreSingleNodeCursor extends StoreAbstractNodeCursor
             NeoStores neoStores,
             StoreStatement storeStatement,
             Consumer<StoreSingleNodeCursor> instanceCache,
-            LockService lockService )
+            LockService lockService,
+            RecordCursors cursors )
     {
-        super( nodeRecord, neoStores, storeStatement, lockService );
+        super( nodeRecord, neoStores, storeStatement, lockService, cursors );
         this.instanceCache = instanceCache;
     }
 
@@ -59,7 +60,7 @@ public class StoreSingleNodeCursor extends StoreAbstractNodeCursor
         {
             try
             {
-                return nodeStore.getRecord( nodeId, nodeRecord, CHECK ).inUse();
+                return cursors.node().next( nodeId, nodeRecord, CHECK );
             }
             finally
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
@@ -23,7 +23,9 @@ import java.util.function.Consumer;
 
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.locking.Lock;
-import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
 
 /**
  * Cursor for a specific property on a node or relationship.
@@ -32,10 +34,14 @@ public class StoreSinglePropertyCursor extends StorePropertyCursor
 {
     private int propertyKeyId;
 
-    public StoreSinglePropertyCursor( PropertyStore propertyStore, Consumer<StoreSinglePropertyCursor> instanceCache )
+    public StoreSinglePropertyCursor(
+            RecordCursor<PropertyRecord> propertyRecordCursor,
+            RecordCursor<DynamicRecord> propertyStringRecordCursor,
+            RecordCursor<DynamicRecord> propertyArrayRecordCursor,
+            Consumer<StoreSinglePropertyCursor> instanceCache )
     {
         //noinspection unchecked
-        super( propertyStore, (Consumer) instanceCache );
+        super( propertyRecordCursor, propertyStringRecordCursor, propertyArrayRecordCursor, (Consumer) instanceCache );
     }
 
     public StoreSinglePropertyCursor init( long firstPropertyId, int propertyKeyId, Lock lock )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
@@ -23,9 +23,7 @@ import java.util.function.Consumer;
 
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.locking.Lock;
-import org.neo4j.kernel.impl.store.RecordCursor;
-import org.neo4j.kernel.impl.store.record.DynamicRecord;
-import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.RecordCursors;
 
 /**
  * Cursor for a specific property on a node or relationship.
@@ -34,14 +32,9 @@ public class StoreSinglePropertyCursor extends StorePropertyCursor
 {
     private int propertyKeyId;
 
-    public StoreSinglePropertyCursor(
-            RecordCursor<PropertyRecord> propertyRecordCursor,
-            RecordCursor<DynamicRecord> propertyStringRecordCursor,
-            RecordCursor<DynamicRecord> propertyArrayRecordCursor,
-            Consumer<StoreSinglePropertyCursor> instanceCache )
+    public StoreSinglePropertyCursor( RecordCursors cursors, Consumer<StoreSinglePropertyCursor> instanceCache )
     {
-        //noinspection unchecked
-        super( propertyRecordCursor, propertyStringRecordCursor, propertyArrayRecordCursor, (Consumer) instanceCache );
+        super( cursors, (Consumer) instanceCache );
     }
 
     public StoreSinglePropertyCursor init( long firstPropertyId, int propertyKeyId, Lock lock )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
@@ -22,9 +22,11 @@ package org.neo4j.kernel.impl.api.store;
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
-import org.neo4j.kernel.impl.store.record.RecordLoad;
+import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.util.InstanceCache;
+
+import static org.neo4j.kernel.impl.store.record.RecordLoad.CHECK;
 
 /**
  * Cursor for a single relationship.
@@ -36,9 +38,9 @@ public class StoreSingleRelationshipCursor extends StoreAbstractRelationshipCurs
 
     public StoreSingleRelationshipCursor( RelationshipRecord relationshipRecord, NeoStores neoStores,
             StoreStatement storeStatement, InstanceCache<StoreSingleRelationshipCursor> instanceCache,
-            LockService lockService )
+            LockService lockService, RecordCursors cursors )
     {
-        super( relationshipRecord, neoStores, storeStatement, lockService );
+        super( relationshipRecord, neoStores, storeStatement, lockService, cursors );
         this.instanceCache = instanceCache;
     }
 
@@ -55,8 +57,7 @@ public class StoreSingleRelationshipCursor extends StoreAbstractRelationshipCurs
         {
             try
             {
-                relationshipRecord.setId( relationshipId );
-                return relationshipStore.getRecord( relationshipId, relationshipRecord, RecordLoad.CHECK ).inUse();
+                return relationshipRecordCursor.next( relationshipId, relationshipRecord, CHECK );
             }
             finally
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api.store;
 
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.util.InstanceCache;
@@ -36,11 +35,10 @@ public class StoreSingleRelationshipCursor extends StoreAbstractRelationshipCurs
     private long relationshipId = -1;
     private final InstanceCache<StoreSingleRelationshipCursor> instanceCache;
 
-    public StoreSingleRelationshipCursor( RelationshipRecord relationshipRecord, NeoStores neoStores,
-            StoreStatement storeStatement, InstanceCache<StoreSingleRelationshipCursor> instanceCache,
-            LockService lockService, RecordCursors cursors )
+    public StoreSingleRelationshipCursor( RelationshipRecord relationshipRecord,
+            InstanceCache<StoreSingleRelationshipCursor> instanceCache, LockService lockService, RecordCursors cursors )
     {
-        super( relationshipRecord, neoStores, storeStatement, lockService, cursors );
+        super( relationshipRecord, lockService, cursors );
         this.instanceCache = instanceCache;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -1146,17 +1144,10 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
     @Override
     public Collection<RECORD> getRecords( long firstId, RecordLoad mode )
     {
-        // TODO we should instead be passed in a consumer of records, so we don't have to spend memory building up
-        // this list
         try ( RecordCursor<RECORD> cursor = newRecordCursor( newRecord() ) )
         {
-            List<RECORD> recordList = new LinkedList<>();
             cursor.acquire( firstId, mode );
-            while ( cursor.next() )
-            {
-                recordList.add( (RECORD) cursor.get().clone() );
-            }
-            return recordList;
+            return cursor.getAll();
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
@@ -63,6 +63,15 @@ public class DynamicNodeLabels implements NodeLabels
         return getDynamicLabelsArray( node.getUsedDynamicLabelRecords(), nodeStore.getDynamicLabelStore() );
     }
 
+    public static long[] get( NodeRecord node, RecordCursor<DynamicRecord> dynamicLabelCursor )
+    {
+        if ( node.isLight() )
+        {
+            NodeStore.ensureHeavy( node, dynamicLabelCursor );
+        }
+        return getDynamicLabelsArrayFromHeavyRecords( node.getUsedDynamicLabelRecords() );
+    }
+
     @Override
     public long[] getIfLoaded()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabelsField.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeLabelsField.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 
 /**
@@ -52,6 +53,13 @@ public class NodeLabelsField
         return fieldPointsToDynamicRecordOfLabels( node.getLabelField() )
                 ? DynamicNodeLabels.get( node, nodeStore )
                 : InlineNodeLabels.get( node );
+    }
+
+    public static long[] get( NodeRecord node, RecordCursor<DynamicRecord> dynamicLabelCursor )
+    {
+        return fieldPointsToDynamicRecordOfLabels( node.getLabelField() )
+               ? DynamicNodeLabels.get( node, dynamicLabelCursor )
+               : InlineNodeLabels.get( node );
     }
 
     public static boolean fieldPointsToDynamicRecordOfLabels( long labelField )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NodeStore.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.store;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
@@ -102,6 +103,14 @@ public class NodeStore extends CommonAbstractStore<NodeRecord,NoStoreHeader>
 
         // Load any dynamic labels and populate the node record
         node.setLabelField( node.getLabelField(), dynamicLabelStore.getRecords( firstDynamicLabelRecord, RecordLoad.NORMAL ) );
+    }
+
+    public static void ensureHeavy( NodeRecord node, RecordCursor<DynamicRecord> dynamicLabelCursor )
+    {
+        long firstDynamicLabelId = NodeLabelsField.firstDynamicLabelRecordId( node.getLabelField() );
+        dynamicLabelCursor.placeAt( firstDynamicLabelId, RecordLoad.NORMAL );
+        List<DynamicRecord> dynamicLabelRecords = dynamicLabelCursor.getAll();
+        node.setLabelField( node.getLabelField(), dynamicLabelRecords );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
@@ -44,6 +44,13 @@ public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
      */
     RecordCursor<R> acquire( long id, RecordLoad mode );
 
+    /**
+     * Moves this cursor to the specified {@code id} with the specified {@link RecordLoad mode} without actually
+     * fetching the record. {@link #next()} and {@link #get()} could be used next to fetch the record.
+     *
+     * @param id the id of the record.
+     * @param mode the mode for subsequent loading.
+     */
     void placeAt( long id, RecordLoad mode );
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.neo4j.cursor.Cursor;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
@@ -87,6 +90,17 @@ public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
       * @return whether or not that record is in use.
       */
     boolean next( long id, R record, RecordLoad mode );
+
+    @SuppressWarnings( "unchecked" )
+    default List<R> getAll()
+    {
+        List<R> recordList = new ArrayList<>();
+        while ( next() )
+        {
+            recordList.add( (R) get().clone() );
+        }
+        return recordList;
+    }
 
     class Delegator<R extends AbstractBaseRecord> implements RecordCursor<R>
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
@@ -91,6 +91,14 @@ public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
       */
     boolean next( long id, R record, RecordLoad mode );
 
+    /**
+     * Read all records in the chain starting from the id this cursor is positioned at using either
+     * {@link #acquire(long, RecordLoad)} or {@link #placeAt(long, RecordLoad)}. Each next record in the chain is
+     * determined by {@link RecordStore#getNextRecordReference(AbstractBaseRecord)}. Each record placed in the
+     * resulting list is a clone of the reused record.
+     *
+     * @return records of the chain in list.
+     */
     @SuppressWarnings( "unchecked" )
     default List<R> getAll()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursor.java
@@ -44,6 +44,8 @@ public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
      */
     RecordCursor<R> acquire( long id, RecordLoad mode );
 
+    void placeAt( long id, RecordLoad mode );
+
     /**
      * Moves to the next record and reads it. If this is the first call since {@link #acquire(long, RecordLoad)}
      * the record specified in acquire will be read, otherwise the next record in the chain,
@@ -64,6 +66,20 @@ public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
      * @return whether or not that record is in use.
      */
     boolean next( long id );
+
+     /**
+      * An additional way of placing this cursor at an arbitrary record id.
+      * Calling this method will not advance the "current id" as to change which {@link #next()} will load next.
+      * This method is useful when there's an opportunity to load a record from an already acquired
+      * {@link PageCursor} and potentially even an already pinned page.
+      *
+      * @param id record id to place cursor at.
+      * @param record record to load the record data into.
+      * @param mode {@link RecordLoad} mode temporarily overriding the default provided in
+      * {@link #acquire(long, RecordLoad)}.
+      * @return whether or not that record is in use.
+      */
+    boolean next( long id, R record, RecordLoad mode );
 
     class Delegator<R extends AbstractBaseRecord> implements RecordCursor<R>
     {
@@ -87,6 +103,12 @@ public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
         }
 
         @Override
+        public void placeAt( long id, RecordLoad mode )
+        {
+            actual.placeAt( id, mode );
+        }
+
+        @Override
         public void close()
         {
             actual.close();
@@ -103,6 +125,12 @@ public interface RecordCursor<R extends AbstractBaseRecord> extends Cursor<R>
         public boolean next( long id )
         {
             return actual.next( id );
+        }
+
+        @Override
+        public boolean next( long id, R record, RecordLoad mode )
+        {
+            return actual.next( id, record, mode );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
@@ -30,6 +30,9 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
 
+/**
+ * Container for {@link RecordCursor}s for different stores. Intended to be reused by pooled transactions.
+ */
 public class RecordCursors implements AutoCloseable
 {
     private final RecordCursor<NodeRecord> node;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
@@ -38,6 +38,7 @@ public class RecordCursors implements AutoCloseable
     private final RecordCursor<PropertyRecord> property;
     private final RecordCursor<DynamicRecord> propertyString;
     private final RecordCursor<DynamicRecord> propertyArray;
+    private final RecordCursor<DynamicRecord> label;
 
     public RecordCursors( NeoStores neoStores )
     {
@@ -52,6 +53,7 @@ public class RecordCursors implements AutoCloseable
         property = newCursor( neoStores.getPropertyStore(), mode );
         propertyString = newCursor( neoStores.getPropertyStore().getStringStore(), mode );
         propertyArray = newCursor( neoStores.getPropertyStore().getArrayStore(), mode );
+        label = newCursor( neoStores.getNodeStore().getDynamicLabelStore(), mode );
     }
 
     private static <R extends AbstractBaseRecord> RecordCursor<R> newCursor( RecordStore<R> store, RecordLoad mode )
@@ -63,7 +65,7 @@ public class RecordCursors implements AutoCloseable
     public void close()
     {
         IOUtils.closeAll( RuntimeException.class,
-                node, relationship, relationshipGroup, property, propertyArray, propertyString );
+                node, relationship, relationshipGroup, property, propertyArray, propertyString, label );
     }
 
     public RecordCursor<NodeRecord> node()
@@ -94,5 +96,10 @@ public class RecordCursors implements AutoCloseable
     public RecordCursor<DynamicRecord> propertyString()
     {
         return propertyString;
+    }
+
+    public RecordCursor<DynamicRecord> label()
+    {
+        return label;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store;
+
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+
+import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
+
+public class RecordCursors implements AutoCloseable
+{
+    private final RecordCursor<NodeRecord> node;
+    private final RecordCursor<RelationshipRecord> relationship;
+    private final RecordCursor<RelationshipGroupRecord> relationshipGroup;
+    private final RecordCursor<PropertyRecord> property;
+    private final RecordCursor<DynamicRecord> propertyString;
+    private final RecordCursor<DynamicRecord> propertyArray;
+
+    public RecordCursors( NeoStores neoStores )
+    {
+        this( neoStores, NORMAL );
+    }
+
+    public RecordCursors( NeoStores neoStores, RecordLoad mode )
+    {
+        node = newCursor( neoStores.getNodeStore(), mode );
+        relationship = newCursor( neoStores.getRelationshipStore(), mode );
+        relationshipGroup = newCursor( neoStores.getRelationshipGroupStore(), mode );
+        property = newCursor( neoStores.getPropertyStore(), mode );
+        propertyString = newCursor( neoStores.getPropertyStore().getStringStore(), mode );
+        propertyArray = newCursor( neoStores.getPropertyStore().getArrayStore(), mode );
+    }
+
+    private static <R extends AbstractBaseRecord> RecordCursor<R> newCursor( RecordStore<R> store, RecordLoad mode )
+    {
+        return store.newRecordCursor( store.newRecord() ).acquire( store.getNumberOfReservedLowIds(), mode );
+    }
+
+    @Override
+    public void close()
+    {
+        node.close();
+        relationship.close();
+        relationshipGroup.close();
+        property.close();
+        propertyArray.close();
+        propertyString.close();
+    }
+
+    public RecordCursor<NodeRecord> node()
+    {
+        return node;
+    }
+
+    public RecordCursor<RelationshipRecord> relationship()
+    {
+        return relationship;
+    }
+
+    public RecordCursor<RelationshipGroupRecord> relationshipGroup()
+    {
+        return relationshipGroup;
+    }
+
+    public RecordCursor<PropertyRecord> property()
+    {
+        return property;
+    }
+
+    public RecordCursor<DynamicRecord> propertyArray()
+    {
+        return propertyArray;
+    }
+
+    public RecordCursor<DynamicRecord> propertyString()
+    {
+        return propertyString;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/RecordCursors.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -61,12 +62,8 @@ public class RecordCursors implements AutoCloseable
     @Override
     public void close()
     {
-        node.close();
-        relationship.close();
-        relationshipGroup.close();
-        property.close();
-        propertyArray.close();
-        propertyString.close();
+        IOUtils.closeAll( RuntimeException.class,
+                node, relationship, relationshipGroup, property, propertyArray, propertyString );
     }
 
     public RecordCursor<NodeRecord> node()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NoRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NoRecordFormat.java
@@ -35,7 +35,7 @@ public class NoRecordFormat<RECORD extends AbstractBaseRecord> implements Record
     @Override
     public RECORD newRecord()
     {
-        throw new UnsupportedOperationException( "Should not be called" );
+        return null;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -539,8 +539,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
             return (a, b) -> {};
         }
 
-        final StorePropertyCursor cursor = new StorePropertyCursor( cursors.property(),
-                cursors.propertyString(), cursors.propertyArray(), (ignored) -> {} );
+        final StorePropertyCursor cursor = new StorePropertyCursor( cursors, ignored -> {} );
         final List<Object> scratch = new ArrayList<>();
         return (ENTITY entity, RECORD record) -> {
             cursor.init( record.getNextProp(), LockService.NO_LOCK );

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
@@ -33,20 +33,28 @@ import org.neo4j.storageengine.api.schema.LabelScanReader;
  * are valuable to reuse over a reasonably large window to reduce garbage churn in general.
  *
  * A {@link StorageStatement} must be {@link #acquire() acquired} before use. After use the statement
- * should be {@link #close() closed}. After closed the statement can be acquired again.
+ * should be {@link #release() released}. After released the statement can be acquired again.
+ * Creating and closing {@link StorageStatement} and there's also benefits keeping these statements opened
+ * during a longer perioud of time, with the assumption that it's still one thread at a time using each.
+ * With that in mind these statements should not be opened and closed for each operation, perhaps not even
+ * for each transaction.
  */
 public interface StorageStatement extends AutoCloseable
 {
     /**
-     * Acquires this statement so that it can be used, should later be {@link #close() closed}.
-     * Since a {@link StorageStatement} can be reused after {@link #close() closed}, this call should
+     * Acquires this statement so that it can be used, should later be {@link #release() released}.
+     * Since a {@link StorageStatement} can be reused after {@link #release() released}, this call should
      * do initialization/clearing of state whereas data structures can be kept between uses.
      */
     void acquire();
 
     /**
-     * Closes this statement and releases any allocated resources. After closed this statement can
-     * be {@link #acquire() acquired} and be used again.
+     * Releases this statement so that it can later be {@link #acquire() acquired} again.
+     */
+    void release();
+
+    /**
+     * Closes this statement so that it can no longer be used nor {@link #acquire() acquired}.
      */
     @Override
     void close();

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
@@ -31,13 +31,16 @@ import org.neo4j.storageengine.api.schema.LabelScanReader;
  * are accessed through this statement interface as opposed to through the {@link StoreReadLayer} directly.
  * One of the main reasons is that the access methods returns objects, like {@link Cursor cursors} which
  * are valuable to reuse over a reasonably large window to reduce garbage churn in general.
- *
+ * <p>
  * A {@link StorageStatement} must be {@link #acquire() acquired} before use. After use the statement
  * should be {@link #release() released}. After released the statement can be acquired again.
  * Creating and closing {@link StorageStatement} and there's also benefits keeping these statements opened
- * during a longer perioud of time, with the assumption that it's still one thread at a time using each.
+ * during a longer period of time, with the assumption that it's still one thread at a time using each.
  * With that in mind these statements should not be opened and closed for each operation, perhaps not even
  * for each transaction.
+ * <p>
+ * All cursors provided by this statement are views over data in the store. They do not interact with transaction
+ * state.
  */
 public interface StorageStatement extends AutoCloseable
 {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
@@ -48,11 +48,8 @@ abstract class BatchRelationshipIterable<T> implements Iterable<T>
         RecordStore<RelationshipGroupRecord> relationshipGroupStore = neoStores.getRelationshipGroupStore();
         RelationshipRecord relationshipRecord = relationshipStore.newRecord();
         RelationshipGroupRecord relationshipGroupRecord = relationshipGroupStore.newRecord();
-        this.relationshipCursor = new StoreNodeRelationshipCursor(
-                relationshipRecord, neoStores,
-                relationshipGroupRecord, null,
-                (cursor) -> {}, NO_LOCK_SERVICE,
-                cursors );
+        this.relationshipCursor = new StoreNodeRelationshipCursor( relationshipRecord, relationshipGroupRecord,
+                cursor -> {}, NO_LOCK_SERVICE, cursors );
 
         // TODO There's an opportunity to reuse lots of instances created here, but this isn't a
         // critical path instance so perhaps not necessary a.t.m.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchRelationshipIterable.java
@@ -27,6 +27,9 @@ import org.neo4j.kernel.impl.api.store.StoreNodeRelationshipCursor;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.RecordCursors;
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
@@ -39,14 +42,17 @@ abstract class BatchRelationshipIterable<T> implements Iterable<T>
 {
     private final StoreNodeRelationshipCursor relationshipCursor;
 
-    public BatchRelationshipIterable( NeoStores neoStores, long nodeId )
+    public BatchRelationshipIterable( NeoStores neoStores, long nodeId, RecordCursors cursors )
     {
-        RelationshipRecord relationshipRecord = new RelationshipRecord( -1 );
-        RelationshipGroupRecord relationshipGroupRecord = new RelationshipGroupRecord( -1 );
+        RelationshipStore relationshipStore = neoStores.getRelationshipStore();
+        RecordStore<RelationshipGroupRecord> relationshipGroupStore = neoStores.getRelationshipGroupStore();
+        RelationshipRecord relationshipRecord = relationshipStore.newRecord();
+        RelationshipGroupRecord relationshipGroupRecord = relationshipGroupStore.newRecord();
         this.relationshipCursor = new StoreNodeRelationshipCursor(
                 relationshipRecord, neoStores,
                 relationshipGroupRecord, null,
-                (cursor) -> {}, NO_LOCK_SERVICE );
+                (cursor) -> {}, NO_LOCK_SERVICE,
+                cursors );
 
         // TODO There's an opportunity to reuse lots of instances created here, but this isn't a
         // critical path instance so perhaps not necessary a.t.m.

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSharingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSharingTest.java
@@ -142,7 +142,7 @@ public class TransactionStatementSharingTest
         statement.close();
 
         // when
-        verify( instances.storageStatement ).close();
+        verify( instances.storageStatement ).release();
         reset( instances.storageStatement );
         ReadOperations ops2 = tx.acquireStatement().readOperations();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -47,7 +47,7 @@ public class KernelStatementTest
     }
 
     @Test
-    public void shouldCloseStorageStatementWhenForceClosed() throws Exception
+    public void shouldReleaseStorageStatementWhenForceClosed() throws Exception
     {
         // given
         StorageStatement storeStatement = mock( StorageStatement.class );
@@ -59,6 +59,6 @@ public class KernelStatementTest
         statement.forceClose();
 
         // then
-        verify( storeStatement ).close();
+        verify( storeStatement ).release();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class StatementLifecycleTest
 {
     @Test
-    public void shouldCloseStoreStatementOnlyWhenReferenceCountDownToZero() throws Exception
+    public void shouldReleaseStoreStatementOnlyWhenReferenceCountDownToZero() throws Exception
     {
         // given
         KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
@@ -47,11 +47,11 @@ public class StatementLifecycleTest
 
         // then
         statement.close();
-        verify( storageStatement ).close();
+        verify( storageStatement ).release();
     }
 
     @Test
-    public void shouldCloseStoreStatementWhenForceClosingStatements() throws Exception
+    public void shouldReleaseStoreStatementWhenForceClosingStatements() throws Exception
     {
         // given
         KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
@@ -63,6 +63,6 @@ public class StatementLifecycleTest
         statement.forceClose();
 
         // then
-        verify( storageStatement ).close();
+        verify( storageStatement ).release();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/StateHandlingStatementOperationsTest.java
@@ -44,7 +44,6 @@ import org.neo4j.kernel.impl.api.legacyindex.InternalAutoIndexing;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
 import org.neo4j.kernel.impl.index.LegacyIndexStore;
 import org.neo4j.kernel.impl.locking.ReentrantLockService;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.util.Cursors;
 import org.neo4j.kernel.impl.util.diffsets.DiffSets;
 import org.neo4j.storageengine.api.LabelItem;
@@ -53,7 +52,6 @@ import org.neo4j.storageengine.api.StorageStatement;
 import org.neo4j.storageengine.api.StoreReadLayer;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -70,6 +68,7 @@ import static org.neo4j.kernel.api.properties.Property.intProperty;
 import static org.neo4j.kernel.impl.api.StatementOperationsTestHelper.mockedState;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asNodeCursor;
 import static org.neo4j.kernel.impl.api.state.StubCursors.asPropertyCursor;
+import static org.neo4j.test.MockedNeoStores.basicMockedNeoStores;
 
 public class StateHandlingStatementOperationsTest
 {
@@ -450,7 +449,7 @@ public class StateHandlingStatementOperationsTest
 
         StoreStatementWithSingleFreshIndexReader( IndexReader reader )
         {
-            super( mock( NeoStores.class ), new ReentrantLockService(), () -> mock( IndexReaderFactory.class ),
+            super( basicMockedNeoStores(), new ReentrantLockService(), () -> mock( IndexReaderFactory.class ),
                     () -> mock( LabelScanReader.class ) );
             this.reader = reader;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerNodeAndRelTest.java
@@ -88,7 +88,7 @@ public class DiskLayerNodeAndRelTest extends DiskLayerTest
 
     private boolean nodeExists( long id )
     {
-        try (StorageStatement statement = disk.newStatement())
+        try ( StorageStatement statement = disk.newStatement() )
         {
             try ( Cursor<NodeItem> node = statement.acquireSingleNodeCursor( id ) )
             {
@@ -99,7 +99,7 @@ public class DiskLayerNodeAndRelTest extends DiskLayerTest
 
     private boolean relationshipExists( long id )
     {
-        try (StorageStatement statement = disk.newStatement())
+        try ( StorageStatement statement = disk.newStatement() )
         {
             try ( Cursor<RelationshipItem> relationship = statement.acquireSingleRelationshipCursor( id ) )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreLabelCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreLabelCursorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.impl.store.DynamicNodeLabels;
+import org.neo4j.kernel.impl.store.InlineNodeLabels;
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.StandaloneDynamicRecordAllocator;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+
+import static java.util.stream.LongStream.iterate;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.kernel.impl.store.record.Record.NO_LABELS_FIELD;
+import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_PROPERTY;
+import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
+
+public class StoreLabelCursorTest
+{
+    @Test
+    public void readNoLabels()
+    {
+        StoreLabelCursor cursor = newCursor();
+        NodeRecord node = new NodeRecord( 1 ).initialize( true, NO_NEXT_PROPERTY.intValue(), false,
+                NO_NEXT_RELATIONSHIP.intValue(), NO_LABELS_FIELD.intValue() );
+
+        cursor.init( node );
+
+        assertFalse( cursor.next() );
+    }
+
+    @Test
+    public void readInlinedLabels()
+    {
+        long[] labels = {1, 2, 42};
+        NodeRecord node = new NodeRecord( 1 ).initialize( true, NO_NEXT_PROPERTY.intValue(), false,
+                NO_NEXT_RELATIONSHIP.intValue(), NO_LABELS_FIELD.intValue() );
+        Collection<DynamicRecord> allocatedDynamicRecords = InlineNodeLabels.putSorted( node, labels, null, null );
+        assertThat( allocatedDynamicRecords, is( empty() ) );
+
+        StoreLabelCursor cursor = newCursor();
+        cursor.init( node );
+
+        verifyCursor( labels, cursor );
+    }
+
+    @Test
+    public void readDynamicLabels()
+    {
+        long[] labels = iterate( 1, id -> id + 2 ).limit( 1_000 ).toArray();
+        NodeRecord node = new NodeRecord( 1 ).initialize( true, NO_NEXT_PROPERTY.intValue(), false,
+                NO_NEXT_RELATIONSHIP.intValue(), NO_LABELS_FIELD.intValue() );
+        Collection<DynamicRecord> allocatedDynamicRecords = DynamicNodeLabels.putSorted( node, labels,
+                mock( NodeStore.class ), new StandaloneDynamicRecordAllocator() );
+        for ( DynamicRecord dynamicRecord : allocatedDynamicRecords )
+        {
+            dynamicRecord.setInUse( true );
+        }
+        node.setLabelField( node.getLabelField(), Collections.emptyList() );
+        assertThat( allocatedDynamicRecords, not( empty() ) );
+
+        StoreLabelCursor cursor = newCursor( allocatedDynamicRecords );
+        cursor.init( node );
+
+        verifyCursor( labels, cursor );
+    }
+
+    private static void verifyCursor( long[] expectedLabels, StoreLabelCursor cursor )
+    {
+        for ( long label : expectedLabels )
+        {
+            assertTrue( cursor.next() );
+            assertEquals( label, cursor.getAsInt() );
+        }
+        assertFalse( cursor.next() );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static StoreLabelCursor newCursor( Collection<DynamicRecord> recordsForRecordCursor )
+    {
+        RecordCursor<DynamicRecord> recordCursor = mock( RecordCursor.class );
+        when( recordCursor.getAll() ).thenReturn( Iterables.asList( recordsForRecordCursor ) );
+        return new StoreLabelCursor( recordCursor, cursor -> {
+        } );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static StoreLabelCursor newCursor()
+    {
+        return new StoreLabelCursor( mock( RecordCursor.class ), cursor -> {
+        } );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
@@ -53,9 +53,7 @@ public class StoreNodeRelationshipCursorTest
         @SuppressWarnings( "unchecked" )
         StoreNodeRelationshipCursor cursor = new StoreNodeRelationshipCursor(
                 new RelationshipRecord( -1 ),
-                stores,
                 new RelationshipGroupRecord( -1 ),
-                mock( StoreStatement.class ),
                 mock( Consumer.class ),
                 NO_LOCK_SERVICE, new RecordCursors( stores ) );
         reset( stores.getRelationshipGroupStore() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
@@ -24,17 +24,16 @@ import org.junit.Test;
 import java.util.function.Consumer;
 
 import org.neo4j.kernel.impl.store.NeoStores;
-import org.neo4j.kernel.impl.store.NodeStore;
-import org.neo4j.kernel.impl.store.RecordStore;
-import org.neo4j.kernel.impl.store.RelationshipGroupStore;
+import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.storageengine.api.Direction;
+import org.neo4j.test.MockedNeoStores;
 
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
 
@@ -49,11 +48,7 @@ public class StoreNodeRelationshipCursorTest
         // on the NodeRecord#getNextRel() value. Although that value could actually be -1
 
         // GIVEN
-        NeoStores stores = mock( NeoStores.class );
-        NodeStore nodeStore = mock( NodeStore.class );
-        when( stores.getNodeStore() ).thenReturn( nodeStore );
-        RecordStore<RelationshipGroupRecord> relationshipGroupStore = mock( RelationshipGroupStore.class );
-        when( stores.getRelationshipGroupStore() ).thenReturn( relationshipGroupStore );
+        NeoStores stores = MockedNeoStores.basicMockedNeoStores();
 
         @SuppressWarnings( "unchecked" )
         StoreNodeRelationshipCursor cursor = new StoreNodeRelationshipCursor(
@@ -62,13 +57,14 @@ public class StoreNodeRelationshipCursorTest
                 new RelationshipGroupRecord( -1 ),
                 mock( StoreStatement.class ),
                 mock( Consumer.class ),
-                NO_LOCK_SERVICE );
+                NO_LOCK_SERVICE, new RecordCursors( stores ) );
+        reset( stores.getRelationshipGroupStore() );
 
         // WHEN
         cursor.init( true, NO_NEXT_RELATIONSHIP.intValue(), 0, Direction.BOTH );
 
         // THEN
-        verifyNoMoreInteractions( relationshipGroupStore );
+        verifyNoMoreInteractions( stores.getRelationshipGroupStore() );
         assertFalse( cursor.next() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
@@ -785,15 +785,16 @@ public class StorePropertyCursorTest
     private static StorePropertyCursor newStorePropertyCursor( PropertyStore propertyStore,
             Consumer<StorePropertyCursor> cache )
     {
-        DynamicStringStore s = propertyStore.getStringStore();
-        DynamicArrayStore a = propertyStore.getArrayStore();
-        RecordCursor<DynamicRecord> sc = s.newRecordCursor( s.newRecord() );
-        RecordCursor<DynamicRecord> ac = a.newRecordCursor( a.newRecord() );
-        return new StorePropertyCursor(
-                propertyStore.newRecordCursor( propertyStore.newRecord() ).acquire( 0, NORMAL ),
-                propertyStore.getStringStore().newRecordCursor( propertyStore.getStringStore().newRecord() ).acquire( 0, NORMAL ),
-                propertyStore.getArrayStore().newRecordCursor( propertyStore.getArrayStore().newRecord() ).acquire( 0, NORMAL ),
-                cache );
+        RecordCursor<PropertyRecord> propertyRecordCursor = propertyStore.newRecordCursor( propertyStore.newRecord() );
+
+        DynamicStringStore stringStore = propertyStore.getStringStore();
+        RecordCursor<DynamicRecord> dynamicStringCursor = stringStore.newRecordCursor( stringStore.newRecord() );
+
+        DynamicArrayStore arrayStore = propertyStore.getArrayStore();
+        RecordCursor<DynamicRecord> dynamicArrayCursor = arrayStore.newRecordCursor( arrayStore.newRecord() );
+
+        return new StorePropertyCursor( propertyRecordCursor.acquire( 0, NORMAL ),
+                dynamicStringCursor.acquire( 0, NORMAL ), dynamicArrayCursor.acquire( 0, NORMAL ), cache );
     }
 
     private static List<PropertyRecord> createPropertyChain( PropertyStore store, int firstRecordId, int keyId,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
@@ -47,6 +47,7 @@ import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.PropertyType;
 import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.format.standard.PropertyRecordFormat;
@@ -786,15 +787,22 @@ public class StorePropertyCursorTest
             Consumer<StorePropertyCursor> cache )
     {
         RecordCursor<PropertyRecord> propertyRecordCursor = propertyStore.newRecordCursor( propertyStore.newRecord() );
+        propertyRecordCursor.acquire( 0, NORMAL );
 
         DynamicStringStore stringStore = propertyStore.getStringStore();
         RecordCursor<DynamicRecord> dynamicStringCursor = stringStore.newRecordCursor( stringStore.newRecord() );
+        dynamicStringCursor.acquire( 0, NORMAL );
 
         DynamicArrayStore arrayStore = propertyStore.getArrayStore();
         RecordCursor<DynamicRecord> dynamicArrayCursor = arrayStore.newRecordCursor( arrayStore.newRecord() );
+        dynamicArrayCursor.acquire( 0, NORMAL );
 
-        return new StorePropertyCursor( propertyRecordCursor.acquire( 0, NORMAL ),
-                dynamicStringCursor.acquire( 0, NORMAL ), dynamicArrayCursor.acquire( 0, NORMAL ), cache );
+        RecordCursors cursors = mock( RecordCursors.class );
+        when( cursors.property() ).thenReturn( propertyRecordCursor );
+        when( cursors.propertyString() ).thenReturn( dynamicStringCursor );
+        when( cursors.propertyArray() ).thenReturn( dynamicArrayCursor );
+
+        return new StorePropertyCursor( cursors, cache );
     }
 
     private static List<PropertyRecord> createPropertyChain( PropertyStore store, int firstRecordId, int keyId,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
@@ -65,8 +65,8 @@ public class StorePropertyPayloadCursorTest
         @Test
         public void nextShouldAlwaysReturnFalseWhenNotInitialized()
         {
-            StorePropertyPayloadCursor cursor = new StorePropertyPayloadCursor( mock( DynamicStringStore.class ),
-                    mock( DynamicArrayStore.class ) );
+            StorePropertyPayloadCursor cursor = new StorePropertyPayloadCursor( mock( RecordCursor.class ),
+                    mock( RecordCursor.class ) );
 
             assertFalse( cursor.next() );
 
@@ -468,7 +468,8 @@ public class StorePropertyPayloadCursorTest
     private static StorePropertyPayloadCursor newCursor( DynamicStringStore dynamicStringStore,
             DynamicArrayStore dynamicArrayStore, Object... values )
     {
-        StorePropertyPayloadCursor cursor = new StorePropertyPayloadCursor( dynamicStringStore, dynamicArrayStore );
+        StorePropertyPayloadCursor cursor = new StorePropertyPayloadCursor(
+                dynamicStringStore.newRecordCursor( null ), dynamicArrayStore.newRecordCursor( null ) );
 
         long[] blocks = asBlocks( values );
         cursor.init( blocks, blocks.length );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleLabelCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleLabelCursorTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.store;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.LongStream;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.impl.store.DynamicNodeLabels;
+import org.neo4j.kernel.impl.store.InlineNodeLabels;
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.StandaloneDynamicRecordAllocator;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.util.InstanceCache;
+
+import static java.util.stream.LongStream.iterate;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.kernel.impl.store.record.Record.NO_LABELS_FIELD;
+import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_PROPERTY;
+import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
+
+public class StoreSingleLabelCursorTest
+{
+    @Test
+    public void readNoLabels()
+    {
+        StoreSingleLabelCursor cursor = newCursor();
+        NodeRecord node = new NodeRecord( 1 ).initialize( true, NO_NEXT_PROPERTY.intValue(), false,
+                NO_NEXT_RELATIONSHIP.intValue(), NO_LABELS_FIELD.intValue() );
+
+        cursor.init( node, 42 );
+
+        assertFalse( cursor.next() );
+    }
+
+    @Test
+    public void readInlinedLabelsWithoutSpecifiedLabel()
+    {
+        long[] labels = {1, 2, 42};
+        StoreSingleLabelCursor cursor = newCursor();
+        NodeRecord node = new NodeRecord( 1 ).initialize( true, NO_NEXT_PROPERTY.intValue(), false,
+                NO_NEXT_RELATIONSHIP.intValue(), NO_LABELS_FIELD.intValue() );
+        Collection<DynamicRecord> allocatedDynamicRecords = InlineNodeLabels.putSorted( node, labels, null, null );
+        assertThat( allocatedDynamicRecords, is( empty() ) );
+
+        cursor.init( node, 3 );
+
+        assertFalse( cursor.next() );
+    }
+
+    @Test
+    public void readInlinedLabelsWithSpecifiedLabel()
+    {
+        long[] labels = {1, 2, 42};
+        StoreSingleLabelCursor cursor = newCursor();
+        NodeRecord node = new NodeRecord( 1 ).initialize( true, NO_NEXT_PROPERTY.intValue(), false,
+                NO_NEXT_RELATIONSHIP.intValue(), NO_LABELS_FIELD.intValue() );
+        Collection<DynamicRecord> allocatedDynamicRecords = InlineNodeLabels.putSorted( node, labels, null, null );
+        assertThat( allocatedDynamicRecords, is( empty() ) );
+
+        cursor.init( node, 2 );
+
+        assertTrue( cursor.next() );
+        assertEquals( 2, cursor.getAsInt() );
+        assertFalse( cursor.next() );
+    }
+
+    @Test
+    public void readDynamicLabelsWithoutSpecifiedLabel()
+    {
+        int maxLabelId = 1_000;
+        int specifiedLabelId = maxLabelId / 2;
+        long[] labels = LongStream.iterate( 1, id -> id + 2 ).limit( maxLabelId ).toArray();
+        NodeRecord node = new NodeRecord( 1 ).initialize( true, NO_NEXT_PROPERTY.intValue(), false,
+                NO_NEXT_RELATIONSHIP.intValue(), NO_LABELS_FIELD.intValue() );
+        Collection<DynamicRecord> allocatedDynamicRecords = DynamicNodeLabels.putSorted( node, labels,
+                mock( NodeStore.class ), new StandaloneDynamicRecordAllocator() );
+        for ( DynamicRecord dynamicRecord : allocatedDynamicRecords )
+        {
+            dynamicRecord.setInUse( true );
+        }
+        node.setLabelField( node.getLabelField(), Collections.emptyList() );
+        assertThat( allocatedDynamicRecords, not( empty() ) );
+
+        StoreSingleLabelCursor cursor = newCursor( allocatedDynamicRecords );
+        cursor.init( node, specifiedLabelId );
+
+        assertFalse( cursor.next() );
+    }
+
+    @Test
+    public void readDynamicLabelsWithSpecifiedLabel()
+    {
+        int maxLabelId = 1_000;
+        int specifiedLabelId = maxLabelId / 2 + 1;
+        long[] labels = iterate( 1, id -> id + 2 ).limit( maxLabelId ).toArray();
+        NodeRecord node = new NodeRecord( 1 ).initialize( true, NO_NEXT_PROPERTY.intValue(), false,
+                NO_NEXT_RELATIONSHIP.intValue(), NO_LABELS_FIELD.intValue() );
+        Collection<DynamicRecord> allocatedDynamicRecords = DynamicNodeLabels.putSorted( node, labels,
+                mock( NodeStore.class ), new StandaloneDynamicRecordAllocator() );
+        for ( DynamicRecord dynamicRecord : allocatedDynamicRecords )
+        {
+            dynamicRecord.setInUse( true );
+        }
+        node.setLabelField( node.getLabelField(), Collections.emptyList() );
+        assertThat( allocatedDynamicRecords, not( empty() ) );
+
+        StoreSingleLabelCursor cursor = newCursor( allocatedDynamicRecords );
+        cursor.init( node, specifiedLabelId );
+
+        assertTrue( cursor.next() );
+        assertEquals( specifiedLabelId, cursor.getAsInt() );
+        assertFalse( cursor.next() );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static StoreSingleLabelCursor newCursor( Collection<DynamicRecord> recordsForRecordCursor )
+    {
+        RecordCursor<DynamicRecord> recordCursor = mock( RecordCursor.class );
+        when( recordCursor.getAll() ).thenReturn( Iterables.asList( recordsForRecordCursor ) );
+        return new StoreSingleLabelCursor( recordCursor, mock( InstanceCache.class ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static StoreSingleLabelCursor newCursor()
+    {
+        return new StoreSingleLabelCursor( mock( RecordCursor.class ), mock( InstanceCache.class ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreStatementTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 import java.util.function.Supplier;
 
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
+import org.neo4j.test.MockedNeoStores;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -44,8 +44,9 @@ public class StoreStatementTest
 
         when( scanStore.get() ).thenReturn( scanReader );
         StoreStatement statement = new StoreStatement(
-                mock( NeoStores.class ), LockService.NO_LOCK_SERVICE,
+                MockedNeoStores.basicMockedNeoStores(), LockService.NO_LOCK_SERVICE,
                 mock( Supplier.class ), scanStore );
+        statement.acquire();
 
         // when
         LabelScanReader actualReader = statement.getLabelScanReader();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
@@ -27,6 +27,7 @@ import org.mockito.InOrder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -54,7 +55,10 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -64,8 +68,10 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.neo4j.io.pagecache.RecordingPageCacheTracer.Event;
@@ -132,7 +138,7 @@ public class CommonAbstractStoreTest
         when( pageCursor.getCurrentPageId() ).thenReturn( pageIdForRecord );
         when( pageCursor.next( anyInt() ) ).thenReturn( true );
 
-        RecordCursor<TheRecord> cursor = store.newRecordCursor( new TheRecord( -1 ) );
+        RecordCursor<TheRecord> cursor = store.newRecordCursor( newRecord( -1 ) );
         cursor.acquire( recordId, RecordLoad.FORCE );
 
         cursor.next( recordId );
@@ -170,10 +176,37 @@ public class CommonAbstractStoreTest
     }
 
     @Test
+    public void recordCursorGetAllForEmptyCursor() throws IOException
+    {
+        TheStore store = newStore();
+        long recordId = 4;
+        long pageIdForRecord = store.pageIdForRecord( recordId );
+
+        when( pageCursor.getCurrentPageId() ).thenReturn( pageIdForRecord );
+        when( pageCursor.next( anyInt() ) ).thenReturn( false );
+
+        RecordCursor<TheRecord> cursor = store.newRecordCursor( newRecord( -1 ) );
+        cursor.acquire( recordId, RecordLoad.FORCE );
+
+        assertThat( cursor.getAll(), is( empty() ) );
+    }
+
+    @Test
+    public void recordCursorGetAll() throws IOException
+    {
+        TheStore store = newStore();
+        RecordCursor<TheRecord> cursor = spy( store.newRecordCursor( store.newRecord() ) );
+        doReturn( true ).doReturn( true ).doReturn( true ).doReturn( false ).when( cursor ).next();
+        doReturn( newRecord( 1 ) ).doReturn( newRecord( 5 ) ).doReturn( newRecord( 42 ) ).when( cursor ).get();
+
+        assertEquals( Arrays.asList( newRecord( 1 ), newRecord( 5 ), newRecord( 42 ) ), cursor.getAll() );
+    }
+
+    @Test
     public void throwsWhenRecordWithNegativeIdIsUpdated()
     {
         TheStore store = newStore();
-        TheRecord record = new TheRecord( -1 );
+        TheRecord record = newRecord( -1 );
 
         try
         {
@@ -193,7 +226,7 @@ public class CommonAbstractStoreTest
         when( recordFormat.getMaxId() ).thenReturn( maxFormatId );
 
         TheStore store = newStore();
-        TheRecord record = new TheRecord( maxFormatId + 1 );
+        TheRecord record = newRecord( maxFormatId + 1 );
 
         try
         {
@@ -210,7 +243,7 @@ public class CommonAbstractStoreTest
     public void throwsWhenRecordWithReservedIdIsUpdated()
     {
         TheStore store = newStore();
-        TheRecord record = new TheRecord( IdGeneratorImpl.INTEGER_MINUS_ONE );
+        TheRecord record = newRecord( IdGeneratorImpl.INTEGER_MINUS_ONE );
 
         try
         {
@@ -229,6 +262,11 @@ public class CommonAbstractStoreTest
         TheStore store = new TheStore( storeFile, config, idType, idGeneratorFactory, pageCache, log, recordFormat );
         store.initialise( false );
         return store;
+    }
+
+    private TheRecord newRecord( long id )
+    {
+        return new TheRecord( id );
     }
 
     private long insertNodeRecordAndObservePinEvent( RecordingPageCacheTracer tracer, NodeStore store )
@@ -281,6 +319,12 @@ public class CommonAbstractStoreTest
         TheRecord( long id )
         {
             super( id );
+        }
+
+        @Override
+        public TheRecord clone()
+        {
+            return new TheRecord( getId() );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
@@ -28,17 +28,20 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
+import java.util.stream.LongStream;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.mockfs.DelegatingFileSystemAbstraction;
 import org.neo4j.graphdb.mockfs.DelegatingStoreChannel;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
@@ -56,13 +59,18 @@ import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.Exceptions.contains;
 import static org.neo4j.kernel.impl.store.DynamicArrayStore.allocateFromNumbers;
 import static org.neo4j.kernel.impl.store.NodeStore.readOwnerFromDynamicLabelsRecord;
@@ -364,6 +372,24 @@ public class NodeStoreTest
         IdGenerator idGenerator = idGeneratorFactory.get( IdType.NODE );
         verify( idGenerator, times( 0 ) ).freeId( 5L );
         verify( idGenerator ).freeId( 10L );
+    }
+
+    @Test
+    @SuppressWarnings( "unchecked" )
+    public void ensureHeavy() throws IOException
+    {
+        long[] labels = LongStream.range( 1, 1000 ).toArray();
+        NodeRecord node = new NodeRecord( 5 );
+        node.setLabelField( 10, Collections.emptyList() );
+        Collection<DynamicRecord> dynamicLabelRecords = DynamicNodeLabels.putSorted( node, labels,
+                mock( NodeStore.class ), new StandaloneDynamicRecordAllocator() );
+        assertThat( dynamicLabelRecords, not( empty() ) );
+        RecordCursor<DynamicRecord> dynamicLabelCursor = mock( RecordCursor.class );
+        when( dynamicLabelCursor.getAll() ).thenReturn( Iterables.asList( dynamicLabelRecords ) );
+
+        NodeStore.ensureHeavy( node, dynamicLabelCursor );
+
+        assertEquals( dynamicLabelRecords, node.getDynamicLabelRecords() );
     }
 
     private NodeStore newNodeStore( FileSystemAbstraction fs ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordCursorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordCursorsTest.java
@@ -72,6 +72,7 @@ public class RecordCursorsTest
         verify( recordCursors.property() ).close();
         verify( recordCursors.propertyString() ).close();
         verify( recordCursors.propertyArray() ).close();
+        verify( recordCursors.label() ).close();
     }
 
     private static RecordCursors newRecordCursorsWithMockedNeoStores()
@@ -83,6 +84,7 @@ public class RecordCursorsTest
         PropertyStore propertyStore = newStoreMockWithRecordCursor( PropertyStore.class );
         DynamicStringStore dynamicStringStore = newStoreMockWithRecordCursor( DynamicStringStore.class );
         DynamicArrayStore dynamicArrayStore = newStoreMockWithRecordCursor( DynamicArrayStore.class );
+        DynamicArrayStore dynamicLabelStore = newStoreMockWithRecordCursor( DynamicArrayStore.class );
 
         when( neoStores.getNodeStore() ).thenReturn( nodeStore );
         when( neoStores.getRelationshipStore() ).thenReturn( relStore );
@@ -90,6 +92,7 @@ public class RecordCursorsTest
         when( neoStores.getPropertyStore() ).thenReturn( propertyStore );
         when( propertyStore.getStringStore() ).thenReturn( dynamicStringStore );
         when( propertyStore.getArrayStore() ).thenReturn( dynamicArrayStore );
+        when( nodeStore.getDynamicLabelStore() ).thenReturn( dynamicLabelStore );
 
         return new RecordCursors( neoStores );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordCursorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordCursorsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RecordCursorsTest
+{
+    @Test
+    public void closesCursors()
+    {
+        RecordCursors cursors = newRecordCursorsWithMockedNeoStores();
+
+        cursors.close();
+
+        verifyAllCursorsClosed( cursors );
+    }
+
+    @Test
+    public void closesCursorsEvenIfSomeCursorFailsToClose()
+    {
+        RecordCursors cursors = newRecordCursorsWithMockedNeoStores();
+        RecordCursor<RelationshipGroupRecord> relGroupCursor = cursors.relationshipGroup();
+        RuntimeException exception = new RuntimeException( "Close failure" );
+        doThrow( exception ).when( relGroupCursor ).close();
+
+        try
+        {
+            cursors.close();
+        }
+        catch ( Exception e )
+        {
+            assertSame( exception, e.getCause() );
+        }
+
+        verifyAllCursorsClosed( cursors );
+    }
+
+    private static void verifyAllCursorsClosed( RecordCursors recordCursors )
+    {
+        verify( recordCursors.node() ).close();
+        verify( recordCursors.relationship() ).close();
+        verify( recordCursors.relationshipGroup() ).close();
+        verify( recordCursors.property() ).close();
+        verify( recordCursors.propertyString() ).close();
+        verify( recordCursors.propertyArray() ).close();
+    }
+
+    private static RecordCursors newRecordCursorsWithMockedNeoStores()
+    {
+        NeoStores neoStores = mock( NeoStores.class );
+        NodeStore nodeStore = newStoreMockWithRecordCursor( NodeStore.class );
+        RelationshipStore relStore = newStoreMockWithRecordCursor( RelationshipStore.class );
+        RelationshipGroupStore relGroupStore = newStoreMockWithRecordCursor( RelationshipGroupStore.class );
+        PropertyStore propertyStore = newStoreMockWithRecordCursor( PropertyStore.class );
+        DynamicStringStore dynamicStringStore = newStoreMockWithRecordCursor( DynamicStringStore.class );
+        DynamicArrayStore dynamicArrayStore = newStoreMockWithRecordCursor( DynamicArrayStore.class );
+
+        when( neoStores.getNodeStore() ).thenReturn( nodeStore );
+        when( neoStores.getRelationshipStore() ).thenReturn( relStore );
+        when( neoStores.getRelationshipGroupStore() ).thenReturn( relGroupStore );
+        when( neoStores.getPropertyStore() ).thenReturn( propertyStore );
+        when( propertyStore.getStringStore() ).thenReturn( dynamicStringStore );
+        when( propertyStore.getArrayStore() ).thenReturn( dynamicArrayStore );
+
+        return new RecordCursors( neoStores );
+    }
+
+    private static <S extends RecordStore<R>, R extends AbstractBaseRecord> S newStoreMockWithRecordCursor(
+            Class<S> storeClass )
+    {
+        S storeMock = mock( storeClass );
+        RecordCursor<R> cursor = newCursorMock();
+        when( storeMock.newRecordCursor( any() ) ).thenReturn( cursor );
+        return storeMock;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static <T extends AbstractBaseRecord> RecordCursor<T> newCursorMock()
+    {
+        RecordCursor<T> cursor = mock( RecordCursor.class );
+        when( cursor.acquire( anyLong(), any() ) ).thenReturn( cursor );
+        return cursor;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StandaloneDynamicRecordAllocator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StandaloneDynamicRecordAllocator.java
@@ -17,14 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.store.format;
+package org.neo4j.kernel.impl.store;
 
 import java.util.Iterator;
 
-import org.neo4j.kernel.impl.store.DynamicRecordAllocator;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 
-class StandaloneDynamicRecordAllocator implements DynamicRecordAllocator
+public class StandaloneDynamicRecordAllocator implements DynamicRecordAllocator
 {
     private int next = 1;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/LimitedRecordGenerators.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/LimitedRecordGenerators.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.store.format;
 
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.PropertyType;
+import org.neo4j.kernel.impl.store.StandaloneDynamicRecordAllocator;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -30,7 +31,6 @@ import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
-import org.neo4j.test.RandomRule;
 import org.neo4j.test.Randoms;
 
 import static java.lang.Long.max;

--- a/community/kernel/src/test/java/org/neo4j/test/MockedNeoStores.java
+++ b/community/kernel/src/test/java/org/neo4j/test/MockedNeoStores.java
@@ -45,10 +45,15 @@ public class MockedNeoStores
         // Cursor, absolutely mocked and cannot be used at all as it is
         RecordCursor cursor = mockedRecordCursor();
 
-        // NodeStore
+        // NodeStore - DynamicLabelStore
         NodeStore nodeStore = mock( NodeStore.class );
         when( nodeStore.newRecordCursor( any() ) ).thenReturn( cursor );
         when( neoStores.getNodeStore() ).thenReturn( nodeStore );
+
+        // NodeStore - DynamicLabelStore
+        DynamicArrayStore dynamicLabelStore = mock( DynamicArrayStore.class );
+        when( dynamicLabelStore.newRecordCursor( any() ) ).thenReturn( cursor );
+        when( nodeStore.getDynamicLabelStore() ).thenReturn( dynamicLabelStore );
 
         // RelationshipStore
         RelationshipStore relationshipStore = mock( RelationshipStore.class );

--- a/community/kernel/src/test/java/org/neo4j/test/MockedNeoStores.java
+++ b/community/kernel/src/test/java/org/neo4j/test/MockedNeoStores.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test;
+
+import org.neo4j.kernel.impl.store.DynamicArrayStore;
+import org.neo4j.kernel.impl.store.DynamicStringStore;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.RelationshipGroupStore;
+import org.neo4j.kernel.impl.store.RelationshipStore;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockedNeoStores
+{
+    @SuppressWarnings( {"unchecked", "rawtypes"} )
+    public static NeoStores basicMockedNeoStores()
+    {
+        NeoStores neoStores = mock( NeoStores.class );
+
+        // Cursor, absolutely mocked and cannot be used at all as it is
+        RecordCursor cursor = mockedRecordCursor();
+
+        // NodeStore
+        NodeStore nodeStore = mock( NodeStore.class );
+        when( nodeStore.newRecordCursor( any() ) ).thenReturn( cursor );
+        when( neoStores.getNodeStore() ).thenReturn( nodeStore );
+
+        // RelationshipStore
+        RelationshipStore relationshipStore = mock( RelationshipStore.class );
+        when( relationshipStore.newRecordCursor( any() ) ).thenReturn( cursor );
+        when( neoStores.getRelationshipStore() ).thenReturn( relationshipStore );
+
+        // RelationshipGroupStore
+        RelationshipGroupStore relationshipGroupStore = mock( RelationshipGroupStore.class );
+        when( relationshipGroupStore.newRecordCursor( any() ) ).thenReturn( cursor );
+        when( neoStores.getRelationshipGroupStore() ).thenReturn( relationshipGroupStore );
+
+        // PropertyStore
+        PropertyStore propertyStore = mock( PropertyStore.class );
+        when( propertyStore.newRecordCursor( any() ) ).thenReturn( cursor );
+        when( neoStores.getPropertyStore() ).thenReturn( propertyStore );
+
+        // PropertyStore -- DynamicStringStore
+        DynamicStringStore propertyStringStore = mock( DynamicStringStore.class );
+        when( propertyStringStore.newRecordCursor( any() ) ).thenReturn( cursor );
+        when( propertyStore.getStringStore() ).thenReturn( propertyStringStore );
+
+        // PropertyStore -- DynamicArrayStore
+        DynamicArrayStore propertyArrayStore = mock( DynamicArrayStore.class );
+        when( propertyArrayStore.newRecordCursor( any() ) ).thenReturn( cursor );
+        when( propertyStore.getArrayStore() ).thenReturn( propertyArrayStore );
+
+        return neoStores;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    public static <R extends AbstractBaseRecord> RecordCursor<R> mockedRecordCursor()
+    {
+        RecordCursor<R> cursor = mock( RecordCursor.class );
+        when( cursor.acquire( anyLong(), any( RecordLoad.class ) ) ).thenReturn( cursor );
+        return cursor;
+    }
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/pool/LinkedQueuePool.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/pool/LinkedQueuePool.java
@@ -196,9 +196,4 @@ public class LinkedQueuePool<R> implements Pool<R>
             dispose( resource );
         }
     }
-
-    public void close( boolean force )
-    {
-        disposeAll();
-    }
 }


### PR DESCRIPTION
Previously most of Kernel API cursors directly used stores to read records. This means they were opening page cursors all the time and pinning/unpinning page cache pages.

This PR makes all Kernel API cursors use record cursors. Record cursors keep underlying page cache cursors open as long as possible thus avoiding excessive pins/unpins. Record cursors are also kept open and pooled with KTIs as part of their StoreStatements.
