### PR TITLE
Addresses the problem of an HA instance being partitioned away from the cluster

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
@@ -299,21 +299,17 @@ class HeartbeatContextImpl
     @Override
     public boolean isFailed( InstanceId node )
     {
-        List<InstanceId> suspicions = getSuspicionsOf( node );
+        List<InstanceId> suspicionsForNode = getSuspicionsOf( node );
+        int countOfInstancesSuspectedByMe = getSuspicionsFor( getMyId() ).size();
 
         /*
-         * This looks weird but trust me, there is a reason for it.
-         * See below in the test, where we subtract the failed size() from the total cluster size? If the instance
-         * under question is already in the failed set then that's it, as expected. But if it is not in the failed set
-         * then we must not take it's opinion under consideration (which we implicitly don't for every member of the
-         * failed set). That's what the adjust represents - the node's opinion on whether it is alive or not. Run a
-         * 3 cluster simulation in your head with 2 instances failed and one coming back online and you'll see why.
+         * If more than half *non suspected instances* suspect this node, fail it. This takes care of partitions
+         * that contain less than half of the cluster, ensuring that they will eventually detect the disconnect without
+         * waiting to have a majority of suspicions. This is accomplished by counting as quorum only instances
+         * that are not suspected by me.
          */
-        int adjust = failed.contains( node ) ? 0 : 1;
-
-        // If more than half suspect this node, fail it
-        return suspicions.size() >
-                (commonState.configuration().getMembers().size() - failed.size() - adjust) / 2;
+        return suspicionsForNode.size() >
+                (commonState.configuration().getMembers().size() - countOfInstancesSuspectedByMe ) / 2;
     }
 
     /**
@@ -352,13 +348,13 @@ class HeartbeatContextImpl
         return new HashSet<>( suspicions );
     }
 
-    private Set<InstanceId> suspicionsFor( InstanceId uri )
+    private Set<InstanceId> suspicionsFor( InstanceId instanceId )
     {
-        Set<InstanceId> serverSuspicions = nodeSuspicions.get( uri );
+        Set<InstanceId> serverSuspicions = nodeSuspicions.get( instanceId );
         if ( serverSuspicions == null )
         {
             serverSuspicions = new HashSet<>();
-            nodeSuspicions.put( uri, serverSuspicions );
+            nodeSuspicions.put( instanceId, serverSuspicions );
         }
         return serverSuspicions;
     }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImpl.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,6 +40,7 @@ import org.neo4j.helpers.Listeners;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.logging.LogProvider;
 
+import static java.util.Arrays.asList;
 import static org.neo4j.helpers.collection.Iterables.toList;
 
 class HeartbeatContextImpl
@@ -46,9 +48,9 @@ class HeartbeatContextImpl
     implements HeartbeatContext
 {
     // HeartbeatContext
-    private Set<InstanceId> failed = new HashSet<InstanceId>();
+    private Set<InstanceId> failed = new HashSet<>();
 
-    private Map<InstanceId, Set<InstanceId>> nodeSuspicions = new HashMap<InstanceId, Set<InstanceId>>();
+    private Map<InstanceId, Set<InstanceId>> nodeSuspicions = new HashMap<>();
 
     private Iterable<HeartbeatListener> heartBeatListeners = Listeners.newListeners();
 
@@ -64,8 +66,8 @@ class HeartbeatContextImpl
     }
 
     private HeartbeatContextImpl( InstanceId me, CommonContextState commonState, LogProvider logging, Timeouts timeouts,
-                          Set<InstanceId> failed, Map<InstanceId, Set<InstanceId>> nodeSuspicions,
-                          Iterable<HeartbeatListener> heartBeatListeners, Executor executor)
+                                  Set<InstanceId> failed, Map<InstanceId, Set<InstanceId>> nodeSuspicions,
+                                  Iterable<HeartbeatListener> heartBeatListeners, Executor executor )
     {
         super( me, commonState, logging, timeouts );
         this.failed = failed;
@@ -74,7 +76,7 @@ class HeartbeatContextImpl
         this.executor = executor;
     }
 
-    public void setCircularDependencies( ClusterContext clusterContext, LearnerContext learnerContext )
+    void setCircularDependencies( ClusterContext clusterContext, LearnerContext learnerContext )
     {
         this.clusterContext = clusterContext;
         this.learnerContext = learnerContext;
@@ -134,15 +136,77 @@ class HeartbeatContextImpl
                 {
                     listener.failed( node );
                 }
-            } );
+            });
         }
+
+        if ( checkSuspectEverybody() )
+        {
+            getLog( HeartbeatContext.class ).warn( "All other instances are being suspected. Moving on to mark all other instances as failed" );
+            markAllOtherMembersAsFailed();
+        }
+    }
+
+    /*
+     * Alters state so that all instances are marked as failed. The state is changed so that any timeouts will not
+     * reset an instance to alive, allowing only for real heartbeats from an instance to mark it again as alive. This
+     * method is expected to be called in the event where all instances are being suspected, in which case a network
+     * partition has happened and we need to set ourselves in an unavailable state.
+     * The way this method achieves its task is by introducing suspicions from everybody about everybody. This mimics
+     * the normal way of doing things, effectively faking a series of suspicion messages from every other instance
+     * before connectivity was lost. As a result, when connectivity is restored, the state will be restored properly
+     * for every instance that actually manages to reconnect.
+     */
+    private void markAllOtherMembersAsFailed()
+    {
+        Set<InstanceId> everyoneElse = new HashSet<>();
+        for ( InstanceId instanceId : getMembers().keySet() )
+        {
+            if( !isMe( instanceId ) )
+            {
+                everyoneElse.add( instanceId );
+            }
+        }
+
+        for ( InstanceId instanceId : everyoneElse )
+        {
+            Set<InstanceId> instancesThisInstanceSuspects = new HashSet<>( everyoneElse );
+            instancesThisInstanceSuspects.remove( instanceId ); // obviously an instance cannot suspect itself
+            suspicions( instanceId, instancesThisInstanceSuspects );
+        }
+    }
+
+    /**
+     * Returns true iff this instance suspects every other instance currently in the cluster, except for itself.
+     */
+    private boolean checkSuspectEverybody()
+    {
+        Map<InstanceId, URI> allClusterMembers = getMembers();
+        Set<InstanceId> suspectedInstances = getSuspicionsFor( getMyId() );
+        int suspected = 0;
+        for ( InstanceId suspectedInstance : suspectedInstances )
+        {
+            if ( allClusterMembers.containsKey( suspectedInstance ) )
+            {
+                suspected++;
+            }
+        }
+
+        return suspected == allClusterMembers.size() - 1;
     }
 
     @Override
     public void suspicions( InstanceId from, Set<InstanceId> suspicions )
     {
-        // A failed instance might suspect instances which are alive so ignore it
-        if ( isFailed( from ) )
+        /*
+         * A thing to be careful about here is the case where a cluster member is marked as failed but it's not yet
+         * in the failed set. This implies the member has gathered enough suspicions to be marked as failed but is
+         * not yet marked as such. This can happen if there is a cluster partition containing only us, in which case
+         * markAllOthersAsFailed() will suspect everyone but not add them to failed (this happens here, further down).
+         * In this case, all suspicions must be processed, since after processing half, the other half of the cluster
+         * will be marked as failed (it has gathered enough suspicions) but we still need to process their messages, in
+         * order to mark as failed the other half.
+         */
+        if ( isFailed( from ) && !failed.contains( from ) )
         {
             getLog( HeartbeatContext.class ).info(
                     "Ignoring suspicions from failed instance " + from + ": " + Iterables.toString( suspicions, "," ) );
@@ -253,20 +317,20 @@ class HeartbeatContextImpl
     }
 
     /**
-     * Get the suspicions as reported by a specific server.
+     * Get all of the servers which suspect a specific member.
      *
-     * @param server which might suspect someone.
-     * @return a list of those members which server suspects.
+     * @param instanceId for the member of interest.
+     * @return a set of servers which suspect the specified member.
      */
     @Override
-    public List<InstanceId> getSuspicionsOf( InstanceId server )
+    public List<InstanceId> getSuspicionsOf( InstanceId instanceId )
     {
-        List<InstanceId> suspicions = new ArrayList<InstanceId>();
+        List<InstanceId> suspicions = new ArrayList<>();
         for ( InstanceId member : commonState.configuration().getMemberIds() )
         {
             Set<InstanceId> memberSuspicions = nodeSuspicions.get( member );
             if ( memberSuspicions != null && !failed.contains( member )
-                    && memberSuspicions.contains( server ) )
+                    && memberSuspicions.contains( instanceId ) )
             {
                 suspicions.add( member );
             }
@@ -276,16 +340,16 @@ class HeartbeatContextImpl
     }
 
     /**
-     * Get all of the servers which suspect a specific member.
+     * Get the suspicions as reported by a specific server.
      *
-     * @param uri for the member of interest.
-     * @return a set of servers which suspect the specified member.
+     * @param instanceId which might suspect someone.
+     * @return a list of those members which server suspects.
      */
     @Override
-    public Set<InstanceId> getSuspicionsFor( InstanceId uri )
+    public Set<InstanceId> getSuspicionsFor( InstanceId instanceId )
     {
-        Set<org.neo4j.cluster.InstanceId> suspicions = suspicionsFor( uri );
-        return new HashSet<org.neo4j.cluster.InstanceId>( suspicions );
+        Set<org.neo4j.cluster.InstanceId> suspicions = suspicionsFor( instanceId );
+        return new HashSet<>( suspicions );
     }
 
     private Set<InstanceId> suspicionsFor( InstanceId uri )
@@ -293,7 +357,7 @@ class HeartbeatContextImpl
         Set<InstanceId> serverSuspicions = nodeSuspicions.get( uri );
         if ( serverSuspicions == null )
         {
-            serverSuspicions = new HashSet<InstanceId>();
+            serverSuspicions = new HashSet<>();
             nodeSuspicions.put( uri, serverSuspicions );
         }
         return serverSuspicions;
@@ -317,11 +381,12 @@ class HeartbeatContextImpl
         return learnerContext.getLastLearnedInstanceId();
     }
 
