### PR TITLE
Fix password change in enterprise auth manager

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthSubject.java
@@ -74,7 +74,8 @@ public class ShiroAuthSubject implements AuthSubject
 
     public boolean doesUsernameMatch( String username )
     {
-        return subject.getPrincipal().equals( username );
+        Object principal = subject.getPrincipal();
+        return principal != null && username.equals( principal );
     }
 
     @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManagerTest.java
@@ -215,6 +215,30 @@ public class ShiroAuthManagerTest
     }
 
     @Test
+    public void shouldSetPasswordThroughAuthSubject() throws Throwable
+    {
+        // Given
+        users.create( new User( "neo", Credential.forPassword( "abc123" ), true ) );
+        manager.start();
+        when( authStrategy.isAuthenticationPermitted( "neo" )).thenReturn( true );
+
+        // When
+        AuthSubject authSubject = manager.login( "neo", "abc123" );
+        assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.PASSWORD_CHANGE_REQUIRED ) );
+
+        authSubject.setPassword( "hello, world!" );
+
+        // Then
+        User user = manager.getUser( "neo" );
+        assertTrue( user.credentials().matchesPassword( "hello, world!" ) );
+        assertThat( users.findByName( "neo" ), equalTo( user ) );
+
+        authSubject.logout();
+        authSubject = manager.login( "neo", "hello, world!" );
+        assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.SUCCESS ) );
+    }
+
+    @Test
     public void shouldReturnNullWhenSettingPasswordForUnknownUser() throws Throwable
     {
         // Given


### PR DESCRIPTION
Authentication with ShiroAuthManager is throwing ExpiredCredentialsException
(if a password change is required) before an identifying principal is assigned.
In this case we have to assign a principal identity with the username to allow
the user to change her password through the changePassword procedure.
At this point we know the username is valid.
