### PR TITLE
Handle deleted entities in property operations

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/helpers/JavaConversionSupport.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/helpers/JavaConversionSupport.scala
@@ -38,22 +38,26 @@ object JavaConversionSupport {
     def next() = iterator.next()
   }
 
+  def asScalaENFXSafe(iterator: PrimitiveIntIterator): Iterator[Int] = makeENFXSafe(iterator.hasNext, iterator.next)(identity)
+
   def mapToScala[T](iterator: PrimitiveIntIterator)(f: Int => T): Iterator[T] = new Iterator[T] {
     def hasNext = iterator.hasNext
     def next() = f(iterator.next())
   }
 
   // Same as mapToScala, but handles concurrency exceptions by swallowing exceptions
-  def mapToScalaENFXSafe[T](iterator: PrimitiveLongIterator)(f: Long => T): Iterator[T] = new Iterator[T] {
+  def mapToScalaENFXSafe[T](iterator: PrimitiveLongIterator)(f: Long => T): Iterator[T] = makeENFXSafe(iterator.hasNext, iterator.next)(f)
+
+  private def makeENFXSafe[S,T](hasMore: () => Boolean, more: () => S)(f: S => T): Iterator[T] = new Iterator[T] {
     private var _next: Option[T] = fetchNext()
 
     // Init
     private def fetchNext(): Option[T] = {
-      if (!iterator.hasNext)
+      if (!hasMore())
         _next = None
       else {
         try {
-          _next = Some(f(iterator.next()))
+          _next = Some(f(more()))
         } catch {
           case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => fetchNext()
           case _: EntityNotFoundException => fetchNext()

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -43,10 +43,10 @@ import org.neo4j.graphdb._
 import org.neo4j.graphdb.traversal.{Evaluators, TraversalDescription, Uniqueness}
 import org.neo4j.helpers.ThisShouldNotHappenError
 import org.neo4j.kernel.GraphDatabaseAPI
-import org.neo4j.kernel.api.{exceptions, _}
 import org.neo4j.kernel.api.constraints.{NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.kernel.api.exceptions.schema.{AlreadyConstrainedException, AlreadyIndexedException}
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
+import org.neo4j.kernel.api.{exceptions, _}
 import org.neo4j.kernel.impl.api.KernelStatement
 import org.neo4j.kernel.impl.core.{NodeManager, ThreadToStatementContextBridge}
 import org.neo4j.kernel.security.URLAccessValidationError
@@ -328,8 +328,11 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       }
     }
 
-    def propertyKeyIds(id: Long): Iterator[Int] =
-      JavaConversionSupport.asScala(statement.readOperations().nodeGetPropertyKeys(id))
+    def propertyKeyIds(id: Long): Iterator[Int] = try {
+      JavaConversionSupport.asScalaENFXSafe(statement.readOperations().nodeGetPropertyKeys(id))
+    } catch {
+      case _: exceptions.EntityNotFoundException => Iterator.empty
+    }
 
     def getProperty(id: Long, propertyKeyId: Int): Any = try {
       statement.readOperations().nodeGetProperty(id, propertyKeyId)
@@ -337,15 +340,22 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
       case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => null
     }
 
-    def hasProperty(id: Long, propertyKey: Int) =
+    def hasProperty(id: Long, propertyKey: Int) = try {
       statement.readOperations().nodeHasProperty(id, propertyKey)
-
-    def removeProperty(id: Long, propertyKeyId: Int) {
-      statement.dataWriteOperations().nodeRemoveProperty(id, propertyKeyId)
+    } catch {
+      case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => false
     }
 
-    def setProperty(id: Long, propertyKeyId: Int, value: Any) {
+    def removeProperty(id: Long, propertyKeyId: Int) = try {
+      statement.dataWriteOperations().nodeRemoveProperty(id, propertyKeyId)
+    } catch {
+      case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => //ignore
+    }
+
+    def setProperty(id: Long, propertyKeyId: Int, value: Any) = try {
       statement.dataWriteOperations().nodeSetProperty(id, properties.Property.property(propertyKeyId, value) )
+    } catch {
+      case _: org.neo4j.kernel.api.exceptions.EntityNotFoundException => //ignore
     }
 
     def getById(id: Long) = try {

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/DeleteNodeStressIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/DeleteNodeStressIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertFalse;
+import static org.neo4j.graphdb.DynamicLabel.label;
+
+public class DeleteNodeStressIT
+{
+
+    private final AtomicBoolean hasFailed = new AtomicBoolean( false );
+
+    @Rule
+    public ImpermanentDatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Before
+    public void setup()
+    {
+        for ( int i = 0; i < 100; i++ )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+
+                for ( int j = 0; j < 100; j++ )
+                {
+                    Node node = db.createNode( label( "L" ) );
+                    node.setProperty( "prop", i + j );
+                }
+                tx.success();
+            }
+        }
+    }
+
+    private final ExecutorService executorService = Executors.newFixedThreadPool( 10 );
+
+
+    @Test
+    public void shouldBeAbleToReturnNodesWhileDeletingNode() throws IOException, ExecutionException, InterruptedException
+    {
+        // Given
+        executeInThread( "MATCH (n:L {prop:42}) OPTIONAL MATCH (m:L {prop:1337}) WITH n MATCH (n) return n" );
+        executeInThread( "MATCH (n:L {prop:42}) DELETE n" );
+
+        // When
+        executorService.awaitTermination( 3L, TimeUnit.SECONDS );
+
+        // Then
+        assertFalse(hasFailed.get());
+    }
+
+    @Test
+    public void shouldBeAbleToCheckPropertiesWhileDeletingNode() throws IOException, ExecutionException, InterruptedException
+    {
+        // Given
+        executeInThread( "MATCH (n:L {prop:42}) OPTIONAL MATCH (m:L {prop:1337}) WITH n MATCH (n) RETURN exists(n.prop)" );
+        executeInThread( "MATCH (n:L {prop:42}) DELETE n" );
+
+        // When
+        executorService.awaitTermination( 3L, TimeUnit.SECONDS );
+        assertFalse(hasFailed.get());
+    }
+
+    @Test
+    public void shouldBeAbleToRemovePropertiesWhileDeletingNode() throws IOException, ExecutionException, InterruptedException
+    {
+        // Given
+        executeInThread( "MATCH (n:L {prop:42}) OPTIONAL MATCH (m:L {prop:1337}) WITH n MATCH (n) REMOVE n.prop" );
+        executeInThread( "MATCH (n:L {prop:42}) DELETE n" );
+
+        // When
+        executorService.awaitTermination( 3L, TimeUnit.SECONDS );
+        assertFalse(hasFailed.get());
+    }
+
+    @Test
+    public void shouldBeAbleToSetPropertiesWhileDeletingNode() throws IOException, ExecutionException, InterruptedException
+    {
+        // Given
+        executeInThread( "MATCH (n:L {prop:42}) OPTIONAL MATCH (m:L {prop:1337}) WITH n MATCH (n) SET n.foo = 'bar'" );
+        executeInThread( "MATCH (n:L {prop:42}) DELETE n" );
+
+        // When
+        executorService.awaitTermination( 3L, TimeUnit.SECONDS );
+        assertFalse(hasFailed.get());
+    }
+
+    private void executeInThread( final String query )
+    {
+        executorService.execute( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                Result execute = db.execute( query );
+                try
+                {
+                    //resultAsString is good test case since it serializes labels, types, properties etc
+                    execute.resultAsString();
+                }
+                catch ( Exception e )
+                {
+                    e.printStackTrace();
+                    hasFailed.set( true );
+                }
+            }
+        } );
+    }
+
+}

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/DeleteRelationshipStressIT.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/DeleteRelationshipStressIT.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertFalse;
+import static org.neo4j.graphdb.DynamicLabel.label;
+
+public class DeleteRelationshipStressIT
+{
+    
+    private final AtomicBoolean hasFailed = new AtomicBoolean( false );
+
+    @Rule
+    public ImpermanentDatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Before
+    public void setup()
+    {
+        for ( int i = 0; i < 100; i++ )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+
+                Node prev = null;
+                for ( int j = 0; j < 100; j++ )
+                {
+                    Node node = db.createNode( label( "L" ) );
+
+                    if (prev != null)
+                    {
+                        Relationship rel = prev.createRelationshipTo( node, DynamicRelationshipType.withName( "T" ) );
+                        rel.setProperty( "prop", i + j );
+                    }
+                    prev = node;
+                }
+                tx.success();
+            }
+        }
+    }
+
+    private final ExecutorService executorService = Executors.newFixedThreadPool( 10 );
+
+
+    @Test
+    public void shouldBeAbleToReturnRelsWhileDeletingRelationship() throws IOException, ExecutionException, InterruptedException
+    {
+        // Given
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) OPTIONAL MATCH (:L)-[:T {prop:1337}]-(:L) WITH r MATCH ()-[r]-() return r" );
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) DELETE r" );
+
+        // When
+        executorService.awaitTermination( 3L, TimeUnit.SECONDS );
+
+        // Then
+        assertFalse(hasFailed.get());
+    }
+
+
+    @Test
+    public void shouldBeAbleToGetPropertyWhileDeletingRelationship() throws IOException, ExecutionException, InterruptedException
+    {
+        // Given
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) OPTIONAL MATCH (:L)-[:T {prop:1337}]-(:L) WITH r MATCH ()-[r]-() return r.prop" );
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) DELETE r" );
+
+        // When
+        executorService.awaitTermination( 3L, TimeUnit.SECONDS );
+        assertFalse(hasFailed.get());
+    }
+
+    @Test
+    public void shouldBeAbleToCheckPropertiesWhileDeletingRelationship() throws IOException, ExecutionException, InterruptedException
+    {
+        // Given
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) OPTIONAL MATCH (:L)-[:T {prop:1337}]-(:L) WITH r MATCH ()-[r]-() return exists(r.prop)" );
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) DELETE r" );
+
+        // When
+        executorService.awaitTermination( 3L, TimeUnit.SECONDS );
+        assertFalse(hasFailed.get());
+    }
+
+    @Test
+    public void shouldBeAbleToRemovePropertiesWhileDeletingRelationship() throws IOException, ExecutionException, InterruptedException
+    {
+        // Given
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) OPTIONAL MATCH (:L)-[:T {prop:1337}]-(:L) WITH r MATCH ()-[r]-() REMOVE r.prop" );
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) DELETE r" );
+
+        // When
+        executorService.awaitTermination( 3L, TimeUnit.SECONDS );
+        assertFalse(hasFailed.get());
+    }
+
+    @Test
+    public void shouldBeAbleToSetPropertiesWhileDeletingRelationship() throws IOException, ExecutionException, InterruptedException
+    {
+        // Given
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) OPTIONAL MATCH (:L)-[:T {prop:1337}]-(:L) WITH r MATCH ()-[r]-() SET r.foo = 'bar'" );
+        executeInThread( "MATCH (:L)-[r:T {prop:42}]-(:L) DELETE r" );
+
+        // When
+        executorService.awaitTermination( 3L, TimeUnit.SECONDS );
+        assertFalse(hasFailed.get());
+    }
+
+    private void executeInThread( final String query )
+    {
+        executorService.execute( new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                Result execute = db.execute( query );
+                try
+                {
+                    //resultAsString is good test case since it serializes labels, types, properties etc
+                    execute.resultAsString();
+                }
+                catch ( Exception e )
+                {
+                    e.printStackTrace();
+                    hasFailed.set( true );
+                }
+            }
+        } );
+    }
+
+}


### PR DESCRIPTION
If a node or a relationship has been deleted while we are trying to access properties of that node or relationship we should not throw `EntitityNotFoundException` all the way out to the end-user. 
