### PR TITLE
Some tweaks for checkpoint stress test

### DIFF
--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
@@ -52,10 +52,10 @@ public class CheckPointingLogRotationStressTesting
     private static final String DEFAULT_STORE_DIR = new File( getProperty( "java.io.tmpdir" ), "store" ).getPath();
     private static final String DEFAULT_NODE_COUNT = "100000";
     private static final String DEFAULT_WORKER_THREADS = "16";
-    private static final String DEFAULT_PAGE_CACHE_MEMORY = "2g";
+    private static final String DEFAULT_PAGE_CACHE_MEMORY = "4g";
     private static final String DEFAULT_PAGE_SIZE = "8k";
 
-    private static final int CHECK_POINT_INTERVAL_SECONDS = 60;
+    private static final int CHECK_POINT_INTERVAL_MINUTES = 1;
 
     @Test
     public void shouldBehaveCorrectlyUnderStress() throws Throwable
@@ -81,7 +81,7 @@ public class CheckPointingLogRotationStressTesting
         GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
                 .setConfig( GraphDatabaseSettings.pagecache_memory, pageCacheMemory )
                 .setConfig( GraphDatabaseSettings.mapped_memory_page_size, pageSize )
-                .setConfig( GraphDatabaseSettings.check_point_interval_time, CHECK_POINT_INTERVAL_SECONDS + "s" )
+                .setConfig( GraphDatabaseSettings.check_point_interval_time, CHECK_POINT_INTERVAL_MINUTES + "m" )
                 .setConfig( GraphDatabaseFacadeFactory.Configuration.tracer, "timer" )
                 .newGraphDatabase();
 
@@ -89,7 +89,7 @@ public class CheckPointingLogRotationStressTesting
         try ( Workload workload = new Workload( db, defaultRandomMutation( nodeCount, db ), threads ) )
         {
             // make sure to run at least one checkpoint during warmup
-            long warmUpTimeMillis = TimeUnit.SECONDS.toMillis( CHECK_POINT_INTERVAL_SECONDS + 30 );
+            long warmUpTimeMillis = TimeUnit.SECONDS.toMillis( CHECK_POINT_INTERVAL_MINUTES * 2 );
             workload.run( warmUpTimeMillis, Workload.TransactionThroughput.NONE );
         }
 

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/CheckPointingLogRotationStressTesting.java
@@ -29,6 +29,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.stresstests.transaction.checkpoint.tracers.TimerTransactionTracer;
@@ -81,6 +82,7 @@ public class CheckPointingLogRotationStressTesting
         GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
                 .setConfig( GraphDatabaseSettings.pagecache_memory, pageCacheMemory )
                 .setConfig( GraphDatabaseSettings.mapped_memory_page_size, pageSize )
+                .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.check_point_interval_time, CHECK_POINT_INTERVAL_MINUTES + "m" )
                 .setConfig( GraphDatabaseFacadeFactory.Configuration.tracer, "timer" )
                 .newGraphDatabase();

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/Workload.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/workload/Workload.java
@@ -29,7 +29,6 @@ import org.neo4j.kernel.stresstests.transaction.checkpoint.mutation.RandomMutati
 
 public class Workload implements Resource
 {
-    private final GraphDatabaseService db;
     private final int threads;
     private final SyncMonitor sync;
     private final Worker worker;
@@ -37,7 +36,6 @@ public class Workload implements Resource
 
     public Workload( GraphDatabaseService db, RandomMutation randomMutation, int threads )
     {
-        this.db = db;
         this.threads = threads;
         this.sync = new SyncMonitor( threads );
         this.worker = new Worker( db, randomMutation, sync, 100 );
@@ -66,12 +64,14 @@ public class Workload implements Resource
             executor.submit( worker );
         }
 
+        TimeUnit.SECONDS.sleep( 20 ); // sleep to make sure workers are started
+
         long now = System.currentTimeMillis();
         long previousReportTime = System.currentTimeMillis();
         long finishLine = runningTimeMillis + now;
         long sampleRate = TimeUnit.SECONDS.toMillis( 10 );
         long lastReport = sampleRate + now;
-        long previousTransactionCount = 0;
+        long previousTransactionCount = sync.transactions();
         Thread.sleep( sampleRate );
         do
         {


### PR DESCRIPTION
- warmup runs for 2 checkpoint intervals
- let worker threads run for 20 seconds before we start collecting throughput results
- print throughput results with timestamps
- require 60% of throughput results to be in one stddev from average
- increase default page cache memory from 2g to 4g
