### PR TITLE
Allow the user to change shutdown timeout.

### DIFF
--- a/packaging/installer-linux/installer-debian/build.xml
+++ b/packaging/installer-linux/installer-debian/build.xml
@@ -25,6 +25,11 @@
                 </fileset>
             </copy>
 
+            <!-- Make the defaults file available to debuild -->
+            <copy file="${project.build.sourceDirectory}/../resources/common/default/neo4j"
+                  toFile="${project.build.outputDirectory}/@{name}/server/default/neo4j"/>
+
+
             <!-- Make the Neo4j wrapper scripts available to debuild -->
             <copy file="${project.build.sourceDirectory}/../resources/common/neo4j-script"
                   toFile="${project.build.outputDirectory}/@{name}/server/scripts/neo4j"/>

--- a/packaging/installer-linux/installer-debian/src/main/resources/common/default/neo4j
+++ b/packaging/installer-linux/installer-debian/src/main/resources/common/default/neo4j
@@ -1,0 +1,5 @@
+# /etc/default/neo4j
+#
+# Number of seconds to wait for shutdown before killing the process.
+#NEO4J_SHUTDOWN_TIMEOUT=120
+#

--- a/packaging/installer-linux/installer-debian/src/main/resources/community/debian/neo4j.install
+++ b/packaging/installer-linux/installer-debian/src/main/resources/community/debian/neo4j.install
@@ -11,3 +11,4 @@ server/plugins      var/lib/neo4j
 
 server/conf/*       etc/neo4j
 server/neo4j        etc/init.d
+server/default/*    etc/default

--- a/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/neo4j-enterprise.install
+++ b/packaging/installer-linux/installer-debian/src/main/resources/enterprise/debian/neo4j-enterprise.install
@@ -11,3 +11,4 @@ server/plugins      var/lib/neo4j
 
 server/conf/*       etc/neo4j
 server/neo4j        etc/init.d
+server/default/*    etc/default

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -47,7 +47,7 @@ setup_arbiter_options() {
       echo "This instance is now joining the cluster."
     }
   else
-    SHUTDOWN_TIMEOUT=120
+    SHUTDOWN_TIMEOUT="${NEO4J_SHUTDOWN_TIMEOUT:-120}"
     MIN_ALLOWED_OPEN_FILES=40000
     MAIN_CLASS="#{neo4j.mainClass}"
 


### PR DESCRIPTION
This is the 3.0 version of the behaviour found here: https://github.com/neo4j/neo4j/pull/7285

changelog: [3.0, packaging] Allow Debian package users to configure shutdown parameters via defaults
