### PR TITLE
Adding test for LogShipper / Pruning race condition fix

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -40,7 +40,6 @@ import org.neo4j.logging.Log;
  */
 public class AvailabilityGuard
 {
-
     public static final String DATABASE_AVAILABLE_MSG = "Fulfilling of requirement makes database available: ";
     public static final String DATABASE_UNAVAILABLE_MSG = "Requirement makes database unavailable: ";
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/DatabaseAvailability.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel;
 
-import java.util.concurrent.TimeUnit;
-
 import org.neo4j.kernel.impl.transaction.TransactionStats;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
@@ -42,11 +40,6 @@ public class DatabaseAvailability implements Lifecycle
     private final AvailabilityGuard availabilityGuard;
     private final TransactionStats transactionMonitor;
     private final long awaitActiveTransactionDeadlineMillis;
-
-    public DatabaseAvailability( AvailabilityGuard availabilityGuard, TransactionStats transactionMonitor )
-    {
-        this( availabilityGuard, transactionMonitor, TimeUnit.SECONDS.toMillis( 10 ) );
-    }
 
     public DatabaseAvailability( AvailabilityGuard availabilityGuard, TransactionStats transactionMonitor,
             long awaitActiveTransactionDeadlineMillis )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
@@ -51,27 +51,13 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
     @Override
     public Executor executor( final Group group )
     {
-        return new Executor()
-        {
-            @Override
-            public void execute( Runnable command )
-            {
-                schedule( group, command );
-            }
-        };
+        return job -> schedule( group, job );
     }
 
     @Override
     public ThreadFactory threadFactory( final Group group )
     {
-        return new ThreadFactory()
-        {
-            @Override
-            public Thread newThread( Runnable r )
-            {
-                return createNewThread( group, r, NO_METADATA );
-            }
-        };
+        return job -> createNewThread( group, job, NO_METADATA );
     }
 
     @Override
@@ -128,6 +114,11 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
         default:
             throw new IllegalArgumentException( "Unsupported strategy to use for delayed jobs: " + group.strategy() );
         }
+    }
+
+    @Override
+    public void stop()
+    {
     }
 
     @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
@@ -50,6 +50,7 @@ import org.neo4j.coreedge.server.AdvertisedSocketAddress;
 import org.neo4j.coreedge.server.CoreMember;
 import org.neo4j.coreedge.server.core.NotMyselfSelectionStrategy;
 import org.neo4j.coreedge.server.edge.CoreServerSelectionStrategy;
+import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.impl.store.kvstore.Rotation;
 import org.neo4j.kernel.impl.util.Listener;
 import org.neo4j.kernel.internal.DatabaseHealth;
@@ -322,7 +323,7 @@ public class RaftInstance<MEMBER> implements LeaderLocator<MEMBER>,
 
             return processable;
         }
