### PR TITLE
Docs fix for configuration settings

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -254,8 +254,7 @@ public abstract class GraphDatabaseSettings
                   "Longer check-point intervals typically means that recovery will take longer to complete in case " +
                   "of a crash. On the other hand, a longer check-point interval can also reduce the I/O load that " +
                   "the database places on the system, as each check-point implies a flushing and forcing of all the " +
-                  "store files. The default is '5m' for a check-point every 5 minutes. Other supported units are 's' " +
-                  "for seconds, and 'ms' for milliseconds." )
+                  "store files." ) 
     public static final Setting<Long> check_point_interval_time = setting( "dbms.checkpoint.interval.time", DURATION, "5m" );
 
     @Description( "Limit the number of IOs the background checkpoint process will consume per second. " +

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -496,7 +496,7 @@ public class Settings
         @Override
         public String toString()
         {
-            return "a duration (valid units are `" + DURATION_UNITS.replace( ", ", "`, `" ) + "`)";
+            return "a duration (valid units are `" + DURATION_UNITS.replace( ", ", "`, `" ) + "`; default unit is `ms`)";
         }
     };
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/docs/SettingsDocumenter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/docs/SettingsDocumenter.java
@@ -225,7 +225,7 @@ public class SettingsDocumenter
 
     private String settingReferenceForHTML( String settingName )
     {
-        return "+<<config_" + settingName + "," + settingName + ">>+";
+        return "<<config_" + settingName + "," + settingName + ">>";
     }
 
     private String settingReferenceForPDF( String settingName )


### PR DESCRIPTION
Clarified default unit for settings of type duration; 
repaired internal links for some settings; 
removed confusing sentence for ha.default_timeout (default documented elsewhere)
