### PR TITLE
Allow auto-parametrization to handle lists

### DIFF
--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/literalReplacement.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/literalReplacement.scala
@@ -75,12 +75,8 @@ object literalReplacement {
   }
 
   def apply(term: ASTNode): (Rewriter, Map[String, Any]) = {
-    // TODO: Replace with .exists
-    val containsParameter: Boolean = term.treeFold(false) {
-      case term: Parameter =>
-        acc => (true, None)
-      case _ =>
-        acc => (acc, if (acc) None else Some(identity))
+    val containsParameter: Boolean = term.exists {
+      case _:Parameter => true
     }
 
     if (containsParameter) {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/literalReplacement.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/literalReplacement.scala
@@ -72,6 +72,11 @@ object literalReplacement {
       acc =>
         val parameter = ast.Parameter(s"  AUTOBOOL${acc.size}", CTBoolean)(l.position)
         (acc + (l -> LiteralReplacement(parameter, l.value)), None)
+    case l: ast.Collection if l.expressions.forall(_.isInstanceOf[Literal])=>
+      acc =>
+        val parameter = ast.Parameter(s"  AUTOLIST${acc.size}", CTList(CTAny))(l.position)
+        val values: Seq[AnyRef] = l.expressions.map(_.asInstanceOf[Literal].value)
+        (acc + (l -> LiteralReplacement(parameter, values)), None)
   }
 
   def apply(term: ASTNode): (Rewriter, Map[String, Any]) = {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/LiteralReplacementTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/rewriters/LiteralReplacementTest.scala
@@ -44,6 +44,7 @@ class LiteralReplacementTest extends CypherFunSuite  {
     assertRewrite(s"RETURN false as result", s"RETURN {`  AUTOBOOL0`} as result", Map("  AUTOBOOL0" -> false))
     assertRewrite("RETURN 'apa' as result", "RETURN {`  AUTOSTRING0`} as result", Map("  AUTOSTRING0" -> "apa"))
     assertRewrite("RETURN \"apa\" as result", "RETURN {`  AUTOSTRING0`} as result", Map("  AUTOSTRING0" -> "apa"))
+    assertRewrite("RETURN [1, 2, 3] as result", "RETURN {`  AUTOLIST0`} as result", Map("  AUTOLIST0" -> Seq(1, 2, 3)))
   }
 
   test("should extract literals in match clause") {
@@ -53,6 +54,7 @@ class LiteralReplacementTest extends CypherFunSuite  {
     assertRewrite(s"MATCH ({a:false})", s"MATCH ({a:{`  AUTOBOOL0`}})", Map("  AUTOBOOL0" -> false))
     assertRewrite("MATCH ({a:'apa'})", "MATCH ({a:{`  AUTOSTRING0`}})", Map("  AUTOSTRING0" -> "apa"))
     assertRewrite("MATCH ({a:\"apa\"})", "MATCH ({a:{`  AUTOSTRING0`}})", Map("  AUTOSTRING0" -> "apa"))
+    assertRewrite("MATCH (n) WHERE ID(n) IN [1, 2, 3]", "MATCH (n) WHERE ID(n) IN {`  AUTOLIST0`}", Map("  AUTOLIST0" -> Seq(1, 2, 3)))
   }
 
   test("should extract literals in skip clause") {
@@ -123,5 +125,6 @@ class LiteralReplacementTest extends CypherFunSuite  {
     case p@Parameter(name, _) if name.startsWith("  AUTOINT") => p.copy(parameterType = CTInteger)(p.position)
     case p@Parameter(name, _) if name.startsWith("  AUTOBOOL") => p.copy(parameterType = CTBoolean)(p.position)
     case p@Parameter(name, _) if name.startsWith("  AUTODOUBLE") => p.copy(parameterType = CTFloat)(p.position)
+    case p@Parameter(name, _) if name.startsWith("  AUTOLIST") => p.copy(parameterType = CTList(CTAny))(p.position)
   })
 }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SchemaIndexTest.scala
@@ -122,6 +122,16 @@ class SchemaIndexTest extends DocumentingTestBase with QueryStatisticsTestSuppor
   }
 
   @Test def use_index_with_in() {
+
+    executePreparationQueries(
+      List(
+        "FOREACH(x in range(0,100) | CREATE (:Person) )",
+        "FOREACH(x in range(0,400) | CREATE (:Person {name: x}) )"
+      )
+    )
+
+    sampleAllIndicesAndWait()
+
     profileQuery(
       title = "Use index with IN",
       text =


### PR DESCRIPTION
Part of a larger initiative to make IN predicates faster in Cypher

The query 

```
MATCH (a)-[r]->(b)
WHERE a IN [...] and b IN [...]
```

where `[...]` is a list with one hundred values, went from an average time of around 6.5 s to 4.5 s (on my computer ™) with these changes
