### PR TITLE
Allow Debian package users to configure shutdown parameters via defaults

### DIFF
--- a/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
+++ b/packaging/installer-linux/installer-debian/src/main/resources/common/neo4j-service
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 ### BEGIN INIT INFO
 # Provides:          neo4j
@@ -73,11 +73,16 @@ do_stop()
 	#   1 if daemon was already stopped
 	#   2 if daemon could not be stopped
 	#   other if a failure occurred
-	start-stop-daemon --chuid ${NEO_USER} --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+	: ${NEO4J_SHUTDOWN_TIMEOUT:=30}
+	: ${NEO4J_SHUTDOWN_KILL:="true"}
+	shutdown_verb="KILL"
+	[ "$NEO4J_SHUTDOWN_KILL" != "true" ] && shutdown_verb="TERM"
+
+	start-stop-daemon --chuid ${NEO_USER} --stop --quiet --retry=TERM/${NEO4J_SHUTDOWN_TIMEOUT}/${shutdown_verb}/5 --pidfile $PIDFILE
 	RETVAL="$?"
 	[ "$RETVAL" = 2 ] && return 2
 
-	start-stop-daemon --chuid ${NEO_USER} --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	start-stop-daemon --chuid ${NEO_USER} --stop --quiet --oknodo --retry=0/${NEO4J_SHUTDOWN_TIMEOUT}/${shutdown_verb}/5 --exec $DAEMON
 	[ "$?" = 2 ] && return 2
 	# Many daemons don't delete their pidfiles when they exit.
 	rm -f $PIDFILE


### PR DESCRIPTION
changelog: [2.2, 2.3, packaging]
