### PR TITLE
Better handling of interrupts in INIT and STOPPED

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
@@ -105,7 +105,7 @@ public class SessionStateMachine implements Session, SessionState
                     @Override
                     protected State onNoImplementation( SessionStateMachine ctx, String command )
                     {
-                        ctx.error( new Neo4jError( Status.Security.Forbidden, "No operations allowed until you send an " +
+                        ctx.error( new Neo4jError( Status.Request.Invalid, "No operations allowed until you send an " +
                                 "INIT message successfully." ) );
                         return halt( ctx );
                     }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
@@ -85,7 +85,7 @@ public class SessionStateMachine implements Session, SessionState
                         catch ( AuthenticationException e )
                         {
                             ctx.error( new Neo4jError( e.status(), e.getMessage() ));
-                            return AUTH_FAILURE;
+                            return INIT_ERROR;
                         }
                         catch ( Throwable e )
                         {
@@ -95,10 +95,18 @@ public class SessionStateMachine implements Session, SessionState
                     }
 
                     @Override
+                    public State interrupt( SessionStateMachine ctx )
+                    {
+                        // this means that you cannot interrupt init
+                        // this ensures that a user has to either finish init or finish noImpl
+                        return UNINITIALIZED;
+                    }
+
+                    @Override
                     protected State onNoImplementation( SessionStateMachine ctx, String command )
                     {
-                        ctx.error( new Neo4jError( Status.Request.Invalid, "No operations allowed until you send an " +
-                                "INIT message." ) );
+                        ctx.error( new Neo4jError( Status.Security.Forbidden, "No operations allowed until you send an " +
+                                "INIT message successfully." ) );
                         return halt( ctx );
                     }
                 },
@@ -313,16 +321,15 @@ public class SessionStateMachine implements Session, SessionState
                         return ERROR;
                     }
                 },
-        /** Failed to authenticate, acknowledging the error here leads you back to UNINITIALIZED and you get to try again */
-        AUTH_FAILURE
+        /** Failed to authenticate, acknowledging the error leads you back to UNINITIALIZED and you get to try again.
+         * This state could be interrupted. Once interrupted, it requires reset to back to UNINITIALIZED.
+         * All other operation are illegal. */
+        INIT_ERROR
                 {
                     @Override
-                    public State reset( SessionStateMachine ctx )
+                    public State interrupt( SessionStateMachine ctx )
                     {
-                        // There may still be a transaction open, so do
-                        // an extra reset on the outcome of ackFailure to ensure we go
-                        // to idle state.
-                        return ackFailure( ctx ).reset( ctx );
+                        return INIT_INTERRUPTED;
                     }
 
                     @Override
@@ -334,8 +341,34 @@ public class SessionStateMachine implements Session, SessionState
                     @Override
                     protected State onNoImplementation( SessionStateMachine ctx, String command )
                     {
-                        ctx.ignored();
-                        return AUTH_FAILURE;
+                        // Just do the same as what UNINIT state will do
+                        return UNINITIALIZED.onNoImplementation( ctx, command );
+                    }
+                },
+
+        /** Interrupted during init_error, resting the error leads you back to UNINITIALIZED and you get to try again.
+         * The state will remain interrupted until the amount of reset messages received is the same as the count of
+         * interrupts.
+         */
+        INIT_INTERRUPTED
+                {
+                    @Override
+                    public State interrupt( SessionStateMachine ctx )
+                    {
+                        return INIT_INTERRUPTED;
+                    }
+
+                    @Override
+                    public State reset( SessionStateMachine ctx )
+                    {
+                        return reset(ctx, UNINITIALIZED);
+                    }
+
+                    @Override
+                    protected State onNoImplementation( SessionStateMachine ctx, String command )
+                    {
+                        // Just do the same as what UNINIT state will do
+                        return UNINITIALIZED.onNoImplementation( ctx, command );
                     }
                 },
 
