### PR TITLE
Automatic detection of record format

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -51,12 +51,10 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.api.index.IndexStoreView;
 import org.neo4j.kernel.impl.locking.LockService;
-import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreAccess;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreIndexStoreView;
 import org.neo4j.logging.DuplicatingLog;
@@ -125,9 +123,7 @@ public class ConsistencyCheckService
         Config consistencyCheckerConfig = tuningConfiguration.with(
                 MapUtil.stringMap( GraphDatabaseSettings.read_only.name(), Settings.TRUE ) );
         StoreFactory factory = new StoreFactory( storeDir, consistencyCheckerConfig,
-                new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem,
-                RecordFormatSelector.autoSelectFormat( consistencyCheckerConfig, NullLogService.getInstance() ),
-                logProvider );
+                new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem, logProvider );
 
         ConsistencySummaryStatistics summary;
         // With the added neo4j_home config the logs directory will end up in db location

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/repair/RelationshipChainExplorerTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/repair/RelationshipChainExplorerTest.java
@@ -44,7 +44,6 @@ import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
 
 public class RelationshipChainExplorerTest
@@ -143,8 +142,9 @@ public class RelationshipChainExplorerTest
         }
         database.shutdown();
         PageCache pageCache = pageCacheRule.getPageCache( new DefaultFileSystemAbstraction() );
-        Config config = new Config( stringMap( GraphDatabaseSettings.record_format.name(), getRecordFormatName() ) );
-        return new StoreAccess( new DefaultFileSystemAbstraction(), pageCache, storeDirectory, config ).initialize();
+        StoreAccess storeAccess = new StoreAccess( new DefaultFileSystemAbstraction(), pageCache, storeDirectory,
+                Config.empty() );
+        return storeAccess.initialize();
     }
 
     protected String getRecordFormatName()

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/store/StoreAssertions.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/store/StoreAssertions.java
@@ -42,14 +42,7 @@ public class StoreAssertions
 
     public static void assertConsistentStore( File dir ) throws ConsistencyCheckIncompleteException, IOException
     {
-        assertConsistentStore( dir, Config.empty() );
-    }
-
-    public static void assertConsistentStore( File dir, Config config ) throws ConsistencyCheckIncompleteException,
-            IOException
-    {
-        Map<String,String> params = config.getParams();
-        params.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
+        Map<String,String> params = stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
         final Config configuration = new Config( params, GraphDatabaseSettings.class, ConsistencyCheckSettings.class );
 
         final ConsistencyCheckService.Result result = new ConsistencyCheckService().runFullConsistencyCheck(

--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +57,7 @@ import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.RandomRule;
 import org.neo4j.test.Randoms;
@@ -72,6 +72,7 @@ import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.input.Inputs;
 import org.neo4j.unsafe.impl.batchimport.input.SimpleInputIterator;
 import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitor;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -180,7 +181,6 @@ public class ParallelBatchImporterTest
             // THEN
             GraphDatabaseService db = new TestGraphDatabaseFactory()
                     .newEmbeddedDatabaseBuilder( directory.graphDbDir() )
-                    .setConfig( GraphDatabaseSettings.record_format, getFormatName() )
                     .newGraphDatabase();
             try ( Transaction tx = db.beginTx() )
             {
@@ -228,8 +228,7 @@ public class ParallelBatchImporterTest
     {
         ConsistencyCheckService consistencyChecker = new ConsistencyCheckService();
         Result result = consistencyChecker.runFullConsistencyCheck( storeDir,
-                new Config( stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m",
-                        GraphDatabaseSettings.record_format.name(), getFormatName()) ),
+                new Config( stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" ) ),
                 ProgressMonitorFactory.NONE,
                 NullLogProvider.getInstance(), false );
         assertTrue( "Database contains inconsistencies, there should be a report in " + storeDir,
@@ -238,7 +237,7 @@ public class ParallelBatchImporterTest
 
     protected String getFormatName()
     {
-        return StringUtils.EMPTY;
+        return StandardV3_0.NAME;
     }
 
     public static abstract class InputIdGenerator

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -260,7 +260,6 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
     private final Log msgLog;
     private final LogService logService;
     private final AutoIndexing autoIndexing;
-    private final RecordFormats formats;
     private final LogProvider logProvider;
     private final DependencyResolver dependencyResolver;
     private final TokenNameLookup tokenNameLookup;
@@ -336,8 +335,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             Monitors monitors,
             Tracers tracers,
             Procedures procedures,
-            IOLimiter ioLimiter,
-            RecordFormats formats )
+            IOLimiter ioLimiter )
     {
         this.storeDir = storeDir;
         this.config = config;
@@ -367,9 +365,6 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         this.tracers = tracers;
         this.procedures = procedures;
         this.ioLimiter = ioLimiter;
-
-        this.formats = RecordFormatSelector.select( config, formats, logService );
-        new RecordFormatPropertyConfigurator( this.formats, this.config ).configure();
 
         readOnly = config.get( Configuration.read_only );
         msgLog = logProvider.getLog( getClass() );
@@ -431,6 +426,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         life.add( new Delegate( Lifecycles.multiple( indexProviders.values() ) ) );
 
         // Upgrade the store before we begin
+        RecordFormats formats = selectStoreFormats( config, storeDir, fs, pageCache, logService );
         upgradeStore( formats );
 
         // Build all modules and their services
@@ -444,7 +440,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
 
             storageEngine = buildStorageEngine(
                     propertyKeyTokenHolder, labelTokens, relationshipTypeTokens, legacyIndexProviderLookup,
-                    indexConfigStore, updateableSchemaState::clear, legacyIndexTransactionOrdering, formats );
+                    indexConfigStore, updateableSchemaState::clear, legacyIndexTransactionOrdering );
 
             LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader =
                     new VersionAwareLogEntryReader<>( storageEngine.commandReaderFactory() );
@@ -534,6 +530,15 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         databaseHealth.healed();
     }
 
+    private static RecordFormats selectStoreFormats( Config config, File storeDir, FileSystemAbstraction fs,
+            PageCache pageCache, LogService logService )
+    {
+        LogProvider logging = logService.getInternalLogProvider();
+        RecordFormats formats = RecordFormatSelector.selectNewestFormat( config, storeDir, fs, pageCache, logging );
+        new RecordFormatPropertyConfigurator( formats, config ).configure();
+        return formats;
+    }
+
     private void upgradeStore( RecordFormats format )
     {
         LabelScanStoreProvider labelScanStoreProvider =
@@ -558,8 +563,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             PropertyKeyTokenHolder propertyKeyTokenHolder, LabelTokenHolder labelTokens,
             RelationshipTypeTokenHolder relationshipTypeTokens,
             LegacyIndexProviderLookup legacyIndexProviderLookup, IndexConfigStore indexConfigStore,
-            Runnable schemaStateChangeCallback, SynchronizedArrayIdOrderingQueue legacyIndexTransactionOrdering,
-            RecordFormats format )
+            Runnable schemaStateChangeCallback, SynchronizedArrayIdOrderingQueue legacyIndexTransactionOrdering )
     {
         LabelScanStoreProvider labelScanStore = dependencyResolver.resolveDependency( LabelScanStoreProvider.class,
                 HighestSelectionStrategy.getInstance() );
@@ -572,7 +576,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 fs, logProvider, propertyKeyTokenHolder, labelTokens, relationshipTypeTokens, schemaStateChangeCallback,
                 constraintSemantics, scheduler, tokenNameLookup, lockService, schemaIndexProvider,
                 indexingServiceMonitor, databaseHealth, labelScanStore, legacyIndexProviderLookup, indexConfigStore,
-                legacyIndexTransactionOrdering, transactionSnapshotSupplier, format );
+                legacyIndexTransactionOrdering, transactionSnapshotSupplier );
 
         // We pretend that the storage engine abstract hides all details within it. Whereas that's mostly
         // true it's not entirely true for the time being. As long as we need this call below, which

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -47,7 +47,6 @@ import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.locking.community.CommunityLockManger;
 import org.neo4j.kernel.impl.logging.LogService;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
@@ -109,8 +108,6 @@ public class CommunityEditionModule extends EditionModule
         coreAPIAvailabilityGuard = new CoreAPIAvailabilityGuard( platformModule.availabilityGuard, transactionStartTimeout );
 
         ioLimiter = IOLimiter.unlimited();
-
-        formats = StandardV3_0.RECORD_FORMATS;
 
         registerRecovery( platformModule.databaseInfo, life, dependencies );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -203,8 +203,7 @@ public class DataSourceModule
                 platformModule.monitors,
                 platformModule.tracers,
                 procedures,
-                editionModule.ioLimiter,
-                editionModule.formats ) );
+                editionModule.ioLimiter ) );
         dataSourceManager.register( neoStoreDataSource );
 
         life.add( new MonitorGc( config, logging.getInternalLog( MonitorGc.class ) ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.coreapi.CoreAPIAvailabilityGuard;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration;
 import org.neo4j.kernel.impl.locking.Locks;
-import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.info.DiagnosticsManager;
@@ -80,8 +79,6 @@ public abstract class EditionModule
     public CoreAPIAvailabilityGuard coreAPIAvailabilityGuard;
 
     public IOLimiter ioLimiter;
-
-    public RecordFormats formats;
 
     protected void doAfterRecoveryAndStartup( DatabaseInfo databaseInfo, DependencyResolver dependencyResolver )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
@@ -26,8 +26,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.CountsAccessor;
-import org.neo4j.kernel.impl.logging.NullLogService;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -87,8 +85,7 @@ public class StoreAccess
     public StoreAccess( FileSystemAbstraction fileSystem, PageCache pageCache, File storeDir, Config config )
     {
         this( new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fileSystem ), pageCache,
-                fileSystem, RecordFormatSelector.autoSelectFormat(config, NullLogService.getInstance()),
-                NullLogProvider.getInstance() ).openAllNeoStores() );
+                fileSystem, NullLogProvider.getInstance() ).openAllNeoStores() );
         this.closeable = true;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
