### PR TITLE
Improve tx tracking in checkpoint stress test

### DIFF
--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/Worker.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/Worker.java
@@ -58,7 +58,6 @@ class Worker implements Runnable
                     randomMutation.perform();
                 }
                 tx.success();
-                monitor.transactionCompleted();
             }
             catch ( DeadlockDetectedException ignore )
             {
@@ -69,6 +68,8 @@ class Worker implements Runnable
                 // ignore and go on
                 e.printStackTrace();
             }
+
+            monitor.transactionCompleted();
         }
         while ( !monitor.stop() );
 


### PR DESCRIPTION
Transaction is considered committed only after it is closed.
Throughput is measured in 'tx/s' instead of 'tx/ms' because this produces a more pleasant number.
All output goes to `System.out` so it is not mixed in the build log.
