### PR TITLE
Change login method take an auth token as a map

### DIFF
--- a/community/bolt/pom.xml
+++ b/community/bolt/pom.xml
@@ -51,7 +51,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-security</artifactId>
+      <artifactId>neo4j-kernel</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -87,6 +87,12 @@
       <artifactId>neo4j-kernel</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-security</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/Authentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/Authentication.java
@@ -49,9 +49,4 @@ public interface Authentication
      * Allows all tokens to authenticate.
      */
     Authentication NONE = authToken -> AuthenticationResult.AUTH_DISABLED;
-
-    String SCHEME_KEY = "scheme";
-    String PRINCIPAL = "principal";
-    String CREDENTIALS = "credentials";
-    String NEW_CREDENTIALS = "new_credentials";
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
@@ -36,6 +36,7 @@ import org.neo4j.logging.LogProvider;
 import static org.neo4j.kernel.api.security.AuthToken.NEW_CREDENTIALS;
 import static org.neo4j.kernel.api.security.AuthToken.PRINCIPAL;
 import static org.neo4j.kernel.api.security.AuthToken.SCHEME_KEY;
+import static org.neo4j.kernel.api.security.AuthToken.newBasicAuthToken;
 
 /**
  * Performs basic authentication with user name and password.
@@ -106,17 +107,17 @@ public class BasicAuthentication implements Authentication
     {
         try
         {
-            String newPassword = AuthToken.safeCast( NEW_CREDENTIALS, authToken );
-
             AuthSubject authSubject = authManager.login( authToken );
 
             switch ( authSubject.getAuthenticationResult() )
             {
             case SUCCESS:
             case PASSWORD_CHANGE_REQUIRED:
+                String username = AuthToken.safeCast( PRINCIPAL, authToken );
+                String newPassword = AuthToken.safeCast( NEW_CREDENTIALS, authToken );
                 authSubject.setPassword( newPassword );
                 //re-authenticate user
-                authSubject = authManager.login( authToken );
+                authSubject = authManager.login( newBasicAuthToken( username, newPassword ) );
                 break;
             default:
                 throw new AuthenticationException( Status.Security.Unauthorized, identifier.get() );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.security.AuthSubject;
+import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker;
@@ -80,7 +81,7 @@ public class SessionStateMachine implements Session, SessionState
                             ctx.credentialsExpired = authResult.credentialsExpired();
                             ctx.result( authResult.credentialsExpired() );
                             ctx.spi.udcRegisterClient( clientName );
-                            ctx.setQuerySourceFromClientNameAndPrincipal( clientName, authToken.get( Authentication.PRINCIPAL ) );
+                            ctx.setQuerySourceFromClientNameAndPrincipal( clientName, authToken.get( AuthToken.PRINCIPAL ) );
                             return IDLE;
                         }
                         catch ( AuthenticationException e )

--- a/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
@@ -35,7 +35,7 @@ import org.neo4j.server.security.auth.BasicAuthManager;
 import org.neo4j.server.security.auth.BasicAuthSubject;
 
 import static java.util.Collections.singletonList;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,13 +49,13 @@ public class BasicAuthenticationTest
     private final Supplier<String> identifier = () -> "UNIQUE";
 
     @Test
-    public void shouldNotDoAnythingOnSuccess() throws AuthenticationException
+    public void shouldNotDoAnythingOnSuccess() throws Exception
     {
         // Given
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ), identifier  );
-        when( manager.login( anyString(), anyString() ) ).thenReturn( authSubject );
+        when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
 
         //Expect nothing
@@ -65,7 +65,7 @@ public class BasicAuthenticationTest
     }
 
     @Test
-    public void shouldThrowAndLogOnFailure() throws AuthenticationException
+    public void shouldThrowAndLogOnFailure() throws Exception
     {
         // Given
         BasicAuthManager manager = mock( BasicAuthManager.class );
@@ -74,7 +74,7 @@ public class BasicAuthenticationTest
         LogProvider logProvider = mock( LogProvider.class );
         when( logProvider.getLog( BasicAuthentication.class ) ).thenReturn( log );
         BasicAuthentication authentication = new BasicAuthentication( manager, logProvider, identifier );
-        when( manager.login( anyString(), anyString() ) ).thenReturn( authSubject );
+        when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.FAILURE );
 
         // Expect
@@ -90,13 +90,13 @@ public class BasicAuthenticationTest
     }
 
     @Test
-    public void shouldIndicateThatCredentialsExpired() throws AuthenticationException
+    public void shouldIndicateThatCredentialsExpired() throws Exception
     {
         // Given
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ), identifier );
-        when( manager.login( anyString(), anyString() ) ).thenReturn( authSubject );
+        when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
 
         // Expect
@@ -110,13 +110,13 @@ public class BasicAuthenticationTest
     }
 
     @Test
-    public void shouldFailWhenTooManyAttempts() throws AuthenticationException
+    public void shouldFailWhenTooManyAttempts() throws Exception
     {
         // Given
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ), identifier );
-        when( manager.login( anyString(), anyString() ) ).thenReturn( authSubject );
+        when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.TOO_MANY_ATTEMPTS );
 
         // Expect
@@ -129,13 +129,13 @@ public class BasicAuthenticationTest
     }
 
     @Test
-    public void shouldBeAbleToUpdateCredentials() throws AuthenticationException
+    public void shouldBeAbleToUpdateCredentials() throws Exception
     {
         // Given
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ), identifier );
-        when( manager.login( anyString(), anyString() ) ).thenReturn( authSubject );
+        when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
 
         //Expect nothing
@@ -146,13 +146,13 @@ public class BasicAuthenticationTest
     }
 
     @Test
-    public void shouldBeAbleToUpdateExpiredCredentials() throws AuthenticationException
+    public void shouldBeAbleToUpdateExpiredCredentials() throws Exception
     {
         // Given
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ), identifier );
-        when( manager.login( anyString(), anyString() ) ).thenReturn( authSubject );
+        when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
 
         //Expect nothing
@@ -163,13 +163,13 @@ public class BasicAuthenticationTest
     }
 
     @Test
-    public void shouldNotBeAbleToUpdateCredentialsIfOldCredentialsAreInvalid() throws AuthenticationException
+    public void shouldNotBeAbleToUpdateCredentialsIfOldCredentialsAreInvalid() throws Exception
     {
         // Given
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ), identifier );
-        when( manager.login( anyString(), anyString() ) ).thenReturn( authSubject );
+        when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.FAILURE );
 
         // Expect
@@ -184,13 +184,13 @@ public class BasicAuthenticationTest
     }
 
     @Test
-    public void shouldFailOnUnknownScheme() throws AuthenticationException
+    public void shouldFailOnUnknownScheme() throws Exception
     {
         // Given
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ), identifier );
-        when( manager.login( anyString(), anyString() ) ).thenReturn( authSubject );
+        when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
 
         // Expect
@@ -203,13 +203,13 @@ public class BasicAuthenticationTest
     }
 
     @Test
-    public void shouldFailOnMalformedToken() throws AuthenticationException
+    public void shouldFailOnMalformedToken() throws Exception
     {
         // Given
         BasicAuthManager manager = mock( BasicAuthManager.class );
         BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
         BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ), identifier );
-        when( manager.login( anyString(), anyString() ) ).thenReturn( authSubject );
+        when( manager.login( anyMap() ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
 
         // Expect

--- a/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
@@ -202,27 +202,6 @@ public class BasicAuthenticationTest
         authentication.authenticate( map( "scheme", "UNKNOWN", "principal", "bob", "credentials", "secret" ) );
     }
 
-    @Test
-    public void shouldFailOnMalformedToken() throws Exception
-    {
-        // Given
-        BasicAuthManager manager = mock( BasicAuthManager.class );
-        BasicAuthSubject authSubject = mock( BasicAuthSubject.class );
-        BasicAuthentication authentication = new BasicAuthentication( manager, mock( LogProvider.class ), identifier );
-        when( manager.login( anyMap() ) ).thenReturn( authSubject );
-        when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
-
-        // Expect
-        exception.expect( AuthenticationException.class );
-        exception.expect( hasStatus( Status.Security.Unauthorized ) );
-        exception.expectMessage(
-                "The value associated with the key `principal` must be a String but was: SingletonList" );
-
-        // When
-        authentication
-                .authenticate( map( "scheme", "basic", "principal", singletonList( "bob" ), "credentials", "secret" ) );
-    }
-
     private HasStatus hasStatus( Status status )
     {
         return new HasStatus( status );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/AuthenticationIT.java
@@ -131,6 +131,22 @@ public class AuthenticationIT
     }
 
     @Test
+    public void shouldFailIfMalformedAuthToken() throws Throwable
+    {
+        // When
+        client.connect( address )
+                .send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
+                .send( TransportTestUtil.chunk(
+                        init( "TestClient/1.1",
+                                map( "principal", "neo4j", "this-should-have-been-credentials", "neo4j", "scheme", "basic" ) ) ) );
+
+        // Then
+        assertThat( client, eventuallyRecieves( new byte[]{0, 0, 0, 1} ) );
+        assertThat( client, eventuallyRecieves( msgFailure( Status.Security.Unauthorized,
+                String.format( "The value associated with the key `credentials` must be a String but was: null (ID:%s)", server.uniqueIdentier()) ) ) );
+    }
+
+    @Test
     public void shouldBeAbleToUpdateCredentials() throws Throwable
     {
         // When

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
@@ -20,12 +20,12 @@
 package org.neo4j.kernel.api.security;
 
 import org.neo4j.helpers.Service;
-import org.neo4j.kernel.api.security.exception.IllegalCredentialsException;
+import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.LogProvider;
 
-import java.io.IOException;
+import java.util.Map;
 
 /**
  * An AuthManager is used to do basic authentication and user management.
@@ -43,12 +43,12 @@ public interface AuthManager extends Lifecycle
     }
 
     /**
-     * Log in using the provided username and password
-     * @param username The name of the user
-     * @param password The password of the user
+     * Log in using the provided authentication token
+     * @param authToken The authentication token to login with. Typically contains principals and credentials.
      * @return An AuthSubject representing the newly logged-in user
+     * @throws InvalidAuthTokenException if the authentication token is malformed
      */
