### PR TITLE
Improve query performance for variable length relationships

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
@@ -337,7 +337,7 @@ class PatternExpressionImplementationAcceptanceTest extends ExecutionEngineFunSu
 
     executionPlanDescription.cd("Argument").arguments should equal(List(EstimatedRows(1)))
     executionPlanDescription.cd("Expand(All)").arguments.toSet should equal(Set(
-      ExpandExpression("n", "  UNNAMED23", Seq("HAS"), "  UNNAMED32", SemanticDirection.OUTGOING, varLength = false),
+      ExpandExpression("n", "  UNNAMED23", Seq("HAS"), "  UNNAMED32", SemanticDirection.OUTGOING, 1, None),
       EstimatedRows(0.25)
     ))
   }

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ASTRewriter.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ASTRewriter.scala
@@ -46,6 +46,7 @@ class ASTRewriter(rewriterSequencer: (String) => RewriterStepSequencer, shouldEx
       enableCondition(containsNoReturnAll),
       foldConstants,
       ApplyRewriter("extractParameters", extractParameters),
+      variableLengthSplitter,
       nameMatchPatternElements,
       enableCondition(noUnnamedPatternElementsInMatch),
       normalizeMatchPredicates,

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/convert/commands/PatternConverters.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/convert/commands/PatternConverters.scala
@@ -186,21 +186,12 @@ object PatternConverters {
         val startNode = node.asAbstractPatterns.head.asInstanceOf[ParsedEntity]
         val endNode = chain.rightNode.asAbstractPatterns.head.asInstanceOf[ParsedEntity]
 
-        val maxDepth = chain.relationship.length match {
-          case Some(Some(ast.Range(_, Some(i)))) => Some(i.value.toInt)
-          case _                                 => None
-        }
-
-        val minDepth = chain.relationship.length match {
-          case Some(Some(ast.Range(Some(i), _))) => Some(i.value.toInt)
-          case _                                 => None
-        }
-
+        val typeNames = chain.relationship.types.map(_.name)
         chain.relationship.length match {
           case None =>
             ParsedRelation(
               chain.relationship.legacyName, props, startNode, endNode,
-              chain.relationship.types.map(_.name), chain.relationship.direction, chain.relationship.optional)
+              typeNames, chain.relationship.direction, chain.relationship.optional)
 
           case _    =>
             val (relName, relIterator) = chain.relationship.variable match {
@@ -210,8 +201,8 @@ object PatternConverters {
                 (chain.relationship.legacyName, None)
             }
 
-            ParsedVarLengthRelation(relName, props, startNode, endNode, chain.relationship.types.map(_.name),
-              chain.relationship.direction, chain.relationship.optional, minDepth, maxDepth, relIterator)
+            ParsedVarLengthRelation(relName, props, startNode, endNode, typeNames, chain.relationship.direction,
+              chain.relationship.optional, chain.relationship.minDepth, chain.relationship.maxDepth, relIterator)
         }
       }
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/variableLengthSplitter.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/variableLengthSplitter.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_1.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v3_1._
+import org.neo4j.cypher.internal.frontend.v3_1.ast._
+
+/**
+  * In order to make planning of longer variable length paths more efficient,
+  * this rewriter introduced anonymous nodes in variable length paths. This makes
+  * it easier, during planning, to solve these paths from both sides and then
+  * join in the middle.
+  *
+  * Long term, the solution should be a bidirectional variable length expand operator.
+  *
+  * ()-[*..x]->() ==> ()-[*..x/2]->()-[*0..x/2 + x%2]->()
+  */
+case object variableLengthSplitter extends Rewriter {
+  def apply(that: AnyRef): AnyRef = instance(that)
+
+  private val rewriter = Rewriter.lift {
+    case pattern@RelationshipChain(leftPattern, rel@RelationshipPattern(None, _, types, Some(Some(range)), props, dir), _)
+      if range.lower.isEmpty && range.upper.exists(_.value > 1) =>
+
+      val totalLength = range.upper.get.value
+      val half = totalLength / 2
+      val one = UnsignedDecimalIntegerLiteral(1)(pattern.position)
+      val lhsRange =
+        Some(Some(Range(Some(one), Some(UnsignedDecimalIntegerLiteral(half)(pattern.position)))(range.position)))
+
+      val relationshipPattern = rel.copy(length = lhsRange)(rel.position.bumped())
+      val newNode = NodePattern(None, List(), None)(rel.position.bumped().bumped())
+      val newChain = RelationshipChain(leftPattern, relationshipPattern, newNode)(rel.position)
+      val rhsUpper = Some(UnsignedDecimalIntegerLiteral(half + (totalLength % 2))(range.position))
+      val rhsRange = Range(Some(UnsignedDecimalIntegerLiteral("0")(range.position)), rhsUpper)(rel.position)
+
+      val newShorterVarLength = rel.copy(length = Some(Some(rhsRange)))(rel.position)
+
+      pattern.copy(element = newChain, relationship = newShorterVarLength)(pattern.position)
+  }
+
+  private val instance = bottomUp(rewriter, _.isInstanceOf[Expression])
+}

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/ExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/ExpandAllPipe.scala
@@ -59,7 +59,7 @@ case class ExpandAllPipe(source: Pipe,
     row.getOrElse(fromName, throw new InternalException(s"Expected to find a node at $fromName but found nothing"))
 
   def planDescriptionWithoutCardinality =
-    source.planDescription.andThen(this.id, "Expand(All)", variables, ExpandExpression(fromName, relName, typeNames, toName, dir))
+    source.planDescription.andThen(this.id, "Expand(All)", variables, ExpandExpression(fromName, relName, typeNames, toName, dir, 1, None))
 
   val symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/ExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/ExpandIntoPipe.scala
@@ -73,7 +73,7 @@ case class ExpandIntoPipe(source: Pipe,
   }
 
   def planDescriptionWithoutCardinality =
-    source.planDescription.andThen(this.id, "Expand(Into)", variables, ExpandExpression(fromName, relName, lazyTypes.names, toName, dir))
+    source.planDescription.andThen(this.id, "Expand(Into)", variables, ExpandExpression(fromName, relName, lazyTypes.names, toName, dir, 1, None))
 
   val symbols = source.symbols.add(fromName, CTNode).add(toName, CTNode).add(relName, CTRelationship)
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/MergeIntoPipe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/MergeIntoPipe.scala
@@ -168,7 +168,7 @@ case class MergeIntoPipe(source: Pipe,
   }
 
   def planDescriptionWithoutCardinality =
-    source.planDescription.andThen(this.id, "Merge(Into)", variables, ExpandExpression(fromName, relName, Seq(typ), toName, dir))
+    source.planDescription.andThen(this.id, "Merge(Into)", variables, ExpandExpression(fromName, relName, Seq(typ), toName, dir, 1, None))
 
   val symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/OptionalExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/OptionalExpandAllPipe.scala
@@ -71,7 +71,7 @@ case class OptionalExpandAllPipe(source: Pipe, fromName: String, relName: String
 
   def planDescriptionWithoutCardinality =
     source.planDescription.
-      andThen(this.id, "OptionalExpand(All)", variables, ExpandExpression(fromName, relName, types.names, toName, dir))
+      andThen(this.id, "OptionalExpand(All)", variables, ExpandExpression(fromName, relName, types.names, toName, dir, 1, None))
 
   def symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/OptionalExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/OptionalExpandIntoPipe.scala
@@ -72,7 +72,7 @@ case class OptionalExpandIntoPipe(source: Pipe, fromName: String, relName: Strin
 
   def planDescriptionWithoutCardinality =
     source.planDescription.
-      andThen(this.id, "OptionalExpand(Into)", variables, ExpandExpression(fromName, relName, types.names, toName, dir))
+      andThen(this.id, "OptionalExpand(Into)", variables, ExpandExpression(fromName, relName, types.names, toName, dir, 1, None))
 
   def symbols = source.symbols.add(toName, CTNode).add(relName, CTRelationship)
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/VarLengthExpandPipe.scala
@@ -142,7 +142,7 @@ case class VarLengthExpandPipe(source: Pipe,
     row.getOrElse(name, throw new InternalException(s"Expected to find a node at $name but found nothing"))
 
   def planDescriptionWithoutCardinality = source.planDescription.
-    andThen(this.id, s"VarLengthExpand(${if (nodeInScope) "Into" else "All"})", variables, ExpandExpression(fromName, relName, types.names, toName, projectedDir, varLength = true))
+    andThen(this.id, s"VarLengthExpand(${if (nodeInScope) "Into" else "All"})", variables, ExpandExpression(fromName, relName, types.names, toName, projectedDir, min, Some(max)))
 
   def symbols = source.symbols.add(toName, CTNode).add(relName, CTList(CTRelationship))
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planDescription/InternalPlanDescription.scala
@@ -111,8 +111,15 @@ object InternalPlanDescription {
     case class RuntimeImpl(value: String) extends Argument{
       override def name = "runtime-impl"
     }
+
+
+    /*
+    length = None           -> a single hop relationship
+    length = Some(None)     -> unlimited var length relationship
+    length = Some(Some(18)) -> var length relationship limited to 18 hops
+     */
     case class ExpandExpression(from: String, relName: String, relTypes:Seq[String], to: String,
-                                direction: SemanticDirection, varLength: Boolean = false) extends Argument
+                                direction: SemanticDirection, minLength: Int, varLength: Option[Option[Int]]) extends Argument
     case class CountNodesExpression(ident: String, label: Option[LazyLabel]) extends Argument
     case class CountRelationshipsExpression(ident: String, startLabel: Option[LazyLabel],
                                             typeNames: LazyTypes, endLabel: Option[LazyLabel]) extends Argument

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/LogicalPlan2PlanDescription.scala
@@ -49,7 +49,7 @@ object LogicalPlan2PlanDescription extends ((LogicalPlan, Map[LogicalPlan, Id]) 
         PlanDescriptionImpl(id = idMap(plan), "ProduceResults", SingleChild(apply(inner, idMap)), Seq(), symbols)
 
       case Expand(inner, IdName(fromName), dir, typeNames, IdName(toName), IdName(relName), mode) =>
-        val expression = ExpandExpression( fromName, relName, typeNames.map( _.name ), toName, dir )
+        val expression = ExpandExpression(fromName, relName, typeNames.map(_.name), toName, dir, 1, None)
         val modeText = mode match {
           case ExpandAll => "Expand(All)"
           case ExpandInto => "Expand(Into)"
@@ -58,7 +58,7 @@ object LogicalPlan2PlanDescription extends ((LogicalPlan, Map[LogicalPlan, Id]) 
 
       case OptionalExpand(inner, IdName(fromName), dir, typeNames, IdName(toName), IdName(relName), mode, predicates) =>
         val expressions = predicates.map(Expression.apply) :+
-          ExpandExpression( fromName, relName, typeNames.map( _.name ), toName, dir )
+          ExpandExpression(fromName, relName, typeNames.map(_.name), toName, dir, 1, None)
         val modeText = mode match {
           case ExpandAll => "OptionalExpand(All)"
           case ExpandInto => "OptionalExpand(Into)"

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/variableLengthSplitterTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/variableLengthSplitterTest.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_1.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v3_1.test_helpers.CypherFunSuite
+
+class variableLengthSplitterTest extends CypherFunSuite with RewriteTest {
+  override def rewriterUnderTest = variableLengthSplitter
+
+  shouldNotBeRewritten("return 1")
+  shouldNotBeRewritten("match (n)-[r]->(m) return *")
+  shouldNotBeRewritten("match (a)-[*0..2]->(b) return *")
+  shouldNotBeRewritten("match (a)-[*..1]->()-[*0..1]->(b) return *")
+
+  shouldBeRewritten(
+    "match (a)-[*..2]->(b) return *",
+    "match (a)-[*1..1]->()-[*0..1]->(b) return *")
+  shouldBeRewritten(
+    "match (a)-[:T*..2]->(b) return *",
+    "match (a)-[:T*1..1]->()-[:T*0..1]->(b) return *")
+  shouldBeRewritten(
+    "match (x)-->(a)-[*..2]->(b) return *",
+    "match (x)-->(a)-[*1..1]->()-[*0..1]->(b) return *")
+  shouldBeRewritten(
+    "match (a)-[*..2]->(b)-->(x) return *",
+    "match (a)-[*1..1]->()-[*0..1]->(b)-->(x) return *")
+  shouldBeRewritten(
+    "match (a)-[*..2 {prop: 42}]->(b) return *",
+    "match (a)-[*1..1 {prop: 42}]->()-[*0..1 {prop: 42}]->(b) return *")
+  shouldBeRewritten(
+    "match (a)-[:T*..2 {prop: 42}]->(b) return *",
+    "match (a)-[:T*1..1 {prop: 42}]->()-[:T*0..1 {prop: 42}]->(b) return *")
+  shouldBeRewritten(
+    "match (a)-[*..3]->(b) return *",
+    "match (a)-[*1..1]->()-[*0..2]->(b) return *")
+  shouldBeRewritten(
+    "match (a)-[*..4]->(b) return *",
+    "match (a)-[*1..2]->()-[*0..2]->(b) return *")
+
+  private def shouldBeRewritten(from: String, to: String): Unit = test("rewrites: " + from) {
+    assertRewrite(from, to)
+  }
+
+  private def shouldNotBeRewritten(q: String): Unit = test("not rewritten: " + q) {
+    assertIsNotRewritten(q)
+  }
+}

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/variableLengthSplitterTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/rewriters/variableLengthSplitterTest.scala
@@ -28,6 +28,8 @@ class variableLengthSplitterTest extends CypherFunSuite with RewriteTest {
   shouldNotBeRewritten("match (n)-[r]->(m) return *")
   shouldNotBeRewritten("match (a)-[*0..2]->(b) return *")
   shouldNotBeRewritten("match (a)-[*..1]->()-[*0..1]->(b) return *")
+  shouldNotBeRewritten("match (a)-[*1..2]->()-[*0..2]->(b) return *")
+  shouldNotBeRewritten("match (a),(b) match p = shortestPath( (a)-[*..2]->(b) ) return *")
 
   shouldBeRewritten(
     "match (a)-[*..2]->(b) return *",
@@ -53,6 +55,10 @@ class variableLengthSplitterTest extends CypherFunSuite with RewriteTest {
   shouldBeRewritten(
     "match (a)-[*..4]->(b) return *",
     "match (a)-[*1..2]->()-[*0..2]->(b) return *")
+  shouldBeRewritten(
+    "match p = (a)-[*..2]->(b) return *",
+    "match p = (a)-[*1..1]->()-[*0..1]->(b) return *")
+
 
   private def shouldBeRewritten(from: String, to: String): Unit = test("rewrites: " + from) {
     assertRewrite(from, to)

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planDescription/PlanDescriptionArgumentSerializerTests.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planDescription/PlanDescriptionArgumentSerializerTests.scala
@@ -35,6 +35,6 @@ class PlanDescriptionArgumentSerializerTests extends CypherFunSuite {
   }
 
   test("ExpandExpression should look like Cypher syntax") {
-    serialize(new ExpandExpression("a", "r", Seq("LIKES", "LOVES"), "b", SemanticDirection.OUTGOING, false)) should equal ("(a)-[r:LIKES|:LOVES]->(b)")
+    serialize(new ExpandExpression("a", "r", Seq("LIKES", "LOVES"), "b", SemanticDirection.OUTGOING, 1, None)) should equal ("(a)-[r:LIKES|:LOVES]->(b)")
   }
 }

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planDescription/RenderTreeTableTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planDescription/RenderTreeTableTest.scala
@@ -310,11 +310,11 @@ class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
     val expandPipe = VarLengthExpandPipe(pipe, "from", "rel", "to", SemanticDirection.INCOMING, SemanticDirection.OUTGOING, LazyTypes.empty, 0, None, nodeInScope = false)(Some(1L))(mock[PipeMonitor])
 
     renderAsTreeTable(expandPipe.planDescription) should equal(
-      """+-----------------------+----------------+-----------+----------------------+
-        || Operator              | Estimated Rows | Variables | Other                |
-        |+-----------------------+----------------+-----------+----------------------+
-        || +VarLengthExpand(All) |              1 | rel, to   | (from)-[rel:*]->(to) |
-        |+-----------------------+----------------+-----------+----------------------+
+      """+-----------------------+----------------+-----------+-------------------------+
+        || Operator              | Estimated Rows | Variables | Other                   |
+        |+-----------------------+----------------+-----------+-------------------------+
+        || +VarLengthExpand(All) |              1 | rel, to   | (from)-[rel:*0..]->(to) |
+        |+-----------------------+----------------+-----------+-------------------------+
         |""".stripMargin)
   }
 
@@ -322,7 +322,7 @@ class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
     val arguments = Seq(
       Rows(42),
       DbHits(33),
-      ExpandExpression("  UNNAMED123", "R", Seq("WHOOP"), "  UNNAMED24", SemanticDirection.OUTGOING),
+      ExpandExpression("  UNNAMED123", "R", Seq("WHOOP"), "  UNNAMED24", SemanticDirection.OUTGOING, 1, None),
       EstimatedRows(1))
 
     val plan = PlanDescriptionImpl(new Id, "NAME", NoChildren, arguments, Set("n", "  UNNAMED123", "  FRESHID12", "  AGGREGATION255"))
@@ -339,7 +339,7 @@ class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
     val arguments = Seq(
       Rows(42),
       DbHits(33),
-      ExpandExpression("source", "through", Seq("SOME","OTHER","THING"), "target", SemanticDirection.OUTGOING),
+      ExpandExpression("source", "through", Seq("SOME","OTHER","THING"), "target", SemanticDirection.OUTGOING, 1, None),
       EstimatedRows(1))
 
     val plan = PlanDescriptionImpl(new Id, "NAME", NoChildren, arguments, Set("n"))

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/LogicalPlan2PlanDescriptionTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/LogicalPlan2PlanDescriptionTest.scala
@@ -66,10 +66,10 @@ class LogicalPlan2PlanDescriptionTest extends CypherFunSuite with TableDrivenPro
         PlanDescriptionImpl(id, "NodeUniqueIndexSeek", NoChildren, Seq(Index("Lebal", "Porp"), EstimatedRows(95)), Set("x"))
 
       , Expand(lhsLP, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(95) ->
-        PlanDescriptionImpl(id, "Expand(All)", SingleChild(lhsPD), Seq(ExpandExpression("a", "r1", Seq.empty, "b", SemanticDirection.OUTGOING), EstimatedRows(95)), Set("a", "r1", "b"))
+        PlanDescriptionImpl(id, "Expand(All)", SingleChild(lhsPD), Seq(ExpandExpression("a", "r1", Seq.empty, "b", SemanticDirection.OUTGOING, 1, None), EstimatedRows(95)), Set("a", "r1", "b"))
 
       , Expand(lhsLP, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("a"), IdName("r1"), ExpandInto)(113) ->
-        PlanDescriptionImpl(id, "Expand(Into)", SingleChild(lhsPD), Seq(ExpandExpression("a", "r1", Seq.empty, "a", SemanticDirection.OUTGOING), EstimatedRows(113)), Set("a", "r1"))
+        PlanDescriptionImpl(id, "Expand(Into)", SingleChild(lhsPD), Seq(ExpandExpression("a", "r1", Seq.empty, "a", SemanticDirection.OUTGOING, 1, None), EstimatedRows(113)), Set("a", "r1"))
 
       , NodeHashJoin(Set(IdName("a")), lhsLP, rhsLP)(2345) ->
         PlanDescriptionImpl(id, "NodeHashJoin", TwoChildren(lhsPD, rhsPD), Seq(KeyNames(Seq("a")), EstimatedRows(2345)), Set("a", "b"))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -31,7 +31,7 @@ import org.neo4j.cypher.internal.compiler.v3_1.planDescription.InternalPlanDescr
 import org.neo4j.cypher.internal.compiler.v3_1.planDescription.{Argument, Children, Id, InternalPlanDescription, NoChildren, PlanDescriptionImpl, SingleChild, TwoChildren}
 import org.neo4j.cypher.internal.compiler.v3_1.spi.InternalResultVisitor
 import org.neo4j.cypher.internal.frontend.v2_3.{notification => notification_2_3}
-import org.neo4j.cypher.internal.frontend.v3_1.{InputPosition, notification}
+import org.neo4j.cypher.internal.frontend.v3_1.{InputPosition, SemanticDirection, notification}
 import org.neo4j.graphdb.{QueryExecutionType, ResourceIterator}
 
 object RewindableExecutionResult {
@@ -148,8 +148,8 @@ object RewindableExecutionResult {
         case v2_3.planDescription.InternalPlanDescription.Arguments.PlannerImpl(value) => Arguments.PlannerImpl(value)
         case v2_3.planDescription.InternalPlanDescription.Arguments.Runtime(value) => Arguments.Runtime(value)
         case v2_3.planDescription.InternalPlanDescription.Arguments.RuntimeImpl(value) => Arguments.RuntimeImpl(value)
-        case v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression(from, relName, relTypes, to, _, varLength) =>
-          Arguments.ExpandExpression(from, relName, relTypes, to, null, varLength)
+        case v2_3.planDescription.InternalPlanDescription.Arguments.ExpandExpression(from, relName, relTypes, to, dir, varLength) =>
+          Arguments.ExpandExpression(from, relName, relTypes, to, SemanticDirection.BOTH, 1, None)
         case v2_3.planDescription.InternalPlanDescription.Arguments.SourceCode(className, sourceCode) =>
           Arguments.SourceCode(className, sourceCode)
       }

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Literal.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Literal.scala
@@ -63,6 +63,10 @@ sealed abstract class DecimalIntegerLiteral(stringVal: String) extends IntegerLi
 case class SignedDecimalIntegerLiteral(stringVal: String)(val position: InputPosition) extends DecimalIntegerLiteral(stringVal) with SignedIntegerLiteral
 case class UnsignedDecimalIntegerLiteral(stringVal: String)(val position: InputPosition) extends DecimalIntegerLiteral(stringVal) with UnsignedIntegerLiteral
 
+object UnsignedDecimalIntegerLiteral {
+  def apply(v: Long)(position: InputPosition) = new UnsignedDecimalIntegerLiteral(v.toString)(position)
+}
+
 sealed abstract class OctalIntegerLiteral(stringVal: String) extends IntegerLiteral with SimpleTyping {
   lazy val value: java.lang.Long = java.lang.Long.parseLong(stringVal, 8)
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Pattern.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Pattern.scala
@@ -363,4 +363,15 @@ case class RelationshipPattern(
   def isSingleLength = length.isEmpty
 
   def isDirected = direction != SemanticDirection.BOTH
+
+  def maxDepth: Option[Int] = length match {
+    case Some(Some(ast.Range(_, Some(i)))) => Some(i.value.toInt)
+    case _                                 => None
+  }
+
+  def minDepth: Option[Int] = length match {
+    case Some(Some(ast.Range(Some(i), _))) => Some(i.value.toInt)
+    case _                                 => None
+  }
+
 }


### PR DESCRIPTION
By splitting up these patterns into smaller pieces, they can be solved using
hash joins from two sides simultaneously
