### PR TITLE
Add special faster handling of IN when checking constant collections

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/TernaryLogicAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/TernaryLogicAcceptanceTest.scala
@@ -23,7 +23,6 @@ import org.neo4j.cypher.ExecutionEngineFunSuite
 
 class TernaryLogicAcceptanceTest extends ExecutionEngineFunSuite {
 
-  test("test") {
     "not null" =>> null
     "null IS NULL" =>> true
 
@@ -53,10 +52,10 @@ class TernaryLogicAcceptanceTest extends ExecutionEngineFunSuite {
     "null in []" =>> false
     "1 in [1,2,3, null]" =>> true
     "5 in [1,2,3, null]" =>> null
-  }
+
 
   implicit class Evaluate(comparison: String) {
-    def =>>(expectedResult: Any) = {
+    def =>>(expectedResult: Any) = test(comparison + " should equal " + expectedResult) {
       val output = executeScalar[Any]("RETURN " + comparison)
 
       output should equal(expectedResult)

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/TernaryLogicAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/TernaryLogicAcceptanceTest.scala
@@ -23,35 +23,35 @@ import org.neo4j.cypher.ExecutionEngineFunSuite
 
 class TernaryLogicAcceptanceTest extends ExecutionEngineFunSuite {
 
-    "not null" =>> null
-    "null IS NULL" =>> true
+  "not null" =>> null
+  "null IS NULL" =>> true
 
-    "null = null" =>> null
-    "null <> null" =>> null
+  "null = null" =>> null
+  "null <> null" =>> null
 
-    "null and null" =>> null
-    "null and true" =>> null
-    "true and null" =>> null
-    "false and null" =>> false
-    "null and false" =>> false
+  "null and null" =>> null
+  "null and true" =>> null
+  "true and null" =>> null
+  "false and null" =>> false
+  "null and false" =>> false
 
-    "null or null" =>> null
-    "null or true" =>> true
-    "true or null" =>> true
-    "false or null" =>> null
-    "null or false" =>> null
+  "null or null" =>> null
+  "null or true" =>> true
+  "true or null" =>> true
+  "false or null" =>> null
+  "null or false" =>> null
 
-    "null xor null" =>> null
-    "null xor true" =>> null
-    "true xor null" =>> null
-    "false xor null" =>> null
-    "null xor false" =>> null
+  "null xor null" =>> null
+  "null xor true" =>> null
+  "true xor null" =>> null
+  "false xor null" =>> null
+  "null xor false" =>> null
 
-    "null in [1,2,3]" =>> null
-    "null in [1,2,3,null]" =>> null
-    "null in []" =>> false
-    "1 in [1,2,3, null]" =>> true
-    "5 in [1,2,3, null]" =>> null
+  "null in [1,2,3]" =>> null
+  "null in [1,2,3,null]" =>> null
+  "null in []" =>> false
+  "1 in [1,2,3, null]" =>> true
+  "5 in [1,2,3, null]" =>> null
 
 
   implicit class Evaluate(comparison: String) {
@@ -61,4 +61,5 @@ class TernaryLogicAcceptanceTest extends ExecutionEngineFunSuite {
       output should equal(expectedResult)
     }
   }
+
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
@@ -55,22 +55,6 @@ class UniqueIndexAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
     result.toList should equal (List(Map("n" -> jake)))
   }
 
-  test("should be able to use unique index on IN an empty collections") {
-    //GIVEN
-    val andres = createLabeledNode(Map("name" -> "Andres"), "Person")
-    val jake = createLabeledNode(Map("name" -> "Jacob"), "Person")
-    relate(andres, createNode())
-    relate(jake, createNode())
-
-    graph.createConstraint("Person", "name")
-
-    //WHEN
-    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN [] RETURN n")
-
-    //THEN
-    result.toList should equal (List())
-  }
-
   test("should be able to use unique index on IN a null value") {
     //GIVEN
     val andres = createLabeledNode(Map("name" -> "Andres"), "Person")

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
@@ -23,9 +23,8 @@ import org.neo4j.cypher.internal.compiler.v3_0.IDPPlannerName
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compiler.v3_0.planDescription.InternalPlanDescription.Arguments.KeyNames
 import org.neo4j.cypher.internal.compiler.v3_0.planner.logical.plans.{NodeHashJoin, NodeIndexSeek}
-import org.neo4j.cypher.{ExecutionEngineFunSuite, HintException, IndexHintException, NewPlannerTestSupport, SyntaxException, _}
-import org.neo4j.graphdb.schema.Schema
-import org.neo4j.graphdb.{QueryExecutionException, Result}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, IndexHintException, NewPlannerTestSupport, SyntaxException, _}
+import org.neo4j.graphdb.QueryExecutionException
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.kernel.api.exceptions.Status
 import org.scalatest.matchers.{MatchResult, Matcher}
@@ -198,22 +197,6 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSup
 
     //THEN
     result.toList should equal(List(Map("n" -> jake)))
-  }
-
-  test("should be able to use index hints on IN an empty collections") {
-    //GIVEN
-    val andres = createLabeledNode(Map("name" -> "Andres"), "Person")
-    val jake = createLabeledNode(Map("name" -> "Jacob"), "Person")
-    relate(andres, createNode())
-    relate(jake, createNode())
-
-    graph.createIndex("Person", "name")
-
-    //WHEN
-    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN [] RETURN n")
-
-    //THEN
-    result.toList should equal(List())
   }
 
   test("should be able to use index hints on IN a null value") {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/commands/ExpressionConverters.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/commands/ExpressionConverters.scala
@@ -334,7 +334,10 @@ object ExpressionConverters {
   }
 
   private def in(e: ast.In) = e.rhs match {
-    case ConstantExpression(value) =>
+    case value: Parameter =>
+      predicates.ConstantIn(toCommandExpression(e.lhs), toCommandExpression(value))
+
+    case value@Collection(expressions) if expressions.forall(_.isInstanceOf[Literal]) =>
       predicates.ConstantIn(toCommandExpression(e.lhs), toCommandExpression(value))
 
     case _ =>

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/commands/ExpressionConverters.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/commands/ExpressionConverters.scala
@@ -333,9 +333,13 @@ object ExpressionConverters {
       predicates.RegularExpression(toCommandExpression(e.lhs), command)
   }
 
-  private def in(e: ast.In) = {
-    val innerEquals = predicates.Equals(toCommandExpression(e.lhs), commandexpressions.Variable("-_-INNER-_-"))
-    commands.AnyInCollection(toCommandExpression(e.rhs), "-_-INNER-_-", innerEquals)
+  private def in(e: ast.In) = e.rhs match {
+    case ConstantExpression(value) =>
+      predicates.ConstantIn(toCommandExpression(e.lhs), toCommandExpression(value))
+
+    case _ =>
+      val innerEquals = predicates.Equals(toCommandExpression(e.lhs), commandexpressions.Variable("-_-INNER-_-"))
+      commands.AnyInCollection(toCommandExpression(e.rhs), "-_-INNER-_-", innerEquals)
   }
 
   private def caseExpression(e: ast.CaseExpression) = e.expression match {

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/commands/ExpressionConverters.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/ast/convert/commands/ExpressionConverters.scala
@@ -337,6 +337,9 @@ object ExpressionConverters {
     case value: Parameter =>
       predicates.ConstantIn(toCommandExpression(e.lhs), toCommandExpression(value))
 
+    case value@Collection(expressions) if expressions.isEmpty =>
+      predicates.Not(predicates.True())
+
     case value@Collection(expressions) if expressions.forall(_.isInstanceOf[Literal]) =>
       predicates.ConstantIn(toCommandExpression(e.lhs), toCommandExpression(value))
 

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/ConstantIn.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/ConstantIn.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.commands.predicates
+
+import org.neo4j.cypher.internal.compiler.v3_0.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.Expression
+import org.neo4j.cypher.internal.compiler.v3_0.helpers.CollectionSupport
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryState
+
+/*
+This class is used for making the common <exp> IN <constant-expression> fast
+
+It uses a cache for the <constant-expression> value, and turns it into a Set, for fast existence checking
+ */
+case class ConstantIn(value: Expression, list: Expression) extends Predicate with CollectionSupport {
+  override def isMatch(ctx: ExecutionContext)(implicit state: QueryState) = {
+    val setToCheck: Set[Any] = state.constantInCache.getOrElseUpdate(list, {
+      val set = makeTraversable(list(ctx)).toSet
+      assert(!set.contains(null), "should never be used with null values in set")
+      set
+    })
+    Option(value(ctx)) map setToCheck.apply
+  }
+
+  override def containsIsNull = false
+
+  override def arguments = Seq(list)
+
+  override def rewrite(f: (Expression) => Expression) = f(ConstantIn(value.rewrite(f), list.rewrite(f)))
+
+  override def symbolTableDependencies = list.symbolTableDependencies
+}

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/IndexLookupBuilder.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/IndexLookupBuilder.scala
@@ -80,6 +80,9 @@ class IndexLookupBuilder extends PlanBuilder {
       case predicate@QueryToken(AnyInCollection(expression, _, Equals(Property(Variable(id), prop),Variable(_))))
         if id == hint.variable && prop.name == hint.property => (predicate, ManyQueryExpression(expression))
 
+      case predicate@QueryToken(ConstantIn(Property(Variable(id), prop),  expression))
+        if id == hint.variable && prop.name == hint.property => (predicate, ManyQueryExpression(expression))
+
       case predicate@QueryToken(PropertyExists(expr@Variable(id), prop))
         if id == hint.variable && prop.name == hint.property => (predicate, ScanQueryExpression(expr))
     }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/NodeFetchStrategy.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/NodeFetchStrategy.scala
@@ -111,6 +111,7 @@ object NodeByIdStrategy extends NodeStrategy {
       case predicate @ Equals(expression, IdFunction(Variable(id))) if id == variable && computable(expression) => SolvedPredicate(expression, predicate)
 
       case predicate @ AnyInCollection(collectionExpression, _, Equals(IdFunction(Variable(id)), _)) if id == variable && computable(collectionExpression) => SolvedPredicate(collectionExpression, predicate)
+      case predicate @ ConstantIn(IdFunction(Variable(id)), collectionExpression) if id == variable && computable(collectionExpression) => SolvedPredicate(collectionExpression, predicate)
     }
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
+++ b/community/cypher/cypher-compiler-3.0/src/main/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/QueryState.scala
@@ -23,7 +23,7 @@ import java.util.UUID
 
 import org.neo4j.collection.primitive.PrimitiveLongSet
 import org.neo4j.cypher.internal.compiler.v3_0._
-import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.PathValueBuilder
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions.{Expression, PathValueBuilder}
 import org.neo4j.cypher.internal.compiler.v3_0.spi.QueryContext
 import org.neo4j.cypher.internal.frontend.v3_0.ParameterNotFoundException
 
@@ -40,7 +40,8 @@ class QueryState(val query: QueryContext,
                  val queryId: AnyRef = UUID.randomUUID().toString,
                  val triadicState: mutable.Map[String, PrimitiveLongSet] = mutable.Map.empty,
                  val repeatableReads: mutable.Map[Pipe, Seq[ExecutionContext]] = mutable.Map.empty,
-                 val publicTypeConverter: Any => Any = identity) {
+                 val publicTypeConverter: Any => Any = identity,
+                 val constantInCache: mutable.Map[Expression, Set[Any]] = mutable.Map.empty) {
   private var _pathValueBuilder: PathValueBuilder = null
 
   def clearPathValueBuilder = {
@@ -58,13 +59,13 @@ class QueryState(val query: QueryContext,
   def getStatistics = query.getOptStatistics.getOrElse(QueryState.defaultStatistics)
 
   def withDecorator(decorator: PipeDecorator) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, publicTypeConverter, constantInCache)
 
   def withInitialContext(initialContext: ExecutionContext) =
-    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), queryId, triadicState, repeatableReads)
+    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), queryId, triadicState, repeatableReads, publicTypeConverter, constantInCache)
 
   def withQueryContext(query: QueryContext) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, publicTypeConverter, constantInCache)
 }
 
 object QueryState {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/ConstantInTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/ConstantInTest.scala
@@ -45,4 +45,25 @@ class ConstantInTest extends CypherFunSuite {
     predicate.isMatch(vNull) should equal(None)
     predicate.isMatch(v14) should equal(Some(false))
   }
+
+  test("check null") {
+    // given
+    val predicate = ConstantIn(Variable("x"), Collection(Literal(1), Literal(2), Literal(null)))
+
+    implicit val state = QueryStateHelper.empty
+
+    val v1 = ExecutionContext.empty.newWith("x" -> 1)
+    val vNull = ExecutionContext.empty.newWith("x" -> null)
+    val v14 = ExecutionContext.empty.newWith("x" -> 14)
+
+    // then when
+    predicate.isMatch(v1) should equal(Some(true))
+    predicate.isMatch(vNull) should equal(None)
+    predicate.isMatch(v14) should equal(None)
+
+    // and twice, just to check that the cache does not mess things up
+    predicate.isMatch(v1) should equal(Some(true))
+    predicate.isMatch(vNull) should equal(None)
+    predicate.isMatch(v14) should equal(None)
+  }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/ConstantInTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/commands/predicates/ConstantInTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_0.commands.predicates
+
+import org.neo4j.cypher.internal.compiler.v3_0.ExecutionContext
+import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions._
+import org.neo4j.cypher.internal.compiler.v3_0.pipes.QueryStateHelper
+import org.neo4j.cypher.internal.frontend.v3_0.test_helpers.CypherFunSuite
+
+class ConstantInTest extends CypherFunSuite {
+  test("tests") {
+    // given
+    val predicate = ConstantIn(Variable("x"), Collection(Literal(1), Literal(2), Literal(3)))
+
+    implicit val state = QueryStateHelper.empty
+
+    val v1 = ExecutionContext.empty.newWith("x" -> 1)
+    val vNull = ExecutionContext.empty.newWith("x" -> null)
+    val v14 = ExecutionContext.empty.newWith("x" -> 14)
+
+    // then when
+    predicate.isMatch(v1) should equal(Some(true))
+    predicate.isMatch(vNull) should equal(None)
+    predicate.isMatch(v14) should equal(Some(false))
+
+    // and twice, just to check that the cache does not mess things up
+    predicate.isMatch(v1) should equal(Some(true))
+    predicate.isMatch(vNull) should equal(None)
+    predicate.isMatch(v14) should equal(Some(false))
+  }
+}

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/StartPointChoosingBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/executionplan/builders/StartPointChoosingBuilderTest.scala
@@ -24,7 +24,7 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_0.ast.convert.commands.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v3_0.commands._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.expressions._
-import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.{Equals, HasLabel}
+import org.neo4j.cypher.internal.compiler.v3_0.commands.predicates.{ConstantIn, Equals, HasLabel}
 import org.neo4j.cypher.internal.compiler.v3_0.commands.values.TokenType._
 import org.neo4j.cypher.internal.compiler.v3_0.commands.values.{KeyToken, TokenType}
 import org.neo4j.cypher.internal.compiler.v3_0.executionplan.PartiallySolvedQuery
@@ -428,6 +428,26 @@ class StartPointChoosingBuilderTest extends BuilderTest {
 
     plan.query.start.toList should equal(List(Unsolved(NodeByIdOrEmpty(otherVariable, propertyLookup))))
     plan.query.where should equal(Seq(Solved(collectionPredicate)))
+  }
+
+  test("should identify a NodeById query even if it is encoded with the new ConstantIn-expression") {
+    // Given ... WITH n MATCH p WHERE id(p) IN n.collection
+
+    val propertyLookup: Property = Property(Variable(_var), PropertyKey("collection"))
+    val idFunction = IdFunction(Variable(otherVariable))
+    val contanstIn = ConstantIn(idFunction, propertyLookup)
+
+
+    val query = newQuery(
+      where = Seq(contanstIn),
+      patterns = Seq(SingleNode(otherVariable))
+    )
+
+    val pipe = new FakePipe(Seq.empty, _var -> CTNode)
+    val plan = assertAccepts(pipe, query)
+
+    plan.query.start.toList should equal(List(Unsolved(NodeByIdOrEmpty(otherVariable, propertyLookup))))
+    plan.query.where should equal(Seq(Solved(contanstIn)))
   }
 
   test("should_produce_label_start_points_when_no_matching_index_exist") {

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/parser/CypherParserTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/parser/CypherParserTest.scala
@@ -1520,7 +1520,7 @@ class CypherParserTest extends CypherFunSuite {
       "start x = NODE(1) where x.prop in ['a','b'] return x",
       Query.
         start(NodeById("x", 1)).
-        where(AnyInCollection(Collection(Literal("a"), Literal("b")), "-_-INNER-_-", Equals(Property(Variable("x"), PropertyKey("prop")), Variable("-_-INNER-_-")))).
+        where(ConstantIn(Property(Variable("x"), PropertyKey("prop")), Collection(Literal("a"), Literal("b")))).
         returns(ReturnItem(Variable("x"), "x"))
     )
   }
@@ -2701,7 +2701,7 @@ class CypherParserTest extends CypherFunSuite {
     expectQuery(
       "match (n:Person)-->() using index n:Person(name) where n.name IN ['Andres'] return n",
       Query.matches(RelatedTo(SingleNode("n", Seq(UnresolvedLabel("Person"))), SingleNode("  UNNAMED19"), "  UNNAMED16", Seq(), SemanticDirection.OUTGOING, Map.empty)).
-        where(AnyInCollection(Collection(Literal("Andres")), "-_-INNER-_-",  Equals(Property(Variable("n"), PropertyKey("name")), Variable("-_-INNER-_-")))).
+        where(ConstantIn(Property(Variable("n"), PropertyKey("name")), Collection(Literal("Andres")))).
         using(SchemaIndex("n", "Person", "name", AnyIndex, None)).
         returns(ReturnItem(Variable("n"), "n"))
     )

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -577,14 +577,6 @@ order by a.COL1""")
     result.toList should equal(List(Map("n" -> node)))
   }
 
-  test("shouldSupportArrayOfArrayOfPrimitivesAsParameterForInKeyword") {
-    val node = createNode("lotteryNumbers" -> Array(42, 87))
-
-    val result = executeWithAllPlannersAndCompatibilityMode("match (n) where id(n) in [1, 2, 3, null] return n")
-
-    result.toList should equal(List(Map("n" -> node)))
-  }
-
   test("params should survive with") {
     val n = createNode()
     val result = executeWithAllPlannersAndCompatibilityMode("match (n) where id(n) = 0 WITH collect(n) as coll where length(coll)={id} RETURN coll", "id"->1)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -577,6 +577,14 @@ order by a.COL1""")
     result.toList should equal(List(Map("n" -> node)))
   }
 
+  test("shouldSupportArrayOfArrayOfPrimitivesAsParameterForInKeyword") {
+    val node = createNode("lotteryNumbers" -> Array(42, 87))
+
+    val result = executeWithAllPlannersAndCompatibilityMode("match (n) where id(n) in [1, 2, 3, null] return n")
+
+    result.toList should equal(List(Map("n" -> node)))
+  }
+
   test("params should survive with") {
     val n = createNode()
     val result = executeWithAllPlannersAndCompatibilityMode("match (n) where id(n) = 0 WITH collect(n) as coll where length(coll)={id} RETURN coll", "id"->1)


### PR DESCRIPTION
test-query:

```
MATCH (a)-[r]->(b) 
WHERE id(a) IN [$idRange] AND id(b) IN [$idRange] 
RETURN r
```

`$idRange` is a string with 100 numbers in it

Small database with 10k nodes, and 1,5M relationships, on my computer, I get these numbers. This is in ms taken per query. First result is always slower because it loads and compiles a bunch of code and works off cold caches.

without fast IN checking:

```
2722
540
533
517
540
528
513
507
518
515
522
```

With fast-in

```
2194
57
52
38
29
28
34
30
31
27
28
```
