### PR TITLE
Makes state change events in response to quorum loss non broadcastable

### DIFF
--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberChangeEvent.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberChangeEvent.java
@@ -26,6 +26,9 @@ import org.neo4j.cluster.InstanceId;
 /**
  * This event represents a change in the cluster members internal state. The possible states
  * are enumerated in {@link HighAvailabilityMemberState}.
+ * {@link #shouldBroadcast} flags whether the event should be broadcast or not. Broadcasting may not be a good idea
+ * in cases where the event is generated as a response to a loss of connectivity, resulting in loss of quorum, since
+ * broadcasting in this case is impossible anyway.
  */
 public class HighAvailabilityMemberChangeEvent
 {
@@ -33,15 +36,18 @@ public class HighAvailabilityMemberChangeEvent
     private final HighAvailabilityMemberState newState;
     private final InstanceId instanceId;
     private final URI serverHaUri;
+    private final boolean shouldBroadcast;
 
     public HighAvailabilityMemberChangeEvent( HighAvailabilityMemberState oldState,
                                               HighAvailabilityMemberState newState,
-                                              InstanceId instanceId, URI serverHaUri )
+                                              InstanceId instanceId, URI serverHaUri,
+                                              boolean shouldBroadcast )
     {
         this.oldState = oldState;
         this.newState = newState;
         this.instanceId = instanceId;
         this.serverHaUri = serverHaUri;
+        this.shouldBroadcast = shouldBroadcast;
     }
 
     public HighAvailabilityMemberState getOldState()
@@ -62,6 +68,11 @@ public class HighAvailabilityMemberChangeEvent
     public URI getServerHaUri()
     {
         return serverHaUri;
+    }
+
+    public boolean shouldBroadcast()
+    {
+        return shouldBroadcast;
     }
 
     @Override

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
@@ -96,15 +96,8 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
         HighAvailabilityMemberState oldState = state;
         state = HighAvailabilityMemberState.PENDING;
         final HighAvailabilityMemberChangeEvent event =
-                new HighAvailabilityMemberChangeEvent( oldState, state, null, null );
-        Listeners.notifyListeners( memberListeners, new Listeners.Notification<HighAvailabilityMemberListener>()
-        {
-            @Override
-            public void notify( HighAvailabilityMemberListener listener )
-            {
-                listener.instanceStops( event );
-            }
-        } );
+                new HighAvailabilityMemberChangeEvent( oldState, state, null, null, true );
+        Listeners.notifyListeners( memberListeners, listener -> listener.instanceStops( event ) );
 
         // If we were previously in a state that allowed access, we must now deny access
         if ( oldState.isAccessAllowed() )
@@ -157,16 +150,8 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
 
                 context.setElectedMasterId( coordinatorId );
                 final HighAvailabilityMemberChangeEvent event =
-                        new HighAvailabilityMemberChangeEvent( oldState, state, coordinatorId, null );
-                Listeners.notifyListeners( memberListeners,
-                        new Listeners.Notification<HighAvailabilityMemberListener>()
-                        {
-                            @Override
-                            public void notify( HighAvailabilityMemberListener listener )
-                            {
-                                listener.masterIsElected( event );
-                            }
-                        } );
+                        new HighAvailabilityMemberChangeEvent( oldState, state, coordinatorId, null, true );
+                Listeners.notifyListeners( memberListeners, listener -> listener.masterIsElected( event ) );
 
                 if ( oldState.isAccessAllowed() && oldState != state )
                 {
@@ -198,16 +183,8 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                     log.debug( "Got masterIsAvailable(" + instanceId + "), moved to " + state + " from " +
                             oldState );
                     final HighAvailabilityMemberChangeEvent event = new HighAvailabilityMemberChangeEvent( oldState,
-                            state, instanceId, roleUri );
-                    Listeners.notifyListeners( memberListeners,
-                            new Listeners.Notification<HighAvailabilityMemberListener>()
-                            {
-                                @Override
-                                public void notify( HighAvailabilityMemberListener listener )
-                                {
-                                    listener.masterIsAvailable( event );
-                                }
-                            } );
+                            state, instanceId, roleUri, true );
+                    Listeners.notifyListeners( memberListeners, listener -> listener.masterIsAvailable( event ) );
 
                     if ( oldState == HighAvailabilityMemberState.TO_MASTER && state ==
                             HighAvailabilityMemberState.MASTER )
