### PR TITLE
Introduce cache to hold uncommitted log entries.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
 import org.neo4j.coreedge.helper.VolatileFuture;
 import org.neo4j.coreedge.raft.log.RaftLog;
 import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 import org.neo4j.coreedge.raft.membership.RaftGroup;
 import org.neo4j.coreedge.raft.membership.RaftMembershipManager;
 import org.neo4j.coreedge.raft.net.Inbound;
@@ -113,6 +114,7 @@ public class RaftInstance<MEMBER> implements LeaderLocator<MEMBER>,
                          LogProvider logProvider, RaftMembershipManager<MEMBER> membershipManager,
                          RaftLogShippingManager<MEMBER> logShipping,
                          Supplier<DatabaseHealth> databaseHealthSupplier,
+                         InFlightMap<Long, RaftLogEntry> inFlightMap,
                          Monitors monitors )
     {
         this.myself = myself;
@@ -130,7 +132,7 @@ public class RaftInstance<MEMBER> implements LeaderLocator<MEMBER>,
 
         this.membershipManager = membershipManager;
 
-        this.state = new RaftState<>( myself, termStorage, membershipManager, entryLog, voteStorage );
+        this.state = new RaftState<>( myself, termStorage, membershipManager, entryLog, voteStorage, inFlightMap );
 
         leaderNotFoundMonitor = monitors.newMonitor( LeaderNotFoundMonitor.class );
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/InFlightMap.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/InFlightMap.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.segmented;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.lang.String.format;
+
+public class InFlightMap<K, V>
+{
+    private final Map<K,V> map;
+
+    public InFlightMap()
+    {
+        this.map = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Adds a new mapping.
+     *
+     * @param key The key of the mapping
+     * @param value The value corresponding to the key provided.
+     * @throws IllegalArgumentException if a mapping for the key already exists
+     */
+    public void register( K key, V value )
+    {
+        V previousValue = map.put( key, value );
+
+        if ( previousValue != null )
+        {
+            map.put( key, previousValue );
+            throw new IllegalArgumentException(
+                    format( "Attempted to register an already seen value to the log entry cache. Key: %s Value: %s",
+                            key, value ) );
+        }
+    }
+
+    public V retrieve( K key )
+    {
+        return map.get( key );
+    }
+
+    /**
+     * Attempts to unregister this object from the map.
+     *
+     * @param key The object to attempt unregistering.
+     * @return true if the attempt to unregister was successful, otherwise false if this object was not found.
+     */
+    public boolean unregister( K key )
+    {
+        return map.remove( key ) != null;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/InFlightMap.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/InFlightMap.java
@@ -26,12 +26,7 @@ import static java.lang.String.format;
 
 public class InFlightMap<K, V>
 {
-    private final Map<K,V> map;
-
-    public InFlightMap()
-    {
-        this.map = new ConcurrentHashMap<>();
-    }
+    private final Map<K,V> map = new ConcurrentHashMap<>();
 
     /**
      * Adds a new mapping.
@@ -42,17 +37,21 @@ public class InFlightMap<K, V>
      */
     public void register( K key, V value )
     {
-        V previousValue = map.put( key, value );
+        V previousValue = map.putIfAbsent( key, value );
 
         if ( previousValue != null )
         {
-            map.put( key, previousValue );
             throw new IllegalArgumentException(
                     format( "Attempted to register an already seen value to the log entry cache. Key: %s Value: %s",
                             key, value ) );
         }
     }
 
+    /**
+     * Returns the mapped value for this key or null if the key has not been registered.
+     * @param key
+     * @return the value for this key, otherwise null.
+     */
     public V retrieve( K key )
     {
         return map.get( key );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentedRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentedRaftLog.java
@@ -254,7 +254,8 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
 
         // Not found in cache but within our valid range, so we must read from the log.
         RaftLogEntry raftLogEntry = readLogEntry( logIndex );
-        return raftLogEntry != null ? raftLogEntry.term() : -1;
+        assert (raftLogEntry != null);
+        return raftLogEntry.term();
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/AppendLogEntry.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/AppendLogEntry.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import org.neo4j.coreedge.raft.log.RaftLog;
 import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 
 public class AppendLogEntry implements LogCommand
 {
@@ -43,8 +44,13 @@ public class AppendLogEntry implements LogCommand
         {
             throw new IllegalStateException( "Attempted to append over an existing entry at index " + index );
         }
-
         raftLog.append( entry );
+    }
+
+    @Override
+    public void applyTo( InFlightMap<Long, RaftLogEntry> inFlightMap ) throws IOException
+    {
+        inFlightMap.register( index, entry );
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/BatchAppendLogEntries.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/BatchAppendLogEntries.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 
 import org.neo4j.coreedge.raft.log.RaftLog;
 import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 
 import static java.lang.String.format;
 
@@ -51,6 +52,15 @@ public class BatchAppendLogEntries implements LogCommand
         }
 
         raftLog.append( Arrays.copyOfRange( entries, offset, entries.length ) );
+    }
+
+    @Override
+    public void applyTo( InFlightMap<Long, RaftLogEntry> inFlightMap )
+    {
+        for ( int i = offset; i < entries.length; i++ )
+        {
+            inFlightMap.register( baseIndex + i , entries[i]);
+        }
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/LogCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/LogCommand.java
@@ -22,8 +22,12 @@ package org.neo4j.coreedge.raft.outcome;
 import java.io.IOException;
 
 import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 
 public interface LogCommand
 {
     void applyTo( RaftLog raftLog ) throws IOException;
+
+    void applyTo( InFlightMap<Long,RaftLogEntry> inFlightMap ) throws IOException;
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/TruncateLogCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/TruncateLogCommand.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.util.Objects;
 
 import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 
 public class TruncateLogCommand implements LogCommand
 {
@@ -37,6 +39,16 @@ public class TruncateLogCommand implements LogCommand
     public void applyTo( RaftLog raftLog ) throws IOException
     {
         raftLog.truncate( fromIndex );
+    }
+
+    @Override
+    public void applyTo( InFlightMap<Long,RaftLogEntry> inFlightMap ) throws IOException
+    {
+        long truncateIndex = fromIndex;
+        while( inFlightMap.unregister( truncateIndex ))
+        {
+            truncateIndex++;
+        }
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/CoreState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/CoreState.java
@@ -20,7 +20,6 @@
 package org.neo4j.coreedge.raft.state;
 
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.util.function.Supplier;
 
 import org.neo4j.coreedge.catchup.storecopy.StoreCopyFailedException;
@@ -29,8 +28,10 @@ import org.neo4j.coreedge.discovery.CoreServerSelectionException;
 import org.neo4j.coreedge.raft.RaftStateMachine;
 import org.neo4j.coreedge.raft.log.RaftLog;
 import org.neo4j.coreedge.raft.log.RaftLogCursor;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
 import org.neo4j.coreedge.raft.log.monitoring.RaftLogCommitIndexMonitor;
 import org.neo4j.coreedge.raft.log.pruning.LogPruner;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 import org.neo4j.coreedge.raft.replication.DistributedOperation;
 import org.neo4j.coreedge.raft.replication.ProgressTracker;
 import org.neo4j.coreedge.raft.replication.session.GlobalSessionTrackerState;
@@ -44,6 +45,8 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
+import static java.lang.String.format;
+
 public class CoreState extends LifecycleAdapter implements RaftStateMachine, LogPruner
 {
     private static final long NOTHING = -1;
@@ -56,6 +59,7 @@ public class CoreState extends LifecycleAdapter implements RaftStateMachine, Log
     private final StateStorage<Long> lastApplyingStorage;
     private final StateStorage<GlobalSessionTrackerState<CoreMember>> sessionStorage;
     private final Supplier<DatabaseHealth> dbHealth;
+    private final InFlightMap<Long,RaftLogEntry> inFlightMap;
     private final Log log;
 
     private long lastApplied = NOTHING;
@@ -80,6 +84,7 @@ public class CoreState extends LifecycleAdapter implements RaftStateMachine, Log
             CoreServerSelectionStrategy selectionStrategy,
             CoreStateApplier applier,
             CoreStateDownloader downloader,
+            InFlightMap<Long,RaftLogEntry> inFlightMap,
             Monitors monitors )
     {
         this.raftLog = raftLog;
@@ -93,6 +98,7 @@ public class CoreState extends LifecycleAdapter implements RaftStateMachine, Log
         this.selectionStrategy = selectionStrategy;
         this.log = logProvider.getLog( getClass() );
         this.dbHealth = dbHealth;
+        this.inFlightMap = inFlightMap;
         this.commitIndexMonitor = monitors.newMonitor( RaftLogCommitIndexMonitor.class, getClass() );
     }
 
@@ -117,24 +123,31 @@ public class CoreState extends LifecycleAdapter implements RaftStateMachine, Log
     private void submitApplyJob( long lastToApply )
     {
         applier.submit( ( status ) -> () -> {
-            try ( RaftLogCursor cursor = raftLog.getEntryCursor( lastApplied + 1 ) )
+            try ( LogEntrySupplier cacheLogEntrySupplier = new CacheApplier();
+                    LogEntrySupplier cursorLogEntrySupplier = new CursorApplier() )
             {
-                lastApplyingStorage.persistStoreData( lastToApply );
-
-                while ( cursor.index() < lastToApply && cursor.next() )
+                LogEntrySupplier currentLogEntrySupplier = cacheLogEntrySupplier;
+                for ( long i = lastApplied + 1; i < lastToApply; i++ )
                 {
-                    if ( cursor.get().content() instanceof DistributedOperation )
+                    lastApplyingStorage.persistStoreData( lastToApply );
+                    RaftLogEntry raftLogEntry = currentLogEntrySupplier.get( i );
+                    if ( raftLogEntry == null )
                     {
-                        DistributedOperation distributedOperation = (DistributedOperation) cursor.get().content();
-
-                        progressTracker.trackReplication( distributedOperation );
-                        handleOperation( cursor.index(), distributedOperation );
-
-                        maybeFlush();
+                        if ( currentLogEntrySupplier == cursorLogEntrySupplier )
+                        {
+                            throw new IllegalStateException(
+                                    format( "Index %d not found in the raft log. lastToApply was: %d, append index " +
+                                            "is %d", i, lastToApply, raftLog.appendIndex() ) );
+                        }
+                        currentLogEntrySupplier = cursorLogEntrySupplier;
+                        raftLogEntry = currentLogEntrySupplier.get( i );
                     }
 
-                    assert cursor.index() == (lastApplied + 1);
-                    lastApplied = cursor.index();
+                    applyEntry( raftLogEntry, i );
+
+                    // no matter what, we need to purge the inflight cache from applied entries
+                    inFlightMap.unregister( i );
+                    lastApplied = i;
 
                     if ( status.isCancelled() )
                     {
@@ -148,6 +161,69 @@ public class CoreState extends LifecycleAdapter implements RaftStateMachine, Log
                 dbHealth.get().panic( e );
             }
         } );
+    }
+
+    private interface LogEntrySupplier extends AutoCloseable
+    {
+        RaftLogEntry get( long indexToApply ) throws IOException;
+    }
+
+    private class CacheApplier implements LogEntrySupplier
+    {
+        @Override
+        public RaftLogEntry get( long indexToApply ) throws IOException
+        {
+            return inFlightMap.retrieve( indexToApply );
+        }
+
+        @Override
+        public void close() throws Exception
+        {
+
+        }
+    }
+
+    private class CursorApplier implements LogEntrySupplier
+    {
+        RaftLogCursor cursor = null;
+
+        @Override
+        public RaftLogEntry get( long indexToApply ) throws IOException
+        {
+            if ( cursor == null )
+            {
+                cursor = raftLog.getEntryCursor( indexToApply );
+            }
+
+            if ( cursor.next() )
+            {
+                return cursor.get();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        @Override
+        public void close() throws Exception
+        {
+            if ( cursor != null )
+            {
+                cursor.close();
+            }
+        }
+    }
+
+    private void applyEntry( RaftLogEntry raftLogEntry, long logIndex ) throws IOException
+    {
+        if ( raftLogEntry.content() instanceof DistributedOperation )
+        {
+            DistributedOperation distributedOperation = (DistributedOperation) raftLogEntry.content();
+            progressTracker.trackReplication( distributedOperation );
+            handleOperation( logIndex, distributedOperation );
+            maybeFlush();
+        }
     }
 
     @Override
@@ -178,7 +254,8 @@ public class CoreState extends LifecycleAdapter implements RaftStateMachine, Log
      *
      * @param source The source address to attempt a download of a snapshot from.
      */
-    public synchronized void downloadSnapshot( AdvertisedSocketAddress source ) throws InterruptedException, StoreCopyFailedException
+    public synchronized void downloadSnapshot( AdvertisedSocketAddress source )
+            throws InterruptedException, StoreCopyFailedException
     {
         applier.sync( true );
         downloader.downloadSnapshot( source, this );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -60,9 +60,9 @@ import org.neo4j.coreedge.raft.log.RaftLogMetadataCache;
 import org.neo4j.coreedge.raft.log.naive.NaiveDurableRaftLog;
 import org.neo4j.coreedge.raft.log.physical.PhysicalRaftLog;
 import org.neo4j.coreedge.raft.log.physical.PhysicalRaftLogFile;
+import org.neo4j.coreedge.raft.log.pruning.PruningScheduler;
 import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 import org.neo4j.coreedge.raft.log.segmented.SegmentedRaftLog;
-import org.neo4j.coreedge.raft.log.pruning.PruningScheduler;
 import org.neo4j.coreedge.raft.membership.CoreMemberSetBuilder;
 import org.neo4j.coreedge.raft.membership.MembershipWaiter;
 import org.neo4j.coreedge.raft.membership.RaftMembershipManager;
@@ -692,7 +692,7 @@ public class EnterpriseCoreEditionModule
                 myself, termState, voteState, raftLog, raftStateMachine, electionTimeout, heartbeatInterval,
                 raftTimeoutService,
                 new RaftOutbound( outbound ), logProvider,
-                raftMembershipManager, logShipping, databaseHealthSupplier, monitors );
+                raftMembershipManager, logShipping, databaseHealthSupplier, inFlightMap, monitors );
 
         int queueSize = config.get( CoreEdgeClusterSettings.raft_in_queue_size );
         int maxBatch = config.get( CoreEdgeClusterSettings.raft_in_queue_max_batch );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -55,12 +55,14 @@ import org.neo4j.coreedge.raft.RaftStateMachine;
 import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
 import org.neo4j.coreedge.raft.log.MonitoredRaftLog;
 import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
 import org.neo4j.coreedge.raft.log.RaftLogMetadataCache;
 import org.neo4j.coreedge.raft.log.naive.NaiveDurableRaftLog;
 import org.neo4j.coreedge.raft.log.physical.PhysicalRaftLog;
 import org.neo4j.coreedge.raft.log.physical.PhysicalRaftLogFile;
-import org.neo4j.coreedge.raft.log.pruning.PruningScheduler;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 import org.neo4j.coreedge.raft.log.segmented.SegmentedRaftLog;
+import org.neo4j.coreedge.raft.log.pruning.PruningScheduler;
 import org.neo4j.coreedge.raft.membership.CoreMemberSetBuilder;
 import org.neo4j.coreedge.raft.membership.MembershipWaiter;
 import org.neo4j.coreedge.raft.membership.RaftMembershipManager;
@@ -356,15 +358,18 @@ public class EnterpriseCoreEditionModule
             CoreStateDownloader downloader = new CoreStateDownloader( localDatabase, storeFetcher, coreToCoreClient,
                     logProvider );
 
+            InFlightMap<Long,RaftLogEntry> inFlightMap = new InFlightMap<>();
+
             coreState = new CoreState(
                     raftLog, config.get( CoreEdgeClusterSettings.state_machine_flush_window_size ),
                     databaseHealthSupplier, logProvider, progressTracker, lastFlushedStorage, lastApplyingStorage,
                     sessionTrackerStorage, new NotMyselfSelectionStrategy( discoveryService, myself ), applier,
-                    downloader, platformModule.monitors );
+                    downloader, inFlightMap, platformModule.monitors );
 
             raft = createRaft( life, loggingOutbound, discoveryService, config, messageLogger, raftLog,
                     coreState, fileSystem, clusterStateDirectory, myself, logProvider, raftServer,
-                    raftTimeoutService, databaseHealthSupplier, platformModule.monitors, platformModule.jobScheduler );
+                    raftTimeoutService, databaseHealthSupplier, inFlightMap, platformModule.monitors,
+                    platformModule.jobScheduler );
 
             life.add( new PruningScheduler( coreState, platformModule.jobScheduler,
                     config.get( CoreEdgeClusterSettings.raft_log_pruning_frequency ) ) );
@@ -612,7 +617,9 @@ public class EnterpriseCoreEditionModule
                                                         RaftServer<CoreMember> raftServer,
                                                         DelayedRenewableTimeoutService raftTimeoutService,
                                                         Supplier<DatabaseHealth> databaseHealthSupplier,
-                                                        Monitors monitors, JobScheduler jobScheduler )
+                                                        InFlightMap<Long, RaftLogEntry> inFlightMap,
+                                                        Monitors monitors,
+                                                        JobScheduler jobScheduler )
     {
         StateStorage<TermState> termState;
         try
@@ -678,7 +685,8 @@ public class EnterpriseCoreEditionModule
                 logProvider, raftLog,
                 Clock.systemUTC(), myself, raftMembershipManager, electionTimeout,
                 config.get( CoreEdgeClusterSettings.catchup_batch_size ),
-                config.get( CoreEdgeClusterSettings.log_shipping_max_lag ) );
+                config.get( CoreEdgeClusterSettings.log_shipping_max_lag ),
+                inFlightMap );
 
         RaftInstance<CoreMember> raftInstance = new RaftInstance<>(
                 myself, termState, voteState, raftLog, raftStateMachine, electionTimeout, heartbeatInterval,

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceBuilder.java
@@ -95,7 +95,7 @@ public class RaftInstanceBuilder<MEMBER>
 
         RaftInstance<MEMBER> raft = new RaftInstance<>( member, termState, voteState, raftLog, raftStateMachine, electionTimeout,
                 heartbeatInterval, renewableTimeoutService, outbound, logProvider,
-                membershipManager, logShipping, databaseHealthSupplier, monitors );
+                membershipManager, logShipping, databaseHealthSupplier, inFlightMap, monitors );
         inbound.registerHandler( raft );
         return raft;
     }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/InFlightLogEntriesCacheTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/InFlightLogEntriesCacheTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.segmented;
+
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class InFlightLogEntriesCacheTest
+{
+    @Test
+    public void shouldRegisterAndUnregisterValues() throws Exception
+    {
+        InFlightMap<Object,Object> entries = new InFlightMap<>();
+
+        List<Object> logEntryList = new LinkedList<>();
+        logEntryList.add( new Object() );
+
+        for ( Object registeredEntry : logEntryList )
+        {
+            entries.register( registeredEntry, registeredEntry );
+        }
+
+        for ( Object expected : logEntryList )
+        {
+            Object retrieved = entries.retrieve( expected );
+            assertEquals( expected, retrieved );
+        }
+
+        Object unexpected = new Object();
+        Object shouldBeNull = entries.retrieve( unexpected );
+        assertNull( shouldBeNull );
+
+        for ( Object expected : logEntryList )
+        {
+            boolean wasThere = entries.unregister( expected );
+            assertEquals( true, wasThere );
+        }
+
+        boolean shouldBeFalse = entries.unregister( unexpected );
+        assertFalse( shouldBeFalse );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldNotReinsertValues() throws Exception
+    {
+        InFlightMap<Object,Object> entries = new InFlightMap<>();
+        Object addedObject = new Object();
+        entries.register( addedObject, addedObject );
+        entries.register( addedObject, addedObject );
+    }
+
+    @Test
+    public void shouldNotReplaceRegisteredValues() throws Exception
+    {
+        InFlightMap<Object,Object> cache = new InFlightMap<>();
+        Object first = new Object();
+        Object second = new Object();
+
+        try
+        {
+            cache.register( first, first );
+            cache.register( first, second );
+            fail("Should not allow silent replacement of values");
+        }
+        catch ( IllegalArgumentException e )
+        {
+            assertEquals( first, cache.retrieve( first ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/outcome/TruncateLogCommandTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/outcome/TruncateLogCommandTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.neo4j.coreedge.raft.ReplicatedInteger.valueOf;
+
+public class TruncateLogCommandTest
+{
+    @Test
+    public void applyTo() throws Exception
+    {
+        //Test that truncate commands correctly remove entries from the cache.
+
+        //given
+        long fromIndex = 2L;
+        TruncateLogCommand truncateLogCommand = new TruncateLogCommand( fromIndex );
+
+        InFlightMap<Long,RaftLogEntry> inFlightMap = new InFlightMap<>();
+
+        inFlightMap.register( 0L, new RaftLogEntry( 0L, valueOf( 0 ) ) );
+        inFlightMap.register( 1L, new RaftLogEntry( 1L, valueOf( 1 ) ) );
+        inFlightMap.register( 2L, new RaftLogEntry( 2L, valueOf( 2 ) ) );
+        inFlightMap.register( 3L, new RaftLogEntry( 3L, valueOf( 3 ) ) );
+
+        //when
+        truncateLogCommand.applyTo( inFlightMap );
+
+        //then
+        assertNotNull( inFlightMap.retrieve( 0L ) );
+        assertNotNull( inFlightMap.retrieve( 1L ) );
+        assertNull( inFlightMap.retrieve( 2L ) );
+        assertNull( inFlightMap.retrieve( 3L ) );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipperTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipperTest.java
@@ -36,6 +36,7 @@ import org.neo4j.coreedge.raft.ReplicatedString;
 import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
 import org.neo4j.coreedge.raft.log.RaftLog;
 import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 import org.neo4j.coreedge.server.RaftTestMember;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.logging.Log;
@@ -99,7 +100,7 @@ public class RaftLogShipperTest
     {
         logShipper =
                 new RaftLogShipper<>( outbound, logProvider, raftLog, clock, leader, follower, leaderTerm, leaderCommit,
-                        retryTimeMillis, catchupBatchSize, maxAllowedShippingLag );
+                        retryTimeMillis, catchupBatchSize, maxAllowedShippingLag, new InFlightMap<>() );
         logShipper.start();
     }
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/CoreStateTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/CoreStateTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import org.neo4j.coreedge.raft.NewLeaderBarrier;
 import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
 import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 import org.neo4j.coreedge.raft.log.monitoring.RaftLogCommitIndexMonitor;
 import org.neo4j.coreedge.raft.replication.DistributedOperation;
 import org.neo4j.coreedge.raft.replication.ProgressTrackerImpl;
@@ -44,21 +45,27 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class CoreStateTest
 {
-    private final InMemoryRaftLog raftLog = new InMemoryRaftLog();
+    private final InMemoryRaftLog raftLog = spy( new InMemoryRaftLog() );
 
     private final InMemoryStateStorage<Long> lastFlushedStorage = new InMemoryStateStorage<>( -1L );
     private final InMemoryStateStorage<Long> lastApplyingStorage = new InMemoryStateStorage<>( -1L );
-    private final InMemoryStateStorage<GlobalSessionTrackerState<CoreMember>> sessionStorage = new InMemoryStateStorage<>( new GlobalSessionTrackerState<>() );
+    private final InMemoryStateStorage<GlobalSessionTrackerState<CoreMember>> sessionStorage =
+            new InMemoryStateStorage<>( new GlobalSessionTrackerState<>() );
 
     private final DatabaseHealth dbHealth = new DatabaseHealth( mock( DatabasePanicEventGenerator.class ),
             NullLogProvider.getInstance().getLog( getClass() ) );
@@ -67,10 +74,12 @@ public class CoreStateTest
     private final int flushEvery = 10;
 
     private final CoreStateApplier applier = new CoreStateApplier( NullLogProvider.getInstance() );
+    private InFlightMap<Long,RaftLogEntry> inFlightMap = spy( new InFlightMap<>() );
     private final Monitors monitors = new Monitors();
     private final CoreState coreState = new CoreState( raftLog, flushEvery, () -> dbHealth, NullLogProvider.getInstance(),
             new ProgressTrackerImpl( globalSession ), lastFlushedStorage, lastApplyingStorage, sessionStorage,
-            mock( CoreServerSelectionStrategy.class ), applier, mock( CoreStateDownloader.class ), monitors );
+            mock( CoreServerSelectionStrategy.class ), applier, mock( CoreStateDownloader.class ), inFlightMap,
+            monitors );
 
     private ReplicatedTransaction nullTx = new ReplicatedTransaction( null );
 
@@ -84,14 +93,17 @@ public class CoreStateTest
     }
 
     private final CoreStateMachines failingTxStateMachine = failingTxStateMachinesMock();
+
     private CoreStateMachines failingTxStateMachinesMock()
     {
         CoreStateMachines stateMachines = mock( CoreStateMachines.class );
-        when( stateMachines.dispatch( any( ReplicatedTransaction.class ), anyLong() ) ).thenThrow( new IllegalStateException() );
+        when( stateMachines.dispatch( any( ReplicatedTransaction.class ), anyLong() ) ).thenThrow(
+                new IllegalStateException( "This is a failing tx state machine and it's supposed to fail" ) );
         return stateMachines;
     }
 
     private int sequenceNumber = 0;
+
     private synchronized ReplicatedContent operation( CoreReplicatedContent tx )
     {
         return new DistributedOperation( tx, globalSession, new LocalOperationId( 0, sequenceNumber++ ) );
@@ -170,12 +182,12 @@ public class CoreStateTest
         }
 
         // when
-        coreState.notifyCommitted( flushEvery*TIMES );
+        coreState.notifyCommitted( flushEvery * TIMES );
         applier.sync( false );
 
         // then
         verify( txStateMachine, times( TIMES ) ).flush();
-        assertEquals( flushEvery*(TIMES-1), (long)lastFlushedStorage.getInitialState() );
+        assertEquals( flushEvery * (TIMES - 1), (long) lastFlushedStorage.getInitialState() );
     }
 
     @Test
@@ -194,5 +206,105 @@ public class CoreStateTest
 
         // then
         assertEquals( false, dbHealth.isHealthy() );
+    }
+
+    @Test
+    public void shouldApplyToLogFromCache() throws Throwable
+    {
+        //given n things to apply in the cache, check that they are actually applied.
+
+        // given
+        coreState.setStateMachine( txStateMachine, -1 );
+        coreState.start();
+
+        inFlightMap.register( 0L, new RaftLogEntry( 1, operation( nullTx ) ) );
+
+        //when
+        coreState.notifyCommitted( 0 );
+        applier.sync( false );
+
+        //then the cache should have had it's get method called.
+        verify( inFlightMap, times( 1 ) ).retrieve( 0L );
+        verifyZeroInteractions( raftLog );
+    }
+
+    @Test
+    public void cacheEntryShouldBePurgedWhenApplied() throws Throwable
+    {
+        //given a cache in submitApplyJob, the contents of the cache should only contain unapplied "things"
+
+        // given
+        coreState.setStateMachine( txStateMachine, -1 );
+        coreState.start();
+
+        inFlightMap.register( 0L, new RaftLogEntry( 0, operation( nullTx ) ) );
+        inFlightMap.register( 1L, new RaftLogEntry( 0, operation( nullTx ) ) );
+        inFlightMap.register( 2L, new RaftLogEntry( 0, operation( nullTx ) ) );
+        //when
+        coreState.notifyCommitted( 0 );
+
+        applier.sync( false );
+
+        //then the cache should have had its get method called.
+        assertNull( inFlightMap.retrieve( 0L ) );
+        assertNotNull( inFlightMap.retrieve( 1L ) );
+        assertNotNull( inFlightMap.retrieve( 2L ) );
+    }
+
+    @Test
+    public void shouldFallbackToLogCursorOnCacheMiss() throws Throwable
+    {
+        // if the cache does not contain all things to be applied, make sure we fall back to the log
+        // should only happen in recovery, otherwise this is probably a bug.
+
+        coreState.setStateMachine( txStateMachine, -1 );
+        coreState.start();
+
+        //given cache with missing entry
+        ReplicatedContent operation0 = operation( nullTx );
+        ReplicatedContent operation1 = operation( nullTx );
+        ReplicatedContent operation2 = operation( nullTx );
+
+        inFlightMap.register( 0L, new RaftLogEntry( 0, operation0 ) );
+        inFlightMap.register( 2L, new RaftLogEntry( 2, operation2 ) );
+
+        raftLog.append( new RaftLogEntry( 0, operation0 ) );
+        raftLog.append( new RaftLogEntry( 1, operation1 ) );
+        raftLog.append( new RaftLogEntry( 2, operation2 ) );
+
+        //when
+        coreState.notifyCommitted( 2 );
+
+        applier.sync( false );
+
+        //then the cache should have had its get method called.
+        verify( inFlightMap, times( 0 ) ).retrieve( 2L );
+        verify( inFlightMap, times( 3 ) ).unregister( anyLong() ); //everything is cleaned up
+
+        verify( txStateMachine, times( 1 ) ).dispatch( nullTx, 0L );
+        verify( txStateMachine, times( 1 ) ).dispatch( nullTx, 1L );
+        verify( txStateMachine, times( 1 ) ).dispatch( nullTx, 2L );
+
+        verify( raftLog, times( 1 ) ).getEntryCursor( 1 );
+    }
+
+    @Test
+    public void shouldFailWhenCacheAndLogMiss() throws Exception
+    {
+        //When an entry is not in the log, we must fail.
+
+        coreState.setStateMachine( txStateMachine, -1 );
+        coreState.start();
+
+        inFlightMap.register( 0L, new RaftLogEntry( 0, operation( nullTx ) ) );
+        raftLog.append( new RaftLogEntry( 0, operation( nullTx ) ) );
+        raftLog.append( new RaftLogEntry( 1, operation( nullTx ) ) );
+
+        //when
+        coreState.notifyCommitted( 2 );
+        applier.sync( false );
+
+        //then
+        assertFalse( dbHealth.isHealthy() );
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateBuilder.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.neo4j.coreedge.raft.RaftMessages;
 import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
 import org.neo4j.coreedge.raft.log.RaftLog;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 import org.neo4j.coreedge.raft.membership.RaftMembership;
 import org.neo4j.coreedge.raft.outcome.LogCommand;
 import org.neo4j.coreedge.raft.outcome.Outcome;
@@ -124,8 +125,8 @@ public class RaftStateBuilder
         StateStorage<VoteState<RaftTestMember>> voteStore = new InMemoryStateStorage<>( new VoteState<>( ) );
         StubMembership membership = new StubMembership();
 
-        RaftState<RaftTestMember> state = new RaftState<>( myself, termStore, membership, entryLog, voteStore
-        );
+        RaftState<RaftTestMember> state =
+                new RaftState<>( myself, termStore, membership, entryLog, voteStore, new InFlightMap<>() );
 
         Collection<RaftMessages.Directed<RaftTestMember>> noMessages = Collections.emptyList();
         List<LogCommand> noLogCommands = Collections.emptyList();

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateTest.java
@@ -19,19 +19,25 @@
  */
 package org.neo4j.coreedge.raft.state;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
-
-import org.junit.Test;
 
 import org.neo4j.coreedge.raft.RaftMessages;
 import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 import org.neo4j.coreedge.raft.membership.RaftMembership;
+import org.neo4j.coreedge.raft.outcome.AppendLogEntry;
 import org.neo4j.coreedge.raft.outcome.LogCommand;
 import org.neo4j.coreedge.raft.outcome.Outcome;
+import org.neo4j.coreedge.raft.outcome.TruncateLogCommand;
 import org.neo4j.coreedge.raft.state.follower.FollowerState;
 import org.neo4j.coreedge.raft.state.follower.FollowerStates;
 import org.neo4j.coreedge.raft.state.term.TermState;
@@ -39,13 +45,51 @@ import org.neo4j.coreedge.raft.state.vote.VoteState;
 import org.neo4j.coreedge.server.RaftTestMember;
 
 import static java.util.Collections.emptySet;
-
 import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.neo4j.coreedge.raft.ReplicatedInteger.valueOf;
 import static org.neo4j.coreedge.raft.roles.Role.CANDIDATE;
 
 public class RaftStateTest
 {
+
+    @Test
+    public void shouldUpdateCacheState() throws Exception
+    {
+        //Test that updates applied to the raft state will be refelcted in the entry cache.
+
+        //given
+        InFlightMap<Long,RaftLogEntry> cache = new InFlightMap<>();
+        RaftState<RaftTestMember> raftState = new RaftState<>( new RaftTestMember( 0 ),
+                new InMemoryStateStorage<>( new TermState() ), new FakeMembership(), new InMemoryRaftLog(),
+                new InMemoryStateStorage<>( new VoteState<>() ), cache );
+
+        List<LogCommand> logCommands = new LinkedList<LogCommand>()
+        {{
+            add( new AppendLogEntry( 1, new RaftLogEntry( 0L, valueOf( 0 ) ) ) );
+            add( new AppendLogEntry( 2, new RaftLogEntry( 0L, valueOf( 1 ) ) ) );
+            add( new AppendLogEntry( 3, new RaftLogEntry( 0L, valueOf( 2 ) ) ) );
+            add( new AppendLogEntry( 4, new RaftLogEntry( 0L, valueOf( 4 ) ) ) );
+            add( new TruncateLogCommand( 3 ) );
+            add( new AppendLogEntry( 3, new RaftLogEntry( 0L, valueOf( 5 ) ) ) );
+        }};
+
+        Outcome<RaftTestMember> raftTestMemberOutcome =
+                new Outcome<>( CANDIDATE, 0, null, -1, null, new HashSet<>(), -1, initialFollowerStates(), true,
+                        logCommands, emptyOutgoingMessages(), Collections.emptySet(), -1 );
+
+        //when
+        raftState.update(raftTestMemberOutcome);
+
+        //then
+        assertNotNull( cache.retrieve( 1L ) );
+        assertNotNull( cache.retrieve( 2L ) );
+        assertNotNull( cache.retrieve( 3L ) );
+        assertEquals( valueOf( 5 ), cache.retrieve( 3L ).content() );
+        assertNull( cache.retrieve( 4L ) );
+    }
+
     @Test
     public void shouldRemoveFollowerStateAfterBecomingLeader() throws Exception
     {
@@ -53,7 +97,8 @@ public class RaftStateTest
         RaftState<RaftTestMember> raftState = new RaftState<>( new RaftTestMember( 0 ),
                 new InMemoryStateStorage<>( new TermState() ),
                 new FakeMembership(), new InMemoryRaftLog(),
-                new InMemoryStateStorage<>( new VoteState<>( ) ) );
+                new InMemoryStateStorage<>( new VoteState<>( ) ),
+                new InFlightMap<>());
 
         raftState.update( new Outcome<>( CANDIDATE, 1, null, -1, null, new HashSet<>(), -1, initialFollowerStates(), true, emptyLogCommands(),
                 emptyOutgoingMessages(), Collections.emptySet(), -1) );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ComparableRaftStateTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/ComparableRaftStateTest.java
@@ -22,6 +22,7 @@ package org.neo4j.coreedge.raft.state.explorer;
 import org.junit.Test;
 
 import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.coreedge.server.RaftTestMember.member;
@@ -36,12 +37,12 @@ public class ComparableRaftStateTest
         ComparableRaftState state1 = new ComparableRaftState( member( 0 ),
                 asSet( member( 0 ), member( 1 ), member( 2 ) ),
                 asSet( member( 0 ), member( 1 ), member( 2 ) ),
-                new InMemoryRaftLog() );
+                new InMemoryRaftLog(), new InFlightMap<>() );
 
         ComparableRaftState state2 = new ComparableRaftState( member( 0 ),
                 asSet( member( 0 ), member( 1 ), member( 2 ) ),
                 asSet( member( 0 ), member( 1 ), member( 2 ) ),
-                new InMemoryRaftLog() );
+                new InMemoryRaftLog(), new InFlightMap<>() );
 
         // then
         assertEquals(state1, state2);


### PR DESCRIPTION
 Log entries which are uncommitted and waiting for cluster members to
 receive the entry are stashed in the cache for the commit step.
