### PR TITLE
Disable user service when auth is disabled

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
@@ -71,7 +71,7 @@ public class CommunityNeoServer extends AbstractNeoServer
     protected Iterable<ServerModule> createServerModules()
     {
         return Arrays.asList(
-                new DBMSModule( webServer ),
+                new DBMSModule( webServer, getConfig() ),
                 new RESTApiModule( webServer, database, getConfig(), getDependencyResolver(), logProvider ),
                 new ManagementApiModule( webServer, getConfig() ),
                 new ThirdPartyJAXRSModule( webServer, getConfig(), logProvider, this ),

--- a/community/server/src/main/java/org/neo4j/server/modules/DBMSModule.java
+++ b/community/server/src/main/java/org/neo4j/server/modules/DBMSModule.java
@@ -19,8 +19,11 @@
  */
 package org.neo4j.server.modules;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.server.rest.dbms.UserService;
 import org.neo4j.server.rest.discovery.DiscoveryService;
 import org.neo4j.server.web.WebServer;
@@ -35,10 +38,12 @@ public class DBMSModule implements ServerModule
     private static final String ROOT_PATH = "/";
 
     private final WebServer webServer;
+    private final Config config;
 
-    public DBMSModule( WebServer webServer )
+    public DBMSModule( WebServer webServer, Config config )
     {
         this.webServer = webServer;
+        this.config = config;
     }
 
     @Override
@@ -49,9 +54,15 @@ public class DBMSModule implements ServerModule
 
     private List<String> getClassNames()
     {
-        return asList(
-                DiscoveryService.class.getName(),
-                UserService.class.getName() );
+        List<String> toReturn = new ArrayList<>( 2 );
+
+        toReturn.add( DiscoveryService.class.getName() );
+        if ( config.get( GraphDatabaseSettings.auth_enabled ) )
+        {
+            toReturn.add( UserService.class.getName() );
+        }
+
+        return toReturn;
     }
 
     @Override

--- a/community/server/src/test/java/org/neo4j/server/modules/DBMSModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/DBMSModuleTest.java
@@ -19,20 +19,27 @@
  */
 package org.neo4j.server.modules;
 
+import org.hamcrest.Description;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Matchers;
 
 import java.net.URI;
 import java.util.List;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.server.CommunityNeoServer;
+import org.neo4j.server.rest.dbms.UserService;
 import org.neo4j.server.web.WebServer;
 import org.neo4j.test.rule.SuppressOutput;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,15 +54,51 @@ public class DBMSModuleTest
     public void shouldRegisterAtRootByDefault() throws Exception
     {
         WebServer webServer = mock( WebServer.class );
+        Config config = mock( Config.class );
 
         CommunityNeoServer neoServer = mock( CommunityNeoServer.class );
         when( neoServer.baseUri() ).thenReturn( new URI( "http://localhost:7575" ) );
         when( neoServer.getWebServer() ).thenReturn( webServer );
+        when( config.get( GraphDatabaseSettings.auth_enabled ) ).thenReturn( true );
 
-        DBMSModule module = new DBMSModule( webServer );
+        DBMSModule module = new DBMSModule( webServer, config );
 
         module.start();
 
-        verify( webServer ).addJAXRSClasses( any( List.class ), anyString(), anyCollection() );
+        verify( webServer ).addJAXRSClasses( anyList(), anyString(), anyCollection() );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldNotRegisterUserServiceWhenAuthDisabled() throws Exception
+    {
+        WebServer webServer = mock( WebServer.class );
+        Config config = mock( Config.class );
+
+        CommunityNeoServer neoServer = mock( CommunityNeoServer.class );
+        when( neoServer.baseUri() ).thenReturn( new URI( "http://localhost:7575" ) );
+        when( neoServer.getWebServer() ).thenReturn( webServer );
+        when( config.get( GraphDatabaseSettings.auth_enabled ) ).thenReturn( false );
+
+        DBMSModule module = new DBMSModule( webServer, config );
+
+        module.start();
+
+        verify( webServer ).addJAXRSClasses( anyList(), anyString(), anyCollection() );
+        verify( webServer, never() ).addJAXRSClasses( Matchers.argThat( new ArgumentMatcher<List<String>>()
+        {
+            @Override
+            public boolean matches( Object argument )
+            {
+                List<String> argumentList = (List<String>) argument;
+                return argumentList.contains( UserService.class.getName() );
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( "<List containing " + UserService.class.getName() + ">" );
+            }
+        } ), anyString(), anyCollection() );
     }
 }


### PR DESCRIPTION
If UserService was started with `auth_enabled` set to `false`, and exception was thrown (because `AuthManager.NO_AUTH` does not implement `UserManager`).

This prevents the UserService from being started when auth is disabled.