@@ -35,13 +35,21 @@ public abstract class BaseRecordFormats implements RecordFormats
 {
     private final int generation;
     private final Capability[] capabilities;
+    private final String name;
     private final String storeVersion;
 
-    protected BaseRecordFormats( String storeVersion, int generation, Capability... capabilities )
+    protected BaseRecordFormats( String name, String storeVersion, int generation, Capability... capabilities )
     {
+        this.name = name;
         this.storeVersion = storeVersion;
         this.generation = generation;
         this.capabilities = capabilities;
+    }
+
+    @Override
+    public String name()
+    {
+        return name;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormats.java
@@ -35,21 +35,13 @@ public abstract class BaseRecordFormats implements RecordFormats
 {
     private final int generation;
     private final Capability[] capabilities;
-    private final String name;
     private final String storeVersion;
 
-    protected BaseRecordFormats( String name, String storeVersion, int generation, Capability... capabilities )
+    protected BaseRecordFormats( String storeVersion, int generation, Capability... capabilities )
     {
-        this.name = name;
         this.storeVersion = storeVersion;
         this.generation = generation;
         this.capabilities = capabilities;
-    }
-
-    @Override
-    public String name()
-    {
-        return name;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
@@ -46,8 +46,6 @@ public interface RecordFormats
         public abstract RecordFormats newInstance();
     }
 
-    String name();
-
     String storeVersion();
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormats.java
@@ -46,6 +46,8 @@ public interface RecordFormats
         public abstract RecordFormats newInstance();
     }
 
+    String name();
+
     String storeVersion();
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
@@ -37,11 +37,10 @@ public class StandardV2_0 extends BaseRecordFormats
 {
     public static final String STORE_VERSION = StoreVersion.STANDARD_V2_0.versionString();
     public static final RecordFormats RECORD_FORMATS = new StandardV2_0();
-    private static final String NAME = "standard_v2.0";
 
     public StandardV2_0()
     {
-        super( NAME, STORE_VERSION, 2, Capability.SCHEMA, Capability.LUCENE_3, Capability.VERSION_TRAILERS );
+        super( STORE_VERSION, 2, Capability.SCHEMA, Capability.LUCENE_3, Capability.VERSION_TRAILERS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_0.java
@@ -37,10 +37,11 @@ public class StandardV2_0 extends BaseRecordFormats
 {
     public static final String STORE_VERSION = StoreVersion.STANDARD_V2_0.versionString();
     public static final RecordFormats RECORD_FORMATS = new StandardV2_0();
+    private static final String NAME = "standard_v2.0";
 
     public StandardV2_0()
     {
-        super( STORE_VERSION, 2, Capability.SCHEMA, Capability.LUCENE_3, Capability.VERSION_TRAILERS );
+        super( NAME, STORE_VERSION, 2, Capability.SCHEMA, Capability.LUCENE_3, Capability.VERSION_TRAILERS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
@@ -37,11 +37,10 @@ public class StandardV2_1 extends BaseRecordFormats
 {
     public static final String STORE_VERSION = StoreVersion.STANDARD_V2_1.versionString();
     public static final RecordFormats RECORD_FORMATS = new StandardV2_1();
-    private static final String NAME = "standard_v2.1";
 
     public StandardV2_1()
     {
-        super( NAME, STORE_VERSION, 3, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
+        super( STORE_VERSION, 3, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
                 Capability.VERSION_TRAILERS );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_1.java
@@ -37,10 +37,11 @@ public class StandardV2_1 extends BaseRecordFormats
 {
     public static final String STORE_VERSION = StoreVersion.STANDARD_V2_1.versionString();
     public static final RecordFormats RECORD_FORMATS = new StandardV2_1();
+    private static final String NAME = "standard_v2.1";
 
     public StandardV2_1()
     {
-        super( STORE_VERSION, 3, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
+        super( NAME, STORE_VERSION, 3, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
                 Capability.VERSION_TRAILERS );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
@@ -37,10 +37,11 @@ public class StandardV2_2 extends BaseRecordFormats
 {
     public static final String STORE_VERSION = StoreVersion.STANDARD_V2_2.versionString();
     public static final RecordFormats RECORD_FORMATS = new StandardV2_2();
+    private static final String NAME = "standard_v2.2";
 
     public StandardV2_2()
     {
-        super( STORE_VERSION, 4, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
+        super( NAME, STORE_VERSION, 4, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
                 Capability.VERSION_TRAILERS );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_2.java
@@ -37,11 +37,10 @@ public class StandardV2_2 extends BaseRecordFormats
 {
     public static final String STORE_VERSION = StoreVersion.STANDARD_V2_2.versionString();
     public static final RecordFormats RECORD_FORMATS = new StandardV2_2();
-    private static final String NAME = "standard_v2.2";
 
     public StandardV2_2()
     {
-        super( NAME, STORE_VERSION, 4, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
+        super( STORE_VERSION, 4, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3,
                 Capability.VERSION_TRAILERS );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
@@ -37,11 +37,10 @@ public class StandardV2_3 extends BaseRecordFormats
 {
     public static final String STORE_VERSION = StoreVersion.STANDARD_V2_3.versionString();
     public static final RecordFormats RECORD_FORMATS = new StandardV2_3();
-    private static final String NAME = "standard_v2.3";
 
     public StandardV2_3()
     {
-        super( NAME, STORE_VERSION, 5, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3 );
+        super( STORE_VERSION, 5, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3 );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV2_3.java
@@ -37,10 +37,11 @@ public class StandardV2_3 extends BaseRecordFormats
 {
     public static final String STORE_VERSION = StoreVersion.STANDARD_V2_3.versionString();
     public static final RecordFormats RECORD_FORMATS = new StandardV2_3();
+    private static final String NAME = "standard_v2.3";
 
     public StandardV2_3()
     {
-        super( STORE_VERSION, 5, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3 );
+        super( NAME, STORE_VERSION, 5, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_3 );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
@@ -41,7 +41,7 @@ public class StandardV3_0 extends BaseRecordFormats
 
     public StandardV3_0()
     {
-        super( NAME, STORE_VERSION, 6, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_5 );
+        super( STORE_VERSION, 6, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_5 );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardV3_0.java
@@ -41,7 +41,7 @@ public class StandardV3_0 extends BaseRecordFormats
 
     public StandardV3_0()
     {
-        super( STORE_VERSION, 6, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_5 );
+        super( NAME, STORE_VERSION, 6, Capability.SCHEMA, Capability.DENSE_NODES, Capability.LUCENE_5 );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/propertydeduplication/PropertyDeduplicator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/legacystore/v21/propertydeduplication/PropertyDeduplicator.java
@@ -39,7 +39,6 @@ import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.SchemaStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.StoreType;
-import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.Record;
@@ -54,18 +53,16 @@ public class PropertyDeduplicator
     private final File workingDir;
     private final PageCache pageCache;
     private final SchemaIndexProvider schemaIndexProvider;
-    private final RecordFormats recordFormats;
     private final PrimitiveIntObjectMap<Long> seenPropertyKeys;
     private final PrimitiveIntObjectMap<DuplicateCluster> localDuplicateClusters;
 
     public PropertyDeduplicator( FileSystemAbstraction fileSystem, File workingDir, PageCache pageCache,
-                                 SchemaIndexProvider schemaIndexProvider, RecordFormats recordFormats )
+                                 SchemaIndexProvider schemaIndexProvider )
     {
         this.fileSystem = fileSystem;
         this.workingDir = workingDir;
         this.pageCache = pageCache;
         this.schemaIndexProvider = schemaIndexProvider;
-        this.recordFormats = recordFormats;
 
         seenPropertyKeys = Primitive.intObjectMap();
         localDuplicateClusters = Primitive.intObjectMap();
@@ -73,10 +70,8 @@ public class PropertyDeduplicator
 
     public void deduplicateProperties() throws IOException
     {
-        final StoreFactory storeFactory =
-                new StoreFactory( fileSystem, workingDir, pageCache, recordFormats, NullLogProvider.getInstance() );
-        try ( NeoStores neoStores = storeFactory.openNeoStores( StoreType.PROPERTY, StoreType
-                .NODE, StoreType.SCHEMA) )
+        StoreFactory factory = new StoreFactory( workingDir, pageCache, fileSystem, NullLogProvider.getInstance() );
+        try ( NeoStores neoStores = factory.openNeoStores( StoreType.PROPERTY, StoreType.NODE, StoreType.SCHEMA) )
         {
             PropertyStore propertyStore = neoStores.getPropertyStore();
             NodeStore nodeStore = neoStores.getNodeStore();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -38,7 +38,6 @@ import org.neo4j.kernel.impl.api.index.IndexStoreView;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.factory.DatabaseInfo;
 import org.neo4j.kernel.impl.logging.LogService;
-import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.impl.spi.SimpleKernelContext;
@@ -50,7 +49,6 @@ import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.util.Dependencies;
@@ -193,7 +191,7 @@ public class BatchingNeoStores implements AutoCloseable
         try ( PageCache pageCache = createPageCache( fileSystem, dbConfig, NullLogProvider.getInstance(),
                 PageCacheTracer.NULL ) )
         {
-            StoreFactory storeFactory = new StoreFactory( fileSystem, new File( storeDir ), pageCache, newFormat,
+            StoreFactory storeFactory = new StoreFactory( new File( storeDir ), pageCache, fileSystem, newFormat,
                             NullLogProvider.getInstance() );
             try ( NeoStores neoStores = storeFactory.openAllNeoStores( true ) )
             {
@@ -212,7 +210,7 @@ public class BatchingNeoStores implements AutoCloseable
     {
         BatchingIdGeneratorFactory idGeneratorFactory = new BatchingIdGeneratorFactory( fileSystem );
         StoreFactory storeFactory = new StoreFactory( storeDir, neo4jConfig, idGeneratorFactory, pageCache, fileSystem,
-                RecordFormatSelector.autoSelectFormat( neo4jConfig, NullLogService.getInstance() ), logProvider );
+                logProvider );
         return storeFactory.openAllNeoStores( true );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/PropertyPhysicalToLogicalConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/PropertyPhysicalToLogicalConverterTest.java
@@ -37,7 +37,6 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
@@ -220,8 +219,7 @@ public class PropertyPhysicalToLogicalConverterTest
         File storeDir = new File( "dir" );
         fs.get().mkdirs( storeDir );
         StoreFactory storeFactory = new StoreFactory( storeDir, Config.empty(), new DefaultIdGeneratorFactory( fs.get() ),
-                pageCacheRule.getPageCache( fs.get() ), fs.get(), StandardV3_0.RECORD_FORMATS, NullLogProvider
-                .getInstance() );
+                pageCacheRule.getPageCache( fs.get() ), fs.get(), NullLogProvider.getInstance() );
         neoStores = storeFactory.openAllNeoStores( true );
         store = neoStores.getPropertyStore();
         converter = new PropertyPhysicalToLogicalConverter( store );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
@@ -51,7 +51,6 @@ import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.format.standard.PropertyRecordFormat;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
@@ -298,7 +297,7 @@ public class StorePropertyCursorTest
                 fs.deleteRecursively( storeDir );
             }
             fs.mkdirs( storeDir );
-            StoreFactory storeFactory = new StoreFactory( fs, storeDir, pageCache, StandardV3_0.RECORD_FORMATS, log );
+            StoreFactory storeFactory = new StoreFactory( storeDir, pageCache, fs, log );
             neoStores = storeFactory.openAllNeoStores( true );
             propertyStore = neoStores.getPropertyStore();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
@@ -42,7 +42,6 @@ import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.PropertyKeyTokenStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -125,8 +124,7 @@ public class ManyPropertyKeysIT
     {
         DefaultFileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         PageCache pageCache = pageCacheRule.getPageCache( fs );
-        StoreFactory storeFactory = new StoreFactory( fs, storeDir, pageCache, StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+        StoreFactory storeFactory = new StoreFactory( storeDir, pageCache, fs, NullLogProvider.getInstance() );
         NeoStores neoStores = storeFactory.openAllNeoStores( true );
         PropertyKeyTokenStore store = neoStores.getPropertyKeyTokenStore();
         for ( int i = 0; i < propertyKeyCount; i++ )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngineRule.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngineRule.java
@@ -42,8 +42,6 @@ import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.ReentrantLockService;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
-import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
@@ -86,8 +84,7 @@ public class RecordStorageEngineRule extends ExternalResource
     }
 
     private RecordStorageEngine get( FileSystemAbstraction fs, PageCache pageCache, LabelScanStore labelScanStore,
-            SchemaIndexProvider schemaIndexProvider, DatabaseHealth databaseHealth, File storeDirectory,
-            RecordFormats recordFormats )
+            SchemaIndexProvider schemaIndexProvider, DatabaseHealth databaseHealth, File storeDirectory )
     {
         if ( !fs.fileExists( storeDirectory ) && !fs.mkdir( storeDirectory ) )
         {
@@ -108,7 +105,7 @@ public class RecordStorageEngineRule extends ExternalResource
                 scheduler, mock( TokenNameLookup.class ), new ReentrantLockService(),
                 schemaIndexProvider, IndexingService.NO_MONITOR, databaseHealth,
                 labelScanStoreProvider, legacyIndexProviderLookup, indexConfigStore,
-                new SynchronizedArrayIdOrderingQueue( 20 ), txSnapshotSupplier, recordFormats ) );
+                new SynchronizedArrayIdOrderingQueue( 20 ), txSnapshotSupplier ) );
     }
 
     @Override
@@ -123,7 +120,6 @@ public class RecordStorageEngineRule extends ExternalResource
         private final FileSystemAbstraction fs;
         private final PageCache pageCache;
         private LabelScanStore labelScanStore = new InMemoryLabelScanStore();
-        private RecordFormats recordFormats = RecordFormatSelector.autoSelectFormat();
         private DatabaseHealth databaseHealth = new DatabaseHealth(
                 new DatabasePanicEventGenerator( new KernelEventHandlers( NullLog.getInstance() ) ),
                 NullLog.getInstance() );
@@ -148,12 +144,6 @@ public class RecordStorageEngineRule extends ExternalResource
             return this;
         }
 
-        public Builder recordFormats( RecordFormats recordFormats)
-        {
-            this.recordFormats = recordFormats;
-            return this;
-        }
-
         public Builder databaseHealth( DatabaseHealth databaseHealth )
         {
             this.databaseHealth = databaseHealth;
@@ -170,7 +160,7 @@ public class RecordStorageEngineRule extends ExternalResource
 
         public RecordStorageEngine build()
         {
-            return get( fs, pageCache, labelScanStore, schemaIndexProvider, databaseHealth, storeDirectory, recordFormats );
+            return get( fs, pageCache, labelScanStore, schemaIndexProvider, databaseHealth, storeDirectory );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
@@ -28,7 +28,6 @@ import java.nio.ByteBuffer;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.storemigration.StoreFile;
@@ -54,8 +53,8 @@ public class FreeIdsAfterRecoveryTest
     public void shouldCompletelyRebuildIdGeneratorsAfterCrash() throws Exception
     {
         // GIVEN
-        StoreFactory storeFactory = new StoreFactory( fs, directory.directory(), pageCacheRule.getPageCache( fs ),
-                StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+        StoreFactory storeFactory = new StoreFactory( directory.directory(), pageCacheRule.getPageCache( fs ), fs,
+                NullLogProvider.getInstance() );
         long highId;
         try ( NeoStores stores = storeFactory.openAllNeoStores( true ) )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -47,7 +47,6 @@ import org.neo4j.kernel.impl.factory.CommunityFacadeFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.PlatformModule;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.ImpermanentGraphDatabase;
@@ -123,7 +122,7 @@ public class IdGeneratorRebuildFailureEmulationTest
         params.put( GraphDatabaseSettings.rebuild_idgenerators_fast.name(), Settings.FALSE );
         Config config = new Config( params, GraphDatabaseSettings.class );
         factory = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs ),
-                pageCacheRule.getPageCache( fs ), fs, StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs ), fs, NullLogProvider.getInstance() );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
@@ -28,7 +28,7 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
 import org.neo4j.kernel.impl.store.record.Record;
@@ -73,7 +73,7 @@ public class LabelTokenStoreTest
         public UnusedLabelTokenStore() throws IOException
         {
             super( file, config, generatorFactory, cache, logProvider, dynamicStringStore,
-                    StandardV3_0.RECORD_FORMATS );
+                    RecordFormatSelector.defaultFormat() );
             storeFile = mock( PagedFile.class );
 
             when( storeFile.io( any( Long.class ), any( Integer.class ) ) ).thenReturn( pageCursor );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/LabelTokenStoreTest.java
@@ -28,7 +28,7 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
 import org.neo4j.kernel.impl.store.record.Record;
@@ -38,7 +38,6 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.autoSelectFormat;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.FORCE;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
 
@@ -74,7 +73,7 @@ public class LabelTokenStoreTest
         public UnusedLabelTokenStore() throws IOException
         {
             super( file, config, generatorFactory, cache, logProvider, dynamicStringStore,
-                    autoSelectFormat( config, NullLogService.getInstance() ) );
+                    StandardV3_0.RECORD_FORMATS );
             storeFile = mock( PagedFile.class );
 
             when( storeFile.io( any( Long.class ), any( Integer.class ) ) ).thenReturn( pageCursor );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
@@ -51,6 +51,7 @@ import org.neo4j.io.pagecache.impl.DelegatingPageCursor;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.record.MetaDataRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
+import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.logging.NullLogger;
 import org.neo4j.test.EphemeralFileSystemRule;
@@ -118,8 +119,8 @@ public class MetaDataStoreTest
 
     private MetaDataStore newMetaDataStore() throws IOException
     {
-        StoreFactory storeFactory = new StoreFactory( fs, STORE_DIR, pageCacheWithFakeOverflow,
-                StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+        LogProvider logProvider = NullLogProvider.getInstance();
+        StoreFactory storeFactory = new StoreFactory( STORE_DIR, pageCacheWithFakeOverflow, fs, logProvider );
         return storeFactory.openNeoStores( true, StoreType.META_DATA ).getMetaDataStore();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -61,9 +61,8 @@ import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.core.RelationshipTypeToken;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.MetaDataStore.Position;
-import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.standard.DynamicRecordFormat;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
@@ -128,7 +127,7 @@ public class NeoStoresTest
         Config config = new Config( new HashMap<>(), GraphDatabaseSettings.class );
         pageCache = pageCacheRule.getPageCache( fs.get() );
         StoreFactory sf = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs.get() ), pageCache,
-                fs.get(), StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                fs.get(), NullLogProvider.getInstance() );
         sf.openAllNeoStores( true ).close();
     }
 
@@ -137,7 +136,7 @@ public class NeoStoresTest
     {
         Config config = new Config( new HashMap<>(), GraphDatabaseSettings.class );
         StoreFactory sf = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs.get() ), pageCache,
-                fs.get(), StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                fs.get(), NullLogProvider.getInstance() );
         NeoStores neoStores = sf.openAllNeoStores( true );
 
         assertNotNull( neoStores.getMetaDataStore() );
@@ -154,7 +153,7 @@ public class NeoStoresTest
     {
         Config config = new Config( new HashMap<>(), GraphDatabaseSettings.class );
         StoreFactory sf = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs.get() ), pageCache,
-                fs.get(), StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                fs.get(), NullLogProvider.getInstance() );
 
         exception.expect( IllegalArgumentException.class );
         exception.expectMessage( "Block size of dynamic array store should be positive integer." );
@@ -170,7 +169,7 @@ public class NeoStoresTest
     {
         Config config = new Config( new HashMap<>(), GraphDatabaseSettings.class );
         StoreFactory sf = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs.get() ), pageCache,
-                fs.get(), StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                fs.get(), NullLogProvider.getInstance() );
         NeoStores neoStores = sf.openNeoStores( true, StoreType.NODE_LABEL );
 
 
@@ -507,9 +506,9 @@ public class NeoStoresTest
         assertEquals( 10, MetaDataStore.setRecord( pageCache, new File( storeDir,
                 MetaDataStore.DEFAULT_NAME ).getAbsoluteFile(), Position.LOG_VERSION, 12 ) );
 
-        Config config = new Config( new HashMap<String, String>(), GraphDatabaseSettings.class );
+        Config config = new Config( new HashMap<>(), GraphDatabaseSettings.class );
         StoreFactory sf = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fileSystem ), pageCache,
-                fileSystem, StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                fileSystem, NullLogProvider.getInstance() );
 
         NeoStores neoStores = sf.openAllNeoStores();
         assertEquals( 12, neoStores.getMetaDataStore().getCurrentLogVersion() );
@@ -521,9 +520,8 @@ public class NeoStoresTest
     {
         FileSystemAbstraction fileSystem = fs.get();
         File neoStoreDir = new File( "/tmp/graph.db/neostore" ).getAbsoluteFile();
-        StoreFactory factory = new StoreFactory( fileSystem, neoStoreDir, pageCache, getRecordFormat(),
-                NullLogProvider.getInstance() );
-        long recordVersion = MetaDataStore.versionStringToLong( getRecordFormat().storeVersion() );
+        StoreFactory factory = newStoreFactory( neoStoreDir, pageCache, fileSystem );
+        long recordVersion = defaultStoreVersion();
         try ( NeoStores neoStores = factory.openAllNeoStores( true ) )
         {
             MetaDataStore metaDataStore = neoStores.getMetaDataStore();
@@ -565,8 +563,7 @@ public class NeoStoresTest
         // given
         Config config = new Config( new HashMap<>(), GraphDatabaseSettings.class );
         StoreFactory sf = new StoreFactory( dir.directory(), config, new DefaultIdGeneratorFactory( fs.get() ),
-                pageCacheRule.getPageCache( fs.get() ), fs.get(), StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs.get() ), fs.get(), NullLogProvider.getInstance() );
 
         // when
         NeoStores neoStores = sf.openAllNeoStores( true );
@@ -595,8 +592,7 @@ public class NeoStoresTest
     public void shouldInitializeTheTxIdToOne()
     {
         StoreFactory factory =
-                new StoreFactory( fs.get(), new File( "graph.db/neostore" ), pageCache, StandardV3_0.RECORD_FORMATS,
-                        NullLogProvider.getInstance() );
+                new StoreFactory( new File( "graph.db/neostore" ), pageCache, fs.get(), NullLogProvider.getInstance() );
 
         try ( NeoStores neoStores = factory.openAllNeoStores( true ) )
         {
@@ -615,8 +611,7 @@ public class NeoStoresTest
     {
         FileSystemAbstraction fileSystem = fs.get();
         File neoStoreDir = new File( "/tmp/graph.db/neostore" ).getAbsoluteFile();
-        StoreFactory factory = new StoreFactory( fileSystem, neoStoreDir, pageCache, StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+        StoreFactory factory = new StoreFactory( neoStoreDir, pageCache, fileSystem, NullLogProvider.getInstance() );
 
         try ( NeoStores neoStores = factory.openAllNeoStores( true ) )
         {
@@ -637,9 +632,8 @@ public class NeoStoresTest
     {
         FileSystemAbstraction fileSystem = fs.get();
         File neoStoreDir = new File( "/tmp/graph.db/neostore" ).getAbsoluteFile();
-        StoreFactory factory = new StoreFactory( fileSystem, neoStoreDir, pageCache, StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
-        long recordVersion = MetaDataStore.versionStringToLong( getRecordFormat().storeVersion() );
+        StoreFactory factory = newStoreFactory( neoStoreDir, pageCache, fileSystem );
+        long recordVersion = defaultStoreVersion();
         try ( NeoStores neoStores = factory.openAllNeoStores( true ) )
         {
             MetaDataStore metaDataStore = neoStores.getMetaDataStore();
@@ -682,8 +676,7 @@ public class NeoStoresTest
         // GIVEN
         FileSystemAbstraction fileSystem = fs.get();
         fileSystem.mkdirs( storeDir );
-        StoreFactory factory = new StoreFactory( fileSystem, storeDir, pageCache, StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+        StoreFactory factory = new StoreFactory( storeDir, pageCache, fileSystem, NullLogProvider.getInstance() );
 
         try ( NeoStores neoStore = factory.openAllNeoStores( true ) )
         {
@@ -704,8 +697,7 @@ public class NeoStoresTest
         // GIVEN
         FileSystemAbstraction fileSystem = fs.get();
         fileSystem.mkdirs( storeDir );
-        StoreFactory factory = new StoreFactory( fileSystem, storeDir, pageCache, StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+        StoreFactory factory = new StoreFactory( storeDir, pageCache, fileSystem, NullLogProvider.getInstance() );
 
         try ( NeoStores neoStore = factory.openAllNeoStores( true ) )
         {
@@ -749,6 +741,17 @@ public class NeoStoresTest
             stringToIndex.put( index.name(), index );
             intToIndex.put( index.id(), index );
         }
+    }
+
+    private static long defaultStoreVersion()
+    {
+        return MetaDataStore.versionStringToLong( RecordFormatSelector.defaultFormat().storeVersion() );
+    }
+
+    private static StoreFactory newStoreFactory( File neoStoreDir, PageCache pageCache, FileSystemAbstraction fs )
+    {
+        return new StoreFactory( neoStoreDir, pageCache, fs, RecordFormatSelector.defaultFormat(),
+                NullLogProvider.getInstance() );
     }
 
     private Token createDummyIndex( int id, String key )
@@ -1370,10 +1373,5 @@ public class NeoStoresTest
                 }
             }
         }
-    }
-
-    private RecordFormats getRecordFormat()
-    {
-        return StandardV3_0.RECORD_FORMATS;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
@@ -47,7 +47,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
@@ -411,7 +410,7 @@ public class NodeStoreTest
             }
         } );
         StoreFactory factory = new StoreFactory( storeDir, Config.empty(), idGeneratorFactory, pageCache, fs,
-                StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                NullLogProvider.getInstance() );
         neoStores = factory.openAllNeoStores( true );
         nodeStore = neoStores.getNodeStore();
         return nodeStore;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/PropertyStoreTest.java
@@ -33,8 +33,7 @@ import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.JumpingIdGeneratorFactory;
-import org.neo4j.kernel.impl.logging.NullLogService;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
@@ -48,7 +47,6 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.select;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.FORCE;
 
 public class PropertyStoreTest
@@ -83,7 +81,7 @@ public class PropertyStoreTest
         final PropertyStore store = new PropertyStore( path, config, new JumpingIdGeneratorFactory( 1 ), pageCache,
                 NullLogProvider.getInstance(), stringPropertyStore,
                 mock( PropertyKeyTokenStore.class ), mock( DynamicArrayStore.class ),
-                select(config, StandardV3_0.RECORD_FORMATS, NullLogService.getInstance()) );
+                RecordFormatSelector.defaultFormat() );
         store.initialise( true );
 
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
@@ -34,7 +34,6 @@ import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
@@ -74,8 +73,7 @@ public abstract class RecordStoreConsistentReadTest<R extends AbstractBaseRecord
         PageCache pageCache = pageCacheRule.getPageCache( fs );
         pageCache = pageCacheRule.withInconsistentReads( pageCache, nextReadIsInconsistent );
         File storeDir = new File( "stores" );
-        StoreFactory factory = new StoreFactory( fs, storeDir, pageCache, StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+        StoreFactory factory = new StoreFactory( storeDir, pageCache, fs, NullLogProvider.getInstance() );
         NeoStores neoStores = factory.openAllNeoStores( true );
         S store = initialiseStore( neoStores );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RelationshipGroupStoreTest.java
@@ -42,7 +42,6 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.Record;
@@ -168,7 +167,7 @@ public class RelationshipGroupStoreTest
             customConfig.put( GraphDatabaseSettings.dense_node_threshold.name(), "" + customThreshold );
         }
         return new StoreFactory( directory, new Config( customConfig ), new DefaultIdGeneratorFactory( fs ), pageCache,
-                fs, StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                fs, NullLogProvider.getInstance() );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStoreTest.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractSchemaRule;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -65,7 +64,7 @@ public class SchemaStoreTest
         config = Config.empty();
         DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs.get() );
         storeFactory = new StoreFactory( storeDir, config, idGeneratorFactory, pageCacheRule.getPageCache( fs.get() ),
-                fs.get(), StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                fs.get(), NullLogProvider.getInstance() );
         neoStores = storeFactory.openAllNeoStores( true );
         store = neoStores.getSchemaStore();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/StoreFactoryTest.java
@@ -34,7 +34,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.PageCacheRule;
@@ -63,8 +62,8 @@ public class StoreFactoryTest
 
         storeDir = testDirectory.graphDbDir();
         fs.mkdirs( storeDir );
-        storeFactory = new StoreFactory( storeDir, Config.empty(), idGeneratorFactory, pageCache,
-                fs, StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+        storeFactory = new StoreFactory( storeDir, Config.empty(), idGeneratorFactory, pageCache, fs,
+                NullLogProvider.getInstance() );
     }
 
     @After
@@ -106,8 +105,7 @@ public class StoreFactoryTest
         PageCache pageCache = pageCacheRule.getPageCache( fs );
         StoreFactory readOnlyStoreFactory = new StoreFactory( testDirectory.directory( "readOnlyStore" ),
                 new Config( MapUtil.stringMap( GraphDatabaseSettings.read_only.name(), Settings.TRUE ) ),
-                new DefaultIdGeneratorFactory( fs ), pageCache, fs, StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+                new DefaultIdGeneratorFactory( fs ), pageCache, fs, NullLogProvider.getInstance() );
         neoStores = readOnlyStoreFactory.openAllNeoStores( true );
         long lastClosedTransactionId = neoStores.getMetaDataStore().getLastClosedTransactionId();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestArrayStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestArrayStore.java
@@ -37,7 +37,6 @@ import org.neo4j.helpers.collection.Pair;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.util.Bits;
@@ -67,7 +66,7 @@ public class TestArrayStore
         DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
         PageCache pageCache = pageCacheRule.getPageCache( fs );
         StoreFactory factory = new StoreFactory( dir, Config.empty(), idGeneratorFactory, pageCache, fs,
-                StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                NullLogProvider.getInstance() );
         neoStores = factory.openAllNeoStores( true );
         arrayStore = neoStores.getPropertyStore().getArrayStore();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestDynamicStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestDynamicStore.java
@@ -38,7 +38,6 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.logging.NullLogProvider;
@@ -67,8 +66,7 @@ public class TestDynamicStore
         fs.get().mkdir( storeDir );
         config = config();
         storeFactory = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs.get() ),
-                pageCacheRule.getPageCache( fs.get() ), fs.get(), StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs.get() ), fs.get(), NullLogProvider.getInstance() );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
@@ -36,7 +36,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.NodeManager;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.NullLogProvider;
@@ -177,8 +176,7 @@ public class TestGraphProperties
 
         Config config = new Config( Collections.<String, String>emptyMap(), GraphDatabaseSettings.class );
         StoreFactory storeFactory = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs.get() ),
-                pageCacheRule.getPageCache( fs.get() ), fs.get(), StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs.get() ), fs.get(), NullLogProvider.getInstance() );
         NeoStores neoStores = storeFactory.openAllNeoStores();
         long prop = neoStores.getMetaDataStore().getGraphNextProp();
         assertTrue( prop != 0 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGrowingFileMemoryMapping.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGrowingFileMemoryMapping.java
@@ -29,7 +29,6 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.format.standard.NodeRecordFormat;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.logging.NullLogProvider;
@@ -65,7 +64,7 @@ public class TestGrowingFileMemoryMapping
         DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fileSystemAbstraction );
         PageCache pageCache = pageCacheRule.getPageCache( fileSystemAbstraction, config );
         StoreFactory storeFactory = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache,
-                fileSystemAbstraction, StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                fileSystemAbstraction, NullLogProvider.getInstance() );
 
         NeoStores neoStores = storeFactory.openAllNeoStores( true );
         NodeStore nodeStore = neoStores.getNodeStore();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestIdGeneratorRebuilding.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestIdGeneratorRebuilding.java
@@ -34,8 +34,7 @@ import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
-import org.neo4j.kernel.impl.logging.NullLogService;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -47,7 +46,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.select;
 
 public class TestIdGeneratorRebuilding
 {
@@ -82,7 +80,7 @@ public class TestIdGeneratorRebuilding
         DynamicArrayStore labelStore = mock( DynamicArrayStore.class );
         NodeStore store = new NodeStore( storeFile, config, new DefaultIdGeneratorFactory( fs ),
                 pageCacheRule.getPageCache( fs ), NullLogProvider.getInstance(), labelStore,
-                select(config, StandardV3_0.RECORD_FORMATS, NullLogService.getInstance()) );
+                RecordFormatSelector.defaultFormat() );
         store.initialise( true );
         store.makeStoreOk();
 
@@ -131,7 +129,7 @@ public class TestIdGeneratorRebuilding
                 GraphDatabaseSettings.rebuild_idgenerators_fast.name(), "false" ) );
 
         StoreFactory storeFactory = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs ),
-                pageCacheRule.getPageCache( fs ), fs, StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs ), fs, NullLogProvider.getInstance() );
         NeoStores neoStores = storeFactory.openAllNeoStores( true );
         DynamicStringStore store = neoStores.getPropertyStore().getStringStore();
 
@@ -187,7 +185,7 @@ public class TestIdGeneratorRebuilding
         DynamicArrayStore labelStore = mock( DynamicArrayStore.class );
         NodeStore store = new NodeStore( storeFile, config, new DefaultIdGeneratorFactory( fs ),
                 pageCacheRule.getPageCache( fs ), NullLogProvider.getInstance(), labelStore,
-                select( config, StandardV3_0.RECORD_FORMATS, NullLogService.getInstance() ) );
+                RecordFormatSelector.defaultFormat() );
         store.initialise( true );
         store.makeStoreOk();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/UpgradeStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/UpgradeStoreIT.java
@@ -43,7 +43,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
-import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.standard.DynamicRecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
@@ -65,7 +65,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.AbstractNeo4jTestCase.deleteFileOrDirectory;
-import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.select;
 
 @Ignore
 public class UpgradeStoreIT
@@ -381,7 +380,7 @@ public class UpgradeStoreIT
         {
             super( fileName, Config.defaults(), new NoLimitIdGeneratorFactory( fs ), pageCache,
                     NullLogProvider.getInstance(), stringStore,
-                    select( Config.defaults(), NullLogService.getInstance() ) );
+                    RecordFormatSelector.defaultFormat() );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
@@ -43,7 +43,6 @@ import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.counts.keys.CountsKey;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.Lifespan;
@@ -317,7 +316,7 @@ public class CountsComputerTest
     {
         cleanupCountsForRebuilding();
 
-        StoreFactory storeFactory = new StoreFactory( fs, dir, pageCache, StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+        StoreFactory storeFactory = new StoreFactory( dir, pageCache, fs, NullLogProvider.getInstance() );
         try ( Lifespan life = new Lifespan();
               NeoStores neoStores = storeFactory.openAllNeoStores() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
@@ -97,6 +97,12 @@ public class RecordFormatPropertyConfiguratorTest
         }
 
         @Override
+        public String name()
+        {
+            return "resizable";
+        }
+
+        @Override
         public String storeVersion()
         {
             return null;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatPropertyConfiguratorTest.java
@@ -97,12 +97,6 @@ public class RecordFormatPropertyConfiguratorTest
         }
 
         @Override
-        public String name()
-        {
-            return "resizable";
-        }
-
-        @Override
         public String storeVersion()
         {
             return null;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
@@ -240,10 +240,10 @@ public class MigrationTestUtils
         return false;
     }
 
-    public static boolean checkNeoStoreHasCurrentFormatVersion( StoreVersionCheck check, File workingDirectory )
+    public static boolean checkNeoStoreHasDefaultFormatVersion( StoreVersionCheck check, File workingDirectory )
     {
         File neostoreFile = new File( workingDirectory, MetaDataStore.DEFAULT_NAME );
-        return check.hasVersion( neostoreFile, RecordFormatSelector.autoSelectFormat().storeVersion() )
+        return check.hasVersion( neostoreFile, RecordFormatSelector.defaultFormat().storeVersion() )
                 .outcome.isSuccessful();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -118,9 +118,8 @@ public class StoreMigratorTest
                 upgradableDatabase.currentVersion() );
 
         // THEN starting the new store should be successful
-        StoreFactory storeFactory = new StoreFactory( fs, storeDirectory, pageCache, selectFormat(),
-                logService.getInternalLogProvider() );
-        storeFactory.openAllNeoStores().close();
+        StoreFactory factory = new StoreFactory( storeDirectory, pageCache, fs,  logService.getInternalLogProvider() );
+        factory.openAllNeoStores().close();
     }
 
     @Test
@@ -152,9 +151,8 @@ public class StoreMigratorTest
         migrator.rebuildCounts( storeDirectory, versionToMigrateFrom, upgradableDatabase.currentVersion() );
 
         // THEN starting the new store should be successful
-        StoreFactory storeFactory = new StoreFactory( fs, storeDirectory, pageCache, selectFormat(),
-                logService.getInternalLogProvider() );
-        storeFactory.openAllNeoStores().close();
+        StoreFactory factory = new StoreFactory( storeDirectory, pageCache, fs, logService.getInternalLogProvider() );
+        factory.openAllNeoStores().close();
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/ApplyRecoveredTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/ApplyRecoveredTransactionsTest.java
@@ -34,7 +34,6 @@ import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -114,7 +113,7 @@ public class ApplyRecoveredTransactionsTest
         FileSystemAbstraction fs = fsr.get();
         File storeDir = new File( "dir" );
         StoreFactory storeFactory = new StoreFactory( storeDir, Config.empty(), new DefaultIdGeneratorFactory( fs ),
-                pageCacheRule.getPageCache( fs ), fs, StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs ), fs, NullLogProvider.getInstance() );
         neoStores = storeFactory.openAllNeoStores( true );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeCommandTest.java
@@ -36,7 +36,6 @@ import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.NodeLabels;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -246,8 +245,7 @@ public class NodeCommandTest
         fs.get().mkdirs( dir );
         @SuppressWarnings("deprecation")
         StoreFactory storeFactory = new StoreFactory( dir, Config.empty(), new DefaultIdGeneratorFactory( fs.get() ),
-                pageCacheRule.getPageCache( fs.get() ), fs.get(), StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs.get() ), fs.get(), NullLogProvider.getInstance() );
         neoStores = storeFactory.openAllNeoStores( true );
         nodeStore = neoStores.getNodeStore();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeLabelsFieldTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeLabelsFieldTest.java
@@ -46,7 +46,6 @@ import org.neo4j.kernel.impl.store.NodeLabels;
 import org.neo4j.kernel.impl.store.NodeLabelsField;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -508,8 +507,7 @@ public class NodeLabelsFieldTest
         fs.get().mkdirs( storeDir );
         Config config = new Config( stringMap( GraphDatabaseSettings.label_block_size.name(), "60" ) );
         StoreFactory storeFactory = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fs.get() ),
-                pageCacheRule.getPageCache( fs.get() ), fs.get(), StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs.get() ), fs.get(), NullLogProvider.getInstance() );
         neoStores = storeFactory.openAllNeoStores( true );
         nodeStore = neoStores.getNodeStore();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
@@ -61,12 +61,6 @@ public class PrepareTrackingRecordFormats implements RecordFormats
     }
 
     @Override
-    public String name()
-    {
-        return actual.name();
-    }
-
-    @Override
     public String storeVersion()
     {
         return actual.storeVersion();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
@@ -61,6 +61,12 @@ public class PrepareTrackingRecordFormats implements RecordFormats
     }
 
     @Override
+    public String name()
+    {
+        return actual.name();
+    }
+
+    @Override
     public String storeVersion()
     {
         return actual.storeVersion();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
@@ -30,11 +30,11 @@ import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.StoreType;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.transaction.state.RelationshipGroupGetter.RelationshipGroupPosition;
+import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
@@ -61,8 +61,8 @@ public class RelationshipGroupGetterTest
         // GIVEN a node with relationship group chain 2-->4-->10-->23
         File dir = new File( "dir" );
         fs.get().mkdirs( dir );
-        StoreFactory storeFactory = new StoreFactory( fs.get(), dir, pageCache.getPageCache( fs.get() ),
-                StandardV3_0.RECORD_FORMATS, NullLogProvider.getInstance() );
+        LogProvider logProvider = NullLogProvider.getInstance();
+        StoreFactory storeFactory = new StoreFactory( dir, pageCache.getPageCache( fs.get() ), fs.get(), logProvider );
         try ( NeoStores stores = storeFactory.openNeoStores( true, StoreType.RELATIONSHIP_GROUP ) )
         {
             RecordStore<RelationshipGroupRecord> store = spy( stores.getRelationshipGroupStore() );

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -46,7 +46,6 @@ import org.neo4j.kernel.impl.factory.CommunityCommitProcessFactory;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.proc.Procedures;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
@@ -95,8 +94,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 new StandardConstraintSemantics(), monitors,
                 new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler ),
                 mock( Procedures.class ),
-                IOLimiter.unlimited(),
-                RecordFormatSelector.autoSelectFormat() );
+                IOLimiter.unlimited() );
 
         return dataSource;
     }

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoresRule.java
@@ -29,8 +29,8 @@ import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
@@ -60,7 +60,9 @@ public class NeoStoresRule extends ExternalResource
 
     public NeoStores open( String... config )
     {
-        return open( StandardV3_0.RECORD_FORMATS, config );
+        Config configuration = new Config( stringMap( config ) );
+        RecordFormats formats = RecordFormatSelector.selectForConfig( configuration, NullLogProvider.getInstance() );
+        return open( formats, config );
     }
 
     public NeoStores open( RecordFormats format, String... config )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertTest.java
@@ -86,7 +86,6 @@ import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.store.SchemaStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.IndexRule;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -318,8 +317,7 @@ public class BatchInsertTest
         inserter.shutdown();
         File dir = new File( inserter.getStoreDir() );
         PageCache pageCache = pageCacheRule.getPageCache( fs );
-        StoreFactory storeFactory = new StoreFactory( fs, dir, pageCache, StandardV3_0.RECORD_FORMATS,
-                NullLogProvider.getInstance() );
+        StoreFactory storeFactory = new StoreFactory( dir, pageCache, fs, NullLogProvider.getInstance() );
         return storeFactory.openAllNeoStores();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/PropertyEncoderStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/PropertyEncoderStepTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
@@ -59,9 +58,8 @@ public class PropertyEncoderStepTest
     {
         File storeDir = new File( "dir" );
         pageCache = pageCacheRule.getPageCache( fsRule.get() );
-        StoreFactory storeFactory = new StoreFactory( fsRule.get(), storeDir, pageCache, StandardV3_0.RECORD_FORMATS,
-                        NullLogProvider.getInstance() );
-        neoStores = storeFactory.openAllNeoStores( true );
+        StoreFactory factory = new StoreFactory( storeDir, pageCache, fsRule.get(), NullLogProvider.getInstance() );
+        neoStores = factory.openAllNeoStores( true );
     }
 
     @After

--- a/community/neo4j/src/test/java/upgrade/StoreUpgradeOnStartupTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgradeOnStartupTest.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.fail;
 import static org.neo4j.consistency.store.StoreAssertions.assertConsistentStore;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.allLegacyStoreFilesHaveVersion;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.allStoreFilesHaveNoTrailer;
-import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.checkNeoStoreHasCurrentFormatVersion;
+import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.checkNeoStoreHasDefaultFormatVersion;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.prepareSampleLegacyDatabase;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.removeCheckPointFromTxLog;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.truncateFile;
@@ -106,7 +106,7 @@ public class StoreUpgradeOnStartupTest
 
         // then
         assertTrue( "Some store files did not have the correct version",
-                checkNeoStoreHasCurrentFormatVersion( check, workingDirectory ) );
+                checkNeoStoreHasDefaultFormatVersion( check, workingDirectory ) );
         assertTrue( allStoreFilesHaveNoTrailer( fileSystem, workingDirectory ) );
         assertConsistentStore( workingDirectory );
     }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -68,7 +68,7 @@ import static org.junit.Assert.fail;
 import static org.neo4j.consistency.store.StoreAssertions.assertConsistentStore;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.allLegacyStoreFilesHaveVersion;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.allStoreFilesHaveNoTrailer;
-import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.checkNeoStoreHasCurrentFormatVersion;
+import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.checkNeoStoreHasDefaultFormatVersion;
 
 @RunWith( Parameterized.class )
 public class StoreUpgraderInterruptionTestIT
@@ -145,7 +145,7 @@ public class StoreUpgraderInterruptionTestIT
         SchemaIndexMigrator indexMigrator = createIndexMigrator();
         newUpgrader(upgradableDatabase, progressMonitor, indexMigrator, migrator ).migrateIfNeeded( workingDirectory );
 
-        assertTrue( checkNeoStoreHasCurrentFormatVersion( check, workingDirectory ) );
+        assertTrue( checkNeoStoreHasDefaultFormatVersion( check, workingDirectory ) );
         assertTrue( allStoreFilesHaveNoTrailer( fs, workingDirectory ) );
 
         assertConsistentStore( workingDirectory );
@@ -195,7 +195,7 @@ public class StoreUpgraderInterruptionTestIT
             assertEquals( "This upgrade is failing", e.getMessage() );
         }
 
