### PR TITLE
Prevents null from being added to legacy indexes

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneCommandApplier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneCommandApplier.java
@@ -61,9 +61,19 @@ public class LuceneCommandApplier extends CommandHandler.Adapter
         CommitContext context = commitContext( command );
         String key = definitions.getKey( command.getKeyId() );
         Object value = command.getValue();
-        context.ensureWriterInstantiated();
-        context.indexType.addToDocument( context.getDocument( new IdData( command.getEntityId() ), true ).document,
-                key, value );
+
+        // Below is a check for a null value where such a value is ignored. This may look strange, but the
+        // reason is that there was this bug where adding a null value to an index would be fine and written
+        // into the log as a command, to later fail during application of that command, i.e. here.
+        // There was a fix introduced to throw IllegalArgumentException out to user right away if passing in
+        // null or object that had toString() produce null. Although databases already affected by this would
+        // not be able to recover, which is why this check is here.
+        if ( value != null )
+        {
+            context.ensureWriterInstantiated();
+            context.indexType.addToDocument( context.getDocument( new IdData( command.getEntityId() ), true ).document,
+                    key, value );
+        }
         return false;
     }
 
@@ -73,10 +83,20 @@ public class LuceneCommandApplier extends CommandHandler.Adapter
         CommitContext context = commitContext( command );
         String key = definitions.getKey( command.getKeyId() );
         Object value = command.getValue();
-        context.ensureWriterInstantiated();
-        RelationshipData entityId = new RelationshipData( command.getEntityId(),
-                command.getStartNode(), command.getEndNode() );
-        context.indexType.addToDocument( context.getDocument( entityId, true ).document, key, value );
+
+        // Below is a check for a null value where such a value is ignored. This may look strange, but the
+        // reason is that there was this bug where adding a null value to an index would be fine and written
+        // into the log as a command, to later fail during application of that command, i.e. here.
+        // There was a fix introduced to throw IllegalArgumentException out to user right away if passing in
+        // null or object that had toString() produce null. Although databases already affected by this would
+        // not be able to recover, which is why this check is here.
+        if ( value != null )
+        {
+            context.ensureWriterInstantiated();
+            RelationshipData entityId = new RelationshipData( command.getEntityId(),
+                    command.getStartNode(), command.getEndNode() );
+            context.indexType.addToDocument( context.getDocument( entityId, true ).document, key, value );
+        }
         return false;
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/LuceneIndex.java
@@ -101,6 +101,7 @@ public abstract class LuceneIndex implements LegacyIndex
     public void addNode( long entityId, String key, Object value )
     {
         assertValidKey( key );
+        assertValidValue( value );
         EntityId entity = new IdData( entityId );
         for ( Object oneValue : IoPrimitiveUtils.asArray( value ) )
         {
@@ -112,11 +113,12 @@ public abstract class LuceneIndex implements LegacyIndex
 
     protected Object getCorrectValue( Object value )
     {
-        if ( value instanceof ValueContext )
-        {
-            return ((ValueContext) value).getCorrectValue();
-        }
-        return value.toString();
+        assertValidValue( value );
+        Object result = value instanceof ValueContext
+                ? ((ValueContext) value).getCorrectValue()
+                : value.toString();
+        assertValidValue( value );
+        return result;
     }
 
     private static void assertValidKey( String key )
@@ -126,6 +128,19 @@ public abstract class LuceneIndex implements LegacyIndex
             throw new IllegalArgumentException( "Key " + key + " forbidden" );
         }
     }
+
+    private static void assertValidValue( Object singleValue )
+    {
+        if ( singleValue == null )
+        {
+            throw new IllegalArgumentException( "Null value" );
+        }
+        if ( !(singleValue instanceof Number) && singleValue.toString() == null )
+        {
+            throw new IllegalArgumentException( "Value of type " + singleValue.getClass() + " has null toString" );
+        }
+    }
+
 
     /**
      * See {@link Index#remove(PropertyContainer, String, Object)} for more
@@ -433,6 +448,7 @@ public abstract class LuceneIndex implements LegacyIndex
         public void addRelationship( long entityId, String key, Object value, long startNode, long endNode )
         {
             assertValidKey( key );
+            assertValidValue( value );
             RelationshipData entity = new RelationshipData( entityId, startNode, endNode );
             for ( Object oneValue : IoPrimitiveUtils.asArray( value ) )
             {

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestLuceneIndex.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/TestLuceneIndex.java
@@ -57,6 +57,7 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.index.lucene.QueryContext;
 import org.neo4j.index.lucene.ValueContext;
 import org.neo4j.kernel.GraphDatabaseAPI;
+import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 
 import static org.apache.lucene.search.NumericRangeQuery.newIntRange;
@@ -1884,5 +1885,65 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
         hits = index.get( "Type", type.name(), start, end );
         assertEquals( 0, count( (Iterator<Relationship>)hits ) );
         assertEquals( 0, hits.size() );
+    }
+
+    @Test
+    public void shouldNotBeAbleToAddNullValuesToNodeIndex() throws Exception
+    {
+        // GIVEN
+        Index<Node> index = nodeIndex( EXACT_CONFIG );
+
+        // WHEN single null
+        try
+        {
+            index.add( graphDb.createNode(), "key", null );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // THEN Good
+        }
+
+        // WHEN null in array
+        try
+        {
+            index.add( graphDb.createNode(), "key", new String[] {"a", null, "c"} );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // THEN Good
+        }
+    }
+
+    @Test
+    public void shouldNotBeAbleToAddNullValuesToRelationshipIndex() throws Exception
+    {
+        // GIVEN
+        RelationshipIndex index = relationshipIndex( EXACT_CONFIG );
+
+        // WHEN single null
+        try
+        {
+            index.add( graphDb.createNode().createRelationshipTo( graphDb.createNode(), MyRelTypes.TEST ), "key",
+                    null );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // THEN Good
+        }
+
+        // WHEN null in array
+        try
+        {
+            index.add( graphDb.createNode().createRelationshipTo( graphDb.createNode(), MyRelTypes.TEST ), "key",
+                    new String[] {"a", null, "c"} );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // THEN Good
+        }
     }
 }


### PR DESCRIPTION
adds some null checks to prevent value objects, who are null or whose
toString() method returns null, from being passed to Lucene as an index value.
Also, databases which crashed by the issue described in https://github.com/neo4j/neo4j/issues/6685
will recover successfully again.

main author: @amorgner
