### PR TITLE
Addresses the problem of an HA instance being partitioned away from the cluster

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
@@ -51,13 +51,13 @@ public enum HeartbeatState
                     {
                         case addHeartbeatListener:
                         {
-                            context.addHeartbeatListener( (HeartbeatListener) message.getPayload() );
+                            context.addHeartbeatListener( message.getPayload() );
                             break;
                         }
 
                         case removeHeartbeatListener:
                         {
-                            context.removeHeartbeatListener( (HeartbeatListener) message.getPayload() );
+                            context.removeHeartbeatListener( message.getPayload() );
                             break;
                         }
 
@@ -71,7 +71,7 @@ public enum HeartbeatState
                                         timeout( HeartbeatMessage.timed_out, message, instanceId ) );
 
                                 // Send first heartbeat immediately
-                                outgoing.offer( timeout( HeartbeatMessage.sendHeartbeat, message, instanceId) );
+                                outgoing.offer( timeout( HeartbeatMessage.sendHeartbeat, message, instanceId ) );
                             }
 
                             return heartbeat;
@@ -97,7 +97,7 @@ public enum HeartbeatState
                         {
                             HeartbeatMessage.IAmAliveState state = message.getPayload();
 
-                            if (context.isMe( state.getServer() ) )
+                            if ( context.isMe( state.getServer() ) )
                             {
                                 break;
                             }
@@ -118,7 +118,8 @@ public enum HeartbeatState
                                         URI aliveServerUri =
                                                 context.getUriForId( aliveServer );
                                         outgoing.offer( Message.to( HeartbeatMessage.suspicions, aliveServerUri,
-                                                new HeartbeatMessage.SuspicionsState( context.getSuspicionsFor( context.getMyId() ) ) ) );
+                                                new HeartbeatMessage.SuspicionsState( context.getSuspicionsFor(
+                                                        context.getMyId() ) ) ) );
                                     }
                                 }
                             }
