### PR TITLE
Fix circular deps in packaging build

### DIFF
--- a/manual/bolt/pom.xml
+++ b/manual/bolt/pom.xml
@@ -3,14 +3,16 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>neo4j-manual-parent</artifactId>
-        <groupId>org.neo4j.doc</groupId>
+        <artifactId>parent</artifactId>
+        <groupId>org.neo4j</groupId>
         <version>3.0.2-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.neo4j.doc</groupId>
     <artifactId>neo4j-bolt-docs</artifactId>
+    <version>3.0.2-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Neo4j - Bolt Documentation</name>


### PR DESCRIPTION
The `-Dfreeze=true` in the packaging build triggers the `freeze` profile in the `manual` module. This profile declares dependencies for the `manual` module on some of its "submodules". One of those submodules depends on `manual` as a parent (c7523522243f7fee633950672e1dfc5577f81035). There is therefore a circular dependency which only rears its ugly head when the `freeze` profile is used, like in the packaging build.

Removing the parental dependency of the submodule on the manual module breaks the circle.