-        assertTrue( checkNeoStoreHasCurrentFormatVersion( check, workingDirectory ) );
+        assertTrue( checkNeoStoreHasDefaultFormatVersion( check, workingDirectory ) );
         assertTrue( allStoreFilesHaveNoTrailer( fs, workingDirectory ) );
 
         assertConsistentStore( workingDirectory );
@@ -205,7 +205,7 @@ public class StoreUpgraderInterruptionTestIT
         newUpgrader( upgradableDatabase, progressMonitor, createIndexMigrator(), migrator )
                 .migrateIfNeeded( workingDirectory );
 
-        assertTrue( checkNeoStoreHasCurrentFormatVersion( check, workingDirectory ) );
+        assertTrue( checkNeoStoreHasDefaultFormatVersion( check, workingDirectory ) );
         assertTrue( allStoreFilesHaveNoTrailer( fs, workingDirectory ) );
 
         pageCache.close();

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -19,7 +19,6 @@
  */
 package upgrade;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -50,12 +49,12 @@ import org.neo4j.kernel.impl.logging.StoreLogService;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_0;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_1;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_2;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader.UnableToUpgradeException;
@@ -92,7 +91,6 @@ import static org.neo4j.consistency.store.StoreAssertions.assertConsistentStore;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.allLegacyStoreFilesHaveVersion;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.allStoreFilesHaveNoTrailer;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.changeVersionNumber;
-import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.checkNeoStoreHasCurrentFormatVersion;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.containsAnyStoreFiles;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.isolatedMigrationDirectoryOf;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.prepareSampleLegacyDatabase;
@@ -158,19 +156,13 @@ public class StoreUpgraderTest
         newUpgrader( upgradableDatabase, pageCache ).migrateIfNeeded( dbDirectory );
 
         // Then
