### PR TITLE
added a trim-strings option to trim string entry types during data import.

### DIFF
--- a/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Configuration.java
@@ -40,6 +40,11 @@ public interface Configuration
     boolean multilineFields();
 
     /**
+     * Whether or not strings should be trimmed for whitespaces.
+     */
+    boolean trimStrings();
+
+    /**
      * @return {@code true} for treating empty strings, i.e. {@code ""} as null, instead of an empty string.
      */
     boolean emptyQuotedStringsAsNull();
@@ -68,6 +73,12 @@ public interface Configuration
 
         @Override
         public boolean emptyQuotedStringsAsNull()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean trimStrings()
         {
             return false;
         }
@@ -106,6 +117,12 @@ public interface Configuration
         public boolean emptyQuotedStringsAsNull()
         {
             return defaults.emptyQuotedStringsAsNull();
+        }
+
+        @Override
+        public boolean trimStrings()
+        {
+            return defaults.trimStrings();
         }
     }
 }

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -85,7 +85,12 @@ public class Extractors
 
     public Extractors( char arrayDelimiter )
     {
-        this( arrayDelimiter, Configuration.DEFAULT.emptyQuotedStringsAsNull() );
+        this( arrayDelimiter, Configuration.DEFAULT.emptyQuotedStringsAsNull(), Configuration.DEFAULT.trimStrings() );
+    }
+
+    public Extractors( char arrayDelimiter, boolean emptyStringsAsNull )
+    {
+        this( arrayDelimiter, emptyStringsAsNull, Configuration.DEFAULT.trimStrings() );
     }
 
     /**
@@ -94,7 +99,7 @@ public class Extractors
      * something that would be impossible otherwise. There's an equivalent {@link #valueOf(String)}
      * method to keep the feel of an enum.
      */
-    public Extractors( char arrayDelimiter, boolean emptyStringsAsNull )
+    public Extractors( char arrayDelimiter, boolean emptyStringsAsNull, boolean trimStrings )
     {
         try
         {
@@ -110,7 +115,7 @@ public class Extractors
                 }
             }
 
-            add( string = new StringExtractor( emptyStringsAsNull ) );
+            add( string = new StringExtractor( emptyStringsAsNull, trimStrings ) );
             add( long_ = new LongExtractor() );
             add( int_ = new IntExtractor() );
             add( char_ = new CharExtractor() );
@@ -119,7 +124,7 @@ public class Extractors
             add( boolean_ = new BooleanExtractor() );
             add( float_ = new FloatExtractor() );
             add( double_ = new DoubleExtractor() );
-            add( stringArray = new StringArrayExtractor( arrayDelimiter ) );
+            add( stringArray = new StringArrayExtractor( arrayDelimiter, trimStrings ) );
             add( booleanArray = new BooleanArrayExtractor( arrayDelimiter ) );
             add( byteArray = new ByteArrayExtractor( arrayDelimiter ) );
             add( shortArray = new ShortArrayExtractor( arrayDelimiter ) );
@@ -282,11 +287,13 @@ public class Extractors
     {
         private String value;
         private final boolean emptyStringsAsNull;
+        private final boolean trimStrings;
 
-        public StringExtractor( boolean emptyStringsAsNull )
+        public StringExtractor( boolean emptyStringsAsNull, boolean trimStrings )
         {
             super( String.class.getSimpleName() );
             this.emptyStringsAsNull = emptyStringsAsNull;
+            this.trimStrings = trimStrings;
         }
 
         @Override
@@ -305,6 +312,10 @@ public class Extractors
         protected boolean extract0( char[] data, int offset, int length )
         {
             value = new String( data, offset, length );
+            if (trimStrings)
+            {
+                value = value.trim();
+            }
             return true;
         }
 
@@ -699,10 +710,12 @@ public class Extractors
     private static class StringArrayExtractor extends ArrayExtractor<String[]>
     {
         private static final String[] EMPTY = new String[0];
+        private final boolean trimStrings;
 
-        StringArrayExtractor( char arrayDelimiter )
+        StringArrayExtractor( char arrayDelimiter, boolean trimStrings )
         {
             super( arrayDelimiter, String.class );
+            this.trimStrings = trimStrings;
         }
 
         @Override
@@ -714,6 +727,10 @@ public class Extractors
             {
                 int numberOfChars = charsToNextDelimiter( data, offset+charIndex, length-charIndex );
                 value[arrayIndex] = new String( data, offset+charIndex, numberOfChars );
+                if (trimStrings)
+                {
+                    value[arrayIndex] = value[arrayIndex].trim();
+                }
                 charIndex += numberOfChars;
             }
         }

--- a/community/csv/src/test/java/org/neo4j/csv/reader/ExtractorsTest.java
+++ b/community/csv/src/test/java/org/neo4j/csv/reader/ExtractorsTest.java
@@ -223,6 +223,38 @@ public class ExtractorsTest
         assertNull( extracted );
     }
 
