### PR TITLE
core-edge: batch append to segmented log

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/InMemoryRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/InMemoryRaftLog.java
@@ -36,7 +36,17 @@ public class InMemoryRaftLog implements RaftLog
     private long term = -1;
 
     @Override
-    public synchronized long append( RaftLogEntry logEntry ) throws IOException
+    public synchronized long append( RaftLogEntry... entries ) throws IOException
+    {
+        long newAppendIndex = appendIndex;
+        for ( RaftLogEntry entry : entries )
+        {
+            newAppendIndex = appendSingle( entry );
+        }
+        return newAppendIndex;
+    }
+
+    private synchronized long appendSingle( RaftLogEntry logEntry ) throws IOException
     {
         Objects.requireNonNull( logEntry );
         if ( logEntry.term() >= term )

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/MonitoredRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/MonitoredRaftLog.java
@@ -36,9 +36,9 @@ public class MonitoredRaftLog implements RaftLog
     }
 
     @Override
-    public long append( RaftLogEntry entry ) throws IOException
+    public long append( RaftLogEntry... entries ) throws IOException
     {
-        long appendIndex = delegate.append( entry );
+        long appendIndex = delegate.append( entries );
         appendIndexMonitor.appendIndex( appendIndex );
         return appendIndex;
     }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/RaftLog.java
@@ -40,7 +40,7 @@ public interface RaftLog extends ReadableRaftLog
      * @param entry The log entry.
      * @return the index at which the entry was appended.
      */
