### PR TITLE
Narrower relationship store backward scan in import

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -276,7 +276,8 @@ public class ParallelBatchImporter implements BatchImporter
             // Stage 5a -- link relationship chains together for dense nodes
             nodeRelationshipCache.setForwardScan( false );
             executeStages( new RelationshipLinkbackStage( topic, config, neoStore.getRelationshipStore(),
-                    nodeRelationshipCache, nextRelationshipId, true/*dense*/ ) );
+                    nodeRelationshipCache, nextRelationshipId,
+                    relationshipStage.getNextRelationshipId(), true/*dense*/ ) );
             nextRelationshipId = relationshipStage.getNextRelationshipId();
             nodeRelationshipCache.clearChangedChunks( true/*dense*/ ); // cheap higher level clearing
         }
@@ -290,7 +291,7 @@ public class ParallelBatchImporter implements BatchImporter
         // Stage 5b -- link relationship chains together for sparse nodes
         nodeRelationshipCache.setForwardScan( false );
         executeStages( new RelationshipLinkbackStage( topic, config, neoStore.getRelationshipStore(),
-                nodeRelationshipCache, 0, false/*sparse*/ ) );
+                nodeRelationshipCache, 0, nextRelationshipId, false/*sparse*/ ) );
 
         if ( minorityRelationshipTypes.length > 0 )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStage.java
@@ -34,10 +34,10 @@ import static org.neo4j.unsafe.impl.batchimport.RecordIdIteration.backwards;
 public class RelationshipLinkbackStage extends Stage
 {
     public RelationshipLinkbackStage( String topic, Configuration config, RelationshipStore store,
-            NodeRelationshipCache cache, long firstRelationshipId, boolean denseNodes )
+            NodeRelationshipCache cache, long lowRelationshipId, long highRelationshipId, boolean denseNodes )
     {
         super( "Relationship --> Relationship" + topic, config );
-        add( new ReadRecordsStep<>( control(), config, store, backwards( store.getHighId(), firstRelationshipId ) ) );
+        add( new ReadRecordsStep<>( control(), config, store, backwards( highRelationshipId, lowRelationshipId ) ) );
         add( new RecordProcessorStep<>( control(), "LINK", config,
                 new RelationshipLinkbackProcessor( cache, denseNodes ), false ) );
         add( new UpdateRecordsStep<>( control(), config, store ) );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStageTest.java
@@ -41,7 +41,7 @@ public class RelationshipLinkbackStageTest
         long highId = 5;
         RelationshipStore store = StoreWithReservedId.newRelationshipStoreMock( highId );
         RelationshipLinkbackStage stage = new RelationshipLinkbackStage( "Test",
-                Configuration.DEFAULT, store, newCache(), 0, false );
+                Configuration.DEFAULT, store, newCache(), 0, highId, false );
 
         ExecutionSupervisors.superviseExecution( ExecutionMonitors.invisible(), Configuration.DEFAULT, stage );
 


### PR DESCRIPTION
Relationships are imported per type and for each type relationship
chains are linked together afterwards. Previously this was done
from high id of relationship store, which is fine but higher than
necessary since high id of relationship store is set before importing
any relationship at all to guard for double-unit records. Now the
scan is made for only the relationships importer for each type.