@@ -222,16 +199,8 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                     log.debug( "Got slaveIsAvailable(" + instanceId + "), " +
                             "moved to " + state + " from " + oldState );
                     final HighAvailabilityMemberChangeEvent event = new HighAvailabilityMemberChangeEvent( oldState,
-                            state, instanceId, roleUri );
-                    Listeners.notifyListeners( memberListeners,
-                            new Listeners.Notification<HighAvailabilityMemberListener>()
-                            {
-                                @Override
-                                public void notify( HighAvailabilityMemberListener listener )
-                                {
-                                    listener.slaveIsAvailable( event );
-                                }
-                            } );
+                            state, instanceId, roleUri, true );
+                    Listeners.notifyListeners( memberListeners, listener -> listener.slaveIsAvailable( event ) );
 
                     if ( oldState == HighAvailabilityMemberState.TO_SLAVE &&
                             state == HighAvailabilityMemberState.SLAVE )
@@ -254,7 +223,7 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                  state == HighAvailabilityMemberState.SLAVE )
             {
                 HighAvailabilityMemberState oldState = state;
-                changeStateToPending();
+                changeStateToPending( true );
                 log.debug( "Got memberIsUnavailable(" + unavailableId + "), moved to " + state + " from " + oldState );
             }
             else
@@ -270,14 +239,14 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
             if ( !isQuorum( getAliveCount(), getTotalCount() ) )
             {
                 HighAvailabilityMemberState oldState = state;
-                changeStateToPending();
+                changeStateToPending( false );
                 log.debug( "Got memberIsFailed(" + instanceId + ") and cluster lost quorum to continue, moved to "
                         + state + " from " + oldState );
             }
             else if ( instanceId.equals( context.getElectedMasterId() ) && state == HighAvailabilityMemberState.SLAVE )
             {
                 HighAvailabilityMemberState oldState = state;
-                changeStateToPending();
+                changeStateToPending( false );
                 log.debug( "Got memberIsFailed(" + instanceId + ") which was the master and i am a slave, moved to "
                         + state + " from " + oldState );
             }
@@ -291,13 +260,13 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
         public void memberIsAlive( InstanceId instanceId )
         {
             // If we now have quorum and the previous state was pending, then ask for an election
-            if ( isQuorum(getAliveCount(), getTotalCount()) && state.equals( HighAvailabilityMemberState.PENDING ) )
+            if ( isQuorum( getAliveCount(), getTotalCount() ) && state.equals( HighAvailabilityMemberState.PENDING ) )
             {
                 election.performRoleElections();
             }
         }
 
-        private void changeStateToPending()
+        private void changeStateToPending( boolean broadcast )
         {
             if ( state.isAccessAllowed() )
             {
@@ -305,18 +274,11 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
             }
 
             final HighAvailabilityMemberChangeEvent event =
-                    new HighAvailabilityMemberChangeEvent( state, HighAvailabilityMemberState.PENDING, null, null );
+                    new HighAvailabilityMemberChangeEvent( state, HighAvailabilityMemberState.PENDING, null, null, broadcast );
 
             state = HighAvailabilityMemberState.PENDING;
 
-            Listeners.notifyListeners( memberListeners, new Listeners.Notification<HighAvailabilityMemberListener>()
-            {
-                @Override
-                public void notify( HighAvailabilityMemberListener listener )
-                {
-                    listener.instanceStops( event );
-                }
-            } );
+            Listeners.notifyListeners( memberListeners, listener -> listener.instanceStops( event ) );
 
             context.setAvailableHaMasterId( null );
             context.setElectedMasterId( null );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcher.java
@@ -248,7 +248,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                 break;
             case PENDING:
 
-                switchToPending( event.getOldState() );
+                switchToPending( event.getOldState(), event.shouldBroadcast() );
                 break;
             default:
                 // do nothing
@@ -403,7 +403,7 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
         }, cancellationHandle );
     }
 
-    private void switchToPending( final HighAvailabilityMemberState oldState )
+    private void switchToPending( final HighAvailabilityMemberState oldState, boolean broadcast )
     {
         msgLog.info( "I am %s, moving to pending", instanceId );
 
@@ -414,13 +414,16 @@ public class HighAvailabilityModeSwitcher implements HighAvailabilityMemberListe
                 return;
             }
 
