### PR TITLE
Fix flaky HaBeanIT tests

### DIFF
--- a/enterprise/ha/src/test/java/jmx/HaBeanIT.java
+++ b/enterprise/ha/src/test/java/jmx/HaBeanIT.java
@@ -94,7 +94,6 @@ public class HaBeanIT
     {
         assertTrue( "should be available", ha.isAvailable() );
         assertEquals( "should be master", HighAvailabilityModeSwitcher.MASTER, ha.getRole() );
-        assertEquals( "should be instance 1", "1", ha.getInstanceId() );
     }
 
     @Test


### PR DESCRIPTION
This should take care of the following test failures.

HaBeanIT.canGetBranchedStoreBean:

```
java.lang.AssertionError: no branched stores for new db expected:<0> but was:<1>
    at org.junit.Assert.fail(Assert.java:88)
    at org.junit.Assert.failNotEquals(Assert.java:834)
    at org.junit.Assert.assertEquals(Assert.java:645)
    at jmx.HaBeanIT.canGetBranchedStoreBean(HaBeanIT.java:229)
```

HaBeanIT.canGetHaBean:

```
org.junit.ComparisonFailure: should be instance 1 expected:<[1]> but was:<[2]>
    at org.junit.Assert.assertEquals(Assert.java:115)
    at jmx.HaBeanIT.assertMasterInformation(HaBeanIT.java:94)
    at jmx.HaBeanIT.canGetHaBean(HaBeanIT.java:87)
```

The second failure is just too pedantic. Since any instance is allowed
to be master, it is not an error to find any instance other than 1 as
the master.

The first I am guessing is due to an unclean directory somehow, and so
added some initialization code to clean up the store dir before starting
the instance.