-    public HeartbeatContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging, Timeouts timeouts,
+    public HeartbeatContextImpl snapshot( CommonContextState commonStateSnapshot, LogProvider logging, Timeouts
+            timeouts,
                                           Executor executor )
     {
-        return new HeartbeatContextImpl( me, commonStateSnapshot, logging, timeouts, new HashSet<>(failed),
-                new HashMap<>(nodeSuspicions), new ArrayList<>(toList(heartBeatListeners)), executor );
+        return new HeartbeatContextImpl( me, commonStateSnapshot, logging, timeouts, new HashSet<>( failed ),
+                new HashMap<>( nodeSuspicions ), new ArrayList<>( toList( heartBeatListeners ) ), executor );
     }
 
     @Override

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
@@ -71,7 +71,7 @@ public enum HeartbeatState
                                         timeout( HeartbeatMessage.timed_out, message, instanceId ) );
 
                                 // Send first heartbeat immediately
-                                outgoing.offer( timeout( HeartbeatMessage.sendHeartbeat, message, instanceId) );
+                                outgoing.offer( timeout( HeartbeatMessage.sendHeartbeat, message, instanceId ) );
                             }
 
                             return heartbeat;
@@ -97,7 +97,7 @@ public enum HeartbeatState
                         {
                             HeartbeatMessage.IAmAliveState state = message.getPayload();
 
-                            if (context.isMe( state.getServer() ) )
+                            if ( context.isMe( state.getServer() ) )
                             {
                                 break;
                             }
@@ -118,7 +118,8 @@ public enum HeartbeatState
                                         URI aliveServerUri =
                                                 context.getUriForId( aliveServer );
                                         outgoing.offer( Message.to( HeartbeatMessage.suspicions, aliveServerUri,
-                                                new HeartbeatMessage.SuspicionsState( context.getSuspicionsFor( context.getMyId() ) ) ) );
+                                                new HeartbeatMessage.SuspicionsState( context.getSuspicionsFor(
+                                                        context.getMyId() ) ) ) );
                                     }
                                 }
                             }