@@ -352,22 +385,8 @@ public class SessionStateMachine implements Session, SessionState
                     @Override
                     public State reset( SessionStateMachine ctx )
                     {
-                        // If > 0 to guard against bugs making the counter negative
-                        if( ctx.interruptCounter.get() > 0 )
-                        {
-                            if( ctx.interruptCounter.decrementAndGet() > 0 )
-                            {
-                                // This happens when the user sends multiple
-                                // interrupts at the same time, we now demand
-                                // an equivalent number of RESET until we go back
-                                // to IDLE.
-                                ctx.ignored();
-                                return INTERRUPTED;
-                            }
-                        }
-                        return IDLE;
+                        return reset( ctx, IDLE );
                     }
-
 
                     @Override
                     public State interrupt( SessionStateMachine ctx )
@@ -386,6 +405,13 @@ public class SessionStateMachine implements Session, SessionState
         /** The state machine is permanently stopped. */
         STOPPED
                 {
+                    @Override
+                    public State interrupt( SessionStateMachine ctx )
+                    {
+                        // ignore all interrupts
+                        return STOPPED;
+                    }
+
                     @Override
                     public State halt( SessionStateMachine ctx )
                     {
@@ -445,6 +471,24 @@ public class SessionStateMachine implements Session, SessionState
         public State reset( SessionStateMachine ctx )
         {
             return onNoImplementation( ctx, "resetting the current session" );
+        }
+
+        State reset( SessionStateMachine ctx, State resetToState )
+        {
+            // If > 0 to guard against bugs making the counter negative
+            if( ctx.interruptCounter.get() > 0 )
+            {
+                if( ctx.interruptCounter.decrementAndGet() > 0 )
+                {
+                    // This happens when the user sends multiple
+                    // interrupts at the same time, we now demand
+                    // an equivalent number of RESET until we go back
+                    // to IDLE.
+                    ctx.ignored();
+                    return ctx.state;
+                }
+            }
+            return resetToState;
         }
 
         public State ackFailure( SessionStateMachine ctx )
@@ -541,6 +585,7 @@ public class SessionStateMachine implements Session, SessionState
             return outcome;
         }
     }
+
 
     private final String id = UUID.randomUUID().toString();
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
@@ -26,7 +26,9 @@ import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.kernel.api.exceptions.Status;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.failed;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.failedWith;
+import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.ignored;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.recorded;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.success;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.successButRequiresPasswordChange;
@@ -56,6 +58,53 @@ public class SessionAuthIT
         assertThat( recorder, recorded(
                 successButRequiresPasswordChange(),
                 failedWith( Status.Security.CredentialsExpired ) ) );
+    }
+
+    @Test
+    public void shouldCloseConnectionOnAuthenticationFailure() throws Throwable
+    {
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "j4oen"
+        ), null, recorder );
+        session.ackFailure( null, recorder );
+        session.run( "RETURN 1337", map(), null, recorder );
+
+        // then
+        assertThat( recorder, recorded( failed(), success(), failed() ));
+    }
+
+    @Test
+    public void shouldBeAbleToReinitializeOnAuthenticationFailure() throws Throwable
+    {
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "j4oen"
+        ), null, recorder );
+        session.ackFailure( null, recorder );
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "neo4j"
+        ), null, recorder );
+
+        // then
+        assertThat( recorder, recorded( failed(), success(), success() ));
     }
 
     @Test

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
@@ -61,7 +61,7 @@ public class SessionAuthIT
     }
 
     @Test
-    public void shouldCloseConnectionOnAuthenticationFailure() throws Throwable
+    public void shouldDisallowRunOnAuthenticationFailureAndAck() throws Throwable
     {
         // given it is important for client applications to programmatically
         // identify expired credentials as the cause of not being authenticated
@@ -78,11 +78,89 @@ public class SessionAuthIT
         session.run( "RETURN 1337", map(), null, recorder );
 
         // then
-        assertThat( recorder, recorded( failed(), success(), failed() ));
+        assertThat( recorder, recorded(
+                failedWith(Status.Security.Unauthorized),
+                success(),
+                failedWith(Status.Security.Forbidden) ));
     }
 
     @Test
