### PR TITLE
Ensure that we publish artifacts for neo4j-slf4j

### DIFF
--- a/community/pom.xml
+++ b/community/pom.xml
@@ -188,6 +188,11 @@ the relevant Commercial Agreement.
           <artifactId>neo4j-harness</artifactId>
           <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.neo4j</groupId>
+          <artifactId>neo4j-slf4j</artifactId>
+          <version>${project.version}</version>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -108,7 +108,6 @@ terms of the relevant Commercial Agreement.
                 <configuration>
                   <excludeTransitive>true</excludeTransitive>
                   <includes>
-                    <include>org.neo4j:neo4j-slf4j:*</include>
                     <include>org.neo4j:*</include>
                     <include>org.neo4j.app:*</include>
                     <include>org.neo4j.build:*</include>


### PR DESCRIPTION
This is a second attempt at fixing this. It's all rather speculative
because it's hard to reproduce the problem except in a full build and we
don't fully understand the Ease plugin. We plan to remove it but it's a
bit of work and we want a quick fix for the failure to publish
neo4j-slf4j.

neo4j-slf4j is not actually used in any of our production code, but is
provided as a utility for users to adapt between our logging and
SLF4J. Previously it was picked up by the Maven Ease plugin because the
examples module that depends on it was in the Community project. But
that has been moved under docs, so there was no dependency on
neo4j-slf4j from any of our modules. Here we add it explicitly to the
list of modules to publish.
