### PR TITLE
Update Java detection, Installation and Uninstall of Windows Service in Powershell scripts

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Confirm-JavaVersion.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Confirm-JavaVersion.ps1
@@ -1,0 +1,115 @@
+# Copyright (c) 2002-2016 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+<#
+.SYNOPSIS
+Confirms whether the specificed java executable is suitable for Neo4j
+
+.DESCRIPTION
+Confirms whether the specificed java executable is suitable for Neo4j
+
+.PARAMETER Path
+Full path to the Java executable, java.exe
+
+.EXAMPLE
+Get-JavaVersion -Path 'C:\Program Files\Java\jre1.8.0_71\bin\java.exe'
+
+Retrieves the Java version for 'C:\Program Files\Java\jre1.8.0_71\bin\java.exe'.
+
+.OUTPUTS
+System.Boolean
+
+.NOTES
+This function is private to the powershell module
+
+#>
+Function Confirm-JavaVersion
+{
+  [cmdletBinding(SupportsShouldProcess=$false,ConfirmImpact='Low')]
+  param (
+    [Parameter(Mandatory=$true,ValueFromPipeline=$false)]
+    [String]$Path
+  )
+
+  Begin {    
+  }
+  
+  Process {
+    $stdError = New-Neo4jTempFile -Prefix 'stderr'
+    
+    # Run Java with redirection
+    $args = @('-version')
+    Write-Verbose "Executing $Path $args"
+    $result = Start-Process -FilePath $Path -ArgumentList $args -NoNewWindow -Wait -RedirectStandardError $stdError -PassThru
+
+    # Check the output
+    if ($result.ExitCode -ne 0) {
+      Write-Verbose "Java returned exit code $($result.ExitCode)"
+      Write-Warning "Unable to determine Java Version"
+      return $true
+    }    
+    if (-not (Test-Path -Path $stdError)) {
+      Write-Verbose "Java did not output version information"
+      Write-Warning "Unable to determine Java Version"
+      return $true
+    }
+    
+    $javaHelpText = "* Please use Oracle(R) Java(TM) 8, OpenJDK(TM) or IBM J9 to run Neo4j Server.`n" +
+                    "* Please see http://docs.neo4j.org/ for Neo4j Server installation instructions."
+
+    # Read the contents of the redirected output
+    $content = (Get-Content -Path $stdError) -join "`n`r"
+
+    # Remove the temp file
+    Remove-Item -Path $stdError -Force | Out-Null
+    
+    # Use a simple regular expression to extract the java version
+    Write-Verbose "Java version response: $content"
+    if ($matches -ne $null) { $matches.Clear() }  
+    if ($content -match 'version \"(.+)\"') {
+      $javaVersion = $matches[1]
+      Write-Verbose "Java Version detected as $javaVersion"
+    } else {
+      Write-Verbose "Could not determing the Java Version"
+      Write-Warning "Unable to determine Java Version"
+      return $true
+    }
+    
+    # Check for Java Version Compatibility
+    # Anything less than Java 1.8 will block execution
+    # Note - This text comparsion will fail for '1.10.xxx' due to how string based comparisons of numbers works.
+    if ($javaVersion -lt '1.8') {
+      Write-Warning "ERROR! Neo4j cannot be started using java version $($javaVersion)"      
+      Write-Warning $javaHelpText
+      return $false
+    }
+    
+    # Check for Java Edition
+    $regex = '(Java HotSpot\(TM\)|OpenJDK|IBM) (64-Bit Server|Server|Client|J9) VM'
+    if (-not ($content -match $regex)) {
+      Write-Warning "WARNING! You are using an unsupported Java runtime"      
+      Write-Warning $javaHelpText
+    }
+
+    return $true
+  }
+  
+  End {
+  }
+}

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Install-Neo4jServer.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Install-Neo4jServer.ps1
@@ -64,16 +64,29 @@ Function Install-Neo4jServer
       if ($prunsrv -eq $null) { throw "Could not determine the command line for PRUNSRV" }
 
       Write-Verbose "Installing Neo4j as a service with command line $($prunsrv.cmd) $($prunsrv.args)"
-      $result = (Start-Process -FilePath $prunsrv.cmd -ArgumentList $prunsrv.args -Wait -NoNewWindow -PassThru -WorkingDirectory $Neo4jServer.Home)
+      $stdError = New-Neo4jTempFile -Prefix 'stderr'
+      $result = (Start-Process -FilePath $prunsrv.cmd -ArgumentList $prunsrv.args -Wait -NoNewWindow -PassThru -WorkingDirectory $Neo4jServer.Home -RedirectStandardError $stdError)
       Write-Verbose "Returned exit code $($result.ExitCode)"
