### PR TITLE
Do not return internal point type

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{CRS, CartesianPoint, GeographicPoint}
+import org.neo4j.cypher.internal.compiler.v3_0.{CRS, CartesianPoint, GeographicPoint}
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, SyntaxException}
 
 class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/Geometry.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/Geometry.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0
+
+trait Geometry {
+  def coordinates: Seq[Double]
+  def crs: CRS
+}
+
+trait Point extends Geometry {
+  def x: Double
+  def y: Double
+  def coordinates = Vector(x, y)
+}
+
+case class CartesianPoint(x: Double, y: Double) extends Point {
+  def crs = CRS.Cartesian
+}
+
+case class GeographicPoint(longitude: Double, latitude: Double, crs: CRS) extends Point {
+  def x: Double = longitude
+  def y: Double = latitude
+}
+
+case class CRS(name: String, code: Int, url: String)
+
+object CRS {
+  val Cartesian = CRS("cartesian", 7203, "http://spatialreference.org/ref/sr-org/7203/")
+  val WGS84 = CRS("WGS-84", 4326, "http://spatialreference.org/ref/epsg/4326/")
+
+  def fromName(name: String) = name match {
+    case Cartesian.name => Cartesian
+    case WGS84.name => WGS84
+    case _ => throw new UnsupportedOperationException("Invalid or unsupported CRS name: " + name)
+  }
+
+  def fromSRID(id: Int) = id match {
+    case Cartesian.`code` => Cartesian
+    case WGS84.`code` => WGS84
+    case _ => throw new UnsupportedOperationException("Invalid or unsupported SRID: " + id)
+  }
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/PipeExecutionResult.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/PipeExecutionResult.scala
@@ -45,7 +45,7 @@ class PipeExecutionResult(val result: ResultIterator,
 
   self =>
 
-  val javaValues = new RuntimeJavaValueConverter(state.query.isGraphKernelResultValue)
+  val javaValues = new RuntimeJavaValueConverter(state.query.isGraphKernelResultValue, state.publicTypeConverter)
   lazy val dumpToString = withDumper(dumper => dumper.dumpToString(_))
 
   def dumpToString(writer: PrintWriter) { withDumper(dumper => dumper.dumpToString(writer)(_)) }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/RuntimeBuilder.scala
@@ -109,14 +109,16 @@ case class ErrorReportingRuntimeBuilder(compiledProducer: CompiledPlanBuilder) e
       InvalidArgumentException("The given query is not currently supported in the selected runtime")
 }
 
-case class InterpretedPlanBuilder(clock: Clock, monitors: Monitors) {
+case class InterpretedPlanBuilder(clock: Clock, monitors: Monitors, publicTypeConverter: Any => Any) {
 
   def apply(periodicCommit: Option[PeriodicCommit], logicalPlan: LogicalPlan, pipeBuildContext: PipeExecutionBuilderContext,
             planContext: PlanContext, tracer: CompilationPhaseTracer, preparedQuery: PreparedQuerySemantics,
             createFingerprintReference: Option[PlanFingerprint] => PlanFingerprintReference,
             config: CypherCompilerConfiguration) =
     closing(tracer.beginPhase(PIPE_BUILDING)) {
-      interpretedToExecutionPlan(new PipeExecutionPlanBuilder(clock, monitors).build(periodicCommit, logicalPlan)(pipeBuildContext, planContext), planContext, preparedQuery, createFingerprintReference, config)
+      interpretedToExecutionPlan(new PipeExecutionPlanBuilder(clock, monitors)
+                                   .build(periodicCommit, logicalPlan)(pipeBuildContext, planContext),
+                                 planContext, preparedQuery, createFingerprintReference, config, publicTypeConverter)
     }
 }
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/coerce.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/coerce.scala
@@ -19,9 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.commands
 
-import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.Point
+import org.neo4j.cypher.internal.compiler.v3_0.Point
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.{IsCollection, IsMap}
-import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_0.CypherTypeException
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/DistanceFunction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/DistanceFunction.scala
@@ -19,12 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.commands.expressions
 
-import org.neo4j.cypher.internal.compiler.v3_0.ExecutionContext
+import java.lang.Math._
+
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryState
 import org.neo4j.cypher.internal.compiler.v3_0.symbols.SymbolTable
+import org.neo4j.cypher.internal.compiler.v3_0.{CRS, ExecutionContext, Geometry}
 import org.neo4j.cypher.internal.frontend.v3_0.CypherTypeException
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
-import Math._
 
 case class DistanceFunction(p1: Expression, p2: Expression) extends Expression {
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.CypherException
 
 import scala.collection.mutable
 
-case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: List[String]) extends ExecutionResultBuilderFactory {
+case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: List[String], publicTypeConverter: Any => Any) extends ExecutionResultBuilderFactory {
   def create(): ExecutionResultBuilder =
     ExecutionWorkflowBuilder()
 
@@ -58,7 +58,9 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo, columns: Lis
 
     def build(queryId: AnyRef, planType: ExecutionMode, params: Map[String, Any], notificationLogger: InternalNotificationLogger): InternalExecutionResult = {
       taskCloser.addTask(queryContext.transactionalContext.close)
-      val state = new QueryState(queryContext, externalResource, params, pipeDecorator, queryId = queryId, triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty)
+      val state = new QueryState(queryContext, externalResource, params, pipeDecorator, queryId = queryId,
+                                 triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty,
+                                 publicTypeConverter = publicTypeConverter)
       try {
         try {
           createResults(state, planType, notificationLogger)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionPlanBuilder.scala
@@ -109,10 +109,11 @@ class ExecutionPlanBuilder(graph: GraphDatabaseQueryService,
 object InterpretedExecutionPlanBuilder {
   def interpretedToExecutionPlan(pipeInfo: PipeInfo, planContext: PlanContext, inputQuery: PreparedQuerySemantics,
                                  createFingerprintReference:Option[PlanFingerprint]=>PlanFingerprintReference,
-                                 config: CypherCompilerConfiguration) = {
+                                 config: CypherCompilerConfiguration,
+                                 publicTypeConverter: Any => Any) = {
     val PipeInfo(pipe, updating, periodicCommitInfo, fp, planner) = pipeInfo
     val columns = inputQuery.statement.returnColumns
-    val resultBuilderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, columns)
+    val resultBuilderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, columns, publicTypeConverter = publicTypeConverter)
     val func = getExecutionPlanFunction(periodicCommitInfo, inputQuery.queryText, updating, resultBuilderFactory, inputQuery
       .notificationLogger)
     new ExecutionPlan {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/StandardInternalExecutionResult.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/StandardInternalExecutionResult.scala
@@ -204,7 +204,7 @@ object StandardInternalExecutionResult {
 
     self: StandardInternalExecutionResult =>
 
-    val javaValues = new RuntimeJavaValueConverter(isGraphKernelResultValue)
+    val javaValues = new RuntimeJavaValueConverter(isGraphKernelResultValue, identity)
 
     @throws(classOf[Exception])
     def accept[EX <: Exception](visitor: InternalResultVisitor[EX]) = {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/procs/DelegatingProcedureExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/procs/DelegatingProcedureExecutablePlanBuilder.scala
@@ -32,7 +32,7 @@ import org.neo4j.cypher.internal.frontend.v3_0.symbols.TypeSpec
   *
   * @param delegate The plan builder to delegate to
   */
-case class DelegatingProcedureExecutablePlanBuilder(delegate: ExecutablePlanBuilder) extends ExecutablePlanBuilder {
+case class DelegatingProcedureExecutablePlanBuilder(delegate: ExecutablePlanBuilder, publicTypeConverter: Any => Any) extends ExecutablePlanBuilder {
 
   override def producePlan(inputQuery: PreparedQuerySemantics, planContext: PlanContext, tracer: CompilationPhaseTracer,
                            createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference): ExecutionPlan = {
@@ -45,7 +45,7 @@ case class DelegatingProcedureExecutablePlanBuilder(delegate: ExecutablePlanBuil
         val mkException = new SyntaxExceptionCreator(inputQuery.queryText, inputQuery.offset)
         errors.foreach { error => throw mkException(error.msg, error.position) }
 
-        ProcedureCallExecutionPlan(signature, args, resolved.callResultTypes, resolved.callResultIndices)
+        ProcedureCallExecutionPlan(signature, args, resolved.callResultTypes, resolved.callResultIndices, publicTypeConverter)
 
       // CREATE CONSTRAINT ON (node:Label) ASSERT node.prop IS UNIQUE
       case CreateUniquePropertyConstraint(node, label, prop) =>

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -43,7 +43,8 @@ import org.neo4j.cypher.internal.frontend.v3_0.symbols.CypherType
 case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
                                       argExprs: Seq[Expression],
                                       resultSymbols: Seq[(String, CypherType)],
-                                      resultIndices: Seq[(Int, String)])
+                                      resultIndices: Seq[(Int, String)],
+                                      publicTypeConverter: Any => Any)
   extends ExecutionPlan {
 
   private val argExprCommands = argExprs.map(toCommandExpression)
@@ -88,7 +89,7 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
   }
 
   private def evaluateArguments(ctx: QueryContext, params: Map[String, Any]): Seq[Any] = {
-    val converter = new RuntimeJavaValueConverter(ctx.isGraphKernelResultValue)
+    val converter = new RuntimeJavaValueConverter(ctx.isGraphKernelResultValue, publicTypeConverter)
     val state = new QueryState(ctx, ExternalCSVResource.empty, params)
     argExprCommands.map(expr => converter.asDeepJavaValue(expr.apply(ExecutionContext.empty)(state)))
   }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeJavaValueConverter.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeJavaValueConverter.scala
@@ -32,7 +32,7 @@ import scala.collection.Map
 //
 // Main use: Converting parameters when using ExecutionEngine from scala
 //
-class RuntimeJavaValueConverter(skip: Any => Boolean) {
+class RuntimeJavaValueConverter(skip: Any => Boolean, converter: Any => Any) {
 
   final def asDeepJavaMap[S](map: Map[S, Any]): JavaMap[S, Any] =
     if (map == null) null else immutableMapValues(map, asDeepJavaValue).asJava: JavaMap[S, Any]
@@ -42,7 +42,7 @@ class RuntimeJavaValueConverter(skip: Any => Boolean) {
     case map: Map[_, _] => immutableMapValues(map, asDeepJavaValue).asJava: JavaMap[_, _]
     case iterable: Iterable[_] => iterable.map(asDeepJavaValue).toVector.asJava: JavaList[_]
     case traversable: TraversableOnce[_] => traversable.map(asDeepJavaValue).toVector.asJava: JavaList[_]
-    case anything => anything
+    case anything => converter(anything)
   }
 
   case class feedIteratorToVisitable[EX <: Exception](iterator: Iterator[Map[String, Any]]) {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ProcedureCallPipe.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/ProcedureCallPipe.scala
@@ -58,7 +58,7 @@ case class ProcedureCallPipe(source: Pipe,
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     //register as parent so that stats are associated with this pipe
     state.decorator.registerParentPipe(this)
-    val converter = new RuntimeJavaValueConverter(state.query.isGraphKernelResultValue)
+    val converter = new RuntimeJavaValueConverter(state.query.isGraphKernelResultValue, state.publicTypeConverter)
 
     rowProcessor(input, state, converter)
   }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
@@ -39,7 +39,8 @@ class QueryState(val query: QueryContext,
                  var initialContext: Option[ExecutionContext] = None,
                  val queryId: AnyRef = UUID.randomUUID().toString,
                  val triadicState: mutable.Map[String, PrimitiveLongSet] = mutable.Map.empty,
-                 val repeatableReads: mutable.Map[Pipe, Seq[ExecutionContext]] = mutable.Map.empty) {
+                 val repeatableReads: mutable.Map[Pipe, Seq[ExecutionContext]] = mutable.Map.empty,
+                 val publicTypeConverter: Any => Any = identity) {
   private var _pathValueBuilder: PathValueBuilder = null
 
   def clearPathValueBuilder = {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedExecutablePlanBuilder.scala
@@ -35,8 +35,6 @@ import org.neo4j.cypher.internal.compiler.v3_0.tracing.rewriters.{ApplyRewriter,
 import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.{InternalException, Scope, SemanticTable}
 
-import scala.util.Try
-
 /* This class is responsible for taking a query from an AST object to a runnable object.  */
 case class CostBasedExecutablePlanBuilder(monitors: Monitors,
                                           metricsFactory: MetricsFactory,
@@ -48,10 +46,12 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
                                           plannerName: CostBasedPlannerName,
                                           runtimeBuilder: RuntimeBuilder,
                                           updateStrategy: UpdateStrategy,
-                                          config: CypherCompilerConfiguration)
+                                          config: CypherCompilerConfiguration,
+                                          publicTypeConverter: Any => Any)
   extends ExecutablePlanBuilder {
 
-  override def producePlan(inputQuery: PreparedQuerySemantics, planContext: PlanContext, tracer: CompilationPhaseTracer, createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference) = {
+  override def producePlan(inputQuery: PreparedQuerySemantics, planContext: PlanContext, tracer: CompilationPhaseTracer,
+                           createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference) = {
     val statement =
       CostBasedExecutablePlanBuilder.rewriteStatement(
         statement = inputQuery.statement,
@@ -78,7 +78,8 @@ case class CostBasedExecutablePlanBuilder(monitors: Monitors,
   }
 
   def produceLogicalPlan(ast: Query, semanticTable: SemanticTable)
-                        (planContext: PlanContext,  notificationLogger: InternalNotificationLogger):
+                        (planContext: PlanContext,
+                         notificationLogger: InternalNotificationLogger):
   (Option[PeriodicCommit], LogicalPlan, PipeExecutionBuilderContext) = {
 
     tokenResolver.resolve(ast)(semanticTable, planContext)

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedPipeBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/CostBasedPipeBuilderFactory.scala
@@ -36,7 +36,8 @@ object CostBasedPipeBuilderFactory {
              plannerName: Option[CostBasedPlannerName],
              runtimeBuilder: RuntimeBuilder,
              config: CypherCompilerConfiguration,
-             updateStrategy: Option[UpdateStrategy]
+             updateStrategy: Option[UpdateStrategy],
+             publicTypeConverter: Any => Any
   ) = {
 
     def createQueryGraphSolver(n: CostBasedPlannerName): QueryGraphSolver = n match {
@@ -63,6 +64,6 @@ object CostBasedPipeBuilderFactory {
     CostBasedExecutablePlanBuilder(monitors, metricsFactory, tokenResolver, queryPlanner,
       createQueryGraphSolver(actualPlannerName), rewriterSequencer, semanticChecker, actualPlannerName, runtimeBuilder,
       actualUpdateStrategy,
-      config)
+      config, publicTypeConverter)
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/execution/PipeExecutionPlanBuilder.scala
@@ -57,7 +57,8 @@ class PipeExecutionPlanBuilder(clock: Clock, monitors: Monitors, pipeBuilderFact
     }
 
     val periodicCommitInfo = periodicCommit.map(x => PeriodicCommitInfo(x.batchSize))
-    PipeInfo(topLevelPipe, plan.solved.exists(_.queryGraph.containsUpdates), periodicCommitInfo, fingerprint, context.plannerName)
+    PipeInfo(topLevelPipe, plan.solved.exists(_.queryGraph.containsUpdates),
+             periodicCommitInfo, fingerprint, context.plannerName)
   }
 
   /*

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/CoerceToTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/CoerceToTest.scala
@@ -19,19 +19,18 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_0.commands.expressions
 
-import org.neo4j.cypher.internal.compiler.v3_0.ExecutionContext
+import java.util.{ArrayList => JavaList, HashMap => JavaMap}
+
 import org.neo4j.cypher.internal.compiler.v3_0.helpers.Counter
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryStateHelper
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
+import org.neo4j.cypher.internal.compiler.v3_0.{ExecutionContext, Point}
 import org.neo4j.cypher.internal.frontend.v3_0.CypherTypeException
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 import org.neo4j.graphdb.{Node, Relationship}
 
 import scala.language.postfixOps
-
-import java.util.{HashMap => JavaMap}
-import java.util.{ArrayList => JavaList}
 
 class CoerceToTest extends CypherFunSuite {
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -23,7 +23,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0._
 import org.neo4j.cypher.internal.compiler.v3_0.pipes.Pipe
-import org.neo4j.cypher.internal.compiler.v3_0.spi.{QueryTransactionalContext, QueryContext}
+import org.neo4j.cypher.internal.compiler.v3_0.spi.{QueryContext, QueryTransactionalContext}
 import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
 
 class ExecutionWorkflowBuilderTest extends CypherFunSuite {
@@ -35,7 +35,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
     when(context.transactionalContext).thenReturn(mock[QueryTransactionalContext])
-    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = true, None, None, PlannerName), List.empty)
+    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = true, None, None, PlannerName), List.empty, identity)
 
     // WHEN
     val builder = builderFactory.create()
@@ -52,7 +52,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     val pipe = mock[Pipe]
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
-    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty)
+    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, identity)
 
     // WHEN
     val builder = builderFactory.create()
@@ -70,7 +70,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
     when(context.transactionalContext).thenReturn(mock[QueryTransactionalContext])
-    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty)
+    val builderFactory = DefaultExecutionResultBuilderFactory(PipeInfo(pipe, updating = false, None, None, PlannerName), List.empty, identity)
 
     // WHEN
     val builder = builderFactory.create()

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/RuleExecutablePlanBuilderTest.scala
@@ -43,7 +43,7 @@ class RuleExecutablePlanBuilderTest extends CypherFunSuite {
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,
     errorIfShortestPathFallbackUsedAtRuntime = false
   )
-  val planBuilder = new LegacyExecutablePlanBuilder(mock[Monitors], config, RewriterStepSequencer.newValidating)
+  val planBuilder = new LegacyExecutablePlanBuilder(mock[Monitors], config, RewriterStepSequencer.newValidating, publicTypeConverter = identity)
 
   test("should_use_distinct_pipe_for_distinct") {
     val pipe = buildExecutionPipe("MATCH n RETURN DISTINCT n")

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/procs/ProcedureCallExecutionPlanTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/procs/ProcedureCallExecutionPlanTest.scala
@@ -34,8 +34,8 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
 
   test("should be able to call procedure with single argument") {
     // Given
-    val proc = ProcedureCallExecutionPlan(readSignature,
-      Seq(add(int(42), int(42))), Seq("b" -> CTInteger), Seq(0 -> "b")
+    val proc = ProcedureCallExecutionPlan(readSignature, Seq(add(int(42), int(42))), Seq("b" -> CTInteger), Seq(0 -> "b"),
+                                          publicTypeConverter = identity
     )
 
     // When
@@ -48,7 +48,8 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
   test("should eagerize write procedure") {
     // Given
     val proc = ProcedureCallExecutionPlan(writeSignature,
-      Seq(add(int(42), int(42))), Seq("b" -> CTInteger), Seq(0 -> "b")
+                                          Seq(add(int(42), int(42))), Seq("b" -> CTInteger), Seq(0 -> "b"),
+                                          publicTypeConverter = identity
     )
 
     // When
@@ -61,7 +62,8 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
   test("should not eagerize read procedure") {
     // Given
     val proc = ProcedureCallExecutionPlan(readSignature,
-      Seq(add(int(42), int(42))), Seq("b" -> CTInteger), Seq(0 -> "b")
+                                          Seq(add(int(42), int(42))), Seq("b" -> CTInteger), Seq(0 -> "b"),
+                                          publicTypeConverter = identity
     )
 
     // When
@@ -86,7 +88,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
     ProcedureReadOnlyAccess
   )
 
-  private val writeSignature =  ProcedureSignature(
+  private val writeSignature = ProcedureSignature(
     QualifiedProcedureName(Seq.empty, "foo"),
     Seq(FieldSignature("a", symbols.CTInteger)),
     Some(Seq(FieldSignature("b", symbols.CTInteger))),
@@ -102,7 +104,8 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
       val input = invocationOnMock.getArguments()(1).asInstanceOf[Seq[AnyRef]]
       new Iterator[Array[AnyRef]] {
         override def hasNext = !iteratorExhausted
-        override def next() = if(hasNext) {
+
+        override def next() = if (hasNext) {
           iteratorExhausted = true
           input.toArray
         } else throw new IllegalStateException("Iterator exhausted")

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RowIteratorVisitationTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RowIteratorVisitationTest.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable.ArrayBuffer
 
 class RowIteratorVisitationTest extends CypherFunSuite {
 
-  val javaValues = new RuntimeJavaValueConverter(_ => false)
+  val javaValues = new RuntimeJavaValueConverter(_ => false, identity)
   import javaValues.feedIteratorToVisitable
 
   test("should convert non-empty iterator to visitor") {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeJavaValueConverterTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/helpers/RuntimeJavaValueConverterTest.scala
@@ -26,7 +26,7 @@ import scala.collection.convert.Wrappers.SeqWrapper
 class RuntimeJavaValueConverterTest extends CypherFunSuite {
 
   test("should used indexed seq when converting list") {
-    val converter: RuntimeJavaValueConverter = new RuntimeJavaValueConverter(_ => false)
+    val converter: RuntimeJavaValueConverter = new RuntimeJavaValueConverter(_ => false, identity)
 
     val converted = converter.asDeepJavaValue(List(1, 2, 3)).asInstanceOf[SeqWrapper[_]]
 
@@ -34,7 +34,7 @@ class RuntimeJavaValueConverterTest extends CypherFunSuite {
   }
 
   test("should used indexed seq when converting iterator") {
-    val converter: RuntimeJavaValueConverter = new RuntimeJavaValueConverter(_ => false)
+    val converter: RuntimeJavaValueConverter = new RuntimeJavaValueConverter(_ => false, identity)
 
     val converted = converter.asDeepJavaValue(List(1, 2, 3).iterator).asInstanceOf[SeqWrapper[_]]
 

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/LogicalPlanningTestSupport.scala
@@ -167,10 +167,11 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
       queryPlanner = queryPlanner,
       rewriterSequencer = rewriterSequencer,
       plannerName = None,
-      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), monitors)),
+      runtimeBuilder = InterpretedRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), monitors, identity)),
       semanticChecker = semanticChecker,
       updateStrategy = None,
-      config = config)
+      config = config,
+      publicTypeConverter = identity)
   }
 
   val config = CypherCompilerConfiguration(

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -76,7 +76,7 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService, logProvider: 
   private val preParsedQueries = new LRUCachev3_0[String, PreParsedQuery](getPlanCacheSize)
   private val parsedQueries = new LRUCachev3_0[String, ParsedQuery](getPlanCacheSize)
 
-  private val javaValues = new RuntimeJavaValueConverter(isGraphKernelResultValue)
+  private val javaValues = new RuntimeJavaValueConverter(isGraphKernelResultValue, identity)
   private val scalaValues = new RuntimeScalaValueConverter(isGraphKernelResultValue)
 
   @throws(classOf[SyntaxException])

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -120,7 +120,8 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
       plannerName = Some(IDPPlannerName),
       runtimeName = Some(CompiledRuntimeName),
       updateStrategy = None,
-      rewriterSequencer = RewriterStepSequencer.newValidating
+      rewriterSequencer = RewriterStepSequencer.newValidating,
+      publicTypeConverter = identity
     )
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherCompilerPerformanceTest.scala
@@ -189,7 +189,8 @@ class CypherCompilerPerformanceTest extends GraphDatabaseFunSuite {
       rewriterSequencer = RewriterStepSequencer.newPlain,
       plannerName = Some(IDPPlannerName),
       runtimeName = Some(CompiledRuntimeName),
-      updateStrategy = None
+      updateStrategy = None,
+      publicTypeConverter = identity
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CompilerComparisonTest.scala
@@ -304,12 +304,14 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
       plannerName = Some(plannerName),
       rewriterSequencer = rewriterSequencer,
       queryPlanner = queryPlanner,
-      runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(clock, monitors), CompiledPlanBuilder(clock,GeneratedQueryStructure)),
+      runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(clock, monitors, identity), CompiledPlanBuilder(clock,GeneratedQueryStructure)),
       semanticChecker = checker,
       config = config,
-      updateStrategy = None
+      updateStrategy = None,
+      publicTypeConverter = identity
     )
-    val pipeBuilder = new SilentFallbackPlanBuilder(new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer), planner,
+    val pipeBuilder = new SilentFallbackPlanBuilder(new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer,
+                                                                                    publicTypeConverter = identity), planner,
                                                     planBuilderMonitor)
     val execPlanBuilder =
       new ExecutionPlanBuilder(graph, clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
@@ -328,7 +330,7 @@ class CompilerComparisonTest extends ExecutionEngineFunSuite with QueryStatistic
     val parser = new CypherParser
     val checker = new SemanticChecker
     val rewriter = new ASTRewriter(rewriterSequencer)
-    val pipeBuilder = new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer)
+    val pipeBuilder = new LegacyExecutablePlanBuilder(monitors, config, rewriterSequencer, publicTypeConverter = identity)
     val execPlanBuilder =
       new ExecutionPlanBuilder(graph, clock, pipeBuilder, PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _))
     val planCacheFactory = () => new LRUCache[Statement, ExecutionPlan](100)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/CypherCompilerAstCacheAcceptanceTest.scala
@@ -57,7 +57,8 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
       plannerName = Some(IDPPlannerName),
       runtimeName = Some(CompiledRuntimeName),
       updateStrategy = None,
-      rewriterSequencer = RewriterStepSequencer.newValidating
+      rewriterSequencer = RewriterStepSequencer.newValidating,
+      publicTypeConverter = identity
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/RuleExecutablePlanBuilderTest.scala
@@ -70,10 +70,11 @@ class RuleExecutablePlanBuilderTest
     queryPlanner = queryPlanner,
     rewriterSequencer = rewriterSequencer,
     plannerName = None,
-    runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), mock[Monitors]), CompiledPlanBuilder(Clock.systemUTC(),GeneratedQueryStructure)),
+    runtimeBuilder = SilentFallbackRuntimeBuilder(InterpretedPlanBuilder(Clock.systemUTC(), mock[Monitors], identity), CompiledPlanBuilder(Clock.systemUTC(),GeneratedQueryStructure)),
     semanticChecker = mock[SemanticChecker],
     updateStrategy = None,
-    config = config
+    config = config,
+    publicTypeConverter = identity
   )
 
   class FakePreparedSemanticQuery(q: AbstractQuery)
@@ -114,7 +115,8 @@ class RuleExecutablePlanBuilderTest
         .updates(DeletePropertyAction(variable, PropertyKey("foo")))
         .returns(ReturnItem(Variable("x"), "x"))
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
+                                                        publicTypeConverter = identity)
 
       val transactionalContext = new TransactionalContextWrapper(new Neo4jTransactionalContext(graph, tx, statement, locker))
       val queryContext = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
@@ -142,7 +144,8 @@ class RuleExecutablePlanBuilderTest
         .where(HasLabel(Variable("x"), Label("Person")))
         .returns(ReturnItem(Variable("x"), "x"))
 
-      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
+      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config,
+                                                            RewriterStepSequencer.newValidating, publicTypeConverter = identity)
       val transactionalContext = new TransactionalContextWrapper(new Neo4jTransactionalContext(graph, tx, statement, locker))
       val queryContext = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
       val labelId = queryContext.getLabelId("Person")
@@ -173,7 +176,8 @@ class RuleExecutablePlanBuilderTest
         .returns(AllVariables())
       val parsedQ = new FakePreparedSemanticQuery(q)
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
+                                                        publicTypeConverter = identity)
       val pipe = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
@@ -201,7 +205,8 @@ class RuleExecutablePlanBuilderTest
         .returns(AllVariables())
       val parsedQ = new FakePreparedSemanticQuery(q)
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
+                                                        publicTypeConverter = identity)
       val pipe = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
@@ -228,7 +233,8 @@ class RuleExecutablePlanBuilderTest
       val parsedQ = new FakePreparedSemanticQuery(q)
 
 
-      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
+      val execPlanBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
+                                                            publicTypeConverter = identity)
       val pipe = execPlanBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).pipe
 
       toSeq(pipe) should equal (Seq(
@@ -252,7 +258,8 @@ class RuleExecutablePlanBuilderTest
       )
       val parsedQ = new FakePreparedSemanticQuery(q)
 
-      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating)
+      val pipeBuilder = new LegacyExecutablePlanBuilder(new WrappedMonitors3_0(kernelMonitors), config, RewriterStepSequencer.newValidating,
+                                                        publicTypeConverter = identity)
 
       // when
       val periodicCommit = pipeBuilder.producePipe(parsedQ, planContext, CompilationPhaseTracer.NO_TRACING).periodicCommit
@@ -264,7 +271,8 @@ class RuleExecutablePlanBuilderTest
   }
 }
 
-class LegacyExecutablePlanBuilderWithCustomPlanBuilders(innerBuilders: Seq[PlanBuilder], monitors:Monitors, config: CypherCompilerConfiguration) extends LegacyExecutablePlanBuilder(monitors, config, RewriterStepSequencer.newValidating) {
+class LegacyExecutablePlanBuilderWithCustomPlanBuilders(innerBuilders: Seq[PlanBuilder], monitors:Monitors, config: CypherCompilerConfiguration)
+  extends LegacyExecutablePlanBuilder(monitors, config, RewriterStepSequencer.newValidating, publicTypeConverter = identity) {
   override val phases = new Phase { def myBuilders: Seq[PlanBuilder] = innerBuilders }
 }
 

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/CRS.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/CRS.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.spatial;
+
+
+/**
+ * A coordinate reference system (CRS) determines how a ${@link Coordinate} should be interpreted
+ * <p>
+ * The CRS is defined by three properties a code, a type, and a link to CRS parameters on the web.
+ * Example:
+ * <code>
+ * {
+ * code: 4326,
+ * type: "WGS-84",
+ * href: "http://spatialreference.org/ref/epsg/4326/"
+ * }
+ * </code>
+ */
+public interface CRS
+{
+
+    /**
+     * The numerical code associated with the CRS
+     *
+     * @return a numerical code associated with the CRS
+     */
+    int getCode();
+
+    /**
+     * The type of the CRS is a descriptive name, indicating which CRS is used
+     *
+     * @return the type of the CRS
+     */
+    String getType();
+
+    /**
+     * A link uniquely identifying the CRS.
+     *
+     * @return A link to where the CRS is described.
+     */
+    String getHref();
+}

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Coordinate.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Coordinate.java
@@ -33,11 +33,11 @@ import static java.util.Arrays.stream;
  * <li>x, y, z ordering in a cartesian reference system</li>
  * <li>east, north, altitude in a projected coordinate reference system</li>
  * <li>longitude, latitude, altitude in a geographic reference system</li>
+ * </ul>
  * <p>
  * Additional numbers are allowed and the meaning of these additional numbers depends on the coordinate reference
  * system
  * (see ${@link CRS})
- * </ul>
  */
 public final class Coordinate
 {

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Coordinate.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Coordinate.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.spatial;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.stream;
+
+/**
+ * A coordinate is used to describe a position in space.
+ * <p>
+ * A coordinate is described by at least two numbers and must adhere to the following ordering
+ * <ul>
+ * <li>x, y, z ordering in a cartesian reference system</li>
+ * <li>east, north, altitude in a projected coordinate reference system</li>
+ * <li>longitude, latitude, altitude in a geographic reference system</li>
+ * <p>
+ * Additional numbers are allowed and the meaning of these additional numbers depends on the coordinate reference
+ * system
+ * (see ${@link CRS})
+ * </ul>
+ */
+public final class Coordinate
+{
+    private final double[] coordinate;
+
+    public Coordinate( double... coordinate )
+    {
+        if ( coordinate.length < 2 )
+        {
+            throw new IllegalArgumentException( "A coordinate must at least two elements" );
+        }
+        this.coordinate = coordinate;
+    }
+
+    /**
+     * Returns the current coordinate.
+     *
+     * @return A list of numbers describing the coordinate.
+     */
+    public List<Double> getCoordinate()
+    {
+        return stream( coordinate ).boxed().collect( Collectors.toList() );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        Coordinate that = (Coordinate) o;
+
+        return Arrays.equals( coordinate, that.coordinate );
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Arrays.hashCode( coordinate );
+    }
+}
+

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Geometry.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Geometry.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.spatial;
+
+import java.util.List;
+
+
+/**
+ * A geometry is defined by a list of coordinates and a coordinate reference system.
+ */
+public interface Geometry
+{
+    /**
+     * Get all coordinates of the geometry.
+     *
+     * @return The coordinates of the geometry.
+     */
+    List<Coordinate> getCoordinates();
+
+    /**
+     * Returns the coordinate reference system associated with the geometry
+     *
+     * @return A ${@link CRS} associated with the geometry
+     */
+    CRS getCRS();
+}

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Point.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/spatial/Point.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.spatial;
+
+/**
+ * A point is a geometry described by a single coordinate in space.
+ * <p>
+ * A call to {@link #getCoordinates()} must return a single element list.
+ */
+public interface Point extends Geometry
+{
+    /**
+     * Returns the single coordinate in space defining this point.
+     *
+     * @return The coordinate of this point.
+     */
+    default Coordinate getCoordinate()
+    {
+        return getCoordinates().get( 0 );
+    }
+}
+

--- a/manual/javadocs/pom.xml
+++ b/manual/javadocs/pom.xml
@@ -138,6 +138,12 @@
       <classifier>sources</classifier>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+      <version>${findbugs.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <licenses>


### PR DESCRIPTION
When using the point function in cypher we should not return internal compiler specific types. This introduces a public API for points and maps to these at runtime.

Note, this introduces new public API so please review that extra carefully.
