### PR TITLE
DumpLogicalLog now takes regex to pick interesting transactions

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/FilteringIOCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/FilteringIOCursor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import java.io.IOException;
+
+import org.neo4j.helpers.Predicate;
+
+/**
+ * {@link IOCursor} implementation that uses a predicate to decide on what to keep and what to skip
+ */
+public class FilteringIOCursor<T> implements IOCursor<T>
+{
+    private final IOCursor<T> delegate;
+    private final Predicate<T> toKeep;
+
+    public FilteringIOCursor( IOCursor<T> delegate, Predicate<T> toKeep )
+    {
+        this.delegate = delegate;
+        this.toKeep = toKeep;
+    }
+
+    @Override
+    public T get()
+    {
+        return delegate.get();
+    }
+
+    @Override
+    public boolean next() throws IOException
+    {
+        do
+        {
+            if ( !delegate.next() )
+            {
+                return false;
+            }
+        } while ( !toKeep.accept( delegate.get() ) );
+        return true;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        delegate.close();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionLogEntryCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionLogEntryCursor.java
@@ -20,49 +20,56 @@
 package org.neo4j.kernel.impl.transaction.log;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
-import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
-import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes;
 
 /**
- * {@link IOCursor} abstraction on top of a {@link LogEntryReader}
+ * Groups {@link LogEntry} instances transaction by transaction
  */
-public class LogEntryCursor implements IOCursor<LogEntry>
+public class TransactionLogEntryCursor implements IOCursor<LogEntry[]>
 {
-    private final LogEntryReader<ReadableVersionableLogChannel> logEntryReader;
-    private final ReadableVersionableLogChannel channel;
-    private LogEntry entry;
+    private final IOCursor<LogEntry> delegate;
+    private final List<LogEntry> transaction = new ArrayList<>();
 
-    public LogEntryCursor( ReadableVersionableLogChannel channel )
+    public TransactionLogEntryCursor( IOCursor<LogEntry> delegate )
     {
-        this( new VersionAwareLogEntryReader<ReadableVersionableLogChannel>(), channel );
-    }
-
-    public LogEntryCursor( LogEntryReader<ReadableVersionableLogChannel> logEntryReader,
-            ReadableVersionableLogChannel channel )
-    {
-        this.logEntryReader = logEntryReader;
-        this.channel = channel;
+        this.delegate = delegate;
     }
 
     @Override
-    public LogEntry get()
+    public LogEntry[] get()
     {
-        return entry;
+        return transaction.toArray( new LogEntry[transaction.size()] );
     }
 
     @Override
-    public boolean next( ) throws IOException
+    public boolean next() throws IOException
     {
-        entry = logEntryReader.readLogEntry( channel );
+        transaction.clear();
+        LogEntry entry;
+        while ( delegate.next() )
+        {
+            entry = delegate.get();
+            transaction.add( entry );
+            if ( isBreakPoint( entry ) )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
-        return entry != null;
+    private boolean isBreakPoint( LogEntry entry )
+    {
+        return entry.getType() == LogEntryByteCodes.TX_1P_COMMIT;
     }
 
     @Override
     public void close() throws IOException
     {
-        channel.close();
+        delegate.close();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DumpLogicalLog.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DumpLogicalLog.java
@@ -29,26 +29,28 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.TimeZone;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 
 import org.neo4j.helpers.Args;
+import org.neo4j.helpers.Predicate;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.impl.store.NeoStore;
+import org.neo4j.kernel.impl.transaction.log.FilteringIOCursor;
 import org.neo4j.kernel.impl.transaction.log.IOCursor;
 import org.neo4j.kernel.impl.transaction.log.LogEntryCursor;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadableVersionableLogChannel;
+import org.neo4j.kernel.impl.transaction.log.TransactionLogEntryCursor;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 
 import static java.util.TimeZone.getTimeZone;
-
 import static javax.transaction.xa.Xid.MAXBQUALSIZE;
 import static javax.transaction.xa.Xid.MAXGTRIDSIZE;
-
 import static org.neo4j.helpers.Format.DEFAULT_TIME_ZONE;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
 import static org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles.getLogVersion;
@@ -57,6 +59,7 @@ import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLo
 public class DumpLogicalLog
 {
     private static final String TO_FILE = "tofile";
+    private static final String TX_FILTER = "txfilter";
 
     private final FileSystemAbstraction fileSystem;
 
@@ -66,7 +69,7 @@ public class DumpLogicalLog
     }
 
     public int dump( String filenameOrDirectory, String logPrefix, PrintStream out,
-                     TimeZone timeZone ) throws IOException
+            TimeZone timeZone, String regex ) throws IOException
     {
         int logsFound = 0;
         for ( String fileName : filenamesOf( filenameOrDirectory, logPrefix ) )
@@ -88,25 +91,54 @@ public class DumpLogicalLog
                 fileChannel.close();
                 throw ex;
             }
-            out.println( "Logical log format:" + logHeader.logFormatVersion + "version: " + logHeader.logVersion +
+            out.println( "Logical log format: " + logHeader.logFormatVersion + " version: " + logHeader.logVersion +
                     " with prev committed tx[" + logHeader.lastCommittedTxId + "]" );
-
-//            LogDeserializer deserializer = new LogDeserializer();
 
             PhysicalLogVersionedStoreChannel channel = new PhysicalLogVersionedStoreChannel(
                     fileChannel, logHeader.logVersion, logHeader.logFormatVersion );
             ReadableVersionableLogChannel logChannel =
                     new ReadAheadLogChannel( channel, NO_MORE_CHANNELS, 4096 );
 
-            try ( IOCursor<LogEntry> cursor = new LogEntryCursor( logChannel ) )
+            IOCursor<LogEntry> entryCursor = new LogEntryCursor( logChannel );
+            TransactionLogEntryCursor transactionCursor = new TransactionLogEntryCursor( entryCursor );
+            try ( IOCursor<LogEntry[]> cursor = regex == null ? transactionCursor :
+                    new FilteringIOCursor<>( transactionCursor, new TransactionRegexCriteria( regex, timeZone ) ) )
             {
-                while (cursor.next())
+                while ( cursor.next() )
                 {
-                    out.println( cursor.get().toString( timeZone ) );
+                    for ( LogEntry entry : cursor.get() )
+                    {
+                        out.println( entry.toString( timeZone ) );
+                    }
                 }
             }
         }
         return logsFound;
+    }
+
+    protected class TransactionRegexCriteria implements Predicate<LogEntry[]>
+    {
+        protected Pattern pattern;
+        private final TimeZone timeZone;
+
+        TransactionRegexCriteria( String regex, TimeZone timeZone )
+        {
+            pattern = Pattern.compile( regex );
+            this.timeZone = timeZone;
+        }
+
+        @Override
+        public boolean accept( LogEntry[] transaction )
+        {
+            for ( LogEntry entry : transaction )
+            {
+                if ( pattern.matcher( entry.toString( timeZone ) ).find() )
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     protected static boolean isAGraphDatabaseDirectory( String fileName )
@@ -115,16 +147,29 @@ public class DumpLogicalLog
         return file.isDirectory() && new File( file, NeoStore.DEFAULT_NAME ).exists();
     }
 
+    /**
+     * Usage: [--txfilter "regex"] [--tofile] storeDirOrFile1 storeDirOrFile2 ...
+     *
+     * --txfilter
+     * Will match regex against each {@link LogEntry} and if there is a match,
+     * include transaction containing the LogEntry in the dump.
+     * regex matching is done with {@link Pattern}
+     *
+     * --tofile
+     * Redirects output to dump-logical-log.txt in the store directory
+     */
     public static void main( String args[] ) throws IOException
     {
         Args arguments = Args.withFlags( TO_FILE ).parse( args );
         TimeZone timeZone = parseTimeZoneConfig( arguments );
+        String regex = arguments.get( TX_FILTER );
         try ( Printer printer = getPrinter( arguments ) )
         {
             for ( String fileAsString : arguments.orphans() )
             {
                 new DumpLogicalLog( new DefaultFileSystemAbstraction() )
-                        .dump( fileAsString, PhysicalLogFile.DEFAULT_NAME, printer.getFor( fileAsString ), timeZone );
+                        .dump( fileAsString, PhysicalLogFile.DEFAULT_NAME, printer.getFor( fileAsString ), timeZone,
+                                regex );
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogEntryWriterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/legacylogs/LegacyLogEntryWriterTest.java
@@ -19,27 +19,18 @@
  */
 package org.neo4j.kernel.impl.storemigration.legacylogs;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.neo4j.kernel.impl.storemigration.legacylogs.LegacyLogFilenames.getLegacyLogFilename;
-import static org.neo4j.kernel.impl.transaction.log.LogPosition.UNSPECIFIED;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart.EMPTY_ADDITIONAL_ARRAY;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
-import org.junit.Test;
 import org.neo4j.function.Function;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.ArrayIOCursor;
 import org.neo4j.kernel.impl.transaction.log.IOCursor;
 import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
@@ -51,6 +42,17 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.neo4j.kernel.impl.storemigration.legacylogs.LegacyLogFilenames.getLegacyLogFilename;
+import static org.neo4j.kernel.impl.transaction.log.LogPosition.UNSPECIFIED;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart.EMPTY_ADDITIONAL_ARRAY;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
 
 public class LegacyLogEntryWriterTest
 {
@@ -142,26 +144,6 @@ public class LegacyLogEntryWriterTest
 
     private IOCursor<LogEntry> mockCursor( final LogEntry... entries )
     {
-        return new IOCursor<LogEntry>()
-        {
-            private int pos = 0;
-
-            @Override
-            public LogEntry get()
-            {
-                return entries[pos++];
-            }
-
-            @Override
-            public boolean next() throws IOException
-            {
-                return pos < entries.length;
-            }
-
-            @Override
-            public void close() throws IOException
-            {// nothing to do
-            }
-        };
+        return new ArrayIOCursor<>( entries );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ArrayIOCursor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ArrayIOCursor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import java.io.IOException;
+
+/**
+ * {@link IOCursor} abstraction over a given array
+ */
+public class ArrayIOCursor<T> implements IOCursor<T>
+{
+    private final T[] entries;
+    private int pos = 0;
+    private boolean closed;
+
+    public ArrayIOCursor( T... entries )
+    {
+        this.entries = entries;
+    }
+
+    @Override
+    public T get()
+    {
+        assert !closed;
+        return entries[pos - 1];
+    }
+
+    @Override
+    public boolean next() throws IOException
+    {
+        assert !closed;
+        return pos++ < entries.length;
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        closed = true;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/FilteringIOCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/FilteringIOCursorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.helpers.Predicates;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.Predicates.in;
+import static org.neo4j.helpers.Predicates.not;
+
+public class FilteringIOCursorTest
+{
+
+    @Test
+    public void shouldNotFilterWhenNothingToFilter() throws IOException
+    {
+        String[] strings = { "a", "b", "c" };
+
+        IOCursor<String> delegate = new ArrayIOCursor<>( strings );
+        FilteringIOCursor<String> cursor = new FilteringIOCursor<>( delegate, Predicates.<String>TRUE() );
+
+        assertEquals( asList( strings ), extractCursorContent( cursor ) );
+    }
+
+    @Test
+    public void shouldFilterFirstObject() throws IOException
+    {
+        String[] strings = { "a", "b", "c" };
+
+        IOCursor<String> delegate = new ArrayIOCursor<>( strings );
+        FilteringIOCursor<String> cursor = new FilteringIOCursor<>( delegate, not( in( "a" ) ) );
+
+        assertEquals( exclude( asList( strings ), "a" ), extractCursorContent( cursor ) );
+    }
+
+    @Test
+    public void shouldFilterMiddleObject() throws IOException
+    {
+        String[] strings = { "a", "b", "c" };
+
+        IOCursor<String> delegate = new ArrayIOCursor<>( strings );
+        FilteringIOCursor<String> cursor = new FilteringIOCursor<>( delegate, not( in( "b" ) ) );
+
+        assertEquals( exclude( asList( strings ), "b" ), extractCursorContent( cursor ) );
+    }
+
+    @Test
+    public void shouldFilterLastObject() throws IOException
+    {
+        String[] strings = { "a", "b", "c" };
+
+        IOCursor<String> delegate = new ArrayIOCursor<>( strings );
+        FilteringIOCursor<String> cursor = new FilteringIOCursor<>( delegate, not( in( "c" ) ) );
+
+        assertEquals( exclude( asList( strings ), "c" ), extractCursorContent( cursor ) );
+    }
+
+    private <T> List<T> exclude( List<T> list, T... toExclude )
+    {
+        List<T> toReturn = new ArrayList<>( list );
+
+        for ( T item : toExclude )
+        {
+            while ( toReturn.remove( item ) )
+            {
+                // Continue
+            }
+        }
+
+        return toReturn;
+    }
+
+    private <T> List<T> extractCursorContent( FilteringIOCursor<T> cursor ) throws IOException
+    {
+        List<T> list = new ArrayList<>();
+
+        while ( cursor.next() )
+        {
+            list.add( cursor.get() );
+        }
+
+        return list;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogEntryCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogEntryCursorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes.COMMAND;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes.TX_1P_COMMIT;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes.TX_START;
+
+public class TransactionLogEntryCursorTest
+{
+    @Test
+    public void shouldDeliverIntactTransactions() throws IOException
+    {
+        // GIVEN
+        // tx 1
+        List<LogEntry> tx1 = makeTransaction( TX_START, COMMAND, TX_1P_COMMIT );
+
+        // tx 2
+        List<LogEntry> tx2 = makeTransaction( TX_START, COMMAND, COMMAND, TX_1P_COMMIT );
+
+        // All transactions
+
+        // The cursor
+        TransactionLogEntryCursor transactionCursor = new TransactionLogEntryCursor( new ArrayIOCursor(
+                transactionsAsArray( tx1, tx2 ) ) );
+
+        // THEN
+        // tx1
+        assertTrue( transactionCursor.next() );
+        assertTx( tx1, transactionCursor.get() );
+
+        // tx2
+        assertTrue( transactionCursor.next() );
+        assertTx( tx2, transactionCursor.get() );
+
+        // No more transactions
+        assertFalse( transactionCursor.next() );
+    }
+
+    @Test
+    public void shouldNotDeliverTransactionsWithoutEnd() throws IOException
+    {
+        // GIVEN
+        // tx 1
+        List<LogEntry> tx1 = makeTransaction( TX_START, COMMAND, COMMAND, COMMAND, TX_1P_COMMIT );
+
+        // tx 2
+        List<LogEntry> tx2 = makeTransaction( TX_START, COMMAND, COMMAND );
+
+        TransactionLogEntryCursor transactionCursor = new TransactionLogEntryCursor( new ArrayIOCursor(
+                transactionsAsArray( tx1, tx2 ) ) );
+
+        // THEN
+        assertTrue( transactionCursor.next() );
+        assertTx( tx1, transactionCursor.get() );
+
+        assertFalse( transactionCursor.next() );
+    }
+
+    private LogEntry[] transactionsAsArray( List<LogEntry>... transactions )
+    {
+        List<LogEntry> allTransactions = new ArrayList<>();
+        for ( List<LogEntry> tx : transactions )
+        {
+            allTransactions.addAll( tx );
+        }
+        return allTransactions.toArray( new LogEntry[allTransactions.size()] );
+    }
+
+    private void assertTx( List<LogEntry> expected, LogEntry[] actual )
+    {
+        assertArrayEquals( expected.toArray( new LogEntry[expected.size()] ), actual );
+    }
+
+    private List<LogEntry> makeTransaction( byte... types )
+    {
+        List<LogEntry> transaction = new ArrayList<>( types.length );
+        for ( Byte type : types )
+        {
+            transaction.add( mockedLogEntry( type ) );
+        }
+        return transaction;
+    }
+
+    private LogEntry mockedLogEntry( byte type )
+    {
+        LogEntry logEntry = mock( LogEntry.class );
+        when( logEntry.getType() ).thenReturn( type );
+        return logEntry;
+    }
+}


### PR DESCRIPTION
If a LogEntry matches the given regex pattern the transaction will be
included in the output, otherwise not.

If no regex pattern is given, behaviour is not changed.

Co-author: @tinwelint 
