### PR TITLE
Fix bug where variable would be lost from symbol table

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -159,4 +159,19 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Ne
       Map("coll" -> Seq(Seq(5, 4, 3), Seq(6, 4, 3)))
     ))
   }
+
+  test("simple expansion using pattern comprehension") {
+    val a = createNode("name" -> "Mats")
+    val b = createNode("name" -> "Max")
+    val c = createNode()
+    relate(a, b)
+    relate(b, c)
+    relate(c, a)
+
+    val query = "MATCH (a) RETURN [(a)-->() | a.name] AS list"
+
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("list" -> List("Mats")), Map("list" -> List("Max")), Map("list" -> List(null))))
+  }
 }

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/ExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/ExpandIntoPipe.scala
@@ -75,7 +75,7 @@ case class ExpandIntoPipe(source: Pipe,
   def planDescriptionWithoutCardinality =
     source.planDescription.andThen(this.id, "Expand(Into)", variables, ExpandExpression(fromName, relName, lazyTypes.names, toName, dir))
 
-  val symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
+  val symbols = source.symbols.add(fromName, CTNode).add(toName, CTNode).add(relName, CTRelationship)
 
   override def localEffects = Effects(ReadsAllNodes, ReadsAllRelationships)
 


### PR DESCRIPTION
`ExpandInto` previously assumed that its source always solved its
from-node. In cases where the source solved the to-node, and the
expansion was incoming, the from-node would be lost from the
symbol table.
