### PR TITLE
Bring back compiled=runtime option

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherPreParser.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CypherPreParser.scala
@@ -54,6 +54,8 @@ case object CypherPreParser extends Parser with Base {
 
   def RuntimeOption = rule("runtime option")(
     option("runtime", "interpreted") ~ push(InterpretedRuntimeOption)
+        //Only here for the parser to be backwards compatible
+      | option("runtime", "compiled") ~ push(InterpretedRuntimeOption)
   )
 
   @deprecated

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherPreParserTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/CypherPreParserTest.scala
@@ -51,6 +51,7 @@ class CypherPreParserTest extends CypherFunSuite with TableDrivenPropertyChecks 
       DPPlannerOption))), (1, 20, 19))),
 
     ("CYPHER runtime=interpreted RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(None, Seq(InterpretedRuntimeOption))), (1, 28, 27))),
+    ("CYPHER runtime=compiled RETURN", PreParsedStatement("RETURN", Seq(ConfigurationOptions(None, Seq(InterpretedRuntimeOption))), (1, 25, 24))),
 
     ("CYPHER 2.3 planner=cost runtime=interpreted RETURN", PreParsedStatement("RETURN", Seq(
       ConfigurationOptions(Some(VersionOption("2.3")), Seq(CostPlannerOption, InterpretedRuntimeOption))), (1, 45, 44))),


### PR DESCRIPTION
Removing the compiled runtime option caused code that used that option to fail
when parsing. This PR brings back the parser option but not the actual code, the
interpreted runtime will still always be used no matter what option is provided.

This should be forward merged to 3.0 but when going to 3.1 it needs to be a
null merge.
