### PR TITLE
Split up the core-convert tool into two.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConversionVerifier.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConversionVerifier.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.convert;
+
+import org.neo4j.kernel.impl.store.StoreId;
+
+public class ConversionVerifier
+{
+    public void conversionGuard( SourceMetadata source,
+                                 TargetMetadata target )
+    {
+        StoreId sourceBefore = source.before();
+        StoreId targetBefore = target.before();
+
+        long sourceLastTxId = source.lastTxId();
+        long targetLastTxId = target.lastTxId();
+
+        if ( !(sourceBefore.theRealEquals( targetBefore ) && sourceLastTxId == targetLastTxId) )
+        {
+            throw new RuntimeException(
+                    String.format( "Cannot convert store. Backup ID does not match on source and target databases. Source: %s, Target: %s", source, target ) );
+        }
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/GenerateClusterSeedCli.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/GenerateClusterSeedCli.java
@@ -34,9 +34,10 @@ import org.neo4j.kernel.impl.util.Converters;
 import org.neo4j.logging.NullLog;
 import org.neo4j.server.configuration.ConfigLoader;
 
+import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
-public class ConvertNonCoreEdgeStoreCli
+public class GenerateClusterSeedCli
 {
     public static void main( String[] incomingArguments ) throws Throwable
     {
@@ -50,14 +51,10 @@ public class ConvertNonCoreEdgeStoreCli
         File homeDir = args.interpretOption( "home-dir", Converters.<File>mandatory(), File::new );
         String databaseName = args.interpretOption( "database", Converters.<String>mandatory(), s -> s );
         String configPath = args.interpretOption( "config", Converters.<String>mandatory(), s -> s );
-        String clusterSeed = args.interpretOption( "cluster-seed", Converters.<String>optional(), s -> s );
-
         Config config = createConfig( homeDir, databaseName, configPath );
 
-        new ConvertClassicStoreCommand( new ConversionVerifier() ).convert(
-                config.get( DatabaseManagementSystemSettings.database_path ),
-                config.get( GraphDatabaseSettings.record_format ),
-                clusterSeed );
+        SourceMetadata metadata = new GenerateClusterSeedCommand().generate( config.get( database_path ) );
+        System.out.println( "Cluster Seed: " + metadata.getConversionId() );
     }
 
     private static Config createConfig( File homeDir, String databaseName, String configPath )
@@ -77,9 +74,9 @@ public class ConvertNonCoreEdgeStoreCli
 
     private static void printUsage( PrintStream out )
     {
-        out.println( "Neo4j Classic to Core Format Conversion Tool" );
-        for ( String line : Args.splitLongLine( "The classic  to core conversion tool is used to convert a classic"
-                + "Neo4j store into one which has a core friendly format.", 80 ) )
+        out.println( "Neo4j Generate Cluster Seed Tool" );
+        for ( String line : Args.splitLongLine( "The generate cluster seed tool generates a cluster seed to be used " +
+                "on a backed up Neo4j database by the Core Conversion Tool.", 80 ) )
         {
             out.println( "\t" + line );
         }
@@ -88,6 +85,6 @@ public class ConvertNonCoreEdgeStoreCli
         out.println( "--home-dir <path-to-neo4j-directory>" );
         out.println( "--database <database-name>" );
         out.println( "--config <path-to-config-directory>" );
-        out.println( "--cluster-seed <value returned from generate-cluster-seed command>" );
+        out.println( "Returns Cluster Seed to be used with the core-convert tool." );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/SourceMetadata.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/SourceMetadata.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.convert;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Objects;
+
+import org.neo4j.kernel.impl.store.StoreId;
+
+public class SourceMetadata
+{
+    private final StoreId before;
+    private final StoreId after;
+    private final long lastTxId;
+
+    public SourceMetadata( StoreId before, StoreId after, long lastTxId )
+    {
+        this.before = before;
+        this.after = after;
+        this.lastTxId = lastTxId;
+    }
+
+    public static SourceMetadata create( String rawConversionId )
+    {
+        byte[] bytes = Base64.getDecoder().decode( rawConversionId );
+        ByteBuffer buffer = ByteBuffer.wrap( bytes );
+
+        long txId = buffer.getLong();
+        StoreId before = readStoreId( buffer );
+        StoreId after = readStoreId( buffer );
+
+        return new SourceMetadata( before, after, txId );
+    }
+
+    private static StoreId readStoreId( ByteBuffer buffer )
+    {
+        long creationTime = buffer.getLong();
+        long randomId = buffer.getLong();
+        long storeVersion = buffer.getLong();
+        long upgradeTime = buffer.getLong();
+        long upgradeId = buffer.getLong();
+
+        return new StoreId( creationTime, randomId, storeVersion, upgradeTime, upgradeId );
+    }
+
+    public StoreId after()
+    {
+        return after;
+    }
+
+    public String getConversionId()
+    {
+        ByteBuffer buffer = ByteBuffer.allocate( 88 );
+
+        buffer.putLong( lastTxId );
+
+        buffer.putLong( before.getCreationTime() );
+        buffer.putLong( before.getRandomId() );
+        buffer.putLong( before.getStoreVersion() );
+        buffer.putLong( before.getUpgradeTime() );
+        buffer.putLong( before.getUpgradeId() );
+
+        buffer.putLong( after.getCreationTime() );
+        buffer.putLong( after.getRandomId() );
+        buffer.putLong( after.getStoreVersion() );
+        buffer.putLong( after.getUpgradeTime() );
+        buffer.putLong( after.getUpgradeId() );
+
+        return Base64.getEncoder().encodeToString( buffer.array() );
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "SourceMetadata{before=%s, after=%s, lastTxId=%d}", before, after, lastTxId );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        SourceMetadata that = (SourceMetadata) o;
+        return lastTxId == that.lastTxId &&
+                storeIdEquals( before, that.before ) &&
+                storeIdEquals( after, that.after );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = 31 + storeIdHashcode( before );
+        result = 31 * result + storeIdHashcode( after );
+        return 31 * result + Objects.hash( lastTxId );
+    }
+
+    private int storeIdHashcode( StoreId storeId )
+    {
+        return this.before == null ? 0 : storeId.theRealHashCode();
+    }
+
+    private boolean storeIdEquals( StoreId one, StoreId two)
+    {
+        return (one == two || (one != null && one.theRealEquals( two )));
+    }
+
+    public StoreId before()
+    {
+        return before;
+    }
+
+    public long lastTxId()
+    {
+        return lastTxId;
+    }
+}

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/TargetMetadata.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/TargetMetadata.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.convert;
+
+import java.util.Objects;
+
+import org.neo4j.kernel.impl.store.StoreId;
+
+public class TargetMetadata
+{
+    private final StoreId before;
+    private final long lastTxId;
+
+    public TargetMetadata( StoreId before, long lastTxId )
+    {
+        this.before = before;
+        this.lastTxId = lastTxId;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "TargetMetadata{before=%s, lastTxId=%d}", before, lastTxId );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        TargetMetadata that = (TargetMetadata) o;
+        return lastTxId == that.lastTxId && storeIdEquals( before, that.before );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = 31 + (this.before == null ? 0 : before.theRealHashCode());
+        return 31 * result + Objects.hash( lastTxId );
+    }
+
+    private boolean storeIdEquals( StoreId one, StoreId two)
+    {
+        return (one == two || (one != null && one.theRealEquals( two )));
+    }
+
+    public StoreId before()
+    {
+        return before;
+    }
+
+    public long lastTxId()
+    {
+        return lastTxId;
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/TestStoreId.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/TestStoreId.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.RANDOM_NUMBER;
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.TIME;
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.UPGRADE_TIME;
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.UPGRADE_TRANSACTION_ID;
+
+public class TestStoreId
+{
+    private final long creationTime;
+    private final long randomNumber;
+    private final long upgradeTime;
+    private final long upgradeId;
+
+    public TestStoreId( long creationTime, long randomNumber, long upgradeTime, long upgradeId )
+    {
+        this.creationTime = creationTime;
+        this.randomNumber = randomNumber;
+        this.upgradeTime = upgradeTime;
+        this.upgradeId = upgradeId;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        TestStoreId storeId = (TestStoreId) o;
+        return creationTime == storeId.creationTime &&
+                randomNumber == storeId.randomNumber &&
+                upgradeTime == storeId.upgradeTime &&
+                upgradeId == storeId.upgradeId;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( creationTime, randomNumber, upgradeTime, upgradeId );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TestStoreId{" +
+                "creationTime=" + creationTime +
+                ", randomNumber=" + randomNumber +
+                ", upgradeTime=" + upgradeTime +
+                ", upgradeId=" + upgradeId +
+                '}';
+    }
+
+    public static void assertAllStoresHaveTheSameStoreId( List<String> coreStoreDirs, FileSystemAbstraction fs )
+            throws IOException
+    {
+        Set<TestStoreId> storeIds = new HashSet<>();
+        try ( PageCache pageCache = StandalonePageCacheFactory.createPageCache( fs ) )
+        {
+            for ( String coreStoreDir : coreStoreDirs )
+            {
+                storeIds.add( doReadStoreId( coreStoreDir, pageCache ) );
+            }
+        }
+        assertEquals( "Store Ids " + storeIds, 1, storeIds.size() );
+    }
+
+    public static TestStoreId readStoreId( String coreStoreDir, DefaultFileSystemAbstraction fs ) throws IOException
+    {
+        try ( PageCache pageCache = StandalonePageCacheFactory.createPageCache( fs ) )
+        {
+            return doReadStoreId( coreStoreDir, pageCache );
+        }
+    }
+
+    private static TestStoreId doReadStoreId( String coreStoreDir, PageCache pageCache ) throws IOException
+    {
+        File metadataStore = new File( coreStoreDir, MetaDataStore.DEFAULT_NAME );
+
+        long creationTime = MetaDataStore.getRecord( pageCache, metadataStore, TIME );
+        long randomNumber = MetaDataStore.getRecord( pageCache, metadataStore, RANDOM_NUMBER );
+        long upgradeTime = MetaDataStore.getRecord( pageCache, metadataStore, UPGRADE_TIME );
+        long upgradeId = MetaDataStore.getRecord( pageCache, metadataStore, UPGRADE_TRANSACTION_ID );
+
+        return new TestStoreId( creationTime, randomNumber, upgradeTime, upgradeId );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/convert/ConversionMetaDataTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/convert/ConversionMetaDataTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.convert;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.store.StoreId;
+
+import static org.junit.Assert.*;
+
+public class ConversionMetaDataTest
+{
+    @Test
+    public void shouldMarshalAndUnmarshalConversionId() throws Exception
+    {
+        // given
+        StoreId before = new StoreId( 1, 2, 3, 4, 5 );
+        StoreId after = new StoreId( 6, 7, 8, 9, 10 );
+        long transactionId = 44L;
+
+        SourceMetadata initialMetadata = new SourceMetadata( before, after, transactionId );
+
+        // when
+        String conversionId = initialMetadata.getConversionId();
+
+        SourceMetadata expectedMetadata = SourceMetadata.create( conversionId );
+
+        // then
+        assertEquals( expectedMetadata, initialMetadata );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/convert/ConversionVerifierTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/convert/ConversionVerifierTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.coreedge.convert;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.store.StoreId;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.*;
+
+public class ConversionVerifierTest
+{
+    @Test
+    public void shouldAcceptValidConvertibleMetadata() throws Exception
+    {
+        // given
+        ConversionVerifier verifier = new ConversionVerifier();
+
+        StoreId before = new StoreId( 1, 2, 3, 4, 5 );
+        StoreId after = new StoreId( 6, 7, 8, 9, 10 );
+        long transactionId = 44L;
+
+        SourceMetadata metadata = new SourceMetadata( before, after, transactionId );
+        TargetMetadata targetMetadata = new TargetMetadata( before, transactionId );
+
+        // when
+        verifier.conversionGuard( metadata, targetMetadata );
+
+        // then happily convert
+    }
+
+    @Test
+    public void shouldRejectIfStoreIdDoesNotMatch() throws Exception
+    {
+        // given
+        ConversionVerifier verifier = new ConversionVerifier();
+
+        StoreId before = new StoreId( 1, 2, 3, 4, 5 );
+        StoreId after = new StoreId( 6, 7, 8, 9, 10 );
+        long transactionId = 44L;
+
+        SourceMetadata metadata = new SourceMetadata( before, after, transactionId );
+        TargetMetadata targetMetadata = new TargetMetadata( new StoreId( 9, 9, 9, 9, 9 ), transactionId );
+
+        // when
+        try
+        {
+            verifier.conversionGuard( metadata, targetMetadata );
+            fail("Should not have been able to convert");
+        }
+        catch ( Exception e )
+        {
+            assertThat( e.getMessage(), containsString( "" ) );
+
+            // then
+            assertThat( e.getMessage(), containsString( "Cannot convert store" ) );
+        }
+
+    }
+
+    @Test
+    public void shouldRejectIfLastTxDoesNotMatch() throws Exception
+    {
+        // given
+        ConversionVerifier verifier = new ConversionVerifier();
+
+        StoreId before = new StoreId( 1, 2, 3, 4, 5 );
+        StoreId after = new StoreId( 6, 7, 8, 9, 10 );
+        long transactionId = 44L;
+
+        SourceMetadata metadata = new SourceMetadata( before, after, transactionId );
+        TargetMetadata targetMetadata = new TargetMetadata( before, 999L );
+
+        // when
+        try
+        {
+            verifier.conversionGuard( metadata, targetMetadata );
+            fail( "Should not have been able to convert" );
+        }
+        catch ( Exception e )
+        {
+            // then
+            assertThat( e.getMessage(), containsString( "Cannot convert store" ) );
+        }
+    }
+}

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
@@ -105,12 +105,18 @@ cmd_core_convert() {
   exec "${JAVA_CMD}" -cp "${CLASSPATH}" -Dfile.encoding=UTF-8 "org.neo4j.coreedge.convert.ConvertNonCoreEdgeStoreCli" --home-dir=${NEO4J_HOME} --config=${NEO4J_CONF} "$@"
 }
 
-
 cmd_restore() {
   setup_environment
   check_java
   build_classpath
   exec "${JAVA_CMD}" -cp "${CLASSPATH}" -Dfile.encoding=UTF-8 "org.neo4j.restore.RestoreDatabaseCli" --home-dir=${NEO4J_HOME} --config=${NEO4J_CONF} "$@"
+}
+
+cmd_generate_cluster_seed() {
+  setup_environment
+  check_java
+  build_classpath
+  exec "${JAVA_CMD}" -cp "${CLASSPATH}" -Dfile.encoding=UTF-8 "org.neo4j.coreedge.convert.GenerateClusterSeedCli" --home-dir=${NEO4J_HOME} --config=${NEO4J_CONF} "$@"
 }
 
 bad_usage() {
@@ -132,6 +138,10 @@ usage() {
       Import a database from a pre-3.0 Neo4j installation. <source-directory> is the database location (e.g.
       <neo4j-root>/data/graph.db).
 
+  ${PROGRAM} generate-cluster-seed --database=<database-name>
+
+    Generates a cluster seed to be used with the core-convert command when restoring a backup for a core-edge cluster
+
   ${PROGRAM} core-convert --database=<database-name>
 
     Converts a database created in a non core-edge Neo4j installation into one that is core format friendly.
@@ -152,11 +162,12 @@ main() {
   declare -r command="$1"
   shift
   case "${command}" in
-    import)         cmd_import "$@" ;;
-    core-convert)   cmd_core_convert "$@" ;;
-    restore)        cmd_restore "$@" ;;
-    help|--help|-h) usage ;;
-    *)              bad_usage "unrecognised command '${command}'" ;;
+    import)                 cmd_import "$@" ;;
+    core-convert)           cmd_core_convert "$@" ;;
+    generate-cluster-seed)  cmd_generate_cluster_seed "$@" ;;
+    restore)                cmd_restore "$@" ;;
+    help|--help|-h)         usage ;;
+    *)                      bad_usage "unrecognised command '${command}'" ;;
   esac
 }
 


### PR DESCRIPTION
We now have a generate-cluster-seed tool as well which takes care of
generating a cluster seed which we will use with the core-convert tool
to make sure we end up restoring exactly the same state on each server
in a restored core-edge cluster.
