### PR TITLE
Fix high_limit DynamicRecord read consistency bug

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -1040,7 +1040,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
             do
             {
                 prepareForReading( cursor, offset, record );
-                recordFormat.read( record, cursor, mode, recordSize, storeFile );
+                recordFormat.read( record, cursor, mode, recordSize );
             }
             while ( cursor.shouldRetry() );
             checkForDecodingErrors( cursor, id, mode );
@@ -1067,7 +1067,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
                 do
                 {
                     cursor.setOffset( offset );
-                    recordFormat.write( record, cursor, recordSize, storeFile );
+                    recordFormat.write( record, cursor, recordSize );
                 }
                 while ( cursor.shouldRetry() );
                 checkForDecodingErrors( cursor, id, NORMAL ); // We don't free ids if something weird goes wrong

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
@@ -278,7 +278,7 @@ public class MetaDataStore extends CommonAbstractStore<MetaDataRecord,NoStoreHea
                         record.setId( position.id );
                         do
                         {
-                            format.read( record, cursor, RecordLoad.CHECK, RECORD_SIZE, pagedFile );
+                            format.read( record, cursor, RecordLoad.CHECK, RECORD_SIZE );
                             if ( record.inUse() )
                             {
                                 value = record.getValue();
@@ -522,7 +522,7 @@ public class MetaDataStore extends CommonAbstractStore<MetaDataRecord,NoStoreHea
         try
         {
             record.setId( position.id );
-            recordFormat.read( record, cursor, NORMAL, RECORD_SIZE, storeFile );
+            recordFormat.read( record, cursor, NORMAL, RECORD_SIZE );
             return record.getValue();
         }
         catch ( IOException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/BaseRecordFormat.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format;
 import java.util.function.Function;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.IntStoreHeader;
 import org.neo4j.kernel.impl.store.StoreHeader;
 import org.neo4j.kernel.impl.store.id.IdSequence;
@@ -32,8 +31,8 @@ import org.neo4j.kernel.impl.store.record.Record;
 
 /**
  * Basic abstract implementation of a {@link RecordFormat} implementing most functionality except
- * {@link #read(AbstractBaseRecord, PageCursor, org.neo4j.kernel.impl.store.record.RecordLoad, int, PagedFile)} and
- * {@link #write(AbstractBaseRecord, PageCursor, int, PagedFile)}.
+ * {@link RecordFormat#read(AbstractBaseRecord, PageCursor, org.neo4j.kernel.impl.store.record.RecordLoad, int)} and
+ * {@link RecordFormat#write(AbstractBaseRecord, PageCursor, int)}.
  *
  * @param <RECORD> type of record.
  */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/RecordFormat.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.StoreHeader;
 import org.neo4j.kernel.impl.store.id.IdSequence;
@@ -39,12 +38,12 @@ import org.neo4j.kernel.impl.store.record.RecordLoad;
 public interface RecordFormat<RECORD extends AbstractBaseRecord>
 {
     /**
-     * Instantiates a new record to use in {@link #read(AbstractBaseRecord, PageCursor, RecordLoad, int, PagedFile)}
-     * and {@link #write(AbstractBaseRecord, PageCursor, int, PagedFile)}. Records may be reused, which is why the instantiation
+     * Instantiates a new record to use in {@link #read(AbstractBaseRecord, PageCursor, RecordLoad, int)}
+     * and {@link #write(AbstractBaseRecord, PageCursor, int)}. Records may be reused, which is why the instantiation
      * is separated from reading and writing.
      *
-     * @return a new record instance, usable in {@link #read(AbstractBaseRecord, PageCursor, RecordLoad, int, PagedFile)}
-     * and {@link #write(AbstractBaseRecord, PageCursor, int, PagedFile)}.
+     * @return a new record instance, usable in {@link #read(AbstractBaseRecord, PageCursor, RecordLoad, int)}
+     * and {@link #write(AbstractBaseRecord, PageCursor, int)}.
      */
     RECORD newRecord();
 
@@ -86,11 +85,9 @@ public interface RecordFormat<RECORD extends AbstractBaseRecord>
      * See {@link RecordStore#getRecord(long, AbstractBaseRecord, RecordLoad)} for more information.
      * @param recordSize size of records of this format. This is passed in like this since not all formats
      * know the record size in advance, but may be read from store header when opening the store.
-     * @param storeFile {@link PagedFile} to get additional {@link PageCursor} from if needed.
      * @throws IOException on error reading.
      */
-    void read( RECORD record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
-            throws IOException;
+    void read( RECORD record, PageCursor cursor, RecordLoad mode, int recordSize ) throws IOException;
 
     /**
      * Called when all changes about a record has been gathered
@@ -115,11 +112,9 @@ public interface RecordFormat<RECORD extends AbstractBaseRecord>
      * @param cursor {@link PageCursor} to write the record data into.
      * @param recordSize size of records of this format. This is passed in like this since not all formats
      * know the record size in advance, but may be read from store header when opening the store.
-     * @param storeFile {@link PagedFile} to get additional {@link PageCursor} from if needed.
      * @throws IOException on error writing.
      */
-    void write( RECORD record, PageCursor cursor, int recordSize, PagedFile storeFile )
-            throws IOException;
+    void write( RECORD record, PageCursor cursor, int recordSize ) throws IOException;
 
     /**
      * @param record to obtain "next" reference from.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/DynamicRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/DynamicRecordFormat.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.store.format.standard;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -48,7 +47,7 @@ public class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRe
     }
 
     @Override
-    public void read( DynamicRecord record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+    public void read( DynamicRecord record, PageCursor cursor, RecordLoad mode, int recordSize )
     {
         /*
          * First 4b
@@ -124,7 +123,7 @@ public class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRe
     }
 
     @Override
-    public void write( DynamicRecord record, PageCursor cursor, int recordSize, PagedFile storeFile )
+    public void write( DynamicRecord record, PageCursor cursor, int recordSize )
     {
         if ( record.inUse() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/MetaDataRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/MetaDataRecordFormat.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format.standard;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.MetaDataStore.Position;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.record.MetaDataRecord;
@@ -47,8 +46,7 @@ public class MetaDataRecordFormat extends BaseOneByteHeaderRecordFormat<MetaData
     }
 
     @Override
-    public void read( MetaDataRecord record, PageCursor cursor, RecordLoad mode, int recordSize,
-            PagedFile storeFile ) throws IOException
+    public void read( MetaDataRecord record, PageCursor cursor, RecordLoad mode, int recordSize ) throws IOException
     {
         int id = record.getIntId();
         Position[] values = Position.values();
@@ -67,7 +65,7 @@ public class MetaDataRecordFormat extends BaseOneByteHeaderRecordFormat<MetaData
     }
 
     @Override
-    public void write( MetaDataRecord record, PageCursor cursor, int recordSize, PagedFile storeFile )
+    public void write( MetaDataRecord record, PageCursor cursor, int recordSize )
             throws IOException
     {
         assert record.inUse();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NoRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NoRecordFormat.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format.standard;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.StoreHeader;
 import org.neo4j.kernel.impl.store.format.RecordFormat;
 import org.neo4j.kernel.impl.store.id.IdSequence;
@@ -57,7 +56,7 @@ public class NoRecordFormat<RECORD extends AbstractBaseRecord> implements Record
     }
 
     @Override
-    public void read( RECORD record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+    public void read( RECORD record, PageCursor cursor, RecordLoad mode, int recordSize )
             throws IOException
     {
         record.clear();
@@ -69,7 +68,7 @@ public class NoRecordFormat<RECORD extends AbstractBaseRecord> implements Record
     }
 
     @Override
-    public void write( RECORD record, PageCursor cursor, int recordSize, PagedFile storeFile ) throws IOException
+    public void write( RECORD record, PageCursor cursor, int recordSize ) throws IOException
     {
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format.standard;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -45,7 +44,7 @@ public class NodeRecordFormat extends BaseOneByteHeaderRecordFormat<NodeRecord>
         return new NodeRecord( -1 );
     }
 
-    public void read( NodeRecord record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+    public void read( NodeRecord record, PageCursor cursor, RecordLoad mode, int recordSize )
             throws IOException
     {
         byte headerByte = cursor.getByte();
@@ -72,7 +71,7 @@ public class NodeRecordFormat extends BaseOneByteHeaderRecordFormat<NodeRecord>
     }
 
     @Override
-    public void write( NodeRecord record, PageCursor cursor, int recordSize, PagedFile storeFile ) throws IOException
+    public void write( NodeRecord record, PageCursor cursor, int recordSize ) throws IOException
     {
         if ( record.inUse() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormatV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormatV2_0.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format.standard;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
@@ -40,7 +39,7 @@ class NodeRecordFormatV2_0 extends BaseOneByteHeaderRecordFormat<NodeRecord>
         return new NodeRecord( -1 );
     }
 
-    public void read( NodeRecord record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+    public void read( NodeRecord record, PageCursor cursor, RecordLoad mode, int recordSize )
             throws IOException
     {
         long headerByte = cursor.getByte();
@@ -69,7 +68,7 @@ class NodeRecordFormatV2_0 extends BaseOneByteHeaderRecordFormat<NodeRecord>
     }
 
     @Override
-    public void write( NodeRecord record, PageCursor cursor, int recordSize, PagedFile storeFile ) throws IOException
+    public void write( NodeRecord record, PageCursor cursor, int recordSize ) throws IOException
     {
         throw new UnsupportedOperationException();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/PropertyRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/PropertyRecordFormat.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.store.format.standard;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.PropertyType;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
@@ -51,7 +50,7 @@ public class PropertyRecordFormat extends BaseRecordFormat<PropertyRecord>
     }
 
     @Override
-    public void read( PropertyRecord record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+    public void read( PropertyRecord record, PageCursor cursor, RecordLoad mode, int recordSize )
     {
         int offsetAtBeginning = cursor.getOffset();
 
@@ -98,7 +97,7 @@ public class PropertyRecordFormat extends BaseRecordFormat<PropertyRecord>
     }
 
     @Override
-    public void write( PropertyRecord record, PageCursor cursor, int recordSize, PagedFile storeFile )
+    public void write( PropertyRecord record, PageCursor cursor, int recordSize )
     {
         if ( record.inUse() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipGroupRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipGroupRecordFormat.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format.standard;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
 import org.neo4j.kernel.impl.store.record.Record;
@@ -47,8 +46,7 @@ public class RelationshipGroupRecordFormat extends BaseOneByteHeaderRecordFormat
     }
 
     @Override
-    public void read( RelationshipGroupRecord record, PageCursor cursor, RecordLoad mode, int recordSize,
-            PagedFile storeFile ) throws IOException
+    public void read( RelationshipGroupRecord record, PageCursor cursor, RecordLoad mode, int recordSize ) throws IOException
     {
         // [    ,   x] in use
         // [    ,xxx ] high next id bits
@@ -84,7 +82,7 @@ public class RelationshipGroupRecordFormat extends BaseOneByteHeaderRecordFormat
     }
 
     @Override
-    public void write( RelationshipGroupRecord record, PageCursor cursor, int recordSize, PagedFile storeFile )
+    public void write( RelationshipGroupRecord record, PageCursor cursor, int recordSize )
             throws IOException
     {
         if ( record.inUse() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormat.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format.standard;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
 import org.neo4j.kernel.impl.store.record.Record;
@@ -48,8 +47,7 @@ public class RelationshipRecordFormat extends BaseOneByteHeaderRecordFormat<Rela
         return new RelationshipRecord( -1 );
     }
 
-    public void read( RelationshipRecord record, PageCursor cursor, RecordLoad mode, int recordSize,
-            PagedFile storeFile ) throws IOException
+    public void read( RelationshipRecord record, PageCursor cursor, RecordLoad mode, int recordSize ) throws IOException
     {
         byte headerByte = cursor.getByte();
         boolean inUse = isInUse( headerByte );
@@ -106,7 +104,7 @@ public class RelationshipRecordFormat extends BaseOneByteHeaderRecordFormat<Rela
     }
 
     @Override
-    public void write( RelationshipRecord record, PageCursor cursor, int recordSize, PagedFile storeFile )
+    public void write( RelationshipRecord record, PageCursor cursor, int recordSize )
             throws IOException
     {
         if ( record.inUse() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormatV2_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipRecordFormatV2_0.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format.standard;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
@@ -41,8 +40,7 @@ class RelationshipRecordFormatV2_0 extends BaseOneByteHeaderRecordFormat<Relatio
     }
 
     @Override
-    public void read( RelationshipRecord record, PageCursor cursor, RecordLoad mode, int recordSize,
-            PagedFile storeFile ) throws IOException
+    public void read( RelationshipRecord record, PageCursor cursor, RecordLoad mode, int recordSize ) throws IOException
     {
         long headerByte = cursor.getByte();
         boolean inUse = isInUse( (byte) headerByte );
@@ -95,7 +93,7 @@ class RelationshipRecordFormatV2_0 extends BaseOneByteHeaderRecordFormat<Relatio
     }
 
     @Override
-    public void write( RelationshipRecord record, PageCursor cursor, int recordSize, PagedFile storeFile )
+    public void write( RelationshipRecord record, PageCursor cursor, int recordSize )
             throws IOException
     {
         throw new UnsupportedOperationException();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/TokenRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/TokenRecordFormat.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.store.format.standard;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
@@ -36,7 +35,7 @@ public abstract class TokenRecordFormat<RECORD extends TokenRecord> extends Base
     }
 
     @Override
-    public void read( RECORD record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+    public void read( RECORD record, PageCursor cursor, RecordLoad mode, int recordSize )
     {
         byte inUseByte = cursor.getByte();
         boolean inUse = isInUse( inUseByte );
@@ -53,7 +52,7 @@ public abstract class TokenRecordFormat<RECORD extends TokenRecord> extends Base
     }
 
     @Override
-    public void write( RECORD record, PageCursor cursor, int recordSize, PagedFile storeFile )
+    public void write( RECORD record, PageCursor cursor, int recordSize )
     {
         if ( record.inUse() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreBehaviourTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreBehaviourTest.java
@@ -35,7 +35,6 @@ import org.neo4j.function.ThrowingAction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.format.BaseRecordFormat;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
@@ -333,7 +332,7 @@ public class CommonAbstractStoreBehaviourTest
         }
 
         @Override
-        public void read( IntRecord record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+        public void read( IntRecord record, PageCursor cursor, RecordLoad mode, int recordSize )
                 throws IOException
         {
             for ( int i = 0; i < intsPerRecord; i++ )
@@ -353,7 +352,7 @@ public class CommonAbstractStoreBehaviourTest
         }
 
         @Override
-        public void write( IntRecord record, PageCursor cursor, int recordSize, PagedFile storeFile ) throws IOException
+        public void write( IntRecord record, PageCursor cursor, int recordSize ) throws IOException
         {
             for ( int i = 0; i < intsPerRecord; i++ )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
@@ -58,7 +58,7 @@ public abstract class RecordFormatTest
     private static final int PAGE_SIZE = (int) kibiBytes( 1 );
 
     // Whoever is hit first
-    private static final long TEST_ITERATIONS = 20_000;
+    private static final long TEST_ITERATIONS = 40_000;
     private static final long TEST_TIME = 500;
     private static final long PRINT_RESULTS_THRESHOLD = SECONDS.toMillis( 1 );
     private static final int DATA_SIZE = 100;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
@@ -218,7 +218,7 @@ public abstract class RecordFormatTest
             do
             {
                 cursor.setOffset( offset );
-                format.read( read, cursor, NORMAL, recordSize, storeFile );
+                format.read( read, cursor, NORMAL, recordSize );
             }
             while ( cursor.shouldRetry() );
             assertFalse( "Out-of-bounds when reading record " + written, cursor.checkAndClearBoundsFlag() );
@@ -252,7 +252,7 @@ public abstract class RecordFormatTest
 
             int offset = Math.toIntExact( record.getId() * recordSize );
             cursor.setOffset( offset );
-            format.write( record, cursor, recordSize, storeFile );
+            format.write( record, cursor, recordSize );
             assertFalse( "Out-of-bounds when writing record " + record, cursor.checkAndClearBoundsFlag() );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PrepareTrackingRecordFormats.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.StoreHeader;
 import org.neo4j.kernel.impl.store.format.Capability;
 import org.neo4j.kernel.impl.store.format.CapabilityType;
@@ -181,10 +180,10 @@ public class PrepareTrackingRecordFormats implements RecordFormats
         }
 
         @Override
-        public void read( RECORD record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+        public void read( RECORD record, PageCursor cursor, RecordLoad mode, int recordSize )
                 throws IOException
         {
-            actual.read( record, cursor, mode, recordSize, storeFile );
+            actual.read( record, cursor, mode, recordSize );
         }
 
         @Override
@@ -195,9 +194,9 @@ public class PrepareTrackingRecordFormats implements RecordFormats
         }
 
         @Override
-        public void write( RECORD record, PageCursor cursor, int recordSize, PagedFile storeFile ) throws IOException
+        public void write( RECORD record, PageCursor cursor, int recordSize ) throws IOException
         {
-            actual.write( record, cursor, recordSize, storeFile );
+            actual.write( record, cursor, recordSize );
         }
 
         @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format.highlimit;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
@@ -62,7 +61,7 @@ class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRecord>
     }
 
     @Override
-    public void read( DynamicRecord record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+    public void read( DynamicRecord record, PageCursor cursor, RecordLoad mode, int recordSize )
             throws IOException
     {
         byte headerByte = cursor.getByte();
@@ -96,7 +95,7 @@ class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRecord>
     }
 
     @Override
-    public void write( DynamicRecord record, PageCursor cursor, int recordSize, PagedFile storeFile ) throws IOException
+    public void write( DynamicRecord record, PageCursor cursor, int recordSize ) throws IOException
     {
         if ( record.inUse() )
         {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
@@ -79,6 +79,10 @@ class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRecord>
             record.initialize( inUse, isStartRecord, next, -1, length );
             readData( record, cursor );
         }
+        else
+        {
+            record.setInUse( inUse );
+        }
     }
 
     private String payloadLengthErrorMessage( DynamicRecord record, int recordSize, int length )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.store.format.highlimit;
 import java.io.IOException;
 
 import org.neo4j.io.pagecache.PageCursor;
-import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.format.BaseOneByteHeaderRecordFormat;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
@@ -63,7 +62,7 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
     }
 
     @Override
-    public void read( PropertyRecord record, PageCursor cursor, RecordLoad mode, int recordSize, PagedFile storeFile )
+    public void read( PropertyRecord record, PageCursor cursor, RecordLoad mode, int recordSize )
             throws IOException
     {
         int offset = cursor.getOffset();
@@ -89,7 +88,7 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
     }
 
     @Override
-    public void write( PropertyRecord record, PageCursor cursor, int recordSize, PagedFile storeFile )
+    public void write( PropertyRecord record, PageCursor cursor, int recordSize )
             throws IOException
     {
         if ( record.inUse() )

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
@@ -43,7 +43,7 @@ public class BaseHighLimitRecordFormatTest
     {
         MyRecordFormat format = new MyRecordFormat();
         StubPageCursor cursor = new StubPageCursor( 0, 3 );
-        format.read( new MyRecord( 0 ), cursor, RecordLoad.NORMAL, 4, null );
+        format.read( new MyRecord( 0 ), cursor, RecordLoad.NORMAL, 4 );
         assertFalse( cursor.checkAndClearBoundsFlag() );
     }
 
@@ -62,7 +62,7 @@ public class BaseHighLimitRecordFormatTest
             }
         };
         format.shortsPerRecord.add( 2 );
-        format.read( new MyRecord( 0 ), cursor, RecordLoad.NORMAL, 4, pagedFile );
+        format.read( new MyRecord( 0 ), cursor, RecordLoad.NORMAL, 4 );
         assertTrue( cursor.checkAndClearBoundsFlag() );
     }
 
@@ -73,7 +73,7 @@ public class BaseHighLimitRecordFormatTest
         StubPageCursor cursor = new StubPageCursor( 0, 3 );
         MyRecord record = new MyRecord( 0 );
         record.setInUse( true );
-        format.write( record, cursor, 4, null );
+        format.write( record, cursor, 4 );
         assertFalse( cursor.checkAndClearBoundsFlag() );
     }
 
@@ -87,7 +87,7 @@ public class BaseHighLimitRecordFormatTest
         record.setSecondaryUnitId( 42 );
         record.setInUse( true );
         format.shortsPerRecord.add( 3 ); // make the write go out of bounds
-        format.write( record, cursor, 4, new StubPagedFile( 3 ) );
+        format.write( record, cursor, 4 );
         assertTrue( cursor.checkAndClearBoundsFlag() );
     }
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormatTest.java
@@ -46,12 +46,12 @@ public class PropertyRecordFormatTest
         int recordOffset = cursor.getOffset();
 
         PropertyRecord record = createRecord( format, recordId );
-        format.write( record, cursor, recordSize, null);
+        format.write( record, cursor, recordSize );
 
         PropertyRecord recordFromStore = format.newRecord();
         recordFromStore.setId( recordId  );
         resetCursor( cursor, recordOffset );
-        format.read( recordFromStore, cursor, RecordLoad.NORMAL, recordSize, null );
+        format.read( recordFromStore, cursor, RecordLoad.NORMAL, recordSize );
 
         // records should be the same
         assertEquals( record.getNextProp(), recordFromStore.getNextProp() );
@@ -61,7 +61,7 @@ public class PropertyRecordFormatTest
         resetCursor( cursor, recordOffset );
         PropertyRecord recordWithOtherId = format.newRecord();
         recordWithOtherId.setId( 1L  );
-        format.read( recordWithOtherId, cursor, RecordLoad.NORMAL, recordSize, null );
+        format.read( recordWithOtherId, cursor, RecordLoad.NORMAL, recordSize );
 
         assertNotEquals( record.getNextProp(), recordWithOtherId.getNextProp() );
         assertNotEquals( record.getPrevProp(), recordWithOtherId.getPrevProp() );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormatTest.java
@@ -91,12 +91,12 @@ public class RelationshipRecordFormatTest
         record.setSecondaryUnitId( 17 );
         record.setRequiresSecondaryUnit( true );
         cursor.setOffset( offsetForId( record.getId(), cursor.getCurrentPageSize(), recordSize ) );
-        format.write( record, cursor, recordSize, storeFile );
+        format.write( record, cursor, recordSize );
 
         // WHEN deleting that record
         record.setInUse( false );
         cursor.setOffset( offsetForId( record.getId(), cursor.getCurrentPageSize(), recordSize ) );
-        format.write( record, cursor, recordSize, storeFile );
+        format.write( record, cursor, recordSize );
 
         // THEN both units should have been marked as unused
         cursor.setOffset( offsetForId( record.getId(), cursor.getCurrentPageSize(), recordSize ) );
@@ -114,12 +114,12 @@ public class RelationshipRecordFormatTest
     private void checkRecord( RelationshipRecordFormat format, int recordSize, StubPageCursor cursor,
             long recordId, int recordOffset, RelationshipRecord record ) throws IOException
     {
-        format.write( record, cursor, recordSize, null);
+        format.write( record, cursor, recordSize );
 
         RelationshipRecord recordFromStore = format.newRecord();
         recordFromStore.setId( recordId  );
         resetCursor( cursor, recordOffset );
-        format.read( recordFromStore, cursor, RecordLoad.NORMAL, recordSize, null );
+        format.read( recordFromStore, cursor, RecordLoad.NORMAL, recordSize );
 
         // records should be the same
         assertEquals( record.getFirstNextRel(), recordFromStore.getFirstNextRel() );
@@ -133,7 +133,7 @@ public class RelationshipRecordFormatTest
         resetCursor( cursor, recordOffset );
         RelationshipRecord recordWithOtherId = format.newRecord();
         recordWithOtherId.setId( 1L  );
-        format.read( recordWithOtherId, cursor, RecordLoad.NORMAL, recordSize, null );
+        format.read( recordWithOtherId, cursor, RecordLoad.NORMAL, recordSize );
 
         assertNotEquals( record.getFirstNextRel(), recordWithOtherId.getFirstNextRel() );
         assertNotEquals( record.getFirstPrevRel(), recordWithOtherId.getFirstPrevRel() );


### PR DESCRIPTION
This also includes some cleanups and optimisations that sped up the RecordFormatTest, so its iteration count could be increased.
