### PR TITLE
Ensure that we publish artifacts for neo4j-slf4j

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -108,6 +108,7 @@ terms of the relevant Commercial Agreement.
                 <configuration>
                   <excludeTransitive>true</excludeTransitive>
                   <includes>
+                    <include>org.neo4j:neo4j-slf4j:*</include>
                     <include>org.neo4j:*</include>
                     <include>org.neo4j.app:*</include>
                     <include>org.neo4j.build:*</include>


### PR DESCRIPTION
This is not actually used in any of our production code, but is provided
as a utility for users to adapt between our logging and
SLF4J. Previously it was picked up by the Maven Ease plugin because the
examples module that depends on it was in the Community project. But
that has been moved under docs, so there was no dependency on
neo4j-slf4j from any of our modules. Here we add it explicitly to the
list of modules to publish.
