### PR TITLE
Limit amount of tokens created by batch import in accordance with store format capabilities.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -33,6 +33,7 @@ import org.neo4j.helpers.collection.Pair;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.standard.StandardFormatSettings;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -255,7 +256,9 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
         }
         else if ( value instanceof Long )
         {
-            long keyAndType = keyId | (((long) PropertyType.LONG.intValue()) << 24);
+
+            long keyAndType = keyId | (((long) PropertyType.LONG.intValue()) <<
+                                       StandardFormatSettings.PROPERTY_TOKEN_MAXIMUM_ID_BITS);
             if ( ShortArray.LONG.getRequiredBits( (Long) value ) <= 35 )
             {   // We only need one block for this value, special layout compared to, say, an integer
                 block.setSingleBlock( keyAndType | (1L << 28) | ((Long) value << 29) );
@@ -267,8 +270,8 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
         }
         else if ( value instanceof Double )
         {
-            block.setValueBlocks( new long[]{
-                    keyId | (((long) PropertyType.DOUBLE.intValue()) << 24),
+            block.setValueBlocks( new long[]{ keyId |
+                    (((long) PropertyType.DOUBLE.intValue()) << StandardFormatSettings.PROPERTY_TOKEN_MAXIMUM_ID_BITS),
                     Double.doubleToRawLongBits( (Double) value )} );
         }
         else if ( value instanceof Byte )
@@ -313,7 +316,7 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
 
     public static long singleBlockLongValue( int keyId, PropertyType type, long longValue )
     {
-        return keyId | (((long) type.intValue()) << 24) | (longValue << 28);
+        return keyId | (((long) type.intValue()) << StandardFormatSettings.PROPERTY_TOKEN_MAXIMUM_ID_BITS) | (longValue << 28);
     }
 
     public static byte[] encodeString( String string )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -316,7 +316,8 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
 
     public static long singleBlockLongValue( int keyId, PropertyType type, long longValue )
     {
-        return keyId | (((long) type.intValue()) << StandardFormatSettings.PROPERTY_TOKEN_MAXIMUM_ID_BITS) | (longValue << 28);
+        return keyId | (((long) type.intValue()) << StandardFormatSettings.PROPERTY_TOKEN_MAXIMUM_ID_BITS) |
+               (longValue << 28);
     }
 
     public static byte[] encodeString( String string )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardFormatSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardFormatSettings.java
@@ -22,14 +22,14 @@ package org.neo4j.kernel.impl.store.format.standard;
 /**
  * Common low limit format settings.
  */
-final class StandardFormatSettings
+public final class StandardFormatSettings
 {
+    public static final int PROPERTY_TOKEN_MAXIMUM_ID_BITS = 24;
     static final int NODE_RECORD_MAXIMUM_ID_BITS = 35;
     static final int RELATIONSHIP_MAXIMUM_ID_BITS = 35;
     static final int PROPERTY_RECORD_MAXIMUM_ID_BITS = 36;
     static final int DYNAMIC_RECORD_MAXIMUM_ID_BITS = 36;
     static final int LABEL_TOKEN_MAXIMUM_ID_BITS = 32;
-    static final int PROPERTY_TOKEN_MAXIMUM_ID_BITS = 32;
     static final int RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS = 16;
     static final int RELATIONSHIP_GROUP_MAXIMUM_ID_BITS = 35;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -403,8 +403,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
     }
 
     private void prepareBatchImportMigration( File storeDir, File migrationDir, RecordFormats oldFormat,
-            RecordFormats newFormat )
-            throws IOException
+            RecordFormats newFormat ) throws IOException
     {
         BatchingNeoStores.createStore( fileSystem, migrationDir.getPath(), config, newFormat );
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -31,11 +31,11 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.logging.LogService;
-import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
@@ -127,7 +127,7 @@ public class ParallelBatchImporter implements BatchImporter
         boolean hasBadEntries = false;
         File badFile = new File( storeDir, Configuration.BAD_FILE_NAME );
         CountingStoreUpdateMonitor storeUpdateMonitor = new CountingStoreUpdateMonitor();
-        RecordFormats recordFormats = RecordFormatSelector.autoSelectFormat( dbConfig, NullLogService.getInstance() );
+        RecordFormats recordFormats = RecordFormatSelector.selectForConfig( dbConfig, NullLogProvider.getInstance() );
         try ( BatchingNeoStores neoStore = new BatchingNeoStores( fileSystem, storeDir, recordFormats, config, logService,
                 additionalInitialIds, dbConfig );
               CountsAccessor.Updater countsUpdater = neoStore.getCountsStore().reset(

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
@@ -98,11 +98,11 @@ public class InputCache implements Closeable
 
     static final byte SAME_GROUP = 0;
     static final byte NEW_GROUP = 1;
-    static final byte PROPERTY_KEY_TOKEN = 1;
-    static final byte LABEL_TOKEN = 2;
-    static final byte RELATIONSHIP_TYPE_TOKEN = 3;
-    static final byte GROUP_TOKEN = 4;
-    static final byte HIGH_TOKEN_TYPE = 5;
+    static final byte PROPERTY_KEY_TOKEN = 0;
+    static final byte LABEL_TOKEN = 1;
+    static final byte RELATIONSHIP_TYPE_TOKEN = 2;
+    static final byte GROUP_TOKEN = 3;
+    static final byte HIGH_TOKEN_TYPE = 4;
     static final short HAS_FIRST_PROPERTY_ID = -1;
     static final byte HAS_LABEL_FIELD = 3;
     static final byte LABEL_REMOVAL = 1;
@@ -111,8 +111,8 @@ public class InputCache implements Closeable
     static final byte HAS_TYPE_ID = 2;
     static final byte SAME_TYPE = 0;
     static final byte NEW_TYPE = 1;
-    static final byte END_OF_HEADER = 0;
-    static final short END_OF_ENTITIES = -2;
+    static final byte END_OF_HEADER = -2;
+    static final short END_OF_ENTITIES = -3;
 
     private final FileSystemAbstraction fs;
     private final File cacheDirectory;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacher.java
@@ -44,6 +44,7 @@ import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_GROUP;
 
 /**
  * Abstract class for caching {@link InputEntity} or derivative to disk using a binary format.
+ * Currently each token type limited to have as maximum {#link Integer.MAX_VALUE} items.
  */
 abstract class InputEntityCacher<ENTITY extends InputEntity> implements Receiver<ENTITY[],IOException>
 {
@@ -54,7 +55,7 @@ abstract class InputEntityCacher<ENTITY extends InputEntity> implements Receiver
     private final int[] previousGroupIds;
 
     private final int[] nextKeyId = new int[HIGH_TOKEN_TYPE];
-    private final long[] maxKeyId = new long[HIGH_TOKEN_TYPE];
+    private final int[] maxKeyId = new int[HIGH_TOKEN_TYPE];
     @SuppressWarnings( "unchecked" )
     private final Map<String,Integer>[] tokens = new Map[HIGH_TOKEN_TYPE];
 
@@ -185,9 +186,14 @@ abstract class InputEntityCacher<ENTITY extends InputEntity> implements Receiver
 
     private void initMaxTokenKeyIds( RecordFormats recordFormats )
     {
-        maxKeyId[PROPERTY_KEY_TOKEN] = recordFormats.propertyKeyToken().getMaxId();
-        maxKeyId[LABEL_TOKEN] = recordFormats.labelToken().getMaxId();
-        maxKeyId[RELATIONSHIP_TYPE_TOKEN] = recordFormats.relationshipTypeToken().getMaxId();
-        maxKeyId[GROUP_TOKEN] = recordFormats.relationshipGroup().getMaxId();
+        maxKeyId[PROPERTY_KEY_TOKEN] = getMaxAcceptableTokenId( recordFormats.propertyKeyToken().getMaxId() );
+        maxKeyId[LABEL_TOKEN] = getMaxAcceptableTokenId( recordFormats.labelToken().getMaxId() );
+        maxKeyId[RELATIONSHIP_TYPE_TOKEN] = getMaxAcceptableTokenId( recordFormats.relationshipTypeToken().getMaxId() );
+        maxKeyId[GROUP_TOKEN] = getMaxAcceptableTokenId( recordFormats.relationshipGroup().getMaxId() );
+    }
+
+    private int getMaxAcceptableTokenId( long maxId )
+    {
+        return (int) Math.min( Integer.MAX_VALUE, maxId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacher.java
@@ -22,8 +22,10 @@ package org.neo4j.unsafe.impl.batchimport.input;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.transaction.log.FlushableChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PositionAwarePhysicalFlushableChannel;
@@ -34,9 +36,11 @@ import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_HEADER;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.GROUP_TOKEN;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_FIRST_PROPERTY_ID;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HIGH_TOKEN_TYPE;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.LABEL_TOKEN;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.NEW_GROUP;
-import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_GROUP;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.PROPERTY_KEY_TOKEN;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.RELATIONSHIP_TYPE_TOKEN;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_GROUP;
 
 /**
  * Abstract class for caching {@link InputEntity} or derivative to disk using a binary format.
@@ -49,16 +53,20 @@ abstract class InputEntityCacher<ENTITY extends InputEntity> implements Receiver
     private final StoreChannel headerChannel;
     private final int[] previousGroupIds;
 
-    private final short[] nextKeyId = new short[HIGH_TOKEN_TYPE];
+    private final int[] nextKeyId = new int[HIGH_TOKEN_TYPE];
+    private final long[] maxKeyId = new long[HIGH_TOKEN_TYPE];
     @SuppressWarnings( "unchecked" )
-    private final Map<String,Short>[] tokens = new Map[HIGH_TOKEN_TYPE];
+    private final Map<String,Integer>[] tokens = new Map[HIGH_TOKEN_TYPE];
 
-    protected InputEntityCacher( StoreChannel channel, StoreChannel header, int bufferSize, int groupSlots )
-            throws IOException
+    protected InputEntityCacher( StoreChannel channel, StoreChannel header, RecordFormats recordFormats, int bufferSize,
+            int groupSlots ) throws IOException
     {
         this.storeChannel = channel;
         this.headerChannel = header;
         this.previousGroupIds = new int[groupSlots];
+
+        initMaxTokenKeyIds( recordFormats );
+
         for ( int i = 0; i < groupSlots; i++ )
         {
             previousGroupIds[i] = Group.GLOBAL.id();
@@ -134,25 +142,26 @@ abstract class InputEntityCacher<ENTITY extends InputEntity> implements Receiver
     {
         if ( key instanceof String )
         {
-            Short id = tokens[type].get( key );
+            Integer id = tokens[type].get( key );
             if ( id == null )
             {
-                if ( nextKeyId[type] == -1 )
+                if ( nextKeyId[type] == maxKeyId[type] )
                 {
-                    throw new IllegalArgumentException( "Too many tokens" );
+                    throw new UnsupportedOperationException( "Too many tokens. Creation of more then " +
+                                                        maxKeyId[type] + " tokens is not supported." );
                 }
                 tokens[type].put( (String) key, id = nextKeyId[type]++ );
                 header.put( type );
                 ValueType.stringType().write( key, header );
             }
-            channel.putShort( id );
+            channel.putInt( id );
         }
         else if ( key instanceof Integer )
         {
             // Here we signal that we have a real token id, not to be confused by the local and contrived
             // toiken ids we generate in here. Following this -1 is the real token id.
-            channel.putShort( (short) -1 );
-            channel.putShort( safeCastLongToShort( (Integer) key ) );
+            channel.putInt( (short) -1 );
+            channel.putInt( (Integer) key );
         }
         else
         {
@@ -172,5 +181,13 @@ abstract class InputEntityCacher<ENTITY extends InputEntity> implements Receiver
         header.close();
         storeChannel.close();
         headerChannel.close();
+    }
+
+    private void initMaxTokenKeyIds( RecordFormats recordFormats )
+    {
+        maxKeyId[PROPERTY_KEY_TOKEN] = recordFormats.propertyKeyToken().getMaxId();
+        maxKeyId[LABEL_TOKEN] = recordFormats.labelToken().getMaxId();
+        maxKeyId[RELATIONSHIP_TYPE_TOKEN] = recordFormats.relationshipTypeToken().getMaxId();
+        maxKeyId[GROUP_TOKEN] = recordFormats.relationshipGroup().getMaxId();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityReader.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityReader.java
@@ -41,9 +41,9 @@ import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_FIRST_PROPE
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HIGH_TOKEN_TYPE;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.LABEL_TOKEN;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.NEW_GROUP;
-import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_GROUP;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.PROPERTY_KEY_TOKEN;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.RELATIONSHIP_TYPE_TOKEN;
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_GROUP;
 
 /**
  * Abstract class for reading cached entities previously stored using {@link InputEntityCacher} or derivative.
@@ -87,11 +87,11 @@ abstract class InputEntityReader<ENTITY extends InputEntity> extends Prefetching
     {
         try ( ReadableClosableChannel reader = reader( header, (int) ByteUnit.kibiBytes( 8 ) ) )
         {
-            short[] tokenIds = new short[HIGH_TOKEN_TYPE];
+            int[] tokenIds = new int[HIGH_TOKEN_TYPE];
             byte type;
             while ( (type = reader.get()) != END_OF_HEADER )
             {
-                short tokenId = tokenIds[type]++;
+                int tokenId = tokenIds[type]++;
                 String name = (String) ValueType.stringType().read( reader );
                 tokens[type].put( tokenId, name );
             }
@@ -143,12 +143,11 @@ abstract class InputEntityReader<ENTITY extends InputEntity> extends Prefetching
 
     protected Object readToken( byte type ) throws IOException
     {
-        short id = channel.getShort();
+        int id = channel.getInt();
         if ( id == -1 )
         {
             // This is a real token id
-            int tokenId = channel.getShort() & 0xFFFF;
-            return tokenId; // as Integer
+            return channel.getInt();
         }
 
         String name = tokens[type].get( id );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeCacher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputNodeCacher.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport.input;
 import java.io.IOException;
 
 import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 
 import static org.neo4j.helpers.ArrayUtil.contains;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_LABEL_CHANGES;
@@ -37,9 +38,10 @@ public class InputNodeCacher extends InputEntityCacher<InputNode>
 {
     private String[] previousLabels = InputEntity.NO_LABELS;
 
-    public InputNodeCacher( StoreChannel channel, StoreChannel header, int bufferSize ) throws IOException
+    public InputNodeCacher( StoreChannel channel, StoreChannel header, RecordFormats recordFormats, int bufferSize )
+            throws IOException
     {
-        super( channel, header, bufferSize, 1 );
+        super( channel, header, recordFormats, bufferSize, 1 );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipCacher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationshipCacher.java
@@ -20,12 +20,14 @@
 package org.neo4j.unsafe.impl.batchimport.input;
 
 import java.io.IOException;
-import org.neo4j.io.fs.StoreChannel;
 
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+
+import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_TYPE_ID;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.NEW_TYPE;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.RELATIONSHIP_TYPE_TOKEN;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.SAME_TYPE;
-import static org.neo4j.unsafe.impl.batchimport.input.InputCache.HAS_TYPE_ID;
 
 /**
  * Caches {@link InputRelationship} to disk using a binary format.
@@ -34,9 +36,10 @@ public class InputRelationshipCacher extends InputEntityCacher<InputRelationship
 {
     private String previousType;
 
-    public InputRelationshipCacher( StoreChannel channel, StoreChannel header, int bufferSize ) throws IOException
+    public InputRelationshipCacher( StoreChannel channel, StoreChannel header, RecordFormats recordFormats,
+            int bufferSize ) throws IOException
     {
-        super( channel, header, bufferSize, 2 );
+        super( channel, header, recordFormats, bufferSize, 2 );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Receiver.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Receiver.java
@@ -20,7 +20,7 @@
 package org.neo4j.unsafe.impl.batchimport.input;
 
 /**
- * A {@link Listener} which is designed to receive one or more items, to then finally be closed
+ * Listener which is designed to receive one or more items, to then finally be closed
  * when all items have been received.
  */
 public interface Receiver<T,EXCEPTION extends Exception> extends AutoCloseable

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -90,8 +90,8 @@ public class BatchingNeoStores implements AutoCloseable
     private final LabelScanStore labelScanStore;
     private final IoTracer ioTracer;
 
-    public BatchingNeoStores( FileSystemAbstraction fileSystem, File storeDir, Configuration config,
-            LogService logService, AdditionalInitialIds initialIds, Config dbConfig )
+    public BatchingNeoStores( FileSystemAbstraction fileSystem, File storeDir, RecordFormats recordFormats,
+            Configuration config, LogService logService, AdditionalInitialIds initialIds, Config dbConfig )
     {
         this.fileSystem = fileSystem;
         this.logProvider = logService.getInternalLogProvider();
@@ -109,7 +109,7 @@ public class BatchingNeoStores implements AutoCloseable
         final PageCacheTracer tracer = new DefaultPageCacheTracer();
         this.pageCache = createPageCache( fileSystem, neo4jConfig, logProvider, tracer );
         this.ioTracer = tracer::bytesWritten;
-        this.neoStores = newNeoStores( pageCache );
+        this.neoStores = newNeoStores( pageCache, recordFormats );
         if ( alreadyContainsData( neoStores ) )
         {
             neoStores.close();
@@ -206,11 +206,11 @@ public class BatchingNeoStores implements AutoCloseable
         }
     }
 
-    private NeoStores newNeoStores( PageCache pageCache )
+    private NeoStores newNeoStores( PageCache pageCache, RecordFormats recordFormats )
     {
         BatchingIdGeneratorFactory idGeneratorFactory = new BatchingIdGeneratorFactory( fileSystem );
         StoreFactory storeFactory = new StoreFactory( storeDir, neo4jConfig, idGeneratorFactory, pageCache, fileSystem,
-                logProvider );
+                recordFormats, logProvider );
         return storeFactory.openAllNeoStores( true );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
@@ -510,9 +510,9 @@ public class IdGeneratorTest
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
             IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1,
                     recordFormat.getMaxId(), false, 0 );
-            idGenerator.setHighId( recordFormat.getMaxId() - 1 );
+            idGenerator.setHighId( recordFormat.getMaxId() );
             long id = idGenerator.nextId();
-            assertEquals( recordFormat.getMaxId() - 1, id );
+            assertEquals( recordFormat.getMaxId(), id );
             idGenerator.freeId( id );
             try
             {
@@ -526,7 +526,7 @@ public class IdGeneratorTest
             idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, recordFormat.getMaxId(), false, 0 );
             assertEquals( recordFormat.getMaxId() + 1, idGenerator.getHighId() );
             id = idGenerator.nextId();
-            assertEquals( recordFormat.getMaxId() - 1, id );
+            assertEquals( recordFormat.getMaxId(), id );
             try
             {
                 idGenerator.nextId();

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacherTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacherTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.input;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.test.RandomRule;
+import org.neo4j.test.Randoms;
+
+import static java.lang.Math.abs;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class InputEntityCacherTest
+{
+
+    private static final AtomicInteger uniqueIdGenerator = new AtomicInteger( 10 );
+    private final ExpectedException expectedException = ExpectedException.none();
+    private final RandomRule randomRule = new RandomRule();
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( randomRule ).around( expectedException );
+
+    @Test
+    public void notAllowCreationOfUnsupportedNumberOfProperties() throws IOException
+    {
+        initExpectedException();
+        cacheNodeWithProperties(10, 10);
+    }
+
+    @Test
+    public void allowCreationOfSupportedNumberOfProperties() throws IOException
+    {
+        cacheNodeWithProperties(9, 10);
+    }
+
+    @Test
+    public void notAllowCreationOfUnsupportedNumberOfGroups() throws IOException
+    {
+        initExpectedException();
+        cacheGroups(10, 10);
+    }
+
+    @Test
+    public void allowCreationOfSupportedNumberOfGroups() throws IOException
+    {
+        cacheGroups(9, 10);
+    }
+
+    @Test
+    public void notAllowCreationOfUnsupportedNumberOfLabels() throws IOException
+    {
+        initExpectedException();
+        cacheLabels(10, 10);
+    }
+
+    @Test
+    public void allowCreationOfSupportedNumberOfLabels() throws IOException
+    {
+        cacheLabels(9, 10);
+    }
+
+    @Test
+    public void notAllowCreationOfUnsupportedNumberOfRelationshipTypes() throws IOException
+    {
+        initExpectedException();
+        cacheRelationship( 10, 10 );
+    }
+
+    @Test
+    public void allowCreationOfSupportedNumberOfRelationshipTypes() throws IOException
+    {
+        cacheRelationship( 9, 10 );
+    }
+
+    private void cacheRelationship( int iterations, int maxNumberOfRelationshipTypes ) throws IOException
+    {
+        RecordFormats recordFormats = mockRecordFormats( 1000, 1000, maxNumberOfRelationshipTypes, 1000 );
+
+        try ( TestRelationshipEntityCacher cacher = getRelationshipCacher( recordFormats ) )
+        {
+            for ( int i = 0; i <= iterations; i++ )
+            {
+                cacher.writeEntity( generateRelationship( getRandoms() ) );
+            }
+        }
+    }
+
+    private void cacheLabels(int iterations, int maxNumberOfLabels ) throws IOException
+    {
+        RecordFormats recordFormats = mockRecordFormats( 1000, maxNumberOfLabels, 1000, 1000 );
+
+        try ( TestNodeEntityCacher cacher = getNodeCacher( recordFormats ) )
+        {
+            for ( int i = 0; i <= iterations; i++ )
+            {
+                cacher.writeLabelDiff( (byte) 0, randomLabels( ), new String[]{} );
+            }
+        }
+    }
+
+    private void cacheGroups(int iterations, int maxNumberOfGroups) throws IOException
+    {
+        RecordFormats recordFormats = mockRecordFormats( 1000, 1000, 1000, maxNumberOfGroups );
+
+        try ( TestInputEntityCacher cacher = getEntityCacher( recordFormats ) )
+        {
+            for ( int i = 0; i <= iterations; i++ )
+            {
+                cacher.writeGroup( generateGroup(), i );
+            }
+        }
+    }
+
+    private void cacheNodeWithProperties(int iterations, int maxNumberOfProperties) throws IOException
+    {
+        RecordFormats recordFormats = mockRecordFormats( maxNumberOfProperties, 1000, 1000, 1000 );
+
+        try ( TestInputEntityCacher cacher = getEntityCacher( recordFormats ) )
+        {
+            Randoms randoms = getRandoms();
+            for ( int i = 0; i <= iterations; i++ )
+            {
+                cacher.writeEntity( generateNode( randoms ) );
+            }
+        }
+    }
+
+    private void initExpectedException()
+    {
+        expectedException.expect( UnsupportedOperationException.class );
+        expectedException.expectMessage( "Too many tokens. Creation of more then 10 tokens is not supported." );
+    }
+
+
+    private InputRelationship generateRelationship( Randoms randoms )
+    {
+        return new InputRelationship( null, 0, 0, generatemProperties( randoms ), null,
+                generateGroup(), randomId( randoms ), generateGroup(), randomId( randoms ),
+                getUniqueString(), null );
+    }
+
+    private InputNode generateNode( Randoms random )
+    {
+        return new InputNode( null, 0, 0, generateGroup(), randomId( random ), generatemProperties( random ), null,
+                randomLabels(), null );
+    }
+
+    private Group generateGroup()
+    {
+        return new Group.Adapter( uniqueIdGenerator.getAndIncrement(), getUniqueString() );
+    }
+
+    private String[] randomLabels()
+    {
+        String[] labels = new String[1];
+        for ( int i = 0; i < labels.length; i++ )
+        {
+            labels[i] = getUniqueString();
+        }
+        return labels;
+    }
+
+    private String getUniqueString()
+    {
+        return uniqueIdGenerator.getAndIncrement() + "";
+    }
+
+    private Object[] generatemProperties( Randoms random )
+    {
+        int length = 1;
+        Object[] properties = new Object[length * 2];
+        for ( int i = 0; i < properties.length; i++ )
+        {
+            properties[i++] = getUniqueString();
+            properties[i] = random.propertyValue() + "";
+        }
+        return properties;
+    }
+
+    private Object randomId( Randoms random )
+    {
+        return abs( random.random().nextLong() );
+    }
+
+    private RecordFormats mockRecordFormats( long maxPropertyKeyId, long maxLabelId, long maxRelationshipTypeId,
+            long maxRelationshipGroupId )
+    {
+        RecordFormats recordFormats = mock( RecordFormats.class );
+        RecordFormat propertyKeyTokenFormat = getRecordFormatMock( maxPropertyKeyId );
+        RecordFormat labelTokenFormat = getRecordFormatMock( maxLabelId );
+        RecordFormat relationshipTypeTokenFormat = getRecordFormatMock( maxRelationshipTypeId );
+        RecordFormat relationshipGroupTokenFormat = getRecordFormatMock( maxRelationshipGroupId );
+        when( recordFormats.propertyKeyToken() ).thenReturn( propertyKeyTokenFormat );
+        when( recordFormats.labelToken() ).thenReturn( labelTokenFormat );
+        when( recordFormats.relationshipTypeToken() ).thenReturn( relationshipTypeTokenFormat );
+        when( recordFormats.relationshipGroup() ).thenReturn( relationshipGroupTokenFormat );
+        return recordFormats;
+    }
+
+    private RecordFormat getRecordFormatMock( long maxId )
+    {
+        RecordFormat recordFormat = mock( RecordFormat.class );
+        when( recordFormat.getMaxId() ).thenReturn( maxId );
+        return recordFormat;
+    }
+
+    private Randoms getRandoms()
+    {
+        return new Randoms( randomRule.random(), Randoms.DEFAULT );
+    }
+
+    private TestInputEntityCacher getEntityCacher( RecordFormats recordFormats ) throws IOException
+    {
+        return new TestInputEntityCacher( mock( StoreChannel.class ),
+                mock( StoreChannel.class ), recordFormats, 100, 100 );
+    }
+
+    private TestNodeEntityCacher getNodeCacher( RecordFormats recordFormats ) throws IOException
+    {
+        return new TestNodeEntityCacher( mock( StoreChannel.class ),
+                mock( StoreChannel.class ), recordFormats, 100 );
+    }
+
+    private TestRelationshipEntityCacher getRelationshipCacher( RecordFormats recordFormats ) throws IOException
+    {
+        return new TestRelationshipEntityCacher( mock( StoreChannel.class ),
+                mock( StoreChannel.class ), recordFormats, 100 );
+    }
+
+    private class TestInputEntityCacher extends InputEntityCacher
+    {
+        TestInputEntityCacher( StoreChannel channel, StoreChannel header,
+                RecordFormats recordFormats, int bufferSize, int groupSlots ) throws IOException
+        {
+            super( channel, header, recordFormats, bufferSize, groupSlots );
+        }
+    }
+
+    private class TestNodeEntityCacher extends InputNodeCacher
+    {
+        TestNodeEntityCacher( StoreChannel channel, StoreChannel header,
+                RecordFormats recordFormats, int bufferSize ) throws IOException
+        {
+            super( channel, header, recordFormats, bufferSize );
+        }
+    }
+
+    private class TestRelationshipEntityCacher extends InputRelationshipCacher
+    {
+        TestRelationshipEntityCacher( StoreChannel channel, StoreChannel header,
+                RecordFormats recordFormats, int bufferSize ) throws IOException
+        {
+            super( channel, header, recordFormats, bufferSize );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacherTokenCreationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacherTokenCreationTest.java
@@ -37,124 +37,128 @@ import static java.lang.Math.abs;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class InputEntityCacherTest
+public class InputEntityCacherTokenCreationTest
 {
 
+    private static final int SUPPORTED_NUMBER_OF_TOKENS = 10;
+    private static final int UNSUPPORTED_NUMER_OF_TOKENS = SUPPORTED_NUMBER_OF_TOKENS + 1;
     private static final AtomicInteger uniqueIdGenerator = new AtomicInteger( 10 );
     private final ExpectedException expectedException = ExpectedException.none();
     private final RandomRule randomRule = new RandomRule();
+
     @Rule
     public RuleChain ruleChain = RuleChain.outerRule( randomRule ).around( expectedException );
 
     @Test
     public void notAllowCreationOfUnsupportedNumberOfProperties() throws IOException
     {
-        initExpectedException();
-        cacheNodeWithProperties(10, 10);
+        initExpectedException( SUPPORTED_NUMBER_OF_TOKENS );
+        cacheNodeWithProperties( UNSUPPORTED_NUMER_OF_TOKENS, SUPPORTED_NUMBER_OF_TOKENS );
     }
 
     @Test
     public void allowCreationOfSupportedNumberOfProperties() throws IOException
     {
-        cacheNodeWithProperties(9, 10);
+        cacheNodeWithProperties( SUPPORTED_NUMBER_OF_TOKENS, SUPPORTED_NUMBER_OF_TOKENS );
     }
 
     @Test
     public void notAllowCreationOfUnsupportedNumberOfGroups() throws IOException
     {
-        initExpectedException();
-        cacheGroups(10, 10);
+        initExpectedException( SUPPORTED_NUMBER_OF_TOKENS );
+        cacheGroups( UNSUPPORTED_NUMER_OF_TOKENS, SUPPORTED_NUMBER_OF_TOKENS );
     }
 
     @Test
     public void allowCreationOfSupportedNumberOfGroups() throws IOException
     {
-        cacheGroups(9, 10);
+        cacheGroups( SUPPORTED_NUMBER_OF_TOKENS, SUPPORTED_NUMBER_OF_TOKENS );
     }
 
     @Test
     public void notAllowCreationOfUnsupportedNumberOfLabels() throws IOException
     {
-        initExpectedException();
-        cacheLabels(10, 10);
+        initExpectedException( SUPPORTED_NUMBER_OF_TOKENS );
+        cacheLabels( UNSUPPORTED_NUMER_OF_TOKENS, SUPPORTED_NUMBER_OF_TOKENS );
     }
 
     @Test
     public void allowCreationOfSupportedNumberOfLabels() throws IOException
     {
-        cacheLabels(9, 10);
+        cacheLabels( SUPPORTED_NUMBER_OF_TOKENS, SUPPORTED_NUMBER_OF_TOKENS );
     }
 
     @Test
     public void notAllowCreationOfUnsupportedNumberOfRelationshipTypes() throws IOException
     {
-        initExpectedException();
-        cacheRelationship( 10, 10 );
+        initExpectedException( SUPPORTED_NUMBER_OF_TOKENS );
+        cacheRelationship( UNSUPPORTED_NUMER_OF_TOKENS, SUPPORTED_NUMBER_OF_TOKENS );
     }
 
     @Test
     public void allowCreationOfSupportedNumberOfRelationshipTypes() throws IOException
     {
-        cacheRelationship( 9, 10 );
+        cacheRelationship( SUPPORTED_NUMBER_OF_TOKENS, SUPPORTED_NUMBER_OF_TOKENS );
     }
 
     private void cacheRelationship( int iterations, int maxNumberOfRelationshipTypes ) throws IOException
     {
         RecordFormats recordFormats = mockRecordFormats( 1000, 1000, maxNumberOfRelationshipTypes, 1000 );
 
-        try ( TestRelationshipEntityCacher cacher = getRelationshipCacher( recordFormats ) )
+        try ( InputRelationshipCacher cacher = getRelationshipCacher( recordFormats ) )
         {
-            for ( int i = 0; i <= iterations; i++ )
+            for ( int i = 0; i < iterations; i++ )
             {
                 cacher.writeEntity( generateRelationship( getRandoms() ) );
             }
         }
     }
 
-    private void cacheLabels(int iterations, int maxNumberOfLabels ) throws IOException
+    private void cacheLabels( int iterations, int maxNumberOfLabels ) throws IOException
     {
         RecordFormats recordFormats = mockRecordFormats( 1000, maxNumberOfLabels, 1000, 1000 );
 
-        try ( TestNodeEntityCacher cacher = getNodeCacher( recordFormats ) )
+        try ( InputNodeCacher cacher = getNodeCacher( recordFormats ) )
         {
-            for ( int i = 0; i <= iterations; i++ )
+            for ( int i = 0; i < iterations; i++ )
             {
-                cacher.writeLabelDiff( (byte) 0, randomLabels( ), new String[]{} );
+                cacher.writeLabelDiff( (byte) 0, randomLabels(), new String[]{} );
             }
         }
     }
 
-    private void cacheGroups(int iterations, int maxNumberOfGroups) throws IOException
+    private void cacheGroups( int iterations, int maxNumberOfGroups ) throws IOException
     {
         RecordFormats recordFormats = mockRecordFormats( 1000, 1000, 1000, maxNumberOfGroups );
 
         try ( TestInputEntityCacher cacher = getEntityCacher( recordFormats ) )
         {
-            for ( int i = 0; i <= iterations; i++ )
+            for ( int i = 0; i < iterations; i++ )
             {
                 cacher.writeGroup( generateGroup(), i );
             }
         }
     }
 
-    private void cacheNodeWithProperties(int iterations, int maxNumberOfProperties) throws IOException
+    private void cacheNodeWithProperties( int iterations, int maxNumberOfProperties ) throws IOException
     {
         RecordFormats recordFormats = mockRecordFormats( maxNumberOfProperties, 1000, 1000, 1000 );
 
         try ( TestInputEntityCacher cacher = getEntityCacher( recordFormats ) )
         {
             Randoms randoms = getRandoms();
-            for ( int i = 0; i <= iterations; i++ )
+            for ( int i = 0; i < iterations; i++ )
             {
                 cacher.writeEntity( generateNode( randoms ) );
             }
         }
     }
 
-    private void initExpectedException()
+    private void initExpectedException( int numberOfSupportedTokens )
     {
         expectedException.expect( UnsupportedOperationException.class );
-        expectedException.expectMessage( "Too many tokens. Creation of more then 10 tokens is not supported." );
+        expectedException.expectMessage( "Too many tokens. Creation of more then " + numberOfSupportedTokens + " " +
+                                         "tokens is not supported." );
     }
 
 
@@ -241,15 +245,15 @@ public class InputEntityCacherTest
                 mock( StoreChannel.class ), recordFormats, 100, 100 );
     }
 
-    private TestNodeEntityCacher getNodeCacher( RecordFormats recordFormats ) throws IOException
+    private InputNodeCacher getNodeCacher( RecordFormats recordFormats ) throws IOException
     {
-        return new TestNodeEntityCacher( mock( StoreChannel.class ),
+        return new InputNodeCacher( mock( StoreChannel.class ),
                 mock( StoreChannel.class ), recordFormats, 100 );
     }
 
-    private TestRelationshipEntityCacher getRelationshipCacher( RecordFormats recordFormats ) throws IOException
+    private InputRelationshipCacher getRelationshipCacher( RecordFormats recordFormats ) throws IOException
     {
-        return new TestRelationshipEntityCacher( mock( StoreChannel.class ),
+        return new InputRelationshipCacher( mock( StoreChannel.class ),
                 mock( StoreChannel.class ), recordFormats, 100 );
     }
 
@@ -259,24 +263,6 @@ public class InputEntityCacherTest
                 RecordFormats recordFormats, int bufferSize, int groupSlots ) throws IOException
         {
             super( channel, header, recordFormats, bufferSize, groupSlots );
-        }
-    }
-
-    private class TestNodeEntityCacher extends InputNodeCacher
-    {
-        TestNodeEntityCacher( StoreChannel channel, StoreChannel header,
-                RecordFormats recordFormats, int bufferSize ) throws IOException
-        {
-            super( channel, header, recordFormats, bufferSize );
-        }
-    }
-
-    private class TestRelationshipEntityCacher extends InputRelationshipCacher
-    {
-        TestRelationshipEntityCacher( StoreChannel channel, StoreChannel header,
-                RecordFormats recordFormats, int bufferSize ) throws IOException
-        {
-            super( channel, header, recordFormats, bufferSize );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/PerTypeRelationshipSplitterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/PerTypeRelationshipSplitterTest.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.RandomRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
@@ -52,7 +53,8 @@ public class PerTypeRelationshipSplitterTest
         // GIVEN
         Collection<InputRelationship> expected = randomRelationships();
         InputIterable<InputRelationship> relationships = wrap( "test", expected );
-        InputCache inputCache = new InputCache( new DefaultFileSystemAbstraction(), directory.directory() );
+        InputCache inputCache = new InputCache( new DefaultFileSystemAbstraction(), directory.directory(),
+                StandardV3_0.RECORD_FORMATS );
         PerTypeRelationshipSplitter perType = new PerTypeRelationshipSplitter( relationships.iterator(),
                 types( expected ), type -> false, type -> Integer.parseInt( type.toString() ), inputCache );
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStoresTest.java
@@ -34,6 +34,7 @@ import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
 import org.neo4j.test.PageCacheRule;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -69,8 +70,8 @@ public class BatchingNeoStoresTest
         // WHEN
         try
         {
-            RecordFormats recordFormats = RecordFormatSelector.autoSelectFormat( Config.empty(),
-                    NullLogService.getInstance() );
+            RecordFormats recordFormats = RecordFormatSelector.selectForConfig( Config.empty(),
+                    NullLogProvider.getInstance() );
             new BatchingNeoStores( fsr.get(), storeDir, recordFormats, DEFAULT, NullLogService.getInstance(), EMPTY,
                     Config.empty() );
             fail( "Should fail on existing data" );


### PR DESCRIPTION
Batch import currently allow create only 2^16 different tokens of each type during import.
This commit introduce a check for max allowable number of tokens of particular type in accordance with current store format.
In case if number of tokens over exceed maximum allowable number exception will be thrown and import will be interrupted.
