### PR TITLE
Give default user access rights in enterprise

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileUserRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileUserRealm.java
@@ -139,6 +139,11 @@ public class FileUserRealm extends AuthorizingRealm
         return userRepository.numberOfUsers();
     }
 
+    int numberOfRoles()
+    {
+        return roleRepository.numberOfRoles();
+    }
+
     User newUser( String username, String initialPassword, boolean requirePasswordChange )
             throws IOException, IllegalCredentialsException
     {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManager.java
@@ -92,6 +92,12 @@ public class ShiroAuthManager extends BasicAuthManager implements RoleManager
         if ( authEnabled && realm.numberOfUsers() == 0 )
         {
             realm.newUser( "neo4j", "neo4j", true );
+
+            if ( realm.numberOfRoles() == 0 )
+            {
+                // Make the default user admin for now
+                realm.newRole( PredefinedRolesBuilder.ADMIN, "neo4j" );
+            }
         }
     }
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManagerTest.java
@@ -248,6 +248,25 @@ public class ShiroAuthManagerTest
     }
 
     @Test
+    public void defaultUserShouldHaveCorrectPermissions() throws Throwable
+    {
+        // Given
+        when( authStrategy.isAuthenticationPermitted( anyString() ) ).thenReturn( true );
+        manager.start();
+
+        // When
+        AuthSubject subject = manager.login( "neo4j", "neo4j");
+        manager.setUserPassword( "neo4j", "1234" );
+        subject.logout();
+        subject = manager.login( "neo4j", "1234");
+
+        // Then
+        assertTrue( subject.allowsReads() );
+        assertTrue( subject.allowsWrites() );
+        assertTrue( subject.allowsSchemaWrites() );
+    }
+
+    @Test
     public void userWithAdminRoleShouldHaveCorrectPermissions() throws Throwable
     {
         // Given


### PR DESCRIPTION
Until we have decided how to properly setup the admin account on
installation of neo4j enterprise, we are following the pattern of
community edition with creating a default user "neo4j" with full access
rights unless you have manually configured the auth file.
