### PR TITLE
Removes the short-lived read locks on property reads

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -185,10 +185,6 @@ import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static org.neo4j.helpers.collection.Iterables.toList;
-import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
-import static org.neo4j.kernel.configuration.Settings.TRUE;
-import static org.neo4j.kernel.configuration.Settings.setting;
-import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
 import static org.neo4j.kernel.impl.transaction.log.pruning.LogPruneStrategyFactory.fromConfigValue;
 
 public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexProviders
@@ -345,13 +341,6 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
     }
 
     public static final String DEFAULT_DATA_SOURCE_NAME = "nioneodb";
-
-    /**
-     * This setting is hidden to the user and is here merely for making it easier to back out of
-     * a change where reading property chains incurs read locks on {@link LockService}.
-     */
-    private static final Setting<Boolean> use_read_locks_on_property_reads =
-            setting( "experimental.use_read_locks_on_property_reads", BOOLEAN, TRUE );
 
     private final Monitors monitors;
     private final Tracers tracers;
@@ -860,14 +849,12 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
 
     private Factory<StoreStatement> storeStatementFactory( final NeoStores neoStores )
     {
-        final LockService lockService =
-                config.get( use_read_locks_on_property_reads ) ? this.lockService : NO_LOCK_SERVICE;
         return new Factory<StoreStatement>()
         {
             @Override
             public StoreStatement newInstance()
             {
-                return new StoreStatement( neoStores, lockService );
+                return new StoreStatement( neoStores );
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorNodeCursor.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.api.store;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.function.Consumer;
 import org.neo4j.graphdb.Resource;
-import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 
@@ -38,10 +37,9 @@ public class StoreIteratorNodeCursor extends StoreAbstractNodeCursor
     public StoreIteratorNodeCursor( NodeRecord nodeRecord,
             NeoStores neoStores,
             StoreStatement storeStatement,
-            Consumer<StoreIteratorNodeCursor> instanceCache,
-            LockService lockService )
+            Consumer<StoreIteratorNodeCursor> instanceCache )
     {
-        super( nodeRecord, neoStores, storeStatement, lockService );
+        super( nodeRecord, neoStores, storeStatement );
         this.instanceCache = instanceCache;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreIteratorRelationshipCursor.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api.store;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.graphdb.Resource;
-import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.util.InstanceCache;
@@ -38,10 +37,9 @@ public class StoreIteratorRelationshipCursor extends StoreAbstractRelationshipCu
 
     public StoreIteratorRelationshipCursor( RelationshipRecord relationshipRecord,
             NeoStores neoStores,
-            StoreStatement storeStatement, InstanceCache<StoreIteratorRelationshipCursor> instanceCache,
-            LockService lockService )
+            StoreStatement storeStatement, InstanceCache<StoreIteratorRelationshipCursor> instanceCache )
     {
-        super( relationshipRecord, neoStores, storeStatement, lockService );
+        super( relationshipRecord, neoStores, storeStatement );
         this.instanceCache = instanceCache;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api.store;
 
 import org.neo4j.function.Consumer;
 import org.neo4j.graphdb.Direction;
-import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RelationshipGroupStore;
@@ -53,10 +52,9 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
             NeoStores neoStores,
             RelationshipGroupRecord groupRecord,
             StoreStatement storeStatement,
-            Consumer<StoreNodeRelationshipCursor> instanceCache,
-            LockService lockService )
+            Consumer<StoreNodeRelationshipCursor> instanceCache )
     {
-        super( relationshipRecord, neoStores, storeStatement, lockService );
+        super( relationshipRecord, neoStores, storeStatement );
 
         this.groupRecord = groupRecord;
         this.instanceCache = instanceCache;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyCursor.java
@@ -25,7 +25,6 @@ import org.neo4j.cursor.Cursor;
 import org.neo4j.function.Consumer;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.api.cursor.PropertyItem;
-import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
@@ -41,7 +40,6 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
     private final StorePropertyPayloadCursor payload;
 
     private long nextPropertyRecordId;
-    private Lock lock;
 
     public StorePropertyCursor( PropertyStore propertyStore, Consumer<StorePropertyCursor> instanceCache )
     {
@@ -50,10 +48,9 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
         this.payload = new StorePropertyPayloadCursor( propertyStore.getStringStore(), propertyStore.getArrayStore() );
     }
 
-    public StorePropertyCursor init( long firstPropertyId, Lock lock )
+    public StorePropertyCursor init( long firstPropertyId )
     {
         nextPropertyRecordId = firstPropertyId;
-        this.lock = lock;
         return this;
     }
 
@@ -115,15 +112,8 @@ public class StorePropertyCursor implements Cursor<PropertyItem>, PropertyItem
     @Override
     public void close()
     {
-        try
-        {
-            payload.clear();
-            instanceCache.accept( this );
-        }
-        finally
-        {
-            lock.release();
-        }
+        payload.clear();
+        instanceCache.accept( this );
     }
 
     static Object payloadValueAsObject( StorePropertyPayloadCursor payload )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api.store;
 
 import org.neo4j.function.Consumer;
 import org.neo4j.kernel.api.StatementConstants;
-import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 
@@ -36,10 +35,9 @@ public class StoreSingleNodeCursor extends StoreAbstractNodeCursor
     public StoreSingleNodeCursor( NodeRecord nodeRecord,
             NeoStores neoStores,
             StoreStatement storeStatement,
-            Consumer<StoreSingleNodeCursor> instanceCache,
-            LockService lockService )
+            Consumer<StoreSingleNodeCursor> instanceCache )
     {
-        super( nodeRecord, neoStores, storeStatement, lockService );
+        super( nodeRecord, neoStores, storeStatement );
         this.instanceCache = instanceCache;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSinglePropertyCursor.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api.store;
 
 import org.neo4j.function.Consumer;
 import org.neo4j.kernel.api.StatementConstants;
-import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.store.PropertyStore;
 
 /**
@@ -37,9 +36,9 @@ public class StoreSinglePropertyCursor extends StorePropertyCursor
         super( propertyStore, (Consumer) instanceCache );
     }
 
-    public StoreSinglePropertyCursor init( long firstPropertyId, int propertyKeyId, Lock lock )
+    public StoreSinglePropertyCursor init( long firstPropertyId, int propertyKeyId )
     {
-        super.init( firstPropertyId, lock );
+        super.init( firstPropertyId );
         this.propertyKeyId = propertyKeyId;
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursor.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.api.store;
 
 import org.neo4j.kernel.api.StatementConstants;
-import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
@@ -35,10 +34,9 @@ public class StoreSingleRelationshipCursor extends StoreAbstractRelationshipCurs
     private final InstanceCache<StoreSingleRelationshipCursor> instanceCache;
 
     public StoreSingleRelationshipCursor( RelationshipRecord relationshipRecord, NeoStores neoStores,
-            StoreStatement storeStatement, InstanceCache<StoreSingleRelationshipCursor> instanceCache,
-            LockService lockService )
+            StoreStatement storeStatement, InstanceCache<StoreSingleRelationshipCursor> instanceCache )
     {
-        super( relationshipRecord, neoStores, storeStatement, lockService );
+        super( relationshipRecord, neoStores, storeStatement );
         this.instanceCache = instanceCache;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreStatement.java
@@ -52,7 +52,7 @@ public class StoreStatement
     private final NodeStore nodeStore;
     private final RelationshipStore relationshipStore;
 
-    public StoreStatement( final NeoStores neoStores, final LockService lockService )
+    public StoreStatement( final NeoStores neoStores )
     {
         this.neoStores = neoStores;
         this.nodeStore = neoStores.getNodeStore();
@@ -63,8 +63,7 @@ public class StoreStatement
             @Override
             protected StoreSingleNodeCursor create()
             {
-                return new StoreSingleNodeCursor( new NodeRecord( -1 ), neoStores, StoreStatement.this, this,
-                        lockService );
+                return new StoreSingleNodeCursor( new NodeRecord( -1 ), neoStores, StoreStatement.this, this );
             }
         };
         iteratorNodeCursor = new InstanceCache<StoreIteratorNodeCursor>()
@@ -72,8 +71,7 @@ public class StoreStatement
             @Override
             protected StoreIteratorNodeCursor create()
             {
-                return new StoreIteratorNodeCursor( new NodeRecord( -1 ), neoStores, StoreStatement.this, this,
-                        lockService );
+                return new StoreIteratorNodeCursor( new NodeRecord( -1 ), neoStores, StoreStatement.this, this );
             }
         };
         singleRelationshipCursor = new InstanceCache<StoreSingleRelationshipCursor>()
@@ -82,7 +80,7 @@ public class StoreStatement
             protected StoreSingleRelationshipCursor create()
             {
                 return new StoreSingleRelationshipCursor( new RelationshipRecord( -1 ),
-                        neoStores, StoreStatement.this, this, lockService );
+                        neoStores, StoreStatement.this, this );
             }
         };
         iteratorRelationshipCursor = new InstanceCache<StoreIteratorRelationshipCursor>()
@@ -91,7 +89,7 @@ public class StoreStatement
             protected StoreIteratorRelationshipCursor create()
             {
                 return new StoreIteratorRelationshipCursor( new RelationshipRecord( -1 ),
-                        neoStores, StoreStatement.this, this, lockService );
+                        neoStores, StoreStatement.this, this );
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchRelationshipIterable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchRelationshipIterable.java
@@ -32,8 +32,6 @@ import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
-import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
-
 abstract class BatchRelationshipIterable<T> implements Iterable<T>
 {
     private final StoreNodeRelationshipCursor relationshipCursor;
@@ -45,7 +43,7 @@ abstract class BatchRelationshipIterable<T> implements Iterable<T>
         this.relationshipCursor = new StoreNodeRelationshipCursor(
                 relationshipRecord, neoStores,
                 relationshipGroupRecord, null,
-                Consumers.<StoreNodeRelationshipCursor>noop(), NO_LOCK_SERVICE );
+                Consumers.<StoreNodeRelationshipCursor>noop() );
 
         // TODO There's an opportunity to reuse lots of instances created here, but this isn't a
         // critical path instance so perhaps not necessary a.t.m.

--- a/community/kernel/src/test/java/org/neo4j/graphdb/ConsistentPropertyReadsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/ConsistentPropertyReadsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.helpers.ArrayUtil;
+import org.neo4j.test.DatabaseRule;
+import org.neo4j.test.EmbeddedDatabaseRule;
+import org.neo4j.test.Race;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for how properties are read and that they should be read consistently, i.e. adhere to neo4j's
+ * interpretation of the ACID guarantees.
+ */
+public class ConsistentPropertyReadsTest
+{
+    @Rule
+    public DatabaseRule db = new EmbeddedDatabaseRule( getClass() );
+
+    @Test
+    public void shouldReadConsistentPropertyValues() throws Throwable
+    {
+        // GIVEN
+        final Node[] nodes = new Node[10];
+        final String[] keys = new String[] {"1", "2", "3"};
+        final String[] values = new String[] {
+                "dsjlfhsdljhsjlghsljfghjlsfhg jlfh jldfgh djlfghdljfgh dljfghdfljgh dlfjg hdfljg hdfljg hdflghdfjgl hdfljg hdfjlg hdfglj hdfgjl dhfglj dhfgjl dfhglsdjfköasjkdlöadksflösf akljdhfwjl htlj3ht jl3rht jl3ht j3lht 3jt h3ltj h34tl j3ht j3t h3jtl h34jtl 3h4tl 3j4ht l34jt h3ljg",
+                "jdlhflahsjlw4hjltwrhtjl4hljterhglwrhyjl5hgwjlrgh rljeghlj rhyljthlj5 4yhj tlrwhtlj rhylj hrjtl h53jl6ht 35qjlhjl4 htjl rh jtl35 hyjl43 hyjl35hjylhwjelth tq3jlth qjlrwhetj lq3rht lqrjwhqlj rhyjl q3htjlhr tjlwhrg jlwrhy jlrht jlgwhjly h3rjl t h",
+                "kfgjlyh3jlghjl45h l4tg hj45l h46jl ghjlgh5glj  hgjl 5hgjl5hjl gh4j3 lgh46 ljh4 jl4h j4hg4lgj h4t jlgh 4t jlgh4tgjlthgje tlhjfldhb8ther8g0u8f0vrehi5köehvjlfhgutwohy ireghlwgh lrej htlweghwrufh wrutl h35ut lhrgvj rhyl5hy jlwhglwrhfu5oy h53tlj h4wlt h5eut herul"
+        };
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < nodes.length; i++ )
+            {
+                nodes[i] = db.createNode();
+                for ( int j = 0; j < keys.length; j++ )
+                {
+                    nodes[i].setProperty( keys[j], values[0] );
+                }
+            }
+            tx.success();
+        }
+
+        int updaters = 10;
+        final AtomicLong updatersDone = new AtomicLong( updaters );
+        Race race = new Race();
+        for ( int i = 0; i < updaters; i++ )
+        {
+            // Changers
+            race.addContestant( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    try
+                    {
+                        ThreadLocalRandom random = ThreadLocalRandom.current();
+                        for ( int j = 0; j < 100; j++ )
+                        {
+                            try ( Transaction tx = db.beginTx() )
+                            {
+                                nodes[random.nextInt( nodes.length )].setProperty( keys[random.nextInt( keys.length )],
+                                        values[random.nextInt( values.length )] );
+                                tx.success();
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        updatersDone.decrementAndGet();
+                    }
+                }
+            } );
+        }
+        for ( int i = 0; i < 10; i++ )
+        {
+            // Readers
+            race.addContestant( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    ThreadLocalRandom random = ThreadLocalRandom.current();
+                    while ( updatersDone.get() > 0 )
+                    {
+                        try ( Transaction tx = db.beginTx() )
+                        {
+                            String value = (String) nodes[random.nextInt( nodes.length )]
+                                    .getProperty( keys[random.nextInt( keys.length )] );
+                            assertTrue( value, ArrayUtil.contains( values, value ) );
+                            tx.success();
+                        }
+                    }
+                }
+            } );
+        }
+
+        // WHEN
+        race.go();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/DiskLayerTest.java
@@ -45,7 +45,6 @@ import org.neo4j.kernel.impl.core.LabelTokenHolder;
 import org.neo4j.kernel.impl.core.PropertyKeyTokenHolder;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.transaction.state.NeoStoresSupplier;
