### PR TITLE
Increase test timeout to reduce flakiness

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -2844,7 +2844,7 @@ public abstract class PageCacheTest<T extends PageCache>
             // The takeLockFuture got it first, so the closeFuture should
             // complete when we release the latch.
             secondThreadGotLockLatch.countDown();
-            closeFuture.get( 2000, TimeUnit.MILLISECONDS );
+            closeFuture.get( 20000, TimeUnit.MILLISECONDS );
         }
     }
 


### PR DESCRIPTION
The whole test usually runs in 11 seconds, but between virtual machines and a garbage collected language, we can get some long stalls.
