### PR TITLE
Fix startup failure logging in NeoStoreDataSource

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -183,7 +183,6 @@ import org.neo4j.unsafe.batchinsert.LabelScanWriter;
 import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.neo4j.helpers.collection.Iterables.toList;
 import static org.neo4j.kernel.impl.transaction.log.pruning.LogPruneStrategyFactory.fromConfigValue;
 
@@ -597,15 +596,14 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
         catch ( Throwable e )
         {
             // Something unexpected happened during startup
-            msgLog.warn( "Exception occurred while setting up store modules. Attempting to close things down.",
-                    e, true );
+            msgLog.warn( "Exception occurred while setting up store modules. Attempting to close things down.", e );
             try
             { // Close the neostore, so that locks are released properly
                 neoStoreModule.neoStores().close();
             }
             catch ( Exception closeException )
             {
-                msgLog.error( "Couldn't close neostore after startup failure" );
+                msgLog.error( "Couldn't close neostore after startup failure", closeException );
             }
             throw Exceptions.launderedException( e );
         }
@@ -617,15 +615,14 @@ public class NeoStoreDataSource implements NeoStoresSupplier, Lifecycle, IndexPr
         catch ( Throwable e )
         {
             // Something unexpected happened during startup
-            msgLog.warn( "Exception occurred while starting the datasource. Attempting to close things down.",
-                    e, true );
+            msgLog.warn( "Exception occurred while starting the datasource. Attempting to close things down.", e );
             try
             { // Close the neostore, so that locks are released properly
                 neoStoreModule.neoStores().close();
             }
             catch ( Exception closeException )
             {
-                msgLog.error( "Couldn't close neostore after startup failure" );
+                msgLog.error( "Couldn't close neostore after startup failure", closeException );
             }
             throw Exceptions.launderedException( e );
         }

--- a/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/NeoStoreDataSourceRule.java
@@ -28,6 +28,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.IdGeneratorFactory;
 import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.TransactionEventHandlers;
@@ -55,6 +56,7 @@ import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
+import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLog;
 import org.neo4j.logging.NullLogProvider;
 
@@ -68,24 +70,29 @@ public class NeoStoreDataSourceRule extends ExternalResource
     private NeoStoreDataSource dataSource;
 
     public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
-                                             PageCache pageCache, Map<String, String> additionalConfig, KernelHealth kernelHealth )
+            PageCache pageCache, Map<String,String> additionalConfig, KernelHealth kernelHealth )
+    {
+        Config config = new Config( stringMap( additionalConfig ), GraphDatabaseSettings.class );
+        IdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
+        LogProvider log = NullLogProvider.getInstance();
+        StoreFactory storeFactory = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs, log );
+        return getDataSource( storeDir, fs, config, storeFactory, idGeneratorFactory, kernelHealth, log );
+    }
+
+    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs, Config config,
+            StoreFactory storeFactory, IdGeneratorFactory idGeneratorFactory, KernelHealth kernelHealth,
+            LogProvider logProvider )
     {
         if ( dataSource != null )
         {
             dataSource.stop();
             dataSource.shutdown();
         }
-        final Config config = new Config( stringMap( additionalConfig ),
-                GraphDatabaseSettings.class );
-
-        DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
-        StoreFactory sf = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs,
-                NullLogProvider.getInstance() );
 
         Locks locks = mock( Locks.class );
         when( locks.newClient() ).thenReturn( mock( Locks.Client.class ) );
 
-        dataSource = new NeoStoreDataSource( storeDir, config, sf, NullLogProvider.getInstance(),
+        dataSource = new NeoStoreDataSource( storeDir, config, storeFactory, logProvider,
                 mock( JobScheduler.class, RETURNS_MOCKS ), mock( TokenNameLookup.class ),
                 dependencyResolverForNoIndexProvider(), mock( PropertyKeyTokenHolder.class ),
                 mock( LabelTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ), locks,


### PR DESCRIPTION
This change makes `NeoStoreDataSource` log startup exceptions with stacktraces. It removes the third boolean argument from the log call. This argument meant 'flush now' with the previous logging framework (in < 2.3) but resulted in just the error message being printed with the new neo4j-logging.
