### PR TITLE
Run security integration tests on enterprise db

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -41,6 +41,7 @@ import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -56,7 +57,12 @@ import static org.neo4j.helpers.collection.MapUtil.map;
 public class AuthenticationIT
 {
     @Rule
-    public Neo4jWithSocket server = new Neo4jWithSocket( getSettingsFunction() );
+    public Neo4jWithSocket server = new Neo4jWithSocket( getTestGraphDatabaseFactory(), getSettingsFunction() );
+
+    protected TestGraphDatabaseFactory getTestGraphDatabaseFactory()
+    {
+        return new TestGraphDatabaseFactory();
+    }
 
     protected Consumer<Map<Setting<?>, String>> getSettingsFunction()
     {

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
@@ -45,14 +45,21 @@ public class Neo4jWithSocket implements TestRule
 {
     private final Consumer<Map<Setting<?>,String>> configure;
     private StoreId storeId;
+    TestGraphDatabaseFactory graphDatabaseFactory;
 
     public Neo4jWithSocket()
     {
-        this( settings -> {} );
+        this( new TestGraphDatabaseFactory(), settings -> {} );
     }
 
     public Neo4jWithSocket( Consumer<Map<Setting<?>, String>> configure )
     {
+        this( new TestGraphDatabaseFactory(), configure );
+    }
+
+    public Neo4jWithSocket( TestGraphDatabaseFactory graphDatabaseFactory, Consumer<Map<Setting<?>, String>> configure )
+    {
+        this.graphDatabaseFactory = graphDatabaseFactory;
         this.configure = configure;
     }
 
@@ -75,7 +82,7 @@ public class Neo4jWithSocket implements TestRule
                 settings.put( BoltKernelExtension.Settings.tls_key_file, tempPath( "key", ".key" ) );
                 settings.put( BoltKernelExtension.Settings.tls_certificate_file, tempPath( "cert", ".cert" ) );
                 configure.accept( settings );
-                final GraphDatabaseService gdb = new TestGraphDatabaseFactory().newImpermanentDatabase( settings );
+                final GraphDatabaseService gdb = graphDatabaseFactory.newImpermanentDatabase( settings );
                 storeId = ((GraphDatabaseFacade) gdb).storeId();
                 try
                 {

--- a/enterprise/security/pom.xml
+++ b/enterprise/security/pom.xml
@@ -85,6 +85,13 @@
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-enterprise-kernel</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
       <artifactId>neo4j-io</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ProceduresProvider.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ProceduresProvider.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.server.security.enterprise.auth;
 
+import org.neo4j.helpers.Service;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.security.AccessMode;
@@ -26,8 +27,14 @@ import org.neo4j.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.impl.enterprise.EnterpriseProceduresProvider;
 import org.neo4j.kernel.impl.proc.Procedures;
 
-public class ProceduresProvider implements EnterpriseProceduresProvider
+@Service.Implementation( EnterpriseProceduresProvider.class )
+public class ProceduresProvider extends Service implements EnterpriseProceduresProvider
 {
+    public ProceduresProvider()
+    {
+        super( "procedures-provider" );
+    }
+
     @Override
     public void registerProcedures( Procedures procedures )
     {

--- a/enterprise/security/src/main/resources/META-INF/services/org.neo4j.kernel.impl.enterprise.EnterpriseProceduresProvider
+++ b/enterprise/security/src/main/resources/META-INF/services/org.neo4j.kernel.impl.enterprise.EnterpriseProceduresProvider
@@ -1,0 +1,1 @@
+org.neo4j.server.security.enterprise.auth.ProceduresProvider

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresTest.java
@@ -39,7 +39,7 @@ import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
 import org.neo4j.server.security.auth.InMemoryUserRepository;
-import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 
 import static java.time.Clock.systemUTC;
 import static org.junit.Assert.assertEquals;
@@ -61,8 +61,7 @@ public class AuthProceduresTest
     @Before
     public void setUp() throws Exception
     {
-        db = (GraphDatabaseAPI) new TestGraphDatabaseFactory().newImpermanentDatabase();
-        registerProcedures( db );
+        db = (GraphDatabaseAPI) new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase();
         manager = new EnterpriseAuthManager( new InMemoryUserRepository(), new InMemoryRoleRepository(),
                 new BasicPasswordPolicy(), systemUTC(), true );
         manager.newUser( "adminSubject", "abc", false );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationIT.java
@@ -25,9 +25,17 @@ import java.util.function.Consumer;
 import org.neo4j.bolt.v1.transport.integration.AuthenticationIT;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 public class EnterpriseAuthenticationIT extends AuthenticationIT
 {
+    @Override
+    protected TestGraphDatabaseFactory getTestGraphDatabaseFactory()
+    {
+        return new TestEnterpriseGraphDatabaseFactory();
+    }
+
     @Override
     protected Consumer<Map<Setting<?>, String>> getSettingsFunction()
     {


### PR DESCRIPTION
Pass the TestGraphDatabaseFactory as a parameter to the Bolt integration
test setup so we can use an enterprise factory in the enterprise tests.
Also fixes loading of procedures in enterprise.
