### PR TITLE
Improved error handling for spatial points

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/CypherAdapterStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/CypherAdapterStream.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.bolt.v1.messaging.BoltIOException;
 import org.neo4j.bolt.v1.runtime.spi.Record;
 import org.neo4j.bolt.v1.runtime.spi.RecordStream;
 import org.neo4j.graphdb.ExecutionPlanDescription;
@@ -32,6 +33,8 @@ import org.neo4j.graphdb.Notification;
 import org.neo4j.graphdb.QueryExecutionType;
 import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.spatial.Point;
+import org.neo4j.kernel.api.exceptions.Status;
 
 public class CypherAdapterStream implements RecordStream
 {
@@ -133,7 +136,7 @@ public class CypherAdapterStream implements RecordStream
             default:
                 return queryType.name();
         }
-    };
+    }
 
     private static class CypherAdapterRecord implements Record
     {
@@ -152,13 +155,28 @@ public class CypherAdapterStream implements RecordStream
             return fields;
         }
 
-        public CypherAdapterRecord reset( Result.ResultRow cypherRecord )
+        public CypherAdapterRecord reset( Result.ResultRow cypherRecord ) throws BoltIOException
         {
             for ( int i = 0; i < fields.length; i++ )
             {
                 fields[i] = cypherRecord.get( fieldNames[i] );
+                assertPackable( fields[i] );
             }
             return this;
+        }
+
+        private void assertPackable( Object field ) throws BoltIOException
+        {
+            //TODO this is a temporary measure, currently the packing of points
+            //fails in Neo4jPack#pack but it fails there when already begun writing
+            //headers to the result, so failing there and writing an error while in the process
+            //of writing a record results in a malformed error message.
+            //What needs to be done is inverting this so that the field has a visitable method
+            //that calls the proper pack method.
+            if (field instanceof Point)
+            {
+                throw new BoltIOException( Status.Request.Invalid, "Point is not yet supported as a return type in Bolt" );
+            }
         }
     }
 

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
@@ -412,6 +412,12 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
     result.toList should equal(List(Map("point" -> CartesianPoint(2.3, 4.5))))
   }
 
+  test("point function should work with integer arguments") {
+    val result = executeWithAllPlanners("RETURN point({x: 2, y: 4, crs: 'cartesian'}) as point")
+    result should useProjectionWith("Point")
+    result.toList should equal(List(Map("point" -> CartesianPoint(2, 4))))
+  }
+
   test("should fail properly if missing cartesian coordinates") {
     a [SyntaxException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
                                                                  "params" -> Map("y" -> 1.0, "crs" -> "cartesian")))

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.compiler.v3_0.{CRS, CartesianPoint, GeographicPoint}
-import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, SyntaxException}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, InvalidArgumentException, NewPlannerTestSupport, SyntaxException}
 
 class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
@@ -419,8 +419,8 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
   }
 
   test("should fail properly if missing cartesian coordinates") {
-    a [SyntaxException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
-                                                                 "params" -> Map("y" -> 1.0, "crs" -> "cartesian")))
+    an [InvalidArgumentException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
+                                                                           "params" -> Map("y" -> 1.0, "crs" -> "cartesian")))
   }
 
   test("should fail properly if missing geographic coordinates") {
@@ -429,8 +429,8 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
   }
 
   test("should fail properly if unknown coordinate system") {
-    a [SyntaxException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
-                                                                 "params" -> Map("y" -> 1.0, "crs" -> "WGS-1337")))
+    an [InvalidArgumentException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
+                                                                 "params" -> Map("crs" -> "WGS-1337")))
   }
 
   test("should fail properly if missing CRS") {

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
@@ -412,6 +412,25 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
     result.toList should equal(List(Map("point" -> CartesianPoint(2.3, 4.5))))
   }
 
