### PR TITLE
Introduce a way to close cleanly raft log segments

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/ReadableRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/ReadableRaftLog.java
@@ -33,11 +33,6 @@ public interface ReadableRaftLog
      */
     long prevIndex();
 
-//    /**
-//     * @return The index of the last committed entry.
-//     */
-//    long commitIndex();
-
     /**
      * Reads the term associated with the entry at the supplied index.
      *

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/physical/PhysicalRaftLogFile.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/physical/PhysicalRaftLogFile.java
@@ -95,8 +95,7 @@ public class PhysicalRaftLogFile implements LogFile, Lifecycle
     public void init() throws IOException
     {
         // Make sure at least a bare bones log file is available before recovery
-        channel = openLogChannelForVersion( logFiles.getHighestLogVersion() );
-        channel.close();
+        openLogChannelForVersion( logFiles.getHighestLogVersion() ).close();
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/EntryStore.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/EntryStore.java
@@ -32,7 +32,7 @@ import org.neo4j.cursor.IOCursor;
  * segment to the next in a transparent manner. It can thus be mainly viewed as a factory for a
  * smart segment-crossing cursor.
  */
-class EntryStore
+class EntryStore implements AutoCloseable
 {
     private Segments segments;
 
@@ -122,5 +122,11 @@ class EntryStore
                 return currentRecord.get();
             }
         };
+    }
+
+    @Override
+    public void close() throws DisposedException
+    {
+        segments.close();
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentedRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentedRaftLog.java
@@ -102,6 +102,12 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
     }
 
     @Override