-        assertTrue( checkNeoStoreHasCurrentFormatVersion( check, dbDirectory ) );
+        assertCorrectStoreVersion( getRecordFormats().storeVersion(), check, dbDirectory );
         assertTrue( allStoreFilesHaveNoTrailer( fileSystem, dbDirectory ) );
 
         // We leave logical logs in place since the new version can read the old
 
         assertFalse( containsAnyStoreFiles( fileSystem, isolatedMigrationDirectoryOf( dbDirectory ) ) );
-        assertConsistentStore( dbDirectory, getTunnningConfig() );
-    }
-
-    private Config getTunnningConfig()
-    {
-        return new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(),
-                getRecordFormatsName() ) );
+        assertConsistentStore( dbDirectory );
     }
 
     @Test
@@ -342,9 +334,8 @@ public class StoreUpgraderTest
         newUpgrader( upgradableDatabase, allowMigrateConfig, pageCache ).migrateIfNeeded( dbDirectory );
 
         // Then
-        StoreFactory storeFactory = new StoreFactory( fileSystem, dbDirectory, pageCache, getRecordFormats(),
-                        NullLogProvider.getInstance() );
-        try ( NeoStores neoStores = storeFactory.openAllNeoStores() )
+        StoreFactory factory = new StoreFactory( dbDirectory, pageCache, fileSystem, NullLogProvider.getInstance() );
+        try ( NeoStores neoStores = factory.openAllNeoStores() )
         {
             assertThat( neoStores.getMetaDataStore().getUpgradeTransaction(),
                     equalTo( neoStores.getMetaDataStore().getLastCommittedTransaction() ) );
@@ -396,6 +387,13 @@ public class StoreUpgraderTest
         assertThat( migrationHelperDirs(), is( emptyCollectionOf( File.class ) ) );
     }
 
