### PR TITLE
core-edge: do not read ahead when applying

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/CoreState.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/CoreState.java
@@ -121,7 +121,7 @@ public class CoreState extends LifecycleAdapter implements RaftStateMachine, Log
             {
                 lastApplyingStorage.persistStoreData( lastToApply );
 
-                while ( cursor.next() && cursor.index() <= lastToApply )
+                while ( cursor.index() < lastToApply && cursor.next() )
                 {
                     if ( cursor.get().content() instanceof DistributedOperation )
                     {


### PR DESCRIPTION
The core state applier was sometimes reading an appended
uncommitted entry. It would not apply it, but still unnecessary.
