### PR TITLE
Remove last applying storage

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/id/ReplicatedIdAllocationStateMachine.java
@@ -76,6 +76,12 @@ public class ReplicatedIdAllocationStateMachine implements StateMachine<Replicat
         storage.persistStoreData( state );
     }
 
+    @Override
+    public long lastAppliedIndex()
+    {
+        return storage.getInitialState().logIndex();
+    }
+
     public synchronized IdAllocationState snapshot()
     {
         return state.newInstance();

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/token/ReplicatedTokenStateMachine.java
@@ -55,7 +55,7 @@ public class ReplicatedTokenStateMachine<TOKEN extends Token> implements StateMa
     private final TokenFactory<TOKEN> tokenFactory;
 
     private final Log log;
-    private long lastCommittedIndex = Long.MAX_VALUE;
+    private long lastCommittedIndex = -1;
 
     public ReplicatedTokenStateMachine( TokenRegistry<TOKEN> tokenRegistry, TokenFactory<TOKEN> tokenFactory,
             LogProvider logProvider )
@@ -138,5 +138,11 @@ public class ReplicatedTokenStateMachine<TOKEN extends Token> implements StateMa
     public synchronized void flush() throws IOException
     {
         // already implicitly flushed to the store
+    }
+
+    @Override
+    public long lastAppliedIndex()
+    {
+        return lastCommittedIndex;
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/tx/ReplicatedTransactionStateMachine.java
@@ -67,12 +67,6 @@ public class ReplicatedTransactionStateMachine<MEMBER> implements StateMachine<R
     }
 
     @Override
-    public void flush() throws IOException
-    {
-        // implicitly flushed
-    }
-
-    @Override
     public synchronized void applyCommand( ReplicatedTransaction replicatedTx, long commandIndex, Consumer<Result> callback )
     {
         if ( commandIndex <= lastCommittedIndex )
@@ -108,6 +102,18 @@ public class ReplicatedTransactionStateMachine<MEMBER> implements StateMachine<R
                 throw panicException( e );
             }
         }
+    }
+
+    @Override
+    public void flush() throws IOException
+    {
+        // implicitly flushed
+    }
+
+    @Override
+    public long lastAppliedIndex()
+    {
+        return lastCommittedIndex;
     }
 
     public synchronized void ensuredApplied()

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/StateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/StateMachine.java
@@ -39,4 +39,10 @@ public interface StateMachine<Command>
      * @throws IOException
      */
     void flush() throws IOException;
+
+    /**
+     * Return the index of the last applied command by this state machine.
+     * @return the last applied index for this state machine
+     */
+    long lastAppliedIndex();
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -334,11 +334,6 @@ public class EnterpriseCoreEditionModule
                     new LongIndexMarshal(), config.get( CoreEdgeClusterSettings.last_flushed_state_size ),
                     databaseHealthSupplier, logProvider ) );
 
-            DurableStateStorage<Long> lastApplyingStorage = life.add( new DurableStateStorage<>(
-                    fileSystem, new File( clusterStateDirectory, "last-applying-state" ), "last-applying",
-                    new LongIndexMarshal(), config.get( CoreEdgeClusterSettings.last_flushed_state_size ),
-                    databaseHealthSupplier, logProvider ) );
-
             StateStorage<GlobalSessionTrackerState<CoreMember>> sessionTrackerStorage;
             try
             {
@@ -363,7 +358,7 @@ public class EnterpriseCoreEditionModule
             coreState = new CoreState(
                     raftLog, config.get( CoreEdgeClusterSettings.state_machine_apply_max_batch_size ),
                     config.get( CoreEdgeClusterSettings.state_machine_flush_window_size ),
-                    databaseHealthSupplier, logProvider, progressTracker, lastFlushedStorage, lastApplyingStorage,
+                    databaseHealthSupplier, logProvider, progressTracker, lastFlushedStorage,
                     sessionTrackerStorage, applier, downloader, inFlightMap, platformModule.monitors );
 
             raft = createRaft( life, loggingOutbound, discoveryService, config, messageLogger, raftLog,
@@ -565,7 +560,6 @@ public class EnterpriseCoreEditionModule
             case SEGMENTED:
             {
                 long rotateAtSize = config.get( CoreEdgeClusterSettings.raft_log_rotation_size );
-                int metaDataCacheSize = config.get( CoreEdgeClusterSettings.raft_log_meta_data_cache_size );
                 String pruningStrategyConfig = config.get( CoreEdgeClusterSettings.raft_log_pruning_strategy );
                 int entryCacheSize = config.get( CoreEdgeClusterSettings.raft_log_entry_cache_size );
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/locks/ReplicatedLockTokenStateMachine.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/locks/ReplicatedLockTokenStateMachine.java
@@ -66,6 +66,12 @@ public class ReplicatedLockTokenStateMachine<MEMBER> implements StateMachine<Rep
         storage.persistStoreData( state );
     }
 
+    @Override
+    public long lastAppliedIndex()
+    {
+        return storage.getInitialState().ordinal();
+    }
+
     public synchronized ReplicatedLockTokenState<MEMBER> snapshot()
     {
         return state.newInstance();


### PR DESCRIPTION
On startup read the last applying index from the state machines rather
than writing it in a storage file on disk.

This should improve performance when applying commands since there is
no need to flush on disk applying index updates.
