### PR TITLE
Fix neo4j-import on Windows with multiple files

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jImport.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Invoke-Neo4jImport.ps1
@@ -50,6 +50,14 @@ Function Invoke-Neo4jImport
   
   Process
   {
+    # The powershell command line interpeter converts comma delimited strings into a System.Object[] array
+    # Search the CommandArgs array and convert anything that's System.Object[] back to a string type
+    for($index = 0; $index -lt $CommandArgs.Length; $index++) {
+      if ($CommandArgs[$index].GetType().ToString() -eq 'System.Object[]') {
+        [string]$CommandArgs[$index] = $CommandArgs[$index] -join ',' 
+      }
+    }
+
     try {
       Return [int](Invoke-Neo4jUtility -Command 'Import' -CommandArgs $CommandArgs -ErrorAction 'Stop')      
     }

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Invoke-Neo4jImport.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Invoke-Neo4jImport.Tests.ps1
@@ -1,0 +1,66 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+$common = Join-Path (Split-Path -Parent $here) 'Common.ps1'
+. $common
+
+Import-Module "$src\Neo4j-Management.psm1"
+
+InModuleScope Neo4j-Management {  
+  Describe "Invoke-Neo4jImport" {
+
+    Context "Nodes and Relationships as comma delimited list" {
+      # Commands from the command line come through as System.Object[]
+      # These commands can be simulated through crafting an appropriate array
+      
+      # neo4j-import --into c:\graphdb --nodes "file1,file2" -relationships "file3,file4"
+      $testCommand = @('--into','C:\graph\db','--nodes', @('file1','file2'),'--relationships', @('file3','file4'))
+
+      Mock Invoke-Neo4jUtility { return 2 }
+      Mock Invoke-Neo4jUtility -Verifiable { return 0} -ParameterFilter {
+        $Command -eq 'Import' `
+        -and $CommandArgs[0] -eq '--into' `
+        -and $CommandArgs[1] -eq 'C:\graph\db' `
+        -and $CommandArgs[2] -eq '--nodes' `
+        -and $CommandArgs[3] -eq 'file1,file2' `
+        -and $CommandArgs[4] -eq '--relationships' `
+        -and $CommandArgs[5] -eq 'file3,file4'
+      }
+
+      $result = Invoke-Neo4jImport -CommandArgs $testCommand
+      It "Should return exit code 0" {
+        $result | Should Be 0
+      }
+
+      It "Should call verified mocks" {
+        Assert-VerifiableMocks
+      }
+    }
+
+    Context "Nodes as a single file" {
+      # Commands from the command line come through as System.Object[]
+      # These commands can be simulated through crafting an appropriate array
+
+      # neo4j-import --into c:\graphdb --nodes singlefile
+      $testCommand = @('--into','C:\graph\db','--nodes', 'singlefile')
+
+      Mock Invoke-Neo4jUtility { return 2 }
+      Mock Invoke-Neo4jUtility -Verifiable { return 0} -ParameterFilter {
+        $Command -eq 'Import' `
+        -and $CommandArgs[0] -eq '--into' `
+        -and $CommandArgs[1] -eq 'C:\graph\db' `
+        -and $CommandArgs[2] -eq '--nodes' `
+        -and $CommandArgs[3] -eq 'singlefile'
+      }
+
+      $result = Invoke-Neo4jImport -CommandArgs $testCommand
+      It "Should return exit code 0" {
+        $result | Should Be 0
+      }
+
+      It "Should call verified mocks" {
+        Assert-VerifiableMocks
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
The Powershell command line interpreter was interpolating command
delimited strings as an arrays. However their type was System.Object[]
which caused a later type conversion issue in Start-Process.  This
commit parses the incoming arguments from the user and then converts
them back into comma delimited strings.  This is only implemented for
the neo4j-import utility.

This commit also adds unit tests for these scenarios

http://stackoverflow.com/questions/37544375/neo4j-import-multiple-file-import-on-windows

fixes: #7307 

changelog: Fixed an argument parsing bug in neo4j-import when multiple csv-files were specified on Windows