@@ -90,7 +89,7 @@ public class DiskLayerTest
                     @Override
                     public StoreStatement newInstance()
                     {
-                        return new StoreStatement( neoStores, LockService.NO_LOCK_SERVICE );
+                        return new StoreStatement( neoStores );
                     }
                 } );
         this.state = new KernelStatement( null, new IndexReaderFactory.Caching( indexingService ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import static org.neo4j.graphdb.Direction.BOTH;
-import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
 import static org.neo4j.kernel.impl.store.record.Record.NO_NEXT_RELATIONSHIP;
 
 public class StoreNodeRelationshipCursorTest
@@ -60,8 +59,7 @@ public class StoreNodeRelationshipCursorTest
                 stores,
                 new RelationshipGroupRecord( -1, -1 ),
                 mock( StoreStatement.class ),
-                mock( Consumer.class ),
-                NO_LOCK_SERVICE );
+                mock( Consumer.class ) );
 
         // WHEN
         cursor.init( true, NO_NEXT_RELATIONSHIP.intValue(), 0, BOTH );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
@@ -70,7 +70,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK;
 
 @RunWith( Enclosed.class )
 public class StorePropertyCursorTest
@@ -239,7 +238,7 @@ public class StorePropertyCursorTest
         {
             // given
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore, cache );
-            storePropertyCursor.init( 0, NO_LOCK );
+            storePropertyCursor.init( 0 );
 
             // when
             storePropertyCursor.close();
