### PR TITLE
ConsistencyCheckTool cleanups

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -174,7 +174,7 @@ public class ConsistencyCheckTool
         );
     }
 
-    static class ToolFailureException extends Exception
+    public static class ToolFailureException extends Exception
     {
         ToolFailureException( String message )
         {
@@ -186,13 +186,13 @@ public class ConsistencyCheckTool
             super( message, cause );
         }
 
-        void exitTool()
+        public void exitTool()
         {
-            printMessage();
+            printErrorMessage();
             exit();
         }
 
-        void printMessage()
+        public void printErrorMessage()
         {
             System.err.println( getMessage() );
             if ( getCause() != null )

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -47,7 +47,6 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 public class ConsistencyCheckTool
 {
     private static final String CONFIG = "config";
-    private static final String PROP_OWNER = "propowner";
     private static final String VERBOSE = "v";
 
     public static void main( String[] args ) throws IOException
@@ -84,7 +83,7 @@ public class ConsistencyCheckTool
 
     ConsistencyCheckService.Result run( String... args ) throws ToolFailureException, IOException
     {
-        Args arguments = Args.withFlags( PROP_OWNER, VERBOSE ).parse( args );
+        Args arguments = Args.withFlags( VERBOSE ).parse( args );
 
         File storeDir = determineStoreDirectory( arguments );
         Config tuningConfiguration = readConfiguration( arguments );
@@ -167,12 +166,11 @@ public class ConsistencyCheckTool
     private String usage()
     {
         return joinAsLines(
-                jarUsage( getClass(), "[-propowner] [-config <neo4j.conf>] [-v] <storedir>" ),
-                "WHERE:   -propowner          also check property owner consistency (more time consuming)",
-                "         -config <filename>  is the location of an optional properties file",
-                "                             containing tuning parameters for the consistency check",
-                "         -v                  produce execution output",
-                "         <storedir>          is the path to the store to check"
+                jarUsage( getClass(), " [-config <neo4j.conf>] [-v] <storedir>" ),
+                "WHERE:   -config <filename>  Is the location of an optional properties file",
+                "                             containing tuning parameters for the consistency check.",
+                "         -v                  Produce execution output.",
+                "         <storedir>          Is the path to the store to check."
         );
     }
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -52,16 +52,22 @@ public class ConsistencyCheckTool
 
     public static void main( String[] args ) throws IOException
     {
-        ConsistencyCheckTool tool = new ConsistencyCheckTool( new ConsistencyCheckService(),
-                new DefaultFileSystemAbstraction(), System.err );
         try
         {
-            tool.run( args );
+            runConsistencyCheckTool( args );
         }
         catch ( ToolFailureException e )
         {
             e.exitTool();
         }
+    }
+
+    public static ConsistencyCheckService.Result runConsistencyCheckTool( String[] args )
+            throws ToolFailureException, IOException
+    {
+        ConsistencyCheckTool tool = new ConsistencyCheckTool( new ConsistencyCheckService(),
+                new DefaultFileSystemAbstraction(), System.err );
+        return tool.run( args );
     }
 
     private final ConsistencyCheckService consistencyCheckService;
@@ -76,7 +82,7 @@ public class ConsistencyCheckTool
         this.systemError = systemError;
     }
 
-    void run( String... args ) throws ToolFailureException, IOException
+    ConsistencyCheckService.Result run( String... args ) throws ToolFailureException, IOException
     {
         Args arguments = Args.withFlags( PROP_OWNER, VERBOSE ).parse( args );
 
@@ -89,7 +95,7 @@ public class ConsistencyCheckTool
         LogProvider logProvider = FormattedLogProvider.toOutputStream( System.out );
         try
         {
-            consistencyCheckService.runFullConsistencyCheck( storeDir, tuningConfiguration,
+            return consistencyCheckService.runFullConsistencyCheck( storeDir, tuningConfiguration,
                     ProgressMonitorFactory.textual( System.err ), logProvider, fs, verbose );
         }
         catch ( ConsistencyCheckIncompleteException e )
@@ -103,18 +109,16 @@ public class ConsistencyCheckTool
         return arguments.getBoolean( VERBOSE, false, true );
     }
 
-    private void checkDbState( File storeDir, Config tuningConfiguration )
+    private void checkDbState( File storeDir, Config tuningConfiguration ) throws ToolFailureException
     {
         try ( PageCache pageCache = StandalonePageCacheFactory.createPageCache( fs, tuningConfiguration ) )
         {
             if ( new RecoveryRequiredChecker( fs, pageCache ).isRecoveryRequiredAt( storeDir ) )
             {
-                systemError.print( Strings.joinAsLines(
+                throw new ToolFailureException( Strings.joinAsLines(
                         "Active logical log detected, this might be a source of inconsistencies.",
                         "Please recover database before running the consistency check.",
                         "To perform recovery please start database and perform clean shutdown." ) );
-
-                exit();
             }
         }
         catch ( IOException e )
@@ -172,7 +176,7 @@ public class ConsistencyCheckTool
         );
     }
 
-    class ToolFailureException extends Exception
+    static class ToolFailureException extends Exception
     {
         ToolFailureException( String message )
         {
@@ -186,13 +190,17 @@ public class ConsistencyCheckTool
 
         void exitTool()
         {
+            printMessage();
+            exit();
+        }
+
+        void printMessage()
+        {
             System.err.println( getMessage() );
             if ( getCause() != null )
             {
                 getCause().printStackTrace( System.err );
             }
-
-            exit();
         }
     }
 

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
@@ -39,7 +39,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.test.EphemeralFileSystemRule;
-import org.neo4j.test.SystemExitRule;
 import org.neo4j.test.TargetDirectory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -60,12 +59,11 @@ import static org.neo4j.test.EphemeralFileSystemRule.shutdownDbAction;
 
 public class ConsistencyCheckToolTest
 {
-    private SystemExitRule systemExitRule = SystemExitRule.none();
     private TargetDirectory.TestDirectory storeDirectory = TargetDirectory.testDirForTest( getClass() );
     private EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
 
     @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( systemExitRule ).around( storeDirectory ).around( fs );
+    public RuleChain ruleChain = RuleChain.outerRule( storeDirectory ).around( fs );
 
     @Test
     public void runsConsistencyCheck() throws Exception
@@ -176,10 +174,9 @@ public class ConsistencyCheckToolTest
         verifyZeroInteractions( service );
     }
 
-    @Test
+    @Test( expected = ToolFailureException.class )
     public void failWhenStoreWasNonCleanlyShutdown() throws Exception
     {
-        systemExitRule.expectExit( 1 );
         createGraphDbAndKillIt();
 
         runConsistencyCheckToolWith( fs.get(), storeDirectory.graphDbDir().getAbsolutePath() );


### PR DESCRIPTION
Makes it easier to use the tool, as opposed to the service, from integration tests.