@@ -168,8 +169,7 @@ public enum HeartbeatState
                                 {
                                     if ( !aliveServer.equals( context.getMyId() ) )
                                     {
-                                        URI sendTo = context.getUriForId(
-                                                aliveServer );
+                                        URI sendTo = context.getUriForId( aliveServer );
                                         outgoing.offer( Message.to( HeartbeatMessage.suspicions, sendTo,
                                                 new HeartbeatMessage.SuspicionsState( context.getSuspicionsFor(
                                                         context.getMyId() ) ) ) );
@@ -188,7 +188,7 @@ public enum HeartbeatState
                         {
                             InstanceId to = message.getPayload();
 
-                            if (!context.isMe( to ) )
+                            if ( !context.isMe( to ) )
                             {
                                 // Check if this node is no longer a part of the cluster
                                 if ( context.getMembers().containsKey( to ) )
@@ -230,7 +230,8 @@ public enum HeartbeatState
                             context.getLog( HeartbeatState.class )
                                     .debug( "Received suspicions as " + suspicions );
 
-                            InstanceId fromId = new InstanceId(Integer.parseInt(message.getHeader( Message.INSTANCE_ID )));
+                            InstanceId fromId = new InstanceId(
+                                    Integer.parseInt( message.getHeader( Message.INSTANCE_ID ) ) );
 
                             /*
                              * Remove ourselves from the suspicions received - we just received a message,
@@ -266,7 +267,7 @@ public enum HeartbeatState
                 }
 
                 private void resetTimeout( HeartbeatContext context, Message<HeartbeatMessage> message,
-                        HeartbeatMessage.IAmAliveState state )
+                                           HeartbeatMessage.IAmAliveState state )
                 {
                     String key = HeartbeatMessage.i_am_alive + "-" + state.getServer();
                     Message<? extends MessageType> oldTimeout = context.cancelTimeout( key );
@@ -278,7 +279,7 @@ public enum HeartbeatState
                             long timeout = context.getTimeoutFor( oldTimeout );
                             context.getLog( HeartbeatState.class ).debug(
                                     "Received " + state + " after missing " + timeoutCount +
-                                    " (" + timeout * timeoutCount + "ms)" );
+                                            " (" + timeout * timeoutCount + "ms)" );
                         }
                     }
                     context.setTimeout( key, timeout( HeartbeatMessage.timed_out, message, state.getServer() ) );

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
@@ -28,6 +28,7 @@ import org.neo4j.cluster.com.message.MessageType;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.LearnerMessage;
 import org.neo4j.cluster.statemachine.State;
 
+import static java.lang.String.format;
 import static org.neo4j.cluster.com.message.Message.internal;
 import static org.neo4j.cluster.com.message.Message.timeout;
 import static org.neo4j.cluster.com.message.Message.to;
@@ -227,11 +228,12 @@ public enum HeartbeatState
                         case suspicions:
                         {
                             HeartbeatMessage.SuspicionsState suspicions = message.getPayload();
-                            context.getLog( HeartbeatState.class )
-                                    .debug( "Received suspicions as " + suspicions );
 
                             InstanceId fromId = new InstanceId(
                                     Integer.parseInt( message.getHeader( Message.INSTANCE_ID ) ) );
+
+                            context.getLog( HeartbeatState.class )
+                                    .debug( format( "Received suspicions as %s from %s", suspicions, fromId ) );
 
                             /*
                              * Remove ourselves from the suspicions received - we just received a message,

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatState.java
@@ -153,7 +153,6 @@ public enum HeartbeatState
 
                         case timed_out:
                         {
-
                             InstanceId server = message.getPayload();
                             context.getLog( HeartbeatState.class )
                                     .debug( "Received timed out for server " + server );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/HeartbeatContextImplTest.java
@@ -21,6 +21,7 @@ package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -34,7 +35,9 @@ import org.neo4j.cluster.protocol.heartbeat.HeartbeatListener;
 import org.neo4j.cluster.timeout.Timeouts;
 import org.neo4j.logging.NullLogProvider;
 
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.ClusterProtocolAtomicbroadcastTestUtil.ids;
@@ -58,9 +61,10 @@ public class HeartbeatContextImplTest
         when( configuration.getMembers() ).thenReturn( members( 3 ) );
         when( configuration.getMemberIds() ).thenReturn( ids( 3 ) );
 
-        final List<Runnable> runnables = new ArrayList<Runnable>();
-        HeartbeatContext context = new HeartbeatContextImpl( me, commonState, NullLogProvider.getInstance(), timeouts, new DelayedDirectExecutor(
-                NullLogProvider.getInstance() )
+        final List<Runnable> runnables = new ArrayList<>();
+        HeartbeatContext context =
+                new HeartbeatContextImpl( me, commonState, NullLogProvider.getInstance(), timeouts,
+                    new DelayedDirectExecutor( NullLogProvider.getInstance() )
         {
             @Override
             public synchronized void execute( Runnable command )
@@ -68,13 +72,80 @@ public class HeartbeatContextImplTest
                 runnables.add( command );
             }
         } );
-        context.addHeartbeatListener( mock( HeartbeatListener.Adapter.class ) );
+        context.addHeartbeatListener( mock( HeartbeatListener.class ) );
 
-        context.suspicions( goodMachine, new HashSet<InstanceId>( Arrays.asList( failedMachine ) ) );
+        context.suspicions( goodMachine, new HashSet<>( singletonList( failedMachine ) ) );
         context.suspect( failedMachine ); // fail
         context.alive( failedMachine ); // alive
 
         // Then
         assertEquals( 2, runnables.size() ); // fail + alive
+    }
+
+    @Test
+    public void shouldFailAllInstancesIfAllOtherInstancesAreSuspected() throws Exception
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId member2 = new InstanceId( 2 );
+        InstanceId member3 = new InstanceId( 3 );
+
+        Timeouts timeouts = mock( Timeouts.class );
+
+        CommonContextState commonState = mock( CommonContextState.class );
+        ClusterConfiguration configuration = mock ( ClusterConfiguration.class );
+        when( commonState.configuration() ).thenReturn( configuration );
+        when( configuration.getMembers() ).thenReturn( members( 3 ) );
+        when( configuration.getMemberIds() ).thenReturn( ids( 3 ) );
+
+        DelayedDirectExecutor executor = new DelayedDirectExecutor( NullLogProvider.getInstance() );
+        HeartbeatContext context =
+                new HeartbeatContextImpl( me, commonState, NullLogProvider.getInstance(), timeouts,
+                        executor );
+
+        final List<InstanceId> failed = new ArrayList<>( 2 );
+        HeartbeatListener listener = new HeartbeatListener()
+        {
+            @Override
+            public void failed( InstanceId server )
+            {
+                failed.add( server );
+            }
+
+            @Override
+            public void alive( InstanceId server )
+            {
+                failed.remove( server );
+            }
+        };
+
+        context.addHeartbeatListener( listener );
+
+        // when
+        // just one suspicion comes, no extra failing action should be taken
+        context.suspect( member2 );
+        executor.drain();
+
+        // then
+        assertEquals( 0, failed.size() );
+
+        // when
+        // the other instance is suspected, all instances must be marked as failed
+        context.suspect( member3 );
+        executor.drain();
+
+        // then
+        assertEquals( 2, failed.size() );
+        assertTrue( failed.contains( member2 ) );
+        assertTrue( failed.contains( member3 ) );
+
+        // when
+        // one of them comes alive again, only that instance should be marked as alive
+        context.alive( member2 );
+        executor.drain();
+
+        // then
+        assertEquals( 1, failed.size() );
+        assertTrue( failed.contains( member3 ) );
     }
 }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterHeartbeatTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterHeartbeatTest.java
@@ -61,7 +61,7 @@ public class ClusterHeartbeatTest
                 down( 100, 3 ).
                 message( 1000, "*** Should have seen failure by now" ).
                 up( 0, 3 ).
-                message( 200, "*** Should have recovered by now" ).
+                message( 2000, "*** Should have recovered by now" ).
                 verifyConfigurations( "after recovery", 0 ).
                 leave( 200, 1 ).
                 leave( 200, 2 ).

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/InstanceIdTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/InstanceIdTest.java
@@ -61,12 +61,12 @@ public class InstanceIdTest
     public void nodeTriesToJoinRunningClusterWithExistingServerId() throws InterruptedException, ExecutionException,
             TimeoutException, URISyntaxException
     {
-        List<URI> correctMembers = new ArrayList<URI>();
+        List<URI> correctMembers = new ArrayList<>();
         correctMembers.add( URI.create( "server1" ) );
         correctMembers.add( URI.create( "server2" ) );
         correctMembers.add( URI.create( "server3" ) );
 
-        Map<String, InstanceId> roles = new HashMap<String, InstanceId>();
+        Map<String, InstanceId> roles = new HashMap<>();
         roles.put( "coordinator", new InstanceId( 1 ) );
 
         testCluster( new int[] {1, 2, 3, 3},
@@ -89,34 +89,36 @@ public class InstanceIdTest
     public void substituteFailedNode() throws InterruptedException, ExecutionException, TimeoutException,
             URISyntaxException
     {
-        List<URI> correctMembers = new ArrayList<URI>();
+        List<URI> correctMembers = new ArrayList<>();
         correctMembers.add( URI.create( "server1" ) );
         correctMembers.add( URI.create( "server2" ) );
         correctMembers.add( URI.create( "server4" ) );
 
-        List<URI> wrongMembers = new ArrayList<URI>();
+        List<URI> wrongMembers = new ArrayList<>();
         wrongMembers.add( URI.create( "server1" ) );
         wrongMembers.add( URI.create( "server2" ) );
         wrongMembers.add( URI.create( "server3" ) );
 
-        Map<String, InstanceId> roles = new HashMap<String, InstanceId>();
+        Map<String, InstanceId> roles = new HashMap<>();
         roles.put( "coordinator", new InstanceId( 1 ) );
 
-        Set<InstanceId> failed = new HashSet<InstanceId>();
+        Set<InstanceId> clusterMemberFailed = new HashSet<>();
+        Set<InstanceId> isolatedMemberFailed = new HashSet<>();
+        isolatedMemberFailed.add( new InstanceId( 1 ) ); // will never receive heartbeats again from 1,2 so they are failed
+        isolatedMemberFailed.add( new InstanceId( 2 ) );
 
         testCluster( new int[]{ 1, 2, 3, 3 },
                 new VerifyInstanceConfiguration[]{
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( wrongMembers, roles, Collections.<InstanceId>emptySet() ),
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed )},
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed ),
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed ),
+                        new VerifyInstanceConfiguration( wrongMembers, roles, isolatedMemberFailed ),
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed )},
                 DEFAULT_NETWORK(),
                 new ClusterTestScriptDSL().
                 rounds( 8000 ).
                 join( 100, 1, 1 ).
                 join( 100, 2, 1 ).
                 join( 100, 3, 1 ).
-//                        assertThat(electionHappened(1, "coordinator")).
                 down( 3000, 3 ).
                 join( 1000, 4, 1, 2, 3 )
         );
@@ -126,27 +128,31 @@ public class InstanceIdTest
     public void substituteFailedNodeAndFailedComesOnlineAgain() throws InterruptedException, ExecutionException, TimeoutException,
             URISyntaxException
     {
-        List<URI> correctMembers = new ArrayList<URI>();
+        List<URI> correctMembers = new ArrayList<>();
         correctMembers.add( URI.create( "server1" ) );
         correctMembers.add( URI.create( "server2" ) );
         correctMembers.add( URI.create( "server4" ) );
 
-        List<URI> badMembers = new ArrayList<URI>();
+        List<URI> badMembers = new ArrayList<>();
         badMembers.add( URI.create( "server1" ) );
         badMembers.add( URI.create( "server2" ) );
         badMembers.add( URI.create( "server3" ) );
 
-        Map<String, InstanceId> roles = new HashMap<String, InstanceId>();
+        Map<String, InstanceId> roles = new HashMap<>();
         roles.put( "coordinator", new InstanceId( 1 ) );
 
-        Set<InstanceId> failed = new HashSet<InstanceId>();
+        Set<InstanceId> clusterMemberFailed = new HashSet<>(); // no failures
+        Set<InstanceId> isolatedMemberFailed = new HashSet<>();
+        isolatedMemberFailed.add( new InstanceId( 1 ) ); // will never receive heartbeats again from 1,2 so they are failed
+        isolatedMemberFailed.add( new InstanceId( 2 ) );
+
 
         testCluster( new int[]{1, 2, 3, 3},
                 new VerifyInstanceConfiguration[]{
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( badMembers, roles, failed ),
-                        new VerifyInstanceConfiguration( correctMembers, roles, failed )},
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed ),
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed ),
+                        new VerifyInstanceConfiguration( badMembers, roles, isolatedMemberFailed ),
+                        new VerifyInstanceConfiguration( correctMembers, roles, clusterMemberFailed )},
                 DEFAULT_NETWORK(),
                 new ClusterTestScriptDSL().
                         rounds( 800 ).

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class HeartbeatStateTest
@@ -66,26 +67,28 @@ public class HeartbeatStateTest
     {
         // Given
         InstanceId instanceId = new InstanceId( 1 );
-        HeartbeatState heartbeat= HeartbeatState.heartbeat;
-        ClusterConfiguration configuration = new ClusterConfiguration("whatever", NullLogProvider.getInstance(),
-                                                                       "cluster://1", "cluster://2" );
-        configuration.joined( instanceId, URI.create("cluster://1" ) );
-        configuration.joined( new InstanceId( 2 ), URI.create("cluster://2" ));
+        HeartbeatState heartbeat = HeartbeatState.heartbeat;
+        ClusterConfiguration configuration = new ClusterConfiguration( "whatever", NullLogProvider.getInstance(),
+                "cluster://1", "cluster://2" );
+        configuration.joined( instanceId, URI.create( "cluster://1" ) );
+        configuration.joined( new InstanceId( 2 ), URI.create( "cluster://2" ) );
 
         MultiPaxosContext context = new MultiPaxosContext( instanceId, 10, Iterables.<ElectionRole, ElectionRole>iterable(
-                        new ElectionRole( "coordinator" ) ), configuration,
-                        Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
-                        Mockito.mock( ObjectInputStreamFactory.class), Mockito.mock( ObjectOutputStreamFactory.class),
-                        Mockito.mock( AcceptorInstanceStore.class), Mockito.mock( Timeouts.class),
-                        mock( ElectionCredentialsProvider.class) );
+                new ElectionRole( "coordinator" ) ), configuration,
+                Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
+                Mockito.mock( ObjectInputStreamFactory.class ), Mockito.mock( ObjectOutputStreamFactory.class ),
+                Mockito.mock( AcceptorInstanceStore.class ), Mockito.mock( Timeouts.class ),
+                mock( ElectionCredentialsProvider.class ) );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
         Message received = Message.internal( HeartbeatMessage.suspicions,
-                new HeartbeatMessage.SuspicionsState( Iterables.toSet( Iterables.<InstanceId, InstanceId>iterable( instanceId ) ) ) );
+                new HeartbeatMessage.SuspicionsState( Iterables.toSet(
+                        Iterables.<InstanceId, InstanceId>iterable( instanceId ) ) ) );
+
         received.setHeader( Message.FROM, "cluster://2" ).setHeader( Message.INSTANCE_ID, "2" );
 
         // When
-        heartbeat.handle( heartbeatContext, received, mock( MessageHolder.class) );
+        heartbeat.handle( heartbeatContext, received, mock( MessageHolder.class ) );
 
         // Then
         assertThat( heartbeatContext.getSuspicionsOf( instanceId ).size(), equalTo( 0 ) );
@@ -97,26 +100,27 @@ public class HeartbeatStateTest
         // Given
         InstanceId myId = new InstanceId( 1 );
         InstanceId foreignId = new InstanceId( 3 );
-        HeartbeatState heartbeat= HeartbeatState.heartbeat;
-        ClusterConfiguration configuration = new ClusterConfiguration("whatever", NullLogProvider.getInstance(),
-                                                                      "cluster://1", "cluster://2" );
-        configuration.joined( myId, URI.create("cluster://1" ) );
-        configuration.joined( new InstanceId( 2 ), URI.create("cluster://2" ));
+        HeartbeatState heartbeat = HeartbeatState.heartbeat;
+        ClusterConfiguration configuration = new ClusterConfiguration( "whatever", NullLogProvider.getInstance(),
+                "cluster://1", "cluster://2" );
+        configuration.joined( myId, URI.create( "cluster://1" ) );
+        configuration.joined( new InstanceId( 2 ), URI.create( "cluster://2" ) );
 
         MultiPaxosContext context = new MultiPaxosContext( myId, 10, Iterables.<ElectionRole, ElectionRole>iterable(
-                        new ElectionRole( "coordinator" ) ), configuration,
-                        Mockito.mock( Executor.class ),  NullLogProvider.getInstance(),
-                        Mockito.mock( ObjectInputStreamFactory.class), Mockito.mock( ObjectOutputStreamFactory.class),
-                        Mockito.mock( AcceptorInstanceStore.class), Mockito.mock( Timeouts.class),
-                        mock( ElectionCredentialsProvider.class) );
+                new ElectionRole( "coordinator" ) ), configuration,
+                Mockito.mock( Executor.class ), NullLogProvider.getInstance(),
+                Mockito.mock( ObjectInputStreamFactory.class ), Mockito.mock( ObjectOutputStreamFactory.class ),
+                Mockito.mock( AcceptorInstanceStore.class ), Mockito.mock( Timeouts.class ),
+                mock( ElectionCredentialsProvider.class ) );
 
         HeartbeatContext heartbeatContext = context.getHeartbeatContext();
         Message received = Message.internal( HeartbeatMessage.suspicions,
-                new HeartbeatMessage.SuspicionsState( Iterables.toSet( Iterables.<InstanceId, InstanceId>iterable( myId, foreignId ) ) ) );
+                new HeartbeatMessage.SuspicionsState( Iterables.toSet(
+                        Iterables.<InstanceId, InstanceId>iterable( myId, foreignId ) ) ) );
         received.setHeader( Message.FROM, "cluster://2" ).setHeader( Message.INSTANCE_ID, "2" );
 
         // When
-        heartbeat.handle( heartbeatContext, received, mock( MessageHolder.class) );
+        heartbeat.handle( heartbeatContext, received, mock( MessageHolder.class ) );
 
         // Then
         assertThat( heartbeatContext.getSuspicionsOf( myId ).size(), equalTo( 0 ) );
@@ -128,22 +132,22 @@ public class HeartbeatStateTest
     {
         // Given
         InstanceId instanceId = new InstanceId( 1 );
-        HeartbeatState heartbeat= HeartbeatState.heartbeat;
+        HeartbeatState heartbeat = HeartbeatState.heartbeat;
         ClusterConfiguration configuration = new ClusterConfiguration( "whatever", NullLogProvider.getInstance(),
                 "cluster://1", "cluster://2" );
-        configuration.joined( instanceId, URI.create("cluster://1" ) );
+        configuration.joined( instanceId, URI.create( "cluster://1" ) );
         InstanceId otherInstance = new InstanceId( 2 );
-        configuration.joined( otherInstance, URI.create("cluster://2" ));
+        configuration.joined( otherInstance, URI.create( "cluster://2" ) );
 
         MultiPaxosContext context = new MultiPaxosContext(
                 instanceId, 10,
-                Iterables.<ElectionRole,ElectionRole>iterable( new ElectionRole( "coordinator" ) ),
+                Iterables.<ElectionRole, ElectionRole>iterable( new ElectionRole( "coordinator" ) ),
                 configuration,
                 Mockito.mock( Executor.class ),
                 NullLogProvider.getInstance(),
-                Mockito.mock( ObjectInputStreamFactory.class),
-                Mockito.mock( ObjectOutputStreamFactory.class),
-                Mockito.mock( AcceptorInstanceStore.class),
+                Mockito.mock( ObjectInputStreamFactory.class ),
+                Mockito.mock( ObjectOutputStreamFactory.class ),
+                Mockito.mock( AcceptorInstanceStore.class ),
                 Mockito.mock( Timeouts.class ),
                 mock( ElectionCredentialsProvider.class ) );
 
@@ -182,7 +186,7 @@ public class HeartbeatStateTest
         MultiPaxosContext context = new MultiPaxosContext(
                 instanceId,
                 10,
-                Iterables.<ElectionRole,ElectionRole>iterable( new ElectionRole( "coordinator" ) ),
+                Iterables.<ElectionRole, ElectionRole>iterable( new ElectionRole( "coordinator" ) ),
                 configuration,
                 mock( Executor.class ),
                 internalLog,

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/DelegateInvocationHandler.java
@@ -138,8 +138,9 @@ public class DelegateInvocationHandler<T> implements InvocationHandler
             if ( delegate == null )
             {
                 throw new TransientDatabaseFailureException(
-                        "Transaction state is not valid. Perhaps a state change of" +
-                        "the database has happened while this transaction was running?" );
+                        "Instance state is not valid. There is no master currently available. Possible causes " +
+                                "include unavailability of a majority of the cluster members or network failure " +
+                                "that caused this instance to be partitioned away from the cluster" );
             }
 
             return proxyInvoke( delegate, method, args );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberListener.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberListener.java
@@ -20,7 +20,8 @@
 package org.neo4j.kernel.ha.cluster;
 
 /**
- * These callback methods correspond to the cluster
+ * These callback methods correspond to broadcasted HA events. The supplied event argument contains the
+ * result of the state change and required information, as interpreted by the HA state machine.
  */
 public interface HighAvailabilityMemberListener
 {
@@ -31,6 +32,13 @@ public interface HighAvailabilityMemberListener
     void slaveIsAvailable( HighAvailabilityMemberChangeEvent event );
 
     void instanceStops( HighAvailabilityMemberChangeEvent event );
+
+    /**
+     * This event is different than the rest, in the sense that it is not a response to a broadcasted message,
+     * rather than the interpretation of the loss of connectivity to other cluster members. This corresponds generally
+     * to a loss of quorum but a special case is the event of being partitioned away completely from the cluster.
+     */
+    void instanceDetached( HighAvailabilityMemberChangeEvent event );
 
     class Adapter implements HighAvailabilityMemberListener
     {
@@ -51,6 +59,11 @@ public interface HighAvailabilityMemberListener
 
         @Override
         public void instanceStops( HighAvailabilityMemberChangeEvent event )
+        {
+        }
+
+        @Override
+        public void instanceDetached( HighAvailabilityMemberChangeEvent event )
         {
         }
     }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
@@ -273,6 +273,13 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                 log.debug( "Got memberIsFailed(" + instanceId + ") and cluster lost quorum to continue, moved to "
                         + state + " from " + oldState );
             }
+            else if ( instanceId.equals( context.getElectedMasterId() ) && state == HighAvailabilityMemberState.SLAVE )
+            {
+                HighAvailabilityMemberState oldState = state;
+                changeStateToPending();
+                log.debug( "Got memberIsFailed(" + instanceId + ") which was the master and i am a slave, moved to "
+                        + state + " from " + oldState );
+            }
             else
             {
                 log.debug( "Got memberIsFailed(" + instanceId + ")" );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachine.java
@@ -271,14 +271,14 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                 HighAvailabilityMemberState oldState = state;
                 changeStateToDetached();
                 log.debug( "Got memberIsFailed(" + instanceId + ") and cluster lost quorum to continue, moved to "
-                        + state + " from " + oldState );
+                        + state + " from " + oldState + ", while maintaining read only capability." );
             }
             else if ( instanceId.equals( context.getElectedMasterId() ) && state == HighAvailabilityMemberState.SLAVE )
             {
                 HighAvailabilityMemberState oldState = state;
                 changeStateToDetached();
                 log.debug( "Got memberIsFailed(" + instanceId + ") which was the master and i am a slave, moved to "
-                        + state + " from " + oldState );
+                        + state + " from " + oldState + ", while maintaining read only capability." );
             }
             else
             {
@@ -334,6 +334,9 @@ public class HighAvailabilityMemberStateMachine extends LifecycleAdapter impleme
                     listener.instanceDetached( event );
                 }
             } );
