### PR TITLE
Use basic auth manager by default

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -502,7 +502,7 @@ public abstract class GraphDatabaseSettings
     public static final Setting<File> auth_store_dir = pathSetting( "dbms.directories.auth", NO_DEFAULT );
 
     @Internal
-    public static final Setting<String> auth_manager = setting( "unsupported.dbms.security.auth_manager", STRING, "" );
+    public static final Setting<String> auth_manager = setting( "unsupported.dbms.security.auth_manager", STRING, "basic-auth-manager" );
 
     // Bolt Settings
 


### PR DESCRIPTION
This turns off the Shiro-based enterprise auth manager as the default in
enterprise edition.
