### PR TITLE
Cleanup jta removal leftovers

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Transaction.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Transaction.java
@@ -27,9 +27,7 @@ package org.neo4j.graphdb;
  * If you attempt to access the graph outside of a transaction, those operations will throw
  * {@link NotInTransactionException}.
  * <p>
- * Transactions are bound to the thread in which they were created. Transactions can either be handled
- * programmatically, through this interface, or by a container through the Java Transaction API (JTA). The
- * Transaction interface makes handling programmatic transactions easier than using JTA programmatically.
+ * Transactions are bound to the thread in which they were created.
  * Here's the idiomatic use of programmatic transactions in Neo4j starting from java 7:
  *
  * <pre>

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -269,12 +269,5 @@ the relevant Commercial Agreement.
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-
-
-    <dependency>
-      <groupId>geronimo-spec</groupId>
-      <artifactId>geronimo-spec-j2ee</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -168,7 +168,7 @@ public class PlatformModule
         diagnosticsManager = life.add( dependencies.satisfyDependency( new DiagnosticsManager( logging.getInternalLog(
                 DiagnosticsManager.class ) ) ) );
 
-        // TODO please fix the bad dependencies instead of doing this. Before the removal of JTA
+        // TODO please fix the bad dependencies instead of doing this.
         // this was the place of the XaDataSourceManager. NeoStoreXaDataSource is create further down than
         // (specifically) KernelExtensions, which creates an interesting out-of-order issue with #doAfterRecovery().
         // Anyways please fix this.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -73,13 +73,6 @@ import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
  * keeping track of transaction state, serialization and deserialization to and from logical log, and applying things
  * to store. It would most likely do this by keeping a component derived from the current WriteTransaction
  * implementation as a sub-component, responsible for handling logical log commands.
- *
- * The class XAResourceManager plays in here as well, in that it shares responsibilities with WriteTransaction to
- * write data to the logical log. As we continue to refactor this subsystem, XAResourceManager should ideally not know
- * about the logical log, but defer entirely to the Kernel to handle this. Doing that will give the kernel full
- * discretion to start experimenting with higher-performing logical log implementations, without being hindered by
- * having to contend with the JTA compliance layers. In short, it would encapsulate the logical log/storage logic better
- * and thus make it easier to change.
  */
 public class TransactionRecordState implements RecordState
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -61,41 +61,6 @@ public class KernelIT extends KernelIntegrationTest
 {
     // TODO: Split this into area-specific tests, see PropertyIT.
 
-    /**
-     * While we transition ownership from the Beans API to the Kernel API for core database
-     * interactions, there will be a bit of a mess. Our first goal is an architecture like this:
-     * <p>
-     * Users
-     * /    \
-     * Beans API   Cypher
-     * \    /
-     * Kernel API
-     * |
-     * Kernel Implementation
-     * <p>
-     * But our current intermediate architecture looks like this:
-     * <p>
-     * Users
-     * /        \
-     * Beans API <--- Cypher
-     * |    \    /
-     * |  Kernel API
-     * |      |
-     * Kernel Implementation
-     * <p>
-     * Meaning Kernel API and Beans API both manipulate the underlying kernel, causing lots of corner cases. Most
-     * notably, those corner cases are related to Transactions, and the interplay between three transaction APIs:
-     * - The Beans API
-     * - The JTA Transaction Manager API
-     * - The Kernel TransactionContext API
-     * <p>
-     * In the long term, the goal is for JTA compliant stuff to live outside of the kernel, as an addon. The Kernel
-     * API will rule supreme over the land of transactions. We are a long way away from there, however, so as a first
-     * intermediary step, the JTA transaction manager rules supreme, and the Kernel API piggybacks on it.
-     * <p>
-     * This test shows us how to use both the Kernel API and the Beans API together in the same transaction,
-     * during the transition phase.
-     */
     @Test
     public void mixingBeansApiWithKernelAPI() throws Exception
     {
@@ -118,14 +83,6 @@ public class KernelIT extends KernelIntegrationTest
         // 5: Commit through the beans API
         transaction.success();
         transaction.close();
-
-        // NOTE: Transactions are still thread-bound right now, because we use JTA to "own" transactions,
-        // meaning if you use
-        // both the Kernel API to create transactions while a Beans API transaction is running in the same
-        // thread, the results are undefined.
-
-        // When the Kernel API implementation is done, the Kernel API transaction implementation is not meant
-        // to be bound to threads.
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LegacyDeadlockCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LegacyDeadlockCompatibility.java
@@ -26,14 +26,12 @@ import java.io.File;
 import java.util.Random;
 import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
-import javax.transaction.Transaction;
 
 import org.neo4j.kernel.DeadlockDetectedException;
 
 import static java.lang.System.currentTimeMillis;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
 @Ignore("Not a test, part of a compatibility suite.")
 // This is the legacy deadlock detection tests
@@ -163,7 +161,6 @@ public class LegacyDeadlockCompatibility extends LockingCompatibilityTestSuite.C
         private final float readWriteRatio;
         private final Locks.Client lm;
         private volatile Exception error;
-        private final Transaction tx = mock( Transaction.class );
         public volatile Long startedWaiting = null;
 
         StressThread( String name, int numberOfIterations, int depthCount,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockServiceMicroBenchmark.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/LockServiceMicroBenchmark.java
@@ -19,14 +19,8 @@
  */
 package org.neo4j.kernel.impl.locking;
 
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.RollbackException;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.xa.XAResource;
-
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.locking.community.LockManagerImpl;
 import org.neo4j.kernel.impl.locking.community.RagManager;
 
@@ -305,48 +299,39 @@ public class LockServiceMicroBenchmark
 
         static class ThreadMark implements Transaction
         {
+
             @Override
-            public void commit()
-                    throws HeuristicMixedException, HeuristicRollbackException, RollbackException, SecurityException,
-                           SystemException
+            public void terminate()
             {
-                throw new UnsupportedOperationException( "not implemented" );
+                throw new UnsupportedOperationException("not implemented");
             }
 
             @Override
-            public boolean delistResource( XAResource xaRes, int flag ) throws IllegalStateException, SystemException
+            public void failure()
             {
-                throw new UnsupportedOperationException( "not implemented" );
+                throw new UnsupportedOperationException("not implemented");
             }
 
             @Override
-            public boolean enlistResource( XAResource xaRes )
-                    throws IllegalStateException, RollbackException, SystemException
+            public void success()
             {
-                throw new UnsupportedOperationException( "not implemented" );
+                throw new UnsupportedOperationException("not implemented");
             }
 
             @Override
-            public int getStatus() throws SystemException
+            public void close()
             {
-                throw new UnsupportedOperationException( "not implemented" );
+                throw new UnsupportedOperationException("not implemented");
             }
 
             @Override
-            public void registerSynchronization( Synchronization synch )
-                    throws IllegalStateException, RollbackException, SystemException
+            public org.neo4j.graphdb.Lock acquireWriteLock( PropertyContainer entity )
             {
-                throw new UnsupportedOperationException( "not implemented" );
+                throw new UnsupportedOperationException("not implemented");
             }
 
             @Override
-            public void rollback() throws IllegalStateException, SystemException
-            {
-                throw new UnsupportedOperationException( "not implemented" );
-            }
-
-            @Override
-            public void setRollbackOnly() throws IllegalStateException, SystemException
+            public org.neo4j.graphdb.Lock acquireReadLock( PropertyContainer entity )
             {
                 throw new UnsupportedOperationException( "not implemented" );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/community/RWLockTest.java
@@ -29,8 +29,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.transaction.Transaction;
 
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 

--- a/community/shell/README.txt
+++ b/community/shell/README.txt
@@ -12,5 +12,5 @@ Issue the following command:
     java -jar neo4j-shell-{version}.jar 
 
 Make sure to replace {version} with the actual version.
-The neo4j-kernel and geronimo jta jar files need to be in the
+The neo4j-kernel jar file need to be in the
 same directory or on the classpath.

--- a/community/shell/pom.xml
+++ b/community/shell/pom.xml
@@ -24,7 +24,6 @@
   </scm>
 
   <properties>
-    <sun.jta.version>1.1</sun.jta.version>
     <jline.groupId>jline</jline.groupId>
     <jline.artifactId>jline</jline.artifactId>
     <jline.version>2.12</jline.version>
@@ -69,7 +68,7 @@ the relevant Commercial Agreement.
               <packageName>org.neo4j.shell</packageName>
             </manifest>
             <manifestEntries>
-              <Class-Path>neo4j-kernel-${project.version}.jar neo4j-index-${project.version}.jar lucene-core-${lucene.version}.jar jta-${sun.jta.version}.jar ${jta.artifactId}-${jta.version}.jar jline-${jline.main.version}.jar
+              <Class-Path>neo4j-kernel-${project.version}.jar neo4j-index-${project.version}.jar lucene-core-${lucene.version}.jar jline-${jline.main.version}.jar
                 ${jline.artifactId}-${jline.version}.jar</Class-Path>
               <Agent-Class>org.neo4j.shell.StartClient</Agent-Class>
             </manifestEntries>

--- a/community/shell/src/docs/dev/shell.asciidoc
+++ b/community/shell/src/docs/dev/shell.asciidoc
@@ -59,7 +59,8 @@ neo4j-sh (0)$
 === Pointing the shell to a path
 
 To start the shell by just pointing it to a Neo4j store path you run the shell jar file.
-Given that the right neo4j-kernel-<version>.jar and jta jar files are in the same path as your neo4j-shell-<version>.jar file you run it with:
+Given that the right neo4j-kernel-<version>.jar is in the same path as your neo4j-shell-<version>.jar file you run it
+with:
 [source,plain]
 ----
 $ neo4j-shell -path path/to/neo4j-db

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jta.groupId>org.apache.geronimo.specs</jta.groupId>
-    <jta.artifactId>geronimo-jta_1.1_spec</jta.artifactId>
-    <jta.version>1.1.1</jta.version>
     <pico.version>2.14.3</pico.version>
     <licensing.prepend.text>notice-agpl-prefix.txt</licensing.prepend.text>
     <licensing.phase>compile</licensing.phase>
@@ -509,12 +506,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <!-- special -->
-      <dependency>
-        <groupId>${jta.groupId}</groupId>
-        <artifactId>${jta.artifactId}</artifactId>
-        <version>${jta.version}</version>
-      </dependency>
       <!-- testing -->
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -576,12 +567,6 @@
           <scope>test</scope>
       </dependency>
 
-      <dependency>
-        <groupId>geronimo-spec</groupId>
-        <artifactId>geronimo-spec-j2ee</artifactId>
-        <version>1.4-rc4</version>
-        <scope>test</scope>
-      </dependency>
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>


### PR DESCRIPTION
Remove build dependencies, update tests to not reference jta api,
update shell documentation and class path entries.
Remove obsolete comments.