+    private static void assertCorrectStoreVersion( String expectedStoreVersion, StoreVersionCheck check, File storeDir )
+    {
+        File neoStoreFile = new File( storeDir, MetaDataStore.DEFAULT_NAME );
+        StoreVersionCheck.Result result = check.hasVersion( neoStoreFile, expectedStoreVersion );
+        assertTrue( "Unexpected store version", result.outcome.isSuccessful() );
+    }
+
     private StoreMigrationParticipant participantThatWillFailWhenMoving( final String failureMessage )
     {
         return new AbstractStoreMigrationParticipant( "Failing" )
@@ -425,7 +423,7 @@ public class StoreUpgraderTest
         SilentMigrationProgressMonitor progressMonitor = new SilentMigrationProgressMonitor();
 
         NullLogService instance = NullLogService.getInstance();
-        StoreMigrator defaultMigrator = new StoreMigrator( fileSystem, pageCache, getTunnningConfig(), instance,
+        StoreMigrator defaultMigrator = new StoreMigrator( fileSystem, pageCache, getTuningConfig(), instance,
                 schemaIndexProvider );
         SchemaIndexMigrator indexMigrator =
                 new SchemaIndexMigrator( fileSystem, schemaIndexProvider, labelScanStoreProvider );
@@ -467,13 +465,13 @@ public class StoreUpgraderTest
         }
     }
 
-    protected RecordFormats getRecordFormats()
+    private Config getTuningConfig()
     {
-        return RecordFormatSelector.autoSelectFormat();
+        return new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), getRecordFormats().name() ) );
     }
 
-    protected String getRecordFormatsName()
+    protected RecordFormats getRecordFormats()
     {
-        return StringUtils.EMPTY;
+        return StandardV3_0.RECORD_FORMATS;
     }
 }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -467,11 +467,16 @@ public class StoreUpgraderTest
 
     private Config getTuningConfig()
     {
-        return new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), getRecordFormats().name() ) );
+        return new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), getRecordFormatsName() ) );
     }
 
     protected RecordFormats getRecordFormats()
     {
         return StandardV3_0.RECORD_FORMATS;
+    }
+
+    protected String getRecordFormatsName()
+    {
+        return StandardV3_0.NAME;
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -162,7 +162,7 @@ class BackupService
                 }
             }, CancellationRequest.NEVER_CANCELLED );
 
-            bumpMessagesDotLogFile( targetDirectory, timestamp );
+            bumpDebugDotLogFileVersion( targetDirectory, timestamp );
             boolean consistent = false;
             try
             {
@@ -205,7 +205,7 @@ class BackupService
             {
                 targetDb.shutdown();
             }
-            bumpMessagesDotLogFile( targetDirectory, backupStartTime );
+            bumpDebugDotLogFileVersion( targetDirectory, backupStartTime );
             clearIdFiles( targetDirectory );
             return outcome;
         }
@@ -353,7 +353,7 @@ class BackupService
         return new BackupOutcome( handler.getLastSeenTransactionId(), consistent );
     }
 
-    private static boolean bumpMessagesDotLogFile( File dbDirectory, long toTimestamp )
+    private static boolean bumpDebugDotLogFileVersion( File dbDirectory, long toTimestamp )
     {
         File[] candidates = dbDirectory.listFiles( new FilenameFilter()
         {

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -46,7 +46,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
@@ -59,7 +58,6 @@ import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.MetaDataStore.Position;
 import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.storemigration.LogFiles;
 import org.neo4j.kernel.impl.storemigration.StoreFile;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
@@ -136,8 +134,7 @@ public class BackupServiceIT
     public int backupPort = 8200;
 
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() )
-            .startLazily().withConfig( getConfig() );
+    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
 
     @Rule
     public SuppressOutput suppressOutput = SuppressOutput.suppressAll();
@@ -327,10 +324,8 @@ public class BackupServiceIT
 
         // it should be possible to at this point to start db based on our backup and create couple of properties
         // their ids should not clash with already existing
-        GraphDatabaseService backupBasedDatabase =
-                new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( backupDir.getAbsoluteFile() )
-                .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
-                        .newGraphDatabase();
+        GraphDatabaseService backupBasedDatabase = new GraphDatabaseFactory()
+                .newEmbeddedDatabase( backupDir.getAbsoluteFile() );
         try
         {
             try ( Transaction transaction = backupBasedDatabase.beginTx() )
@@ -865,20 +860,14 @@ public class BackupServiceIT
         }
     }
 
-    private Config getConfig()
-    {
-        return new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(),
-                StandardV3_0.NAME ) );
-    }
-
     private DbRepresentation getBackupDbRepresentation()
     {
-        return DbRepresentation.of( backupDir, getConfig() );
+        return DbRepresentation.of( backupDir );
     }
 
     private DbRepresentation getDbRepresentation()
     {
-        return DbRepresentation.of( storeDir, getConfig() );
+        return DbRepresentation.of( storeDir );
     }
 
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/EmbeddedServer.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/EmbeddedServer.java
@@ -26,7 +26,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Settings;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 
 public class EmbeddedServer implements ServerInterface
 {
@@ -37,7 +36,6 @@ public class EmbeddedServer implements ServerInterface
         GraphDatabaseBuilder graphDatabaseBuilder = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir );
         graphDatabaseBuilder.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE );
         graphDatabaseBuilder.setConfig( OnlineBackupSettings.online_backup_server, serverAddress );
-        graphDatabaseBuilder.setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME );
         graphDatabaseBuilder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
         this.db = graphDatabaseBuilder.newGraphDatabase();
     }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupTests.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/IncrementalBackupTests.java
@@ -35,10 +35,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
@@ -228,7 +225,6 @@ public class IncrementalBackupTests
                 newEmbeddedDatabaseBuilder( path ).
                 setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE ).
                 setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE ).
-                setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME ).
                 newGraphDatabase();
     }
 
@@ -247,12 +243,6 @@ public class IncrementalBackupTests
 
     private DbRepresentation getBackupDbRepresentation()
     {
-        return DbRepresentation.of( backupPath, getFormatConfig() );
-    }
-
-    private Config getFormatConfig()
-    {
-        return new Config(
-                MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), StandardV3_0.NAME ) );
+        return DbRepresentation.of( backupPath );
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestConfiguration.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestConfiguration.java
@@ -27,9 +27,7 @@ import org.junit.Test;
 import java.io.File;
 
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Settings;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -54,9 +52,7 @@ public class TestConfiguration
     @Test
     public void testOnByDefault() throws Exception
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( SOURCE_DIR )
-                .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
-                .newGraphDatabase();
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( SOURCE_DIR );
         OnlineBackup.from( HOST_ADDRESS ).full( BACKUP_DIR );
         db.shutdown();
     }
@@ -66,7 +62,6 @@ public class TestConfiguration
     {
         GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( SOURCE_DIR )
                 .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
-                .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
                 .newGraphDatabase();
         try
         {
@@ -84,7 +79,6 @@ public class TestConfiguration
     {
         GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( SOURCE_DIR )
                 .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE )
-                .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
                 .newGraphDatabase();
 
         OnlineBackup.from( HOST_ADDRESS ).full( BACKUP_DIR );
@@ -97,8 +91,7 @@ public class TestConfiguration
         String customPort = "12345";
         GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( SOURCE_DIR )
                 .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE )
-                .setConfig( OnlineBackupSettings.online_backup_server, ":"+customPort )
-                .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
+                .setConfig( OnlineBackupSettings.online_backup_server, ":" + customPort )
                 .newGraphDatabase();
         try
         {

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -56,7 +56,6 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
 import static java.lang.Math.max;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.record_format;
 import static org.neo4j.helpers.Format.bytes;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
@@ -319,7 +318,6 @@ public class StoreCopyClient
                 .setUserLogProvider( NullLogProvider.getInstance() )
                 .newEmbeddedDatabaseBuilder( tempStore.getAbsoluteFile() )
                 .setConfig( "dbms.backup.enabled", Settings.FALSE )
-                .setConfig( record_format, config.get( record_format ) )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.allow_store_upgrade,

--- a/enterprise/com/src/test/java/org/neo4j/com/StoreIdTestFactory.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/StoreIdTestFactory.java
@@ -26,11 +26,11 @@ import org.neo4j.kernel.impl.store.format.RecordFormats;
 
 public class StoreIdTestFactory
 {
-    private static RecordFormats select = RecordFormatSelector.autoSelectFormat();
+    private static final RecordFormats format = RecordFormatSelector.defaultFormat();
 
     private static long currentStoreVersionAsLong()
     {
-        return MetaDataStore.versionStringToLong( select.storeVersion() );
+        return MetaDataStore.versionStringToLong( format.storeVersion() );
     }
 
     public static StoreId newStoreIdForCurrentVersion()
@@ -41,7 +41,7 @@ public class StoreIdTestFactory
     public static StoreId newStoreIdForCurrentVersion( long creationTime, long randomId, long upgradeTime, long
             upgradeId )
     {
-        return new StoreId( creationTime, randomId, MetaDataStore.versionStringToLong( select.storeVersion() ),
+        return new StoreId( creationTime, randomId, MetaDataStore.versionStringToLong( format.storeVersion() ),
                 upgradeTime, upgradeId );
     }
 }

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerIT.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerIT.java
@@ -35,10 +35,8 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
-import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
@@ -62,9 +60,8 @@ public class ResponsePackerIT
         LogicalTransactionStore transactionStore = mock( LogicalTransactionStore.class );
         FileSystemAbstraction fs = fsRule.get();
         PageCache pageCache = pageCacheRule.getPageCache( fs );
-        Monitors monitors = new Monitors();
 
-        try ( NeoStores neoStore = createNeoStore( fs, pageCache, monitors ) )
+        try ( NeoStores neoStore = createNeoStore( fs, pageCache ) )
         {
             MetaDataStore store = neoStore.getMetaDataStore();
             store.transactionCommitted( 2, 111 );
@@ -104,13 +101,11 @@ public class ResponsePackerIT
         }
     }
 
-    private NeoStores createNeoStore( FileSystemAbstraction fs, PageCache pageCache, Monitors monitors )
-            throws IOException
+    private NeoStores createNeoStore( FileSystemAbstraction fs, PageCache pageCache ) throws IOException
     {
         File storeDir = new File( "/store/" );
         fs.mkdirs( storeDir );
-        StoreFactory storeFactory = new StoreFactory( fs, storeDir, pageCache, RecordFormatSelector.autoSelectFormat(),
-                NullLogProvider.getInstance() );
+        StoreFactory storeFactory = new StoreFactory( storeDir, pageCache, fs, NullLogProvider.getInstance() );
         return storeFactory.openAllNeoStores( true );
     }
 }

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
@@ -57,13 +58,11 @@ import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -140,50 +139,34 @@ public class StoreCopyClientTest
     }
 
     @Test
-    public void storeCopyClientMustRespectConfiguredRecordFormat() throws Exception
+    public void storeCopyClientMustWorkWithStandardRecordFormat() throws Exception
     {
-        final File copyDir = new File( testDir.directory(), "copy" );
-        final File originalDir = new File( testDir.directory(), "original" );
-        PageCache pageCache = pageCacheRule.getPageCache( fs );
-        String unkownFormat = "unkown_format";
-        Config config = Config.empty().augment( stringMap( record_format.name(), unkownFormat ) );
-        StoreCopyClient copier = new StoreCopyClient(
-                copyDir, config, loadKernelExtensions(), NullLogProvider.getInstance(), fs, pageCache,
-                new StoreCopyClient.Monitor.Adapter(), false );
-
-        final GraphDatabaseAPI original = (GraphDatabaseAPI) startDatabase( originalDir );
-        StoreCopyClient.StoreCopyRequester storeCopyRequest = storeCopyRequest( originalDir, original );
-
-        // This should complain about the unkown format
-        try
-        {
-            copier.copyStore( storeCopyRequest, CancellationRequest.NEVER_CANCELLED );
-            fail( "copyStore should have failed with this format configuration" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e.getMessage(), containsString( unkownFormat ) );
-        }
+        checkStoreCopyClientWithRecordFormats( StandardV3_0.NAME );
     }
 
     @Test
-    public void storeCopyClientMustWorkWithLowLimitRecordFormat() throws Exception
+    public void storeCopyClientMustWorkWithHighLimitRecordFormat() throws Exception
+    {
+        checkStoreCopyClientWithRecordFormats( HighLimit.NAME );
+    }
+
+    private void checkStoreCopyClientWithRecordFormats( String recordFormatsName ) throws Exception
     {
         final File copyDir = new File( testDir.directory(), "copy" );
         final File originalDir = new File( testDir.directory(), "original" );
         PageCache pageCache = pageCacheRule.getPageCache( fs );
-        Config config = Config.empty().augment( stringMap( record_format.name(), StandardV3_0.NAME ) );
+        Config config = Config.empty().augment( stringMap( record_format.name(), recordFormatsName ) );
         StoreCopyClient copier = new StoreCopyClient(
                 copyDir, config, loadKernelExtensions(), NullLogProvider.getInstance(), fs, pageCache,
                 new StoreCopyClient.Monitor.Adapter(), false );
 
-        final GraphDatabaseAPI original = (GraphDatabaseAPI) startDatabase( originalDir, StandardV3_0.NAME );
+        final GraphDatabaseAPI original = (GraphDatabaseAPI) startDatabase( originalDir, recordFormatsName );
         StoreCopyClient.StoreCopyRequester storeCopyRequest = storeCopyRequest( originalDir, original );
 
         copier.copyStore( storeCopyRequest, CancellationRequest.NEVER_CANCELLED );
 
         // Must not throw
-        startDatabase( copyDir, StandardV3_0.NAME ).shutdown();
+        startDatabase( copyDir, recordFormatsName ).shutdown();
     }
 
     @Test

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -135,7 +135,6 @@ import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.store.StoreId;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.stats.IdBasedStoreEntityCounters;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
@@ -175,8 +174,6 @@ public class HighlyAvailableEditionModule
     public HighlyAvailableEditionModule( final PlatformModule platformModule )
     {
         ioLimiter = new ConfigurableIOLimiter( platformModule.config );
-
-        formats = StandardV3_0.RECORD_FORMATS;
 
         final LifeSupport life = platformModule.life;
         life.add( platformModule.dataSourceManager );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
@@ -29,12 +29,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.neo4j.backup.OnlineBackupSettings;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.ha.ClusterRule;
@@ -83,7 +79,7 @@ public class BackupHaIT
         cluster.sync();
 
         // Verify that backed up database can be started and compare representation
-        DbRepresentation backupRepresentation = DbRepresentation.of( backupPath, getConfig() );
+        DbRepresentation backupRepresentation = DbRepresentation.of( backupPath );
         assertEquals( beforeChange, backupRepresentation );
         assertNotEquals( backupRepresentation, afterChange );
     }
@@ -106,7 +102,7 @@ public class BackupHaIT
             cluster.sync();
 
             // Verify that old data is back
-            DbRepresentation backupRepresentation = DbRepresentation.of( backupPath, getConfig() );
+            DbRepresentation backupRepresentation = DbRepresentation.of( backupPath );
             assertEquals( beforeChange, backupRepresentation );
             assertNotEquals( backupRepresentation, afterChange );
         }
@@ -125,11 +121,5 @@ public class BackupHaIT
             args.add( clusterName );
         }
         return args.toArray( new String[args.size()] );
