### PR TITLE
Update default settings for non unique index sampling, sampler set initial size evaluation.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -303,10 +303,17 @@ public abstract class GraphDatabaseSettings
     public static final Setting<Boolean> index_background_sampling_enabled =
             setting("dbms.index_sampling.background_enabled", BOOLEAN, TRUE );
 
-    @Description("Size of buffer used by index sampling")
-    public static final Setting<Long> index_sampling_buffer_size =
-            setting("dbms.index_sampling.buffer_size", BYTES, "8m",
+    @Description("Size of buffer used by index sampling. " +
+                 "This configuration setting is no longet applicable as from Neo4j 3.0.3." +
+                 "Please use dbms.index_sampling.sample_size_limit instead.")
+    @Deprecated
+    public static final Setting<Long> index_sampling_buffer_size = setting("dbms.index_sampling.buffer_size", BYTES, "64m",
                     min( /* 1m */ 1048576L ), max( (long) Integer.MAX_VALUE ) );
+
+    @Description("Index sampling chunk size limit")
+    public static final Setting<Integer> index_sample_size_limit = setting("dbms.index_sampling.sample_size_limit",
+            INTEGER, String.valueOf( ByteUnit.mebiBytes( 8 ) ), min( (int) ByteUnit.mebiBytes( 1 ) ),
+            max( Integer.MAX_VALUE ) );
 
     @Description("Percentage of index updates of total index size required before sampling of a given index is triggered")
     public static final Setting<Integer> index_sampling_update_percentage =

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -304,7 +304,7 @@ public abstract class GraphDatabaseSettings
             setting("dbms.index_sampling.background_enabled", BOOLEAN, TRUE );
 
     @Description("Size of buffer used by index sampling. " +
-                 "This configuration setting is no longet applicable as from Neo4j 3.0.3." +
+                 "This configuration setting is no longer applicable as from Neo4j 3.0.3." +
                  "Please use dbms.index_sampling.sample_size_limit instead.")
     @Deprecated
     public static final Setting<Long> index_sampling_buffer_size = setting("dbms.index_sampling.buffer_size", BYTES, "64m",

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -305,7 +305,7 @@ public abstract class GraphDatabaseSettings
 
     @Description("Size of buffer used by index sampling")
     public static final Setting<Long> index_sampling_buffer_size =
-            setting("dbms.index_sampling.buffer_size", BYTES, "64m",
+            setting("dbms.index_sampling.buffer_size", BYTES, "8m",
                     min( /* 1m */ 1048576L ), max( (long) Integer.MAX_VALUE ) );
 
     @Description("Percentage of index updates of total index size required before sampling of a given index is triggered")

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -19,6 +19,39 @@
  */
 package org.neo4j.kernel.configuration;
 
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.ByteUnit;
+
+/**
+ * Migrations of old graph database settings.
+ */
 public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrator
 {
+    public GraphDatabaseConfigurationMigrator()
+    {
+        registerMigrations();
+    }
+
+    private void registerMigrations()
+    {
+        add( new SpecificPropertyMigration( "dbms.index_sampling.buffer_size",
+                "dbms.index_sampling.buffer_size has been replaced with dbms.index_sampling.sample_size_limit" )
+        {
+            @Override
+            public void setValueWithOldSetting( String value, Map<String,String> rawConfiguration )
+            {
+                if ( StringUtils.isNotEmpty( value ) )
+                {
+                    String oldSettingDefaultValue = GraphDatabaseSettings.index_sampling_buffer_size.getDefaultValue();
+                    Long newValue = oldSettingDefaultValue.equals( value ) ? ByteUnit.mebiBytes( 8 )
+                                                                           : Settings.BYTES.apply( value );
+                    rawConfiguration.put( "dbms.index_sampling.sample_size_limit", String.valueOf( newValue ) );
+                }
+            }
+        } );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingConfig.java
@@ -30,7 +30,7 @@ public class IndexSamplingConfig
 
     public IndexSamplingConfig( Config config )
     {
-        this.sampleSizeLimit = config.get( GraphDatabaseSettings.index_sampling_buffer_size ).intValue();
+        this.sampleSizeLimit = config.get( GraphDatabaseSettings.index_sample_size_limit );
         this.updateRatio = ((double) config.get( GraphDatabaseSettings.index_sampling_update_percentage )) / 100.0d;
         this.backgroundSampling = config.get( GraphDatabaseSettings.index_background_sampling_enabled );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingConfig.java
@@ -24,20 +24,20 @@ import org.neo4j.kernel.configuration.Config;
 
 public class IndexSamplingConfig
 {
-    private final int bufferSize;
+    private final int sampleSizeLimit;
     private final double updateRatio;
     private final boolean backgroundSampling;
 
     public IndexSamplingConfig( Config config )
     {
-        this.bufferSize = config.get( GraphDatabaseSettings.index_sampling_buffer_size ).intValue();
+        this.sampleSizeLimit = config.get( GraphDatabaseSettings.index_sampling_buffer_size ).intValue();
         this.updateRatio = ((double) config.get( GraphDatabaseSettings.index_sampling_update_percentage )) / 100.0d;
         this.backgroundSampling = config.get( GraphDatabaseSettings.index_background_sampling_enabled );
     }
 
-    public int bufferSize()
+    public int sampleSizeLimit()
     {
-        return bufferSize;
+        return sampleSizeLimit;
     }
 
     public double updateRatio()
@@ -71,14 +71,14 @@ public class IndexSamplingConfig
         IndexSamplingConfig that = (IndexSamplingConfig) o;
 
         return backgroundSampling == that.backgroundSampling &&
-               bufferSize == that.bufferSize &&
+               sampleSizeLimit == that.sampleSizeLimit &&
                Double.compare( that.updateRatio, updateRatio ) == 0;
     }
 
     @Override
     public int hashCode()
     {
-        int result = bufferSize;
+        int result = sampleSizeLimit;
         long temp = Double.doubleToLongBits( updateRatio );
         result = 31 * result + (int) (temp ^ (temp >>> 32));
         result = 31 * result + (backgroundSampling ? 1 : 0);

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/NonUniqueIndexSampler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/NonUniqueIndexSampler.java
@@ -24,9 +24,7 @@ import org.neo4j.storageengine.api.schema.IndexSample;
 
 public class NonUniqueIndexSampler
 {
-    private static final int INITIAL_SIZE = 1 << 16;
-
-    private final int bufferSizeLimit;
+    private final int sampleSizeLimit;
     private final MultiSet<String> values;
 
     private int sampledSteps = 0;
@@ -35,12 +33,12 @@ public class NonUniqueIndexSampler
 
     private long accumulatedUniqueValues = 0;
     private long accumulatedSampledSize = 0;
-    private long bufferSize = 0;
+    private long sampleSize = 0;
 
-    public NonUniqueIndexSampler( int bufferSizeLimit )
+    public NonUniqueIndexSampler( int sampleSizeLimit )
     {
-        this.bufferSizeLimit = bufferSizeLimit;
-        this.values = new MultiSet<>( INITIAL_SIZE );
+        this.values = new MultiSet<>( calculateInitialSetSize( sampleSizeLimit ) );
+        this.sampleSizeLimit = sampleSizeLimit;
     }
 
     public void include( String value )
@@ -51,14 +49,14 @@ public class NonUniqueIndexSampler
     public void include( String value, long increment )
     {
         assert increment > 0;
-        if ( bufferSize >= bufferSizeLimit )
+        if ( sampleSize >= sampleSizeLimit )
         {
             nextStep();
         }
 
         if ( values.increment( value, increment ) == increment )
         {
-            bufferSize += value.length();
+            sampleSize += value.length();
         }
     }
 
@@ -72,7 +70,7 @@ public class NonUniqueIndexSampler
         assert decrement > 0;
         if ( values.increment( value, -decrement ) == 0 )
         {
-            bufferSize -= value.length();
+            sampleSize -= value.length();
         }
     }
 
@@ -98,9 +96,24 @@ public class NonUniqueIndexSampler
     {
         accumulatedUniqueValues += values.uniqueSize();
         accumulatedSampledSize += values.size();
-        bufferSize = 0;
+        sampleSize = 0;
 
         sampledSteps++;
         values.clear();
+    }
+
+    /**
+     * Evaluate initial set size that evaluate initial set as log2(sampleSizeLimit) / 2 based on provided sample size
+     * limit.
+     * Minimum possible size is 1 << 10.
+     * Maximum possible size is 1 << 16.
+     *
+     * @param sampleSizeLimit specified sample size limit
+     * @return initial set size
+     */
+    private int calculateInitialSetSize( int sampleSizeLimit )
+    {
+        int basedOnSampleSize = Math.max( 10, (int) (Math.log( sampleSizeLimit ) / Math.log( 2 )) / 2 );
+        return (1 << Math.min( 16, basedOnSampleSize ));
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
@@ -21,11 +21,13 @@ package org.neo4j.kernel.configuration;
 
 import org.junit.Test;
 
+import java.util.Map;
+
 import org.neo4j.logging.NullLog;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 /**
@@ -36,7 +38,25 @@ public class TestGraphDatabaseConfigurationMigrator
     @Test
     public void testNoMigration()
     {
-        ConfigurationMigrator migrator = new GraphDatabaseConfigurationMigrator(  );
+        ConfigurationMigrator migrator = new GraphDatabaseConfigurationMigrator();
         assertThat( migrator.apply( stringMap( "foo", "bar" ), NullLog.getInstance() ), equalTo( stringMap( "foo", "bar" ) ) );
+    }
+
+    @Test
+    public void migrateIndexSamplingBufferSizeIfPresent()
+    {
+        ConfigurationMigrator migrator = new GraphDatabaseConfigurationMigrator();
+        Map<String,String> resultConfig = migrator.apply( stringMap( "dbms.index_sampling.buffer_size", "64m" ), NullLog.getInstance() );
+        assertEquals( "Old property should be migrated to new one with correct value",
+                resultConfig, stringMap( "dbms.index_sampling.sample_size_limit", "8388608" ));
+    }
+
+    @Test
+    public void skipMigrationOfIndexSamplingBufferSizeIfNotPresent()
+    {
+        ConfigurationMigrator migrator = new GraphDatabaseConfigurationMigrator();
+        Map<String,String> resultConfig = migrator.apply( stringMap( "dbms.index_sampling.sample_size_limit", "8388600" ), NullLog.getInstance() );
+        assertEquals( "Nothing to migrate should be the same",
+                resultConfig, stringMap( "dbms.index_sampling.sample_size_limit", "8388600" ));
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulator.java
@@ -42,7 +42,7 @@ public class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
     public NonUniqueLuceneIndexPopulator( LuceneSchemaIndex luceneIndex, IndexSamplingConfig samplingConfig )
     {
         super( luceneIndex );
-        this.sampler = new NonUniqueIndexSampler( samplingConfig.bufferSize() );
+        this.sampler = new NonUniqueIndexSampler( samplingConfig.sampleSizeLimit() );
     }
 
     @Override

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/NonUniqueLuceneIndexSampler.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/sampler/NonUniqueLuceneIndexSampler.java
@@ -58,7 +58,7 @@ public class NonUniqueLuceneIndexSampler extends LuceneIndexSampler
     @Override
     protected IndexSample performSampling() throws IndexNotFoundKernelException
     {
-        NonUniqueIndexSampler sampler = new NonUniqueIndexSampler( indexSamplingConfig.bufferSize() );
+        NonUniqueIndexSampler sampler = new NonUniqueIndexSampler( indexSamplingConfig.sampleSizeLimit() );
         IndexReader indexReader = indexSearcher.getIndexReader();
         for ( LeafReaderContext readerContext : indexReader.leaves() )
         {


### PR DESCRIPTION
Decrease default non unique sampler step size limit to 8m instead of 64m.
Update default set size evaluation to be less greedy, make it sample step size dependent.

Performance wise new default size/initial set size combination gives about 30% increase while populating sampler.
And it does not make sense to create new map for values each time.

Closes #7106.
