### PR TITLE
Work around for OpenJDK 9 being in the Ubuntu 16.04 repos

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/community/debian/control
@@ -10,7 +10,7 @@ Package: neo4j
 Architecture: all
 Pre-Depends: dpkg (>= 1.15.7.2)
 Depends: ${misc:Depends}, bash, daemon, adduser, psmisc, lsb-base, java8-runtime | j2re1.8
-Conflicts: 
+Conflicts: java9-runtime-headless, java9-runtime
 Replaces: neo4j-enterprise, neo4j-advanced
 Description: graph database server
  Neo4j server is a database that stores data as graphs rather than tables.

--- a/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
+++ b/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/control
@@ -10,7 +10,7 @@ Package: neo4j-enterprise
 Architecture: all
 Pre-Depends: dpkg (>= 1.15.7.2)
 Depends: ${misc:Depends}, bash, daemon, adduser, psmisc, lsb-base, java8-runtime | j2re1.8
-Conflicts: 
+Conflicts: java9-runtime-headless, java9-runtime
 Replaces: neo4j, neo4j-advanced
 Description: graph database server
  Neo4j server is a database that stores data as graphs rather than tables.


### PR DESCRIPTION
The Ubuntu 16.04 repos include Java 9, despite its not having been
released yet (see https://bugs.launchpad.net/ubuntu/+source/openjdk-9/+bug/1584118).
Because the Java 9 package provides java8-runtime, this results in Java
9 being installed by default when people install our package on Ubuntu
16.04.

This causes problems because:
- We are not compatible with Java 9 because there is a change in
  command line argument order and the JVM fails to start.
- We don't support Java 9 and have not tested against it.

This change adds makes our package conflict with Java 9, so Java 8 is
installed instead.

Fixes #7188.

changelog: [packaging] Work around for OpenJDK9 being in Ubuntu 16.04 repos [#7188](https://github.com/neo4j/neo4j/issues/7188)
