### PR TITLE
Fix a bug in decoding of dynamic records in the standard format

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/DynamicRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/DynamicRecordFormat.java
@@ -89,6 +89,10 @@ public class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRe
 
             readData( record, cursor );
         }
+        else
+        {
+            record.setInUse( inUse );
+        }
     }
 
     public static String payloadTooBigErrorMessage( DynamicRecord record, int recordSize, int nrOfBytes )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/RecordFormatTest.java
@@ -58,8 +58,8 @@ public abstract class RecordFormatTest
     private static final int PAGE_SIZE = (int) kibiBytes( 1 );
 
     // Whoever is hit first
-    private static final long TEST_ITERATIONS = 40_000;
-    private static final long TEST_TIME = 500;
+    private static final long TEST_ITERATIONS = 1_000_000;
+    private static final long TEST_TIME = 1000;
     private static final long PRINT_RESULTS_THRESHOLD = SECONDS.toMillis( 1 );
     private static final int DATA_SIZE = 100;
     protected static final long NULL = Record.NULL_REFERENCE.intValue();


### PR DESCRIPTION
Same as 1d59c7e but this time in the standard format.
Also made the record format tests more aggressive.

Changelog: Fix very rare decoding bug with dynamic records, where unused records would temporarily appear to be in use and contain garbage data