-    }
-
-    private Config getConfig()
-    {
-        return new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(),
-                StandardV3_0.NAME ) );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestBranchedData.java
@@ -35,7 +35,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.helpers.collection.Iterables;
@@ -47,7 +46,6 @@ import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
 import org.neo4j.kernel.impl.ha.ClusterManager.RepairKit;
 import org.neo4j.kernel.impl.logging.StoreLogService;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.impl.util.StoreUtil;
 import org.neo4j.kernel.lifecycle.LifeRule;
@@ -331,9 +329,6 @@ public class TestBranchedData
 
     private GraphDatabaseService startGraphDatabaseService( File storeDir )
     {
-        return new TestGraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder(  storeDir )
-                .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
-                .newGraphDatabase();
+        return new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreHaIT.java
@@ -30,12 +30,10 @@ import java.util.Arrays;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.ha.ClusterManager.ManagedCluster;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -119,7 +117,6 @@ public class LabelScanStoreHaIT
                     {
                         GraphDatabaseService db = new TestGraphDatabaseFactory()
                                 .newEmbeddedDatabaseBuilder( storeDir.getAbsoluteFile() )
-                                .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
                                 .newGraphDatabase();
                         try
                         {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
@@ -28,7 +28,6 @@ import java.util.function.LongSupplier;
 import org.neo4j.kernel.ha.transaction.OnDiskLastTxIdGetter;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
@@ -55,9 +54,8 @@ public class OnDiskLastTxIdGetterTest
     @Test
     public void lastTransactionIdIsBaseTxIdWhileNeoStoresAreStopped()
     {
-        final StoreFactory storeFactory = new StoreFactory( fs.get(), new File( "store" ),
-                pageCacheRule.getPageCache( fs.get() ), RecordFormatSelector.autoSelectFormat(),
-                NullLogProvider.getInstance() );
+        final StoreFactory storeFactory = new StoreFactory( new File( "store" ), pageCacheRule.getPageCache( fs.get() ),
+                fs.get(), NullLogProvider.getInstance() );
         final NeoStores neoStores = storeFactory.openAllNeoStores( true );
         neoStores.close();
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -83,7 +83,6 @@ import org.neo4j.kernel.ha.com.master.Slaves;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.NullLogService;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.lifecycle.LifeSupport;
@@ -130,8 +129,7 @@ public class ClusterManager
 
     public static final long DEFAULT_TIMEOUT_SECONDS = 60L;
     public static final Map<String,String> CONFIG_FOR_SINGLE_JVM_CLUSTER = unmodifiableMap( stringMap(
-            GraphDatabaseSettings.pagecache_memory.name(), "8m",
-            GraphDatabaseSettings.record_format.name(), StandardV3_0.NAME ) );
+            GraphDatabaseSettings.pagecache_memory.name(), "8m" ) );
 
     public interface StoreDirInitializer
     {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -25,7 +25,6 @@ import org.neo4j.kernel.impl.enterprise.transaction.log.checkpoint.ConfigurableI
 import org.neo4j.kernel.impl.factory.CommunityEditionModule;
 import org.neo4j.kernel.impl.factory.EditionModule;
 import org.neo4j.kernel.impl.factory.PlatformModule;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.stats.IdBasedStoreEntityCounters;
 
 /**
@@ -39,7 +38,6 @@ public class EnterpriseEditionModule extends CommunityEditionModule
         super( platformModule );
         platformModule.dependencies.satisfyDependency( new IdBasedStoreEntityCounters( this.idGeneratorFactory ) );
         ioLimiter = new ConfigurableIOLimiter( platformModule.config );
-        formats = StandardV3_0.RECORD_FORMATS;
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -54,7 +54,7 @@ public class HighLimit extends BaseRecordFormats
 
     public HighLimit()
     {
-        super( NAME, STORE_VERSION, 7, Capability.DENSE_NODES, Capability.SCHEMA, Capability.LUCENE_5 );
+        super( STORE_VERSION, 7, Capability.DENSE_NODES, Capability.SCHEMA, Capability.LUCENE_5 );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -54,7 +54,7 @@ public class HighLimit extends BaseRecordFormats
 
     public HighLimit()
     {
-        super( STORE_VERSION, 7, Capability.DENSE_NODES, Capability.SCHEMA, Capability.LUCENE_5 );
+        super( NAME, STORE_VERSION, 7, Capability.DENSE_NODES, Capability.SCHEMA, Capability.LUCENE_5 );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/graphdb/StartupConstraintSemanticsTest.java
@@ -24,10 +24,8 @@ import org.junit.Test;
 
 import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.constraints.StandardConstraintSemantics;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.TargetDirectory;
 
 import static org.hamcrest.Matchers.instanceOf;
@@ -59,10 +57,7 @@ public class StartupConstraintSemanticsTest
         // when
         try
         {
-            graphDb = new GraphDatabaseFactory()
-                    .newEmbeddedDatabaseBuilder( dir.graphDbDir() )
-                    .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
-                    .newGraphDatabase();
+            graphDb = new GraphDatabaseFactory().newEmbeddedDatabase( dir.graphDbDir() );
             fail( "should have failed to start!" );
         }
         // then

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatSelectorTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatSelectorTest.java
@@ -21,70 +21,349 @@ package org.neo4j.kernel.impl.store.format;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import org.neo4j.helpers.collection.MapUtil;
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
+import org.neo4j.kernel.impl.store.format.standard.StandardV2_0;
+import org.neo4j.kernel.impl.store.format.standard.StandardV2_1;
+import org.neo4j.kernel.impl.store.format.standard.StandardV2_2;
+import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.PageCacheRule;
 
-import static org.junit.Assert.assertEquals;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.record_format;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.STORE_VERSION;
+import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.defaultFormat;
+import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.selectForConfig;
+import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.selectForStore;
+import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.selectForStoreOrConfig;
+import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.selectForVersion;
+import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.selectNewestFormat;
 
 public class RecordFormatSelectorTest
 {
+    private static final LogProvider LOG = NullLogProvider.getInstance();
+
     @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    public final PageCacheRule pageCacheRule = new PageCacheRule();
+    private final FileSystemAbstraction fs = new EphemeralFileSystemAbstraction();
+    private final File storeDir = new File( "graph.db" );
 
     @Test
-    public void selectSpecifiedRecordFormat() throws Exception
+    public void defaultFormatTest()
     {
-        Config config = new Config( MapUtil.stringMap( record_format.name(), HighLimit.NAME ) );
-        RecordFormats formatSelector = RecordFormatSelector.select( config,
-                StandardV3_0.RECORD_FORMATS, NullLogService.getInstance() );
-        assertEquals( HighLimit.RECORD_FORMATS.storeVersion(), formatSelector.storeVersion() );
+        assertSame( StandardV3_0.RECORD_FORMATS, defaultFormat() );
     }
 
     @Test
-    public void selectDefaultFormatByDefault() throws Exception
+    public void selectForVersionTest()
     {
+        assertSame( StandardV2_0.RECORD_FORMATS, selectForVersion( StandardV2_0.STORE_VERSION ) );
+        assertSame( StandardV2_1.RECORD_FORMATS, selectForVersion( StandardV2_1.STORE_VERSION ) );
+        assertSame( StandardV2_2.RECORD_FORMATS, selectForVersion( StandardV2_2.STORE_VERSION ) );
+        assertSame( StandardV2_3.RECORD_FORMATS, selectForVersion( StandardV2_3.STORE_VERSION ) );
+        assertSame( StandardV3_0.RECORD_FORMATS, selectForVersion( StandardV3_0.STORE_VERSION ) );
+        assertSame( HighLimit.RECORD_FORMATS, selectForVersion( HighLimit.STORE_VERSION ) );
+    }
+
+    @Test
+    public void selectForWrongVersionTest()
+    {
+        try
+        {
+            selectForVersion( "vA.B.9" );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
+    }
+
+    @Test
+    public void selectForConfigWithRecordFormatParameter()
+    {
+        assertSame( StandardV3_0.RECORD_FORMATS, selectForConfig( config( StandardV3_0.NAME ), LOG ) );
+        assertSame( HighLimit.RECORD_FORMATS, selectForConfig( config( HighLimit.NAME ), LOG ) );
+    }
+
+    @Test
+    public void selectForConfigWithoutRecordFormatParameter()
+    {
+        assertSame( defaultFormat(), selectForConfig( Config.empty(), LOG ) );
+    }
+
+    @Test
+    public void selectForConfigWithWrongRecordFormatParameter()
+    {
+        try
+        {
+            selectForConfig( config( "unknown_format" ), LOG );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
+    }
+
+    @Test
+    public void selectForStoreWithValidStore() throws IOException
+    {
+        PageCache pageCache = getPageCache();
+        verifySelectForStore( pageCache, StandardV2_0.RECORD_FORMATS );
+        verifySelectForStore( pageCache, StandardV2_1.RECORD_FORMATS );
+        verifySelectForStore( pageCache, StandardV2_2.RECORD_FORMATS );
+        verifySelectForStore( pageCache, StandardV2_3.RECORD_FORMATS );
+        verifySelectForStore( pageCache, StandardV3_0.RECORD_FORMATS );
+        verifySelectForStore( pageCache, HighLimit.RECORD_FORMATS );
+    }
+
+    @Test
+    public void selectForStoreWithNoStore() throws IOException
+    {
+        assertNull( selectForStore( storeDir, fs, getPageCache(), LOG ) );
+    }
+
+    @Test
+    public void selectForStoreWithThrowingPageCache() throws IOException
+    {
+        createNeoStoreFile();
+        PageCache pageCache = mock( PageCache.class );
+        when( pageCache.pageSize() ).thenReturn( 8192 );
+        when( pageCache.map( any(), anyInt(), anyVararg() ) ).thenThrow( new IOException( "No reading..." ) );
+        assertNull( selectForStore( storeDir, fs, pageCache, LOG ) );
+    }
+
+    @Test
+    public void selectForStoreWithInvalidStoreVersion() throws IOException
+    {
+        PageCache pageCache = getPageCache();
+        prepareNeoStoreFile( "v9.Z.9", pageCache );
+        assertNull( selectForStore( storeDir, fs, getPageCache(), LOG ) );
+    }
+
+    @Test
+    public void selectForStoreOrConfigWithSameStandardConfiguredAndStoredFormat() throws IOException
+    {
+        PageCache pageCache = getPageCache();
+        prepareNeoStoreFile( StandardV3_0.STORE_VERSION, pageCache );
+
+        Config config = config( StandardV3_0.NAME );
+
+        assertSame( StandardV3_0.RECORD_FORMATS, selectForStoreOrConfig( config, storeDir, fs, pageCache, LOG ) );
+    }
+
+    @Test
+    public void selectForStoreOrConfigWithSameHighLimitConfiguredAndStoredFormat() throws IOException
+    {
+        PageCache pageCache = getPageCache();
+        prepareNeoStoreFile( HighLimit.STORE_VERSION, pageCache );
+
+        Config config = config( HighLimit.NAME );
+
+        assertSame( HighLimit.RECORD_FORMATS, selectForStoreOrConfig( config, storeDir, fs, pageCache, LOG ) );
+    }
+
+    @Test
+    public void selectForStoreOrConfigWithDifferentlyConfiguredAndStoredFormat() throws IOException
+    {
+        PageCache pageCache = getPageCache();
+        prepareNeoStoreFile( StandardV3_0.STORE_VERSION, pageCache );
+
+        Config config = config( HighLimit.STORE_VERSION );
+
+        try
+        {
+            selectForStoreOrConfig( config, storeDir, fs, pageCache, LOG );
+            fail( "Exception expected" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
+    }
+
+    @Test
+    public void selectForStoreOrConfigWithOnlyStandardStoredFormat() throws IOException
+    {
+        PageCache pageCache = getPageCache();
+        prepareNeoStoreFile( StandardV3_0.STORE_VERSION, pageCache );
+
         Config config = Config.empty();
-        RecordFormats formatSelector = RecordFormatSelector.select( config,
-                StandardV3_0.RECORD_FORMATS, NullLogService.getInstance() );
-        assertEquals( StandardV3_0.RECORD_FORMATS.storeVersion(), formatSelector.storeVersion() );
+
+        assertSame( StandardV3_0.RECORD_FORMATS, selectForStoreOrConfig( config, storeDir, fs, pageCache, LOG ) );
     }
 
     @Test
-    public void shouldNotResolveNoneExistingRecordFormat() throws Exception
+    public void selectForStoreOrConfigWithOnlyHighLimitStoredFormat() throws IOException
     {
-        Config config = new Config( MapUtil.stringMap( record_format.name(), "notAValidRecordFormat" ) );
-        expectedException.expect( IllegalArgumentException.class );
+        PageCache pageCache = getPageCache();
+        prepareNeoStoreFile( HighLimit.STORE_VERSION, pageCache );
 
-        RecordFormatSelector.select( config, StandardV3_0.RECORD_FORMATS, NullLogService.getInstance() );
+        Config config = Config.empty();
+
+        assertSame( HighLimit.RECORD_FORMATS, selectForStoreOrConfig( config, storeDir, fs, pageCache, LOG ) );
     }
 
     @Test
-    public void autoSelectStandardFormat()
+    public void selectForStoreOrConfigWithOnlyStandardConfiguredFormat() throws IOException
     {
-        RecordFormats recordFormats = RecordFormatSelector.autoSelectFormat();
-        assertEquals( "Autoselectable format should be equal to default format.", recordFormats,
-                StandardV3_0.RECORD_FORMATS );
+        PageCache pageCache = getPageCache();
+
+        Config config = config( StandardV3_0.NAME );
+
+        assertSame( StandardV3_0.RECORD_FORMATS, selectForStoreOrConfig( config, storeDir, fs, pageCache, LOG ) );
     }
 
     @Test
-    public void autoselectCommunityFormat()
+    public void selectForStoreOrConfigWithOnlyHighLimitConfiguredFormat() throws IOException
     {
-        RecordFormats recordFormats = RecordFormatSelector.autoSelectFormat( Config.empty(), NullLogService.getInstance() );
-        assertEquals( "autoselect should select specified format.", recordFormats, StandardV3_0.RECORD_FORMATS );
+        PageCache pageCache = getPageCache();
+
+        Config config = config( HighLimit.NAME );
+
+        assertSame( HighLimit.RECORD_FORMATS, selectForStoreOrConfig( config, storeDir, fs, pageCache, LOG ) );
     }
 
     @Test
-    public void overrideWithNonExistingFormatFailure()
+    public void selectForStoreOrConfigWithWrongConfiguredFormat() throws IOException
     {
-        Config config = new Config( MapUtil.stringMap( record_format.name(), "notAValidRecordFormat" ) );
-        expectedException.expect( IllegalArgumentException.class );
+        PageCache pageCache = getPageCache();
 
-        RecordFormatSelector.autoSelectFormat( config, NullLogService.getInstance() );
+        Config config = config( "unknown_format" );
+
+        try
+        {
+            selectForStoreOrConfig( config, storeDir, fs, pageCache, LOG );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
+    }
+
+    @Test
+    public void selectForStoreOrConfigWithoutConfiguredAndStoredFormats() throws IOException
+    {
+        assertSame( defaultFormat(), selectForStoreOrConfig( Config.empty(), storeDir, fs, getPageCache(), LOG ) );
+    }
+
+    @Test
+    public void selectNewestFormatWithConfiguredStandardFormat()
+    {
+        assertSame( StandardV3_0.RECORD_FORMATS,
+                selectNewestFormat( config( StandardV3_0.NAME ), storeDir, fs, getPageCache(), LOG ) );
+    }
+
+    @Test
+    public void selectNewestFormatWithConfiguredHighLimitFormat()
+    {
+        assertSame( HighLimit.RECORD_FORMATS,
+                selectNewestFormat( config( HighLimit.NAME ), storeDir, fs, getPageCache(), LOG ) );
+    }
+
+    @Test
+    public void selectNewestFormatWithWrongConfiguredFormat()
+    {
+        try
+        {
+            selectNewestFormat( config( "unknown_format" ), storeDir, fs, getPageCache(), LOG );
+        }
+        catch ( Exception e )
+        {
+            assertThat( e, instanceOf( IllegalArgumentException.class ) );
+        }
+    }
+
+    @Test
+    public void selectNewestFormatWithoutConfigAndStore()
+    {
+        assertSame( defaultFormat(), selectNewestFormat( Config.empty(), storeDir, fs, getPageCache(), LOG ) );
+    }
+
+    @Test
+    public void selectNewestFormatForExistingStandardStore() throws IOException
+    {
+        PageCache pageCache = getPageCache();
+        prepareNeoStoreFile( StandardV3_0.STORE_VERSION, pageCache );
+
+        Config config = Config.empty();
+
+        assertSame( StandardV3_0.RECORD_FORMATS, selectNewestFormat( config, storeDir, fs, getPageCache(), LOG ) );
+    }
+
+    @Test
+    public void selectNewestFormatForExistingHighLimitStore() throws IOException
+    {
+        PageCache pageCache = getPageCache();
+        prepareNeoStoreFile( HighLimit.STORE_VERSION, pageCache );
+
+        Config config = Config.empty();
+
+        assertSame( HighLimit.RECORD_FORMATS, selectNewestFormat( config, storeDir, fs, getPageCache(), LOG ) );
+    }
+
+    @Test
+    public void selectNewestFormatForExistingStoreWithLegacyFormat() throws IOException
+    {
+        PageCache pageCache = getPageCache();
+        prepareNeoStoreFile( StandardV2_3.STORE_VERSION, pageCache );
+
+        Config config = Config.empty();
+
+        assertSame( defaultFormat(), selectNewestFormat( config, storeDir, fs, getPageCache(), LOG ) );
+    }
+
+    private PageCache getPageCache()
+    {
+        return pageCacheRule.getPageCache( fs );
+    }
+
+    private void verifySelectForStore( PageCache pageCache, RecordFormats format ) throws IOException
+    {
+        prepareNeoStoreFile( format.storeVersion(), pageCache );
+        assertSame( format, selectForStore( storeDir, fs, pageCache, LOG ) );
+    }
+
+    private File prepareNeoStoreFile( String storeVersion, PageCache pageCache ) throws IOException
+    {
+        File neoStoreFile = createNeoStoreFile();
+        long value = MetaDataStore.versionStringToLong( storeVersion );
+        MetaDataStore.setRecord( pageCache, neoStoreFile, STORE_VERSION, value );
+        return neoStoreFile;
+    }
+
+    private File createNeoStoreFile() throws IOException
+    {
+        fs.mkdir( storeDir );
+        File neoStoreFile = new File( storeDir, MetaDataStore.DEFAULT_NAME );
+        fs.create( neoStoreFile ).close();
+        return neoStoreFile;
+    }
+
+    private static Config config( String recordFormatName )
+    {
+        return new Config( stringMap( GraphDatabaseSettings.record_format.name(), recordFormatName ) );
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatSelectorTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatSelectorTest.java
@@ -191,7 +191,7 @@ public class RecordFormatSelectorTest
         PageCache pageCache = getPageCache();
         prepareNeoStoreFile( StandardV3_0.STORE_VERSION, pageCache );
 
-        Config config = config( HighLimit.STORE_VERSION );
+        Config config = config( HighLimit.NAME );
 
         try
         {

--- a/enterprise/neo4j-enterprise/src/test/java/batchimport/ParallelBatchImporterTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/batchimport/ParallelBatchImporterTest.java
@@ -19,7 +19,7 @@
  */
 package batchimport;
 
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
@@ -38,6 +38,6 @@ public class ParallelBatchImporterTest extends org.neo4j.unsafe.impl.batchimport
     @Override
     public String getFormatName()
     {
-        return StandardV3_0.NAME;
+        return HighLimit.NAME;
     }
 }

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceRecordFormatIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceRecordFormatIT.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.progress.ProgressMonitorFactory;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.FormattedLogProvider;
+import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.SuppressOutput;
+import org.neo4j.test.TargetDirectory;
+
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.test.TargetDirectory.testDirForTest;
+
+@RunWith( Parameterized.class )
+public class ConsistencyCheckServiceRecordFormatIT
+{
+    @ClassRule
+    public static final TargetDirectory.TestDirectory dir =
+            testDirForTest( ConsistencyCheckServiceRecordFormatIT.class );
+
+    private final File storeDir = dir.directory( "db" );
+    private final EmbeddedDatabaseRule db = new EmbeddedDatabaseRule( storeDir ).startLazily();
+
+    @Rule
+    public final RuleChain ruleChain = RuleChain.outerRule( SuppressOutput.suppressAll() ).around( db );
+
+    @Parameter
+    public String recordFormat;
+
+    @Parameters( name = "{0}" )
+    public static List<String> recordFormats()
+    {
+        return Arrays.asList( StandardV3_0.NAME, HighLimit.NAME );
+    }
+
+    @Before
+    public void configureRecordFormat() throws Exception
+    {
+        db.setConfig( GraphDatabaseSettings.record_format, recordFormat );
+    }
+
+    @Test
+    public void checkTinyConsistentStore() throws Exception
+    {
+        db.ensureStarted();
+        createLinkedList( db, 1_000 );
+        db.shutdownAndKeepStore();
+
+        assertConsistentStore( db );
+    }
+
+    private static void createLinkedList( GraphDatabaseService db, int size )
+    {
+        Node previous = null;
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < size; i++ )
+            {
+                Label label = (i % 2 == 0) ? TestLabel.FOO : TestLabel.BAR;
+                Node current = db.createNode( label );
+                current.setProperty( "value", ThreadLocalRandom.current().nextLong() );
+
+                if ( previous != null )
+                {
+                    previous.createRelationshipTo( current, TestRelType.FORWARD );
+                    current.createRelationshipTo( previous, TestRelType.BACKWARD );
+                }
+                previous = current;
+            }
+            tx.success();
+        }
+    }
+
+    private static void assertConsistentStore( GraphDatabaseAPI db ) throws Exception
+    {
+        ConsistencyCheckService service = new ConsistencyCheckService();
+
+        File storeDir = new File( db.getStoreDir() );
+        ConsistencyCheckService.Result result = service.runFullConsistencyCheck( storeDir, Config.empty(),
+                ProgressMonitorFactory.textual( System.out ), FormattedLogProvider.toOutputStream( System.out ), true );
+
+        assertTrue( "Store is inconsistent", result.isSuccessful() );
+    }
+
+    private enum TestLabel implements Label
+    {
+        FOO,
+        BAR
+    }
+
+    private enum TestRelType implements RelationshipType
+    {
+        FORWARD,
+        BACKWARD
+    }
+}

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 public class HighLimitWithSmallRecords extends HighLimit
 {
     public static final String NAME = "high_limit_with_small_records";
+    public static final String STORE_VERSION = "vT.H.0";
     public static final RecordFormats RECORD_FORMATS = new HighLimitWithSmallRecords();
 
     private static final int NODE_RECORD_SIZE = NodeRecordFormat.RECORD_SIZE / 2;
@@ -39,6 +40,18 @@ public class HighLimitWithSmallRecords extends HighLimit
 
     private HighLimitWithSmallRecords()
     {
+    }
+
+    @Override
+    public String name()
+    {
+        return NAME;
+    }
+
+    @Override
+    public String storeVersion()
+    {
+        return STORE_VERSION;
     }
 
     @Override

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitWithSmallRecords.java
@@ -43,12 +43,6 @@ public class HighLimitWithSmallRecords extends HighLimit
     }
 
     @Override
