### PR TITLE
Reuse same posting format instance for all fields in schema and label scan store indexes

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterConfigs.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/IndexWriterConfigs.java
@@ -48,6 +48,11 @@ public final class IndexWriterConfigs
     private static final int POPULATION_RAM_BUFFER_SIZE_MB =
             FeatureToggles.getInteger( IndexWriterConfigs.class, "population.ram.buffer.size", 50 );
 
+    /**
+     * Default postings format for schema and label scan store indexes.
+     */
+    private static final BlockTreeOrdsPostingsFormat blockTreeOrdsPostingsFormat = new BlockTreeOrdsPostingsFormat();
+
     private IndexWriterConfigs()
     {
         throw new AssertionError( "Not for instantiation!" );
@@ -66,8 +71,7 @@ public final class IndexWriterConfigs
             public PostingsFormat getPostingsFormatForField( String field )
             {
                 PostingsFormat postingFormat = super.getPostingsFormatForField( field );
-                return CODEC_BLOCK_TREE_ORDS_POSTING_FORMAT ? new BlockTreeOrdsPostingsFormat() :
-                       postingFormat;
+                return CODEC_BLOCK_TREE_ORDS_POSTING_FORMAT ? blockTreeOrdsPostingsFormat : postingFormat;
             }
         });
 


### PR DESCRIPTION
We do not need to create new format any field.
In case if  field have it's own instance of posting format, it will be persisted into separate file during index writer flush - 'format-field file',
In situation when we have a lot of fields stored we ending up with tons of small files that will eventually cause 'Too many open files' exception.