+
+            context.setAvailableHaMasterId( null );
+            context.setElectedMasterId( null );
         }
 
         private long getAliveCount()

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcher.java
@@ -485,8 +485,9 @@ public class HighAvailabilityModeSwitcher
         {
             modeSwitcherFuture.get( 10, TimeUnit.SECONDS );
         }
-        catch ( Exception ignored )
+        catch ( Exception e )
         {
+            msgLog.warn( "Exception received while waiting for switching to pending", e );
         }
     }
 
@@ -530,8 +531,9 @@ public class HighAvailabilityModeSwitcher
         {
             modeSwitcherFuture.get( 10, TimeUnit.SECONDS );
         }
-        catch ( Exception ignored )
+        catch ( Exception e )
         {
+            msgLog.warn( "Exception received while waiting for switching to detached", e );
         }
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SimpleHighAvailabilityMemberContext.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/cluster/SimpleHighAvailabilityMemberContext.java
@@ -75,4 +75,15 @@ public class SimpleHighAvailabilityMemberContext implements HighAvailabilityMemb
     {
         return slaveOnly;
     }
+
+    @Override
+    public String toString()
+    {
+        return "SimpleHighAvailabilityMemberContext{" +
+                "electedMasterId=" + electedMasterId +
+                ", availableHaMasterId=" + availableHaMasterId +
+                ", myId=" + myId +
+                ", slaveOnly=" + slaveOnly +
+                '}';
+    }
 }

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -750,13 +750,8 @@ public class HighlyAvailableEditionModule
     protected void registerRecovery( final String editionName, final DependencyResolver dependencyResolver,
                                      final LogService logging )
     {
-        memberStateMachine.addHighAvailabilityMemberListener( new HighAvailabilityMemberListener()
+        memberStateMachine.addHighAvailabilityMemberListener( new HighAvailabilityMemberListener.Adapter()
         {
-            @Override
-            public void masterIsElected( HighAvailabilityMemberChangeEvent event )
-            {
-            }
-
             @Override
             public void masterIsAvailable( HighAvailabilityMemberChangeEvent event )
             {
@@ -775,11 +770,6 @@ public class HighlyAvailableEditionModule
                 {
                     doAfterRecoveryAndStartup( false );
                 }
-            }
-
-            @Override
-            public void instanceStops( HighAvailabilityMemberChangeEvent event )
-            {
             }
 
             private void doAfterRecoveryAndStartup( boolean isMaster )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterFailoverIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterFailoverIT.java
@@ -34,10 +34,9 @@ import org.neo4j.test.LoggerRule;
 import org.neo4j.test.TargetDirectory;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.kernel.impl.ha.ClusterManager.clusterOfSize;
 
 @RunWith( Parameterized.class )
-public class TestFailover
+public class ClusterFailoverIT
 {
     @Rule
     public LoggerRule logger = new LoggerRule();
@@ -58,7 +57,7 @@ public class TestFailover
         });
     }
 
-    public TestFailover( int clusterSize )
+    public ClusterFailoverIT( int clusterSize )
     {
         this.clusterSize = clusterSize;
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionTestIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionTestIT.java
@@ -19,20 +19,30 @@
  */
 package org.neo4j.kernel.ha;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.function.Predicate;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.TransientDatabaseFailureException;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.ha.ClusterManager.NetworkFlag;
 import org.neo4j.test.LoggerRule;
 import org.neo4j.test.TargetDirectory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityMemberState.PENDING;
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
+import static org.neo4j.kernel.impl.ha.ClusterManager.masterSeesMembers;
+import static org.neo4j.kernel.impl.ha.ClusterManager.masterSeesSlavesAsAvailable;
+import static org.neo4j.kernel.impl.ha.ClusterManager.memberSeesOtherMemberAsFailed;
 
 public class ClusterPartitionTestIT
 {
@@ -41,8 +51,12 @@ public class ClusterPartitionTestIT
     @Rule
     public TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
 
+    private final String testPropKey = "testPropKey";
+    private final String testPropValue = "testPropValue";
+    private long testNodeId;
+
     @Test
-    public void isolatedMasterShouldRemoveSelfFromCluster() throws Throwable
+    public void isolatedMasterShouldRemoveSelfFromClusterAndBecomeReadOnly() throws Throwable
     {
         int clusterSize = 3;
 
@@ -60,12 +74,20 @@ public class ClusterPartitionTestIT
             cluster.await( allSeesAllAsAvailable() );
             cluster.await( masterAvailable() );
 
-
             HighlyAvailableGraphDatabase oldMaster = cluster.getMaster();
 
-            cluster.fail( oldMaster, NetworkFlag.values() );
+            addSomeData( oldMaster );
 
-            cluster.await( oldMasterEvicted( oldMaster ), 20 );
+            ClusterManager.RepairKit fail = cluster.fail( oldMaster, NetworkFlag.values() );
+            cluster.await( instanceEvicted( oldMaster ), 20 );
+
+            ensureInstanceIsReadOnlyInPendingState( oldMaster );
+
+            fail.repair();
+
+            cluster.await( allSeesAllAsAvailable() );
+
+            ensureInstanceIsWritable( oldMaster );
         }
         finally
         {
@@ -73,20 +95,276 @@ public class ClusterPartitionTestIT
         }
     }
 
-    private Predicate<ClusterManager.ManagedCluster> oldMasterEvicted( final HighlyAvailableGraphDatabase oldMaster )
+    @Test
+    public void isolatedSlaveShouldRemoveSelfFromClusterAndBecomeReadOnly() throws Throwable
+    {
+        int clusterSize = 3;
+
+        ClusterManager manager = new ClusterManager.Builder().withRootDirectory( dir.cleanDirectory( "testcluster" ) )
+                .withProvider( ClusterManager.clusterOfSize( clusterSize ) )
+                .withSharedConfig( stringMap(
+                        ClusterSettings.heartbeat_interval.name(), "1" ) )
+                .build();
+
+        try
+        {
+            manager.start();
+            ClusterManager.ManagedCluster cluster = manager.getDefaultCluster();
+
+            cluster.await( allSeesAllAsAvailable() );
+            cluster.await( masterAvailable() );
+
+            HighlyAvailableGraphDatabase slave = cluster.getAnySlave();
+
+            addSomeData( slave );
+
+            ClusterManager.RepairKit fail = cluster.fail( slave, NetworkFlag.values() );
+            cluster.await( instanceEvicted( slave ), 20 );
+
+            ensureInstanceIsReadOnlyInPendingState( slave );
+
+            fail.repair();
+
+            cluster.await( allSeesAllAsAvailable() );
+
+            ensureInstanceIsWritable( slave );
+        }
+        finally
+        {
+            manager.safeShutdown();
+        }
+    }
+
+    @Test
+    public void losingQuorumIncrementallyShouldMakeAllInstancesPendingAndReadOnly() throws Throwable
+    {
+        int clusterSize = 5; // we need 5 to differentiate between all other instances gone and just quorum being gone
+
+        ClusterManager manager = new ClusterManager.Builder().withRootDirectory( dir.cleanDirectory( "testcluster" ) )
+                .withProvider( ClusterManager.clusterOfSize( clusterSize ) )
+                .withSharedConfig( stringMap(
+                        ClusterSettings.heartbeat_interval.name(), "1",
+                        HaSettings.tx_push_factor.name(), "4" ) ) // so we know the initial data made it everywhere
+                .build();
+
+        try
+        {
+            manager.start();
+            ClusterManager.ManagedCluster cluster = manager.getDefaultCluster();
+
+            cluster.await( allSeesAllAsAvailable() );
+            cluster.await( masterAvailable() );
+
+            HighlyAvailableGraphDatabase master = cluster.getMaster();
+            addSomeData( master );
+
+            /*
+             * we need 3 failures. We'll end up with the old master and a slave connected. They should both be in
+             * PENDING state, allowing reads but not writes. Repairing just one of the removed instances should
+             * result in a master being elected and all instances being read and writable.
+             * The instances we remove do not need additional verification for their state. Their behaviour is already
+             * known by other tests.
+             */
+            HighlyAvailableGraphDatabase failed1;
+            ClusterManager.RepairKit rk1;
+            HighlyAvailableGraphDatabase failed2;
+            HighlyAvailableGraphDatabase failed3;
+            HighlyAvailableGraphDatabase remainingSlave;
+
+            failed1 = cluster.getAnySlave();
+            failed2 = cluster.getAnySlave( failed1 );
+            failed3 = cluster.getAnySlave( failed1, failed2 );
+            remainingSlave = cluster.getAnySlave( failed1, failed2, failed3 );
+
+            rk1 = killIncrementally( cluster, failed1, failed2, failed3 );
+
+            cluster.await( memberSeesOtherMemberAsFailed( remainingSlave, failed1 ) );
+            cluster.await( memberSeesOtherMemberAsFailed( remainingSlave, failed2 ) );
+            cluster.await( memberSeesOtherMemberAsFailed( remainingSlave, failed3 ) );
+
+            cluster.await( memberSeesOtherMemberAsFailed( master, failed1 ) );
+            cluster.await( memberSeesOtherMemberAsFailed( master, failed2 ) );
+            cluster.await( memberSeesOtherMemberAsFailed( master, failed3 ) );
+
+            ensureInstanceIsReadOnlyInPendingState( master );
+            ensureInstanceIsReadOnlyInPendingState( remainingSlave );
+
+            rk1.repair();
+
+            cluster.await( masterAvailable( failed2, failed3 ) );
+            cluster.await( masterSeesSlavesAsAvailable( 2 ) );
+
+            ensureInstanceIsWritable( master );
+            ensureInstanceIsWritable( remainingSlave );
+            ensureInstanceIsWritable( failed1 );
+
+        }
+        finally
+        {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    @Ignore("Currently failing because the clustering layer does not properly detect such failures. WIP.")
+    public void losingQuorumAbruptlyShouldMakeAllInstancesPendingAndReadOnly() throws Throwable
+    {
+        int clusterSize = 5; // we need 5 to differentiate between all other instances gone and just quorum being gone
+
+        ClusterManager manager = new ClusterManager.Builder().withRootDirectory( dir.cleanDirectory( "testcluster" ) )
+                .withProvider( ClusterManager.clusterOfSize( clusterSize ) )
+                .withSharedConfig( stringMap(
+                        ClusterSettings.heartbeat_interval.name(), "1",
+                        HaSettings.tx_push_factor.name(), "4" ) ) // so we know the initial data made it everywhere
+                .build();
+
+        try
+        {
+            manager.start();
+            ClusterManager.ManagedCluster cluster = manager.getDefaultCluster();
+
+            cluster.await( allSeesAllAsAvailable() );
+            cluster.await( masterAvailable() );
+
+            HighlyAvailableGraphDatabase master = cluster.getMaster();
+            addSomeData( master );
+
+            /*
+             * we need 3 failures. We'll end up with the old master and a slave connected. They should both be in
+             * PENDING state, allowing reads but not writes. Repairing just one of the removed instances should
+             * result in a master being elected and all instances being read and writable.
+             * The instances we remove do not need additional verification for their state. Their behaviour is already
+             * known by other tests.
+             */
+            HighlyAvailableGraphDatabase failed1;
+            ClusterManager.RepairKit rk1;
+            HighlyAvailableGraphDatabase failed2;
+            HighlyAvailableGraphDatabase failed3;
+            HighlyAvailableGraphDatabase remainingSlave;
+
+            failed1 = cluster.getAnySlave();
+            failed2 = cluster.getAnySlave( failed1 );
+            failed3 = cluster.getAnySlave( failed1, failed2 );
+            remainingSlave = cluster.getAnySlave( failed1, failed2, failed3 );
+
+            rk1 = killAbruptly( cluster, failed1, failed2, failed3 );
+
+            cluster.await( memberSeesOtherMemberAsFailed( remainingSlave, failed1 ) );
+            cluster.await( memberSeesOtherMemberAsFailed( remainingSlave, failed2 ) );
+            cluster.await( memberSeesOtherMemberAsFailed( remainingSlave, failed3 ) );
+
+            cluster.await( memberSeesOtherMemberAsFailed( master, failed1 ) );
+            cluster.await( memberSeesOtherMemberAsFailed( master, failed2 ) );
+            cluster.await( memberSeesOtherMemberAsFailed( master, failed3 ) );
+
+            ensureInstanceIsReadOnlyInPendingState( master );
+            ensureInstanceIsReadOnlyInPendingState( remainingSlave );
+
+            rk1.repair();
+
+            cluster.await( masterAvailable( failed2, failed3 ) );
+            cluster.await( masterSeesMembers( 2 ) );
+
+            ensureInstanceIsWritable( master );
+            ensureInstanceIsWritable( remainingSlave );
+            ensureInstanceIsWritable( failed1 );
+
+        }
+        finally
+        {
+            manager.shutdown();
+        }
+    }
+
+    private ClusterManager.RepairKit killAbruptly( ClusterManager.ManagedCluster cluster,
+                                                   HighlyAvailableGraphDatabase failed1,
+                                                   HighlyAvailableGraphDatabase failed2,
+                                                   HighlyAvailableGraphDatabase failed3 ) throws Throwable
+    {
+        ClusterManager.RepairKit firstFailure = cluster.fail( failed1 );
+        cluster.fail( failed2 );
+        cluster.fail( failed3 );
+
+        cluster.await( instanceEvicted( failed1 ) );
+        cluster.await( instanceEvicted( failed2 ) );
+        cluster.await( instanceEvicted( failed3 ) );
+
+        return firstFailure;
+    }
+
+    private ClusterManager.RepairKit killIncrementally( ClusterManager.ManagedCluster cluster,
+                                                   HighlyAvailableGraphDatabase failed1,
+                                                   HighlyAvailableGraphDatabase failed2,
+                                                   HighlyAvailableGraphDatabase failed3 ) throws Throwable
+    {
+        ClusterManager.RepairKit firstFailure = cluster.fail( failed1 );
+        cluster.await( instanceEvicted( failed1 ) );
+        cluster.fail( failed2 );
+        cluster.await( instanceEvicted( failed2 ) );
+        cluster.fail( failed3 );
+        cluster.await( instanceEvicted( failed3 ) );
+
+        return firstFailure;
+    }
+
+
+    private void addSomeData( HighlyAvailableGraphDatabase instance )
+    {
+        try ( Transaction tx = instance.beginTx() )
+        {
+            Node testNode = instance.createNode();
+            testNodeId = testNode.getId();
+            testNode.setProperty( testPropKey, testPropValue );
+            tx.success();
+        }
+    }
+
+    /*
+     * This method must be called on an instance that has had addSomeData() called on it.
+     */
+    private void ensureInstanceIsReadOnlyInPendingState( HighlyAvailableGraphDatabase instance )
+    {
+        assertEquals( PENDING, instance.getInstanceState() );
+
+        try ( Transaction tx = instance.beginTx() )
+        {
+            assertEquals( testPropValue, instance.getNodeById( testNodeId ).getProperty( testPropKey ) );
+            tx.success();
+        }
+
+        try ( Transaction ignored = instance.beginTx() )
+        {
+            instance.getNodeById( testNodeId ).delete();
+            fail( "Should not be able to do write transactions when detached" );
+        }
+        catch ( TransientDatabaseFailureException e )
+        {
+            // expected
+        }
+    }
+
+    private void ensureInstanceIsWritable( HighlyAvailableGraphDatabase instance )
+    {
+        try ( Transaction tx = instance.beginTx() )
+        {
+            instance.createNode().setProperty( testPropKey, testPropValue );
+            tx.success();
+        }
+    }
+
+    private Predicate<ClusterManager.ManagedCluster> instanceEvicted( final HighlyAvailableGraphDatabase instance )
     {
         return new Predicate<ClusterManager.ManagedCluster>()
         {
             @Override
             public boolean test( ClusterManager.ManagedCluster managedCluster )
             {
-
-                InstanceId oldMasterServerId = managedCluster.getServerId( oldMaster );
+                InstanceId instanceId = managedCluster.getServerId( instance );
 
                 Iterable<HighlyAvailableGraphDatabase> members = managedCluster.getAllMembers();
                 for ( HighlyAvailableGraphDatabase member : members )
                 {
-                    if ( oldMasterServerId.equals( managedCluster.getServerId( member ) ) )
+                    if ( instanceId.equals( managedCluster.getServerId( member ) ) )
                     {
                         if ( member.role().equals( "UNKNOWN" ) )
                         {

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionTestIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterPartitionTestIT.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.function.Predicate;
+import org.neo4j.kernel.impl.ha.ClusterManager;
+import org.neo4j.kernel.impl.ha.ClusterManager.NetworkFlag;
+import org.neo4j.test.LoggerRule;
+import org.neo4j.test.TargetDirectory;
+
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
+import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
+
+public class ClusterPartitionTestIT
+{
+    @Rule
+    public LoggerRule logger = new LoggerRule();
+    @Rule
+    public TargetDirectory.TestDirectory dir = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void isolatedMasterShouldRemoveSelfFromCluster() throws Throwable
+    {
+        int clusterSize = 3;
+
+        ClusterManager manager = new ClusterManager.Builder().withRootDirectory( dir.cleanDirectory( "testcluster" ) )
+                .withProvider( ClusterManager.clusterOfSize( clusterSize ) )
+                .withSharedConfig( stringMap(
+                        ClusterSettings.heartbeat_interval.name(), "1" ) )
+                .build();
+
+        try
+        {
+            manager.start();
+            ClusterManager.ManagedCluster cluster = manager.getDefaultCluster();
+
+            cluster.await( allSeesAllAsAvailable() );
+            cluster.await( masterAvailable() );
+
+
+            HighlyAvailableGraphDatabase oldMaster = cluster.getMaster();
+
+            cluster.fail( oldMaster, NetworkFlag.values() );
+
+            cluster.await( oldMasterEvicted( oldMaster ), 20 );
+        }
+        finally
+        {
+            manager.safeShutdown();
+        }
+    }
+
+    private Predicate<ClusterManager.ManagedCluster> oldMasterEvicted( final HighlyAvailableGraphDatabase oldMaster )
+    {
+        return new Predicate<ClusterManager.ManagedCluster>()
+        {
+            @Override
+            public boolean test( ClusterManager.ManagedCluster managedCluster )
+            {
+
+                InstanceId oldMasterServerId = managedCluster.getServerId( oldMaster );
+
+                Iterable<HighlyAvailableGraphDatabase> members = managedCluster.getAllMembers();
+                for ( HighlyAvailableGraphDatabase member : members )
+                {
+                    if ( oldMasterServerId.equals( managedCluster.getServerId( member ) ) )
+                    {
+                        if ( member.role().equals( "UNKNOWN" ) )
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+
+            }
+        };
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/FailoverWithAdditionalSlaveFailuresIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/FailoverWithAdditionalSlaveFailuresIT.java
@@ -41,7 +41,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
 
 @RunWith( Parameterized.class )
-public class TestFailoverWithAdditionalSlaveFailures
+public class FailoverWithAdditionalSlaveFailuresIT
 {
     @Rule
     public LoggerRule logger = new LoggerRule();
@@ -70,7 +70,7 @@ public class TestFailoverWithAdditionalSlaveFailures
         });
     }
 
-    public TestFailoverWithAdditionalSlaveFailures( int clusterSize, int[] slavesToFail )
+    public FailoverWithAdditionalSlaveFailuresIT( int clusterSize, int[] slavesToFail )
     {
         this.clusterSize = clusterSize;
         this.slavesToFail = slavesToFail;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HAStateMachineIllegalTransitionsTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HAStateMachineIllegalTransitionsTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.ha.cluster;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityMemberStateMachineTest.mockAddClusterMemberListener;
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.MASTER;
+import static org.neo4j.kernel.ha.cluster.HighAvailabilityModeSwitcher.SLAVE;
+
+import java.net.URI;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.member.ClusterMemberEvents;
+import org.neo4j.cluster.member.ClusterMemberListener;
+import org.neo4j.cluster.protocol.election.Election;
+import org.neo4j.kernel.impl.store.StoreId;
+
+/*
+ * These tests reproduce state transitions which are illegal. The general requirement for them is that they
+ * set the instance to PENDING state and ask for an election, in the hopes that the result will come with
+ * proper ordering and therefore cause a proper state transition chain to MASTER or SLAVE.
+ */
+public class HAStateMachineIllegalTransitionsTest
+{
+    private final InstanceId me = new InstanceId( 1 );
+    private ClusterMemberListener memberListener;
+    private HighAvailabilityMemberStateMachine stateMachine;
+    private Election election;
+
+    @Before
+    public void setup() throws Throwable
+    {
+        HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
+
+        ClusterMemberEvents events = mock( ClusterMemberEvents.class );
+        HighAvailabilityMemberStateMachineTest.ClusterMemberListenerContainer memberListenerContainer =
+                mockAddClusterMemberListener( events );
+
+        election = mock( Election.class );
+
+        stateMachine = buildMockedStateMachine( context, events, election );
+        stateMachine.init();
+        memberListener = memberListenerContainer.get();
+        HighAvailabilityMemberStateMachineTest.HAStateChangeListener probe = new
+                HighAvailabilityMemberStateMachineTest.HAStateChangeListener();
+        stateMachine.addHighAvailabilityMemberListener( probe );
+    }
+
+    @Test
+    public void shouldProperlyHandleMasterAvailableWhenInPending() throws Throwable
+    {
+        /*
+         * If the instance is in PENDING state, masterIsAvailable for itself should leave it to PENDING
+         * and ask for elections
+         */
+
+        // sanity check of starting state
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
+
+        // when
+        // It receives available master without having gone through TO_MASTER
+        memberListener.memberIsAvailable( MASTER, me, URI.create( "ha://whatever" ), StoreId.DEFAULT );
+
+        // then
+        assertPendingStateAndElectionsAsked();
+    }
+
+    @Test
+    public void shouldProperlyHandleSlaveAvailableWhenInPending() throws Throwable
+    {
+        /*
+         * If the instance is in PENDING state, slaveIsAvailable for itself should set it to PENDING
+         * and ask for elections
+         */
+        // sanity check of starting state
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
+
+        // when
+        // It receives available SLAVE without having gone through TO_SLAVE
+        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://whatever" ), StoreId.DEFAULT );
+
+        // then
+        assertPendingStateAndElectionsAsked();
+    }
+
+    @Test
+    public void shouldProperlyHandleNonElectedMasterBecomingAvailableWhenInToSlave() throws Throwable
+    {
+        /*
+         * If the instance is in TO_SLAVE and a masterIsAvailable comes that does not refer to the elected master,
+         * the instance should go to PENDING and ask for elections
+         */
+        // Given
+        InstanceId other = new InstanceId( 2 );
+        InstanceId rogueMaster = new InstanceId( 3 );
+
+        // sanity check of starting state
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
+
+        // when
+        // It becomes available master without having gone through TO_MASTER
+        memberListener.memberIsAvailable( MASTER, other, URI.create( "ha://whatever" ), StoreId.DEFAULT );
+
+        // sanity check it is TO_SLAVE
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.TO_SLAVE ) );
+
+        // when
+        // it receives that another master became master but which is different than the currently elected one
+        memberListener.memberIsAvailable( MASTER, rogueMaster, URI.create( "ha://fromNowhere" ), StoreId.DEFAULT );
+
+        // then
+        assertPendingStateAndElectionsAsked();
+    }
+
+    @Test
+    public void shouldProperlyHandleConflictingMasterAvailableMessage() throws Throwable
+    {
+        /*
+         * If the instance is currently in TO_MASTER and a masterIsAvailable comes for another instance, then
+         * this instance should transition to PENDING and ask for an election.
+         */
+        // Given
+        InstanceId rogue = new InstanceId( 2 );
+        // sanity check of starting state
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
+
+        // when
+        // It receives available master without having gone through TO_MASTER
+        memberListener.coordinatorIsElected( me );
+
+        // then
+        // sanity check it transitioned to TO_MASTER
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.TO_MASTER ) );
+
+        // when
+        // it receives a masterIsAvailable for another instance
+        memberListener.memberIsAvailable( MASTER, rogue, URI.create( "ha://someUri" ), StoreId.DEFAULT );
+
+        // then
+        assertPendingStateAndElectionsAsked();
+    }
+
+    @Test
+    public void shouldProperlyHandleConflictingSlaveIsAvailableMessageWhenInToMaster() throws Throwable
+    {
+        /*
+         * If the instance is in TO_MASTER state, slaveIsAvailable for itself should set it to PENDING
+         * and ask for elections
+         */
+        // Given
+        // sanity check of starting state
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
+
+        // when
+        // It receives available master without having gone through TO_MASTER
+        memberListener.coordinatorIsElected( me );
+
+        // then
+        // sanity check it transitioned to TO_MASTER
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.TO_MASTER ) );
+
+        // when
+        // it receives a masterIsAvailable for another instance
+        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://someUri" ), StoreId.DEFAULT );
+
+        // then
+        assertPendingStateAndElectionsAsked();
+    }
+
+    @Test
+    public void shouldProperlyHandleConflictingSlaveIsAvailableWhenInMaster() throws Throwable
+    {
+        /*
+         * If the instance is in MASTER state, slaveIsAvailable for itself should set it to PENDING
+         * and ask for elections
+         */
+        // sanity check of starting state
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
+
+        // when
+        // It receives available master without having gone through TO_MASTER
+        memberListener.coordinatorIsElected( me );
+
+        // then
+        // sanity check it transitioned to TO_MASTER
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.TO_MASTER ) );
+
+        // when
+        // it receives a masterIsAvailable for itself, completing the transition
+        memberListener.memberIsAvailable( MASTER, me, URI.create( "ha://someUri" ), StoreId.DEFAULT );
+
+        // then
+        // it should move to MASTER
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.MASTER ) );
+
+        // when
+        // it receives a slaveIsAvailable for itself while in the MASTER state
+        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://someUri" ), StoreId.DEFAULT );
+
+        // then
+        assertPendingStateAndElectionsAsked();
+    }
+
+    @Test
+    public void shouldProperlyHandleMasterIsAvailableWhenInMasterState() throws Throwable
+    {
+        /*
+         * If the instance is in MASTER state and a masterIsAvailable is received for another instance, then
+         * this instance should got to PENDING and ask for elections
+         */
+        // Given
+        InstanceId rogue = new InstanceId( 2 );
+        // sanity check of starting state
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
+
+        // when
+        // It receives available master without having gone through TO_MASTER
+        memberListener.coordinatorIsElected( me );
+
+        // then
+        // sanity check it transitioned to TO_MASTER
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.TO_MASTER ) );
+
+        // when
+        // it receives a masterIsAvailable for itself, completing the transition
+        memberListener.memberIsAvailable( MASTER, me, URI.create( "ha://someUri" ), StoreId.DEFAULT );
+
+        // then
+        // it should move to MASTER
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.MASTER ) );
+
+        // when
+        // it receives a slaveIsAvailable for itself while in the MASTER state
+        memberListener.memberIsAvailable( MASTER, rogue, URI.create( "ha://someUri" ), StoreId.DEFAULT );
+
+        // then
+        assertPendingStateAndElectionsAsked();
+    }
+
+    @Test
+    public void shouldProperlyHandleMasterIsAvailableWhenInSlaveState() throws Throwable
+    {
+        /*
+         * If the instance is in SLAVE state and receives masterIsAvailable for an instance different than the
+         * current master, it should revert to PENDING and ask for elections
+         */
+        // Given
+        InstanceId master = new InstanceId( 2 );
+        InstanceId rogueMaster = new InstanceId( 3 );
+        // sanity check of starting state
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
+
+        // when
+        // a master is elected normally
+        memberListener.coordinatorIsElected( master );
+        memberListener.memberIsAvailable( MASTER, master, URI.create( "ha://someUri" ), StoreId.DEFAULT );
+
+        // then
+        // sanity check it transitioned to TO_SLAVE
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.TO_SLAVE ) );
+
+        // when
+        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://myUri" ), StoreId.DEFAULT );
+
+        // then
+        // we should be in SLAVE state
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.SLAVE ) );
+
+        // when
+        // it receives a masterIsAvailable for an unelected master while in the slave state
+        memberListener.memberIsAvailable( MASTER, rogueMaster, URI.create( "ha://someOtherUri" ), StoreId.DEFAULT );
+
+        // then
+        assertPendingStateAndElectionsAsked();
+    }
+
+    private void assertPendingStateAndElectionsAsked()
+    {
+        // it should remain in pending
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
+        // and it should ask for elections
+        verify( election ).performRoleElections();
+    }
+
+    private HighAvailabilityMemberStateMachine buildMockedStateMachine( HighAvailabilityMemberContext context,
+                                                                        ClusterMemberEvents events,
+                                                                        Election election )
+    {
+        return new HighAvailabilityMemberStateMachineTest.StateMachineBuilder()
+                .withContext( context ).withEvents( events ).withElection( election ).build();
+    }
+}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -384,6 +384,7 @@ public class HighAvailabilityMemberStateMachineTest
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
     }
 
