### PR TITLE
Set ulimit as part of startup so it also set respected on restart.

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
+++ b/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
@@ -54,6 +54,7 @@ SCRIPTNAME=/etc/init.d/$NAME-service
 
 do_start()
 {
+	do_ulimit
 	# Return
 	#   0 if daemon has been started
 	#   1 if daemon was already running
@@ -96,7 +97,6 @@ do_ulimit()
 case "$1" in
   start)
 	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
-	do_ulimit
 	do_start
 	case "$?" in
 		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;


### PR DESCRIPTION
changelog: [packaging] Fix: `NEO4J_ULIMIT_NOFILE` is now respected on Debian package service restart
