### PR TITLE
Refactor Listeners

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
@@ -19,68 +19,136 @@
  */
 package org.neo4j.helpers;
 
-import java.util.Collection;
-import java.util.LinkedList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
+import javax.annotation.Nonnull;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 /**
- * Helper class for dealing with listeners
+ * Mutable thread-safe container of listeners that can be notified with {@link Notification}.
+ *
+ * @param <T> the type of listeners.
  */
-public class Listeners
+public class Listeners<T> implements Iterable<T>
 {
-    public interface Notification<T>
+    private final List<T> listeners;
+
+    /**
+     * Construct new empty listeners;
+     */
+    public Listeners()
     {
-        void notify( T listener );
+        this.listeners = createListeners( emptyList() );
     }
 
-    public static <T> Collection<T> newListeners()
+    /**
+     * Construct a copy of the given listeners.
+     *
+     * @param other listeners to copy.
+     */
+    public Listeners( @Nonnull Listeners<T> other )
     {
-        return new LinkedList<>();
+        requireNonNull( other, "prototype listeners can't be null" );
+
+        this.listeners = createListeners( other.listeners );
     }
 
-    public static <T> Collection<T> addListener( T listener, Collection<T> listeners )
+    /**
+     * Adds the specified listener to this container.
+     *
+     * @param listener the listener to add.
+     */
+    public void add( @Nonnull T listener )
     {
-        List<T> newListeners = new LinkedList<>( listeners );
-        newListeners.add( listener );
-        return newListeners;
+        requireNonNull( listener, "added listener can't be null" );
+
+        listeners.add( listener );
     }
 
-    public static <T> Collection<T> removeListener( T listener, Collection<T> listeners )
+    /**
+     * Remove the first occurrence of the specified listener from this container, if it is present.
+     *
+     * @param listener the listener to remove.
+     */
+    public void remove( @Nonnull T listener )
     {
-        List<T> newListeners = new LinkedList<>( listeners );
-        newListeners.remove( listener );
-        return newListeners;
+        requireNonNull( listener, "removed listener can't be null" );
+
+        listeners.remove( listener );
     }
 
-    public static <T> void notifyListeners( Collection<T> listeners, Notification<T> notification )
+    /**
+     * Notify all listeners in this container with the given notification.
+     * Notification of each listener is synchronized on this listener.
+     *
+     * @param notification the notification to be applied to each listener.
+     */
+    public void notify( @Nonnull Notification<T> notification )
     {
+        requireNonNull( notification, "notification can't be null" );
+
         for ( T listener : listeners )
         {
-            notifySingleListener( notification, listener );
+            notifySingleListener( listener, notification );
         }
     }
 
-    public static <T> void notifyListeners( Collection<T> listeners, Executor executor, Notification<T> notification )
+    /**
+     * Notify all listeners in this container with the given notification using the given executor.
+     * Each notification is submitted as a {@link Runnable} to the executor.
+     * Notification of each listener is synchronized on this listener.
+     *
+     * @param executor the executor to submit notifications to.
+     * @param notification the notification to be applied to each listener.
+     */
+    public void notify( @Nonnull Executor executor, @Nonnull Notification<T> notification )
     {
-        for ( final T listener : listeners )
+        requireNonNull( executor, "executor can't be null" );
+        requireNonNull( notification, "notification can't be null" );
+
+        for ( T listener : listeners )
         {
-            executor.execute( () -> notifySingleListener( notification, listener ) );
+            executor.execute( () -> notifySingleListener( listener, notification ) );
         }
     }
 
-    private static <T> void notifySingleListener( Notification<T> notification, T listener )
+    /**
+     * Returns the iterator over listeners in this container in the order they were added.
+     * <p>
+     * The returned iterator provides a snapshot of the state of the list
+     * when the iterator was constructed. No synchronization is needed while
+     * traversing the iterator. The iterator does <em>NOT</em> support the
+     * {@code remove} method.
+     *
+     * @return iterator over listeners.
+     */
+    @Override
+    public Iterator<T> iterator()
+    {
+        return listeners.iterator();
+    }
+
+    private static <T> void notifySingleListener( T listener, Notification<T> notification )
     {
         synchronized ( listener )
         {
-            try
-            {
-                notification.notify( listener );
-            }
-            catch ( Throwable e )
-            {
-                throw new RuntimeException( e );
-            }
+            notification.notify( listener );
         }
+    }
+
+    private static <T> List<T> createListeners( List<T> existingListeners )
+    {
+        List<T> result = new CopyOnWriteArrayList<>();
+        result.addAll( existingListeners );
+        return result;
+    }
+
+    public interface Notification<T>
+    {
+        void notify( T listener );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel;
 
-import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,8 +30,6 @@ import org.neo4j.helpers.Format;
 import org.neo4j.helpers.Listeners;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.logging.Log;
-
-import static org.neo4j.helpers.Listeners.notifyListeners;
 
 /**
  * The availability guard ensures that the database will only take calls when it is in an ok state.
@@ -112,7 +109,7 @@ public class AvailabilityGuard
     private final AtomicInteger requirementCount = new AtomicInteger( 0 );
     private final Set<AvailabilityRequirement> blockingRequirements = new CopyOnWriteArraySet<>();
     private final AtomicBoolean isShutdown = new AtomicBoolean( false );
-    private Collection<AvailabilityListener> listeners = Listeners.newListeners();
+    private final Listeners<AvailabilityListener> listeners = new Listeners<>();
     private final Clock clock;
     private final Log log;
 
@@ -139,14 +136,7 @@ public class AvailabilityGuard
             if ( requirementCount.getAndIncrement() == 0 && !isShutdown.get() )
             {
                 log.info( DATABASE_UNAVAILABLE_MSG + requirement.description() );
-                notifyListeners( listeners, new Listeners.Notification<AvailabilityListener>()
-                {
-                    @Override
-                    public void notify( AvailabilityListener listener )
-                    {
-                        listener.unavailable();
-                    }
-                } );
+                listeners.notify( AvailabilityListener::unavailable );
             }
         }
     }
@@ -168,14 +158,7 @@ public class AvailabilityGuard
             if ( requirementCount.getAndDecrement() == 1 && !isShutdown.get() )
             {
                 log.info( DATABASE_AVAILABLE_MSG + requirement.description() );
-                notifyListeners( listeners, new Listeners.Notification<AvailabilityListener>()
-                {
-                    @Override
-                    public void notify( AvailabilityListener listener )
-                    {
-                        listener.available();
-                    }
-                } );
+                listeners.notify( AvailabilityListener::available );
             }
         }
     }
@@ -194,14 +177,7 @@ public class AvailabilityGuard
 
             if ( requirementCount.get() == 0 )
             {
-                notifyListeners( listeners, new Listeners.Notification<AvailabilityListener>()
-                {
-                    @Override
-                    public void notify( AvailabilityListener listener )
-                    {
-                        listener.unavailable();
-                    }
-                } );
+                listeners.notify( AvailabilityListener::unavailable );
             }
         }
     }
@@ -325,7 +301,7 @@ public class AvailabilityGuard
      */
     public void addListener( AvailabilityListener listener )
     {
-        listeners = Listeners.addListener( listener, listeners );
+        listeners.add( listener );
     }
 
     /**
@@ -335,7 +311,7 @@ public class AvailabilityGuard
      */
     public void removeListener( AvailabilityListener listener )
     {
-        listeners = Listeners.removeListener( listener, listeners );
+        listeners.remove( listener );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DataSourceManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DataSourceManager.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction.state;
 
-import java.util.Collection;
 import java.util.function.Supplier;
 
 import org.neo4j.helpers.Listeners;
@@ -45,7 +44,7 @@ public class DataSourceManager implements Lifecycle, Supplier<KernelAPI>
     }
 
     private LifeSupport life = new LifeSupport();
-    private Collection<Listener> dsRegistrationListeners = Listeners.newListeners();
+    private final Listeners<Listener> dsRegistrationListeners = new Listeners<>();
     private NeoStoreDataSource dataSource;
 
     public void addListener( Listener listener )
@@ -63,22 +62,22 @@ public class DataSourceManager implements Lifecycle, Supplier<KernelAPI>
             {   // OK
             }
         }
-        dsRegistrationListeners = Listeners.addListener( listener, dsRegistrationListeners );
+        dsRegistrationListeners.add( listener );
     }
 
