### PR TITLE
Hides stack traces from InputException errors in import tool

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -61,6 +61,7 @@ import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.DuplicateInputIdException;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Input;
+import org.neo4j.unsafe.impl.batchimport.input.InputException;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.input.MissingRelationshipDataException;
@@ -552,6 +553,10 @@ public class ImportTool
                                Options.MULTILINE_FIELDS.argument() + "=false. If you know that your input data " +
                                "include fields containing new-line characters then import with this option set to " +
                                "true.", e, stackTrace );
+        }
+        else if ( Exceptions.contains( e, InputException.class ) )
+        {
+            printErrorMessage( "Error in input data", e, stackTrace );
         }
         // Fallback to printing generic error and stack trace
         else

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -22,7 +22,6 @@ package org.neo4j.tooling;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -578,7 +577,7 @@ public class ImportToolTest
         int extraColumns = 3;
         try
         {
-            executeImportAndCatchOutput(
+            importTool(
                     "--into", dbRule.getStoreDirAbsolutePath(),
                     "--delimiter", "TAB",
                     "--array-delimiter", String.valueOf( config.arrayDelimiter() ),
@@ -593,6 +592,7 @@ public class ImportToolTest
         catch ( InputException e )
         {
             // THEN
+            assertFalse( suppressOutput.getErrorVoice().containsMessage( e.getClass().getName() ) );
             assertTrue( e.getMessage().contains( "Extra column not present in header on line" ) );
         }
     }
@@ -607,7 +607,7 @@ public class ImportToolTest
 
         // WHEN data file contains more columns than header file
         int extraColumns = 3;
-        executeImportAndCatchOutput(
+        importTool(
                 "--into", dbRule.getStoreDirAbsolutePath(),
                 "--bad", bad.getAbsolutePath(),
                 "--bad-tolerance", Integer.toString( nodeIds.size() * extraColumns ),
@@ -1567,6 +1567,34 @@ public class ImportToolTest
         assertEquals( stringBlockSize + BLOCK_HEADER_SIZE, stores.getPropertyStore().getStringBlockSize() );
     }
 
+    @Test
+    public void shouldPrintStackTraceOnInputExceptionIfToldTo() throws Exception
+    {
+        // GIVEN
+        List<String> nodeIds = nodeIds();
+        Configuration config = Configuration.TABS;
+
+        // WHEN data file contains more columns than header file
+        int extraColumns = 3;
+        try
+        {
+            importTool(
+                    "--into", dbRule.getStoreDirAbsolutePath(),
+                    "--nodes", nodeHeader( config ).getAbsolutePath() + MULTI_FILE_DELIMITER +
+                            nodeData( false, config, nodeIds, alwaysTrue(), Charset.defaultCharset(), extraColumns )
+                                    .getAbsolutePath(),
+                    "--stacktrace" );
+
+            fail( "Should have thrown exception" );
+        }
+        catch ( InputException e )
+        {
+            // THEN
+            assertTrue( suppressOutput.getErrorVoice().containsMessage( e.getClass().getName() ) );
+            assertTrue( e.getMessage().contains( "Extra column not present in header on line" ) );
+        }
+    }
+
     private File writeArrayCsv( String[] headers, String[] values ) throws FileNotFoundException
     {
         File data = file( fileName( "whitespace.csv" ) );
@@ -2046,22 +2074,5 @@ public class ImportToolTest
     public static void importTool( String... arguments ) throws IOException
     {
         ImportTool.main( arguments, true );
-    }
-
-    private String executeImportAndCatchOutput(String... arguments) throws IOException
-    {
-        PrintStream originalStream = System.out;
-        ByteArrayOutputStream outputStreamBuffer = new ByteArrayOutputStream();
-        PrintStream replacement = new PrintStream( outputStreamBuffer );
-        System.setOut( replacement );
-        try
-        {
-            importTool( arguments );
-            return new String( outputStreamBuffer.toByteArray() );
-        }
-        finally
-        {
-            System.setOut( originalStream );
-        }
     }
 }


### PR DESCRIPTION
because they are common and expected when input data contains
invalid data. Stack traces for these exceptions, which aren't
necessarily very informant can still be turned on using
the --stacktrace argument.

CHANGELOG: [tools] Errors related to input data will not print stack trace unless supplying --stacktrace
