### PR TITLE
Mark EqualsAcceptanceTest as ported to the TCK

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/ReturnAcceptanceTest.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
+import org.neo4j.cypher._
 import org.neo4j.cypher.internal.compiler.v3_1.commands.expressions.PathImpl
 import org.neo4j.cypher.internal.compiler.v3_1.test_helpers.CustomMatchers
-import org.neo4j.cypher.{EntityNotFoundException, ExecutionEngineFunSuite, NewPlannerTestSupport, SyntaxException}
 import org.neo4j.graphdb._
 
 import scala.util.Random
@@ -98,7 +98,7 @@ order by a.age""").toList)
     createNode()
     createNode()
 
-    intercept[SyntaxException](executeWithAllPlannersAndCompatibilityMode("match (n) where id(n) in [0,1] return n order by n").toList)
+    intercept[IncomparableValuesException](executeWithAllPlannersAndCompatibilityMode("match (n) where id(n) in [0,1] return n order by n").toList)
   }
 
   // EXCEPTION EXPECTED ABOVE THIS ROW

--- a/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
+++ b/community/cypher/compatibility-suite/src/test/scala/cypher/feature/steps/CypherTCKSteps.scala
@@ -41,6 +41,7 @@ class CypherTCKSteps extends FunSuiteLike with Matchers with TCKCucumberTemplate
   val requiredScenarioName = FeatureSuiteTest.SCENARIO_NAME_REQUIRED.trim.toLowerCase
 
   val unsupportedScenarios = Set("Fail when adding new label predicate on already bound node 5",
+                                 "Fail when trying to compare strings and numbers",
                                  "`toInt()` handling `Any` type",
                                  "`toInt()` failing on invalid arguments",
                                  "`toFloat()` handling `Any` type",

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/CypherException.scala
@@ -136,7 +136,7 @@ class ArithmeticException(message: String, cause: Throwable) extends CypherExcep
 }
 
 class IncomparableValuesException(lhs: String, rhs: String, cause: Throwable)
-  extends SyntaxException(s"Don't know how to compare that. Left: ${lhs}; Right: ${rhs}", cause) {
+  extends CypherTypeException(s"Don't know how to compare that. Left: $lhs; Right: $rhs", cause) {
   def this(lhs: String, rhs: String) = this(lhs, rhs, null)
 }
 


### PR DESCRIPTION
- Fix a bug where `IncomparableValues` was a `SyntaxException`; is now a `TypeException`
- Move test to acceptance module

Pending https://github.com/opencypher/openCypher/pull/81
