### PR TITLE
Default values in procedures

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -50,7 +50,7 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
   extends ExecutionPlan {
 
   private val argExprCommands: Seq[expressions.Expression] =  argExprs.map(toCommandExpression) ++
-    signature.inputSignature.drop(argExprs.size).flatMap(_.default).map(Literal(_))
+    signature.inputSignature.drop(argExprs.size).flatMap(_.default).map(o => Literal(o.value))
 
   override def run(ctx: QueryContext, planType: ExecutionMode, params: Map[String, Any]): InternalExecutionResult = {
     val input = evaluateArguments(ctx, params)

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -20,6 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v3_1.executionplan.procs
 
 import org.neo4j.cypher.internal.compiler.v3_1.ast.convert.commands.ExpressionConverters._
+import org.neo4j.cypher.internal.compiler.v3_1.commands.expressions
+import org.neo4j.cypher.internal.compiler.v3_1.commands.expressions.Literal
 import org.neo4j.cypher.internal.compiler.v3_1.executionplan.{ExecutionPlan, InternalExecutionResult, ProcedureCallMode, READ_ONLY}
 import org.neo4j.cypher.internal.compiler.v3_1.helpers.{Counter, RuntimeJavaValueConverter}
 import org.neo4j.cypher.internal.compiler.v3_1.pipes.{ExternalCSVResource, QueryState}
@@ -47,7 +49,8 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
                                       publicTypeConverter: Any => Any)
   extends ExecutionPlan {
 
-  private val argExprCommands = argExprs.map(toCommandExpression)
+  private val argExprCommands: Seq[expressions.Expression] =  argExprs.map(toCommandExpression) ++
+    signature.inputSignature.drop(argExprs.size).flatMap(_.default).map(Literal(_))
 
   override def run(ctx: QueryContext, planType: ExecutionMode, params: Map[String, Any]): InternalExecutionResult = {
     val input = evaluateArguments(ctx, params)

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/execution/PipeExecutionPlanBuilder.scala
@@ -314,7 +314,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
 
     case ProcedureCall(_, call@ResolvedCall(signature, callArguments, callResults, _, _)) =>
       val callMode = ProcedureCallMode.fromAccessMode(signature.accessMode)
-      val callArgumentCommands = callArguments.map(Some(_)).zipAll(signature.inputSignature.map(_.default), None, None).map {
+      val callArgumentCommands = callArguments.map(Some(_)).zipAll(signature.inputSignature.map(_.default.map(_.value)), None, None).map {
         case (given, default) => given.map(toCommandExpression).getOrElse(Literal(default.get))
       }
       val rowProcessing = ProcedureCallRowProcessing(signature)

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
@@ -23,8 +23,8 @@ import org.neo4j.cypher.internal.frontend.v3_1.ast.UnresolvedCall
 import org.neo4j.cypher.internal.frontend.v3_1.symbols.CypherType
 
 case class ProcedureSignature(name: QualifiedProcedureName,
-                              inputSignature: Seq[FieldSignature],
-                              outputSignature: Option[Seq[FieldSignature]],
+                              inputSignature: IndexedSeq[FieldSignature],
+                              outputSignature: Option[IndexedSeq[FieldSignature]],
                               accessMode: ProcedureAccessMode = ProcedureReadOnlyAccess) {
 
   def outputFields = outputSignature.getOrElse(Seq.empty)
@@ -41,7 +41,7 @@ case class QualifiedProcedureName(namespace: Seq[String], name: String) {
   override def toString = s"""${namespace.mkString(".")}.$name"""
 }
 
-case class FieldSignature(name: String, typ: CypherType)
+case class FieldSignature(name: String, typ: CypherType, default: Option[AnyRef] = None)
 
 sealed trait ProcedureAccessMode
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/ProcedureSignature.scala
@@ -41,7 +41,8 @@ case class QualifiedProcedureName(namespace: Seq[String], name: String) {
   override def toString = s"""${namespace.mkString(".")}.$name"""
 }
 
-case class FieldSignature(name: String, typ: CypherType, default: Option[AnyRef] = None)
+case class CypherValue(value: AnyRef, cypherType: CypherType)
+case class FieldSignature(name: String, typ: CypherType, default: Option[CypherValue] = None)
 
 sealed trait ProcedureAccessMode
 

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/RewriteProcedureCallsTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/RewriteProcedureCallsTest.scala
@@ -30,8 +30,8 @@ class RewriteProcedureCallsTest extends CypherFunSuite with AstConstructionTestS
   val ns = ProcedureNamespace(List("my", "proc"))(pos)
   val name = ProcedureName("foo")(pos)
   val qualifiedName = QualifiedProcedureName(ns.parts, name.name)
-  val signatureInputs = Seq(FieldSignature("a", CTInteger))
-  val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+  val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+  val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
   val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
   val lookup: (QualifiedProcedureName) => ProcedureSignature = _ => signature
 

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/CallClauseTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/CallClauseTest.scala
@@ -33,8 +33,8 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("should resolve CALL my.proc.foo") {
     val unresolved = UnresolvedCall(ns, name, None, None)(pos)
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
-    val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+    val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(Parameter("a", CTAny)(pos))
     val callResults = Seq(ProcedureResultItem(varFor("x"))(pos), ProcedureResultItem(varFor("y"))(pos))
@@ -58,7 +58,7 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("should resolve void CALL my.proc.foo") {
     val unresolved = UnresolvedCall(ns, name, None, None)(pos)
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
     val signatureOutputs = None
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(Parameter("a", CTAny)(pos))
@@ -82,8 +82,8 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("should resolve CALL my.proc.foo YIELD x, y") {
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
-    val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+    val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(Parameter("a", CTAny)(pos))
     val callResults = Seq(ProcedureResultItem(varFor("x"))(pos), ProcedureResultItem(varFor("y"))(pos))
@@ -107,8 +107,8 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("should resolve CALL my.proc.foo(a)") {
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
-    val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+    val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(Parameter("a", CTAny)(pos))
     val callResults = Seq(ProcedureResultItem(varFor("x"))(pos), ProcedureResultItem(varFor("y"))(pos))
@@ -132,7 +132,7 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("should resolve void CALL my.proc.foo(a)") {
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
     val signatureOutputs = None
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(Parameter("a", CTAny)(pos))
@@ -157,8 +157,8 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("should resolve CALL my.proc.foo(a) YIELD x, y AS z") {
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
-    val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+    val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(Parameter("a", CTAny)(pos))
     val callResults = Seq(
@@ -183,7 +183,7 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("pretends to be based on user-declared arguments and results upon request") {
-    val signature = ProcedureSignature(qualifiedName, Seq.empty, Some(Seq.empty), ProcedureReadOnlyAccess)
+    val signature = ProcedureSignature(qualifiedName, IndexedSeq.empty, Some(IndexedSeq.empty), ProcedureReadOnlyAccess)
     val call = ResolvedCall(signature, null, null, declaredArguments = false, declaredResults = false)(pos)
 
     call.withFakedFullDeclarations.declaredArguments should be(true)
@@ -191,8 +191,8 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("adds coercion of arguments to signature types upon request") {
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
-    val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+    val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(Parameter("a", CTAny)(pos))
     val callResults = Seq(
@@ -218,8 +218,8 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("should verify number of arguments during semantic checking of resolved calls") {
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
-    val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+    val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq.empty
     val callResults = Seq(
@@ -235,8 +235,8 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("should verify that result variables are unique during semantic checking of resolved calls") {
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
-    val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+    val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(Parameter("a", CTAny)(pos))
     val callResults = Seq(
@@ -252,8 +252,8 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("should verify that output field names are correct during semantic checking of resolved calls") {
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
-    val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+    val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(Parameter("a", CTAny)(pos))
     val callResults = Seq(
@@ -269,8 +269,8 @@ class CallClauseTest extends CypherFunSuite with AstConstructionTestSupport {
   }
 
   test("should verify result types during semantic checking of resolved calls") {
-    val signatureInputs = Seq(FieldSignature("a", CTInteger))
-    val signatureOutputs = Some(Seq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
+    val signatureInputs = IndexedSeq(FieldSignature("a", CTInteger))
+    val signatureOutputs = Some(IndexedSeq(FieldSignature("x", CTInteger), FieldSignature("y", CTList(CTNode))))
     val signature = ProcedureSignature(qualifiedName, signatureInputs, signatureOutputs, ProcedureReadOnlyAccess)
     val callArguments = Seq(StringLiteral("nope")(pos))
     val callResults = Seq(

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/convert/plannerQuery/StatementConvertersTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/convert/plannerQuery/StatementConvertersTest.scala
@@ -879,8 +879,8 @@ class StatementConvertersTest extends CypherFunSuite with LogicalPlanningTestSup
   test("CALL foo() YIELD all RETURN all") {
     val signature = ProcedureSignature(
       QualifiedProcedureName(Seq.empty, "foo"),
-      inputSignature = Seq.empty,
-      outputSignature = Some(Seq(FieldSignature("all", CTInteger)))
+      inputSignature = IndexedSeq.empty,
+      outputSignature = Some(IndexedSeq(FieldSignature("all", CTInteger)))
     )
     val query = buildPlannerQuery("CALL foo() YIELD all RETURN all", Some(_ => signature))
 

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/ProcedureCallExecutionPlanTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/executionplan/procs/ProcedureCallExecutionPlanTest.scala
@@ -82,16 +82,16 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
   def string(s: String): Expression = StringLiteral(s)(pos)
 
   private val readSignature = ProcedureSignature(
-    QualifiedProcedureName(Seq.empty, "foo"),
-    Seq(FieldSignature("a", symbols.CTInteger)),
-    Some(Seq(FieldSignature("b", symbols.CTInteger))),
+    QualifiedProcedureName(IndexedSeq.empty, "foo"),
+    IndexedSeq(FieldSignature("a", symbols.CTInteger)),
+    Some(IndexedSeq(FieldSignature("b", symbols.CTInteger))),
     ProcedureReadOnlyAccess
   )
 
   private val writeSignature = ProcedureSignature(
     QualifiedProcedureName(Seq.empty, "foo"),
-    Seq(FieldSignature("a", symbols.CTInteger)),
-    Some(Seq(FieldSignature("b", symbols.CTInteger))),
+    IndexedSeq(FieldSignature("a", symbols.CTInteger)),
+    Some(IndexedSeq(FieldSignature("b", symbols.CTInteger))),
     ProcedureReadWriteAccess
   )
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
@@ -36,6 +36,7 @@ import org.neo4j.kernel.api.exceptions.schema.SchemaKernelException
 import org.neo4j.kernel.api.index.{IndexDescriptor, InternalIndexState}
 import org.neo4j.kernel.api.proc.Neo4jTypes.AnyType
 import org.neo4j.kernel.api.proc.{Neo4jTypes, ProcedureSignature => KernelProcedureSignature}
+import org.neo4j.kernel.impl.proc.Neo4jValue
 
 import scala.collection.JavaConverters._
 
@@ -132,7 +133,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapperv3_1)
   override def procedureSignature(name: QualifiedProcedureName) = {
     val kn = new KernelProcedureSignature.ProcedureName(name.namespace.asJava, name.name)
     val ks = tc.statement.readOperations().procedureGet(kn)
-    val input = ks.inputSignature().asScala.map(s => FieldSignature(s.name(), asCypherType(s.neo4jType()), asOption(s.defaultValue()))).toIndexedSeq
+    val input = ks.inputSignature().asScala.map(s => FieldSignature(s.name(), asCypherType(s.neo4jType()), asOption(s.defaultValue()).map(asCypherValue))).toIndexedSeq
     val output = if (ks.isVoid) None else Some(ks.outputSignature().asScala.map(s => FieldSignature(s.name(), asCypherType(s.neo4jType()))).toIndexedSeq)
     val mode = asCypherProcMode(ks.mode())
 
@@ -149,6 +150,8 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapperv3_1)
     case _ => throw new CypherExecutionException(
       "Unable to execute procedure, because it requires an unrecognized execution mode: " + mode.name(), null )
   }
+
+  private def asCypherValue(neo4jValue: Neo4jValue) = CypherValue(neo4jValue.value, asCypherType(neo4jValue.neo4jType()))
 
   private def asCypherType(neoType: AnyType): CypherType = neoType match {
     case Neo4jTypes.NTString => symbols.CTString

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.proc.Neo4jTypes.AnyType;
+import org.neo4j.kernel.impl.proc.Neo4jValue;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
@@ -97,14 +98,14 @@ public class ProcedureSignature
     {
         private final String name;
         private final AnyType type;
-        private final Optional<Object> defaultValue;
+        private final Optional<Neo4jValue> defaultValue;
 
         public FieldSignature( String name, AnyType type)
         {
             this(name, type, Optional.empty());
         }
 
-        public FieldSignature( String name, AnyType type, Optional<Object> defaultValue )
+        public FieldSignature( String name, AnyType type, Optional<Neo4jValue> defaultValue )
         {
             this.name = name;
             this.type = type;
@@ -121,7 +122,7 @@ public class ProcedureSignature
             return type;
         }
 
-        public Optional<Object> defaultValue()
+        public Optional<Neo4jValue> defaultValue()
         {
             return defaultValue;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
@@ -130,7 +130,8 @@ public class ProcedureSignature
         @Override
         public String toString()
         {
-            return String.format("%s :: %s", name, type);
+            String nameValue = defaultValue.isPresent() ? name + " = " + defaultValue.get().value() : name;
+            return String.format("%s :: %s", nameValue, type);
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/ProcedureSignature.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.proc.Neo4jTypes.AnyType;
@@ -96,11 +97,18 @@ public class ProcedureSignature
     {
         private final String name;
         private final AnyType type;
+        private final Optional<Object> defaultValue;
 
-        public FieldSignature( String name, AnyType type )
+        public FieldSignature( String name, AnyType type)
+        {
+            this(name, type, Optional.empty());
+        }
+
+        public FieldSignature( String name, AnyType type, Optional<Object> defaultValue )
         {
             this.name = name;
             this.type = type;
+            this.defaultValue = defaultValue;
         }
 
         public String name()
@@ -111,6 +119,11 @@ public class ProcedureSignature
         public AnyType neo4jType()
         {
             return type;
+        }
+
+        public Optional<Object> defaultValue()
+        {
+            return defaultValue;
         }
 
         @Override
@@ -253,7 +266,7 @@ public class ProcedureSignature
         /** Define an input field */
         public Builder in( String name, AnyType type )
         {
-            inputSignature.add( new FieldSignature( name, type ) );
+            inputSignature.add( new FieldSignature( name, type) );
             return this;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -354,9 +354,9 @@ public class DataSourceModule
         platform.life.add( procedures );
         platform.dependencies.satisfyDependency( procedures );
 
-        procedures.registerType( Node.class, new SimpleConverter( NTNode, Node.class ) );
-        procedures.registerType( Relationship.class, new SimpleConverter( NTRelationship, Relationship.class ) );
-        procedures.registerType( Path.class, new SimpleConverter( NTPath, Path.class ) );
+        procedures.registerType( Node.class, new SimpleConverter( NTNode, Node.class) );
+        procedures.registerType( Relationship.class, new SimpleConverter( NTRelationship, Relationship.class) );
+        procedures.registerType( Path.class, new SimpleConverter( NTPath, Path.class) );
 
         // Register injected public API components
         Log proceduresLog = platform.logging.getUserLog( Procedures.class  );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -88,7 +88,7 @@ import static org.neo4j.kernel.api.proc.Neo4jTypes.NTRelationship;
 /**
  * Datasource module for {@link GraphDatabaseFacadeFactory}. This implements all the
  * remaining services not yet created by either the {@link PlatformModule} or {@link EditionModule}.
- * <p/>
+ * <p>
  * When creating new services, this would be the default place to put them, unless they need to go into the other
  * modules for any reason.
  */
@@ -349,18 +349,19 @@ public class DataSourceModule
         Log internalLog = platform.logging.getInternalLog( Procedures.class );
 
         Procedures procedures = new Procedures(
-                new BuiltInProcedures( Version.getKernel().getReleaseVersion(),  platform.databaseInfo.edition.toString()),
-                pluginDir,  internalLog );
+                new BuiltInProcedures( Version.getKernel().getReleaseVersion(),
+                        platform.databaseInfo.edition.toString() ),
+                pluginDir, internalLog );
         platform.life.add( procedures );
         platform.dependencies.satisfyDependency( procedures );
 
-        procedures.registerType( Node.class, new SimpleConverter( NTNode, Node.class) );
-        procedures.registerType( Relationship.class, new SimpleConverter( NTRelationship, Relationship.class) );
-        procedures.registerType( Path.class, new SimpleConverter( NTPath, Path.class) );
+        procedures.registerType( Node.class, new SimpleConverter( NTNode, Node.class ) );
+        procedures.registerType( Relationship.class, new SimpleConverter( NTRelationship, Relationship.class ) );
+        procedures.registerType( Path.class, new SimpleConverter( NTPath, Path.class ) );
 
         // Register injected public API components
-        Log proceduresLog = platform.logging.getUserLog( Procedures.class  );
-        procedures.registerComponent( Log.class, (ctx) -> proceduresLog );
+        Log proceduresLog = platform.logging.getUserLog( Procedures.class );
+        procedures.registerComponent( Log.class, ( ctx ) -> proceduresLog );
 
         // Register injected private API components: useful to have available in procedures to access the kernel etc.
         ProcedureGDSFactory gdsFactory = new ProcedureGDSFactory( platform.config, platform.storeDir,
@@ -375,7 +376,7 @@ public class DataSourceModule
         //  - Group-transaction writes (same pattern as above, but rather than splitting large transactions,
         //                              combine lots of small ones)
         //  - Bleeding-edge performance (KernelTransaction, to bypass overhead of working with Core API)
-        procedures.registerComponent( DependencyResolver.class, (ctx) -> platform.dependencies );
+        procedures.registerComponent( DependencyResolver.class, ( ctx ) -> platform.dependencies );
         procedures.registerComponent( KernelTransaction.class, ( ctx ) -> ctx.get( KERNEL_TRANSACTION ) );
         procedures.registerComponent( GraphDatabaseAPI.class, ( ctx ) -> platform.graphDatabaseFacade );
 
@@ -394,7 +395,7 @@ public class DataSourceModule
 
     /**
      * At end of startup, wait for instance to become available for transactions.
-     * <p/>
+     * <p>
      * This helps users who expect to be able to access the instance after
      * the constructor is run.
      */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ListConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ListConverter.java
@@ -19,29 +19,37 @@
  */
 package org.neo4j.kernel.impl.proc;
 
+import java.lang.reflect.Type;
 import java.util.function.Function;
 
-import static org.neo4j.kernel.impl.proc.Neo4jValue.ntMap;
-import static org.neo4j.kernel.impl.proc.ParseUtil.parseMap;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
 
-/**
- * A naive implementation of a Cypher-map/json parser. If you find yourself using this
- * for parsing huge json-document in a place where performance matters - you probably need
- * to rethink your decision.
- */
-public class MapConverter implements Function<String,Neo4jValue>
+import static org.neo4j.kernel.impl.proc.Neo4jValue.ntList;
+import static org.neo4j.kernel.impl.proc.ParseUtil.parseList;
+
+
+public class ListConverter implements Function<String,Neo4jValue>
 {
+    private final Type type;
+    private final Neo4jTypes.AnyType neoType;
+
+    public ListConverter( Type type, Neo4jTypes.AnyType neoType )
+    {
+        this.type = type;
+        this.neoType = neoType;
+    }
+
     @Override
     public Neo4jValue apply( String s )
     {
         String value = s.trim();
         if ( value.equalsIgnoreCase( "null" ) )
         {
-            return ntMap( null );
+            return ntList( null, neoType );
         }
         else
         {
-            return ntMap( parseMap( value ) );
+            return ntList( parseList( value, type ), neoType );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MapConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MapConverter.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.neo4j.kernel.impl.proc.Neo4jValue.ntMap;
+
+/**
+ * A naive implementation of a Cypher-map/json parser. If you find yourself using this
+ * for parsing huge json-document in a place where performance matters - you probably need
+ * to rethink your decision.
+ */
+public class MapConverter implements Function<String,Neo4jValue>
+{
+    @Override
+    public Neo4jValue apply( String s )
+    {
+        String value = s.trim();
+        if ( value.equalsIgnoreCase( "null" ) )
+        {
+            return ntMap( null );
+        }
+        else
+        {
+            return ntMap( parseMap( value ) );
+        }
+    }
+
+    Map<String,Object> parseMap( String s )
+    {
+        int pos = 0;
+        int braceCounter = 0;
+        Map<String,Object> map = new HashMap<>();
+        StringBuilder builder = new StringBuilder();
+        while ( pos < s.length() )
+        {
+
+            char character = s.charAt( pos );
+            switch ( character )
+            {
+            case ' ':
+                ++pos;
+                break;
+            case '{':
+                if ( braceCounter++ > 0 )
+                {
+                    builder.append( s.charAt( pos ) );
+                }
+                ++pos;
+                break;
+            case ',':
+                if ( braceCounter == 1 )
+                {
+                    addKeyValue( map, builder.toString().trim() );
+                    builder = new StringBuilder();
+                }
+                else
+                {
+                    builder.append( s.charAt( pos ) );
+                }
+                ++pos;
+                break;
+            case '}':
+                if ( --braceCounter == 0 )
+                {
+                    addKeyValue( map, builder.toString().trim() );
+                }
+                else
+                {
+                    builder.append( s.charAt( pos ) );
+                }
+                ++pos;
+                break;
+            default:
+                builder.append( s.charAt( pos++ ) );
+                break;
+            }
+        }
+        if ( braceCounter != 0 )
+        {
+            throw new IllegalArgumentException( String.format( "%s contains unbalanced '{', '}'.", s ) );
+        }
+
+       return map;
+    }
+
+    private void addKeyValue( Map<String,Object> map, String keyValue )
+    {
+        if ( keyValue.isEmpty() )
+        {
+            return;
+        }
+        int split = keyValue.indexOf( ":" );
+        if ( split < 0 )
+        {
+            throw new IllegalArgumentException( "Keys and values must be separated with ':'" );
+        }
+        String key = parseKey( keyValue.substring( 0, split ).trim() );
+        Object value = parseValue( keyValue.substring( split + 1 ).trim() );
+
+        if ( map.containsKey( key ) )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "Multiple occurrences of key '%s'", key ) );
+        }
+        map.put( key, value );
+    }
+
+    private String parseKey( String s )
+    {
+        int pos = 0;
+        while ( pos < s.length() )
+        {
+            char c = s.charAt( pos );
+            switch ( c )
+            {
+            case '\'':
+            case '\"':
+                ++pos;
+                break;
+            default:
+                return s.substring( pos, s.length() - pos );
+            }
+        }
+
+        throw new IllegalArgumentException( "" );
+    }
+
+    private Object parseValue( String s )
+    {
+        int pos = 0;
+        while ( pos < s.length() )
+        {
+            char c = s.charAt( pos );
+            int closing;
+            switch ( c )
+            {
+            case ' ':
+                ++pos;
+                break;
+            case '\'':
+                closing = s.indexOf( '\'', pos + 1 );
+                if ( closing < 0 )
+                {
+                    throw new IllegalArgumentException( "Did not find a matching end quote, '" );
+                }
+                return s.substring( pos + 1, closing );
+            case '\"':
+                closing = s.indexOf( '\"', pos + 1 );
+                if ( closing < 0 )
+                {
+                    throw new IllegalArgumentException( "Did not find a matching end quote, \"" );
+                }
+                return s.substring( pos + 1, closing );
+            case '{':
+                return parseMap( s.substring( pos ) );
+            case '[':
+                return parseList( s.substring( pos ) );
+
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                String number = s.substring( pos );
+                try
+                {
+                    return Long.parseLong( number );
+                }
+                catch ( NumberFormatException e )
+                {
+                    return Double.parseDouble( number );
+                }
+
+            //deliberate fallthrough
+            case 'n':
+                if ( s.charAt( pos + 1 ) == 'u' && s.charAt( pos + 2 ) == 'l' && s.charAt( pos + 3 ) == 'l' )
+                {
+                    return null;
+                }
+
+            case 't':
+                if ( s.charAt( pos + 1 ) == 'r' && s.charAt( pos + 2 ) == 'u' && s.charAt( pos + 3 ) == 'e' )
+                {
+                    return true;
+                }
+            case 'f':
+                if ( s.charAt( pos + 1 ) == 'a' && s.charAt( pos + 2 ) == 'l' && s.charAt( pos + 3 ) == 's' && s.charAt( pos + 4 ) == 'e' )
+                {
+                    return false;
+                }
+
+            default:
+                throw new IllegalArgumentException( String.format( "%s is not a valid value", s ) );
+            }
+        }
+
+        throw new IllegalArgumentException( String.format( "%s is not a valid value", s ) );
+    }
+
+    Object parseList( String s )
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
@@ -77,7 +77,7 @@ public class MethodSignatureCompiler
             try
             {
                 NeoValueConverter valueConverter = typeMappers.converterFor( type );
-                Optional<Object> defaultValue = valueConverter.defaultValue( parameter );
+                Optional<Neo4jValue> defaultValue = valueConverter.defaultValue( parameter );
                 //it is not allowed to have holes in default values
                 if (seenDefault && !defaultValue.isPresent())
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
@@ -24,10 +24,12 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.ProcedureSignature.FieldSignature;
+import org.neo4j.kernel.impl.proc.TypeMappers.NeoValueConverter;
 import org.neo4j.procedure.Name;
 
 /**
@@ -48,6 +50,7 @@ public class MethodSignatureCompiler
         Parameter[] params = method.getParameters();
         Type[] types = method.getGenericParameterTypes();
         List<FieldSignature> signature = new ArrayList<>(params.length);
+        boolean seenDefault = false;
         for ( int i = 0; i < params.length; i++ )
         {
             Parameter param = params[i];
@@ -60,7 +63,8 @@ public class MethodSignatureCompiler
                         "Please add the annotation, recompile the class and try again.",
                         i, method.getName(), Name.class.getSimpleName() );
             }
-            String name = param.getAnnotation( Name.class ).value();
+            Name parameter = param.getAnnotation( Name.class );
+            String name = parameter.value();
 
             if( name.trim().length() == 0 )
             {
@@ -72,7 +76,20 @@ public class MethodSignatureCompiler
 
             try
             {
-                signature.add(new FieldSignature( name, typeMappers.neoTypeFor( type ) ));
+                NeoValueConverter valueConverter = typeMappers.converterFor( type );
+                Optional<Object> defaultValue = valueConverter.defaultValue( parameter );
+                //it is not allowed to have holes in default values
+                if (seenDefault && !defaultValue.isPresent())
+                {
+                    throw new ProcedureException( Status.Procedure.ProcedureRegistrationFailed,
+                            "Non-default argument at position %d with name %s in method %s follows default argument. " +
+                            "Add a default value or rearrange arguments so that the non-default values comes first.",
+                            i, parameter.value(), method.getName() );
+                }
+
+                seenDefault = defaultValue.isPresent();
+                signature.add( new FieldSignature( name, valueConverter.type(),
+                        defaultValue ) );
             }
             catch ( ProcedureException e )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Neo4jValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Neo4jValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.proc;
 
+import java.util.Map;
+
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 
 public class Neo4jValue
@@ -60,5 +62,43 @@ public class Neo4jValue
     public static  Neo4jValue ntBoolean(boolean value)
     {
         return new Neo4jValue( value, Neo4jTypes.NTBoolean );
+    }
+
+    public static  Neo4jValue ntMap(Map<String, Object> value)
+    {
+        return new Neo4jValue( value, Neo4jTypes.NTMap );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Neo4jValue{" +
+               "value=" + value +
+               ", type=" + type +
+               '}';
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        { return true; }
+        if ( o == null || getClass() != o.getClass() )
+        { return false; }
+
+        Neo4jValue that = (Neo4jValue) o;
+
+        if ( value != null ? !value.equals( that.value ) : that.value != null )
+        { return false; }
+        return type.equals( that.type );
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = value != null ? value.hashCode() : 0;
+        result = 31 * result + type.hashCode();
+        return result;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Neo4jValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Neo4jValue.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+
+public class Neo4jValue
+{
+    private final Object value;
+    private final Neo4jTypes.AnyType type;
+
+    public Neo4jValue( Object value, Neo4jTypes.AnyType type )
+    {
+        this.value = value;
+        this.type = type;
+    }
+
+    public Object value()
+    {
+        return value;
+    }
+
+    public Neo4jTypes.AnyType neo4jType()
+    {
+        return type;
+    }
+
+    public static  Neo4jValue ntString(String value)
+    {
+        return new Neo4jValue( value, Neo4jTypes.NTString );
+    }
+
+    public static  Neo4jValue ntInteger(long value)
+    {
+        return new Neo4jValue( value, Neo4jTypes.NTInteger );
+    }
+
+    public static  Neo4jValue ntFloat(double value)
+    {
+        return new Neo4jValue( value, Neo4jTypes.NTFloat );
+    }
+
+    public static  Neo4jValue ntBoolean(boolean value)
+    {
+        return new Neo4jValue( value, Neo4jTypes.NTBoolean );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Neo4jValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Neo4jValue.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.proc;
 
+import java.util.List;
 import java.util.Map;
 
 import org.neo4j.kernel.api.proc.Neo4jTypes;
@@ -67,6 +68,11 @@ public class Neo4jValue
     public static  Neo4jValue ntMap(Map<String, Object> value)
     {
         return new Neo4jValue( value, Neo4jTypes.NTMap );
+    }
+
+    public static Neo4jValue ntList(List<?> value, Neo4jTypes.AnyType inner)
+    {
+        return new Neo4jValue( value, Neo4jTypes.NTList( inner ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ParseUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ParseUtil.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Contains simple parsing utils for parsing Cypher lists, maps and values.
+ *
+ * The methods here are not very optimized and are deliberately simple. If you find yourself using these method
+ * for parsing big json documents you should probably rethink your choice.
+ */
+public final class ParseUtil
+{
+    private ParseUtil()
+    {
+        throw new UnsupportedOperationException( "Do not instantiate" );
+    }
+
+    static Map<String,Object> parseMap( String s )
+    {
+        int pos = 0;
+        int braceCounter = 0;
+        Map<String,Object> map = new HashMap<>();
+        StringBuilder builder = new StringBuilder();
+        boolean inList = false;
+        while ( pos < s.length() )
+        {
+
+            char character = s.charAt( pos );
+            switch ( character )
+            {
+            case ' ':
+                ++pos;
+                break;
+            case '{':
+                if ( braceCounter++ > 0 )
+                {
+                    builder.append( s.charAt( pos ) );
+                }
+                ++pos;
+                break;
+            case ',':
+                if ( !inList && braceCounter == 1 )
+                {
+                    addKeyValue( map, builder.toString().trim() );
+                    builder = new StringBuilder();
+                }
+                else
+                {
+                    builder.append( s.charAt( pos ) );
+                }
+                ++pos;
+                break;
+            case '}':
+                if ( --braceCounter == 0 )
+                {
+                    addKeyValue( map, builder.toString().trim() );
+                }
+                else
+                {
+                    builder.append( s.charAt( pos ) );
+                }
+                ++pos;
+                break;
+            case '[':
+                inList = true;
+                builder.append( s.charAt( pos++ ) );
+                break;
+            case ']':
+                inList = false;
+                builder.append( s.charAt( pos++ ) );
+                break;
+            default:
+                builder.append( s.charAt( pos++ ) );
+                break;
+            }
+        }
+        if ( braceCounter != 0 )
+        {
+            throw new IllegalArgumentException( String.format( "%s contains unbalanced '{', '}'.", s ) );
+        }
+
+        return map;
+    }
+
+    private static void addKeyValue( Map<String,Object> map, String keyValue )
+    {
+        if ( keyValue.isEmpty() )
+        {
+            return;
+        }
+        int split = keyValue.indexOf( ":" );
+        if ( split < 0 )
+        {
+            throw new IllegalArgumentException( "Keys and values must be separated with ':'" );
+        }
+        String key = parseKey( keyValue.substring( 0, split ).trim() );
+        Object value = parseValue( keyValue.substring( split + 1 ).trim(), Object.class );
+
+        if ( map.containsKey( key ) )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "Multiple occurrences of key '%s'", key ) );
+        }
+        map.put( key, value );
+    }
+
+    private static String parseKey( String s )
+    {
+        int pos = 0;
+        while ( pos < s.length() )
+        {
+            char c = s.charAt( pos );
+            switch ( c )
+            {
+            case '\'':
+            case '\"':
+                ++pos;
+                break;
+            default:
+                return s.substring( pos, s.length() - pos );
+            }
+        }
+
+        throw new IllegalArgumentException( "" );
+    }
+
+    private static Object parseValue( String s, Type type )
+    {
+        int pos = 0;
+        while ( pos < s.length() )
+        {
+            char c = s.charAt( pos );
+            int closing;
+            switch ( c )
+            {
+            case ' ':
+                ++pos;
+                break;
+            case '\'':
+                closing = s.indexOf( '\'', pos + 1 );
+                if ( closing < 0 )
+                {
+                    throw new IllegalArgumentException( "Did not find a matching end quote, '" );
+                }
+                return s.substring( pos + 1, closing );
+            case '\"':
+                closing = s.indexOf( '\"', pos + 1 );
+                if ( closing < 0 )
+                {
+                    throw new IllegalArgumentException( "Did not find a matching end quote, \"" );
+                }
+                return s.substring( pos + 1, closing );
+            case '{':
+                return parseMap( s.substring( pos ) );
+            case '[':
+                if ( type instanceof ParameterizedType )
+                {
+                    return parseList( s.substring( pos ), ((ParameterizedType) type).getActualTypeArguments()[0] );
+                }
+                else
+                {
+                    return parseList( s.substring( pos ), Object.class );
+                }
+
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                String number = s.substring( pos );
+                try
+                {
+                    return Long.parseLong( number );
+                }
+                catch ( NumberFormatException e )
+                {
+                    return Double.parseDouble( number );
+                }
+
+                //deliberate fallthrough
+            case 'n':
+                if ( s.charAt( pos + 1 ) == 'u' && s.charAt( pos + 2 ) == 'l' && s.charAt( pos + 3 ) == 'l' )
+                {
+                    return null;
+                }
+
+            case 't':
+                if ( s.charAt( pos + 1 ) == 'r' && s.charAt( pos + 2 ) == 'u' && s.charAt( pos + 3 ) == 'e' )
+                {
+                    return true;
+                }
+            case 'f':
+                if ( s.charAt( pos + 1 ) == 'a' && s.charAt( pos + 2 ) == 'l' && s.charAt( pos + 3 ) == 's' &&
+                     s.charAt( pos + 4 ) == 'e' )
+                {
+                    return false;
+                }
+
+            default:
+                throw new IllegalArgumentException( String.format( "%s is not a valid value", s ) );
+            }
+        }
+
+        throw new IllegalArgumentException( String.format( "%s is not a valid value", s ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    static <T> List<T> parseList( String s, Type type )
+    {
+        int pos = 0;
+        int braceCounter = 0;
+        List<Object> list = new ArrayList<>();
+        StringBuilder builder = new StringBuilder();
+        while ( pos < s.length() )
+        {
+
+            char character = s.charAt( pos );
+            switch ( character )
+            {
+            case ' ':
+                ++pos;
+                break;
+            case '[':
+                if ( braceCounter++ > 0 )
+                {
+                    builder.append( s.charAt( pos ) );
+                }
+                ++pos;
+                break;
+            case ',':
+                if ( braceCounter == 1 )
+                {
+                    Object o = parseValue( builder.toString().trim(), type );
+                    assertType(o, type);
+                    list.add( o );
+                    builder = new StringBuilder();
+                }
+                else
+                {
+                    builder.append( s.charAt( pos ) );
+                }
+                ++pos;
+                break;
+            case ']':
+                if ( --braceCounter == 0 )
+                {
+                    String value = builder.toString().trim();
+                    if ( !value.isEmpty() )
+                    {
+
+                        Object o = parseValue( value, type );
+                        assertType(o, type);
+
+                        list.add( o );
+                    }
+                }
+                else
+                {
+                    builder.append( s.charAt( pos ) );
+                }
+                ++pos;
+                break;
+            default:
+                builder.append( s.charAt( pos++ ) );
+                break;
+            }
+        }
+        if ( braceCounter != 0 )
+        {
+            throw new IllegalArgumentException( String.format( "%s contains unbalanced '[', ']'.", s ) );
+        }
+
+        return (List<T>) list;
+    }
+
+    private static void assertType(Object obj, Type type)
+    {
+        if (obj == null)
+        {
+            return;
+        }
+        //Since type erasure has already happened here we cannot verify ParameterizedType
+        if (type instanceof Class<?>)
+        {
+            Class<?> clazz = (Class<?>) type;
+            if ( !clazz.isAssignableFrom( obj.getClass() ) )
+            {
+                throw new IllegalArgumentException(
+                        String.format( "Expects a list of %s but got a list of %s", clazz.getSimpleName(),
+                                obj.getClass().getSimpleName() ) );
+            }
+
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ParseUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ParseUtil.java
@@ -148,6 +148,10 @@ public final class ParseUtil
         throw new IllegalArgumentException( "" );
     }
 
+    /**
+     * Parses value into object. Make sure you call trim on the string
+     * before calling this method. The type is used for type checking lists.
+     */
     private static Object parseValue( String s, Type type )
     {
         int pos = 0;
@@ -161,14 +165,14 @@ public final class ParseUtil
                 ++pos;
                 break;
             case '\'':
-                closing = s.indexOf( '\'', pos + 1 );
+                closing = s.lastIndexOf( '\'' );
                 if ( closing < 0 )
                 {
                     throw new IllegalArgumentException( "Did not find a matching end quote, '" );
                 }
                 return s.substring( pos + 1, closing );
             case '\"':
-                closing = s.indexOf( '\"', pos + 1 );
+                closing = s.lastIndexOf( '\"' );
                 if ( closing < 0 )
                 {
                     throw new IllegalArgumentException( "Did not find a matching end quote, \"" );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
@@ -149,7 +149,7 @@ public class TypeMappers
         }
     });
     private final NeoValueConverter TO_BOOLEAN = new SimpleConverter( NTBoolean, Boolean.class, s -> ntBoolean( parseBoolean(s) ));
-    private final NeoValueConverter TO_MAP = new SimpleConverter( NTMap, Map.class);
+    private final NeoValueConverter TO_MAP = new SimpleConverter( NTMap, Map.class, new MapConverter());
     private final NeoValueConverter TO_LIST = toList( TO_ANY );
 
     private NeoValueConverter toList( NeoValueConverter inner )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
@@ -111,7 +111,8 @@ public class TypeMappers
 
             if( rawType == List.class )
             {
-                return toList( converterFor( pt.getActualTypeArguments()[0] ) );
+                Type type = pt.getActualTypeArguments()[0];
+                return toList( converterFor( type ), type );
             }
             else if( rawType == Map.class )
             {
@@ -150,13 +151,11 @@ public class TypeMappers
     });
     private final NeoValueConverter TO_BOOLEAN = new SimpleConverter( NTBoolean, Boolean.class, s -> ntBoolean( parseBoolean(s) ));
     private final NeoValueConverter TO_MAP = new SimpleConverter( NTMap, Map.class, new MapConverter());
-    private final NeoValueConverter TO_LIST = toList( TO_ANY );
+    private final NeoValueConverter TO_LIST = toList( TO_ANY, Object.class );
 
-    private NeoValueConverter toList( NeoValueConverter inner )
+    private NeoValueConverter toList( NeoValueConverter inner, Type type )
     {
-        return new SimpleConverter( NTList( inner.type() ), List.class, s -> {
-            throw new UnsupportedOperationException("Default values for type List is not supported" );
-        } );
+        return new SimpleConverter( NTList( inner.type() ), List.class, new ListConverter(type, inner.type() ));
     }
 
     private ProcedureException javaToNeoMappingError( Type cls )

--- a/community/kernel/src/main/java/org/neo4j/procedure/Name.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Name.java
@@ -37,4 +37,13 @@ public @interface Name
      * @return the name of this input argument.
      */
     String value();
+
+    String defaultValue() default DEFAULT_VALUE;
+
+    /*
+     * Defaults in annotation requires compile time constants, the only way
+     * to check if a returned defaultValue() is a default is to use a constant
+     * that is highly unlikely to be used in real code.
+     */
+    String DEFAULT_VALUE = " <[6795b15e-8693-4a21-b57a-4a7b87f09a5a]> ";
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ListConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ListConverterTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTAny;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTBoolean;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTFloat;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTInteger;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTList;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTMap;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTString;
+import static org.neo4j.kernel.impl.proc.Neo4jValue.ntList;
+
+public class ListConverterTest
+{
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldHandleNullString()
+    {
+        // Given
+        ListConverter converter = new ListConverter( String.class, NTString );
+        String listString = "null";
+
+        // When
+        Neo4jValue converted = converter.apply( listString );
+
+        // Then
+        assertThat( converted, equalTo( ntList( null, NTString ) ) );
+    }
+
+    @Test
+    public void shouldHandleEmptyList()
+    {
+        // Given
+        ListConverter converter = new ListConverter( String.class, NTString );
+        String listString = "[]";
+
+        // When
+        Neo4jValue converted = converter.apply( listString );
+
+        // Then
+        assertThat( converted, equalTo( ntList( emptyList(), NTString ) ) );
+    }
+
+    @Test
+    public void shouldHandleEmptyListWithSpaces()
+    {
+        // Given
+        ListConverter converter = new ListConverter( String.class, NTString );
+        String listString = " [  ]   ";
+
+        // When
+        Neo4jValue converted = converter.apply( listString );
+
+        // Then
+        assertThat( converted, equalTo( ntList( emptyList(), NTString ) ) );
+    }
+
+    @Test
+    public void shouldHandleSingleQuotedValue()
+    {
+        // Given
+        ListConverter converter = new ListConverter( String.class, NTString );
+        String listString = "['foo', 'bar']";
+
+        // When
+        Neo4jValue converted = converter.apply( listString );
+
+        // Then
+        assertThat( converted, equalTo( ntList( asList( "foo", "bar" ), NTString ) ) );
+    }
+
+    @Test
+    public void shouldHandleDoubleQuotedValue()
+    {
+        // Given
+        ListConverter converter = new ListConverter( String.class, NTString );
+        String listString = "[\"foo\", \"bar\"]";
+
+        // When
+        Neo4jValue converted = converter.apply( listString );
+
+        // Then
+        assertThat( converted, equalTo( ntList( asList( "foo", "bar" ), NTString ) ) );
+    }
+
+    @Test
+    public void shouldHandleIntegerValue()
+    {
+        // Given
+        ListConverter converter = new ListConverter( Long.class, NTInteger );
+        String listString = "[1337, 42]";
+
+        // When
+        Neo4jValue converted = converter.apply( listString );
+
+        // Then
+        assertThat( converted, equalTo( ntList( asList( 1337L, 42L ), NTInteger ) ) );
+    }
+
+    @Test
+    public void shouldHandleFloatValue()
+    {
+        // Given
+        ListConverter converter = new ListConverter( Double.class, NTFloat );
+        String listSting = "[2.718281828, 3.14]";
+
+        // When
+        Neo4jValue converted = converter.apply( listSting );
+
+        // Then
+        assertThat( converted, equalTo( ntList( asList( 2.718281828, 3.14 ), NTFloat ) ) );
+    }
+
+    @Test
+    public void shouldHandleNullValue()
+    {
+        // Given
+        ListConverter converter = new ListConverter( Double.class, NTFloat );
+        String listString = "[null]";
+
+        // When
+        Neo4jValue converted = converter.apply( listString );
+
+        // Then
+        assertThat( converted, equalTo( ntList( singletonList( null ), NTFloat ) ) );
+    }
+
+    @Test
+    public void shouldHandleBooleanValues()
+    {
+        // Given
+        ListConverter converter = new ListConverter( Boolean.class, NTBoolean );
+        String mapString = "[false, true]";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntList( asList( false, true ), NTBoolean ) ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldHandleNestedLists()
+    {
+        // Given
+        ParameterizedType type = mock( ParameterizedType.class );
+        when( type.getActualTypeArguments() ).thenReturn( new Type[]{Object.class} );
+        ListConverter converter = new ListConverter( type, NTList( NTAny ) );
+        String mapString = "[42, [42, 1337]]";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        List<Object> list = (List<Object>) converted.value();
+        assertThat( list.get( 0 ), equalTo( 42L ) );
+        assertThat( list.get( 1 ), equalTo( asList( 42L, 1337L ) ) );
+    }
+
+    @Test
+    public void shouldFailOnInvalidMixedTyoes()
+    {
+        // Given
+        ListConverter converter = new ListConverter( Long.class, NTInteger );
+        String listString = "[1337, 'forty-two']";
+
+        // Expect
+        exception.expect( IllegalArgumentException.class );
+        exception.expectMessage( "Expects a list of Long but got a list of String" );
+
+        // When
+        converter.apply( listString );
+    }
+
+    @Test
+    public void shouldPassOnValidMixedTyoes()
+    {
+        // Given
+        ListConverter converter = new ListConverter( Object.class, NTAny );
+        String listString = "[1337, 'forty-two']";
+
+        // When
+        Neo4jValue value = converter.apply( listString );
+
+        // Then
+        assertThat( value, equalTo( ntList( asList( 1337L, "forty-two" ), NTAny ) ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldHandleListsOfMaps()
+    {
+        // Given
+        ListConverter converter = new ListConverter( Map.class, NTMap );
+        String mapString = "[{k1: 42}, {k1: 1337}]";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        List<Object> list = (List<Object>) converted.value();
+        assertThat( list.get( 0 ), equalTo( map( "k1", 42L ) ) );
+        assertThat( list.get( 1 ), equalTo( map( "k1", 1337L ) ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
@@ -92,6 +92,58 @@ public class MapConverterTest
     }
 
     @Test
+    public void shouldHandleEscapedSingleQuotedInValue1()
+    {
+        // Given
+        String mapString = "{key: 'va\'lue'}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", "va\'lue" ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleEscapedSingleQuotedInValue2()
+    {
+        // Given
+        String mapString = "{key: \"va\'lue\"}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", "va\'lue" ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleEscapedDoubleQuotedInValue1()
+    {
+        // Given
+        String mapString = "{key: \"va\"lue\"}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", "va\"lue" ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleEscapedDoubleQuotedInValue2()
+    {
+        // Given
+        String mapString = "{key: 'va\"lue'}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", "va\"lue" ) ) ) );
+    }
+
+    @Test
     public void shouldHandleDoubleQuotedValue()
     {
         // Given
@@ -128,6 +180,32 @@ public class MapConverterTest
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", "value" ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleKeyWithEscapedSingleQuote()
+    {
+        // Given
+        String mapString = "{\"k\'ey\": \"value\"}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "k\'ey", "value" ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleKeyWithEscapedDoubleQuote()
+    {
+        // Given
+        String mapString = "{\"k\"ey\": \"value\"}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "k\"ey", "value" ) ) ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
@@ -25,6 +25,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Map;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -165,7 +166,7 @@ public class MapConverterTest
         Neo4jValue converted = converter.apply( mapString );
 
         // Then
-        assertThat( converted, equalTo( ntMap( map( "key", null) ) ) );
+        assertThat( converted, equalTo( ntMap( map( "key", null ) ) ) );
     }
 
     @Test
@@ -238,7 +239,6 @@ public class MapConverterTest
         assertThat( map1.get( "k1" ), equalTo( 1337L ) );
         assertThat( map2.get( "k1" ), equalTo( 1337L ) );
         assertThat( map3.get( "k1" ), equalTo( 1337L ) );
-
     }
 
     @Test
@@ -253,5 +253,21 @@ public class MapConverterTest
 
         // When
         converter.apply( mapString );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldHandleMapsWithLists()
+    {
+        // Given
+        String mapString = "{k1: [1337, 42]}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        Map<String,Object> map1 = (Map<String,Object>) converted.value();
+        assertThat( map1.get( "k1" ), equalTo( asList( 1337L, 42L ) ) );
+
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.helpers.collection.MapUtil.map;
+import static org.neo4j.kernel.impl.proc.Neo4jValue.ntMap;
+
+public class MapConverterTest
+{
+    private final MapConverter converter = new MapConverter();
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldHandleNullString()
+    {
+        // Given
+        String mapString = "null";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( null ) ) );
+    }
+
+    @Test
+    public void shouldHandleEmptyMap()
+    {
+        // Given
+        String mapString = "{}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( emptyMap() ) ) );
+    }
+
+    @Test
+    public void shouldHandleEmptyMapWithSpaces()
+    {
+        // Given
+        String mapString = " {  }  ";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( emptyMap() ) ) );
+    }
+
+    @Test
+    public void shouldHandleSingleQuotedValue()
+    {
+        // Given
+        String mapString = "{key: 'value'}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", "value" ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleDoubleQuotedValue()
+    {
+        // Given
+        String mapString = "{key: \"value\"}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", "value" ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleSingleQuotedKey()
+    {
+        // Given
+        String mapString = "{'key;: 'value'}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", "value" ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleDoubleQuotedKey()
+    {
+        // Given
+        String mapString = "{\"key\": \"value\"}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", "value" ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleIntegerValue()
+    {
+        // Given
+        String mapString = "{key: 1337}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", 1337L ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleFloatValue()
+    {
+        // Given
+        String mapString = "{key: 2.718281828}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", 2.718281828 ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleNullValue()
+    {
+        // Given
+        String mapString = "{key: null}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", null) ) ) );
+    }
+
+    @Test
+    public void shouldHandleFalseValue()
+    {
+        // Given
+        String mapString = "{key: false}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", false ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleTrueValue()
+    {
+        // Given
+        String mapString = "{key: true}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "key", true ) ) ) );
+    }
+
+    @Test
+    public void shouldHandleMultipleKeys()
+    {
+        // Given
+        String mapString = "{k1: 2.718281828, k2: 'e'}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        assertThat( converted, equalTo( ntMap( map( "k1", 2.718281828, "k2", "e" ) ) ) );
+    }
+
+    @Test
+    public void shouldFailWhenDuplicateKey()
+    {
+        // Given
+        String mapString = "{k1: 2.718281828, k1: 'e'}";
+
+        // Expect
+        exception.expect( IllegalArgumentException.class );
+        exception.expectMessage( "Multiple occurrences of key 'k1'" );
+
+        // When
+        converter.apply( mapString );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void shouldHandleNestedMaps()
+    {
+        // Given
+        String mapString = "{k1: 1337, k2: { k1 : 1337, k2: {k1: 1337}}}";
+
+        // When
+        Neo4jValue converted = converter.apply( mapString );
+
+        // Then
+        Map<String,Object> map1 = (Map<String,Object>) converted.value();
+        Map<String,Object> map2 = (Map<String,Object>) map1.get( "k2" );
+        Map<String,Object> map3 = (Map<String,Object>) map2.get( "k2" );
+        assertThat( map1.get( "k1" ), equalTo( 1337L ) );
+        assertThat( map2.get( "k1" ), equalTo( 1337L ) );
+        assertThat( map3.get( "k1" ), equalTo( 1337L ) );
+
+    }
+
+    @Test
+    public void shouldFailOnMalformedMap()
+    {
+        // Given
+        String mapString = "{k1: 2.718281828, k2: 'e'}}";
+
+        // Expect
+        exception.expect( IllegalArgumentException.class );
+        exception.expectMessage( "{k1: 2.718281828, k2: 'e'}} contains unbalanced '{', '}'." );
+
+        // When
+        converter.apply( mapString );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -123,6 +123,19 @@ public class ReflectiveProcedureWithArgumentsTest
         compile( ClassWithProcedureWithMisplacedDefault.class );
     }
 
+    @Test
+    public void shouldFailIfWronglyTypedDefaultValue() throws Throwable
+    {
+        // Expect
+        exception.expect( ProcedureException.class );
+        exception.expectMessage( String.format("Argument `a` at position 0 in `defaultValues` with%n" +
+                "type `long` cannot be converted to a Neo4j type: Default value `forty-two` could not be parsed as a " +
+                "Long" ));
+
+        // When
+        compile( ClassWithProcedureWithBadlyTypedDefault.class );
+    }
+
     public static class MyOutputRecord
     {
         public String name;
@@ -183,6 +196,15 @@ public class ReflectiveProcedureWithArgumentsTest
     {
         @Procedure
         public Stream<MyOutputRecord> defaultValues( @Name( "a" ) String a , @Name( value = "b", defaultValue = "42") long b, @Name( "c" ) Object c)
+        {
+            return Stream.empty();
+        }
+    }
+
+    public static class ClassWithProcedureWithBadlyTypedDefault
+    {
+        @Procedure
+        public Stream<MyOutputRecord> defaultValues( @Name( value = "a", defaultValue = "forty-two") long b)
         {
             return Stream.empty();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureWithArgumentsTest.java
@@ -110,6 +110,19 @@ public class ReflectiveProcedureWithArgumentsTest
         compile( ClassWithProcedureWithoutAnnotatedArgs.class );
     }
 
+    @Test
+    public void shouldFailIfMisplacedDefaultValue() throws Throwable
+    {
+        // Expect
+        exception.expect( ProcedureException.class );
+        exception.expectMessage(
+                "Non-default argument at position 2 with name c in method defaultValues follows default argument. " +
+                "Add a default value or rearrange arguments so that the non-default values comes first." );
+
+        // When
+        compile( ClassWithProcedureWithMisplacedDefault.class );
+    }
+
     public static class MyOutputRecord
     {
         public String name;
@@ -153,6 +166,25 @@ public class ReflectiveProcedureWithArgumentsTest
         public Stream<MyOutputRecord> listCoolPeople( String name, int age )
         {
             return Stream.of( new MyOutputRecord( name + " is " + age + " years old." ) );
+        }
+    }
+
+    public static class ClassWithProcedureWithDefaults
+    {
+        @Procedure
+        public Stream<MyOutputRecord> defaultValues( @Name( value = "a", defaultValue = "a") String a , @Name( value = "b", defaultValue = "42") long b, @Name( value = "c",
+                defaultValue = "3.14") double c)
+        {
+            return Stream.empty();
+        }
+    }
+
+    public static class ClassWithProcedureWithMisplacedDefault
+    {
+        @Procedure
+        public Stream<MyOutputRecord> defaultValues( @Name( "a" ) String a , @Name( value = "b", defaultValue = "42") long b, @Name( "c" ) Object c)
+        {
+            return Stream.empty();
         }
     }
 

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -105,6 +105,84 @@ public class ProcedureIT
     }
 
     @Test
+    public void shouldCallProcedureWithDefaultArgument() throws Throwable
+    {
+        //Given/When
+        Result res = db.execute( "CALL org.neo4j.procedure.simpleArgumentWithDefault" );
+
+        // Then
+        assertThat( res.next(), equalTo( map( "someVal", 42L ) ) );
+        assertFalse( res.hasNext() );
+    }
+
+    @Test
+    public void shouldCallYieldProcedureWithDefaultArgument() throws Throwable
+    {
+        // Given/When
+        Result res = db.execute(
+                "CALL org.neo4j.procedure.simpleArgumentWithDefault() YIELD someVal as n RETURN n + 1295 as val" );
+
+        // Then
+        assertThat( res.next(), equalTo( map( "val", 1337L ) ) );
+        assertFalse( res.hasNext() );
+    }
+
+    @Test
+    public void shouldCallProcedureWithAllDefaultArgument() throws Throwable
+    {
+        //Given/When
+        Result res = db.execute( "CALL org.neo4j.procedure.defaultValues" );
+
+        // Then
+        assertThat( res.next(), equalTo( map( "string", "a string", "integer", 42L, "aFloat", 3.14, "aBoolean", true ) ) );
+        assertFalse( res.hasNext() );
+    }
+
+    @Test
+    public void shouldCallProcedureWithOneProvidedRestDefaultArgument() throws Throwable
+    {
+        //Given/When
+        Result res = db.execute( "CALL org.neo4j.procedure.defaultValues('another string')");
+
+        // Then
+        assertThat( res.next(), equalTo( map( "string", "another string", "integer", 42L, "aFloat", 3.14, "aBoolean", true ) ) );
+        assertFalse( res.hasNext() );
+    }
+
+    @Test
+    public void shouldCallProcedureWithTwoProvidedRestDefaultArgument() throws Throwable
+    {
+        //Given/When
+        Result res = db.execute( "CALL org.neo4j.procedure.defaultValues('another string', 1337)");
+
+        // Then
+        assertThat( res.next(), equalTo( map( "string", "another string", "integer", 1337L, "aFloat", 3.14, "aBoolean", true ) ) );
+        assertFalse( res.hasNext() );
+    }
+
+    @Test
+    public void shouldCallProcedureWithThreeProvidedRestDefaultArgument() throws Throwable
+    {
+        //Given/When
+        Result res = db.execute( "CALL org.neo4j.procedure.defaultValues('another string', 1337, 2.718281828)");
+
+        // Then
+        assertThat( res.next(), equalTo( map( "string", "another string", "integer", 1337L, "aFloat", 2.718281828, "aBoolean", true ) ) );
+        assertFalse( res.hasNext() );
+    }
+
+    @Test
+    public void shouldCallProcedureWithFourProvidedRestDefaultArgument() throws Throwable
+    {
+        //Given/When
+        Result res = db.execute( "CALL org.neo4j.procedure.defaultValues('another string', 1337, 2.718281828, false)");
+
+        // Then
+        assertThat( res.next(), equalTo( map( "string", "another string", "integer", 1337L, "aFloat", 2.718281828, "aBoolean", false ) ) );
+        assertFalse( res.hasNext() );
+    }
+
+    @Test
     public void shouldGiveNiceErrorMessageOnWrongStaticType() throws Throwable
     {
         //Expect
@@ -897,6 +975,22 @@ public class ProcedureIT
         }
     }
 
+    public static class PrimitiveOutput
+    {
+        public String string;
+        public long integer;
+        public double aFloat;
+        public boolean aBoolean;
+
+        public PrimitiveOutput( String string, long integer, double aFloat, boolean aBoolean )
+        {
+            this.string = string;
+            this.integer = integer;
+            this.aFloat = aFloat;
+            this.aBoolean = aBoolean;
+        }
+    }
+
     public static class DoubleOutput
     {
         public double result = 0.0d;
@@ -974,6 +1068,23 @@ public class ProcedureIT
         public Stream<Output> simpleArgument( @Name( "name" ) long someValue )
         {
             return Stream.of( new Output( someValue ) );
+        }
+
+        @Procedure
+        public Stream<Output> simpleArgumentWithDefault( @Name( value = "name", defaultValue = "42") long someValue )
+        {
+            return Stream.of( new Output( someValue ) );
+        }
+
+        @Procedure
+        public Stream<PrimitiveOutput> defaultValues(
+                @Name( value = "string", defaultValue = "a string") String string,
+                @Name( value = "integer", defaultValue = "42") long integer,
+                @Name( value = "float", defaultValue = "3.14") double aFloat,
+                @Name( value = "boolean", defaultValue = "true") boolean aBoolean
+                )
+        {
+            return Stream.of( new PrimitiveOutput( string, integer, aFloat, aBoolean ) );
         }
 
         @Procedure

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -1004,6 +1004,17 @@ public class ProcedureIT
         }
     }
 
+    @Test
+    public void shouldCallProcedureWithDefaultNodeArgument() throws Throwable
+    {
+        //Given/When
+        Result res = db.execute( "CALL org.neo4j.procedure.nodeWithDefault" );
+
+        // Then
+        assertThat( res.next(), equalTo( map( "node", null ) ) );
+        assertFalse( res.hasNext() );
+    }
+
     @Before
     public void setUp() throws IOException
     {
@@ -1096,6 +1107,11 @@ public class ProcedureIT
         public NodeOutput()
         {
 
+        }
+
+        public NodeOutput(Node node)
+        {
+            this.node = node;
         }
 
         void setNode( Node node )
@@ -1411,6 +1427,12 @@ public class ProcedureIT
         }
 
         @Procedure( mode = WRITE )
+        public Stream<NodeOutput> nodeWithDefault( @Name( value = "node", defaultValue = "null") Node node )
+        {
+            return Stream.of(new NodeOutput(node));
+        }
+
+        @Procedure
         public Stream<NodeListRecord> nodeList()
         {
             List<Node> nodesList = new ArrayList<>();

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -1015,6 +1015,25 @@ public class ProcedureIT
         assertFalse( res.hasNext() );
     }
 
+    @Test
+    public void shouldIndicateDefaultValueWhenListingProcedures() throws Throwable
+    {
+        //Given/When
+        Result res = db.execute( "CALL dbms.procedures()" );
+
+        while(res.hasNext())
+        {
+            Map<String,Object> result = res.next();
+            if ( result.get("name").equals( "org.neo4j.procedure.nodeWithDefault" ))
+            {
+                assertThat(result.get("signature"),
+                        equalTo("org.neo4j.procedure.nodeWithDefault(node = null :: NODE?) :: (node :: NODE?)"));
+            }
+        }
+        // Then
+        assertFalse( res.hasNext() );
+    }
+
     @Before
     public void setUp() throws IOException
     {

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -275,6 +275,38 @@ public class ProcedureIT
     }
 
     @Test
+    public void shouldCallProcedureWithMapArgumentDefaultingToNull() throws Throwable
+    {
+        // Given
+        try ( Transaction ignore = db.beginTx() )
+        {
+            // When
+            Result res = db.execute(
+                    "CALL org.neo4j.procedure.mapWithNullDefault()" );
+
+            // Then
+            assertThat( res.next(), equalTo( map( "map", null ) ) );
+            assertFalse( res.hasNext() );
+        }
+    }
+
+    @Test
+    public void shouldCallProcedureWithMapArgumentDefaultingToMap() throws Throwable
+    {
+        // Given
+        try ( Transaction ignore = db.beginTx() )
+        {
+            // When
+            Result res = db.execute(
+                    "CALL org.neo4j.procedure.mapWithOtherDefault" );
+
+            // Then
+            assertThat( res.next(), equalTo( map( "map", map("default", true) ) ) );
+            assertFalse( res.hasNext() );
+        }
+    }
+
+    @Test
     public void shouldCallProcedureWithNodeReturn() throws Throwable
     {
         // Given
@@ -991,6 +1023,16 @@ public class ProcedureIT
         }
     }
 
+    public static class MapOutput
+    {
+        public Map<String, Object> map;
+
+        public MapOutput(Map<String, Object> map)
+        {
+            this.map = map;
+        }
+    }
+
     public static class DoubleOutput
     {
         public double result = 0.0d;
@@ -1128,6 +1170,18 @@ public class ProcedureIT
         public Stream<Output> mapArgument( @Name( "map" ) Map<String,Object> map )
         {
             return Stream.of( new Output( map.size() ) );
+        }
+
+        @Procedure
+        public Stream<MapOutput> mapWithNullDefault( @Name( value = "map", defaultValue = "null") Map<String,Object> map )
+        {
+            return Stream.of( new MapOutput( map ) );
+        }
+
+        @Procedure
+        public Stream<MapOutput> mapWithOtherDefault( @Name( value = "map", defaultValue = "{default: true}") Map<String,Object> map )
+        {
+            return Stream.of( new MapOutput( map ) );
         }
 
         @Procedure

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -1451,7 +1451,7 @@ public class ProcedureIT
             return Stream.of(new NodeOutput(node));
         }
 
-        @Procedure
+        @Procedure( mode = WRITE )
         public Stream<NodeListRecord> nodeList()
         {
             List<Node> nodesList = new ArrayList<>();

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -307,6 +307,38 @@ public class ProcedureIT
     }
 
     @Test
+    public void shouldCallProcedureWithListWithDefault() throws Throwable
+    {
+        // Given
+        try ( Transaction ignore = db.beginTx() )
+        {
+            // When
+            Result res = db.execute(
+                    "CALL org.neo4j.procedure.listWithDefault" );
+
+            // Then
+            assertThat( res.next(), equalTo( map( "list", Arrays.asList( 42L, 1337L ) ) ) );
+            assertFalse( res.hasNext() );
+        }
+    }
+
+    @Test
+    public void shouldCallProcedureWithGenericListWithDefault() throws Throwable
+    {
+        // Given
+        try ( Transaction ignore = db.beginTx() )
+        {
+            // When
+            Result res = db.execute(
+                    "CALL org.neo4j.procedure.genericListWithDefault" );
+
+            // Then
+            assertThat( res.next(), equalTo( map( "list", Arrays.asList( 42L, 1337L ) ) ) );
+            assertFalse( res.hasNext() );
+        }
+    }
+
+    @Test
     public void shouldCallProcedureWithNodeReturn() throws Throwable
     {
         // Given
@@ -1033,6 +1065,16 @@ public class ProcedureIT
         }
     }
 
+    public static class ListOutput
+    {
+        public List<Long> list;
+
+        public ListOutput(List<Long> list)
+        {
+            this.list = list;
+        }
+    }
+
     public static class DoubleOutput
     {
         public double result = 0.0d;
@@ -1182,6 +1224,18 @@ public class ProcedureIT
         public Stream<MapOutput> mapWithOtherDefault( @Name( value = "map", defaultValue = "{default: true}") Map<String,Object> map )
         {
             return Stream.of( new MapOutput( map ) );
+        }
+
+        @Procedure
+        public Stream<ListOutput> listWithDefault( @Name( value = "list", defaultValue = "[42, 1337]") List<Long> list )
+        {
+            return Stream.of( new ListOutput(list ) );
+        }
+
+        @Procedure
+        public Stream<ListOutput> genericListWithDefault( @Name( value = "list", defaultValue = "[[42, 1337]]") List<List<Long>> list )
+        {
+            return Stream.of( new ListOutput(list.get(0) ) );
         }
 
         @Procedure

--- a/manual/embedded-examples/src/docs/dev/procedures.asciidoc
+++ b/manual/embedded-examples/src/docs/dev/procedures.asciidoc
@@ -405,12 +405,17 @@ public class FullTextIndex
      * the current state of the node.
      *
      * This procedure works largely the same as {@link #search(String, String)},
-     * with two notable differences. One, it is annotated with `mode = SCHEMA`,
-     * which is <i>required</i> if you want to perform updates to indexes in your
+     * with three notable differences. One, it is annotated with `mode = SCHEMA`,
+     * which is <i>required</i> if you want to perform updates to the graph in your
      * procedure.
      *
      * Two, it returns {@code void} rather than a stream. This is simply a short-hand
      * for saying our procedure always returns an empty stream of empty records.
+     *
+     * Three, it uses a default value for the property list, in this way you can call
+     * the procedure by simply invoking {@code CALL index(nodeId)}. Default values are
+     * are provided as the Cypher string representation of the given type, e.g.
+     * {@code {default: true}}, {@code null}, or {@code -1}.
      *
      * @param nodeId the id of the node to index
      * @param propKeys a list of property keys to index, only the ones the node
@@ -418,7 +423,7 @@ public class FullTextIndex
      */
     @Procedure( name = "example.index", mode = SCHEMA )
     public void index( @Name("nodeId") long nodeId,
-                       @Name("properties") List<String> propKeys )
+                       @Name(value = "properties", defaultValue = "[]") List<String> propKeys )
     {
         Node node = db.getNodeById( nodeId );
 


### PR DESCRIPTION
Provide default values in procedures:

Syntax: 

```
@Procedure
public Stream<Output> simpleArgumentWithDefault( @Name( value = "name", defaultValue = "42") long someValue )
{
    return Stream.of( new Output( someValue ) );
}
```

The default value is given as the corresponding cypher representation of the given type.
For example:
- `@Name( value = "name", defaultValue = "null") Map<String,Object> someValue`
- `@Name( value = "name", defaultValue = "{foo: ['bar', 'baz']}") Map<String,Object> someValue`
- `@Name( value = "name", defaultValue = "[42, 1337]") List<Long> someValue`

changelog: [procedures] Support for default parameters in procedures,
