### PR TITLE
New changeUserPassword procedure

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProcedures.java
@@ -53,6 +53,26 @@ public class AuthProcedures
     }
 
     @PerformsDBMS
+    @Procedure( "dbms.changeUserPassword" )
+    public void changeUserPassword( @Name( "username" ) String username, @Name( "newPassword" ) String newPassword )
+            throws IllegalCredentialsException, IOException
+    {
+        ShiroAuthSubject shiroSubject = ShiroAuthSubject.castOrFail( authSubject );
+        if ( shiroSubject.doesUsernameMatch( username ) )
+        {
+            shiroSubject.getUserManager().setPassword( shiroSubject, username, newPassword );
+        }
+        else if ( !shiroSubject.isAdmin() )
+        {
+            throw new AuthorizationViolationException( PERMISSION_DENIED );
+        }
+        else
+        {
+            shiroSubject.getUserManager().setUserPassword( username, newPassword );
+        }
+    }
+
+    @PerformsDBMS
     @Procedure( "dbms.addUserToRole" )
     public void addUserToRole( @Name( "username" ) String username, @Name( "roleName" ) String roleName ) throws IOException
     {


### PR DESCRIPTION
Allows changing the password for any user if subject is admin
Allows changing own password if any subject

changelog: [3.1, security] Added a new procedure for admins to change another users password 