-    public String name()
-    {
-        return NAME;
-    }
-
-    @Override
     public String storeVersion()
     {
         return STORE_VERSION;

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertEnterpriseTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/unsafe/batchinsert/BatchInsertEnterpriseTest.java
@@ -21,16 +21,27 @@ package org.neo4j.unsafe.batchinsert;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.TargetDirectory;
 
@@ -43,16 +54,20 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
  * Just testing the {@link BatchInserter} in an enterprise setting, i.e. with all packages and extensions
  * that exist in enterprise edition.
  */
+@RunWith( Parameterized.class )
 public class BatchInsertEnterpriseTest
 {
-    private enum Labels implements Label
-    {
-        One,
-        Two
-    }
-
     @Rule
     public final TargetDirectory.TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+
+    @Parameter
+    public String recordFormat;
+
+    @Parameters( name = "{0}" )
+    public static List<String> recordFormats()
+    {
+        return Arrays.asList( StandardV3_0.NAME, HighLimit.NAME );
+    }
 
     @Test
     public void shouldInsertDifferentTypesOfThings() throws Exception
@@ -60,7 +75,7 @@ public class BatchInsertEnterpriseTest
         // GIVEN
         BatchInserter inserter = BatchInserters.inserter( directory.directory(), stringMap(
                 GraphDatabaseSettings.log_queries.name(), "true",
-                GraphDatabaseSettings.record_format.name(), StandardV3_0.NAME,
+                GraphDatabaseSettings.record_format.name(), recordFormat,
                 GraphDatabaseSettings.log_queries_filename.name(), directory.file( "query.log" ).getAbsolutePath() ) );
         long node1Id, node2Id, relationshipId;
         try
@@ -97,8 +112,85 @@ public class BatchInsertEnterpriseTest
         }
     }
 
-    private Map<String,Object> someProperties( int id )
+    @Test
+    public void insertIntoExistingDatabase() throws IOException
+    {
+        File storeDir = directory.directory();
+
+        GraphDatabaseService db = newDb( storeDir, recordFormat );
+        try
+        {
+            createThreeNodes( db );
+        }
+        finally
+        {
+            db.shutdown();
+        }
+
+        BatchInserter inserter = BatchInserters.inserter( storeDir );
+        try
+        {
+            long start = inserter.createNode( someProperties( 5 ), Labels.One );
+            long end = inserter.createNode( someProperties( 5 ), Labels.One );
+            inserter.createRelationship( start, end, MyRelTypes.TEST, someProperties( 5 ) );
+        }
+        finally
+        {
+            inserter.shutdown();
+        }
+
+        db = newDb( storeDir, recordFormat );
+        try
+        {
+            verifyNodeCount( db, 4 );
+        }
+        finally
+        {
+            db.shutdown();
+        }
+    }
+
+    private static void verifyNodeCount( GraphDatabaseService db, int expectedNodeCount )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertEquals( expectedNodeCount, Iterables.count( db.getAllNodes() ) );
+            tx.success();
+        }
+    }
+
+    private static void createThreeNodes( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node start = db.createNode( Labels.One );
+            someProperties( 5 ).forEach( start::setProperty );
+
+            Node end = db.createNode( Labels.Two );
+            someProperties( 5 ).forEach( end::setProperty );
+
+            Relationship rel = start.createRelationshipTo( end, MyRelTypes.TEST );
+            someProperties( 5 ).forEach( rel::setProperty );
+
+            tx.success();
+        }
+    }
+
+    private static Map<String,Object> someProperties( int id )
     {
         return map( "key", "value" + id, "number", 10 + id );
+    }
+
+    private GraphDatabaseService newDb( File storeDir, String recordFormat )
+    {
+        return new EnterpriseGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
+                .setConfig( GraphDatabaseSettings.record_format, recordFormat )
+                .newGraphDatabase();
+    }
+
+    private enum Labels implements Label
+    {
+        One,
+        Two
     }
 }

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/EnterpriseStoreUpgraderTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/EnterpriseStoreUpgraderTest.java
@@ -37,4 +37,10 @@ public class EnterpriseStoreUpgraderTest extends StoreUpgraderTest
     {
         return HighLimit.RECORD_FORMATS;
     }