+
+      # Process the output
+      if ($result.ExitCode -eq 0) {
+        Write-Host "Neo4j service installed"
+      } else {
+        Write-Host "Neo4j service did not install"
+        # Write out STDERR if it did not install
+        Get-Contet -Path $stdError -ErrorAction 'SilentlyContinue' | ForEach-Object -Process {
+          Write-Host $_
+        }
+      }
+
+      # Remove the temp file
+      If (Test-Path -Path $stdError) { Remove-Item -Path $stdError -Force | Out-Null }
 
       Write-Output $result.ExitCode
     } else {
       Write-Verbose "Service already installed"
       Write-Output 0
-    }
-    
-    Write-Host "Neo4j service installed"
+    }    
   }
   
   End

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/New-Neo4jTempFile.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/New-Neo4jTempFile.ps1
@@ -1,0 +1,64 @@
+# Copyright (c) 2002-2016 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+<#
+.SYNOPSIS
+Returns a temporary filename with optional prefix
+
+.DESCRIPTION
+Returns a temporary filename with optional prefix
+
+.PARAMETER Prefix
+Optional prefix to for the temporary filename
+
+.EXAMPLE
+New-Neo4jTempFile
+
+Returns a temporary filename
+
+.OUTPUTS
+String Filename of a temporary file which does not yet exist
+
+.NOTES
+This function is private to the powershell module
+
+#>
+Function New-Neo4jTempFile
+{
+  [cmdletBinding(SupportsShouldProcess=$false,ConfirmImpact='Low')]
+  param (
+    [Parameter(Mandatory=$false,ValueFromPipeline=$false)]
+    [String]$Prefix = ''
+  )
+
+  Begin {
+  }
+  
+  Process {
+    Do { 
+      $RandomFileName = Join-Path -Path (Get-Neo4jEnv 'Temp') -ChildPath ($Prefix + [System.IO.Path]::GetRandomFileName())
+    } 
+    Until (-not (Test-Path -Path $RandomFileName))
+
+    return $RandomFileName
+  }
+  
+  End {
+  }
+}