-        catch ( Throwable e )
+        catch ( MismatchingStoreIdException e )
         {
             panicAndStop( incomingMessage, e );
             throw e;
@@ -331,7 +332,6 @@ public class RaftInstance<MEMBER> implements LeaderLocator<MEMBER>,
 
     private void panicAndStop( RaftMessages.RaftMessage<MEMBER> incomingMessage, Throwable e )
     {
-        // TODO: perhaps try to recover from some errors, like IllegalArgumentExceptions from the log
         log.error( "Failed to process Raft message " + incomingMessage, e );
         databaseHealthSupplier.get().panic( e );
         electionTimer.cancel();

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
@@ -157,7 +157,7 @@ public class RaftInstance<MEMBER> implements LeaderLocator<MEMBER>,
         electionTimer = renewableTimeoutService.create(
                 Timeouts.ELECTION, electionTimeout, randomTimeoutRange(), timeout -> {
                     log.info( "Election timeout triggered, base timeout value is %d%n", electionTimeout );
-                    handle( new RaftMessages.Timeout.Election<>( myself, localDatabase.storeId() ) );
+                    handle( new RaftMessages.Timeout.Election<>( myself ) );
                     timeout.renew();
                 } );
         renewableTimeoutService.create(

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessages.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftMessages.java
@@ -513,9 +513,9 @@ public interface RaftMessages
     {
         class Election<MEMBER> extends BaseMessage<MEMBER>
         {
-            public Election( MEMBER from, StoreId storeId )
+            public Election( MEMBER from )
             {
-                super( from, Type.ELECTION_TIMEOUT, storeId );
+                super( from, Type.ELECTION_TIMEOUT, null );
             }
 
             @Override

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/DelegatingRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/DelegatingRaftLog.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.raft.log;
+
+import java.io.IOException;
+
+public class DelegatingRaftLog implements RaftLog
+{
+    private final RaftLog inner;
+
+    public DelegatingRaftLog( RaftLog inner )
+    {
+        this.inner = inner;
+    }
+
+    @Override
+    public long append( RaftLogEntry... entry ) throws IOException
+    {
+        return inner.append( entry );
+    }
+
+    @Override
+    public void truncate( long fromIndex ) throws IOException
+    {
+        inner.truncate( fromIndex );
+    }
+
+    @Override
+    public long prune( long safeIndex ) throws IOException
+    {
+        return inner.prune( safeIndex );
+    }
+
+    @Override
+    public long skip( long index, long term ) throws IOException
+    {
+        return inner.skip( index, term );
+    }
+
+    @Override
+    public long appendIndex()
+    {
+        return inner.appendIndex();
+    }
+
+    @Override
+    public long prevIndex()
+    {
+        return inner.prevIndex();
+    }
+
+    @Override
+    public long readEntryTerm( long logIndex ) throws IOException
+    {
+        return inner.readEntryTerm( logIndex );
+    }
+
+    @Override
+    public RaftLogCursor getEntryCursor( long fromIndex ) throws IOException
+    {
+        return inner.getEntryCursor( fromIndex );
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/MonitoredRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/MonitoredRaftLog.java
@@ -24,21 +24,20 @@ import java.io.IOException;
 import org.neo4j.coreedge.raft.log.monitoring.RaftLogAppendIndexMonitor;
 import org.neo4j.kernel.monitoring.Monitors;
 
-public class MonitoredRaftLog implements RaftLog
+public class MonitoredRaftLog extends DelegatingRaftLog
 {
-    private final RaftLog delegate;
     private final RaftLogAppendIndexMonitor appendIndexMonitor;
 
     public MonitoredRaftLog( RaftLog delegate, Monitors monitors )
     {
-        this.delegate = delegate;
+        super( delegate );
         this.appendIndexMonitor = monitors.newMonitor( RaftLogAppendIndexMonitor.class, getClass() );
     }
 
     @Override
     public long append( RaftLogEntry... entries ) throws IOException
     {
-        long appendIndex = delegate.append( entries );
+        long appendIndex = super.append( entries );
         appendIndexMonitor.appendIndex( appendIndex );
         return appendIndex;
     }
@@ -46,43 +45,7 @@ public class MonitoredRaftLog implements RaftLog
     @Override
     public void truncate( long fromIndex ) throws IOException
     {
-        delegate.truncate( fromIndex );
-        appendIndexMonitor.appendIndex( delegate.appendIndex() );
-    }
-
-    @Override
-    public long prune( long safeIndex ) throws IOException
-    {
-        return delegate.prune( safeIndex );
-    }
-
-    @Override
-    public long appendIndex()
-    {
-        return delegate.appendIndex();
-    }
-
-    @Override
-    public long prevIndex()
-    {
-        return delegate.prevIndex();
-    }
-
-    @Override
-    public long readEntryTerm( long logIndex ) throws IOException
-    {
-        return delegate.readEntryTerm( logIndex );
-    }
-
-    @Override
-    public RaftLogCursor getEntryCursor( long fromIndex ) throws IOException
-    {
-        return delegate.getEntryCursor( fromIndex );
-    }
-
-    @Override
-    public long skip( long index, long term ) throws IOException
-    {
-        return delegate.skip( index, term );
+        super.truncate( fromIndex );
+        appendIndexMonitor.appendIndex( super.appendIndex() );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Election.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/roles/Election.java
@@ -47,13 +47,9 @@ public class Election
                 new RaftMessages.Vote.Request<>( ctx.myself(), outcome.getTerm(), ctx.myself(), ctx.entryLog()
                         .appendIndex(), ctx.entryLog().readEntryTerm( ctx.entryLog().appendIndex() ), storeId );
 
-        for ( MEMBER member : currentMembers )
-        {
-            if ( !member.equals( ctx.myself() ) )
-            {
-                outcome.addOutgoingMessage( new RaftMessages.Directed<>( member, voteForMe ) );
-            }
-        }
+        currentMembers.stream().filter( member -> !member.equals( ctx.myself() ) ).forEach( member ->
+            outcome.addOutgoingMessage( new RaftMessages.Directed<>( member, voteForMe ) )
+        );
 
         outcome.setVotedFor( ctx.myself() );
         log.info( "Election started with vote request: %s and members: %s%n", voteForMe, currentMembers );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/InFlightLogEntrySupplier.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/InFlightLogEntrySupplier.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.coreedge.raft.state;
 
 import java.io.IOException;

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/InFlightLogEntrySupplier.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/InFlightLogEntrySupplier.java
@@ -1,0 +1,70 @@
+package org.neo4j.coreedge.raft.state;
+
+import java.io.IOException;
+
+import org.neo4j.coreedge.raft.log.RaftLogCursor;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.raft.log.ReadableRaftLog;
+import org.neo4j.coreedge.raft.log.segmented.InFlightMap;
+
+public class InFlightLogEntrySupplier implements AutoCloseable
+{
+    private final ReadableRaftLog raftLog;
+    private final InFlightMap<Long, RaftLogEntry> inFlightMap;
+
+    private RaftLogCursor cursor;
+    private boolean useInFlightMap = true;
+
+    public InFlightLogEntrySupplier( ReadableRaftLog raftLog, InFlightMap<Long,RaftLogEntry> inFlightMap )
+    {
+        this.raftLog = raftLog;
+        this.inFlightMap = inFlightMap;
+    }
+
+    public RaftLogEntry get( long logIndex ) throws IOException
+    {
+        RaftLogEntry entry = null;
+
+        if ( useInFlightMap )
+        {
+            entry = inFlightMap.retrieve( logIndex );
+        }
+
+        if ( entry == null )
+        {
+            useInFlightMap = false;
+            entry = getUsingCursor( logIndex );
+        }
+
+        inFlightMap.unregister( logIndex );
+
+        return entry;
+    }
+
+    private RaftLogEntry getUsingCursor( long logIndex ) throws IOException
+    {
+        if ( cursor == null )
+        {
+            cursor = raftLog.getEntryCursor( logIndex );
+        }
+
+        if ( cursor.next() )
+        {
+            assert cursor.index() == logIndex;
+            return cursor.get();
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        if ( cursor != null )
+        {
+            cursor.close();
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -769,7 +769,7 @@ public class EnterpriseCoreEditionModule
                                    final DependencyResolver dependencyResolver )
     {
         life.addLifecycleListener( ( instance, from, to ) -> {
-            if ( instance instanceof DatabaseAvailability && to.equals( LifecycleStatus.STARTED ) )
+            if ( instance instanceof DatabaseAvailability && LifecycleStatus.STARTED.equals( to ) )
             {
                 doAfterRecoveryAndStartup( databaseInfo, dependencyResolver );
             }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/OutboundMessageCollector.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/OutboundMessageCollector.java
@@ -77,7 +77,7 @@ public class OutboundMessageCollector implements Outbound<RaftTestMember>
 
         for ( Message message : sentTo( member ) )
         {
-            if( message instanceof RaftMessages.AppendEntries.Request )
+            if ( message instanceof RaftMessages.AppendEntries.Request )
             {
                 for ( RaftLogEntry actualEntry : ((RaftMessages.AppendEntries.Request) message).entries() )
                 {

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/FollowerTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/roles/FollowerTest.java
@@ -78,8 +78,7 @@ public class FollowerTest
                 .build();
 
         // when
-        Outcome<RaftTestMember> outcome = new Follower().handle(
-                new Election<>( myself, storeId.storeId() ), state, log(), storeId );
+        Outcome<RaftTestMember> outcome = new Follower().handle( new Election<>( myself ), state, log(), storeId );
 
         state.update( outcome );
 
@@ -102,7 +101,7 @@ public class FollowerTest
         Follower follower = new Follower();
 
         // when
-        Outcome outcome = follower.handle( new Election<>( myself, storeId.storeId() ), state, log(), storeId );
+        Outcome outcome = follower.handle( new Election<>( myself ), state, log(), storeId );
 
         // then
         assertEquals( CANDIDATE, outcome.getRole() );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/ElectionTimeout.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/ElectionTimeout.java
@@ -42,7 +42,7 @@ public class ElectionTimeout implements Action
     {
         ClusterState newClusterState = new ClusterState( previous );
         Queue<RaftMessages.RaftMessage<RaftTestMember>> newQueue = new LinkedList<>( previous.queues.get( member ) );
-        newQueue.offer( new RaftMessages.Timeout.Election<>( member, new StoreId( 1, 2, 3, 4, 5 ) ) );
+        newQueue.offer( new RaftMessages.Timeout.Election<>( member ) );
         newClusterState.queues.put( member, newQueue );
         return newClusterState;
     }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/OutOfOrderDeliveryTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/explorer/action/OutOfOrderDeliveryTest.java
@@ -32,14 +32,12 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 
 public class OutOfOrderDeliveryTest
 {
-    private final StoreId storeId = new StoreId( 1,2,3,4,5 );
-
     @Test
     public void shouldReOrder() throws Exception
     {
         // given
         ClusterState clusterState = new ClusterState( asSet( member( 0 ) ) );
-        clusterState.queues.get( member( 0 ) ).add( new Election<>( member( 0 ), storeId ) );
+        clusterState.queues.get( member( 0 ) ).add( new Election<>( member( 0 ) ) );
         clusterState.queues.get( member( 0 ) ).add( new Heartbeat<>( member( 0 ) ) );
 
         // when
@@ -47,6 +45,6 @@ public class OutOfOrderDeliveryTest
 
         // then
         assertEquals( new Heartbeat<>( member( 0 ) ), reOrdered.queues.get( member( 0 ) ).poll() );
-        assertEquals( new Election<>( member( 0 ), storeId ), reOrdered.queues.get( member( 0 ) ).poll() );
+        assertEquals( new Election<>( member( 0 ) ), reOrdered.queues.get( member( 0 ) ).poll() );
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/test/matchers/Matchers.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/test/matchers/Matchers.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test.matchers;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import org.neo4j.coreedge.network.Message;
+import org.neo4j.coreedge.raft.RaftMessages;
+import org.neo4j.coreedge.raft.log.RaftLogEntry;
+import org.neo4j.coreedge.server.RaftTestMember;
+
+public final class Matchers
+{
+    private Matchers()
+    {
+    }
+
+    public static Matcher<? super List<Message>> hasMessage( RaftMessages.BaseMessage<RaftTestMember> message )
+    {
+        return new TypeSafeMatcher<List<Message>>()
+        {
+            @Override
+            protected boolean matchesSafely( List<Message> messages )
+            {
+                return messages.contains( message );
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( "has message " + message );
+            }
+        };
+    }
+
+    public static Matcher<? super List<Message>> hasRaftLogEntries( RaftLogEntry... expectedEntries )
+    {
+        return new TypeSafeMatcher<List<Message>>()
+        {
+            @Override
+            protected boolean matchesSafely( List<Message> messages )
+            {
+                List<RaftLogEntry> entries = messages.stream()
+                        .filter( message -> message instanceof RaftMessages.AppendEntries.Request )
+                        .map( m -> ((RaftMessages.AppendEntries.Request) m) )
+                        .flatMap( x -> Arrays.stream( x.entries() ) )
+                        .collect( Collectors.toList() );
+
+                return entries.containsAll( Arrays.asList( expectedEntries ) );
+
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( "log entries " + Arrays.toString( expectedEntries ) );
+            }
+        };
+    }
+}


### PR DESCRIPTION
If we were catching up a follower and the log was pruned away
while we were in the process of doing that we could end up with an
exception when trying to read from the Raft Log.

This commit adds a test that simulates that scenario.
