### PR TITLE
Fixes an issue with wrong degrees in import-tool

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -44,11 +44,13 @@ import java.util.UUID;
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.ConsistencyCheckService.Result;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
@@ -74,6 +76,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
@@ -359,6 +363,7 @@ public class ParallelBatchImporterTest
                 String inputId = uniqueId( input.group(), node );
                 assertNull( nodeByInputId.put( inputId, node ) );
                 verifiedNodes++;
+                assertDegrees( node );
             }
             assertEquals( nodeCount, verifiedNodes );
 
@@ -389,6 +394,19 @@ public class ParallelBatchImporterTest
                 verifiedRelationships++;
             }
             assertEquals( relationshipCount, verifiedRelationships );
+        }
+    }
+
+    private void assertDegrees( Node node )
+    {
+        for ( RelationshipType type : node.getRelationshipTypes() )
+        {
+            for ( Direction direction : Direction.values() )
+            {
+                long degree = node.getDegree( type, direction );
+                long actualDegree = count( node.getRelationships( type, direction ) );
+                assertEquals( actualDegree, degree );
+            }
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCacheTest.java
@@ -137,7 +137,6 @@ public class NodeRelationshipCacheTest
             long previous = cache.getAndPutRelationship( i, directions[i % directions.length],
                     random.nextInt( 1_000_000 ), true );
             assertEquals( -1L, previous );
-            assertEquals( 1, cache.getCount( i, directions[i % directions.length] ) );
         }
 
         // WHEN
@@ -147,7 +146,6 @@ public class NodeRelationshipCacheTest
             long previous = cache.getAndPutRelationship( i, directions[i % directions.length],
                     random.nextInt( 1_000_000 ), false );
             assertEquals( -1L, previous );
-            assertEquals( 1, cache.getCount( i, directions[i % directions.length] ) );
         }
 
         // THEN
@@ -155,8 +153,28 @@ public class NodeRelationshipCacheTest
         for ( int i = 0; i < nodes; i++ )
         {
             assertEquals( -1L, cache.getFirstRel( nodes, groupVisitor ) );
-            assertEquals( 1, cache.getCount( i, directions[i % directions.length] ) );
         }
+    }
+
+    @Test
+    public void shouldResetCountAfterGetOnDenseNodes() throws Exception
+    {
+        // GIVEN
+        cache = new NodeRelationshipCache( NumberArrayFactory.AUTO, 1, 100, base );
+        long nodeId = 0;
+        cache.setHighNodeId( 1 );
+        cache.incrementCount( nodeId );
+        cache.incrementCount( nodeId );
+        cache.getAndPutRelationship( nodeId, OUTGOING, 10, true );
+        cache.getAndPutRelationship( nodeId, OUTGOING, 12, true );
+        assertTrue( cache.isDense( nodeId ) );
+
+        // WHEN
+        long count = cache.getCount( nodeId, OUTGOING );
+        assertEquals( 2, count );
+
+        // THEN
+        assertEquals( 0, cache.getCount( nodeId, OUTGOING ) );
     }
 
     @Test


### PR DESCRIPTION
Since import tool was changed to import relationships per type there has
been a bug where degrees for dense nodes would not be reset between
relationship types and so degrees would be accumulative from one type
to the next. This fixes that and enhances ParallelBatchImporterTest
to verify degrees, where it now fails w/o this fix.
