### PR TITLE
Make `ExternalResourceNotFound` a `ClientError`

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/Neo4jErrorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/Neo4jErrorTest.java
@@ -21,11 +21,13 @@ package org.neo4j.bolt.v1.runtime.internal;
 
 import org.junit.Test;
 
+import org.neo4j.cypher.LoadExternalResourceException;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.api.exceptions.Status;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Neo4jErrorTest
@@ -49,5 +51,15 @@ public class Neo4jErrorTest
 
         // Then
         assertEquals( error.status(), Status.Transaction.DeadlockDetected );
+    }
+
+    @Test
+    public void loadExternalResourceShouldNotReferToLog()
+    {
+        // Given
+        Neo4jError error = Neo4jError.from( new LoadExternalResourceException( "foo", null ) );
+
+        // Then
+        assertThat( error.status().code().classification().refersToLog(), is( false ) );
     }
 }

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -216,7 +216,7 @@ public interface Status
                 "The database was unable to execute the statement." ),
 
         // transient errors
-        ExternalResourceFailed( TransientError,
+        ExternalResourceFailed( ClientError,
                 "Access to an external resource failed"),
 
         // client notifications (performance)
@@ -573,7 +573,7 @@ public interface Status
             ROLLBACK, NONE,
         }
 
-        
+
         private enum PublishingPolicy
         {
             REPORTS_TO_CLIENT, REFERS_TO_LOG


### PR DESCRIPTION
The only usage of this status code is for when `LOAD CSV` is unable to
load its csv file parameter. Telling this to the client directly is more helpful
than referring them to the server log. The assumption here is that the client
has supplied an incorrect parameter (wrong file name).
