### PR TITLE
Change error message for incorrect auth file

### DIFF
--- a/community/security/src/main/java/org/neo4j/server/security/auth/FileUserRepository.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/FileUserRepository.java
@@ -214,7 +214,7 @@ public class FileUserRepository extends LifecycleAdapter implements UserReposito
             loadedUsers = serialization.deserializeUsers( fileBytes );
         } catch ( UserSerialization.FormatException e )
         {
-            log.error( "Ignoring authorization file \"%s\" (%s)", authFile.toAbsolutePath(), e.getMessage() );
+            log.error( "Failed to read authentication file \"%s\" (%s)", authFile.toAbsolutePath(), e.getMessage() );
             throw new IllegalStateException( "Failed to read authentication file: " + authFile );
         }
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileRoleRepository.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileRoleRepository.java
@@ -102,7 +102,7 @@ public class FileRoleRepository extends AbstractRoleRepository
         }
         catch ( RoleSerialization.FormatException e )
         {
-            log.error( "Ignoring role file \"%s\" (%s)", roleFile.toAbsolutePath(), e.getMessage() );
+            log.error( "Failed to read role file \"%s\" (%s)", roleFile.toAbsolutePath(), e.getMessage() );
             throw new IllegalStateException( "Failed to read role file: " + roleFile );
         }
 


### PR DESCRIPTION
The error message should reflect that we fail hard when reading an
incorrectly formatted auth file.
Fix the test name and assertions to reflect this.
