### PR TITLE
Adds diagnostic logging to various CE components

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
@@ -143,6 +143,7 @@ public class RaftInstance<MEMBER> implements LeaderLocator<MEMBER>,
     {
         electionTimer = renewableTimeoutService.create(
                 Timeouts.ELECTION, electionTimeout, randomTimeoutRange(), timeout -> {
+                    log.info( "Election timeout triggered, base timeout value is %d%n", electionTimeout );
                     handle( new RaftMessages.Timeout.Election<>( myself ) );
                     timeout.renew();
                 } );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Election.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Election.java
@@ -25,14 +25,17 @@ import java.util.Set;
 import org.neo4j.coreedge.raft.RaftMessages;
 import org.neo4j.coreedge.raft.outcome.Outcome;
 import org.neo4j.coreedge.raft.state.ReadableRaftState;
+import org.neo4j.logging.Log;
 
 public class Election
 {
-    public static <MEMBER> boolean start( ReadableRaftState<MEMBER> ctx, Outcome<MEMBER> outcome ) throws IOException
+    public static <MEMBER> boolean start( ReadableRaftState<MEMBER> ctx, Outcome<MEMBER> outcome, Log log ) throws IOException
     {
         Set<MEMBER> currentMembers = ctx.votingMembers();
         if ( currentMembers == null || !currentMembers.contains( ctx.myself() ) )
         {
+            log.info( "Election attempted but not started, current members are %s, i am %s%n",
+                    currentMembers, ctx.myself()  );
             return false;
         }
 
@@ -51,6 +54,7 @@ public class Election
         }
 
         outcome.setVotedFor( ctx.myself() );
+        log.info( "Election started with vote request: %s and members: %s%n", voteForMe, currentMembers );
         return true;
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Follower.java
@@ -105,9 +105,10 @@ public class Follower implements RaftMessageHandler
 
             case ELECTION_TIMEOUT:
             {
-                if ( Election.start( ctx, outcome ) )
+                if ( Election.start( ctx, outcome, log ) )
                 {
                     outcome.setNextRole( CANDIDATE );
+                    log.info( "Moving to CANDIDATE state after successfully starting election %n" );
                 }
                 break;
             }


### PR DESCRIPTION
State changes of RAFT members are now logged, along with reasons they
 happened
RaftLogShipper will now print which instance it manages in every
 log line it produces. It will also print state changes, along with
 reasons it did so
Election timeouts are now logged
