### PR TITLE
Added check for password on user creation

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthManager.java
@@ -134,6 +134,8 @@ public class ShiroAuthManager extends BasicAuthManager implements RoleManager
     {
         assertAuthEnabled();
 
+        passwordPolicy.validatePassword( initialPassword );
+
         return realm.newUser( username, initialPassword, requirePasswordChange );
     }
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthProceduresTest.java
@@ -206,6 +206,13 @@ public class AuthProceduresTest
     }
 
     @Test
+    public void shouldNotCreateUserWithEmptyPassword() throws Exception
+    {
+        testCallFail( db, adminSubject, "CALL dbms.createUser('craig', '', true)", QueryExecutionException.class,
+                "Password cannot be empty." );
+    }
+
+    @Test
     public void shouldNotCreateExistingUser() throws Exception
     {
 


### PR DESCRIPTION
When creating new users the password wasn't validated, making it possible to create users with illegal password e.g. an empty password.