+
     @Test
     public void whenHAModeSwitcherSwitchesToSlaveTheOtherModeSwitcherDoNotGetTheOldMasterClient() throws Throwable
     {
@@ -618,7 +619,7 @@ public class HighAvailabilityMemberStateMachineTest
         return members;
     }
 
-    private ClusterMemberListenerContainer mockAddClusterMemberListener( ClusterMemberEvents events )
+    static ClusterMemberListenerContainer mockAddClusterMemberListener( ClusterMemberEvents events )
     {
         final ClusterMemberListenerContainer listenerContainer = new ClusterMemberListenerContainer();
         doAnswer( new Answer()
@@ -652,7 +653,7 @@ public class HighAvailabilityMemberStateMachineTest
                 clusterMembers ).withGuard( guard ).build();
     }
 
-    private class StateMachineBuilder
+    static class StateMachineBuilder
     {
         HighAvailabilityMemberContext context = mock( HighAvailabilityMemberContext.class );
         ClusterMemberEvents events = mock( ClusterMemberEvents.class );
@@ -697,7 +698,7 @@ public class HighAvailabilityMemberStateMachineTest
         }
     }
 
-    private static class ClusterMemberListenerContainer
+    static class ClusterMemberListenerContainer
     {
         private ClusterMemberListener clusterMemberListener;
 
@@ -718,7 +719,7 @@ public class HighAvailabilityMemberStateMachineTest
         }
     }
 