+
+    @Override
+    protected String getRecordFormatsName()
+    {
+        return HighLimit.NAME;
+    }
 }

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/EnterpriseStoreUpgraderTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/EnterpriseStoreUpgraderTest.java
@@ -20,7 +20,7 @@
 package upgrade;
 
 import org.neo4j.kernel.impl.store.format.RecordFormats;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 
 /**
  * Runs the store upgrader tests from older versions, migrating to the current enterprise version.
@@ -35,12 +35,6 @@ public class EnterpriseStoreUpgraderTest extends StoreUpgraderTest
     @Override
     protected RecordFormats getRecordFormats()
     {
-        return StandardV3_0.RECORD_FORMATS;
-    }
-
-    @Override
-    protected String getRecordFormatsName()
-    {
-        return StandardV3_0.NAME;
+        return HighLimit.RECORD_FORMATS;
     }
 }

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/RecordFormatsMigrationIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/RecordFormatsMigrationIT.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package upgrade;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Exceptions;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory;
+import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.storemigration.StoreUpgrader.UnexpectedUpgradingStoreFormatException;
+import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.TargetDirectory;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.test.TargetDirectory.testDirForTest;
+
+public class RecordFormatsMigrationIT
+{
+    private static final Label LABEL = Label.label( "Centipede" );
+    private static final String PROPERTY = "legs";
+    private static final int VALUE = 42;
+
+    private final FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
+
+    @Rule
+    public final TargetDirectory.TestDirectory testDir = testDirForTest( RecordFormatsMigrationIT.class, fs );
+
+    @Test
+    public void migrateStandardToHighLimit() throws IOException
+    {
+        executeAndStopDb( startStandardFormatDb(), this::createNode );
+        assertStandardStore();
+
+        executeAndStopDb( startHighLimitFormatDb(), this::assertNodeExists );
+        assertHighLimitStore();
+    }
+
+    @Test
+    public void migrateHighLimitToStandard() throws IOException
+    {
+        executeAndStopDb( startHighLimitFormatDb(), this::createNode );
+        assertHighLimitStore();
+
+        try
+        {
+            startStandardFormatDb();
+            fail( "Should not be possible to downgrade" );
+        }
+        catch ( Exception e )
+        {
+            assertThat( Exceptions.rootCause( e ), instanceOf( UnexpectedUpgradingStoreFormatException.class ) );
+        }
+        assertHighLimitStore();
+    }
+
+    private void createNode( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node start = db.createNode( LABEL );
+            start.setProperty( PROPERTY, VALUE );
+            tx.success();
+        }
+    }
+
+    private void assertNodeExists( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertNotNull( db.findNode( LABEL, PROPERTY, VALUE ) );
+            tx.success();
+        }
+    }
+
+    private GraphDatabaseService startStandardFormatDb()
+    {
+        return startDb( StandardV3_0.NAME );
+    }
+
+    private GraphDatabaseService startHighLimitFormatDb()
+    {
+        return startDb( HighLimit.NAME );
+    }
+
+    private GraphDatabaseService startDb( String recordFormatName )
+    {
+        return new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDir.graphDbDir() )
+                .setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.record_format, recordFormatName )
+                .newGraphDatabase();
+    }
+
+    private void assertStandardStore() throws IOException
+    {
+        assertStoreFormat( StandardV3_0.RECORD_FORMATS );
+    }
+
+    private void assertHighLimitStore() throws IOException
+    {
+        assertStoreFormat( HighLimit.RECORD_FORMATS );
+    }
+
+    private void assertStoreFormat( RecordFormats expected ) throws IOException
+    {
+        Config config = new Config( stringMap( GraphDatabaseSettings.pagecache_memory.name(), "8m" ) );
+        try ( PageCache pageCache = StandalonePageCacheFactory.createPageCache( fs, config ) )
+        {
+            RecordFormats actual = RecordFormatSelector.selectForStoreOrConfig( config, testDir.graphDbDir(), fs,
+                    pageCache, NullLogProvider.getInstance() );
+            assertNotNull( actual );
+            assertEquals( expected.storeVersion(), actual.storeVersion() );
+        }
+    }
+
+    private static void executeAndStopDb( GraphDatabaseService db, Consumer<GraphDatabaseService> action )
+    {
+        try
+        {
+            action.accept( db );
+        }
+        finally
+        {
+            db.shutdown();
+        }
+    }
+}

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom20IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom20IT.java
@@ -94,12 +94,16 @@ public class StoreMigratorFrom20IT
     private LabelScanStoreProvider labelScanStoreProvider;
 
     @Parameter
+    public String recordFormatName;
+    @Parameter( 1 )
     public RecordFormats recordFormat;
 
     @Parameters( name = "{0}" )
-    public static List<RecordFormats> recordFormats()
+    public static List<Object[]> recordFormats()
     {
-        return Arrays.asList( StandardV3_0.RECORD_FORMATS, HighLimit.RECORD_FORMATS );
+        return Arrays.asList(
+                new Object[]{StandardV3_0.NAME, StandardV3_0.RECORD_FORMATS},
+                new Object[]{HighLimit.NAME, HighLimit.RECORD_FORMATS} );
     }
 
     @Before
@@ -243,7 +247,7 @@ public class StoreMigratorFrom20IT
 
     private Config getConfig()
     {
-        return new Config( stringMap( GraphDatabaseSettings.record_format.name(), recordFormat.name() ),
+        return new Config( stringMap( GraphDatabaseSettings.record_format.name(), recordFormatName ),
                 GraphDatabaseSettings.class );
     }
 }

--- a/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom21IT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/upgrade/StoreMigratorFrom21IT.java
@@ -38,7 +38,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterators;
-import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.api.KernelAPI;
@@ -46,7 +45,6 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.storemigration.MigrationTestUtils;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.NullLogProvider;
@@ -100,17 +98,13 @@ public class StoreMigratorFrom21IT
         File dir = MigrationTestUtils.find21FormatStoreDirectoryWithDuplicateProperties( storeDir.directory() );
 
         GraphDatabaseBuilder builder = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( dir )
-                        .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" )
-                        .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME );
+                        .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
         GraphDatabaseService database = builder.newGraphDatabase();
         database.shutdown();
         ConsistencyCheckService service = new ConsistencyCheckService();
 
-        ConsistencyCheckService.Result result = service.runFullConsistencyCheck(
-                dir.getAbsoluteFile(), Config.defaults().with( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), StandardV3_0.NAME ) ),
-                ProgressMonitorFactory.NONE,
-                NullLogProvider
-                        .getInstance(), false );
+        ConsistencyCheckService.Result result = service.runFullConsistencyCheck( dir.getAbsoluteFile(),
+                Config.empty(), ProgressMonitorFactory.NONE, NullLogProvider.getInstance(), false );
         assertTrue( result.isSuccessful() );
 
         database = builder.newGraphDatabase();

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -62,7 +62,6 @@ import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.store.MetaDataStore;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -173,7 +172,6 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
             builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
-            builder.setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME );
             builder.setConfig( GraphDatabaseSettings.logs_directory, testDir.directory( "logs" ).getAbsolutePath() );
             GraphDatabaseService db = builder.newGraphDatabase();
             try
@@ -186,7 +184,7 @@ public class StoreUpgradeIntegrationTest
                 db.shutdown();
             }
 
-            assertConsistentStore( dir, getConfig() );
+            assertConsistentStore( dir );
         }
 
         @Test
@@ -205,7 +203,6 @@ public class StoreUpgradeIntegrationTest
             props.setProperty( GraphDatabaseSettings.logs_directory.name(), rootDir.getAbsolutePath() );
             props.setProperty( GraphDatabaseSettings.allow_store_upgrade.name(), "true" );
             props.setProperty( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
-            props.setProperty( GraphDatabaseSettings.record_format.name(), StandardV3_0.NAME );
             props.setProperty( httpConnector( "1" ).type.name(), "HTTP" );
             props.setProperty( httpConnector( "1" ).enabled.name(), "true" );
             try ( FileWriter writer = new FileWriter( configFile ) )
@@ -237,7 +234,6 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
             builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
-            builder.setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME );
             builder.setConfig( GraphDatabaseSettings.logs_directory, testDir.directory( "logs" ).getAbsolutePath() );
             GraphDatabaseService db = builder.newGraphDatabase();
             try
@@ -249,7 +245,7 @@ public class StoreUpgradeIntegrationTest
                 db.shutdown();
             }
 
-            assertConsistentStore( dir, getConfig() );
+            assertConsistentStore( dir );
 
             // start the cluster with the db migrated from the old instance
             File haDir = new File( dir.getParentFile(), "ha-stuff" );
@@ -275,8 +271,8 @@ public class StoreUpgradeIntegrationTest
                 clusterManager.safeShutdown();
             }
 
-            assertConsistentStore( new File( master.getStoreDir() ), getConfig() );
-            assertConsistentStore( new File( slave.getStoreDir() ), getConfig() );
+            assertConsistentStore( new File( master.getStoreDir() ) );
+            assertConsistentStore( new File( slave.getStoreDir() ) );
         }
     }
 
@@ -310,7 +306,6 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
             builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
-            builder.setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME );
             try
             {
                 builder.newGraphDatabase();
@@ -357,7 +352,6 @@ public class StoreUpgradeIntegrationTest
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
             builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
-            builder.setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME );
             GraphDatabaseService db = builder.newGraphDatabase();
             try
             {
@@ -590,11 +584,5 @@ public class StoreUpgradeIntegrationTest
             }
         }
         throw new IllegalStateException( "Index did not become ONLINE within reasonable time" );
-    }
-
-    private static Config getConfig()
-    {
-        return new Config( stringMap( GraphDatabaseSettings.record_format.name(),
-                StandardV3_0.NAME ) );
     }
 }

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
@@ -31,7 +31,6 @@ import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.logging.NullLogService;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.stresstests.transaction.checkpoint.tracers.TimerTransactionTracer;
 import org.neo4j.kernel.stresstests.transaction.checkpoint.workload.Workload;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
@@ -82,7 +81,6 @@ public class CheckPointingLogRotationStressTesting
         GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
                 .setConfig( GraphDatabaseSettings.pagecache_memory, pageCacheMemory )
                 .setConfig( GraphDatabaseSettings.mapped_memory_page_size, pageSize )
-                .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
                 .setConfig( GraphDatabaseSettings.check_point_interval_time, CHECK_POINT_INTERVAL_SECONDS + "s" )
                 .setConfig( GraphDatabaseFacadeFactory.Configuration.tracer, "timer" )
                 .newGraphDatabase();

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpCountsStore.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpCountsStore.java
@@ -36,7 +36,6 @@ import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.TokenStore;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.kvstore.HeaderField;
 import org.neo4j.kernel.impl.store.kvstore.Headers;
 import org.neo4j.kernel.impl.store.kvstore.MetadataVisitor;
@@ -71,8 +70,7 @@ public class DumpCountsStore implements CountsVisitor, MetadataVisitor, UnknownK
         {
             if ( fs.isDirectory( path ) )
             {
-                StoreFactory factory = new StoreFactory( fs, path, pages, RecordFormatSelector.autoSelectFormat(),
-                        NullLogProvider.getInstance() );
+                StoreFactory factory = new StoreFactory( path, pages, fs, NullLogProvider.getInstance() );
 
                 NeoStores neoStores = factory.openAllNeoStores();
                 neoStores.getCounts().accept( new DumpCountsStore( out, neoStores ) );

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpStore.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpStore.java
@@ -36,7 +36,6 @@ import org.neo4j.kernel.impl.store.SchemaStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.store.TokenStore;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -70,9 +69,8 @@ public class DumpStore<RECORD extends AbstractBaseRecord, STORE extends RecordSt
         final DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
         try ( PageCache pageCache = createPageCache( fs ) )
         {
-            Function<File,StoreFactory> createStoreFactory =
-                    file -> new StoreFactory( file.getParentFile(), Config.defaults(), idGeneratorFactory, pageCache, fs,
-                            RecordFormatSelector.autoSelectFormat(), logProvider() );
+            Function<File,StoreFactory> createStoreFactory = file -> new StoreFactory( file.getParentFile(),
+                    Config.defaults(), idGeneratorFactory, pageCache, fs, logProvider() );
 
             for ( String arg : args )
             {

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpStoreChain.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpStoreChain.java
@@ -36,7 +36,6 @@ import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.StoreType;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -120,7 +119,7 @@ public abstract class DumpStoreChain<RECORD extends AbstractBaseRecord>
             DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
             Config config = Config.defaults();
             StoreFactory storeFactory = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs,
-                    RecordFormatSelector.autoSelectFormat(), logProvider() );
+                    logProvider() );
 
             try ( NeoStores neoStores = storeFactory.openNeoStores( getStoreTypes() ) )
             {

--- a/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
+++ b/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
@@ -123,15 +123,10 @@ public class StoreMigration
         try ( PageCache pageCache = createPageCache( fs, config ) )
         {
             long startTime = System.currentTimeMillis();
-            new DatabaseMigrator(
-                    progressMonitor,
-                    fs,
-                    config,
-                    logService,
-                    schemaIndexProvider,
-                    labelScanStoreProvider,
-                    legacyIndexProvider.getIndexProviders(),
-                    pageCache, RecordFormatSelector.autoSelectFormat(config, logService) ).migrate( storeDirectory );
+            DatabaseMigrator migrator = new DatabaseMigrator( progressMonitor, fs, config, logService,
+                    schemaIndexProvider, labelScanStoreProvider, legacyIndexProvider.getIndexProviders(),
+                    pageCache, RecordFormatSelector.selectForConfig( config, userLogProvider ) );
+            migrator.migrate( storeDirectory );
             long duration = System.currentTimeMillis() - startTime;
             log.info( format( "Migration completed in %d s%n", duration / 1000 ) );
         }

--- a/tools/src/main/java/org/neo4j/tools/rawstorereader/RsdrMain.java
+++ b/tools/src/main/java/org/neo4j/tools/rawstorereader/RsdrMain.java
@@ -41,7 +41,6 @@ import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
@@ -108,8 +107,7 @@ public class RsdrMain
     {
         IdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( files );
         NullLogProvider logProvider = NullLogProvider.getInstance();
-        return new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, files, RecordFormatSelector.autoSelectFormat(),
-                logProvider );
+        return new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, files, logProvider );
     }
 
     private static void interact( NeoStores neoStores ) throws IOException

--- a/tools/src/test/java/org/neo4j/tools/migration/StoreMigrationTest.java
+++ b/tools/src/test/java/org/neo4j/tools/migration/StoreMigrationTest.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.SuppressOutput;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -54,10 +52,7 @@ public class StoreMigrationTest
         StoreMigration.main( new String[]{testDir.graphDbDir().getAbsolutePath()} );
 
         // after migration we can open store and do something
-        GraphDatabaseService database = new TestGraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( testDir.graphDbDir() )
-                .setConfig( GraphDatabaseSettings.record_format, StandardV3_0.NAME )
-                .newGraphDatabase();
+        GraphDatabaseService database = new TestGraphDatabaseFactory().newEmbeddedDatabase( testDir.graphDbDir() );
         try (Transaction transaction = database.beginTx())
         {
             Node node = database.createNode();

--- a/tools/src/test/java/org/neo4j/tools/rebuild/RebuildFromLogsTest.java
+++ b/tools/src/test/java/org/neo4j/tools/rebuild/RebuildFromLogsTest.java
@@ -38,9 +38,7 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.MetaDataStore;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.SuppressOutput;
@@ -48,8 +46,6 @@ import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.record_format;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 import static org.neo4j.test.TargetDirectory.testDirForTest;
 
@@ -91,7 +87,7 @@ public class RebuildFromLogsTest
 
     private DbRepresentation getDbRepresentation( File path )
     {
-        return DbRepresentation.of( path, getConfig() );
+        return DbRepresentation.of( path );
     }
 
     @Test
@@ -135,18 +131,9 @@ public class RebuildFromLogsTest
         assertEquals( getDbRepresentation( prototypePath ), getDbRepresentation( rebuildPath ) );
     }
 
-    private Config getConfig()
-    {
-        return new Config( stringMap( record_format.name(), StandardV3_0.NAME ) );
-    }
-
     private GraphDatabaseAPI db( File rebuiltPath )
     {
-        return (GraphDatabaseAPI) new TestGraphDatabaseFactory()
-                .newEmbeddedDatabaseBuilder( rebuiltPath )
-                .setConfig( record_format, StandardV3_0.NAME )
-                .newGraphDatabase();
-
+        return (GraphDatabaseAPI) new TestGraphDatabaseFactory().newEmbeddedDatabase( rebuiltPath );
     }
 
     enum Transaction


### PR DESCRIPTION
This commit removes the need to always explicitly configure record format, if it is something else than default. This means that previously, tools like consistency checked and backup always needed an explicit config parameter `GraphDatabaseSettings.record_format` when applied to a high_limit store.

Detection of format happens inside `NeoStoreDataSource` and `StoreFactory`. Later is often directly used by tools like consistency checker.