-    public void shouldBeAbleToReinitializeOnAuthenticationFailure() throws Throwable
+    public void shouldDisallowRunAfterAuthFailureAndReset() throws Throwable
+    {
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "j4oen"
+        ), null, recorder );
+        session.reset( null, recorder );
+        session.run( "RETURN 1337", map(), null, recorder );
+
+        // then
+        assertThat( recorder, recorded(
+                failedWith(Status.Security.Unauthorized),
+                success(),
+                failedWith(Status.Security.Forbidden) ));
+    }
+
+    @Test
+    public void shouldIgnoreAfterSecurityForbidden() throws Throwable
+    {
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.ackFailure( null, recorder );
+        session.run( "RETURN 1337", map(), null, recorder );
+
+        // then
+        assertThat( recorder, recorded(
+                failedWith(Status.Security.Forbidden),
+                ignored() ));
+    }
+
+    @Test
+    public void shouldDisallowRunBeforeSuccessInit() throws Throwable
+    {
+
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.run( "RETURN 1337", map(), null, recorder );
+        session.run( "RETURN 1337", map(), null, recorder );
+
+        // then
+        assertThat( recorder, recorded( failedWith(Status.Security.Forbidden), ignored() ));
+    }
+
+    @Test
+    public void shouldDisallowResetBeforeSuccessInit() throws Throwable
+    {
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.reset( null, recorder );
+        session.run( "RETURN 1337", map(), null, recorder );
+
+        // then
+        assertThat( recorder, recorded( failedWith( Status.Security.Forbidden ), ignored() ));
+    }
+
+    @Test
+    public void shouldBeAbleToReinitializeOnAuthenticationFailureAndAck() throws Throwable
     {
         // given it is important for client applications to programmatically
         // identify expired credentials as the cause of not being authenticated
@@ -96,6 +174,32 @@ public class SessionAuthIT
                 "credentials", "j4oen"
         ), null, recorder );
         session.ackFailure( null, recorder );
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "neo4j"
+        ), null, recorder );
+
+        // then
+        assertThat( recorder, recorded( failed(), success(), success() ));
+    }
+
+    @Test
+    public void shouldBeAbleToReinitializeOnAuthenticationFailureAndReset() throws Throwable
+    {
+        // given it is important for client applications to programmatically
+        // identify expired credentials as the cause of not being authenticated
+        Session session = env.newSession( "test" );
+        RecordingCallback recorder = new RecordingCallback();
+
+        // when
+        session.init( "TestClient/1.0.0", map(
+                "scheme", "basic",
+                "principal", "neo4j",
+                "credentials", "j4oen"
+        ), null, recorder );
+        session.reset( null, recorder );
         // when
         session.init( "TestClient/1.0.0", map(
                 "scheme", "basic",

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionAuthIT.java
@@ -81,7 +81,7 @@ public class SessionAuthIT
         assertThat( recorder, recorded(
                 failedWith(Status.Security.Unauthorized),
                 success(),
-                failedWith(Status.Security.Forbidden) ));
+                failedWith(Status.Request.Invalid) ));
     }
 
     @Test
@@ -105,11 +105,11 @@ public class SessionAuthIT
         assertThat( recorder, recorded(
                 failedWith(Status.Security.Unauthorized),
                 success(),
-                failedWith(Status.Security.Forbidden) ));
+                failedWith(Status.Request.Invalid) ));
     }
 
     @Test