-    private static final class HAStateChangeListener implements HighAvailabilityMemberListener
+    static final class HAStateChangeListener implements HighAvailabilityMemberListener
     {
         boolean masterIsElected = false;
         boolean masterIsAvailable = false;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -212,8 +212,9 @@ public class HighAvailabilityMemberStateMachineTest
 
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
-        assertThat( probe.instanceStops, is( true ) );
-        verify( guard, times( 2 ) ).require( any( AvailabilityRequirement.class ) );
+        assertThat( probe.instanceStops, is( false ) );
+        assertThat( probe.instanceDetached, is( true ) );
+        verify( guard, times( 1 ) ).require( any( AvailabilityRequirement.class ) );
     }
 
     @Test
@@ -287,8 +288,9 @@ public class HighAvailabilityMemberStateMachineTest
 
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
-        assertThat( probe.instanceStops, is( true ) );
-        verify( guard, times( 2 ) ).require( any( AvailabilityRequirement.class ) );
+        assertThat( probe.instanceStops, is( false ) );
+        assertThat( probe.instanceDetached, is( true ) );
+        verify( guard, times( 1 ) ).require( any( AvailabilityRequirement.class ) );
     }
 
     @Test
@@ -321,7 +323,8 @@ public class HighAvailabilityMemberStateMachineTest
 
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
-        assertThat( probe.instanceStops, is( true ) );
+        assertThat( probe.instanceStops, is( false ) );
+        assertThat( probe.instanceDetached, is( true ) );
         verify( guard, times( 1 ) ).require( any( AvailabilityRequirement.class ) );
     }
 