-    public void register( final NeoStoreDataSource dataSource )
+    public void register( NeoStoreDataSource dataSource )
     {
         this.dataSource = dataSource;
         if ( life.getStatus().equals( LifecycleStatus.STARTED ) )
         {
-            Listeners.notifyListeners( dsRegistrationListeners, listener -> listener.registered( dataSource ) );
+            dsRegistrationListeners.notify( listener -> listener.registered( dataSource ) );
         }
     }
 
-    public void unregister( final NeoStoreDataSource dataSource )
+    public void unregister( NeoStoreDataSource dataSource )
     {
         this.dataSource = null;
-        Listeners.notifyListeners( dsRegistrationListeners, listener -> listener.unregistered( dataSource ) );
+        dsRegistrationListeners.notify( listener -> listener.unregistered( dataSource ) );
         life.remove( dataSource );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/helpers/ListenersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ListenersTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.helpers.collection.Iterables;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.helpers.NamedThreadFactory.named;
+
+public class ListenersTest
+{
+    @Test( expected = NullPointerException.class )
+    public void copyConstructorWithNull()
+    {
+        new Listeners<>( null );
+    }
+
+    @Test
+    public void copyConstructor()
+    {
+        Listeners<Listener> original = newListeners( new Listener(), new Listener(), new Listener() );
+
+        Listeners<Listener> copy = new Listeners<>( original );
+
+        assertEquals( Iterables.asList( original ), Iterables.asList( copy ) );
+    }
+
+    @Test( expected = NullPointerException.class )
+    public void addNull()
+    {
+        new Listeners<>().add( null );
+    }
+
+    @Test
+    public void add()
+    {
+        Listener[] listenersArray = {new Listener(), new Listener(), new Listener()};
+
+        Listeners<Listener> listeners = newListeners( listenersArray );
+
+        assertArrayEquals( listenersArray, Iterables.asArray( Listener.class, listeners ) );
+    }
+
+    @Test( expected = NullPointerException.class )
+    public void removeNull()
+    {
+        new Listeners<>().remove( null );
+    }
+
+    @Test
+    public void remove()
+    {
+        Listener listener1 = new Listener();
+        Listener listener2 = new Listener();
+        Listener listener3 = new Listener();
+
+        Listeners<Listener> listeners = newListeners( listener1, listener2, listener3 );
+
+        assertEquals( Arrays.asList( listener1, listener2, listener3 ), Iterables.asList( listeners ) );
+
+        listeners.remove( listener1 );
+        assertEquals( Arrays.asList( listener2, listener3 ), Iterables.asList( listeners ) );
+
+        listeners.remove( listener3 );
+        assertEquals( singletonList( listener2 ), Iterables.asList( listeners ) );
+    }
+
+    @Test( expected = NullPointerException.class )
+    public void notifyWithNullNotification()
+    {
+        new Listeners<>().notify( null );
+    }
+
+    @Test
+    public void notifyWithNotification()
+    {
+        String message = "foo";
+        Listener listener1 = new Listener();
+        Listener listener2 = new Listener();
+
+        Listeners<Listener> listeners = newListeners( listener1, listener2 );
+
+        listeners.notify( listener -> listener.process( message ) );
+
+        assertEquals( message, listener1.message );
+        assertEquals( currentThread().getName(), listener1.threadName );
+
+        assertEquals( message, listener2.message );
+        assertEquals( currentThread().getName(), listener2.threadName );
+    }
+
+    @Test( expected = NullPointerException.class )
+    public void notifyWithNullExecutorAndNullNotification()
+    {
+        new Listeners<>().notify( null, null );
+    }
+
+    @Test( expected = NullPointerException.class )
+    public void notifyWithNullExecutorAndNotification()
+    {
+        new Listeners<Listener>().notify( null, listener -> listener.process( "foo" ) );
+    }
+
+    @Test( expected = NullPointerException.class )
+    public void notifyWithExecutorAndNullNotification()
+    {
+        new Listeners<Listener>().notify( newSingleThreadExecutor(), null );
+    }
+
+    @Test
+    public void notifyWithExecutorAndNotification() throws Exception
+    {
+        String message = "foo";
+        String threadNamePrefix = "test-thread";
+        Listener listener1 = new Listener();
+        Listener listener2 = new Listener();
+
+        Listeners<Listener> listeners = newListeners( listener1, listener2 );
+
+        ExecutorService executor = newSingleThreadExecutor( named( threadNamePrefix ) );
+        listeners.notify( executor, listener -> listener.process( message ) );
+        executor.shutdown();
+        executor.awaitTermination( 1, TimeUnit.MINUTES );
+
+        assertEquals( message, listener1.message );
+        assertThat( listener1.threadName, startsWith( threadNamePrefix ) );
+
+        assertEquals( message, listener2.message );
+        assertThat( listener2.threadName, startsWith( threadNamePrefix ) );
+    }
+
+    @Test
+    public void listenersIterable()
+    {
+        Listener listener1 = new Listener();
+        Listener listener2 = new Listener();
+        Listener listener3 = new Listener();
+
+        Listeners<Listener> listeners = newListeners( listener1, listener2, listener3 );
+
+        assertEquals( Arrays.asList( listener1, listener2, listener3 ), Iterables.asList( listeners ) );
+    }
+
+    @SafeVarargs
+    private static <T> Listeners<T> newListeners( T... listeners )
+    {
+        Listeners<T> result = new Listeners<>();
+        for ( T listener : listeners )
+        {
+            result.add( listener );
+        }
+        return result;
+    }
+
+    private static class Listener
+    {
+        volatile String message;
+        volatile String threadName;
+
+        void process( String message )
+        {
+            this.message = message;
+            this.threadName = currentThread().getName();
+        }
+    }
+}

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AtomicBroadcastContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/AtomicBroadcastContextImpl.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context;
 
-import java.util.Collection;
 import java.util.concurrent.Executor;
 
 import org.neo4j.cluster.protocol.atomicbroadcast.AtomicBroadcastListener;
@@ -42,7 +41,7 @@ class AtomicBroadcastContextImpl
     extends AbstractContextImpl
     implements AtomicBroadcastContext
 {
-    private Collection<AtomicBroadcastListener> listeners = Listeners.newListeners();
+    private final Listeners<AtomicBroadcastListener> listeners = new Listeners<>();
     private final Executor executor;
     private final HeartbeatContext heartbeatContext;
 
@@ -58,26 +57,19 @@ class AtomicBroadcastContextImpl
     @Override
     public void addAtomicBroadcastListener( AtomicBroadcastListener listener )
     {
-        listeners = Listeners.addListener( listener, listeners );
+        listeners.add( listener );
     }
 
     @Override
     public void removeAtomicBroadcastListener( AtomicBroadcastListener listener )
     {
-        listeners = Listeners.removeListener( listener, listeners );
+        listeners.remove( listener );
     }
 
     @Override
-    public void receive( final Payload value )
+    public void receive( Payload value )
     {
-        Listeners.notifyListeners( listeners, executor, new Listeners.Notification<AtomicBroadcastListener>()
-        {
-            @Override
-            public void notify( final AtomicBroadcastListener listener )
-            {
-                listener.receive( value );
-            }
-        } );
+        listeners.notify( executor, listener -> listener.receive( value ) );
     }
 
     public AtomicBroadcastContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging,

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/TestProtocolServer.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/TestProtocolServer.java
@@ -21,7 +21,6 @@ package org.neo4j.cluster;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import org.neo4j.cluster.com.message.Message;
@@ -149,12 +148,12 @@ public class TestProtocolServer
     public class TestMessageSource
             implements MessageSource, MessageProcessor
     {
-        Collection<MessageProcessor> listeners = Listeners.newListeners();
+        final Listeners<MessageProcessor> listeners = new Listeners<>();
 
         @Override
         public void addMessageProcessor( MessageProcessor listener )
         {
-            listeners = Listeners.addListener( listener, listeners );
+            listeners.add( listener );
         }
 
         @Override


### PR DESCRIPTION
Commit changes `Listeners` class to be a container of listeners instead of a static utility helper. This results in better encapsulation of actual listeners storage and makes it clearer how to use `Listeners`.
