### PR TITLE
Error message for aggregation as procedure input

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/InQueryProcedureCallAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/InQueryProcedureCallAcceptanceTest.scala
@@ -208,6 +208,14 @@ class InQueryProcedureCallAcceptanceTest extends ProcedureCallAcceptanceTest {
     result shouldBe empty
   }
 
+  test("should fail when using aggregating function as argument") {
+    // Given
+    registerDummyInOutProcedure(Neo4jTypes.NTNumber)
+
+    // Then
+    a [SyntaxException] shouldBe thrownBy(execute("MATCH (n) CALL my.first.proc(count(n)) YIELD out0 RETURN out0"))
+  }
+
   test("should fail if calling non-existent procedure") {
     a [CypherExecutionException] shouldBe thrownBy(execute("CALL no.such.thing.exists(42) YIELD x RETURN *"))
   }
@@ -226,7 +234,7 @@ class InQueryProcedureCallAcceptanceTest extends ProcedureCallAcceptanceTest {
   }
 
   test("should fail if calling procedure via rule planner") {
-    a [InternalException] shouldBe thrownBy(execute(
+    an [InternalException] shouldBe thrownBy(execute(
       "CYPHER planner=rule CALL db.labels() YIELD label RETURN *"
     ))
   }

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -657,6 +657,40 @@ public class ProcedureIT
         assertFalse( res.hasNext() );
     }
 
+    @Test
+    public void shouldGiveNiceErrorMessageWhenAggregationFunctionInProcedureCall()
+    {
+        try (Transaction ignore = db.beginTx())
+        {
+            db.createNode( Label.label( "Person" ) );
+            db.createNode( Label.label( "Person" ) );
+
+            // Expect
+            exception.expect( QueryExecutionException.class );
+
+            // When
+            db.execute(
+                    "MATCH (n:Person) CALL org.neo4j.procedure.nodeListArgument(collect(n)) YIELD someVal RETURN someVal" );
+        }
+    }
+
+    @Test
+    public void shouldWorkWhenUsingWithToProjectList()
+    {
+        try (Transaction ignore = db.beginTx())
+        {
+            db.createNode( Label.label( "Person" ) );
+            db.createNode( Label.label( "Person" ) );
+
+            // When
+            Result res = db.execute(
+                    "MATCH (n:Person) WITH collect(n) as persons CALL org.neo4j.procedure.nodeListArgument(persons) YIELD someVal RETURN someVal" );
+
+            // THEN
+            assertThat(res.next().get( "someVal" ), equalTo(2L));
+        }
+    }
+
     @Before
     public void setUp() throws IOException
     {
@@ -770,6 +804,12 @@ public class ProcedureIT
         public Stream<Output> simpleArgument( @Name( "name" ) long someValue )
         {
             return Stream.of( new Output( someValue ) );
+        }
+
+        @Procedure
+        public Stream<Output> nodeListArgument( @Name( "nodes" ) List<Node> nodes )
+        {
+            return Stream.of( new Output( nodes.size() ) );
         }
 
         @Procedure


### PR DESCRIPTION
It is not valid to give an aggregation function call as a direct argument to
a procedure. But instead of failing in late rewriter validation we should give
a proper semantic exception.
