### PR TITLE
Improve warmup in checkpoint stress test

### DIFF
--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
@@ -55,6 +55,8 @@ public class CheckPointingLogRotationStressTesting
     private static final String DEFAULT_PAGE_CACHE_MEMORY = "2g";
     private static final String DEFAULT_PAGE_SIZE = "8k";
 
+    private static final int CHECK_POINT_INTERVAL_SECONDS = 60;
+
     @Test
     public void shouldBehaveCorrectlyUnderStress() throws Throwable
     {
@@ -79,14 +81,16 @@ public class CheckPointingLogRotationStressTesting
         GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
                 .setConfig( GraphDatabaseSettings.pagecache_memory, pageCacheMemory )
                 .setConfig( GraphDatabaseSettings.mapped_memory_page_size, pageSize )
-                .setConfig( GraphDatabaseSettings.check_point_interval_time, "1m" )
+                .setConfig( GraphDatabaseSettings.check_point_interval_time, CHECK_POINT_INTERVAL_SECONDS + "s" )
                 .setConfig( GraphDatabaseFacadeFactory.Configuration.tracer, "timer" )
                 .newGraphDatabase();
 
         System.out.println("3/6\tWarm up db...");
         try ( Workload workload = new Workload( db, defaultRandomMutation( nodeCount, db ), threads ) )
         {
-            workload.run( TimeUnit.SECONDS.toMillis( 30 ), Workload.TransactionThroughput.NONE );
+            // make sure to run at least one checkpoint during warmup
+            long warmUpTimeMillis = TimeUnit.SECONDS.toMillis( CHECK_POINT_INTERVAL_SECONDS + 30 );
+            workload.run( warmUpTimeMillis, Workload.TransactionThroughput.NONE );
         }
 
         System.out.println( "4/6\tStarting workload..." );


### PR DESCRIPTION
Previously no checkpoints occurred during warmup because it lasted not long enough. This PR makes warmup 30 seconds longer than the specified checkpoint interval.
