### PR TITLE
Resolved ambiguity with Geographic and Cartesian CRS

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionsAcceptanceTest.scala
@@ -409,13 +409,31 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
   test("point function should work with literal map and cartesian coordinates") {
     val result = executeWithAllPlanners("RETURN point({x: 2.3, y: 4.5, crs: 'cartesian'}) as point")
     result should useProjectionWith("Point")
-    result.toList should equal(List(Map("point" -> CartesianPoint(2.3, 4.5))))
+    result.toList should equal(List(Map("point" -> CartesianPoint(2.3, 4.5, CRS.Cartesian))))
+  }
+
+  test("point function should work with literal map and geographic coordinates") {
+    val result = executeWithAllPlanners("RETURN point({longitude: 2.3, latitude: 4.5, crs: 'WGS-84'}) as point")
+    result should useProjectionWith("Point")
+    result.toList should equal(List(Map("point" -> GeographicPoint(2.3, 4.5, CRS.WGS84))))
+  }
+
+  test("point function should not work with literal map and incorrect cartesian CRS") {
+    an [InvalidArgumentException] shouldBe thrownBy(
+      executeWithAllPlanners("RETURN point({x: 2.3, y: 4.5, crs: 'cart'}) as point")
+    )
+  }
+
+  test("point function should not work with literal map and incorrect geographic CRS") {
+    an [InvalidArgumentException] shouldBe thrownBy(
+      executeWithAllPlanners("RETURN point({x: 2.3, y: 4.5, crs: 'WGS84'}) as point")
+    )
   }
 
   test("point function should work with integer arguments") {
-    val result = executeWithAllPlanners("RETURN point({x: 2, y: 4, crs: 'cartesian'}) as point")
+    val result = executeWithAllPlanners("RETURN point({x: 2, y: 4}) as point")
     result should useProjectionWith("Point")
-    result.toList should equal(List(Map("point" -> CartesianPoint(2, 4))))
+    result.toList should equal(List(Map("point" -> CartesianPoint(2, 4, CRS.Cartesian))))
   }
 
   test("should fail properly if missing cartesian coordinates") {
@@ -423,18 +441,31 @@ class FunctionsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTes
                                                                            "params" -> Map("y" -> 1.0, "crs" -> "cartesian")))
   }
 
-  test("should fail properly if missing geographic coordinates") {
-    a [SyntaxException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
-                                                                 "params" -> Map("y" -> 1.0, "crs" -> "WGS-84")))
+  test("should fail properly if missing geographic longitude") {
+    a [InvalidArgumentException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
+      "params" -> Map("latitude" -> 1.0, "crs" -> "WGS-84")))
+  }
+
+  test("should fail properly if missing geographic latitude") {
+    a [InvalidArgumentException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
+      "params" -> Map("longitude" -> 1.0, "crs" -> "WGS-84")))
   }
 
   test("should fail properly if unknown coordinate system") {
     an [InvalidArgumentException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({params}) as point",
-                                                                 "params" -> Map("crs" -> "WGS-1337")))
+                                                                 "params" -> Map("x" -> 1, "y" -> 2, "crs" -> "WGS-1337")))
   }
 
-  test("should fail properly if missing CRS") {
-    a [SyntaxException] shouldBe thrownBy(executeWithAllPlanners("RETURN point({x: 2.3, y: 4.5}) as point"))
+  test("should default to Cartesian if missing cartesian CRS") {
+    val result = executeWithAllPlanners("RETURN point({x: 2.3, y: 4.5}) as point")
+    result should useProjectionWith("Point")
+    result.toList should equal(List(Map("point" -> CartesianPoint(2.3, 4.5, CRS.Cartesian))))
+  }
+
+  test("should default to WGS83 if missing geographic CRS") {
+    val result = executeWithAllPlanners("RETURN point({longitude: 2.3, latitude: 4.5}) as point")
+    result should useProjectionWith("Point")
+    result.toList should equal(List(Map("point" -> GeographicPoint(2.3, 4.5, CRS.WGS84))))
   }
 
   test("point function should work with previous map") {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/Geometry.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/Geometry.scala
@@ -30,9 +30,7 @@ trait Point extends Geometry {
   def coordinates = Vector(x, y)
 }
 
-case class CartesianPoint(x: Double, y: Double) extends Point {
-  def crs = CRS.Cartesian
-}
+case class CartesianPoint(x: Double, y: Double, crs: CRS) extends Point
 
 case class GeographicPoint(longitude: Double, latitude: Double, crs: CRS) extends Point {
   def x: Double = longitude

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Point.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Point.scala
@@ -37,8 +37,7 @@ case object Point extends Function with SimpleTypedFunction {
   protected def checkPointMap(expression: Expression): SemanticCheck = expression match {
     //Cartesian point
     case map: MapExpression if map.items.exists(withKey("x")) && map.items.exists(withKey("y")) =>
-      if (map.items.exists(withKey("crs"))) SemanticCheckResult.success
-      else SemanticError(s"A cartesian point must contain a 'crs' (coordinate reference system)", map.position)
+      SemanticCheckResult.success
     //Geographic point
     case map: MapExpression if map.items.exists(withKey("longitude")) && map.items.exists(withKey("latitude")) =>
       SemanticCheckResult.success


### PR DESCRIPTION
Now the difference is defined by the existance of x/y versus latitude/longitude. For Cartesian the default cartesian CRS is the only accepted CRS, for geographic the default WGS84 is the only accepted CRS.
