### PR TITLE
Fix credentials check on password change required

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileUserRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileUserRealm.java
@@ -123,15 +123,21 @@ public class FileUserRealm extends AuthorizingRealm
             throw new AuthenticationException( "User " + usernamePasswordToken.getUsername() + " does not exist" );
         }
 
+        SimpleAuthenticationInfo authenticationInfo =
+                new SimpleAuthenticationInfo( user.name(), user.credentials(), getName() );
+
         // TODO: This will not work if AuthenticationInfo is cached,
         // unless you always do SecurityManager.logout properly (which will invalidate the cache)
         // For REST we may need to connect HttpSessionListener.sessionDestroyed with logout
         if ( user.passwordChangeRequired() )
         {
+            // We need to assert that the credentials match ourselves before requesting the user to change password
+            // (normally this assertion is done by Shiro after we return from this method)
+            assertCredentialsMatch( token, authenticationInfo );
             throw new ExpiredCredentialsException( "Password change required" );
         }
 
-        return new SimpleAuthenticationInfo( user.name(), user.credentials(), getName() );
+        return authenticationInfo;
     }
 
     int numberOfUsers()

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManagerTest.java
@@ -239,6 +239,21 @@ public class ShiroAuthManagerTest
     }
 
     @Test
+    public void shouldNotRequestPasswordChangeWithInvalidCredentials() throws Throwable
+    {
+        // Given
+        users.create( new User( "neo", Credential.forPassword( "abc123" ), true ) );
+        manager.start();
+        when( authStrategy.isAuthenticationPermitted( "neo" )).thenReturn( true );
+
+        // When
+        AuthSubject authSubject = manager.login( "neo", "wrong" );
+
+        // Then
+        assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.FAILURE ) );
+    }
+
+    @Test
     public void shouldReturnNullWhenSettingPasswordForUnknownUser() throws Throwable
     {
         // Given


### PR DESCRIPTION
In the ShiroAuthManager internal FileUserRealm, when the user is
required to change password we need to first assert that the
credentials are valid before requesting a password change.