-    AuthSubject login( String username, String password );
+    AuthSubject login( Map<String,Object> authToken ) throws InvalidAuthTokenException;
 
     /**
      * Implementation that does no authentication.
@@ -76,7 +76,7 @@ public interface AuthManager extends Lifecycle
         }
 
         @Override
-        public AuthSubject login( String username, String password )
+        public AuthSubject login( Map<String,Object> authToken )
         {
             return AuthSubject.AUTH_DISABLED;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 
+import static org.neo4j.helpers.collection.MapUtil.map;
+
 public interface AuthToken
 {
     String SCHEME_KEY = "scheme";
@@ -40,5 +42,10 @@ public interface AuthToken
                     (value == null ? "null" : value.getClass().getSimpleName()));
         }
         return (String) value;
+    }
+
+    static Map<String,Object> newBasicAuthToken( String username, String password )
+    {
+        return map( AuthToken.SCHEME_KEY, "basic", AuthToken.PRINCIPAL, username, AuthToken.CREDENTIALS, password );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthToken.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.security;
+
+import java.util.Map;
+
+import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
+
+public interface AuthToken
+{
+    String SCHEME_KEY = "scheme";
+    String PRINCIPAL = "principal";
+    String CREDENTIALS = "credentials";
+    String NEW_CREDENTIALS = "new_credentials";
+
+    static String safeCast( String key, Map<String,Object> authToken ) throws InvalidAuthTokenException
+    {
+        Object value = authToken.get( key );
+        if ( value == null || !(value instanceof String) )
+        {
+            throw new InvalidAuthTokenException(
+                    "The value associated with the key `" + key + "` must be a String but was: " +
+                    (value == null ? "null" : value.getClass().getSimpleName()));
+        }
+        return (String) value;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/exception/InvalidAuthTokenException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/exception/InvalidAuthTokenException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.security.exception;
+
+import org.neo4j.kernel.api.exceptions.Status;
+
+public class InvalidAuthTokenException extends Exception implements Status.HasStatus
+{
+    private final Status status;
+
+    public InvalidAuthTokenException( String message )
+    {
+        super(message);
+        this.status = Status.Security.Unauthorized;
+    }
+
+    @Override
+    public Status status()
+    {
+        return status;
+    }
+}

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -21,12 +21,15 @@ package org.neo4j.server.security.auth;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.util.Map;
 
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.api.security.AuthSubject;
+import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.exception.IllegalCredentialsException;
+import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.server.security.auth.exception.ConcurrentModificationException;
 
 /**
@@ -93,9 +96,13 @@ public class BasicAuthManager implements AuthManager, UserManager
     }
 
     @Override
-    public AuthSubject login( String username, String password )
+    public AuthSubject login( Map<String,Object> authToken ) throws InvalidAuthTokenException
     {
         assertAuthEnabled();
+
+        String username = AuthToken.safeCast( AuthToken.PRINCIPAL, authToken );
+        String password = AuthToken.safeCast( AuthToken.CREDENTIALS, authToken );
+
         User user = users.findByName( username );
         AuthenticationResult result = AuthenticationResult.FAILURE;
         if ( user != null )

--- a/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 
 public class BasicAuthManagerTest
 {
@@ -67,7 +68,7 @@ public class BasicAuthManagerTest
         when( authStrategy.authenticate( user, "abc123" )).thenReturn( AuthenticationResult.SUCCESS );
 
         // When
-        AuthSubject authSubject = manager.login( "jake", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "jake", "abc123" ) );
         AuthenticationResult result = authSubject.getAuthenticationResult();
 
         // Then
@@ -87,7 +88,7 @@ public class BasicAuthManagerTest
         when( authStrategy.authenticate( user, "abc123" )).thenReturn( AuthenticationResult.TOO_MANY_ATTEMPTS );
 
         // When
-        AuthSubject authSubject = manager.login( "jake", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "jake", "abc123" ) );
         AuthenticationResult result = authSubject.getAuthenticationResult();
 
         // Then
@@ -107,7 +108,7 @@ public class BasicAuthManagerTest
         when( authStrategy.authenticate( user, "abc123" )).thenReturn( AuthenticationResult.SUCCESS );
 
         // When
-        AuthSubject authSubject = manager.login( "jake", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "jake", "abc123" ) );
         AuthenticationResult result = authSubject.getAuthenticationResult();
 
         // Then
@@ -126,7 +127,7 @@ public class BasicAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject authSubject = manager.login( "unknown", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "unknown", "abc123" ) );
         AuthenticationResult result = authSubject.getAuthenticationResult();
 
         // Then
@@ -238,7 +239,7 @@ public class BasicAuthManagerTest
 
         try
         {
-            manager.login( "foo", "bar" );
+            manager.login( authToken( "foo", "bar" ) );
             fail( "exception expected" );
         } catch ( IllegalStateException e )
         {

--- a/community/security/src/test/java/org/neo4j/server/security/auth/SecurityTestUtils.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/SecurityTestUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.auth;
+
+import java.util.Map;
+
+import org.neo4j.kernel.api.security.AuthToken;
+
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class SecurityTestUtils
+{
+    public static Map<String,Object> authToken( String username, String password )
+    {
+        return map( AuthToken.SCHEME_KEY, "basic", AuthToken.PRINCIPAL, username, AuthToken.CREDENTIALS, password );
+    }
+}

--- a/community/security/src/test/java/org/neo4j/server/security/auth/SecurityTestUtils.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/SecurityTestUtils.java
@@ -21,14 +21,12 @@ package org.neo4j.server.security.auth;
 
 import java.util.Map;
 
-import org.neo4j.kernel.api.security.AuthToken;
-
-import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.api.security.AuthToken.newBasicAuthToken;
 
 public class SecurityTestUtils
 {
     public static Map<String,Object> authToken( String username, String password )
     {
-        return map( AuthToken.SCHEME_KEY, "basic", AuthToken.PRINCIPAL, username, AuthToken.CREDENTIALS, password );
+        return newBasicAuthToken( username, password );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
@@ -48,6 +48,7 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static javax.servlet.http.HttpServletRequest.BASIC_AUTH;
 import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.api.security.AuthToken.newBasicAuthToken;
 import static org.neo4j.server.web.XForwardUtil.X_FORWARD_HOST_HEADER_KEY;
 import static org.neo4j.server.web.XForwardUtil.X_FORWARD_PROTO_HEADER_KEY;
 
@@ -142,9 +143,7 @@ public class AuthorizationEnabledFilter extends AuthorizationFilter
     private AuthSubject authenticate( String username, String password ) throws InvalidAuthTokenException
     {
         AuthManager authManager = authManagerSupplier.get();
-
-        Map<String,Object> authToken = map( AuthToken.SCHEME_KEY,
-                "basic", AuthToken.PRINCIPAL, username, AuthToken.CREDENTIALS, password );
+        Map<String,Object> authToken = newBasicAuthToken( username, password );
 
         AuthSubject authSubject = authManager.login( authToken );
         return authSubject;
@@ -181,7 +180,6 @@ public class AuthorizationEnabledFilter extends AuthorizationFilter
                         "code", Status.Security.Unauthorized.code().serialize(),
                         "message", message ) ) ) );
     }
-
 
     private static ThrowingConsumer<HttpServletResponse, IOException> passwordChangeRequired( final String username, final String baseURL )
     {

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import static org.neo4j.logging.AssertableLogProvider.inLog;
+import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 
 public class AuthorizationFilterTest
 {
@@ -171,7 +172,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
         when( servletRequest.getRemoteAddr() ).thenReturn( "remote_ip_address" );
-        when( authManager.login( "foo", "bar" ) ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.FAILURE );
 
         // When
@@ -198,7 +199,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/user/foo" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
-        when( authManager.login( "foo", "bar" ) ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
 
         // When
@@ -221,7 +222,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getRequestURL() ).thenReturn( new StringBuffer( "http://bar.baz:7474/db/data/" ) );
         when( servletRequest.getRequestURI() ).thenReturn( "/db/data/" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
-        when( authManager.login( "foo", "bar" ) ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
 
         // When
@@ -246,7 +247,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
-        when( authManager.login( "foo", "bar" ) ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.TOO_MANY_ATTEMPTS );
 
         // When
@@ -270,7 +271,7 @@ public class AuthorizationFilterTest
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
-        when( authManager.login( "foo", "bar" ) ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
 
         // When

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManager.java
@@ -31,11 +31,14 @@ import org.apache.shiro.subject.Subject;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.util.Map;
 
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.api.security.AuthSubject;
+import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.exception.IllegalCredentialsException;
+import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.server.security.auth.AuthenticationStrategy;
 import org.neo4j.server.security.auth.BasicAuthManager;
 import org.neo4j.server.security.auth.PasswordPolicy;
@@ -142,9 +145,13 @@ public class ShiroAuthManager extends BasicAuthManager implements RoleManager
         return realm.newRole( roleName, users );
     }
 
-    public AuthSubject login( String username, String password )
+    @Override
+    public AuthSubject login( Map<String,Object> authToken ) throws InvalidAuthTokenException
     {
         assertAuthEnabled();
+
+        String username = AuthToken.safeCast( AuthToken.PRINCIPAL, authToken );
+        String password = AuthToken.safeCast( AuthToken.CREDENTIALS, authToken );
 
         // Start with an anonymous subject
         Subject subject = buildSubject( null );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManagerTest.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 
 public class ShiroAuthManagerTest
 {
@@ -96,7 +97,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthenticationResult result = manager.login( "jake", "abc123" ).getAuthenticationResult();
+        AuthenticationResult result = manager.login( authToken( "jake", "abc123" ) ).getAuthenticationResult();
 
         // Then
         assertThat( result, equalTo( AuthenticationResult.SUCCESS ) );
@@ -112,7 +113,7 @@ public class ShiroAuthManagerTest
         when( authStrategy.isAuthenticationPermitted( user.name() )).thenReturn( false );
 
         // When
-        AuthSubject authSubject = manager.login( "jake", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "jake", "abc123" ) );
         AuthenticationResult result = authSubject.getAuthenticationResult();
 
         // Then
@@ -128,7 +129,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthenticationResult result = manager.login( "jake", "abc123" ).getAuthenticationResult();
+        AuthenticationResult result = manager.login( authToken( "jake", "abc123" ) ).getAuthenticationResult();
 
         // Then
         assertThat( result, equalTo( AuthenticationResult.PASSWORD_CHANGE_REQUIRED ) );
@@ -143,7 +144,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject authSubject = manager.login( "unknown", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "unknown", "abc123" ) );
         AuthenticationResult result = authSubject.getAuthenticationResult();
 
         // Then
@@ -221,7 +222,7 @@ public class ShiroAuthManagerTest
         manager.suspendUser( "jake" );
 
         // Then
-        AuthSubject authSubject = manager.login( "jake", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "jake", "abc123" ) );
         assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.FAILURE ) );
     }
 
@@ -238,7 +239,7 @@ public class ShiroAuthManagerTest
         manager.activateUser( "jake" );
 
         // Then
-        AuthSubject authSubject = manager.login( "jake", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "jake", "abc123" ) );
         assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.SUCCESS ) );
     }
 
@@ -255,7 +256,7 @@ public class ShiroAuthManagerTest
         manager.suspendUser( "jake" );
 
         // Then
-        AuthSubject authSubject = manager.login( "jake", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "jake", "abc123" ) );
         assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.FAILURE ) );
     }
 
@@ -271,7 +272,7 @@ public class ShiroAuthManagerTest
         manager.activateUser( "jake" );
 
         // Then
-        AuthSubject authSubject = manager.login( "jake", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "jake", "abc123" ) );
         assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.SUCCESS ) );
     }
 
@@ -337,7 +338,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject authSubject = manager.login( "neo", "abc123" );
+        AuthSubject authSubject = manager.login( authToken( "neo", "abc123" ) );
         assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.PASSWORD_CHANGE_REQUIRED ) );
 
         authSubject.setPassword( "hello, world!" );
@@ -348,7 +349,7 @@ public class ShiroAuthManagerTest
         assertThat( users.findByName( "neo" ), equalTo( user ) );
 
         authSubject.logout();
-        authSubject = manager.login( "neo", "hello, world!" );
+        authSubject = manager.login( authToken( "neo", "hello, world!" ) );
         assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.SUCCESS ) );
     }
 
@@ -360,7 +361,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject authSubject = manager.login( "neo", "wrong" );
+        AuthSubject authSubject = manager.login( authToken( "neo", "wrong" ) );
 
         // Then
         assertThat( authSubject.getAuthenticationResult(), equalTo( AuthenticationResult.FAILURE ) );
@@ -405,10 +406,10 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject subject = manager.login( "neo4j", "neo4j");
+        AuthSubject subject = manager.login( authToken( "neo4j", "neo4j" ) );
         manager.setUserPassword( "neo4j", "1234" );
         subject.logout();
-        subject = manager.login( "neo4j", "1234");
+        subject = manager.login( authToken( "neo4j", "1234" ) );
 
         // Then
         assertTrue( subject.allowsReads() );
@@ -424,7 +425,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject subject = manager.login( "morpheus", "abc123");
+        AuthSubject subject = manager.login( authToken( "morpheus", "abc123" ) );
 
         // Then
         assertTrue( subject.allowsReads() );
@@ -440,7 +441,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject subject = manager.login( "trinity", "abc123");
+        AuthSubject subject = manager.login( authToken( "trinity", "abc123" ) );
 
         // Then
         assertTrue( subject.allowsReads() );
@@ -456,7 +457,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject subject = manager.login( "tank", "abc123");
+        AuthSubject subject = manager.login( authToken( "tank", "abc123" ) );
 
         // Then
         assertTrue( "should allow reads", subject.allowsReads() );
@@ -472,7 +473,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject subject = manager.login( "neo", "abc123");
+        AuthSubject subject = manager.login( authToken( "neo", "abc123" ) );
 
         // Then
         assertTrue( subject.allowsReads() );
@@ -488,7 +489,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject subject = manager.login( "smith", "abc123");
+        AuthSubject subject = manager.login( authToken( "smith", "abc123" ) );
 
         // Then
         assertFalse( subject.allowsReads() );
@@ -504,7 +505,7 @@ public class ShiroAuthManagerTest
         manager.start();
 
         // When
-        AuthSubject subject = manager.login( "morpheus", "abc123");
+        AuthSubject subject = manager.login( authToken( "morpheus", "abc123" ) );
         assertTrue( subject.allowsReads() );
         assertTrue( subject.allowsWrites() );
         assertTrue( subject.allowsSchemaWrites() );
@@ -528,7 +529,7 @@ public class ShiroAuthManagerTest
 
         try
         {
-            manager.login( "foo", "bar" );
+            manager.login( authToken( "foo", "bar" ) );
             fail( "exception expected" );
         } catch ( IllegalStateException e )
         {

--- a/manual/bolt/pom.xml
+++ b/manual/bolt/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>neo4j-bolt</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-security</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!--Test dependencies-->
         <dependency>


### PR DESCRIPTION
Bolt already gets authentication information from the client as a
Map<String,Object>.
Instead of extracting username and password within Bolt BasicAuthentication,
we now pass the map to AuthManager.login(), so that we can cater for more
advanced authentication mechanisms.
