### PR TITLE
NodeIndexScan should not claim to solve regexp

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/indexScanLeafPlanner.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/planner/logical/steps/indexScanLeafPlanner.scala
@@ -46,7 +46,7 @@ object indexScanLeafPlanner extends LeafPlanner {
         val name = scannable.name
         val propertyKeyName = scannable.propertyKey.name
 
-        produce(name, propertyKeyName, qg, scannable.property, predicate, lpp.planNodeIndexScan)
+        produce(name, propertyKeyName, qg, scannable.property, scannable.expr, lpp.planNodeIndexScan)
 
     }.flatten
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexScanAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/NodeIndexScanAcceptanceTest.scala
@@ -53,4 +53,27 @@ class NodeIndexScanAcceptanceTest extends ExecutionEngineFunSuite with NewPlanne
     // Then
     result should (use("NodeIndexScan") and evaluateTo(List(Map("p" -> person))))
   }
+
+  test("Regexp filter on top of NodeIndexScan (GH #7059)") {
+    // Given
+    graph.createIndex("phone_type", "label")
+    createLabeledNode(Map("id" -> "8bbee2f14a493fa08bef918eaac0c57caa4f9799", "label" -> "ay"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "5fe613811746aa2a1c29d04c6e107974c3a92486", "label" -> "aa"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "a573480b0f13ca9f33d82df91392f9397031a687", "label" -> "g"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "cf8d30601edd84e19f45e9dfd18d2342b92a36eb", "label" -> "t"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "dd4121287c9b542269bda97744d9e828a46bdac4", "label" -> "ae"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "cf406352f4436a5399025fa3f7a7336a24dabdd3", "label" -> "uw"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "a7d330b126594cd47000193698c8d0f9650bc8c4", "label" -> "eh"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "62021e8bd919b0e84427a1e08dfd7704e6a6bd88", "label" -> "r"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "ea1e1deb3f3634ba823a2d5dac56f8bbd2b5b66d", "label" -> "k"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "35321f07bc9b3028d3f5ee07808969a3bd7d76ee", "label" -> "s"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "c960cff2a19a2088c5885f82725428db0694d7ae", "label" -> "d"), "phone_type", "timed")
+    createLabeledNode(Map("id" -> "139dbf46f0dc8a325e27ffd118331ca2947e34f0", "label" -> "z"), "phone_type", "timed")
+
+    // When
+    val result = executeWithCostPlannerOnly("CYPHER 3.0 MATCH (n:phone_type:timed) where n.label =~ 'a.' return count(n)")
+
+    // Then
+    result should (use("NodeIndexScan") and evaluateTo(List(Map("count(n)" -> 3))))
+  }
 }


### PR DESCRIPTION
NodeIndexScan was falsely claiming to solve regexp predicates which leads
to invalid results.

Fixes #7059

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neo4j/neo4j/7157)

<!-- Reviewable:end -->
