### PR TITLE
Mark LabelAcceptance as ported to the TCK

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/WhereAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/WhereAcceptanceTest.scala
@@ -23,14 +23,16 @@ import org.neo4j.cypher.{ExecutionEngineFunSuite, IncomparableValuesException, N
 
 class WhereAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
+  // TCK'd
   test("NOT(p1 AND p2) should return true when p2 is false") {
     createNode("apa")
 
-    val result = executeWithAllPlannersAndCompatibilityMode("match (n)where not(n.name = 'apa' and false) return n")
+    val result = executeWithAllPlannersAndCompatibilityMode("MATCH (n) WHERE NOT(n.name = 'apa' AND false) RETURN n")
 
     result should have size 1
   }
 
+  // TCK'd
   test("should throw exception if comparing string and number") {
     createLabeledNode(Map("prop" -> "15"), "Label")
 
@@ -39,6 +41,7 @@ class WhereAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
     a[IncomparableValuesException] should be thrownBy executeWithAllPlannersAndCompatibilityMode(query)
   }
 
+  // Not TCK material
   test("should be able to handle a large DNF predicate without running out of memory") {
     // given
     val query = """MATCH (a)-[r]->(b) WHERE

--- a/community/cypher/compatibility-suite/pom.xml
+++ b/community/cypher/compatibility-suite/pom.xml
@@ -48,7 +48,7 @@
     <version-package>cypher.internal</version-package>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
-    <opencypher.version>1.2016-05-16</opencypher.version>
+    <opencypher.version>1.2016-05-17</opencypher.version>
   </properties>
 
   <repositories>

--- a/community/cypher/compatibility-suite/pom.xml
+++ b/community/cypher/compatibility-suite/pom.xml
@@ -48,7 +48,7 @@
     <version-package>cypher.internal</version-package>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
-    <opencypher.version>1.2016-05-11</opencypher.version>
+    <opencypher.version>1.2016-05-16</opencypher.version>
   </properties>
 
   <repositories>

--- a/community/cypher/compatibility-suite/src/main/scala/cypher/feature/parser/ParsingFunctions.scala
+++ b/community/cypher/compatibility-suite/src/main/scala/cypher/feature/parser/ParsingFunctions.scala
@@ -23,6 +23,8 @@ import java.util
 
 import cucumber.api.DataTable
 import cypher.feature.parser.matchers.{QueryStatisticsMatcher, ResultMatcher, RowMatcher, ValueMatcher}
+import org.opencypher.tools.tck.InvalidFeatureFormatException
+import org.opencypher.tools.tck.constants.TCKSideEffects._
 
 import scala.collection.JavaConverters._
 
@@ -109,19 +111,13 @@ object statisticsParser extends (DataTable => QueryStatisticsMatcher) {
       case (DELETED_RELATIONSHIPS, index) => matcher.setRelationshipsDeleted(Integer.valueOf(values.get(index)))
       case (ADDED_LABELS, index) => matcher.setLabelsCreated(Integer.valueOf(values.get(index)))
       case (DELETED_LABELS, index) => matcher.setLabelsDeleted(Integer.valueOf(values.get(index)))
-      case (ADDED_PROPS, index) => matcher.setPropertiesCreated(Integer.valueOf(values.get(index)))
-      case (DELETED_PROPS, index) => matcher.setPropertiesDeleted(Integer.valueOf(values.get(index)))
+      case (ADDED_PROPERTIES, index) => matcher.setPropertiesCreated(Integer.valueOf(values.get(index)))
+      case (DELETED_PROPERTIES, index) => matcher.setPropertiesDeleted(Integer.valueOf(values.get(index)))
+      case (sideEffect, _) => throw new InvalidFeatureFormatException(
+        s"Invalid side effect: $sideEffect. Valid ones are: ${ALL.mkString(",")}")
     }
 
     matcher
   }
 
-  val ADDED_NODES = "+nodes"
-  val DELETED_NODES = "-nodes"
-  val ADDED_RELATIONSHIPS = "+relationships"
-  val DELETED_RELATIONSHIPS = "-relationships"
-  val ADDED_LABELS = "+labels"
-  val DELETED_LABELS = "-labels"
-  val ADDED_PROPS = "+properties"
-  val DELETED_PROPS = "-properties"
 }

--- a/community/cypher/compatibility-suite/src/main/scala/cypher/feature/reporting/CypherResultReporter.scala
+++ b/community/cypher/compatibility-suite/src/main/scala/cypher/feature/reporting/CypherResultReporter.scala
@@ -49,8 +49,7 @@ class CypherResultReporter(producer: OutputProducer, jsonWriter: PrintStream, ch
 
   private var query: String = null
   private var status: String = Result.PASSED
-  private val shortQuery: Regex = TCKStepDefinitions.EXECUTING_QUERY.r
-  private val docStringQuery: Regex = TCKStepDefinitions.EXECUTING_LONG_QUERY.r
+  private val execQRegex: Regex = TCKStepDefinitions.EXECUTING_QUERY.r
 
   override def done(): Unit = {
     jsonWriter.println(producer.dump())
@@ -68,8 +67,8 @@ class CypherResultReporter(producer: OutputProducer, jsonWriter: PrintStream, ch
   override def step(step: Step) {
     if (step.getKeyword.trim == "When") {
       step.getName match {
-        case shortQuery(q) => query = q
-        case docStringQuery() => query = step.getDocString.getValue
+        case execQRegex() => query = step.getDocString.getValue
+        case _ => throw new IllegalStateException("An illegal 'When' step was encountered: " + step.getName)
       }
     }
   }

--- a/community/cypher/compatibility-suite/src/main/scala/cypher/feature/reporting/CypherResultReporter.scala
+++ b/community/cypher/compatibility-suite/src/main/scala/cypher/feature/reporting/CypherResultReporter.scala
@@ -50,6 +50,7 @@ class CypherResultReporter(producer: OutputProducer, jsonWriter: PrintStream, ch
   private var query: String = null
   private var status: String = Result.PASSED
   private val execQRegex: Regex = TCKStepDefinitions.EXECUTING_QUERY.r
+  private val controlQRegex = TCKStepDefinitions.EXECUTING_CONTROL_QUERY.r
 
   override def done(): Unit = {
     jsonWriter.println(producer.dump())
@@ -68,6 +69,7 @@ class CypherResultReporter(producer: OutputProducer, jsonWriter: PrintStream, ch
     if (step.getKeyword.trim == "When") {
       step.getName match {
         case execQRegex() => query = step.getDocString.getValue
+        case controlQRegex() => // do nothing
         case _ => throw new IllegalStateException("An illegal 'When' step was encountered: " + step.getName)
       }
     }

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
@@ -157,6 +157,12 @@ class CypherTCKSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
     }
   }
 
+  When(EXECUTING_CONTROL_QUERY) { (query: String) =>
+    result = Try {
+      graph.execute(query, params)
+    }
+  }
+
   private def successful(value: Try[Result]): Result = value match {
     case Success(r) => new ResultWrapper(r)
     case Failure(e) => fail(s"Expected successful result, but got error: $e")

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
@@ -40,6 +40,8 @@ class CypherTCKSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
 
   val requiredScenarioName = FeatureSuiteTest.SCENARIO_NAME_REQUIRED.trim.toLowerCase
 
+  val unsupportedScenarios = Set("Fail when adding new label predicate on already bound node 5")
+
   // Stateful
   var graph: GraphDatabaseService = null
   var result: Try[Result] = null
@@ -152,7 +154,8 @@ class CypherTCKSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
   }
 
   private def ifEnabled(f: => Unit): Unit = {
-    if (requiredScenarioName.isEmpty || currentScenarioName.contains(requiredScenarioName)) {
+    val blacklist = unsupportedScenarios.map(_.toLowerCase)
+    if (!blacklist(currentScenarioName) && (requiredScenarioName.isEmpty || currentScenarioName.contains(requiredScenarioName))) {
       f
     }
   }

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
@@ -89,13 +89,6 @@ class CypherTCKSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
     }
   }
 
-  And(INIT_LONG_QUERY) { (query: String) =>
-    ifEnabled {
-      // side effects are necessary for setting up graph state
-      graph.execute(query)
-    }
-  }
-
   And(PARAMETERS) { (values: DataTable) =>
     ifEnabled {
       params = parseParameters(values)
@@ -103,14 +96,6 @@ class CypherTCKSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
   }
 
   When(EXECUTING_QUERY) { (query: String) =>
-    ifEnabled {
-      result = Try {
-        graph.execute(query, params)
-      }
-    }
-  }
-
-  When(EXECUTING_LONG_QUERY) { (query: String) =>
     ifEnabled {
       result = Try {
         graph.execute(query, params)

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/TCKErrorHandler.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/TCKErrorHandler.scala
@@ -59,7 +59,9 @@ case class TCKErrorHandler(typ: String, phase: String, detail: String) extends M
         else if (e.getMessage.matches("Can't use aggregate functions inside of aggregate functions\\."))
           detail should equal(NESTED_AGGREGATION)
         else if (e.getMessage.matches("Can't create node `(\\w+)` with labels or properties here. The variable is already declared in this context"))
-          detail should equal("VariableAlreadyBound")
+          detail should equal(VARIABLE_ALREADY_BOUND)
+        else if (e.getMessage.matches("Can't create node `\\w+` with labels or properties here. The variable is already declared in this context"))
+          detail should equal(VARIABLE_ALREADY_BOUND)
 
         // Runtime errors
         else if (e.getMessage.matches("Expected .+ to be a java.lang.String, but it was a .+"))

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/TCKErrorHandler.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/TCKErrorHandler.scala
@@ -60,7 +60,7 @@ case class TCKErrorHandler(typ: String, phase: String, detail: String) extends M
           detail should equal(NESTED_AGGREGATION)
         else if (e.getMessage.matches("Can't create node `(\\w+)` with labels or properties here. The variable is already declared in this context"))
           detail should equal(VARIABLE_ALREADY_BOUND)
-        else if (e.getMessage.matches("Can't create node `\\w+` with labels or properties here. The variable is already declared in this context"))
+        else if (e.getMessage.matches("Can't create `\\w+` with properties or labels here. The variable is already declared in this context"))
           detail should equal(VARIABLE_ALREADY_BOUND)
 
         // Runtime errors

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/TCKErrorHandler.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/TCKErrorHandler.scala
@@ -74,6 +74,8 @@ case class TCKErrorHandler(typ: String, phase: String, detail: String) extends M
           detail should equal(CREATE_BLOCKED_BY_CONSTRAINT)
         else if (e.getMessage.matches("Cannot delete node\\<\\d+\\>, because it still has relationships. To delete this node, you must first delete its relationships."))
           detail should equal(DELETE_CONNECTED_NODE)
+        else if (e.getMessage.matches("Don't know how to compare that\\..+"))
+          detail should equal(INCOMPARABLE_VALUES)
 
         else fail(s"Unknown $phase error: $e", e)
 


### PR DESCRIPTION
- Basically rewrite the test class to adhere to current standards, like `NewPlannerTestSupport`
- Clean up some duplicate code in TCK implementation
- Implement 'control query' notion in TCK - assert on the graph state after having executed an updating query using a new query and its results