--- a/packaging/standalone/src/tests/Neo4j-Management/Common.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/Common.ps1
@@ -17,6 +17,8 @@ Function global:New-MockJavaHome() {
   "This is a mock java.exe" | Out-File "$javaHome\bin\java.exe"
   "This is a mock java.exe" | Out-File "$javaHome\bin\server\jvm.dll"
 
+  $global:mockJavaExe = "$javaHome\bin\java.exe"
+
   return $javaHome
 }
 

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Confirm-JavaVersion.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Confirm-JavaVersion.Tests.ps1
@@ -1,0 +1,149 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+$common = Join-Path (Split-Path -Parent $here) 'Common.ps1'
+. $common
+
+Import-Module "$src\Neo4j-Management.psm1"
+
+InModuleScope Neo4j-Management {
+  Describe "Confirm-JavaVersion" {
+
+    # Setup mocking environment
+    #  Mock Java environment
+    $javaHome = global:New-MockJavaHome
+    Mock Get-Neo4jEnv { $javaHome } -ParameterFilter { $Name -eq 'JAVA_HOME' } 
+
+    Context "Java returns a non zero exit code for version query" {
+      # Mock the java version output file
+      Mock Start-Process -Verifiable { @{ 'exitcode' = 1} }
+      $tempFilename = Join-Path -Path $TestDrive -ChildPath 'stderr.txt'
+      Mock New-Neo4jTempFile { $tempFilename }
+      Mock Write-Warning -Verifiable -ParameterFilter { $Message -eq 'Unable to determine Java Version' }
+  
+      $result = Confirm-JavaVersion -Path $global:mockJavaExe
+
+      It "should return true" {
+        $result | Should Be $true
+      }
+
+      It "calls verified mocks" {
+        Assert-VerifiableMocks
+      }
+    }
+
+    Context "Java returns a zero exit code but no content" {
+      # Mock the java version output file
+      Mock Start-Process -Verifiable { @{ 'exitcode' = 0} }
+      $tempFilename = Join-Path -Path $TestDrive -ChildPath 'stderr.txt'
+      Mock New-Neo4jTempFile { $tempFilename }
+      Mock Write-Warning -Verifiable -ParameterFilter { $Message -eq 'Unable to determine Java Version' }
+  
+      $result = Confirm-JavaVersion -Path $global:mockJavaExe
+
+      It "should return true" {
+        $result | Should Be $true
+      }
+
+      It "calls verified mocks" {
+        Assert-VerifiableMocks
+      }
+    }
+
+    Context "Java returns a zero exit code but invalid content" {
+      # Mock the java version output file
+      Mock Start-Process -Verifiable { @{ 'exitcode' = 0} }
+      $tempFilename = Join-Path -Path $TestDrive -ChildPath 'stderr.txt'
+      Set-Content -Path $tempFilename -Value 'invalid java ver info' | Out-Null
+      Mock New-Neo4jTempFile { $tempFilename }
+      Mock Write-Warning -Verifiable -ParameterFilter { $Message -eq 'Unable to determine Java Version' }
+  
+      $result = Confirm-JavaVersion -Path $global:mockJavaExe
+
+      It "should return true" {
+        $result | Should Be $true
+      }
+
+      It "calls verified mocks" {
+        Assert-VerifiableMocks
+      }
+    }
+
+    # Java Detection Tests
+    Context "Valid Java install (1.8 JDK) in JAVA_HOME environment variable" {
+      # Mock the java version output file
+      Mock Start-Process -Verifiable { @{ 'exitcode' = 0} }
+      $tempFilename = Join-Path -Path $TestDrive -ChildPath 'stderr.txt'
+      Set-Content -Path $tempFilename -Value 'java version "1.8.0"`n`rJava HotSpot(TM) 64-Bit Server VM (build 11.11-a11, mixed mode)' | Out-Null
+      Mock New-Neo4jTempFile { $tempFilename }
+      Mock Write-Warning { }
+
+      $result = Confirm-JavaVersion -Path $global:mockJavaExe
+
+      It "should return true" {
+        $result | Should Be $true
+      }
+
+      It "should remove the redirection file" {
+        $tempFilename | Should Not Exist
+      }
+
+      It "should not emit warnings" {
+        Assert-MockCalled Write-Warning -Times 0 
+      }
+
+      It "calls verified mocks" {
+        Assert-VerifiableMocks
+      }
+    }
+
+    Context "Unsupport Java install (1.8 Bad-JRE) in JAVA_HOME environment variable" {
+      # Mock the java version output file
+      Mock Start-Process -Verifiable { @{ 'exitcode' = 0} }
+      $tempFilename = Join-Path -Path $TestDrive -ChildPath 'stderr.txt'
+      Set-Content -Path $tempFilename -Value 'java version "1.8.0"`n`rJava BadSpot(TM) 64-Bit Server VM (build 11.11-a11, mixed mode)' | Out-Null
+      Mock New-Neo4jTempFile { $tempFilename }
+      Mock Write-Warning -Verifiable -ParameterFilter { $Message -eq 'WARNING! You are using an unsupported Java runtime' }
+
+      $result = Confirm-JavaVersion -Path $global:mockJavaExe
+
+      It "should return true" {
+        $result | Should Be $true
+      }
+
+      It "should remove the redirection file" {
+        $tempFilename | Should Not Exist
+      }
+
+      It "calls verified mocks" {
+        Assert-VerifiableMocks
+      }
+    }
+
+    Context "Legacy Java install (1.7 JDK) in JAVA_HOME environment variable" {
+      # Mock the java version output file
+      Mock Start-Process -Verifiable { @{ 'exitcode' = 0} }
+      $tempFilename = Join-Path -Path $TestDrive -ChildPath 'stderr.txt'
+      Set-Content -Path $tempFilename -Value 'java version "1.7.0"`n`rJava HotSpot(TM) 64-Bit Server VM (build 11.11-a11, mixed mode)' | Out-Null
+      Mock New-Neo4jTempFile { $tempFilename }
+      Mock Write-Warning { }
+
+      $result = Confirm-JavaVersion -Path $global:mockJavaExe
+
+      It "should return false" {
+        $result | Should Be $false
+      }
+
+      It "should remove the redirection file" {
+        $tempFilename | Should Not Exist
+      }
+
+      It "should emit a warning" {
+        Assert-MockCalled Write-Warning
+      }
+
+      It "calls verified mocks" {
+        Assert-VerifiableMocks
+      }
+    }
+  }
+}

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Java.Tests.ps1
@@ -18,6 +18,7 @@ InModuleScope Neo4j-Management {
     Mock Get-ItemProperty { $null } -ParameterFilter {
       $Path -like 'Registry::*\JavaSoft\Java Runtime Environment*'
     }
+    Mock Confirm-JavaVersion { $true }
 
     # Java Detection Tests
     Context "Valid Java install in JAVA_HOME environment variable" {
@@ -29,6 +30,18 @@ InModuleScope Neo4j-Management {
 
       It "should have empty shell arguments" {
         $result.args | Should BeNullOrEmpty
+      }
+    }
+
+    Context "Legacy Java install in JAVA_HOME environment variable" {
+      Mock Confirm-JavaVersion -Verifiable { $false }
+      
+      It "should throw if java is not supported" {
+        { Get-Java -ErrorAction Stop } | Should Throw
+      }
+
+      It "calls verified mocks" {
+        Assert-VerifiableMocks
       }
     }
 

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
@@ -18,6 +18,7 @@ InModuleScope Neo4j-Management {
     Mock Get-ItemProperty { $null } -ParameterFilter {
       $Path -like 'Registry::*\JavaSoft\Java Runtime Environment*'
     }
+    Mock Confirm-JavaVersion { $true }
     # Mock Neo4j environment
     Mock Get-Neo4jEnv { $global:mockNeo4jHome } -ParameterFilter { $Name -eq 'NEO4J_HOME' } 
 


### PR DESCRIPTION
This commit updates the powershell management scripts
- Added Confirm-JavaVersion private function
- Added New-Neo4jTempFile function to generate temp file names
- Added tests for Confirm-JavaVersion function
- Update affect unit tests and mocked Confirm-JavaVersion
- Install-Neo4jService and Uninstall-Neo4jService output an appropriate message and debug information depending on the exit code.

Confirmation logic is based on https://github.com/neo4j/neo4j/blob/3.0/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh
