### PR TITLE
Increase test timeout to reduce flakiness (continued)

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheSlowTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheSlowTest.java
@@ -433,7 +433,7 @@ public abstract class PageCacheSlowTest<T extends PageCache> extends PageCacheTe
             // The takeLockFuture got it first, so the closeFuture should
             // complete when we release the latch.
             secondThreadGotLockLatch.countDown();
-            closeFuture.get( 2000, TimeUnit.MILLISECONDS );
+            closeFuture.get( 20000, TimeUnit.MILLISECONDS );
         }
     }
 


### PR DESCRIPTION
The whole test usually runs in 11 seconds,
but between virtual machines and a garbage collected language, we can get some long stalls.

When forward merging #7189, the wrong assumptione that the addressed
test had been removed was made. This PR is essentially a forward merge of #7189.