+    public void shutdown() throws DisposedException
+    {
+        entryStore.close();
+    }
+
+    @Override
     public synchronized long append( RaftLogEntry entry ) throws IOException
     {
         ensureOk();

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/Segments.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/Segments.java
@@ -41,7 +41,7 @@ import static java.lang.String.format;
 /**
  * Keeps track of all the segments that the RAFT log consists of.
  */
-class Segments
+class Segments implements AutoCloseable
 {
     private final OpenEndRangeMap<Long/*minIndex*/,SegmentFile> rangeMap = new OpenEndRangeMap<>();
     private final List<SegmentFile> segmentFiles;
@@ -247,5 +247,34 @@ class Segments
     public ListIterator<SegmentFile> getSegmentFileIteratorAtEnd()
     {
         return segmentFiles.listIterator( segmentFiles.size() );
+    }
+
+    @Override
+    public void close() throws DisposedException
+    {
+        DisposedException error = null;
+        for ( SegmentFile segment : segmentFiles )
+        {
+            try
+            {
+                segment.close();
+            }
+            catch ( DisposedException ex )
+            {
+                if ( error == null )
+                {
+                    error = ex;
+                }
+                else
+                {
+                    error.addSuppressed( ex );
+                }
+            }
+        }
+
+        if ( error != null )
+        {
+            throw error;
+        }
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/EntryStoreTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/EntryStoreTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log.segmented;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class EntryStoreTest
+{
+    @Test
+    public void segmentsShouldBeClosedWhenEntryStoreIsClosed() throws Exception
+    {
+        Segments segments = mock( Segments.class );
+        new EntryStore( segments ).close();
+        verify( segments ).close();
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/SegmentFileTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/SegmentFileTest.java
@@ -22,192 +22,242 @@ package org.neo4j.coreedge.raft.log.segmented;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.coreedge.raft.ReplicatedString.valueOf;
+import static org.neo4j.coreedge.raft.log.segmented.SegmentFile.create;
 
 import java.io.File;
-import java.io.IOException;
 
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+
 import org.neo4j.coreedge.raft.log.DummyRaftableContentSerializer;
 import org.neo4j.coreedge.raft.log.EntryRecord;
 import org.neo4j.coreedge.raft.log.RaftLogEntry;
 import org.neo4j.cursor.IOCursor;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 public class SegmentFileTest
 {
+    @Rule
+    public final EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+    private final File rafLogFile = new File( "raft-log.0" );
+    private final DummyRaftableContentSerializer contentMarshal = new DummyRaftableContentSerializer();
+    private final NullLogProvider logProvider = NullLogProvider.getInstance();
+    private final SegmentHeader segmentHeader = new SegmentHeader( -1, 0, -1, -1 );
+
     // various constants used throughout tests
-    private RaftLogEntry entry1 = new RaftLogEntry( 30, valueOf( "contentA" ) );
-    private RaftLogEntry entry2 = new RaftLogEntry( 31, valueOf( "contentB" ) );
-    private RaftLogEntry entry3 = new RaftLogEntry( 32, valueOf( "contentC" ) );
-    private RaftLogEntry entry4 = new RaftLogEntry( 33, valueOf( "contentD" ) );
-
-    // the single segment that we test upon
-    private SegmentFile segment;
-
-    @Before
-    public void setup() throws IOException
-    {
-        segment = SegmentFile.create( new EphemeralFileSystemAbstraction(), new File( "raft-log.0" ),
-                new DummyRaftableContentSerializer(), NullLogProvider.getInstance(), new SegmentHeader( -1, 0, -1, -1 ) );
-    }
+    private final RaftLogEntry entry1 = new RaftLogEntry( 30, valueOf( "contentA" ) );
+    private final RaftLogEntry entry2 = new RaftLogEntry( 31, valueOf( "contentB" ) );
+    private final RaftLogEntry entry3 = new RaftLogEntry( 32, valueOf( "contentC" ) );
+    private final RaftLogEntry entry4 = new RaftLogEntry( 33, valueOf( "contentD" ) );
 
     @Test
     public void shouldReportCorrectInitialValues() throws Exception
     {
-        assertEquals( 0, segment.header().version() );
-        assertFalse( segment.isDisposed() );
+        try ( SegmentFile segment = create( fsRule.get(), rafLogFile, contentMarshal, logProvider, segmentHeader ) )
+        {
+            assertEquals( 0, segment.header().version() );
+            assertFalse( segment.isDisposed() );
 
-        IOCursor<EntryRecord> reader = segment.getReader( 0 );
-        assertFalse( reader.next() );
+            IOCursor<EntryRecord> reader = segment.getReader( 0 );
+            assertFalse( reader.next() );
+        }
     }
 
     @Test
     public void shouldBeAbleToWriteAndRead() throws Exception
     {
-        // given
-        segment.write( 0, entry1 );
-
-        // when
-        IOCursor<EntryRecord> reader = segment.getReader( 0 );
-
-        // then
-        assertTrue( reader.next() );
-        assertEquals( entry1, reader.get().logEntry() );
-    }
-
-    @Test
-    public void shouldBeAbleToReadFromOffset() throws Exception
-    {
-        // given
-        segment.write( 0, entry1 );
-        segment.write( 1, entry2 );
-        segment.write( 2, entry3 );
-        segment.write( 3, entry4 );
-
-        // when
-        IOCursor<EntryRecord> reader = segment.getReader( 2 );
-
-        // then
-        assertTrue( reader.next() );
-        assertEquals( entry3, reader.get().logEntry() );
-    }
-
-    @Test
-    public void shouldBeAbleToRepeatedlyReadWrittenValues() throws Exception
-    {
-        // given
-        segment.write( 0, entry1 );
-        segment.write( 1, entry2 );
-        segment.write( 2, entry3 );
-
-        for ( int i = 0; i < 3; i++ )
+        try ( SegmentFile segment = create( fsRule.get(), rafLogFile, contentMarshal, logProvider, segmentHeader ) )
         {
+            // given
+            segment.write( 0, entry1 );
+
             // when
             IOCursor<EntryRecord> reader = segment.getReader( 0 );
 
             // then
             assertTrue( reader.next() );
             assertEquals( entry1, reader.get().logEntry() );
-            assertTrue( reader.next() );
-            assertEquals( entry2, reader.get().logEntry() );
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToReadFromOffset() throws Exception
+    {
+        try ( SegmentFile segment = create( fsRule.get(), rafLogFile, contentMarshal, logProvider, segmentHeader ) )
+        {
+            // given
+            segment.write( 0, entry1 );
+            segment.write( 1, entry2 );
+            segment.write( 2, entry3 );
+            segment.write( 3, entry4 );
+
+            // when
+            IOCursor<EntryRecord> reader = segment.getReader( 2 );
+
+            // then
             assertTrue( reader.next() );
             assertEquals( entry3, reader.get().logEntry() );
-            assertFalse( reader.next() );
+        }
+    }
 
-            reader.close();
+    @Test
+    public void shouldBeAbleToRepeatedlyReadWrittenValues() throws Exception
+    {
+        try ( SegmentFile segment = create( fsRule.get(), rafLogFile, contentMarshal, logProvider, segmentHeader ) )
+        {
+            // given
+            segment.write( 0, entry1 );
+            segment.write( 1, entry2 );
+            segment.write( 2, entry3 );
+
+            for ( int i = 0; i < 3; i++ )
+            {
+                // when
+                IOCursor<EntryRecord> reader = segment.getReader( 0 );
+
+                // then
+                assertTrue( reader.next() );
+                assertEquals( entry1, reader.get().logEntry() );
+                assertTrue( reader.next() );
+                assertEquals( entry2, reader.get().logEntry() );
+                assertTrue( reader.next() );
+                assertEquals( entry3, reader.get().logEntry() );
+                assertFalse( reader.next() );
+
+                reader.close();
+            }
         }
     }
 
     @Test
     public void shouldCallDisposeHandler() throws Exception
     {
-        // given
-        Runnable onDisposeHandler = mock( Runnable.class );
+        try ( SegmentFile segment = create( fsRule.get(), rafLogFile, contentMarshal, logProvider, segmentHeader ) )
+        {
+            // given
+            Runnable onDisposeHandler = mock( Runnable.class );
 
-        // when
-        segment.closeWriter();
-        segment.markForDisposal( onDisposeHandler );
+            // when
+            segment.closeWriter();
+            segment.markForDisposal( onDisposeHandler );
 
-        // then
-        verify( onDisposeHandler ).run();
+            // then
+            verify( onDisposeHandler ).run();
+        }
     }
 
     @Test
     public void shouldCallDisposeHandlerAfterWriterIsClosed() throws Exception
     {
-        // given
-        Runnable onDisposeHandler = mock( Runnable.class );
-        segment.write( 0, entry1 );
+        try ( SegmentFile segment = create( fsRule.get(), rafLogFile, contentMarshal, logProvider, segmentHeader ) )
+        {
+            // given
+            Runnable onDisposeHandler = mock( Runnable.class );
+            segment.write( 0, entry1 );
 
-        // when
-        segment.markForDisposal( onDisposeHandler );
+            // when
+            segment.markForDisposal( onDisposeHandler );
 
-        // then
-        verify( onDisposeHandler, never() ).run();
+            // then
+            verify( onDisposeHandler, never() ).run();
 
-        // when
-        segment.closeWriter();
+            // when
+            segment.closeWriter();
 
-        // then
-        assertTrue( segment.isDisposed() );
-        verify( onDisposeHandler ).run();
+            // then
+            assertTrue( segment.isDisposed() );
+            verify( onDisposeHandler ).run();
+        }
     }
 
     @Test
     public void shouldCallDisposeHandlerAfterLastReaderIsClosed() throws Exception
     {
-        // given
-        Runnable onDisposeHandler = mock( Runnable.class );
-        IOCursor<EntryRecord> reader0 = segment.getReader( 0 );
-        IOCursor<EntryRecord> reader1 = segment.getReader( 1 );
+        try ( SegmentFile segment = create( fsRule.get(), rafLogFile, contentMarshal, logProvider, segmentHeader ) )
+        {
+            // given
+            Runnable onDisposeHandler = mock( Runnable.class );
+            IOCursor<EntryRecord> reader0 = segment.getReader( 0 );
+            IOCursor<EntryRecord> reader1 = segment.getReader( 1 );
 
-        // when
-        segment.closeWriter();
-        segment.markForDisposal( onDisposeHandler );
-        reader0.close();
+            // when
+            segment.closeWriter();
+            segment.markForDisposal( onDisposeHandler );
+            reader0.close();
 
-        // then
-        verify( onDisposeHandler, never() ).run();
+            // then
+            verify( onDisposeHandler, never() ).run();
 
-        // when
-        reader1.close();
+            // when
+            reader1.close();
 
-        // then
-        assertTrue( segment.isDisposed() );
-        verify( onDisposeHandler ).run();
+            // then
+            assertTrue( segment.isDisposed() );
+            verify( onDisposeHandler ).run();
+        }
     }
 
     @Test
     public void shouldCallDisposeHandlerAfterBothReadersAndWriterAreClosed() throws Exception
     {
-        // given
-        Runnable onDisposeHandler = mock( Runnable.class );
-        IOCursor<EntryRecord> reader0 = segment.getReader( 0 );
-        IOCursor<EntryRecord> reader1 = segment.getReader( 1 );
-        IOCursor<EntryRecord> reader2 = segment.getReader( 1 );
+        try ( SegmentFile segment = create( fsRule.get(), rafLogFile, contentMarshal, logProvider, segmentHeader ) )
+        {
+            // given
+            Runnable onDisposeHandler = mock( Runnable.class );
+            IOCursor<EntryRecord> reader0 = segment.getReader( 0 );
+            IOCursor<EntryRecord> reader1 = segment.getReader( 1 );
+            IOCursor<EntryRecord> reader2 = segment.getReader( 1 );
 
-        segment.write( 0, entry1 );
+            segment.write( 0, entry1 );
 
-        // when
-        segment.markForDisposal( onDisposeHandler );
-        reader0.close();
-        reader1.close();
-        segment.closeWriter();
+            // when
+            segment.markForDisposal( onDisposeHandler );
+            reader0.close();
+            reader1.close();
+            segment.closeWriter();
 
-        // then
-        verify( onDisposeHandler, never() ).run();
+            // then
+            verify( onDisposeHandler, never() ).run();
 
-        // when
-        reader2.close();
+            // when
+            reader2.close();
 
-        // then
-        assertTrue( segment.isDisposed() );
-        verify( onDisposeHandler ).run();
+            // then
+            assertTrue( segment.isDisposed() );
+            verify( onDisposeHandler ).run();
+        }
+    }
+
+    @Test
+    public void shouldDisposePoolAndWriterOnClose() throws Exception
+    {
+        SegmentFile segment = create( fsRule.get(), rafLogFile, contentMarshal, logProvider, segmentHeader );
+        segment.close();
+
+        try
+        {
+            segment.getReader( 0 );
+            fail( "should have thrown" );
+        }
+        catch ( DisposedException ex )
+        {
+            // good!
+        }
+
+        try
+        {
+            segment.writer();
+            fail( "should have thrown" );
+        }
+        catch ( DisposedException ex )
+        {
+            // good!
+        }
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/SegmentsTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/SegmentsTest.java
@@ -22,119 +22,162 @@ package org.neo4j.coreedge.raft.log.segmented;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.neo4j.coreedge.raft.replication.ReplicatedContent;
 import org.neo4j.coreedge.raft.state.ChannelMarshal;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.logging.LogProvider;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class SegmentsTest
 {
+    private final FileSystemAbstraction fsa = mock( FileSystemAbstraction.class, RETURNS_MOCKS );
+    private final File baseDirectory = new File( "." );
+    private final FileNames fileNames = new FileNames( baseDirectory );
+    @SuppressWarnings( "unchecked" )
+    private final ChannelMarshal<ReplicatedContent> contentMarshal = mock( ChannelMarshal.class );
+    private final LogProvider logProvider = mock( LogProvider.class, RETURNS_MOCKS );
+    private final SegmentHeader header = mock( SegmentHeader.class );
+    private final List<SegmentFile> segmentFiles = asList(
+            new SegmentFile( fsa, fileNames.getForVersion( 0 ), contentMarshal, logProvider, header ),
+            new SegmentFile( fsa, fileNames.getForVersion( 1 ), contentMarshal, logProvider, header ) );
+
     @Test
     public void shouldCreateNext() throws Exception
     {
         // Given
-        FileSystemAbstraction fsa = mock( FileSystemAbstraction.class, RETURNS_MOCKS );
-        FileNames fileNames = mock( FileNames.class );
-        ChannelMarshal<ReplicatedContent> contentMarshal = mock( ChannelMarshal.class );
-        LogProvider logProvider = mock( LogProvider.class );
+        try( Segments segments = new Segments( fsa, fileNames, segmentFiles, contentMarshal, logProvider, -1 ) )
+        {
+            // When
+            segments.rotate( 10, 10, 12 );
+            segments.last().closeWriter();
+            SegmentFile last = segments.last();
 
-        Segments segments = new Segments( fsa, fileNames, Collections.emptyList(), contentMarshal, logProvider, -1 );
-
-        // When
-        segments.rotate( 10, 10, 12 );
-        segments.last().closeWriter();
-        SegmentFile last = segments.last();
-
-        // Then
-        assertEquals( 10, last.header().prevFileLastIndex() );
-        assertEquals( 10, last.header().prevIndex() );
-        assertEquals( 12, last.header().prevTerm() );
+            // Then
+            assertEquals( 10, last.header().prevFileLastIndex() );
+            assertEquals( 10, last.header().prevIndex() );
+            assertEquals( 12, last.header().prevTerm() );
+        }
     }
 
     @Test
     public void shouldDeleteOnPrune() throws Exception
     {
+        verifyZeroInteractions( fsa );
         // Given
-        FileSystemAbstraction fsa = mock( FileSystemAbstraction.class, RETURNS_MOCKS );
-        File baseDirectory = new File( "." );
-        FileNames fileNames = new FileNames( baseDirectory );
-        ChannelMarshal<ReplicatedContent> contentMarshal = mock( ChannelMarshal.class );
-        LogProvider logProvider = mock( LogProvider.class );
+        try( Segments segments = new Segments( fsa, fileNames, segmentFiles, contentMarshal, logProvider, -1 ) )
+        {
+            SegmentFile toPrune = segments.rotate( -1, -1, -1 ); // this is version 0 and will be deleted on prune later
+            segments.last().closeWriter(); // need to close writer otherwise dispose will not be called
+            segments.rotate( 10, 10, 2 );
+            segments.last().closeWriter(); // ditto
+            segments.rotate( 20, 20, 2 );
 
-        Segments segments = new Segments( fsa, fileNames, Collections.emptyList(), contentMarshal, logProvider, -1 );
+            // When
+            segments.prune( 11 );
 
-        SegmentFile toPrune = segments.rotate( -1, -1, -1 ); // this is version 0 and will be deleted on prune later
-        segments.last().closeWriter(); // need to close writer otherwise dispose will not be called
-        segments.rotate( 10, 10, 2 );
-        segments.last().closeWriter(); // ditto
-        segments.rotate( 20, 20, 2 );
-
-        // When
-        segments.prune( 11 );
-
-        verify( fsa, times( 1 ) ).deleteFile( fileNames.getForVersion( toPrune.header().version() ) );
+            verify( fsa, times( segmentFiles.size() ) ).deleteFile( fileNames.getForVersion( toPrune.header().version() ) );
+        }
     }
 
     @Test
     public void shouldNeverDeleteOnTruncate() throws Exception
     {
         // Given
-        FileSystemAbstraction fsa = mock( FileSystemAbstraction.class, RETURNS_MOCKS );
-        File baseDirectory = new File( "." );
-        FileNames fileNames = new FileNames( baseDirectory );
-        ChannelMarshal<ReplicatedContent> contentMarshal = mock( ChannelMarshal.class );
-        LogProvider logProvider = mock( LogProvider.class );
+        try( Segments segments = new Segments( fsa, fileNames, segmentFiles, contentMarshal, logProvider, -1 ) )
+        {
+            segments.rotate( -1, -1, -1 );
+            segments.last().closeWriter(); // need to close writer otherwise dispose will not be called
+            segments.rotate( 10, 10, 2 ); // we will truncate this whole file away
+            segments.last().closeWriter();
 
-        Segments segments = new Segments( fsa, fileNames, Collections.emptyList(), contentMarshal, logProvider, -1 );
+            // When
+            segments.truncate( 20, 9, 4 );
 
-        segments.rotate( -1, -1, -1 );
-        segments.last().closeWriter(); // need to close writer otherwise dispose will not be called
-        segments.rotate( 10, 10, 2 ); // we will truncate this whole file away
-        segments.last().closeWriter();
-
-        // When
-        segments.truncate( 20, 9, 4 );
-
-        // Then
-        verify( fsa, times( 0 ) ).deleteFile( any() );
+            // Then
+            verify( fsa, times( 0 ) ).deleteFile( any() );
+        }
     }
 
     @Test
     public void shouldDeleteTruncatedFilesOnPrune() throws Exception
     {
         // Given
-        FileSystemAbstraction fsa = mock( FileSystemAbstraction.class, RETURNS_MOCKS );
-        File baseDirectory = new File( "." );
-        FileNames fileNames = new FileNames( baseDirectory );
-        ChannelMarshal<ReplicatedContent> contentMarshal = mock( ChannelMarshal.class );
-        LogProvider logProvider = mock( LogProvider.class );
+        try( Segments segments = new Segments( fsa, fileNames, segmentFiles, contentMarshal, logProvider, -1 ) )
+        {
+            SegmentFile toBePruned = segments.rotate( -1, -1, -1 );
+            segments.last().closeWriter(); // need to close writer otherwise dispose will not be called
+            SegmentFile toBeTruncated = segments.rotate( 10, 10, 2 );// we will truncate this whole file away
+            segments.last().closeWriter();
 
-        Segments segments = new Segments( fsa, fileNames, Collections.emptyList(), contentMarshal, logProvider, -1 );
+            // When
+            // We truncate a whole file
+            segments.truncate( 20, 9, 4 );
+            // And we prune all files before that file
+            segments.prune( 10 );
 
-        SegmentFile toBePruned = segments.rotate( -1, -1, -1 );
-        segments.last().closeWriter(); // need to close writer otherwise dispose will not be called
-        SegmentFile toBeTruncated = segments.rotate( 10, 10, 2 );// we will truncate this whole file away
-        segments.last().closeWriter();
+            // Then
+            // the truncate file is part of the deletes that happen while prunning
+            verify( fsa, times( segmentFiles.size() ) ).deleteFile(
+                    fileNames.getForVersion( toBePruned.header().version() ) );
+            verify( fsa, times( segmentFiles.size() ) ).deleteFile(
+                    fileNames.getForVersion( toBeTruncated.header().version() ) );
+        }
+    }
+
+    @Test
+    public void shouldCloseTheSegments() throws Exception
+    {
+        // Given
+        Segments segments = new Segments( fsa, fileNames, segmentFiles, contentMarshal, logProvider, -1 );
 
         // When
-        // We truncate a whole file
-        segments.truncate( 20, 9, 4 );
-        // And we prune all files before that file
-        segments.prune( 10 );
+        segments.close();
 
         // Then
-        // the truncate file is part of the deletes that happen while prunning
-        verify( fsa, times( 1 ) ).deleteFile( fileNames.getForVersion( toBePruned.header().version() ) );
-        verify( fsa, times( 1 ) ).deleteFile( fileNames.getForVersion( toBeTruncated.header().version() ) );
+        segments.getSegmentFileIteratorAtEnd().forEachRemaining( segment -> assertTrue( segment.isDisposed() ) );
+    }
+
+    @Test
+    public void shouldNotSwallowExceptionOnClose() throws Exception
+    {
+        // Given
+        List<SegmentFile> segmentFiles = new ArrayList<>( this.segmentFiles.size() );
+        for ( SegmentFile segmentFile: this.segmentFiles )
+        {
+            SegmentFile spy = spy( segmentFile );
+            doThrow( new DisposedException() ).when( spy ).close();
+            segmentFiles.add( spy );
+        }
+        Segments segments = new Segments( fsa, fileNames, segmentFiles, contentMarshal, logProvider, -1 );
+
+        // When
+        try
+        {
+            segments.close();
+            fail( "should have thrown" );
+        }
+        catch ( DisposedException ex)
+        {
+            // Then
+            Throwable[] suppressed = ex.getSuppressed();
+            assertEquals( 1, suppressed.length );
+            assertTrue( suppressed[0] instanceof DisposedException );
+        }
     }
 
     @Test
@@ -142,15 +185,7 @@ public class SegmentsTest
     {
         //Given a prune index of n, if the smallest value for a segment file is n+c, the pruning should not remove
         // any files and not result in a failure.
-
-        // Given
-        FileSystemAbstraction fsa = mock( FileSystemAbstraction.class, RETURNS_MOCKS );
-        File baseDirectory = new File( "." );
-        FileNames fileNames = new FileNames( baseDirectory );
-        ChannelMarshal<ReplicatedContent> contentMarshal = mock( ChannelMarshal.class );
-        LogProvider logProvider = mock( LogProvider.class );
-
-        Segments segments = new Segments( fsa, fileNames, Collections.emptyList(), contentMarshal, logProvider, -1 );
+        Segments segments = new Segments( fsa, fileNames, segmentFiles, contentMarshal, logProvider, -1 );
 
         segments.rotate( -1, -1, -1 );
         segments.last().closeWriter(); // need to close writer otherwise dispose will not be called


### PR DESCRIPTION
Before these changes the store channels, reader pools, and writers
were abruptaly closed on db shutdown.
