### PR TITLE
Set a user-agent in http when using load csv

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceUserAgentTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceUserAgentTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import java.io.{File, PrintWriter}
+import java.net.{URL, URLConnection, URLStreamHandler, URLStreamHandlerFactory}
+
+import org.neo4j.cypher._
+import org.neo4j.cypher.internal.ExecutionEngine
+import org.neo4j.cypher.internal.compiler.v3_0.spi.CSVResources
+import org.neo4j.cypher.internal.compiler.v3_0.test_helpers.CreateTempFileTestSupport
+import org.neo4j.cypher.internal.frontend.v3_0.helpers.StringHelper.RichString
+import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
+import org.neo4j.graphdb.config.Configuration
+import org.neo4j.graphdb.factory.GraphDatabaseSettings
+import org.neo4j.graphdb.security.URLAccessRule
+import org.neo4j.test.TestGraphDatabaseFactory
+import org.scalatest.BeforeAndAfterAll
+import sun.net.www.protocol.http.HttpURLConnection
+
+class LoadCsvAcceptanceUserAgentTest
+  extends ExecutionEngineFunSuite with BeforeAndAfterAll with NewPlannerTestSupport {
+
+  test("should be able to download data from the web") {
+    val url = s"http://127.0.0.1:$port/test.csv".cypherEscape
+
+    val result = executeScalarWithAllPlanners[Long](s"LOAD CSV FROM '$url' AS line RETURN count(line)")
+    result should equal(3)
+  }
+
+  test("should be able to download from a website when redirected and cookies are set") {
+    val url = s"http://127.0.0.1:$port/redirect_test.csv".cypherEscape
+
+    val result = executeScalarWithAllPlanners[Long](s"LOAD CSV FROM '$url' AS line RETURN count(line)")
+    result should equal(3)
+  }
+  private val CSV_DATA_CONTENT = "1,1,1\n2,2,2\n3,3,3\n".getBytes
+  private val CSV_PATH = "/test.csv"
+  private val CSV_COOKIE_PATH = "/cookie_test.csv"
+  private val CSV_REDIRECT_PATH = "/redirect_test.csv"
+  private val MAGIC_COOKIE = "neoCookie=Magic"
+  private val NEO_USER_AGENT = s"${CSVResources.NEO_USER_AGENT_PREFIX}${HttpURLConnection.userAgent}"
+  private var httpServer: HttpServerTestSupport = _
+  private var port = -1
+
+  override def beforeAll() {
+    val  builder = new HttpServerTestSupportBuilder()
+    builder.onPathReplyWithData(CSV_PATH, CSV_DATA_CONTENT)
+    builder.onPathReplyOnlyWhen(CSV_PATH, HttpServerTestSupport.hasUserAgent(NEO_USER_AGENT))
+
+    builder.onPathReplyWithData(CSV_COOKIE_PATH, CSV_DATA_CONTENT)
+    builder.onPathReplyOnlyWhen(CSV_COOKIE_PATH, HttpServerTestSupport.hasCookie(MAGIC_COOKIE))
+    builder.onPathReplyOnlyWhen(CSV_COOKIE_PATH, HttpServerTestSupport.hasUserAgent(NEO_USER_AGENT))
+
+    builder.onPathRedirectTo(CSV_REDIRECT_PATH, CSV_COOKIE_PATH)
+    builder.onPathTransformResponse(CSV_REDIRECT_PATH, HttpServerTestSupport.setCookie(MAGIC_COOKIE))
+    builder.onPathReplyOnlyWhen(CSV_REDIRECT_PATH, HttpServerTestSupport.hasUserAgent(NEO_USER_AGENT))
+
+    httpServer = builder.build()
+    httpServer.start()
+    port = httpServer.boundInfo.getPort
+    assert(port > 0)
+  }
+
+  override def afterAll() {
+    httpServer.stop()
+  }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/HttpServerTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/HttpServerTestSupport.scala
@@ -175,6 +175,11 @@ object HttpServerTestSupport {
     cookieString.exists(cookie => cookie.split(";").contains(cookie))
   }
 
+  def hasUserAgent(userAgent: String)(exchange: HttpExchange) = {
+    val userAgentString = Option(exchange.getRequestHeaders.getFirst("User-Agent"))
+    userAgentString.contains(userAgent)
+  }
+
   def setCookie(cookie: String)(exchange: HttpExchange) = {
     exchange.getResponseHeaders.set("Set-Cookie", cookie)
     exchange


### PR DESCRIPTION
In order to differentiate Neo load csv requests from other Java
applications, a Neo specific user-agent is set when using load csv
connections.