@@ -168,8 +169,7 @@ public enum HeartbeatState
                                 {
                                     if ( !aliveServer.equals( context.getMyId() ) )
                                     {
-                                        URI sendTo = context.getUriForId(
-                                                aliveServer );
+                                        URI sendTo = context.getUriForId( aliveServer );
                                         outgoing.offer( Message.to( HeartbeatMessage.suspicions, sendTo,
                                                 new HeartbeatMessage.SuspicionsState( context.getSuspicionsFor(
                                                         context.getMyId() ) ) ) );
@@ -188,7 +188,7 @@ public enum HeartbeatState
                         {
                             InstanceId to = message.getPayload();
 
-                            if (!context.isMe( to ) )
+                            if ( !context.isMe( to ) )
                             {
                                 // Check if this node is no longer a part of the cluster
                                 if ( context.getMembers().containsKey( to ) )
@@ -230,7 +230,8 @@ public enum HeartbeatState
                             context.getLog( HeartbeatState.class )
                                     .debug( "Received suspicions as " + suspicions );
 
-                            InstanceId fromId = new InstanceId(Integer.parseInt(message.getHeader( Message.INSTANCE_ID )));
+                            InstanceId fromId = new InstanceId(
+                                    Integer.parseInt( message.getHeader( Message.INSTANCE_ID ) ) );
 
                             /*
                              * Remove ourselves from the suspicions received - we just received a message,
@@ -251,13 +252,13 @@ public enum HeartbeatState
 
                         case addHeartbeatListener:
                         {
-                            context.addHeartbeatListener( (HeartbeatListener) message.getPayload() );
+                            context.addHeartbeatListener( message.getPayload() );
                             break;
                         }
 
                         case removeHeartbeatListener:
                         {
-                            context.removeHeartbeatListener( (HeartbeatListener) message.getPayload() );
+                            context.removeHeartbeatListener( message.getPayload() );
                             break;
                         }
                     }
@@ -266,7 +267,7 @@ public enum HeartbeatState
                 }
 
                 private void resetTimeout( HeartbeatContext context, Message<HeartbeatMessage> message,
-                        HeartbeatMessage.IAmAliveState state )
+                                           HeartbeatMessage.IAmAliveState state )
                 {
                     String key = HeartbeatMessage.i_am_alive + "-" + state.getServer();
                     Message<? extends MessageType> oldTimeout = context.cancelTimeout( key );
@@ -278,7 +279,7 @@ public enum HeartbeatState
                             long timeout = context.getTimeoutFor( oldTimeout );
                             context.getLog( HeartbeatState.class ).debug(
                                     "Received " + state + " after missing " + timeoutCount +
-                                    " (" + timeout * timeoutCount + "ms)" );
+                                            " (" + timeout * timeoutCount + "ms)" );
                         }
                     }
                     context.setTimeout( key, timeout( HeartbeatMessage.timed_out, message, state.getServer() ) );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterHeartbeatTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterHeartbeatTest.java
@@ -61,7 +61,7 @@ public class ClusterHeartbeatTest
                 down( 100, 3 ).
                 message( 1000, "*** Should have seen failure by now" ).
                 up( 0, 3 ).
-                message( 200, "*** Should have recovered by now" ).
+                message( 2000, "*** Should have recovered by now" ).
                 verifyConfigurations( "after recovery", 0 ).
                 leave( 200, 1 ).
                 leave( 200, 2 ).

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/InstanceIdTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/InstanceIdTest.java
@@ -44,10 +44,10 @@ public class InstanceIdTest
     {
         testCluster( new int[] { 1, 1 }, new VerifyInstanceConfiguration[]
                 {
-                new VerifyInstanceConfiguration( Collections.<URI>emptyList(), Collections.<String, InstanceId>emptyMap(),
-                                        Collections.<InstanceId>emptySet() ),
-                new VerifyInstanceConfiguration( Collections.<URI>emptyList(), Collections.<String, InstanceId>emptyMap(),
-                                        Collections.<InstanceId>emptySet() )
+                new VerifyInstanceConfiguration( Collections.emptyList(), Collections.emptyMap(),
+                        Collections.emptySet() ),
+                new VerifyInstanceConfiguration( Collections.emptyList(), Collections.emptyMap(),
+                        Collections.emptySet() )
                 },
                 DEFAULT_NETWORK(), new ClusterTestScriptDSL().
                 rounds( 600 ).
@@ -61,21 +61,21 @@ public class InstanceIdTest
     public void nodeTriesToJoinRunningClusterWithExistingServerId() throws InterruptedException, ExecutionException,
             TimeoutException, URISyntaxException
     {
-        List<URI> correctMembers = new ArrayList<URI>();
+        List<URI> correctMembers = new ArrayList<>();
         correctMembers.add( URI.create( "server1" ) );
         correctMembers.add( URI.create( "server2" ) );
         correctMembers.add( URI.create( "server3" ) );
 
-        Map<String, InstanceId> roles = new HashMap<String, InstanceId>();
+        Map<String, InstanceId> roles = new HashMap<>();
         roles.put( "coordinator", new InstanceId( 1 ) );
 
         testCluster( new int[] {1, 2, 3, 3},
                 new VerifyInstanceConfiguration[]{
-                new VerifyInstanceConfiguration( correctMembers, roles, Collections.<InstanceId>emptySet() ),
-                new VerifyInstanceConfiguration( correctMembers, roles, Collections.<InstanceId>emptySet() ),
-                new VerifyInstanceConfiguration( correctMembers, roles, Collections.<InstanceId>emptySet() ),
-                new VerifyInstanceConfiguration( Collections.<URI>emptyList(), Collections.<String, InstanceId>emptyMap(),
-                        Collections.<InstanceId>emptySet() )}, DEFAULT_NETWORK(), new ClusterTestScriptDSL().
+                new VerifyInstanceConfiguration( correctMembers, roles, Collections.emptySet() ),
+                new VerifyInstanceConfiguration( correctMembers, roles, Collections.emptySet() ),
+                new VerifyInstanceConfiguration( correctMembers, roles, Collections.emptySet() ),
+                new VerifyInstanceConfiguration( Collections.emptyList(), Collections.emptyMap(),
+                        Collections.emptySet() )}, DEFAULT_NETWORK(), new ClusterTestScriptDSL().
                 rounds( 600 ).
                 join( 100, 1, 1 ).
                 join( 100, 2, 1 ).
@@ -89,34 +89,36 @@ public class InstanceIdTest
     public void substituteFailedNode() throws InterruptedException, ExecutionException, TimeoutException,
             URISyntaxException
     {
-        List<URI> correctMembers = new ArrayList<URI>();
+        List<URI> correctMembers = new ArrayList<>();
         correctMembers.add( URI.create( "server1" ) );
         correctMembers.add( URI.create( "server2" ) );
         correctMembers.add( URI.create( "server4" ) );
 
-        List<URI> wrongMembers = new ArrayList<URI>();
+        List<URI> wrongMembers = new ArrayList<>();
         wrongMembers.add( URI.create( "server1" ) );
         wrongMembers.add( URI.create( "server2" ) );
         wrongMembers.add( URI.create( "server3" ) );
 
-        Map<String, InstanceId> roles = new HashMap<String, InstanceId>();
+        Map<String, InstanceId> roles = new HashMap<>();
         roles.put( "coordinator", new InstanceId( 1 ) );
 
-        Set<InstanceId> failed = new HashSet<InstanceId>();
+        Set<InstanceId> clusterMemberFailed = new HashSet<>();
+        Set<InstanceId> isolatedMemberFailed = new HashSet<>();
+        isolatedMemberFailed.add( new InstanceId( 1 ) ); // will never receive heartbeats again from 1,2 so they are failed
+        isolatedMemberFailed.add( new InstanceId( 2 ) );
 
         testCluster( new int[]{ 1, 2, 3, 3 },
                 new VerifyInstanceConfiguration[]{
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( wrongMembers, roles, Collections.<InstanceId>emptySet() ),
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed )},
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed ),
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed ),
+                        new VerifyInstanceConfiguration( wrongMembers, roles, isolatedMemberFailed ),
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed )},
                 DEFAULT_NETWORK(),
                 new ClusterTestScriptDSL().
                 rounds( 8000 ).
                 join( 100, 1, 1 ).
                 join( 100, 2, 1 ).
                 join( 100, 3, 1 ).
-//                        assertThat(electionHappened(1, "coordinator")).
                 down( 3000, 3 ).
                 join( 1000, 4, 1, 2, 3 )
         );
@@ -126,27 +128,31 @@ public class InstanceIdTest
     public void substituteFailedNodeAndFailedComesOnlineAgain() throws InterruptedException, ExecutionException, TimeoutException,
             URISyntaxException
     {
-        List<URI> correctMembers = new ArrayList<URI>();
+        List<URI> correctMembers = new ArrayList<>();
         correctMembers.add( URI.create( "server1" ) );
         correctMembers.add( URI.create( "server2" ) );
         correctMembers.add( URI.create( "server4" ) );
 
-        List<URI> badMembers = new ArrayList<URI>();
+        List<URI> badMembers = new ArrayList<>();
         badMembers.add( URI.create( "server1" ) );
         badMembers.add( URI.create( "server2" ) );
         badMembers.add( URI.create( "server3" ) );
 
-        Map<String, InstanceId> roles = new HashMap<String, InstanceId>();
+        Map<String, InstanceId> roles = new HashMap<>();
         roles.put( "coordinator", new InstanceId( 1 ) );
 
-        Set<InstanceId> failed = new HashSet<InstanceId>();
+        Set<InstanceId> clusterMemberFailed = new HashSet<>(); // no failures
+        Set<InstanceId> isolatedMemberFailed = new HashSet<>();
+        isolatedMemberFailed.add( new InstanceId( 1 ) ); // will never receive heartbeats again from 1,2 so they are failed
+        isolatedMemberFailed.add( new InstanceId( 2 ) );
+
 
         testCluster( new int[]{1, 2, 3, 3},
                 new VerifyInstanceConfiguration[]{
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( badMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed )},
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed ),
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed ),
+                        new VerifyInstanceConfiguration( badMembers, roles, isolatedMemberFailed ),
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed )},
                 DEFAULT_NETWORK(),
                 new ClusterTestScriptDSL().
                         rounds( 800 ).

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cluster.protocol.heartbeat;
 
+import java.net.URI;
+import java.util.concurrent.Executor;
+
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
-
-import java.net.URI;
-import java.util.concurrent.Executor;
 
 import org.neo4j.cluster.DelayedDirectExecutor;
 import org.neo4j.cluster.InstanceId;
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class HeartbeatStateTest
@@ -66,26 +67,27 @@ public class HeartbeatStateTest
     {
         // Given
         InstanceId instanceId = new InstanceId( 1 );
-        HeartbeatState heartbeat= HeartbeatState.heartbeat;
-        ClusterConfiguration configuration = new ClusterConfiguration("whatever", NullLogProvider.getInstance(),
-                                                                       "cluster://1", "cluster://2" );
-        configuration.joined( instanceId, URI.create("cluster://1" ) );
-        configuration.joined( new InstanceId( 2 ), URI.create("cluster://2" ));
+        HeartbeatState heartbeat = HeartbeatState.heartbeat;
+        ClusterConfiguration configuration = new ClusterConfiguration( "whatever", NullLogProvider.getInstance(),
+                "cluster://1", "cluster://2" );
+        configuration.joined( instanceId, URI.create( "cluster://1" ) );
+        configuration.joined( new InstanceId( 2 ), URI.create( "cluster://2" ) );
 
-        MultiPaxosContext context = new MultiPaxosContext( instanceId, 10, Iterables.<ElectionRole, ElectionRole>iterable(
-                        new ElectionRole( "coordinator" ) ), configuration,
-                        Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
-                        Mockito.mock( ObjectInputStreamFactory.class), Mockito.mock( ObjectOutputStreamFactory.class),
-                        Mockito.mock( AcceptorInstanceStore.class), Mockito.mock( Timeouts.class),
-                        mock( ElectionCredentialsProvider.class) );
+        MultiPaxosContext context = new MultiPaxosContext( instanceId, 10, Iterables.iterable(
+                new ElectionRole( "coordinator" ) ), configuration,
+                Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
+                Mockito.mock( ObjectInputStreamFactory.class ), Mockito.mock( ObjectOutputStreamFactory.class ),
+                Mockito.mock( AcceptorInstanceStore.class ), Mockito.mock( Timeouts.class ),
+                mock( ElectionCredentialsProvider.class ) );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
         Message received = Message.internal( HeartbeatMessage.suspicions,
-                new HeartbeatMessage.SuspicionsState( Iterables.asSet( Iterables.<InstanceId, InstanceId>iterable( instanceId ) ) ) );
+                new HeartbeatMessage.SuspicionsState( Iterables.asSet( Iterables.<InstanceId, InstanceId>iterable(
+                        instanceId ) ) ) );
         received.setHeader( Message.FROM, "cluster://2" ).setHeader( Message.INSTANCE_ID, "2" );
 
         // When
-        heartbeat.handle( heartbeatContext, received, mock( MessageHolder.class) );
+        heartbeat.handle( heartbeatContext, received, mock( MessageHolder.class ) );
 
         // Then
         assertThat( heartbeatContext.getSuspicionsOf( instanceId ).size(), equalTo( 0 ) );
@@ -97,26 +99,27 @@ public class HeartbeatStateTest
         // Given
         InstanceId myId = new InstanceId( 1 );
         InstanceId foreignId = new InstanceId( 3 );
-        HeartbeatState heartbeat= HeartbeatState.heartbeat;
-        ClusterConfiguration configuration = new ClusterConfiguration("whatever", NullLogProvider.getInstance(),
-                                                                      "cluster://1", "cluster://2" );
-        configuration.joined( myId, URI.create("cluster://1" ) );
-        configuration.joined( new InstanceId( 2 ), URI.create("cluster://2" ));
+        HeartbeatState heartbeat = HeartbeatState.heartbeat;
+        ClusterConfiguration configuration = new ClusterConfiguration( "whatever", NullLogProvider.getInstance(),
+                "cluster://1", "cluster://2" );
+        configuration.joined( myId, URI.create( "cluster://1" ) );
+        configuration.joined( new InstanceId( 2 ), URI.create( "cluster://2" ) );
 
-        MultiPaxosContext context = new MultiPaxosContext( myId, 10, Iterables.<ElectionRole, ElectionRole>iterable(
-                        new ElectionRole( "coordinator" ) ), configuration,
-                        Mockito.mock( Executor.class ),  NullLogProvider.getInstance(),
-                        Mockito.mock( ObjectInputStreamFactory.class), Mockito.mock( ObjectOutputStreamFactory.class),
-                        Mockito.mock( AcceptorInstanceStore.class), Mockito.mock( Timeouts.class),
-                        mock( ElectionCredentialsProvider.class) );
+        MultiPaxosContext context = new MultiPaxosContext( myId, 10, Iterables.iterable(
+                new ElectionRole( "coordinator" ) ), configuration,
+                Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
+                Mockito.mock( ObjectInputStreamFactory.class ), Mockito.mock( ObjectOutputStreamFactory.class ),
+                Mockito.mock( AcceptorInstanceStore.class ), Mockito.mock( Timeouts.class ),
+                mock( ElectionCredentialsProvider.class ) );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
         Message received = Message.internal( HeartbeatMessage.suspicions,
-                new HeartbeatMessage.SuspicionsState( Iterables.asSet( Iterables.<InstanceId, InstanceId>iterable( myId, foreignId ) ) ) );
+                new HeartbeatMessage.SuspicionsState( Iterables.asSet( Iterables.<InstanceId, InstanceId>iterable(
+                        myId, foreignId ) ) ) );
         received.setHeader( Message.FROM, "cluster://2" ).setHeader( Message.INSTANCE_ID, "2" );
 
         // When
-        heartbeat.handle( heartbeatContext, received, mock( MessageHolder.class) );
+        heartbeat.handle( heartbeatContext, received, mock( MessageHolder.class ) );
 
         // Then
         assertThat( heartbeatContext.getSuspicionsOf( myId ).size(), equalTo( 0 ) );
@@ -128,22 +131,22 @@ public class HeartbeatStateTest
     {
         // Given
         InstanceId instanceId = new InstanceId( 1 );
-        HeartbeatState heartbeat= HeartbeatState.heartbeat;
+        HeartbeatState heartbeat = HeartbeatState.heartbeat;
         ClusterConfiguration configuration = new ClusterConfiguration( "whatever", NullLogProvider.getInstance(),
                 "cluster://1", "cluster://2" );
-        configuration.joined( instanceId, URI.create("cluster://1" ) );
+        configuration.joined( instanceId, URI.create( "cluster://1" ) );
         InstanceId otherInstance = new InstanceId( 2 );
-        configuration.joined( otherInstance, URI.create("cluster://2" ));
+        configuration.joined( otherInstance, URI.create( "cluster://2" ) );
 
         MultiPaxosContext context = new MultiPaxosContext(
                 instanceId, 10,
-                Iterables.<ElectionRole,ElectionRole>iterable( new ElectionRole( "coordinator" ) ),
+                Iterables.iterable( new ElectionRole( "coordinator" ) ),
                 configuration,
                 Mockito.mock( Executor.class ),
                 NullLogProvider.getInstance(),
-                Mockito.mock( ObjectInputStreamFactory.class),
-                Mockito.mock( ObjectOutputStreamFactory.class),
-                Mockito.mock( AcceptorInstanceStore.class),
+                Mockito.mock( ObjectInputStreamFactory.class ),
+                Mockito.mock( ObjectOutputStreamFactory.class ),
+                Mockito.mock( AcceptorInstanceStore.class ),
                 Mockito.mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class ) );
 
@@ -182,7 +185,7 @@ public class HeartbeatStateTest
         MultiPaxosContext context = new MultiPaxosContext(
                 instanceId,
                 10,
-                Iterables.<ElectionRole,ElectionRole>iterable( new ElectionRole( "coordinator" ) ),
+                Iterables.iterable( new ElectionRole( "coordinator" ) ),
                 configuration,
                 mock( Executor.class ),
                 internalLog,
@@ -199,14 +202,7 @@ public class HeartbeatStateTest
                 mock( MessageSender.class ),
                 timeouts,
                 mock( DelayedDirectExecutor.class ),
-                new Executor()
-                {
-                    @Override
-                    public void execute( Runnable command )
-                    {
-                        command.run();
-                    }
-                },
+                command -> command.run(),
                 instanceId );
         stateMachines.addStateMachine(
                 new StateMachine( context.getHeartbeatContext(), HeartbeatMessage.class, HeartbeatState.start,

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
@@ -274,6 +274,13 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                 log.debug( "Got memberIsFailed(" + instanceId + ") and cluster lost quorum to continue, moved to "
                         + state + " from " + oldState );
             }
+            else if ( instanceId.equals( context.getElectedMasterId() ) && state == HighAvailabilityMemberState.SLAVE )
+            {
+                HighAvailabilityMemberState oldState = state;
+                changeStateToPending();
+                log.debug( "Got memberIsFailed(" + instanceId + ") which was the master and i am a slave, moved to "
+                        + state + " from " + oldState );
+            }
             else
             {
                 log.debug( "Got memberIsFailed(" + instanceId + ")" );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterFailoverIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterFailoverIT.java
@@ -34,10 +34,9 @@ import org.neo4j.test.LoggerRule;
 import org.neo4j.test.TargetDirectory;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.kernel.impl.ha.ClusterManager.clusterOfSize;
 
 @RunWith( Parameterized.class )
-public class TestFailover
+public class ClusterFailoverIT
 {
     @Rule
     public LoggerRule logger = new LoggerRule();
@@ -58,7 +57,7 @@ public class TestFailover
         });
     }
 
-    public TestFailover( int clusterSize )
+    public ClusterFailoverIT( int clusterSize )
     {
         this.clusterSize = clusterSize;
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionTestIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionTestIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Predicate;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.kernel.impl.ha.ClusterManager;
+import org.neo4j.kernel.impl.ha.ClusterManager.NetworkFlag;
+import org.neo4j.kernel.impl.ha.ClusterManager.RepairKit;
+import org.neo4j.test.LoggerRule;
+import org.neo4j.test.TargetDirectory;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
+import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
+
+public class ClusterPartitionTestIT
+{
+    @Rule
+    public LoggerRule logger = new LoggerRule();
+    @Rule
+    public TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void isolatedMasterShouldRemoveSelfFromCluster() throws Throwable
+    {
+        int clusterSize = 3;
+
+        ClusterManager manager = new ClusterManager.Builder().withRootDirectory( dir.cleanDirectory( "testcluster" ) ).
+                withCluster( ClusterManager.clusterOfSize( clusterSize ) )
+                .withSharedConfig( stringMap(
+                        ClusterSettings.heartbeat_interval.name(), "1" ) )
+                .build();
+
+        try
+        {
+            manager.start();
+            ClusterManager.ManagedCluster cluster = manager.getCluster();
+
+            cluster.await( allSeesAllAsAvailable() );
+            cluster.await( masterAvailable() );
+
+            Collection<HighlyAvailableGraphDatabase> failed = new ArrayList<>();
+            Collection<RepairKit> repairKits = new ArrayList<>();
+
+            HighlyAvailableGraphDatabase oldMaster = cluster.getMaster();
+            failed.add( oldMaster );
+
+            repairKits.add( cluster.fail( oldMaster, false, NetworkFlag.values() ) );
+
+            cluster.await( oldMasterEvicted( oldMaster ), 20 );
+        }
+        finally
+        {
+            manager.safeShutdown();
+        }
+    }
+
+    private Predicate<ClusterManager.ManagedCluster> oldMasterEvicted( HighlyAvailableGraphDatabase oldMaster )
+    {
+        return managedCluster -> {
+            InstanceId oldMasterServerId = managedCluster.getServerId( oldMaster );
+
+            Iterable<HighlyAvailableGraphDatabase> members = managedCluster.getAllMembers();
+            for ( HighlyAvailableGraphDatabase member : members )
+            {
+                if ( oldMasterServerId.equals( managedCluster.getServerId( member ) ) )
+                {
+                    if ( member.role().equals( "UNKNOWN" ) )
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+
+        };
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/FailoverWithAdditionalSlaveFailuresIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/FailoverWithAdditionalSlaveFailuresIT.java
@@ -42,7 +42,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
 
 @RunWith( Parameterized.class )
-public class TestFailoverWithAdditionalSlaveFailures
+public class FailoverWithAdditionalSlaveFailuresIT
 {
     @Rule
     public LoggerRule logger = new LoggerRule();
@@ -71,7 +71,7 @@ public class TestFailoverWithAdditionalSlaveFailures
         });
     }
 
-    public TestFailoverWithAdditionalSlaveFailures( int clusterSize, int[] slavesToFail )
+    public FailoverWithAdditionalSlaveFailuresIT( int clusterSize, int[] slavesToFail )
     {
         this.clusterSize = clusterSize;
         this.slavesToFail = slavesToFail;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -26,8 +26,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -81,6 +83,8 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -185,7 +189,7 @@ public class HighAvailabilityMemberStateMachineTest
         HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
 
         AvailabilityGuard guard = mock( AvailabilityGuard.class );
-        ObservedClusterMembers members = mockClusterMembers( me, other );
+        ObservedClusterMembers members = mockClusterMembers( me, emptyList(), singletonList( other ) );
 
         ClusterMemberEvents events = mock( ClusterMemberEvents.class );
         ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
@@ -213,14 +217,15 @@ public class HighAvailabilityMemberStateMachineTest
     }
 
     @Test
-    public void whenInSlaveStateLosingQuorumShouldPutInPending() throws Throwable
+    public void whenInSlaveStateLosingOtherSlaveShouldNotPutInPending() throws Throwable
     {
         // Given
         InstanceId me = new InstanceId( 1 );
-        InstanceId other = new InstanceId( 2 );
+        InstanceId master = new InstanceId( 2 );
+        InstanceId otherSlave = new InstanceId( 3 );
         HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
         AvailabilityGuard guard = mock( AvailabilityGuard.class );
-        ObservedClusterMembers members = mockClusterMembers( me, other );
+        ObservedClusterMembers members = mockClusterMembers( me, singletonList( master ), singletonList( otherSlave ) );
 
         ClusterMemberEvents events = mock( ClusterMemberEvents.class );
         ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
@@ -233,13 +238,52 @@ public class HighAvailabilityMemberStateMachineTest
         stateMachine.addHighAvailabilityMemberListener( probe );
 
         // Send it to MASTER
-        memberListener.memberIsAvailable( MASTER, other, URI.create( "ha://whatever" ), StoreId.DEFAULT );
-        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://whatever2" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( MASTER, master, URI.create( "ha://whatever" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://whatever3" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( SLAVE, otherSlave, URI.create( "ha://whatever2" ), StoreId.DEFAULT );
 
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.SLAVE ) );
 
         // When
-        memberListener.memberIsFailed( new InstanceId( 2 ) );
+        memberListener.memberIsFailed( otherSlave );
+
+        // Then
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.SLAVE ) );
+        assertThat( probe.instanceStops, is( false ) );
+    }
+
+
+    @Test
+    public void whenInSlaveStateLosingMasterShouldPutInPending() throws Throwable
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId master = new InstanceId( 2 );
+        InstanceId otherSlave = new InstanceId( 3 );
+        HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
+        AvailabilityGuard guard = mock( AvailabilityGuard.class );
+        ObservedClusterMembers members = mockClusterMembers( me, singletonList( otherSlave ), singletonList( master ) );
+
+        ClusterMemberEvents events = mock( ClusterMemberEvents.class );
+        ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
+
+        HighAvailabilityMemberStateMachine stateMachine = buildMockedStateMachine( context, events, members, guard );
+
+        stateMachine.init();
+        ClusterMemberListener memberListener = memberListenerContainer.get();
+        HAStateChangeListener probe = new HAStateChangeListener();
+        stateMachine.addHighAvailabilityMemberListener( probe );
+
+        // Send it to MASTER
+        memberListener.coordinatorIsElected( master );
+        memberListener.memberIsAvailable( MASTER, master, URI.create( "ha://whatever" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://whatever3" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( SLAVE, otherSlave, URI.create( "ha://whatever2" ), StoreId.DEFAULT );
+
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.SLAVE ) );
+
+        // When
+        memberListener.memberIsFailed( master );
 
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
@@ -255,7 +299,7 @@ public class HighAvailabilityMemberStateMachineTest
         InstanceId other = new InstanceId( 2 );
         HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
         AvailabilityGuard guard = mock( AvailabilityGuard.class );
-        ObservedClusterMembers members = mockClusterMembers( me, other );
+        ObservedClusterMembers members = mockClusterMembers( me, emptyList(), singletonList( other ) );
 
         ClusterMemberEvents events = mock( ClusterMemberEvents.class );
         ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
@@ -289,7 +333,7 @@ public class HighAvailabilityMemberStateMachineTest
         InstanceId other = new InstanceId( 2 );
         HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
         AvailabilityGuard guard = mock( AvailabilityGuard.class );
-        ObservedClusterMembers members = mockClusterMembers( me, other );
+        ObservedClusterMembers members = mockClusterMembers( me, emptyList(), singletonList( other ) );
 
         ClusterMemberEvents events = mock( ClusterMemberEvents.class );
         ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
@@ -526,19 +570,39 @@ public class HighAvailabilityMemberStateMachineTest
         haModeSwitcher.shutdown();
     }
 
-    private ObservedClusterMembers mockClusterMembers( InstanceId me, InstanceId other )
+    private ObservedClusterMembers mockClusterMembers( InstanceId me, List<InstanceId> alive, List<InstanceId> failed )
     {
         ObservedClusterMembers members = mock( ObservedClusterMembers.class );
 
         // we cannot set outside of the package the isAlive to return false. So do it with a mock
-        ClusterMember otherMember = mock( ClusterMember.class );
-        when( otherMember.getInstanceId() ).thenReturn( other );
-        when( otherMember.isAlive() ).thenReturn( false );
+        List<ClusterMember> aliveMembers = new ArrayList<>( alive.size() );
+        List<ClusterMember> failedMembers = new ArrayList<>( failed.size() );
+        for ( InstanceId instanceId : alive )
+        {
+            ClusterMember otherMember = mock( ClusterMember.class );
+            when( otherMember.getInstanceId() ).thenReturn( instanceId );
+            // the failed argument tells us which instance should be marked as failed
+            when( otherMember.isAlive() ).thenReturn( true );
+            aliveMembers.add( otherMember );
+        }
+
+        for ( InstanceId instanceId : failed )
+        {
+            ClusterMember otherMember = mock( ClusterMember.class );
+            when( otherMember.getInstanceId() ).thenReturn( instanceId );
+            // the failed argument tells us which instance should be marked as failed
+            when( otherMember.isAlive() ).thenReturn( false );
+            failedMembers.add( otherMember );
+        }
 
         ClusterMember thisMember = new ClusterMember( me );
+        aliveMembers.add( thisMember );
 
-        when( members.getMembers() ).thenReturn( Arrays.asList( otherMember, thisMember ) );
-        when( members.getAliveMembers() ).thenReturn( Collections.singleton( thisMember ) );
+        List<ClusterMember> allMembers = new ArrayList<>();
+        allMembers.addAll( aliveMembers ); // thisMember is in aliveMembers
+        allMembers.addAll( failedMembers );
+        when( members.getMembers() ).thenReturn( allMembers );
+        when( members.getAliveMembers() ).thenReturn( aliveMembers );
 
         return members;
     }
@@ -556,7 +620,7 @@ public class HighAvailabilityMemberStateMachineTest
         doAnswer( invocation -> {
             listenerContainer.set( (ClusterMemberListener) invocation.getArguments()[0] );
             return null;
-        } ).when( events ).addClusterMemberListener( Matchers.<ClusterMemberListener>any() );
+        } ).when( events ).addClusterMemberListener( Matchers.any() );
         return listenerContainer;
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -1338,7 +1338,7 @@ public class ClusterManager
             }
             String state = stateToString( this );
             throw new IllegalStateException( format(
-                    "Awaited condition never met, waited %s secondes for %s:%n%s", maxSeconds, predicate, state ) );
+                    "Awaited condition never met, waited %s seconds for %s:%n%s", maxSeconds, predicate, state ) );
         }
 
         /**


### PR DESCRIPTION
Any instance will now acknowledge the case of suspecting every other instance,
 effectively interpreting it as a case of lost connectivity. The reaction
 now will be to mark all other cluster members as failed, which leads to
 this instance detecting the loss of quorum and therefore becoming unavailable.
 Restoration of connectivity to sufficient instances will make the instance
 available again.
Given the above behaviour, and to handle the case where the current
 master is the instace partitioned away, when a slave detects that the
 master has become unavailable it will set itself to PENDING state, waiting
 the election of a new one.
Finally, some tests had to be changed because previously the assumption
 was that a partitioned instance would maintain its status, which is
 no longer true.
