### PR TITLE
Update version of internal dependencies

### DIFF
--- a/community/cypher/compatibility-suite/pom.xml
+++ b/community/cypher/compatibility-suite/pom.xml
@@ -48,7 +48,7 @@
     <version-package>cypher.internal</version-package>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
-    <opencypher.version>1.2016-04-22</opencypher.version>
+    <opencypher.version>1.2016-05-11</opencypher.version>
   </properties>
 
   <repositories>

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
@@ -102,58 +102,7 @@ class CypherTCKSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
   }
 
   Then(EXPECT_ERROR) { (typ: String, phase: String, detail: String) =>
-    phase match {
-      case TCKErrorPhases.COMPILE_TIME => checkError(result, typ, phase, detail)
-      case TCKErrorPhases.RUNTIME => result match {
-        case Success(triedResult) =>
-          // might need to exhaust result to provoke error
-          val consumedResult = Try {
-            while (triedResult.hasNext) {
-              triedResult.next()
-            }
-            triedResult
-          }
-          checkError(consumedResult, typ, phase, detail)
-        case x => checkError(x, typ, phase, detail)
-      }
-      case _ => fail(s"Unknown phase $phase specified. Supported values are '${TCKErrorPhases.COMPILE_TIME}' and '${TCKErrorPhases.RUNTIME}'.")
-    }
-  }
-
-  private def checkError(result: Try[Result], typ: String, phase: String, detail: String) = {
-    val statusType = if (typ == TCKErrorTypes.CONSTRAINT_VALIDATION_FAILED) "Schema" else "Statement"
-    result match {
-      case Failure(e: QueryExecutionException) =>
-        s"Neo.ClientError.$statusType.$typ" should equal(e.getStatusCode)
-
-        // Compile time errors
-        if (e.getMessage.matches("Invalid input .+ is not a valid value, must be a positive integer[\\s.\\S]+"))
-          detail should equal(NEGATIVE_INTEGER_ARGUMENT)
-        else if (e.getMessage.matches("Can't use aggregate functions inside of aggregate functions\\."))
-          detail should equal(NESTED_AGGREGATION)
-
-        // Runtime errors
-        else if (e.getMessage.matches("Expected .+ to be a java.lang.String, but it was a .+"))
-          detail should equal(MAP_ELEMENT_ACCESS_BY_NON_STRING)
-        else if (e.getMessage.matches("Expected .+ to be a java.lang.Number, but it was a .+"))
-          detail should equal(LIST_ELEMENT_ACCESS_BY_NON_INTEGER)
-        else if (e.getMessage.matches(".+ is not a collection or a map. Element access is only possible by performing a collection lookup using an integer index, or by performing a map lookup using a string key .+"))
-          detail should equal(INVALID_ELEMENT_ACCESS)
-        else if (e.getMessage.matches(".+ can not create a new node due to conflicts with( both)? existing( and missing)? unique nodes.*"))
-          detail should equal(CREATE_BLOCKED_BY_CONSTRAINT)
-        else if (e.getMessage.matches("Node [0-9]+ already exists with label .+ and property \".+\"=\\[.+\\]"))
-          detail should equal(CREATE_BLOCKED_BY_CONSTRAINT)
-        else if (e.getMessage.matches("Cannot delete node\\<\\d+\\>, because it still has relationships. To delete this node, you must first delete its relationships."))
-          detail should equal(DELETE_CONNECTED_NODE)
-
-        else fail(s"Unknown $phase error: $e", e)
-
-      case Failure(e) =>
-        fail(s"Unknown $phase error: $e", e)
-
-      case _: Success[_] =>
-        fail(s"No $phase error was raised")
-    }
+    TCKErrorHandler(typ, phase, detail).check(result)
   }
 
   Then(EXPECT_SORTED_RESULT) { (expectedTable: DataTable) =>

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/TCKErrorHandler.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/TCKErrorHandler.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cypher.feature.steps
+
+import org.neo4j.graphdb.{QueryExecutionException, Result}
+import org.opencypher.tools.tck.constants.TCKErrorDetails._
+import org.opencypher.tools.tck.constants.{TCKErrorPhases, TCKErrorTypes}
+import org.scalatest.{Assertions, Matchers}
+
+import scala.util.{Failure, Success, Try}
+
+case class TCKErrorHandler(typ: String, phase: String, detail: String) extends Matchers with Assertions {
+
+  def check(result: Try[Result]) = {
+    phase match {
+      case TCKErrorPhases.COMPILE_TIME => checkError(result, typ, phase, detail)
+      case TCKErrorPhases.RUNTIME => result match {
+        case Success(triedResult) =>
+          // might need to exhaust result to provoke error
+          val consumedResult = Try {
+            while (triedResult.hasNext) {
+              triedResult.next()
+            }
+            triedResult
+          }
+          checkError(consumedResult, typ, phase, detail)
+        case x => checkError(x, typ, phase, detail)
+      }
+      case _ => fail(s"Unknown phase $phase specified. Supported values are '${TCKErrorPhases.COMPILE_TIME}' and '${TCKErrorPhases.RUNTIME}'.")
+    }
+  }
+
+  private def checkError(result: Try[Result], typ: String, phase: String, detail: String) = {
+    val statusType = if (typ == TCKErrorTypes.CONSTRAINT_VALIDATION_FAILED) "Schema" else "Statement"
+    result match {
+      case Failure(e: QueryExecutionException) =>
+        s"Neo.ClientError.$statusType.$typ" should equal(e.getStatusCode)
+
+        // Compile time errors
+        if (e.getMessage.matches("Invalid input .+ is not a valid value, must be a positive integer[\\s.\\S]+"))
+          detail should equal(NEGATIVE_INTEGER_ARGUMENT)
+        else if (e.getMessage.matches("Can't use aggregate functions inside of aggregate functions\\."))
+          detail should equal(NESTED_AGGREGATION)
+
+        // Runtime errors
+        else if (e.getMessage.matches("Expected .+ to be a java.lang.String, but it was a .+"))
+          detail should equal(MAP_ELEMENT_ACCESS_BY_NON_STRING)
+        else if (e.getMessage.matches("Expected .+ to be a java.lang.Number, but it was a .+"))
+          detail should equal(LIST_ELEMENT_ACCESS_BY_NON_INTEGER)
+        else if (e.getMessage.matches(".+ is not a collection or a map. Element access is only possible by performing a collection lookup using an integer index, or by performing a map lookup using a string key .+"))
+          detail should equal(INVALID_ELEMENT_ACCESS)
+        else if (e.getMessage.matches(".+ can not create a new node due to conflicts with( both)? existing( and missing)? unique nodes.*"))
+          detail should equal(CREATE_BLOCKED_BY_CONSTRAINT)
+        else if (e.getMessage.matches("Node [0-9]+ already exists with label .+ and property \".+\"=\\[.+\\]"))
+          detail should equal(CREATE_BLOCKED_BY_CONSTRAINT)
+        else if (e.getMessage.matches("Cannot delete node\\<\\d+\\>, because it still has relationships. To delete this node, you must first delete its relationships."))
+          detail should equal(DELETE_CONNECTED_NODE)
+
+        else fail(s"Unknown $phase error: $e", e)
+
+      case Failure(e) =>
+        fail(s"Unknown $phase error: $e", e)
+
+      case _: Success[_] =>
+        fail(s"No $phase error was raised")
+    }
+
+  }
+}

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/DeleteEntityAction.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/DeleteEntityAction.scala
@@ -47,7 +47,7 @@ case class DeleteEntityAction(elementToDelete: Expression, forced: Boolean)
   private def delete(x: graphdb.PropertyContainer, state: QueryState, forced: Boolean) {
     x match {
       case n: graphdb.Node if !state.query.nodeOps.isDeletedInThisTx(n) =>
-        if (forced) state.query.nodeOps.detachDelete(n)
+        if (forced) state.query.detachDelete(n)
         else state.query.nodeOps.delete(n)
 
       case r: graphdb.Relationship if !state.query.relationshipOps.isDeletedInThisTx(r) =>

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/DeletePipe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/DeletePipe.scala
@@ -52,7 +52,7 @@ case class DeletePipe(src: Pipe, expression: Expression, forced: Boolean)(val es
   }
 
   private def deleteNode(n: Node)(implicit state: QueryState) = if (!state.query.nodeOps.isDeletedInThisTx(n)) {
-    if (forced) state.query.nodeOps.detachDelete(n)
+    if (forced) state.query.detachDelete(n)
     else state.query.nodeOps.delete(n)
   }
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/DelegatingQueryContext.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/DelegatingQueryContext.scala
@@ -33,6 +33,7 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
 
   protected def singleDbHit[A](value: A): A = value
   protected def manyDbHits[A](value: Iterator[A]): Iterator[A] = value
+  protected def manyDbHits(count: Int): Int = count
 
   type EntityAccessor = inner.EntityAccessor
 
@@ -191,17 +192,16 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
 
   override def isGraphKernelResultValue(v: Any): Boolean =
     inner.isGraphKernelResultValue(v)
+
+  override def detachDelete(node: Node): Int = manyDbHits(inner.detachDelete(node))
 }
 
 class DelegatingOperations[T <: PropertyContainer](protected val inner: Operations[T]) extends Operations[T] {
 
   protected def singleDbHit[A](value: A): A = value
   protected def manyDbHits[A](value: Iterator[A]): Iterator[A] = value
-  protected def manyDbHits(count: Int): Int = count
 
   override def delete(obj: T): Unit = singleDbHit(inner.delete(obj))
-
-  override def detachDelete(obj: T) = manyDbHits(inner.detachDelete(obj))
 
   override def setProperty(obj: Long, propertyKey: Int, value: Any): Unit =
     singleDbHit(inner.setProperty(obj, propertyKey, value))

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContext.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContext.scala
@@ -165,12 +165,12 @@ trait QueryContext extends TokenContext {
   // Check if a runtime value is a node, relationship, path or some such value returned from
   // other query context values by calling down to the underlying database
   def isGraphKernelResultValue(v: Any): Boolean
+
+  def detachDelete(node: Node): Int
 }
 
 trait Operations[T <: PropertyContainer] {
   def delete(obj: T)
-
-  def detachDelete(obj: T): Int
 
   def setProperty(obj: Long, propertyKeyId: Int, value: Any)
 

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContextAdaptation.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/QueryContextAdaptation.scala
@@ -157,4 +157,6 @@ trait QueryContextAdaptation {
   override def getPropertyKeyName(id: Int): String = ???
 
   override def getLabelId(labelName: String): Int = ???
+
+  override def detachDelete(node: Node): Int = ???
 }

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -216,7 +216,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-3.0</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_1.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/ExceptionTranslatingQueryContextFor3_1.scala
@@ -216,6 +216,8 @@ class ExceptionTranslatingQueryContextFor3_1(val inner: QueryContext) extends Qu
   override def getOptRelTypeId(relType: String) =
     translateException(inner.getOptRelTypeId(relType))
 
+  override def detachDelete(node: Node): Int = translateException(inner.detachDelete(node))
+
   class ExceptionTranslatingOperations[T <: PropertyContainer](inner: Operations[T])
     extends DelegatingOperations[T](inner) {
     override def delete(obj: T) =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_0/TransactionBoundQueryContext.scala
@@ -347,6 +347,14 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
 
     override def releaseExclusiveLock(obj: Long) =
       transactionalContext.statement.readOperations().releaseExclusive(ResourceTypes.NODE, obj)
+
+    override def detachDelete(obj: Node): Int =
+      try {
+        transactionalContext.statement.dataWriteOperations().nodeDetachDelete(obj.getId)
+      } catch {
+        case _: exceptions.EntityNotFoundException => 0
+        // node has been deleted by another transaction, oh well...
+      }
   }
 
   class RelationshipOperations extends BaseOperations[Relationship] {
@@ -410,6 +418,8 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
 
     override def releaseExclusiveLock(obj: Long) =
       transactionalContext.statement.readOperations().acquireExclusive(ResourceTypes.RELATIONSHIP, obj)
+
+    override def detachDelete(obj: Relationship): Int = ???
   }
 
   override def getOrCreatePropertyKeyId(propertyKey: String) =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundQueryContext.scala
@@ -298,14 +298,6 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
       }
     }
 
-    override def detachDelete(obj: Node): Int = {
-      try {
-        transactionalContext.statement.dataWriteOperations().nodeDetachDelete(obj.getId)
-      } catch {
-        case _: exceptions.EntityNotFoundException => 0 // node has been deleted by another transaction, oh well...
-      }
-    }
-
     override def propertyKeyIds(id: Long): Iterator[Int] =
       JavaConversionSupport.asScala(transactionalContext.statement.readOperations().nodeGetPropertyKeys(id))
 
@@ -366,8 +358,6 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
         case _: exceptions.EntityNotFoundException => // node has been deleted by another transaction, oh well...
       }
     }
-
-    override def detachDelete(obj: Relationship): Int = ???
 
     override def propertyKeyIds(id: Long): Iterator[Int] =
       asScala(transactionalContext.statement.readOperations().relationshipGetPropertyKeys(id))
@@ -617,6 +607,14 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
         if (filters.isEmpty) nextNode
         else if (filters.forall(filter => filter test nextNode)) nextNode
         else null
+    }
+  }
+
+  override def detachDelete(node: Node): Int = {
+    try {
+      transactionalContext.statement.dataWriteOperations().nodeDetachDelete(node.getId)
+    } catch {
+      case _: exceptions.EntityNotFoundException => 0 // node has been deleted by another transaction, oh well...
     }
   }
 }


### PR DESCRIPTION
- Bump `cypher-compiler-3.0` to use `3.0.1`
- Bump openCypher to latest version
- Small refactoring of error handling in the TCK implementation
- Refactor of `detachDelete()` function to remove inherited variant with a `Relationship` parameter