-    public void shouldIgnoreAfterSecurityForbidden() throws Throwable
+    public void shouldIgnoreAfterRequestInvalid() throws Throwable
     {
         // given it is important for client applications to programmatically
         // identify expired credentials as the cause of not being authenticated
@@ -122,7 +122,7 @@ public class SessionAuthIT
 
         // then
         assertThat( recorder, recorded(
-                failedWith(Status.Security.Forbidden),
+                failedWith(Status.Request.Invalid),
                 ignored() ));
     }
 
@@ -140,7 +140,7 @@ public class SessionAuthIT
         session.run( "RETURN 1337", map(), null, recorder );
 
         // then
-        assertThat( recorder, recorded( failedWith(Status.Security.Forbidden), ignored() ));
+        assertThat( recorder, recorded( failedWith(Status.Request.Invalid), ignored() ));
     }
 
     @Test
@@ -156,7 +156,7 @@ public class SessionAuthIT
         session.run( "RETURN 1337", map(), null, recorder );
 
         // then
-        assertThat( recorder, recorded( failedWith( Status.Security.Forbidden ), ignored() ));
+        assertThat( recorder, recorded( failedWith( Status.Request.Invalid ), ignored() ));
     }
 
     @Test

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineResetTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachineResetTest.java
@@ -21,10 +21,14 @@ package org.neo4j.bolt.v1.runtime.internal;
 
 import org.junit.Test;
 
+import org.neo4j.bolt.security.auth.BasicAuthenticationResult;
 import org.neo4j.bolt.v1.runtime.integration.RecordingCallback;
+import org.neo4j.kernel.api.security.AccessMode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.neo4j.bolt.v1.runtime.Session.Callback.noOp;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.ignored;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.recorded;
@@ -38,7 +42,9 @@ public class SessionStateMachineResetTest
     {
         // Given
         RecordingCallback recorder = new RecordingCallback();
-        SessionStateMachine ssm = new SessionStateMachine( mock( SessionStateMachine.SPI.class ) );
+        SessionStateMachine.SPI spi = mock( SessionStateMachine.SPI.class );
+        when( spi.authenticate( any() ) ).thenReturn( new BasicAuthenticationResult( AccessMode.Static.FULL, false) );
+        SessionStateMachine ssm = new SessionStateMachine( spi );
         ssm.init( "bob/1.0", map(), null, noOp() );
 
         // When
@@ -60,7 +66,9 @@ public class SessionStateMachineResetTest
     {
         // Given
         RecordingCallback recorder = new RecordingCallback();
-        SessionStateMachine ssm = new SessionStateMachine( mock( SessionStateMachine.SPI.class ) );
+        SessionStateMachine.SPI spi = mock( SessionStateMachine.SPI.class );
+        when( spi.authenticate( any() ) ).thenReturn( new BasicAuthenticationResult( AccessMode.Static.FULL, false) );
+        SessionStateMachine ssm = new SessionStateMachine( spi );
         ssm.init( "bob/1.0", map(), null, noOp() );
 
         // When

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/StateMachineErrorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/StateMachineErrorTest.java
@@ -228,7 +228,7 @@ public class StateMachineErrorTest
         machine.run( "RETURN 1", null, null, messages );
 
         // Then
-        assertThat( messages.next(), failedWith( Status.Security.Forbidden ) );
+        assertThat( messages.next(), failedWith( Status.Request.Invalid ) );
         assertThat( machine.state(), equalTo( SessionStateMachine.State.STOPPED ) );
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/StateMachineErrorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/StateMachineErrorTest.java
@@ -228,7 +228,7 @@ public class StateMachineErrorTest
         machine.run( "RETURN 1", null, null, messages );
 
         // Then
-        assertThat( messages.next(), failedWith( Status.Request.Invalid ) );
+        assertThat( messages.next(), failedWith( Status.Security.Forbidden ) );
         assertThat( machine.state(), equalTo( SessionStateMachine.State.STOPPED ) );
     }
 }


### PR DESCRIPTION
Based on https://github.com/neo4j/neo4j/pull/7370
changelog: [Bolt] Better handling of RESET message in session state machine - #7356 
