### PR TITLE
Make `min()` and `max()` work on strings properly

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -309,4 +309,12 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
 
     result1.size should equal(result2.size)
   }
+
+  test("max() should aggregate strings") {
+    val query = "UNWIND ['a', 'b', 'B', null, 'abc', 'abc1'] AS i RETURN max(i)"
+
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("max(i)" -> "b")))
+  }
 }

--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -317,4 +317,12 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerT
 
     result.toList should equal(List(Map("max(i)" -> "b")))
   }
+
+  test("min() should aggregate strings") {
+    val query = "UNWIND ['a', 'b', 'B', null, 'abc', 'abc1'] AS i RETURN min(i)"
+
+    val result = executeWithAllPlanners(query)
+
+    result.toList should equal(List(Map("min(i)" -> "B")))
+  }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/MaxFunctionTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/MaxFunctionTest.scala
@@ -54,7 +54,19 @@ class MaxFunctionTest extends CypherFunSuite with AggregateTest {
     result shouldBe a[java.lang.Integer]
   }
 
-  test("noNumberValuesThrowAnException") {
+  test("mixed numbers and strings throws") {
     intercept[IncomparableValuesException](aggregateOn(1, "wut"))
+  }
+
+  test("aggregating strings work") {
+    val result = aggregateOn("abc", "a", "b", "B", "abc1")
+
+    result should equal("b")
+  }
+
+  test("nulls are simply skipped") {
+    val result = aggregateOn("abc", "a", null, "B", "abc1")
+
+    result should equal("abc1")
   }
 }

--- a/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/MinFunctionTest.scala
+++ b/community/cypher/cypher-compiler-3.0/src/test/scala/org/neo4j/cypher/internal/compiler/v3_0/pipes/aggregation/MinFunctionTest.scala
@@ -55,8 +55,20 @@ class MinFunctionTest extends CypherFunSuite with AggregateTest {
     result should equal(1)
   }
 
-  test("noNumberValuesThrowAnException") {
+  test("mixed numbers and strings throws") {
     intercept[IncomparableValuesException](aggregateOn(1, "wut"))
+  }
+
+  test("aggregating strings work") {
+    val result = aggregateOn("abc", "a", "b", "B", "abc1")
+
+    result should equal("B")
+  }
+
+  test("nulls are simply skipped") {
+    val result = aggregateOn("abc", "a", "b", null, "abc1")
+
+    result should equal("a")
   }
 
   def createAggregator(inner: Expression) = new MinFunction(inner)

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Max.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Max.scala
@@ -19,14 +19,32 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_0.ast.functions
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{AggregatingFunction, SimpleTypedFunction}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression.SemanticContext
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{AggregatingFunction, Expression, FunctionInvocation}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
+import org.neo4j.cypher.internal.frontend.v3_0.{SemanticCheck, SemanticCheckResult, SemanticError, SemanticState}
 
-case object Max extends AggregatingFunction with SimpleTypedFunction {
+case object Max extends AggregatingFunction {
+
   def name = "max"
 
-  val signatures = Vector(
-    Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
-  )
+  override protected def semanticCheck(ctx: SemanticContext, invocation: FunctionInvocation): SemanticCheck =
+    checkMinArgs(invocation, 1) ifOkChain
+      checkMaxArgs(invocation, 1) ifOkChain
+      checkTypeOfArgument(invocation) ifOkChain
+      invocation.specifyType(invocation.args.head.types)
+
+  private def checkTypeOfArgument(invocation: FunctionInvocation): SemanticCheck = (s: SemanticState) => {
+    val argument = invocation.args.head
+    val specifiedType = s.expressionType(argument).specified
+    val correctType = Seq(CTFloat, CTInteger, CTString, CTNumber, CTAny).foldLeft(false) {
+      case (acc, t) => acc || specifiedType.contains(t)
+    }
+
+    if (correctType) SemanticCheckResult.success(s)
+    else {
+      val message = s"Type mismatch: expected Number or String but was ${specifiedType.mkString(", ")}"
+        SemanticCheckResult.error(s, SemanticError(message, argument.position))
+    }
+  }
 }

--- a/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Min.scala
+++ b/community/cypher/frontend-3.0/src/main/scala/org/neo4j/cypher/internal/frontend/v3_0/ast/functions/Min.scala
@@ -19,14 +19,31 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_0.ast.functions
 
-import org.neo4j.cypher.internal.frontend.v3_0.ast.{AggregatingFunction, SimpleTypedFunction}
+import org.neo4j.cypher.internal.frontend.v3_0.ast.Expression.SemanticContext
+import org.neo4j.cypher.internal.frontend.v3_0.ast.{AggregatingFunction, FunctionInvocation}
 import org.neo4j.cypher.internal.frontend.v3_0.symbols._
+import org.neo4j.cypher.internal.frontend.v3_0.{SemanticCheckResult, SemanticError, SemanticState, _}
 
-case object Min extends AggregatingFunction with SimpleTypedFunction {
+case object Min extends AggregatingFunction {
   def name = "min"
 
-  val signatures = Vector(
-    Signature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    Signature(argumentTypes = Vector(CTFloat), outputType = CTFloat)
-  )
+  override protected def semanticCheck(ctx: SemanticContext, invocation: FunctionInvocation): SemanticCheck =
+    checkMinArgs(invocation, 1) ifOkChain
+      checkMaxArgs(invocation, 1) ifOkChain
+      checkTypeOfArgument(invocation) ifOkChain
+      invocation.specifyType(invocation.args.head.types)
+
+  private def checkTypeOfArgument(invocation: FunctionInvocation): SemanticCheck = (s: SemanticState) => {
+    val argument = invocation.args.head
+    val specifiedType = s.expressionType(argument).specified
+    val correctType = Seq(CTFloat, CTInteger, CTString, CTNumber, CTAny).foldLeft(false) {
+      case (acc, t) => acc || specifiedType.contains(t)
+    }
+
+    if (correctType) SemanticCheckResult.success(s)
+    else {
+      val message = s"Type mismatch: expected Number or String but was ${specifiedType.mkString(", ")}"
+      SemanticCheckResult.error(s, SemanticError(message, argument.position))
+    }
+  }
 }


### PR DESCRIPTION
Previously, it was possible to use `min()` and `max()` functions on string inputs, as made visible in this issue: #6979 

The function signature did not support this, however, so in the presence of type information this was prohibited. This PR changes that.

changelog: `min()` and `max()` now accepts strings properly - fixes [#6979](https://github.com/neo4j/neo4j/issues/6979)