-            if ( oldState.equals( HighAvailabilityMemberState.SLAVE ) )
+            if ( broadcast )
             {
-                clusterMemberAvailability.memberIsUnavailable( SLAVE );
-            }
-            else if ( oldState.equals( HighAvailabilityMemberState.MASTER ) )
-            {
-                clusterMemberAvailability.memberIsUnavailable( MASTER );
+                if ( oldState.equals( HighAvailabilityMemberState.SLAVE ) )
+                {
+                    clusterMemberAvailability.memberIsUnavailable( SLAVE );
+                }
+                else if ( oldState.equals( HighAvailabilityMemberState.MASTER ) )
+                {
+                    clusterMemberAvailability.memberIsUnavailable( MASTER );
+                }
             }
 
             componentSwitcher.switchToPending();

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfillerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfillerTest.java
@@ -79,14 +79,14 @@ public class UpdatePullingTransactionObligationFulfillerTest
 
         doAnswer( invocation -> {
             ((HighAvailabilityMemberListener) invocation.getArguments()[0]).slaveIsAvailable(
-                    new HighAvailabilityMemberChangeEvent( null, null, serverId, null )
+                    new HighAvailabilityMemberChangeEvent( null, null, serverId, null, true )
             );
             return null;
         } ).when( machine ).addHighAvailabilityMemberListener( any( HighAvailabilityMemberListener.class ) );
 
         doAnswer( invocation -> {
             ((HighAvailabilityMemberListener) invocation.getArguments()[0]).instanceStops(
-                    new HighAvailabilityMemberChangeEvent( null, null, serverId, null )
+                    new HighAvailabilityMemberChangeEvent( null, null, serverId, null, true )
             );
             return null;
         } ).when( machine ).removeHighAvailabilityMemberListener( any( HighAvailabilityMemberListener.class ) );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -54,7 +54,6 @@ import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.AvailabilityGuard.AvailabilityRequirement;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.ha.DelegateInvocationHandler;
 import org.neo4j.kernel.ha.MasterClient214;
 import org.neo4j.kernel.ha.PullerFactory;
@@ -177,6 +176,7 @@ public class HighAvailabilityMemberStateMachineTest
 
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.TO_SLAVE ) );
+        assertThat( probe.lastEvent.shouldBroadcast(), is( true ) );
         assertThat( probe.masterIsAvailable, is( true ) );
     }
 
@@ -213,6 +213,7 @@ public class HighAvailabilityMemberStateMachineTest
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
         assertThat( probe.instanceStops, is( true ) );
+        assertThat( probe.lastEvent.shouldBroadcast(), is( false ) );
         verify( guard, times( 2 ) ).require( any( AvailabilityRequirement.class ) );
     }
 
@@ -250,6 +251,7 @@ public class HighAvailabilityMemberStateMachineTest
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.SLAVE ) );
         assertThat( probe.instanceStops, is( false ) );
+        assertThat( probe.lastEvent.shouldBroadcast(), is( true ) );
     }
 
 
@@ -288,6 +290,7 @@ public class HighAvailabilityMemberStateMachineTest
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
         assertThat( probe.instanceStops, is( true ) );
+        assertThat( probe.lastEvent.shouldBroadcast(), is( false ) );
         verify( guard, times( 2 ) ).require( any( AvailabilityRequirement.class ) );
     }
 
@@ -322,6 +325,7 @@ public class HighAvailabilityMemberStateMachineTest
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
         assertThat( probe.instanceStops, is( true ) );
+        assertThat( probe.lastEvent.shouldBroadcast(), is( false ) );
         verify( guard, times( 1 ) ).require( any( AvailabilityRequirement.class ) );
     }
 
@@ -355,6 +359,7 @@ public class HighAvailabilityMemberStateMachineTest
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
         assertThat( probe.instanceStops, is( true ) );
+        assertThat( probe.lastEvent.shouldBroadcast(), is( false ) );
         verify( guard, times( 1 ) ).require( any( AvailabilityRequirement.class ) );
     }
 
@@ -494,11 +499,11 @@ public class HighAvailabilityMemberStateMachineTest
         Config config = new Config( Collections.singletonMap( ClusterSettings.server_id.name(), me.toString() ) );
 
         TransactionStats transactionCounters = mock( TransactionStats.class );
-        when( transactionCounters.getNumberOfActiveTransactions() ).thenReturn( 0l );
+        when( transactionCounters.getNumberOfActiveTransactions() ).thenReturn( 0L );
 
         PageCache pageCacheMock = mock( PageCache.class );
         PagedFile pagedFileMock = mock( PagedFile.class );
