### PR TITLE
Setting to turn on tx termination aware locks

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -1077,8 +1077,8 @@ public class NeoStoreDataSource implements NeoStoreProvider, Lifecycle, IndexPro
                         neoStore, locks, integrityValidator, constraintIndexCreator, indexingService, labelScanStore,
                         statementOperations, updateableSchemaState, schemaWriteGuard, schemaIndexProviderMap,
                         transactionHeaderInformationFactory, persistenceCache, storeLayer, transactionCommitProcess,
-                        indexConfigStore,
-                        legacyIndexProviderLookup, hooks, transactionMonitor, life, tracers ) );
+                        indexConfigStore, legacyIndexProviderLookup, hooks, transactionMonitor, life, config,
+                        tracers ) );
 
         final Kernel kernel = new Kernel( kernelTransactions, hooks, kernelHealth, transactionMonitor );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -120,8 +120,6 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         }
     }
 
-    private static final boolean TX_TERMINATION_AWARE_LOCKS = Boolean.getBoolean( "tx_termination_aware_locks" );
-
     // Logic
     private final SchemaWriteGuard schemaWriteGuard;
     private final IndexingService indexService;
@@ -147,6 +145,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     private final TransactionToRecordStateVisitor txStateToRecordStateVisitor = new TransactionToRecordStateVisitor();
     private final Collection<Command> extractedCommands = new ArrayCollection<>( 32 );
     private final Locks locksManager;
+    private final boolean txTerminationAwareLocks;
     private TransactionState txState;
     private LegacyIndexTransactionState legacyIndexTransactionState;
     private TransactionType transactionType = TransactionType.ANY;
@@ -185,7 +184,8 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                                             Pool<KernelTransactionImplementation> pool,
                                             Clock clock,
                                             TransactionTracer tracer,
-                                            NeoStoreTransactionContext context )
+                                            NeoStoreTransactionContext context,
+                                            boolean txTerminationAwareLocks )
     {
         this.operations = operations;
         this.schemaWriteGuard = schemaWriteGuard;
@@ -196,6 +196,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.providerMap = providerMap;
         this.schemaState = schemaState;
         this.locksManager = locks;
+        this.txTerminationAwareLocks = txTerminationAwareLocks;
         this.hooks = hooks;
         this.constraintIndexCreator = constraintIndexCreator;
         this.headerInformationFactory = headerInformationFactory;
@@ -252,7 +253,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         {
             failure = true;
             terminated = true;
-            if ( TX_TERMINATION_AWARE_LOCKS )
+            if ( txTerminationAwareLocks && locks != null )
             {
                 locks.markForTermination();
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -32,7 +32,6 @@ import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.store.PersistenceCache;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
-import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.NoOpLocks;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
@@ -66,6 +65,7 @@ public class KernelTransactionFactory
                 mock(Pool.class),
                 Clock.SYSTEM_CLOCK,
                 TransactionTracer.NULL,
-                mock( NeoStoreTransactionContext.class ) );
+                mock( NeoStoreTransactionContext.class ),
+                false );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionImplementationTest.java
@@ -40,9 +40,7 @@ import org.neo4j.kernel.impl.api.store.PersistenceCache;
 import org.neo4j.kernel.impl.api.store.StoreReadLayer;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.Locks;
-import org.neo4j.kernel.impl.locking.NoOpClient;
 import org.neo4j.kernel.impl.locking.NoOpLocks;
-import org.neo4j.kernel.impl.locking.community.CommunityLockManger;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
@@ -54,9 +52,9 @@ import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.test.DoubleLatch;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.doAnswer;
@@ -66,10 +64,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class KernelTransactionImplementationTest
 {
@@ -443,8 +438,8 @@ public class KernelTransactionImplementationTest
         KernelTransactionImplementation transaction = new KernelTransactionImplementation(
                 null, null, null, null, null, recordState, recordStateAccessor, null, neoStore,
                 locks, hooks, null, headerInformationFactory, commitProcess, transactionMonitor,
-                persistenceCache, storeReadLayer,
-                legacyIndexState, pool, clock, TransactionTracer.NULL, mock( NeoStoreTransactionContext.class ) );
+                persistenceCache, storeReadLayer, legacyIndexState, pool, clock, TransactionTracer.NULL,
+                mock( NeoStoreTransactionContext.class ), false );
         transaction.initialize( 0 );
         return transaction;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -26,11 +26,11 @@ import org.mockito.stubbing.Answer;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.locking.LockGroup;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.store.NeoStore;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
-import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
@@ -39,6 +39,7 @@ import org.neo4j.kernel.impl.transaction.state.NeoStoreTransactionContext;
 import org.neo4j.kernel.impl.transaction.state.NeoStoreTransactionContextSupplier;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess.RecordProxy;
+import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.util.StringLogger;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
@@ -136,7 +137,7 @@ public class KernelTransactionsTest
         return new KernelTransactions( contextSupplier, mock( NeoStore.class ), locks,
                 mock( IntegrityValidator.class ), null, null, null, null, null, null, null,
                 TransactionHeaderInformationFactory.DEFAULT, null, null, commitProcess, null,
-                null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
+                null, new TransactionHooks(), mock( TransactionMonitor.class ), life, new Config(),
                 new Tracers( "null", StringLogger.DEV_NULL ) );
     }
 


### PR DESCRIPTION
This commit changes system property to a setting because the later is more convenient to use.

**NOTE:** forward merge should be a null-merge