@@ -354,7 +357,8 @@ public class HighAvailabilityMemberStateMachineTest
 
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
-        assertThat( probe.instanceStops, is( true ) );
+        assertThat( probe.instanceStops, is( false ) );
+        assertThat( probe.instanceDetached, is( true ) );
         verify( guard, times( 1 ) ).require( any( AvailabilityRequirement.class ) );
     }
 
@@ -720,6 +724,7 @@ public class HighAvailabilityMemberStateMachineTest
         boolean masterIsAvailable = false;
         boolean slaveIsAvailable = false;
         boolean instanceStops = false;
+        boolean instanceDetached = false;
         HighAvailabilityMemberChangeEvent lastEvent = null;
 
         @Override
@@ -729,6 +734,7 @@ public class HighAvailabilityMemberStateMachineTest
             masterIsAvailable = false;
             slaveIsAvailable = false;
             instanceStops = false;
+            instanceDetached = false;
             lastEvent = event;
         }
 
@@ -739,6 +745,7 @@ public class HighAvailabilityMemberStateMachineTest
             masterIsAvailable = true;
             slaveIsAvailable = false;
             instanceStops = false;
+            instanceDetached = false;
             lastEvent = event;
         }
 
@@ -749,6 +756,7 @@ public class HighAvailabilityMemberStateMachineTest
             masterIsAvailable = false;
             slaveIsAvailable = true;
             instanceStops = false;
+            instanceDetached = false;
             lastEvent = event;
         }
 
@@ -759,6 +767,18 @@ public class HighAvailabilityMemberStateMachineTest
             masterIsAvailable = false;
             slaveIsAvailable = false;
             instanceStops = true;
+            instanceDetached = false;
+            lastEvent = event;
+        }
+
+        @Override
+        public void instanceDetached( HighAvailabilityMemberChangeEvent event )
+        {
+            masterIsElected = false;
+            masterIsAvailable = false;
+            slaveIsAvailable = false;
+            instanceStops = false;
+            instanceDetached = true;
             lastEvent = event;
         }
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -23,8 +23,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -81,6 +83,8 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -185,7 +189,7 @@ public class HighAvailabilityMemberStateMachineTest
         HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
 
         AvailabilityGuard guard = mock( AvailabilityGuard.class );
