### PR TITLE
Complete Procedure documentation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/procedure/Procedure.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Procedure.java
@@ -48,7 +48,10 @@ import java.lang.annotation.Target;
  *     <li>{@link Double} or {@code double}</li>
  *     <li>{@link Number}</li>
  *     <li>{@link Boolean} or {@code boolean}</li>
- *     <li>{@link java.util.Map} with key {@link String} and value {@link Object}</li>
+ *     <li>{@link org.neo4j.graphdb.Node}</li>
+ *     <li>{@link org.neo4j.graphdb.Relationship}</li>
+ *     <li>{@link org.neo4j.graphdb.Path}</li>
+ *     <li>{@link java.util.Map} with key {@link String} and value of any type in this list, including {@link java.util.Map}</li>
  *     <li>{@link java.util.List} with element type of any type in this list, including {@link java.util.List}</li>
  *     <li>{@link Object}, meaning any valid input types</li>
  * </ul>
@@ -69,7 +72,7 @@ import java.lang.annotation.Target;
  *     <li>{@link org.neo4j.graphdb.Node}</li>
  *     <li>{@link org.neo4j.graphdb.Relationship}</li>
  *     <li>{@link org.neo4j.graphdb.Path}</li>
- *     <li>{@link java.util.Map} with key {@link String} and value {@link Object}</li>
+ *     <li>{@link java.util.Map} with key {@link String} and value of any type in this list, including {@link java.util.Map}</li>
  *     <li>{@link java.util.List} of elements of any valid field type, including {@link java.util.List}</li>
  *     <li>{@link Object}, meaning any of the valid field types</li>
  * </ul>


### PR DESCRIPTION
I initiated less than 2 weeks ago this project: https://github.com/fbiville/neo4j-sproc-compiler. 
It is an annotation processor that validates stored procedure declarations at compile-time.

Doing so, I noticed any discrepancies between what is documented and what is actually allowed (see https://github.com/neo4j-contrib/neo4j-apoc-procedures for instance).

The two major missing parts are the following:
- `Node`, `Relationship`, `Path` are valid input types (directly or as `List` or `Map` value type parameter)
- `Map` value types can be the same as `List` value types for both procedure inputs and record fields (e.g. `Map<String,List<Map<String,Node>>>` is perfectly valid).

Without those rules, my annotation processor would trigger 57 errors (or so) on neo4j-apoc-procedures. By implementing those two extra rules, the error count drops down to 2: there were `Map` rawtypes (it is accepted but should not be advertised in my opinion).

This PR therefore completes and advertises the documentation on these types.
