### PR TITLE
Clear auth cache on user management operations

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileUserRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileUserRealm.java
@@ -33,6 +33,7 @@ import org.apache.shiro.authz.SimpleRole;
 import org.apache.shiro.authz.permission.RolePermissionResolver;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
+import org.apache.shiro.subject.SimplePrincipalCollection;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -230,6 +231,7 @@ public class FileUserRealm extends AuthorizingRealm
                 }
             }
         }
+        clearCachedAuthorizationInfoForUser( username );
     }
 
     void removeUserFromRole( String username, String roleName ) throws IOException
@@ -262,6 +264,7 @@ public class FileUserRealm extends AuthorizingRealm
                 }
             }
         }
+        clearCachedAuthorizationInfoForUser( username );
     }
 
     boolean deleteUser( String username ) throws IOException
@@ -280,6 +283,7 @@ public class FileUserRealm extends AuthorizingRealm
                 throw new IllegalArgumentException( "The user '" + username + "' does not exist" );
             }
         }
+        clearCacheForUser( username );
         return result;
     }
 
@@ -371,5 +375,15 @@ public class FileUserRealm extends AuthorizingRealm
             throw new IllegalArgumentException(
                     "Role name contains illegal characters. Please use simple ascii characters and numbers." );
         }
+    }
+
+    private void clearCachedAuthorizationInfoForUser( String username )
+    {
+        clearCachedAuthorizationInfo( new SimplePrincipalCollection( username, this.getName() ) );
+    }
+
+    private void clearCacheForUser( String username )
+    {
+        clearCache( new SimplePrincipalCollection( username, this.getName() ) );
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileUserRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/FileUserRealm.java
@@ -90,7 +90,7 @@ public class FileUserRealm extends AuthorizingRealm
             }
             else
             {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
         }
     };
@@ -309,6 +309,7 @@ public class FileUserRealm extends AuthorizingRealm
                 suspendUser( username );
             }
         }
+        clearCacheForUser( username );
     }
 
     void activateUser( String username ) throws IOException
@@ -333,6 +334,7 @@ public class FileUserRealm extends AuthorizingRealm
                 activateUser( username );
             }
         }
+        clearCacheForUser( username );
     }
 
     User findUser( String username )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresTest.java
@@ -62,17 +62,20 @@ public class AuthProceduresTest
     private ShiroAuthManager manager;
 
     @Before
-    public void setUp() throws Exception
+    public void setUp() throws Throwable
     {
         db = (GraphDatabaseAPI) new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase();
         manager = new EnterpriseAuthManager( new InMemoryUserRepository(), new InMemoryRoleRepository(),
                 new BasicPasswordPolicy(), systemUTC(), true );
+        manager.init();
+        manager.start();
         manager.newUser( "noneSubject", "abc", false );
         manager.newUser( "adminSubject", "abc", false );
         manager.newUser( "schemaSubject", "abc", false );
         manager.newUser( "readWriteSubject", "abc", false );
         manager.newUser( "readSubject", "123", false );
-        manager.newRole( PredefinedRolesBuilder.ADMIN, "adminSubject" );
+        // Currently admin role is created by default
+        manager.addUserToRole( "adminSubject", PredefinedRolesBuilder.ADMIN );
         manager.newRole( PredefinedRolesBuilder.ARCHITECT, "schemaSubject" );
         manager.newRole( PredefinedRolesBuilder.PUBLISHER, "readWriteSubject" );
         manager.newRole( PredefinedRolesBuilder.READER, "readSubject" );
@@ -85,9 +88,11 @@ public class AuthProceduresTest
     }
 
     @After
-    public void tearDown()
+    public void tearDown() throws Throwable
     {
         db.shutdown();
+        manager.stop();
+        manager.shutdown();
     }
 
     @Test


### PR DESCRIPTION
The user management operations in the internal Shiro realm needs to clear
the relevant cached information.
