### PR TITLE
Fix bug with partitioned index document update when document will be added to each partition.

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/writer/PartitionedIndexWriter.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/writer/PartitionedIndexWriter.java
@@ -67,9 +67,14 @@ public class PartitionedIndexWriter implements LuceneIndexWriter
     public void updateDocument( Term term, Document doc ) throws IOException
     {
         List<IndexPartition> partitions = index.getPartitions();
-        for ( IndexPartition partition : partitions )
+        if ( index.hasSinglePartition( partitions ) )
         {
-            partition.getIndexWriter().updateDocument( term, doc );
+            index.getFirstPartition( partitions ).getIndexWriter().updateDocument( term, doc );
+        }
+        else
+        {
+            deleteDocuments( term );
+            addDocument( doc );
         }
     }
 


### PR DESCRIPTION
As part of partitioned operation update will be executed in each partition and new 'updated' document will be added into each partition.
Special handling introduced for case of single partition to preserve update atomicity in that case.
In case of partitioned index we will perform delete first and then will insert new document.