@@ -332,7 +331,7 @@ public class StorePropertyCursorTest
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
             // when
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId ) )
             {
                 // then
                 assertTrue( cursor.next() );
@@ -395,7 +394,7 @@ public class StorePropertyCursorTest
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
             // when
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId ) )
             {
                 // then
                 assertTrue( cursor.next() );
@@ -427,7 +426,7 @@ public class StorePropertyCursorTest
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
             // when
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId ) )
             {
                 PropertyItem item;
 
@@ -474,7 +473,7 @@ public class StorePropertyCursorTest
 
             StorePropertyCursor storePropertyCursor = newStorePropertyCursor( propertyStore );
 
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId ) )
             {
                 assertTrue( cursor.next() );
                 PropertyItem item = cursor.get();
@@ -484,7 +483,7 @@ public class StorePropertyCursorTest
             }
 
             // when using it
-            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId, NO_LOCK ) )
+            try ( Cursor<PropertyItem> cursor = storePropertyCursor.init( recordId ) )
             {
                 // then
                 assertTrue( cursor.next() );
@@ -509,7 +508,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( propertyValues ), valuesFromCursor );
@@ -526,7 +525,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId );
 
                 assertTrue( cursor.next() );
                 assertEquals( "1", cursor.value() );
@@ -552,7 +551,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( "1", 3, 5L, '7', "9 and 10" ), valuesFromCursor );
@@ -571,7 +570,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( "1", "2", 6L, '7', '8', "9 and 10" ), valuesFromCursor );
@@ -591,7 +590,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( firstPropertyId, NO_LOCK );
+                cursor.init( firstPropertyId );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( Collections.emptyList(), valuesFromCursor );
@@ -610,7 +609,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( chainStartId, NO_LOCK );
+                cursor.init( chainStartId );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 assertEquals( asList( values ), valuesFromCursor );
@@ -687,7 +686,7 @@ public class StorePropertyCursorTest
 
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( chainStartId, NO_LOCK );
+                cursor.init( chainStartId );
 
                 List<Object> valuesFromCursor = asPropertyValuesList( cursor );
                 for ( int i = 0; i < valuesFromCursor.size(); i++ )
@@ -730,7 +729,7 @@ public class StorePropertyCursorTest
         {
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( recordId, NO_LOCK );
+                cursor.init( recordId );
                 assertTrue( cursor.next() );
                 assertEquals( expectedValue, cursor.value() );
                 assertFalse( cursor.next() );
@@ -741,7 +740,7 @@ public class StorePropertyCursorTest
         {
             try ( StorePropertyCursor cursor = newStorePropertyCursor( propertyStore ) )
             {
-                cursor.init( recordId, NO_LOCK );
+                cursor.init( recordId );
                 assertTrue( cursor.next() );
                 assertArrayEquals( expectedValue, (byte[]) cursor.value() );
                 assertFalse( cursor.next() );


### PR DESCRIPTION
in favor of the technique of tracking open transactions and freeing ids
at safe points in time. All code for the read locks is now removed
and ConsistentPropertyReadTest shows that properties are still read
consistently.

CHANGELOG:
Reading properties scales better by no longer needing to acquire read locks.
This also removes `experimental.use_read_locks_on_property_reads` setting.