+  test("should fail properly if missing cartesian coordinates") {
+    a [SyntaxException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
+                                                                 "params" -> Map("y" -> 1.0, "crs" -> "cartesian")))
+  }
+
+  test("should fail properly if missing geographic coordinates") {
+    a [SyntaxException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
+                                                                 "params" -> Map("y" -> 1.0, "crs" -> "WGS-84")))
+  }
+
+  test("should fail properly if unknown coordinate system") {
+    a [SyntaxException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
+                                                                 "params" -> Map("y" -> 1.0, "crs" -> "WGS-1337")))
+  }
+
+  test("should fail properly if missing CRS") {
+    a [SyntaxException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({x: 2.3, y: 4.5}) as point"))
+  }
+
   test("point function should work with previous map") {
     val result = executeWithAllPlanners("WITH {latitude: 12.78, longitude: 56.7} as data RETURN point(data) as point")
     result should useProjectionWith("Point")

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/PointFunction.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/expressions/PointFunction.scala
@@ -34,14 +34,14 @@ case class PointFunction(data: Expression) extends NullInNullOutExpression(data)
       map.getOrElse("crs", CRS.WGS84.name) match {
         case CRS.Cartesian.name =>
           if (!map.contains("x") || !map.contains("y")) throw new SyntaxException("A cartesian point must contain 'x' and 'y' coordinates")
-          val x = map("x").asInstanceOf[Double]
-          val y = map("y").asInstanceOf[Double]
+          val x = safeToDouble(map("x"))
+          val y = safeToDouble(map("y"))
           CartesianPoint(x, y)
 
         case CRS.WGS84.name =>
           if (!map.contains("longitude") || !map.contains("latitude")) throw new SyntaxException("A cartesian point must contain 'x' and 'y' coordinates")
-          val longitude = map("longitude").asInstanceOf[Double]
-          val latitude = map("latitude").asInstanceOf[Double]
+          val longitude = safeToDouble(map("longitude"))
+          val latitude = safeToDouble(map("latitude"))
           GeographicPoint(longitude, latitude, CRS.WGS84)
 
         case unknown => throw new SyntaxException(s"$unknown is not a supported coordinate system, supported values " +
@@ -59,4 +59,9 @@ case class PointFunction(data: Expression) extends NullInNullOutExpression(data)
   override def symbolTableDependencies = data.symbolTableDependencies
 
   override def toString = "Point(" + data + ")"
+
+  private def safeToDouble(value: Any) = value match {
+    case n: Number => n.doubleValue()
+    case other => throw new SyntaxException(other.getClass.getSimpleName + " is not a valid coordinate type.")
+  }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/SemanticErrorAcceptanceTest.scala
@@ -666,6 +666,18 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
       "A single relationship type must be specified for MERGE (line 1, column 9 (offset: 8))")
   }
 
+  test("give a nice error message when missing crs in cartesian point") {
+    executeAndEnsureError("RETURN point({x: 2.3, y: 4.5}) as point",
+                          "A cartesian point must contain a 'crs' (coordinate reference system) (line 1, column 14 (offset: 13))")
+  }
+
+  test("give a nice error message when using unknown arguments in point") {
+    executeAndEnsureError("RETURN point({xxx: 2.3, yyy: 4.5}) as point",
+                          "A map with keys 'xxx', 'yyy' is not describing a valid point, a point is described either by " +
+                            "using cartesian coordinates e.g. {x: 2.3, y: 4.5, crs: 'cartesian'} or using geographic " +
+                            "coordinates e.g. {latitude: 12.78, longitude: 56.7, crs: 'WGS-84'}. (line 1, column 14 (offset: 13))")
+  }
+
   def executeAndEnsureError(query: String, expected: String, params: (String,Any)*) {
     import org.neo4j.cypher.internal.frontend.v3_0.helpers.StringHelper._
 

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Point.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Point.scala
@@ -25,21 +25,22 @@ import org.neo4j.cypher.internal.frontend.v3_0.symbols._
 import org.neo4j.cypher.internal.frontend.v3_0.{SemanticCheck, SemanticCheckResult, SemanticError}
 
 case object Point extends Function with SimpleTypedFunction {
+
   def name = "point"
 
   override def semanticCheck(ctx: SemanticContext, invocation: FunctionInvocation) =
-    super.semanticCheck(ctx, invocation) ifOkChain  checkPointMap(invocation.args(0))
+    super.semanticCheck(ctx, invocation) ifOkChain checkPointMap(invocation.args(0))
 
   /*
    * Checks so that the point map is properly formatted
    */
   protected def checkPointMap(expression: Expression): SemanticCheck = expression match {
     //Cartesian point
-    case map: MapExpression if map.items.exists(withKey("x")) &&  map.items.exists(withKey("y")) =>
-        if (map.items.exists(withKey("crs"))) SemanticCheckResult.success
-        else SemanticError(s"A cartesian point must contain a 'crs' (coordinate reference system)", map.position)
+    case map: MapExpression if map.items.exists(withKey("x")) && map.items.exists(withKey("y")) =>
+      if (map.items.exists(withKey("crs"))) SemanticCheckResult.success
+      else SemanticError(s"A cartesian point must contain a 'crs' (coordinate reference system)", map.position)
     //Geographic point
-    case map: MapExpression if map.items.exists(withKey("longitude")) &&  map.items.exists(withKey("latitude")) =>
+    case map: MapExpression if map.items.exists(withKey("longitude")) && map.items.exists(withKey("latitude")) =>
       SemanticCheckResult.success
 
     case map: MapExpression => SemanticError(
@@ -47,11 +48,11 @@ case object Point extends Function with SimpleTypedFunction {
         s"a point is described either by using cartesian coordinates e.g. {x: 2.3, y: 4.5, crs: 'cartesian'} or using " +
         s"geographic coordinates e.g. {latitude: 12.78, longitude: 56.7, crs: 'WGS-84'}.", map.position)
 
-    //if using variable of parameter we can't introspect the map here
+    //if using variable or parameter we can't introspect the map here
     case _ => SemanticCheckResult.success
-    }
+  }
 
-  private def withKey(key: String)(kv: (PropertyKeyName, Expression )) =  kv._1.name == key
+  private def withKey(key: String)(kv: (PropertyKeyName, Expression)) = kv._1.name == key
 
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTMap), outputType = CTPoint)

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Point.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Point.scala
@@ -19,11 +19,39 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_0.ast.functions
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{Function, SimpleTypedFunction}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression.SemanticContext
+import org.neo4j.cypher.internal.frontend.v3_0.ast._
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
+import org.neo4j.cypher.internal.frontend.v3_0.{SemanticCheck, SemanticCheckResult, SemanticError}
 
 case object Point extends Function with SimpleTypedFunction {
   def name = "point"
+
+  override def semanticCheck(ctx: SemanticContext, invocation: FunctionInvocation) =
+    super.semanticCheck(ctx, invocation) ifOkChain  checkPointMap(invocation.args(0))
+
+  /*
+   * Checks so that the point map is properly formatted
+   */
+  protected def checkPointMap(expression: Expression): SemanticCheck = expression match {
+    //Cartesian point
+    case map: MapExpression if map.items.exists(withKey("x")) &&  map.items.exists(withKey("y")) =>
+        if (map.items.exists(withKey("crs"))) SemanticCheckResult.success
+        else SemanticError(s"A cartesian point must contain a 'crs' (coordinate reference system)", map.position)
+    //Geographic point
+    case map: MapExpression if map.items.exists(withKey("longitude")) &&  map.items.exists(withKey("latitude")) =>
+      SemanticCheckResult.success
+
+    case map: MapExpression => SemanticError(
+      s"A map with keys ${map.items.map((a) => s"'${a._1.name}'").mkString(", ")} is not describing a valid point, " +
+        s"a point is described either by using cartesian coordinates e.g. {x: 2.3, y: 4.5, crs: 'cartesian'} or using " +
+        s"geographic coordinates e.g. {latitude: 12.78, longitude: 56.7, crs: 'WGS-84'}.", map.position)
+
+    //if using variable of parameter we can't introspect the map here
+    case _ => SemanticCheckResult.success
+    }
+
+  private def withKey(key: String)(kv: (PropertyKeyName, Expression )) =  kv._1.name == key
 
   val signatures = Vector(
     Signature(argumentTypes = Vector(CTMap), outputType = CTPoint)


### PR DESCRIPTION
- `point( {x: 0.1, y: 1.1})` should not fail with `java.util.NoSuchElementException`  but have a proper error message and type
- `point({x: 0.1, y: 1.1, crs: "NOT_EXISING"})` should fail with proper error message and type instead of being a `scala.MatchError`
- `point({x: 1, y: 2, crs: "cartesian"})` should be allowed and not produce a `java.lang.ClassCastException`
- Bolt should temporarily fail on points with a nice error message, until we have proper support for points in Bolt