-        when( pagedFileMock.getLastPageId() ).thenReturn( 1l );
+        when( pagedFileMock.getLastPageId() ).thenReturn( 1L );
         when( pageCacheMock.map( any( File.class ), anyInt() ) ).thenReturn( pagedFileMock );
 
         TransactionIdStore transactionIdStoreMock = mock( TransactionIdStore.class );
@@ -510,7 +515,7 @@ public class HighAvailabilityMemberStateMachineTest
                 handler,
                 mock( ClusterMemberAvailability.class ), mock( RequestContextFactory.class ),
                 mock( PullerFactory.class, RETURNS_MOCKS ),
-                Iterables.<KernelExtensionFactory<?>>empty(), masterClientResolver,
+                Iterables.empty(), masterClientResolver,
                 monitor,
                 new StoreCopyClient.Monitor.Adapter(),
                 Suppliers.singleton( dataSource ),

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcherTest.java
@@ -82,7 +82,7 @@ public class HighAvailabilityModeSwitcherTest
 
         // When
         toTest.masterIsElected( new HighAvailabilityMemberChangeEvent( HighAvailabilityMemberState.MASTER,
-                HighAvailabilityMemberState.MASTER, new InstanceId( 2 ), URI.create( "ha://someone" ) ) );
+                HighAvailabilityMemberState.MASTER, new InstanceId( 2 ), URI.create( "ha://someone" ), true ) );
 
         // Then
           /*
@@ -102,7 +102,7 @@ public class HighAvailabilityModeSwitcherTest
 
         // When
         toTest.masterIsAvailable( new HighAvailabilityMemberChangeEvent( HighAvailabilityMemberState.SLAVE,
-                HighAvailabilityMemberState.SLAVE, new InstanceId( 2 ), URI.create( "ha://someone" ) ) );
+                HighAvailabilityMemberState.SLAVE, new InstanceId( 2 ), URI.create( "ha://someone" ), true ) );
 
         // Then
           /*
@@ -122,7 +122,7 @@ public class HighAvailabilityModeSwitcherTest
 
         // When
         toTest.masterIsElected( new HighAvailabilityMemberChangeEvent( HighAvailabilityMemberState.SLAVE,
-                HighAvailabilityMemberState.SLAVE, new InstanceId( 2 ), URI.create( "ha://someone" ) ) );
+                HighAvailabilityMemberState.SLAVE, new InstanceId( 2 ), URI.create( "ha://someone" ), true ) );
 
         // Then
           /*
@@ -142,7 +142,7 @@ public class HighAvailabilityModeSwitcherTest
 
         // When
         toTest.slaveIsAvailable( new HighAvailabilityMemberChangeEvent( HighAvailabilityMemberState.MASTER,
-                HighAvailabilityMemberState.MASTER, new InstanceId( 2 ), URI.create( "ha://someone" ) ) );
+                HighAvailabilityMemberState.MASTER, new InstanceId( 2 ), URI.create( "ha://someone" ), true ) );
 
         // Then
           /*
@@ -191,16 +191,16 @@ public class HighAvailabilityModeSwitcherTest
         // When
         // This will start a switch to slave
         toTest.masterIsAvailable( new HighAvailabilityMemberChangeEvent( PENDING,
-                TO_SLAVE, mock( InstanceId.class ), URI.create( "ha://server1" ) ) );
+                TO_SLAVE, mock( InstanceId.class ), URI.create( "ha://server1" ), true ) );
         // Wait until it starts and blocks on the cancellation request
         switching.await();
         // change the elected master, moving to pending, cancelling the previous change. This will block until the
         // previous switch is aborted
         toTest.masterIsElected( new HighAvailabilityMemberChangeEvent( TO_SLAVE, PENDING, new InstanceId( 2 ),
-                URI.create( "ha://server2" ) ) );
+                URI.create( "ha://server2" ), true ) );
         // Now move to the new master by switching to TO_SLAVE
         toTest.masterIsAvailable( new HighAvailabilityMemberChangeEvent( PENDING, TO_SLAVE, new InstanceId( 2 ),
-                URI.create( "ha://server2" ) ) );
+                URI.create( "ha://server2" ), true ) );
 
         // Then
         // The second switch must happen and this test won't block
@@ -269,7 +269,7 @@ public class HighAvailabilityModeSwitcherTest
                         .class ) );
 
         modeSwitcher.masterIsAvailable(
-                new HighAvailabilityMemberChangeEvent( PENDING, TO_SLAVE, new InstanceId( 1 ), uri1 ) );
+                new HighAvailabilityMemberChangeEvent( PENDING, TO_SLAVE, new InstanceId( 1 ), uri1, true ) );
         firstMasterAvailableHandled.await(); // wait until the first masterIsAvailable triggers the exception handling
         verify( switchToSlave ).switchToSlave( any( LifeSupport.class ), any( URI.class ), eq( uri1 ),
                 any( CancellationRequest.class ) );
@@ -278,7 +278,7 @@ public class HighAvailabilityModeSwitcherTest
         // masterIsAvailable for instance 2
         URI uri2 = URI.create( "ha://server2" );
         modeSwitcher.masterIsAvailable(
-                new HighAvailabilityMemberChangeEvent( TO_SLAVE, TO_SLAVE, new InstanceId( 2 ), uri2 ) );
+                new HighAvailabilityMemberChangeEvent( TO_SLAVE, TO_SLAVE, new InstanceId( 2 ), uri2, true ) );
         secondMasterAvailableComes.countDown();
         secondMasterAvailableHandled.await(); // wait until switchToSlave method is invoked again
 
@@ -330,12 +330,12 @@ public class HighAvailabilityModeSwitcherTest
 
         // The first message goes through, start the first run
         toTest.masterIsAvailable(
-                new HighAvailabilityMemberChangeEvent( PENDING, TO_SLAVE, new InstanceId( 1 ), uri1 ) );
+                new HighAvailabilityMemberChangeEvent( PENDING, TO_SLAVE, new InstanceId( 1 ), uri1, true ) );
         // Wait for it to be processed but get just before the exception
         firstCallMade.await();
         // It is just about to throw the exception, i.e. rerun. Send in the event
         toTest.masterIsElected(
-                new HighAvailabilityMemberChangeEvent( TO_SLAVE, TO_SLAVE, new InstanceId( 1 ), null ) );
+                new HighAvailabilityMemberChangeEvent( TO_SLAVE, TO_SLAVE, new InstanceId( 1 ), null, true ) );
         // Allow to continue and do the second run
         waitForSecondMessage.countDown();
         // Wait for the call to finish
@@ -372,7 +372,7 @@ public class HighAvailabilityModeSwitcherTest
         // When
         // The HAMS tries to switch to slave for a master that is itself
         toTest.masterIsAvailable(
-                new HighAvailabilityMemberChangeEvent( PENDING, TO_SLAVE, new InstanceId( 2 ), serverHaUri ) );
+                new HighAvailabilityMemberChangeEvent( PENDING, TO_SLAVE, new InstanceId( 2 ), serverHaUri, true ) );
 
         // Then
         // No switching to slave must happen
@@ -471,7 +471,7 @@ public class HighAvailabilityModeSwitcherTest
         // When
         modeSwitcher.masterIsAvailable( new HighAvailabilityMemberChangeEvent( PENDING, TO_SLAVE, mock( InstanceId
                 .class ),
-                URI.create( "http://localhost:9090?serverId=42" ) ) );
+                URI.create( "http://localhost:9090?serverId=42" ), true ) );
         modeSwitchHappened.await();
         modeSwitcher.forceElections();
 
@@ -521,7 +521,7 @@ public class HighAvailabilityModeSwitcherTest
         {
             // the instance fails to switch to master
             theSwitcher.masterIsElected( new HighAvailabilityMemberChangeEvent( HighAvailabilityMemberState.PENDING,
-                    HighAvailabilityMemberState.TO_MASTER, instanceId, listeningAt ) );
+                    HighAvailabilityMemberState.TO_MASTER, instanceId, listeningAt, true ) );
 
         }
         finally


### PR DESCRIPTION
There are cases where an instance changes its state to PENDING but
 broadcasting it does not make sense. There are two cases for this, one
 is when the current master goes away (and there is no coordinator) and when
 quorum is lost (and broadcasting is impossible). If the transition
 to PENDING, in these cases, were to happen, it would be retried when
 connectivity/quorum was restored, resulting in outdated info being
 circulated.
 This patch makes it so that moving to PENDING state under these circumstances
 does not result in a broadcast.

Also fixes TransactionThroughMasterSwitchStressIT by making the elected
 master predictable through use of slave_only instances.