-        ObservedClusterMembers members = mockClusterMembers( me, other );
+        ObservedClusterMembers members = mockClusterMembers( me, Collections.<InstanceId>emptyList(), singletonList( other ) );
 
         ClusterMemberEvents events = mock( ClusterMemberEvents.class );
         ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
@@ -213,14 +217,15 @@ public class HighAvailabilityMemberStateMachineTest
     }
 
     @Test
-    public void whenInSlaveStateLosingQuorumShouldPutInPending() throws Throwable
+    public void whenInSlaveStateLosingOtherSlaveShouldNotPutInPending() throws Throwable
     {
         // Given
         InstanceId me = new InstanceId( 1 );
-        InstanceId other = new InstanceId( 2 );
+        InstanceId master = new InstanceId( 2 );
+        InstanceId otherSlave = new InstanceId( 3 );
         HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
         AvailabilityGuard guard = mock( AvailabilityGuard.class );
-        ObservedClusterMembers members = mockClusterMembers( me, other );
+        ObservedClusterMembers members = mockClusterMembers( me, singletonList( master ), singletonList( otherSlave ) );
 
         ClusterMemberEvents events = mock( ClusterMemberEvents.class );
         ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
@@ -233,13 +238,52 @@ public class HighAvailabilityMemberStateMachineTest
         stateMachine.addHighAvailabilityMemberListener( probe );
 
         // Send it to MASTER
-        memberListener.memberIsAvailable( MASTER, other, URI.create( "ha://whatever" ), StoreId.DEFAULT );
-        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://whatever2" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( MASTER, master, URI.create( "ha://whatever" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://whatever3" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( SLAVE, otherSlave, URI.create( "ha://whatever2" ), StoreId.DEFAULT );
 
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.SLAVE ) );
 
         // When
-        memberListener.memberIsFailed( new InstanceId( 2 ) );
+        memberListener.memberIsFailed( otherSlave );
+
+        // Then
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.SLAVE ) );
+        assertThat( probe.instanceStops, is( false ) );
+    }
+
+
+    @Test
+    public void whenInSlaveStateLosingMasterShouldPutInPending() throws Throwable
+    {
+        // Given
+        InstanceId me = new InstanceId( 1 );
+        InstanceId master = new InstanceId( 2 );
+        InstanceId otherSlave = new InstanceId( 3 );
+        HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
+        AvailabilityGuard guard = mock( AvailabilityGuard.class );
+        ObservedClusterMembers members = mockClusterMembers( me, singletonList( otherSlave ), singletonList( master ) );
+
+        ClusterMemberEvents events = mock( ClusterMemberEvents.class );
+        ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
+
+        HighAvailabilityMemberStateMachine stateMachine = buildMockedStateMachine( context, events, members, guard );
+
+        stateMachine.init();
+        ClusterMemberListener memberListener = memberListenerContainer.get();
+        HAStateChangeListener probe = new HAStateChangeListener();
+        stateMachine.addHighAvailabilityMemberListener( probe );
+
+        // Send it to MASTER
+        memberListener.coordinatorIsElected( master );
+        memberListener.memberIsAvailable( MASTER, master, URI.create( "ha://whatever" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( SLAVE, me, URI.create( "ha://whatever3" ), StoreId.DEFAULT );
+        memberListener.memberIsAvailable( SLAVE, otherSlave, URI.create( "ha://whatever2" ), StoreId.DEFAULT );
+
+        assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.SLAVE ) );
+
+        // When
+        memberListener.memberIsFailed( master );
 
         // Then
         assertThat( stateMachine.getCurrentState(), equalTo( HighAvailabilityMemberState.PENDING ) );
@@ -255,7 +299,7 @@ public class HighAvailabilityMemberStateMachineTest
         InstanceId other = new InstanceId( 2 );
         HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
         AvailabilityGuard guard = mock( AvailabilityGuard.class );
-        ObservedClusterMembers members = mockClusterMembers( me, other );
+        ObservedClusterMembers members = mockClusterMembers( me, Collections.<InstanceId>emptyList(), singletonList( other ) );
 
         ClusterMemberEvents events = mock( ClusterMemberEvents.class );
         ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
@@ -289,7 +333,7 @@ public class HighAvailabilityMemberStateMachineTest
         InstanceId other = new InstanceId( 2 );
         HighAvailabilityMemberContext context = new SimpleHighAvailabilityMemberContext( me, false );
         AvailabilityGuard guard = mock( AvailabilityGuard.class );
-        ObservedClusterMembers members = mockClusterMembers( me, other );
+        ObservedClusterMembers members = mockClusterMembers( me, Collections.<InstanceId>emptyList(), singletonList( other ) );
 
         ClusterMemberEvents events = mock( ClusterMemberEvents.class );
         ClusterMemberListenerContainer memberListenerContainer = mockAddClusterMemberListener( events );
@@ -533,19 +577,39 @@ public class HighAvailabilityMemberStateMachineTest
         otherModeSwitcher.shutdown();
     }
 
-    private ObservedClusterMembers mockClusterMembers( InstanceId me, InstanceId other )
+    private ObservedClusterMembers mockClusterMembers( InstanceId me, List<InstanceId> alive, List<InstanceId> failed )
     {
         ObservedClusterMembers members = mock( ObservedClusterMembers.class );
 
         // we cannot set outside of the package the isAlive to return false. So do it with a mock
-        ClusterMember otherMember = mock( ClusterMember.class );
-        when( otherMember.getInstanceId() ).thenReturn( other );
-        when( otherMember.isAlive() ).thenReturn( false );
+        List<ClusterMember> aliveMembers = new ArrayList<>( alive.size() );
+        List<ClusterMember> failedMembers = new ArrayList<>( failed.size() );
+        for ( InstanceId instanceId : alive )
+        {
+            ClusterMember otherMember = mock( ClusterMember.class );
+            when( otherMember.getInstanceId() ).thenReturn( instanceId );
+            // the failed argument tells us which instance should be marked as failed
+            when( otherMember.isAlive() ).thenReturn( true );
+            aliveMembers.add( otherMember );
+        }
+
+        for ( InstanceId instanceId : failed )
+        {
+            ClusterMember otherMember = mock( ClusterMember.class );
+            when( otherMember.getInstanceId() ).thenReturn( instanceId );
+            // the failed argument tells us which instance should be marked as failed
+            when( otherMember.isAlive() ).thenReturn( false );
+            failedMembers.add( otherMember );
+        }
 
         ClusterMember thisMember = new ClusterMember( me );
+        aliveMembers.add( thisMember );
 
-        when( members.getMembers() ).thenReturn( Arrays.asList( otherMember, thisMember ) );
-        when( members.getAliveMembers() ).thenReturn( Collections.singleton( thisMember ) );
+        List<ClusterMember> allMembers = new ArrayList<>();
+        allMembers.addAll( aliveMembers ); // thisMember is in aliveMembers
+        allMembers.addAll( failedMembers );
+        when( members.getMembers() ).thenReturn( allMembers );
+        when( members.getAliveMembers() ).thenReturn( aliveMembers );
 
         return members;
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
@@ -614,7 +614,7 @@ public class HighAvailabilityModeSwitcherTest
     }
 
     @Test
-    public void shouldSwitchToSlaveForNullMasterAndBeSilentWhenMovingToDetached() throws Exception
+    public void shouldSwitchToSlaveForNullMasterAndBeSilentWhenMovingToDetached() throws Throwable
     {
         // Given
         ClusterMemberAvailability availability = mock( ClusterMemberAvailability.class );
@@ -630,6 +630,8 @@ public class HighAvailabilityModeSwitcherTest
         toTest.addModeSwitcher( mockSwitcher );
 
         // When
+        toTest.init();
+        toTest.start();
         toTest.instanceDetached( new HighAvailabilityMemberChangeEvent( HighAvailabilityMemberState.MASTER,
                 HighAvailabilityMemberState.PENDING, null, null ) );
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityModeSwitcherTest.java
@@ -613,6 +613,32 @@ public class HighAvailabilityModeSwitcherTest
         verify( election ).demote( instanceId );
     }
 
+    @Test
+    public void shouldSwitchToSlaveForNullMasterAndBeSilentWhenMovingToDetached() throws Exception
+    {
+        // Given
+        ClusterMemberAvailability availability = mock( ClusterMemberAvailability.class );
+        HighAvailabilityModeSwitcher toTest = new HighAvailabilityModeSwitcher( mock( SwitchToSlave.class ),
+                mock( SwitchToMaster.class ),
+                mock( Election.class ),
+                availability,
+                mock( ClusterClient.class ),
+                storeSupplierMock(),
+                mock( InstanceId.class ), NullLogService.getInstance(),
+                neoStoreDataSourceSupplierMock() );
+        ModeSwitcher mockSwitcher = mock( ModeSwitcher.class );
+        toTest.addModeSwitcher( mockSwitcher );
+
+        // When
+        toTest.instanceDetached( new HighAvailabilityMemberChangeEvent( HighAvailabilityMemberState.MASTER,
+                HighAvailabilityMemberState.PENDING, null, null ) );
+
+        // Then
+        verify( mockSwitcher ).switchToSlave();
+        verifyZeroInteractions( availability );
+
+    }
+
     public static Supplier<StoreId> storeSupplierMock()
     {
         Supplier<StoreId> supplier = mock( Supplier.class );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ClusterManager.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
 import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.InstanceId;
@@ -1455,7 +1456,7 @@ public class ClusterManager
             }
             String state = stateToString( this );
             throw new IllegalStateException( format(
-                    "Awaited condition never met, waited %s secondes for %s:%n%s", maxSeconds, predicate, state ) );
+                    "Awaited condition never met, waited %s seconds for %s:%n%s", maxSeconds, predicate, state ) );
         }
 
         /**


### PR DESCRIPTION
This is a set of changes that make explicit the behaviour of instances or groups of instances that are no longer in contact with a majority of the HA cluster. The various commits introduce the ability to detect that state, act on it and revert to read only mode and help with the handling of some edge cases.

changelog: [2.3, HA] Partitioned instances revert to PENDING state while allowing read only operations
