### PR TITLE
Proper handling of AuthenticationFailure version 2

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
@@ -26,7 +26,9 @@ import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.kernel.api.exceptions.Status;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.failed;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.failedWith;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.ignored;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.recorded;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.success;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.successButRequiresPasswordChange;
@@ -56,6 +58,53 @@ public class SessionAuthIT
         assertThat( recorder, recorded(
                 successButRequiresPasswordChange(),
                 failedWith( Status.Security.CredentialsExpired ) ) );
+    }
+
+    @Test
+    public void shouldCloseConnectionOnAuthenticationFailure() throws Throwable
+    {
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "j4oen"
+        ), null, recorder );
+        session.ackFailure( null, recorder );
+        session.run( "RETURN 1337", map(), null, recorder );
+
+        // then
+        assertThat( recorder, recorded( failed(), success(), failed() ));
+    }
+
+    @Test
+    public void shouldBeAbleToReinitializeOnAuthenticationFailure() throws Throwable
+    {
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "j4oen"
+        ), null, recorder );
+        session.ackFailure( null, recorder );
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "neo4j"
+        ), null, recorder );
+
+        // then
+        assertThat( recorder, recorded( failed(), success(), success() ));
     }
 
     @Test


### PR DESCRIPTION
Like https://github.com/neo4j/neo4j/pull/7357 but doesn't close the connection, either merge this one or the other not both.