-    long append( RaftLogEntry entry ) throws IOException;
+    long append( RaftLogEntry... entry ) throws IOException;
 
     /**
      * Truncates the log starting from the supplied index. Committed

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/naive/NaiveDurableRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/naive/NaiveDurableRaftLog.java
@@ -157,7 +157,17 @@ public class NaiveDurableRaftLog extends LifecycleAdapter implements RaftLog
     }
 
     @Override
-    public long append( RaftLogEntry logEntry ) throws IOException
+    public synchronized long append( RaftLogEntry... entries ) throws IOException
+    {
+        long newAppendIndex = appendIndex;
+        for ( RaftLogEntry entry : entries )
+        {
+            newAppendIndex = appendSingle( entry );
+        }
+        return newAppendIndex;
+    }
+
+    private long appendSingle( RaftLogEntry logEntry ) throws IOException
     {
         if ( logEntry.term() >= term )
         {

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/physical/PhysicalRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/physical/PhysicalRaftLog.java
@@ -134,7 +134,17 @@ public class PhysicalRaftLog implements RaftLog, Lifecycle
     }
 
     @Override
-    public long append( RaftLogEntry entry ) throws IOException
+    public synchronized long append( RaftLogEntry... entries ) throws IOException
+    {
+        long newAppendIndex = appendIndex.get();
+        for ( RaftLogEntry entry : entries )
+        {
+            newAppendIndex = appendSingle( entry );
+        }
+        return newAppendIndex;
+    }
+
+    private long appendSingle( RaftLogEntry entry ) throws IOException
     {
         if ( entry.term() >= term )
         {

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentFile.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentFile.java
@@ -206,7 +206,6 @@ class SegmentFile implements AutoCloseable
     public void write( long logIndex, RaftLogEntry entry ) throws IOException
     {
         EntryRecord.write( getOrCreateWriter(), contentMarshal, logIndex, entry.term(), entry.content() );
-        flush();
     }
 
     void flush() throws IOException

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentedRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentedRaftLog.java
@@ -104,15 +104,20 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
     }
 
     @Override
-    public synchronized long append( RaftLogEntry entry ) throws IOException
+    public synchronized long append( RaftLogEntry... entries ) throws IOException
     {
         ensureOk();
-        updateTerm( entry );
-        state.appendIndex++;
 
         try
         {
-            state.segments.last().write( state.appendIndex, entry );
+            for ( RaftLogEntry entry : entries )
+            {
+                state.appendIndex++;
+                updateTerm( entry );
+                state.segments.last().write( state.appendIndex, entry );
+                cacheEntry( entry );
+            }
+            state.segments.last().flush();
         }
         catch ( Throwable e )
         {
@@ -123,11 +128,6 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
         if ( state.segments.last().position() >= rotateAtSize )
         {
             rotateSegment( state.appendIndex, state.appendIndex, state.currentTerm );
-        }
-
-        if ( entryCache != null )
-        {
-            entryCache.put( state.appendIndex, entry );
         }
 
         return state.appendIndex;
@@ -164,10 +164,7 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
                     state.appendIndex );
         }
 
-        if ( entryCache != null )
-        {
-            entryCache.clear();
-        }
+        invalidateCache();
 
         long newAppendIndex = fromIndex - 1;
         long newTerm = readEntryTerm( newAppendIndex );
@@ -231,7 +228,7 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
 
     private RaftLogEntry readLogEntry( long logIndex ) throws IOException
     {
-        RaftLogEntry entry = entryCache != null ? entryCache.get( logIndex ) : null;
+        RaftLogEntry entry = getFromCache( logIndex );
         if ( entry != null )
         {
             return entry;
@@ -268,5 +265,26 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
         state.prevIndex = oldestNotDisposed.header().prevIndex();
         state.prevTerm = oldestNotDisposed.header().prevTerm();
         return state.prevIndex;
+    }
+
+    private void cacheEntry( RaftLogEntry entry )
+    {
+        if( entryCache != null )
+        {
+            entryCache.put( state.appendIndex, entry );
+        }
+    }
+
+    private RaftLogEntry getFromCache( long logIndex )
+    {
+        return entryCache != null ? entryCache.get( logIndex ) : null;
+    }
+
+    private void invalidateCache()
+    {
+        if ( entryCache != null )
+        {
+            entryCache.clear();
+        }
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/BatchAppendLogEntries.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/outcome/BatchAppendLogEntries.java
@@ -50,10 +50,7 @@ public class BatchAppendLogEntries implements LogCommand
             throw new IllegalStateException( "Attempted to append over an existing entry starting at index " + lastIndex );
         }
 
-        for ( int i = offset; i < entries.length; i++ )
-        {
-            raftLog.append( entries[i] );
-        }
+        raftLog.append( Arrays.copyOfRange( entries, offset, entries.length ) );
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/CoreEdgeClusterSettings.java
@@ -94,12 +94,14 @@ public class CoreEdgeClusterSettings
             setting( "core_edge.log_shipping_max_lag", INTEGER, "256" );
 
     @Description("Size of the RAFT in queue")
+    @Internal
     public static final Setting<Integer> raft_in_queue_size =
             setting( "core_edge.raft_in_queue_size", INTEGER, "64" );
 
     @Description("Largest batch processed by RAFT")
+    @Internal
     public static final Setting<Integer> raft_in_queue_max_batch =
-            setting( "core_edge.raft_in_queue_max_batch", INTEGER, "16" );
+            setting( "core_edge.raft_in_queue_max_batch", INTEGER, "64" );
 
     @Description("Time out for a token to be replicated")
     public static final Setting<Long> token_creation_timeout =

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/RaftInstanceTest.java
@@ -490,7 +490,7 @@ public class RaftInstanceTest
         private boolean startExploding = false;
 
         @Override
-        public long append( RaftLogEntry entry ) throws IOException
+        public long append( RaftLogEntry... entries ) throws IOException
         {
             if ( startExploding )
             {

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftInstanceLogTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftInstanceLogTest.java
@@ -205,12 +205,11 @@ public class RaftInstanceLogTest
         // when instance A as leader
         ReplicatedInteger newData = valueOf( 99 );
 
-        // Will not match as the entry at index 5 has term  2
         raft.handle( appendEntriesRequest().leaderTerm( 8 ).prevLogIndex( -1 ).prevLogTerm( -1 )
                 .logEntry( new RaftLogEntry( 1, newData ) )
                 .logEntry( new RaftLogEntry( 1, newData ) )
                 .logEntry( new RaftLogEntry( 1, newData ) )
-                .logEntry( new RaftLogEntry( 4, newData ) )
+                .logEntry( new RaftLogEntry( 4, newData ) ) // term mismatch - existing term is 2
                 .logEntry( new RaftLogEntry( 4, newData ) )
                 .logEntry( new RaftLogEntry( 5, newData ) )
                 .logEntry( new RaftLogEntry( 5, newData ) )

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogContractTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/RaftLogContractTest.java
@@ -58,9 +58,10 @@ public abstract class RaftLogContractTest
     {
         // given
         RaftLog log = createRaftLog();
-        log.append( new RaftLogEntry( 45, valueOf( 99 ) ) );
-        log.append( new RaftLogEntry( 46, valueOf( 99 ) ) );
-        log.append( new RaftLogEntry( 47, valueOf( 99 ) ) );
+        log.append(
+                new RaftLogEntry( 45, valueOf( 99 ) ),
+                new RaftLogEntry( 46, valueOf( 99 ) ),
+                new RaftLogEntry( 47, valueOf( 99 ) ) );
 
         // truncate the last 2
         log.truncate( 1 );
@@ -92,8 +93,7 @@ public abstract class RaftLogContractTest
         RaftLogEntry logEntryA = new RaftLogEntry( 1, valueOf( 1 ) );
         RaftLogEntry logEntryB = new RaftLogEntry( 1, valueOf( 2 ) );
 
-        log.append( logEntryA );
-        log.append( logEntryB );
+        log.append( logEntryA, logEntryB );
 
         assertThat( log.appendIndex(), is( 1L ) );
 
@@ -113,14 +113,11 @@ public abstract class RaftLogContractTest
         RaftLogEntry logEntryD = new RaftLogEntry( 1, valueOf( 4 ) );
         RaftLogEntry logEntryE = new RaftLogEntry( 1, valueOf( 5 ) );
 
-        log.append( logEntryA );
-        log.append( logEntryB );
-        log.append( logEntryC );
+        log.append( logEntryA, logEntryB, logEntryC );
 
         log.truncate( 1 );
 
-        log.append( logEntryD );
-        log.append( logEntryE );
+        log.append( logEntryD, logEntryE );
 
         assertThat( log.appendIndex(), is( 2L ) );
         assertThat( readLogEntry( log, 0 ), equalTo( logEntryA ) );
@@ -137,8 +134,7 @@ public abstract class RaftLogContractTest
         RaftLogEntry logEntryA = new RaftLogEntry( 1, valueOf( 1 ) );
         RaftLogEntry logEntryB = new RaftLogEntry( 1, valueOf( 2 ) );
 
-        log.append( logEntryA );
-        log.append( logEntryB );
+        log.append( logEntryA, logEntryB );
 
         try
         {
@@ -166,8 +162,7 @@ public abstract class RaftLogContractTest
         RaftLogEntry logEntryA = new RaftLogEntry( 1, valueOf( 1 ) );
         RaftLogEntry logEntryB = new RaftLogEntry( 1, ReplicatedString.valueOf( "hejzxcjkzhxcjkxz" ) );
 
-        log.append( logEntryA );
-        log.append( logEntryB );
+        log.append( logEntryA, logEntryB );
 
         assertThat( log.appendIndex(), is( 1L ) );
 
@@ -180,8 +175,9 @@ public abstract class RaftLogContractTest
     {
         // given
         RaftLog log = createRaftLog();
-        log.append( new RaftLogEntry( 0, valueOf( 1 ) ) );
-        log.append( new RaftLogEntry( 1, valueOf( 2 ) ) );
+        log.append(
+                new RaftLogEntry( 0, valueOf( 1 ) ),
+                new RaftLogEntry( 1, valueOf( 2 ) ) );
 
         try
         {

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/VerifyingRaftLog.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/VerifyingRaftLog.java
@@ -42,10 +42,10 @@ class VerifyingRaftLog implements RaftLog
     }
 
     @Override
-    public long append( RaftLogEntry entry ) throws IOException
+    public long append( RaftLogEntry... entries ) throws IOException
     {
-        long appendIndex = expected.append( entry );
-        assertEquals( appendIndex, other.append( entry ) );
+        long appendIndex = expected.append( entries );
+        assertEquals( appendIndex, other.append( entries ) );
         return appendIndex;
     }
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/SegmentFileTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/log/segmented/SegmentFileTest.java
@@ -77,6 +77,7 @@ public class SegmentFileTest
         {
             // given
             segment.write( 0, entry1 );
+            segment.flush();
 
             // when
             IOCursor<EntryRecord> reader = segment.getReader( 0 );
@@ -97,6 +98,7 @@ public class SegmentFileTest
             segment.write( 1, entry2 );
             segment.write( 2, entry3 );
             segment.write( 3, entry4 );
+            segment.flush();
 
             // when
             IOCursor<EntryRecord> reader = segment.getReader( 2 );
@@ -116,6 +118,7 @@ public class SegmentFileTest
             segment.write( 0, entry1 );
             segment.write( 1, entry2 );
             segment.write( 2, entry3 );
+            segment.flush();
 
             for ( int i = 0; i < 3; i++ )
             {
@@ -161,6 +164,7 @@ public class SegmentFileTest
             // given
             Runnable onDisposeHandler = mock( Runnable.class );
             segment.write( 0, entry1 );
+            segment.flush();
 
             // when
             segment.markForDisposal( onDisposeHandler );
@@ -216,6 +220,7 @@ public class SegmentFileTest
             IOCursor<EntryRecord> reader2 = segment.getReader( 1 );
 
             segment.write( 0, entry1 );
+            segment.flush();
 
             // when
             segment.markForDisposal( onDisposeHandler );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/outcome/BatchAppendLogEntriesTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/outcome/BatchAppendLogEntriesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.outcome;
+
+import org.junit.Test;
+
+import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.coreedge.raft.ReplicatedInteger.valueOf;
+import static org.neo4j.coreedge.raft.log.RaftLogHelper.readLogEntry;
+
+public class BatchAppendLogEntriesTest
+{
+    private RaftLogEntry entryA = new RaftLogEntry( 0, valueOf( 100 ) );
+    private RaftLogEntry entryB = new RaftLogEntry( 1, valueOf( 200 ) );
+    private RaftLogEntry entryC = new RaftLogEntry( 2, valueOf( 300 ) );
+    private RaftLogEntry entryD = new RaftLogEntry( 3, valueOf( 400 ) );
+
+    @Test
+    public void shouldApplyMultipleEntries() throws Exception
+    {
+        // given
+        InMemoryRaftLog log = new InMemoryRaftLog();
+        BatchAppendLogEntries batchAppendLogEntries =
+                new BatchAppendLogEntries( 0, 0, new RaftLogEntry[]{entryA, entryB, entryC} );
+
+        // when
+        batchAppendLogEntries.applyTo( log );
+
+        // then
+        assertEquals( entryA, readLogEntry( log, 0 ) );
+        assertEquals( entryB, readLogEntry( log, 1 ) );
+        assertEquals( entryC, readLogEntry( log, 2 ) );
+        assertEquals( 2, log.appendIndex() );
+    }
+
+    @Test
+    public void shouldApplyFromOffsetOnly() throws Exception
+    {
+        // given
+        InMemoryRaftLog log = new InMemoryRaftLog();
+        BatchAppendLogEntries batchAppendLogEntries =
+                new BatchAppendLogEntries( 0, 2, new RaftLogEntry[]{entryA, entryB, entryC, entryD} );
+
+        // when
+        batchAppendLogEntries.applyTo( log );
+
+        // then
+        assertEquals( entryC, readLogEntry( log, 0 ) );
+        assertEquals( entryD, readLogEntry( log, 1 ) );
+        assertEquals( 1, log.appendIndex() );
+    }
+}


### PR DESCRIPTION
The interface of RaftLog is updated to handle an array of entries and
the BatchAppendLogEntries command is updated to utilize it.

Only the segmented log is actually updated to take advantage of it. The
other log implementations can easily be adapted later if required.

The contract test has been updated to utilize a single append call
with several entries where applicable.

The in-queue and max-batch of the RAFT were also both marked internal
and fixed at 64. They are still configurable but it seems likely
unnecessary in most all cases to do it, so no need to clutter the
interface with it.