+    @Test
+    public void shouldTrimStringIfConfiguredTo() throws Exception
+    {
+        // GIVEN
+        Extractors extractors = new Extractors( ',', true, true);
+        String value = " abcde fgh  ";
+
+        // WHEN
+        char[] asChars = value.toCharArray();
+        Extractor<String> extractor = extractors.string();
+        extractor.extract( asChars, 0, asChars.length, true );
+
+        // THEN
+        assertEquals( value.trim(), extractor.value() );
+    }
+
+    @Test
+    public void shouldNotTrimStringIfNotConfiguredTo() throws Exception
+    {
+        // GIVEN
+        Extractors extractors = new Extractors( ',', true, false);
+        String value = " abcde fgh  ";
+
+        // WHEN
+        char[] asChars = value.toCharArray();
+        Extractor<String> extractor = extractors.string();
+        extractor.extract( asChars, 0, asChars.length, true );
+
+        // THEN
+        assertEquals( value, extractor.value() );
+    }
+
     private String toString( long[] values, char delimiter )
     {
         StringBuilder builder = new StringBuilder();

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/CSVResources.scala
@@ -49,6 +49,8 @@ object CSVResources {
     override def multilineFields(): Boolean = true
 
     override def emptyQuotedStringsAsNull(): Boolean = true
+
+    override def trimStrings(): Boolean = false
   }
 }
 

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -134,6 +134,10 @@ public class ImportTool
                 "<true/false>",
                 "Whether or not fields from input source can span multiple lines, i.e. contain newline characters." ),
 
+        TRIM_STRINGS( "trim-strings", org.neo4j.csv.reader.Configuration.DEFAULT.trimStrings(),
+                "<true/false>",
+                "Whether or not strings should be trimmed for whitespaces."),
+
         INPUT_ENCODING( "input-encoding", null,
                 "<character set>",
                 "Character set that input data is encoded in. Provided value must be one out of the available "
@@ -673,6 +677,7 @@ public class ImportTool
                 CHARACTER_CONVERTER );
         final Boolean multiLineFields = args.getBoolean( Options.MULTILINE_FIELDS.key(), null );
         final Boolean emptyStringsAsNull = args.getBoolean( Options.IGNORE_EMPTY_STRINGS.key(), null );
+        final Boolean trimStrings = args.getBoolean( Options.TRIM_STRINGS.key(), null);
         return new Configuration.Default()
         {
             @Override
@@ -719,6 +724,14 @@ public class ImportTool
             public int bufferSize()
             {
                 return defaultSettingsSuitableForTests ? 10_000 : super.bufferSize();
+            }
+
+            @Override
+            public boolean trimStrings()
+            {
+                return trimStrings != null
+                        ? trimStrings.booleanValue()
+                        : defaultConfiguration.trimStrings();
             }
         };
     }

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -1104,6 +1104,59 @@ public class ImportToolTest
     }
 
     @Test
+    public void shouldNotTrimStringsByDefault() throws Exception
+    {
+        // GIVEN
+        String name = "  This is a line with leading and trailing whitespaces   ";
+        File data = data( ":ID,name", "1,\"" + name + "\"");
+
+        // WHEN
+        importTool(
+                "--into", dbRule.getStoreDirAbsolutePath(),
+                "--nodes", data.getAbsolutePath() );
+
+        // THEN
+        GraphDatabaseService db = dbRule.getGraphDatabaseAPI();
+        try ( Transaction tx = db.beginTx() )
+        {
+            ResourceIterator<Node> allNodes = db.getAllNodes().iterator();
+            Node node = Iterators.single( allNodes );
+            allNodes.close();
+
+            assertEquals( name, node.getProperty( "name" ) );
+
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldTrimStringsIfConfiguredTo() throws Exception
+    {
+        // GIVEN
+        String name = "  This is a line with leading and trailing whitespaces   ";
+        File data = data( ":ID,name", "1,\"" + name + "\"");
+
+        // WHEN
+        importTool(
+                "--into", dbRule.getStoreDirAbsolutePath(),
+                "--nodes", data.getAbsolutePath(),
+                "--trim-strings", "true" );
+
+        // THEN
+        GraphDatabaseService db = dbRule.getGraphDatabaseAPI();
+        try ( Transaction tx = db.beginTx() )
+        {
+            ResourceIterator<Node> allNodes = db.getAllNodes().iterator();
+            Node node = Iterators.single( allNodes );
+            allNodes.close();
+
+            assertEquals( name.trim(), node.getProperty( "name" ) );
+
+            tx.success();
+        }
+    }
+
+    @Test
     public void shouldPrintReferenceLinkOnDataImportErrors() throws Exception
     {
         String[] versionParts = Version.getKernel().getReleaseVersion().split("-");

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -247,7 +247,7 @@ public class DataFactories
             {
                 headerSeeker = headerCharSeekerFactory.open( dataSeeker, config );
                 Mark mark = new Mark();
-                Extractors extractors = new Extractors( config.arrayDelimiter(), config.emptyQuotedStringsAsNull() );
+                Extractors extractors = new Extractors( config.arrayDelimiter(), config.emptyQuotedStringsAsNull(), config.trimStrings() );
                 Extractor<?> idExtractor = idType.extractor( extractors );
                 int delimiter = config.delimiter();
                 List<Header.Entry> columns = new ArrayList<>();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserializer.java
@@ -50,7 +50,7 @@ public class InputEntityDeserializer<ENTITY extends InputEntity>
     private final Function<ENTITY,ENTITY> decorator;
     private final Deserialization<ENTITY> deserialization;
     private final Validator<ENTITY> validator;
-    private final Extractors.StringExtractor stringExtractor = new Extractors.StringExtractor( false );
+    private final Extractors.StringExtractor stringExtractor = new Extractors.StringExtractor( false, false );
     private final Collector badCollector;
 
     InputEntityDeserializer( Header header, CharSeeker data, int delimiter,


### PR DESCRIPTION
solves issue #6331
set --trim-strings=true in import tool argument list to trim the fields which have string entry type.
