### PR TITLE
Defragments relationship groups as part of import

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreType.java
@@ -23,11 +23,12 @@ import java.io.IOException;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.store.id.IdType;
+import org.neo4j.kernel.impl.storemigration.StoreFile;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 
 public enum StoreType
 {
-    NODE_LABEL( StoreFactory.NODE_LABELS_STORE_NAME )
+    NODE_LABEL( StoreFile.NODE_LABEL_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -36,7 +37,7 @@ public enum StoreType
                             GraphDatabaseSettings.label_block_size );
                 }
             },
-    NODE( StoreFactory.NODE_STORE_NAME )
+    NODE( StoreFile.NODE_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -44,7 +45,7 @@ public enum StoreType
                     return neoStores.createNodeStore( getStoreName() );
                 }
             },
-    PROPERTY_KEY_TOKEN_NAME( StoreFactory.PROPERTY_KEY_TOKEN_NAMES_STORE_NAME )
+    PROPERTY_KEY_TOKEN_NAME( StoreFile.PROPERTY_KEY_TOKEN_NAMES_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -53,7 +54,7 @@ public enum StoreType
                             TokenStore.NAME_STORE_BLOCK_SIZE );
                 }
             },
-    PROPERTY_KEY_TOKEN( StoreFactory.PROPERTY_KEY_TOKEN_STORE_NAME )
+    PROPERTY_KEY_TOKEN( StoreFile.PROPERTY_KEY_TOKEN_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -61,7 +62,7 @@ public enum StoreType
                     return neoStores.createPropertyKeyTokenStore( getStoreName() );
                 }
             },
-    PROPERTY_STRING( StoreFactory.PROPERTY_STRINGS_STORE_NAME )
+    PROPERTY_STRING( StoreFile.PROPERTY_STRING_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -70,7 +71,7 @@ public enum StoreType
                             GraphDatabaseSettings.string_block_size );
                 }
             },
-    PROPERTY_ARRAY( StoreFactory.PROPERTY_ARRAYS_STORE_NAME )
+    PROPERTY_ARRAY( StoreFile.PROPERTY_ARRAY_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -79,7 +80,7 @@ public enum StoreType
                             GraphDatabaseSettings.array_block_size );
                 }
             },
-    PROPERTY( StoreFactory.PROPERTY_STORE_NAME )
+    PROPERTY( StoreFile.PROPERTY_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -87,7 +88,7 @@ public enum StoreType
                     return neoStores.createPropertyStore( getStoreName() );
                 }
             },
-    RELATIONSHIP( StoreFactory.RELATIONSHIP_STORE_NAME )
+    RELATIONSHIP( StoreFile.RELATIONSHIP_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -95,7 +96,7 @@ public enum StoreType
                     return neoStores.createRelationshipStore( getStoreName() );
                 }
             },
-    RELATIONSHIP_TYPE_TOKEN_NAME( StoreFactory.RELATIONSHIP_TYPE_TOKEN_NAMES_STORE_NAME )
+    RELATIONSHIP_TYPE_TOKEN_NAME( StoreFile.RELATIONSHIP_TYPE_TOKEN_NAMES_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -104,7 +105,7 @@ public enum StoreType
                             TokenStore.NAME_STORE_BLOCK_SIZE );
                 }
             },
-    RELATIONSHIP_TYPE_TOKEN( StoreFactory.RELATIONSHIP_TYPE_TOKEN_STORE_NAME )
+    RELATIONSHIP_TYPE_TOKEN( StoreFile.RELATIONSHIP_TYPE_TOKEN_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -112,7 +113,7 @@ public enum StoreType
                     return neoStores.createRelationshipTypeTokenStore( getStoreName() );
                 }
             },
-    LABEL_TOKEN_NAME( StoreFactory.LABEL_TOKEN_NAMES_STORE_NAME )
+    LABEL_TOKEN_NAME( StoreFile.LABEL_TOKEN_NAMES_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -121,7 +122,7 @@ public enum StoreType
                             TokenStore.NAME_STORE_BLOCK_SIZE );
                 }
             },
-    LABEL_TOKEN( StoreFactory.LABEL_TOKEN_STORE_NAME )
+    LABEL_TOKEN( StoreFile.LABEL_TOKEN_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -129,7 +130,7 @@ public enum StoreType
                     return neoStores.createLabelTokenStore( getStoreName() );
                 }
             },
-    SCHEMA( StoreFactory.SCHEMA_STORE_NAME )
+    SCHEMA( StoreFile.SCHEMA_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -137,7 +138,7 @@ public enum StoreType
                     return neoStores.createSchemaStore( getStoreName() );
                 }
             },
-    RELATIONSHIP_GROUP( StoreFactory.RELATIONSHIP_GROUP_STORE_NAME )
+    RELATIONSHIP_GROUP( StoreFile.RELATIONSHIP_GROUP_STORE )
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -145,12 +146,12 @@ public enum StoreType
                     return neoStores.createRelationshipGroupStore( getStoreName() );
                 }
             },
-    COUNTS( StoreFactory.COUNTS_STORE, false )
+    COUNTS( null, false )
             {
                 @Override
                 public CountsTracker open( final NeoStores neoStores )
                 {
-                    return neoStores.createCountStore( getStoreName() );
+                    return neoStores.createCountStore( StoreFactory.COUNTS_STORE );
                 }
 
                 @Override
@@ -165,8 +166,14 @@ public enum StoreType
                         throw new UnderlyingStorageException( e );
                     }
                 }
+
+                @Override
+                public String getStoreName()
+                {
+                    return StoreFactory.COUNTS_STORE;
+                }
             },
-    META_DATA( MetaDataStore.DEFAULT_NAME ) // Make sure this META store is last
+    META_DATA( StoreFile.NEO_STORE ) // Make sure this META store is last
             {
                 @Override
                 public CommonAbstractStore open( NeoStores neoStores )
@@ -176,16 +183,16 @@ public enum StoreType
             };
 
     private final boolean recordStore;
-    private final String storeName;
+    private final StoreFile storeFile;
 
-    StoreType( String storeName )
+    StoreType( StoreFile storeFile )
     {
-        this( storeName, true );
+        this( storeFile, true );
     }
 
-    StoreType( String storeName, boolean recordStore )
+    StoreType( StoreFile storeFile, boolean recordStore )
     {
-        this.storeName = storeName;
+        this.storeFile = storeFile;
         this.recordStore = recordStore;
     }
 
@@ -198,7 +205,12 @@ public enum StoreType
 
     public String getStoreName()
     {
-        return storeName;
+        return storeFile.fileNamePart();
+    }
+
+    public StoreFile getStoreFile()
+    {
+        return storeFile;
     }
 
     void close( NeoStores me, Object object )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreFile.java
@@ -202,6 +202,11 @@ public enum StoreFile
         return fileName( StoreFileType.STORE );
     }
 
+    public String fileNamePart()
+    {
+        return storeFileNamePart;
+    }
+
     public boolean isRecordStore()
     {
         return recordStore;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CacheGroupsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CacheGroupsStep.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
+import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
+import org.neo4j.unsafe.impl.batchimport.staging.ProcessorStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+/**
+ * Caches {@link RelationshipGroupRecord} into {@link RelationshipGroupCache}.
+ */
+public class CacheGroupsStep extends ProcessorStep<RelationshipGroupRecord[]>
+{
+    private final RelationshipGroupCache cache;
+
+    public CacheGroupsStep( StageControl control, Configuration config, RelationshipGroupCache cache )
+    {
+        super( control, "CACHE", config, 1 );
+        this.cache = cache;
+    }
+
+    @Override
+    protected void process( RelationshipGroupRecord[] batch, BatchSender sender ) throws Throwable
+    {
+        for ( RelationshipGroupRecord groupRecord : batch )
+        {
+            cache.put( groupRecord );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStage.java
@@ -21,7 +21,6 @@ package org.neo4j.unsafe.impl.batchimport;
 
 import java.io.IOException;
 
-import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
@@ -40,7 +39,6 @@ import static org.neo4j.unsafe.impl.batchimport.input.InputCache.MAIN;
 public class CalculateDenseNodesStage extends Stage
 {
     private RelationshipTypeCheckerStep typer;
-    private final NodeStore nodeStore;
     private final NodeRelationshipCache cache;
 
     public CalculateDenseNodesStage( Configuration config, InputIterable<InputRelationship> relationships,
@@ -61,7 +59,6 @@ public class CalculateDenseNodesStage extends Stage
         add( new CalculateRelationshipsStep( control(), config, neoStores.getRelationshipStore() ) );
         add( new CalculateDenseNodePrepareStep( control(), config, badCollector ) );
         add( new CalculateDenseNodesStep( control(), config, cache ) );
-        nodeStore = neoStores.getNodeStore();
     }
 
     /*
@@ -70,14 +67,5 @@ public class CalculateDenseNodesStage extends Stage
     public Object[] getRelationshipTypes( long belowOrEqualToThreshold )
     {
         return typer.getRelationshipTypes( belowOrEqualToThreshold );
-    }
-
-    @Override
-    public void close()
-    {
-        // At this point we know how many nodes we have, so we tell the cache that instead of having the
-        // cache keeping track of that in a the face of concurrent updates.
-        cache.setHighNodeId( nodeStore.getHighId() );
-        super.close();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
+import org.neo4j.unsafe.impl.batchimport.staging.ReadRecordsStep;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
+import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
+
+/**
+ * Stage for counting groups per node, populates {@link RelationshipGroupCache}.
+ */
+public class CountGroupsStage extends Stage
+{
+    public CountGroupsStage( Configuration config, BatchingNeoStores neoStore, RelationshipGroupCache groupCache )
+    {
+        super( "Count groups", config );
+
+        RecordStore<RelationshipGroupRecord> store = neoStore.getRelationshipGroupStore();
+        add( new ReadRecordsStep<>( control(), config, store, RecordIdIteration.allIn( store ) ) );
+        add( new CountGroupsStep( control(), config, groupCache ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CountGroupsStep.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
+import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
+import org.neo4j.unsafe.impl.batchimport.staging.ProcessorStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+/**
+ * After this step is {@link #done()} all BOTH ID fields in the rel group cache will contain,
+ * for each node, the absolute number of groups from node 0 up to this point there is.
+ */
+public class CountGroupsStep extends ProcessorStep<RelationshipGroupRecord[]>
+{
+    private final RelationshipGroupCache cache;
+
+    public CountGroupsStep( StageControl control, Configuration config, RelationshipGroupCache groupCache )
+    {
+        super( control, "COUNT", config, 1 );
+        this.cache = groupCache;
+    }
+
+    @Override
+    protected void process( RelationshipGroupRecord[] batch, BatchSender sender ) throws Throwable
+    {
+        for ( RelationshipGroupRecord group : batch )
+        {
+            cache.incrementGroupCount( group.getOwningNode() );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EncodeGroupsStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/EncodeGroupsStep.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
+import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
+import org.neo4j.unsafe.impl.batchimport.staging.ProcessorStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+/**
+ * Takes cached {@link RelationshipGroupRecord relationship groups} and sets real ids and
+ * {@link RelationshipGroupRecord#getNext() next pointers}, making them ready for writing to store.
+ */
+public class EncodeGroupsStep extends ProcessorStep<RelationshipGroupRecord[]>
+{
+    private long nextId = -1;
+    private final RecordStore<RelationshipGroupRecord> store;
+
+    public EncodeGroupsStep( StageControl control, Configuration config, RecordStore<RelationshipGroupRecord> store )
+    {
+        super( control, "ENCODE", config, 1 );
+        this.store = store;
+    }
+
+    @Override
+    protected void process( RelationshipGroupRecord[] batch, BatchSender sender ) throws Throwable
+    {
+        int groupStartIndex = 0;
+        for ( int i = 0; i < batch.length; i++ )
+        {
+            RelationshipGroupRecord group = batch[i];
+
+            // The iterator over the groups will not produce real next pointers, they are instead
+            // a count meaning how many groups come after it. This encoder will set the real group ids.
+            long count = group.getNext();
+            boolean lastInChain = count == 0;
+
+            group.setId( nextId == -1 ? nextId = store.nextId() : nextId );
+            if ( !lastInChain )
+            {
+                group.setNext( nextId = store.nextId() );
+            }
+            else
+            {
+                group.setNext( nextId = -1 );
+
+                // OK so this group is the last in this chain, which means all the groups in this chain
+                // are now fully populated. We can now prepare these groups so that their potential
+                // secondary units ends up very close by.
+                for ( int j = groupStartIndex; j <= i; j++ )
+                {
+                    store.prepareForCommit( batch[j] );
+                }
+
+                groupStartIndex = i + 1;
+            }
+        }
+
+        sender.send( batch );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeFirstGroupStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeFirstGroupStage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
+import org.neo4j.unsafe.impl.batchimport.staging.ReadRecordsStep;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
+
+import static org.neo4j.unsafe.impl.batchimport.RecordIdIteration.allIn;
+
+/**
+ * Updates dense nodes with which will be the {@link NodeRecord#setNextRel(long) first group} to point to,
+ * after a {@link RelationshipGroupDefragmenter} has been run.
+ */
+public class NodeFirstGroupStage extends Stage
+{
+    public NodeFirstGroupStage( Configuration config, RecordStore<RelationshipGroupRecord> groupStore,
+            RecordStore<NodeRecord> nodeStore, ByteArray cache )
+    {
+        super( "Node --> Group", config );
+        add( new ReadRecordsStep<>( control(), config, groupStore, allIn( groupStore ) ) );
+        add( new NodeSetFirstGroupStep( control(), config, nodeStore, cache ) );
+        add( new UpdateRecordsStep<>( control(), config, nodeStore ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeSetFirstGroupStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeSetFirstGroupStep.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
+import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
+import org.neo4j.unsafe.impl.batchimport.staging.ProcessorStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
+
+/**
+ * Scans {@link RelationshipGroupRecord group records} and discovers which should affect the owners.
+ */
+public class NodeSetFirstGroupStep extends ProcessorStep<RelationshipGroupRecord[]>
+{
+    private final int batchSize;
+    private final ByteArray cache;
+    private final RecordCursor<NodeRecord> nodeRecordCursor;
+
+    private NodeRecord[] current;
+    private int cursor;
+
+    public NodeSetFirstGroupStep( StageControl control, Configuration config,
+            RecordStore<NodeRecord> nodeStore, ByteArray cache )
+    {
+        super( control, "FIRST", config, 1 );
+        this.cache = cache;
+        this.batchSize = config.batchSize();
+        this.nodeRecordCursor = nodeStore.newRecordCursor( nodeStore.newRecord() );
+        newBatch();
+    }
+
+    @Override
+    public void start( int orderingGuarantees )
+    {
+        nodeRecordCursor.acquire( 0, NORMAL );
+        super.start( orderingGuarantees );
+    }
+
+    private void newBatch()
+    {
+        current = new NodeRecord[batchSize];
+        cursor = 0;
+    }
+
+    @Override
+    protected void process( RelationshipGroupRecord[] batch, BatchSender sender ) throws Throwable
+    {
+        for ( RelationshipGroupRecord group : batch )
+        {
+            long nodeId = group.getOwningNode();
+            if ( cache.getByte( nodeId, 0 ) == 0 )
+            {
+                cache.setByte( nodeId, 0, (byte) 1 );
+                nodeRecordCursor.next( nodeId );
+                NodeRecord node = nodeRecordCursor.get().clone();
+                node.setNextRel( group.getId() );
+
+                current[cursor++] = node;
+                if ( cursor == batchSize )
+                {
+                    sender.send( current );
+                    newBatch();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void lastCallForEmittingOutstandingBatches( BatchSender sender )
+    {
+        if ( cursor > 0 )
+        {
+            sender.send( current );
+        }
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        nodeRecordCursor.close();
+        super.close();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -182,6 +182,9 @@ public class ParallelBatchImporter implements BatchImporter
                 // the node and calc dense node stages in parallel.
                 executeStages( nodeStage, calculateDenseNodesStage );
             }
+            // At this point we know how many nodes we have, so we tell the cache that instead of having the
+            // cache keeping track of that in a the face of concurrent updates.
+            nodeRelationshipCache.setHighNodeId( neoStore.getNodeStore().getHighId() );
 
             importRelationships( nodeRelationshipCache, storeUpdateMonitor, neoStore, writeMonitor,
                     idMapper, cachedRelationships, inputCache,

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -36,6 +36,8 @@ import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.unsafe.impl.batchimport.cache.GatheringMemoryStatsVisitor;
+import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
@@ -53,8 +55,10 @@ import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
 import org.neo4j.unsafe.impl.batchimport.store.io.IoMonitor;
 
+import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
 import static org.neo4j.helpers.collection.Iterators.asSet;
+import static org.neo4j.io.ByteUnit.mebiBytes;
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
 import static org.neo4j.unsafe.impl.batchimport.SourceOrCachedInputIterable.cachedForSure;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
@@ -186,8 +190,15 @@ public class ParallelBatchImporter implements BatchImporter
                     calculateDenseNodesStage.getRelationshipTypes( config.batchSize() ) );
 
             // Release this potentially really big piece of cached data
+            long memoryWeCanHoldForCertain = totalMemoryUsageOf( idMapper, nodeRelationshipCache );
+            long highNodeId = nodeRelationshipCache.getHighNodeId();
+            idMapper.close();
+            idMapper = null;
             nodeRelationshipCache.close();
             nodeRelationshipCache = null;
+
+            new RelationshipGroupDefragmenter( config, executionMonitor ).run(
+                    max( max( memoryWeCanHoldForCertain, highNodeId * 4), mebiBytes( 1 ) ), neoStore, highNodeId );
 
             // Stage 6 -- count nodes per label and labels per node
             nodeLabelsCache = new NodeLabelsCache( AUTO, neoStore.getLabelRepository().getHighId() );
@@ -230,6 +241,16 @@ public class ParallelBatchImporter implements BatchImporter
                 fileSystem.deleteFile( badFile );
             }
         }
+    }
+
+    private long totalMemoryUsageOf( MemoryStatsVisitor.Visitable... users )
+    {
+        GatheringMemoryStatsVisitor total = new GatheringMemoryStatsVisitor();
+        for ( MemoryStatsVisitor.Visitable user : users )
+        {
+            user.acceptMemoryStatsVisitor( total );
+        }
+        return total.getHeapUsage() + total.getOffHeapUsage();
     }
 
     private void importRelationships( NodeRelationshipCache nodeRelationshipCache,

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordIdIteration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RecordIdIteration.java
@@ -26,7 +26,7 @@ import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 
 public class RecordIdIteration
 {
-    public static final PrimitiveLongIterator backwards( long highExcluded, long lowIncluded )
+    public static final PrimitiveLongIterator backwards( long lowIncluded, long highExcluded )
     {
         return new PrimitiveLongCollections.PrimitiveLongBaseIterator()
         {
@@ -57,5 +57,10 @@ public class RecordIdIteration
     public static PrimitiveLongIterator allIn( RecordStore<? extends AbstractBaseRecord> store )
     {
         return forwards( store.getNumberOfReservedLowIds(), store.getHighId() );
+    }
+
+    public static PrimitiveLongIterator allInReversed( RecordStore<? extends AbstractBaseRecord> store )
+    {
+        return backwards( store.getNumberOfReservedLowIds(), store.getHighId() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCache.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import java.util.Iterator;
+
+import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
+import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+
+import static org.neo4j.helpers.Format.bytes;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
+
+/**
+ * Holds information vital for making {@link RelationshipGroupDefragmenter} work the way it does.
+ *
+ * The defragmenter goes potentially multiple rounds through the relationship group store and each round
+ * selects groups from a range of node ids. This cache can cache the groups for the nodes in this range.
+ *
+ * First all group counts per node are updated ({@link #incrementGroupCount(long)}).
+ * Then {@link #prepare(long)} is called from lowest node id (0) and given the maximum configured memory
+ * given to this cache in its constructor the highest node id to cacne is returned. Then groups are
+ * {@link #put(RelationshipGroupRecord)} and cached in here to later be {@link #iterator() retrieved}
+ * where they are now ordered by node and type.
+ * This will go on until the entire node range have been visited.
+ *
+ * @see RelationshipGroupDefragmenter
+ */
+public class RelationshipGroupCache implements Iterable<RelationshipGroupRecord>, AutoCloseable
+{
+    public static final int GROUP_ENTRY_SIZE = 1/*header*/ + 2/*type*/ + 6/*relationship id*/*3/*all directions*/;
+
+    private final ByteArray groupCountCache;
+    private final ByteArray cache;
+    private final long highNodeId;
+    private final LongArray offsets = AUTO.newDynamicLongArray( 100_000, 0 );
+    private final byte[] scratch = new byte[GROUP_ENTRY_SIZE];
+    private long fromNodeId;
+    private long toNodeId;
+    private long highCacheId;
+
+    public RelationshipGroupCache( NumberArrayFactory arrayFactory, long maxMemory, long highNodeId )
+    {
+        this.groupCountCache = arrayFactory.newByteArray( highNodeId, new byte[2] );
+        this.highNodeId = highNodeId;
+
+        long memoryDedicatedToCounting = 2*highNodeId;
+        long memoryLeftForGroupCache = maxMemory - memoryDedicatedToCounting;
+        if ( memoryLeftForGroupCache < 0 )
+        {
+            throw new IllegalArgumentException( "Too little memory to cache any groups, provided " +
+                    bytes( maxMemory ) + " where " + bytes( memoryDedicatedToCounting ) +
+                    " was dedicated to group counting" );
+        }
+        this.cache = arrayFactory.newByteArray( memoryLeftForGroupCache / GROUP_ENTRY_SIZE, new byte[GROUP_ENTRY_SIZE] );
+    }
+
+    /**
+     * Before caching any relationship groups all group counts for all nodes are incremented by calling
+     * this method once for every encountered group (its node id).
+     *
+     * @param nodeId node to increment group count for.
+     */
+    public void incrementGroupCount( long nodeId )
+    {
+        int count = groupCountCache.getShort( nodeId, 0 ) & 0xFFFF;
+        count++;
+        if ( (count & ~0xFFFF) != 0 )
+        {
+            throw new IllegalStateException(
+                    "Invalid number of relationship groups for node " + nodeId + " " + count );
+        }
+        groupCountCache.setShort( nodeId, 0, (short) count );
+    }
+
+    /**
+     * Getter here because we can use this already allocated data structure for other things in and
+     * around places where this group cache is used.
+     */
+    ByteArray getGroupCountCache()
+    {
+        return groupCountCache;
+    }
+
+    /**
+     * Looks at max amount of configured memory (in constructor) and figures out for how many nodes their groups
+     * can be cached. Before the first call to this method all {@link #incrementGroupCount(long)} calls
+     * must have been made. After a call to this there should be a sequence of {@link #put(RelationshipGroupRecord)}
+     * calls to cache the groups. If this call returns a node id which is lower than the highest node id in the
+     * store then more rounds of caching should be performed after completing this round.
+     *
+     * @param fromNodeId inclusive
+     * @return toNodeId exclusive
+     */
+    public long prepare( long fromNodeId )
+    {
+        cache.clear(); // this will have all the "first" bytes set to 0, which means !inUse
+        this.fromNodeId = fromNodeId; // keep for use in put later on
+
+        highCacheId = 0;
+        for ( long nodeId = fromNodeId; nodeId < highNodeId; nodeId++ )
+        {
+            short count = groupCountCache.getShort( nodeId, 0 );
+            if ( highCacheId + count > cache.length() )
+            {
+                // Cannot include this one, so up until the previous is good
+                return this.toNodeId = nodeId;
+            }
+            offsets.set( rebase( nodeId ), highCacheId );
+            highCacheId += count;
+        }
+        return this.toNodeId = highNodeId;
+    }
+
+    private long rebase( long toNodeId )
+    {
+        return toNodeId - fromNodeId;
+    }
+
+    /**
+     * Caches a relationship group into this cache, it will be cached if the
+     * {@link RelationshipGroupRecord#getOwningNode() owner} is within the {@link #prepare(long) prepared} range,
+     * where {@code true} will be returned, otherwise {@code false}.
+     *
+     * @param groupRecord {@link RelationshipGroupRecord} to cache.
+     * @return whether or not the group was cached, i.e. whether or not it was within the prepared range.
+     */
+    public boolean put( RelationshipGroupRecord groupRecord )
+    {
+        long nodeId = groupRecord.getOwningNode();
+        assert nodeId < highNodeId;
+        if ( nodeId < fromNodeId || nodeId >= toNodeId )
+        {
+            return false;
+        }
+
+        long baseIndex = offsets.get( rebase( nodeId ) );
+        // grouCount is extra validation, really
+        int groupCount = groupCountCache.getShort( nodeId, 0 );
+        long index = scanForFreeFrom( baseIndex, groupCount, groupRecord.getType() );
+
+        // Put the group at this index
+        cache.setByte( index, 0, (byte) 1 );
+        cache.setShort( index, 1, (short) groupRecord.getType() );
+        cache.set6ByteLong( index, 1 + 2, groupRecord.getFirstOut() );
+        cache.set6ByteLong( index, 1 + 2 + 6, groupRecord.getFirstIn() );
+        cache.set6ByteLong( index, 1 + 2 + 6 + 6, groupRecord.getFirstLoop() );
+        return true;
+    }
+
+    private long scanForFreeFrom( long startIndex, int groupCount, int type )
+    {
+        long desiredIndex = -1;
+        long freeIndex = -1;
+        for ( int i = 0; i < groupCount; i++ )
+        {
+            long candidateIndex = startIndex + i;
+            boolean free = cache.getByte( candidateIndex, 0 ) == 0;
+            if ( free )
+            {
+                freeIndex = candidateIndex;
+                break;
+            }
+
+            if ( desiredIndex == -1 )
+            {
+                int existingType = cache.getShort( candidateIndex, 1 ) & 0xFFFF;
+                if ( existingType == type )
+                {
+                    throw new IllegalStateException( "Tried to put multiple groups with same type " + type );
+                }
+
+                if ( type < existingType )
+                {
+                    // This means that the groups have arrived here out of order, please put this group
+                    // in the correct place, not at the end
+                    desiredIndex = candidateIndex;
+                }
+            }
+        }
+
+        if ( freeIndex == -1 )
+        {
+            throw new IllegalStateException( "There's no room for me for startIndex:" + startIndex +
+                    " with a group count of " + groupCount + ". This means that there's an asymmetry between calls " +
+                    "to incrementGroupCount and actual contents sent into put" );
+        }
+
+        // For the future: Instead of doing the sorting here right away be doing the relatively expensive move
+        // of potentially multiple items one step to the right in the array, then an idea is to simply mark
+        // this group as in need of sorting and then there may be a step later which can use all CPUs
+        // on the machine, jumping from group to group and see if the "needs sorting" flag has been raised
+        // and if so sort that group. This is fine as it is right now because the groups put into this cache
+        // will be almost entirely sorted, since we come here straight after import. Although if this thing
+        // is to be used as a generic relationship group defragmenter this sorting will have to be fixed
+        // to something like what is described above in this comment.
+        if ( desiredIndex != -1 )
+        {
+            moveRight( desiredIndex, freeIndex );
+            return desiredIndex;
+        }
+        return freeIndex;
+    }
+
+    private void moveRight( long fromIndex, long toIndex )
+    {
+        for ( long index = toIndex; index > fromIndex; index-- )
+        {
+            cache.get( index-1, scratch );
+            cache.set( index, scratch );
+        }
+    }
+
+    /**
+     * @return cached {@link RelationshipGroupRecord} sorted by node id and then type id.
+     */
+    @Override
+    public Iterator<RelationshipGroupRecord> iterator()
+    {
+        return new PrefetchingIterator<RelationshipGroupRecord>()
+        {
+            private long cursor;
+            private long nodeId = fromNodeId;
+            private int countLeftForThisNode = groupCountCache.getShort( nodeId, 0 );
+            {
+                findNextNodeWithGroupsIfNeeded();
+            }
+
+            @Override
+            protected RelationshipGroupRecord fetchNextOrNull()
+            {
+                while ( cursor < highCacheId )
+                {
+                    RelationshipGroupRecord group = null;
+                    if ( cache.getByte( cursor, 0 ) == 1 )
+                    {
+                        // Here we have an alive group
+                        group = new RelationshipGroupRecord( -1 ).initialize( true,
+                                cache.getShort( cursor, 1 ) & 0xFFFF,
+                                cache.get6ByteLong( cursor, 1 + 2 ),
+                                cache.get6ByteLong( cursor, 1 + 2 + 6 ),
+                                cache.get6ByteLong( cursor, 1 + 2 + 6 + 6 ),
+                                nodeId,
+                                // Special: we want to convey information about how many groups are coming
+                                // after this one so that chains can be ordered accordingly in the store
+                                // so this isn't at all "next" in the true sense of chain next.
+                                countLeftForThisNode-1 );
+                    }
+
+                    cursor++;
+                    countLeftForThisNode--;
+                    findNextNodeWithGroupsIfNeeded();
+
+                    if ( group != null )
+                    {
+                        return group;
+                    }
+                }
+                return null;
+            }
+
+            private void findNextNodeWithGroupsIfNeeded()
+            {
+                if ( countLeftForThisNode == 0 )
+                {
+                    do
+                    {
+                        nodeId++;
+                        countLeftForThisNode = nodeId >= groupCountCache.length() ? 0 :
+                            groupCountCache.getShort( nodeId, 0 );
+                    }
+                    while ( countLeftForThisNode == 0 && nodeId < groupCountCache.length() );
+                }
+            }
+        };
+    }
+
+    @Override
+    public void close()
+    {
+        cache.close();
+        offsets.close();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
+import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitor;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
+import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
+
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
+import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.superviseExecution;
+
+/**
+ * Defragments {@link RelationshipGroupRecord} so that they end up sequential per node in the group store.
+ * There's one constraint which is assumed to be true here: any relationship group that we see in the store
+ * for any given {@link RelationshipGroupRecord#getOwningNode() owner} must have a lower
+ * {@link RelationshipGroupRecord#getType() type} than any previous group encountered for that node,
+ * i.e. all {@link RelationshipGroupRecord#getNext() next pointers} must be either
+ * {@link Record#NO_NEXT_RELATIONSHIP NULL} or lower than the group id at hand. When this is true,
+ * and the defragmenter verifies this constraint, the groups will be reversed so that types are instead
+ * ascending and groups are always co-located.
+ */
+public class RelationshipGroupDefragmenter
+{
+    private final Configuration config;
+    private final ExecutionMonitor executionMonitor;
+
+    public RelationshipGroupDefragmenter( Configuration config, ExecutionMonitor executionMonitor )
+    {
+        this.config = config;
+        this.executionMonitor = executionMonitor;
+    }
+
+    public void run( long memoryWeCanHoldForCertain, BatchingNeoStores neoStore, long highNodeId )
+    {
+        try ( RelationshipGroupCache groupCache =
+                new RelationshipGroupCache( AUTO, memoryWeCanHoldForCertain, highNodeId ) )
+        {
+            // Count all nodes, how many groups each node has each
+            executeStage( new CountGroupsStage( config, neoStore, groupCache ) );
+            long fromNodeId = 0;
+            long toNodeId = 0;
+            RecordStore<RelationshipGroupRecord> fromStore = neoStore.getRelationshipGroupStore();
+            RecordStore<RelationshipGroupRecord> toStore =
+                    neoStore.getReplacementNeoStores( StoreType.RELATIONSHIP_GROUP ).getRelationshipGroupStore();
+            while ( fromNodeId < highNodeId )
+            {
+                // See how many nodes' groups we can fit into the cache this iteration of the loop.
+                // Groups that doesn't fit in this round will be included in consecutive rounds.
+                toNodeId = groupCache.prepare( fromNodeId );
+                // Cache those groups
+                executeStage( new ScanAndCacheGroupsStage( config, fromStore, groupCache ) );
+                // And write them in sequential order in the store
+                executeStage( new WriteGroupsStage( config, groupCache, toStore ) );
+
+                // Make adjustments for the next iteration
+                fromNodeId = toNodeId;
+            }
+
+            // Now update nodes to point to the new groups
+            ByteArray groupCountCache = groupCache.getGroupCountCache();
+            groupCountCache.clear();
+            executeStage( new NodeFirstGroupStage( config, toStore, neoStore.getNodeStore(), groupCountCache ) );
+        }
+    }
+
+    private void executeStage( Stage stage )
+    {
+        superviseExecution( executionMonitor, config, stage );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipLinkbackStage.java
@@ -37,7 +37,7 @@ public class RelationshipLinkbackStage extends Stage
             NodeRelationshipCache cache, long lowRelationshipId, long highRelationshipId, boolean denseNodes )
     {
         super( "Relationship --> Relationship" + topic, config );
-        add( new ReadRecordsStep<>( control(), config, store, backwards( highRelationshipId, lowRelationshipId ) ) );
+        add( new ReadRecordsStep<>( control(), config, store, backwards( lowRelationshipId, highRelationshipId ) ) );
         add( new RecordProcessorStep<>( control(), "LINK", config,
                 new RelationshipLinkbackProcessor( cache, denseNodes ), false ) );
         add( new UpdateRecordsStep<>( control(), config, store ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ScanAndCacheGroupsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ScanAndCacheGroupsStage.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.Configuration;
+import org.neo4j.unsafe.impl.batchimport.staging.ReadRecordsStep;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
+
+import static org.neo4j.unsafe.impl.batchimport.RecordIdIteration.allInReversed;
+
+public class ScanAndCacheGroupsStage extends Stage
+{
+    public ScanAndCacheGroupsStage( Configuration config, RecordStore<RelationshipGroupRecord> store,
+            RelationshipGroupCache cache )
+    {
+        super( "Gather", config );
+        add( new ReadRecordsStep<>( control(), config, store, allInReversed( store ) ) );
+        add( new CacheGroupsStep( control(), config, cache ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/WriteGroupsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/WriteGroupsStage.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
+
+import static org.neo4j.unsafe.impl.batchimport.RelationshipGroupCache.GROUP_ENTRY_SIZE;
+
+/**
+ * Writes cached {@link RelationshipGroupRecord} to store.
+ */
+public class WriteGroupsStage extends Stage
+{
+    public WriteGroupsStage( Configuration config, RelationshipGroupCache cache,
+            RecordStore<RelationshipGroupRecord> store )
+    {
+        super( "Write", config );
+        add( new ReadGroupsFromCacheStep( control(), config, cache.iterator(), GROUP_ENTRY_SIZE ) );
+        add( new EncodeGroupsStep( control(), config, store ) );
+        add( new UpdateRecordsStep<>( control(), config, store ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
@@ -138,6 +138,11 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Visitable
         this.chunkChangedArray = new byte[chunkOf( nodeId ) + 1];
     }
 
+    public long getHighNodeId()
+    {
+        return this.highId;
+    }
+
     private static int getCount( ByteArray array, long index, int offset )
     {
         long rawCount = array.getInt( index, offset ) & COUNT_MASK;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
@@ -74,4 +74,6 @@ public interface IdMapper extends MemoryStatsVisitor.Visitable
      * @return the actual node id previously specified by {@link #put(Object, long, Group)}, or {@code -1} if not found.
      */
     long get( Object inputId, Group group );
+
+    void close();
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
@@ -74,6 +74,11 @@ public class IdMappers
         {
             return getClass().getSimpleName();
         }
+
+        @Override
+        public void close()
+        {   // Nothing to close
+        }
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
@@ -49,4 +49,10 @@ abstract class AbstractTracker<ARRAY extends NumberArray> implements Tracker
     {
         array.swap( fromIndex, toIndex, count );
     }
+
+    @Override
+    public void close()
+    {
+        array.close();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -793,7 +793,6 @@ public class EncodingIdMapper implements IdMapper
         nullSafeAcceptMemoryStatsVisitor( visitor, collisionTrackerCache );
         nullSafeAcceptMemoryStatsVisitor( visitor, collisionSourceDataCache );
         nullSafeAcceptMemoryStatsVisitor( visitor, collisionNodeIdCache );
-        // TODO mention anything about the collisionValues data structure?
     }
 
     private void nullSafeAcceptMemoryStatsVisitor( MemoryStatsVisitor visitor, MemoryStatsVisitor.Visitable mem )
@@ -808,5 +807,18 @@ public class EncodingIdMapper implements IdMapper
     public String toString()
     {
         return getClass().getSimpleName() + "[" + encoder + "," + radix + "]";
+    }
+
+    @Override
+    public void close()
+    {
+        dataCache.close();
+        trackerCache.close();
+        if ( collisionSourceDataCache != null )
+        {
+            collisionTrackerCache.close();
+            collisionSourceDataCache.close();
+        }
+        collisionNodeIdCache.close();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
@@ -39,7 +39,7 @@ import org.neo4j.unsafe.impl.batchimport.input.Group;
  * a smaller data structure for smaller datasets, for example those that fit inside {@code int} range.
  * That's why this abstraction exists so that the best suited implementation can be picked for every import.
  */
-public interface Tracker extends MemoryStatsVisitor.Visitable
+public interface Tracker extends MemoryStatsVisitor.Visitable, AutoCloseable
 {
     /**
      * @param index data index to get the value for.
@@ -63,4 +63,7 @@ public interface Tracker extends MemoryStatsVisitor.Visitable
      * @param value value to set at that index.
      */
     void set( long index, long value );
+
+    @Override
+    void close();
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/IteratorBatcherStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/IteratorBatcherStep.java
@@ -21,18 +21,18 @@ package org.neo4j.unsafe.impl.batchimport.staging;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
-
-import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import java.util.Iterator;
 
 /**
  * Takes an Iterator and chops it up into array batches downstream.
  */
-public class IteratorBatcherStep<T> extends IoProducerStep
+public abstract class IteratorBatcherStep<T> extends IoProducerStep
 {
-    private final InputIterator<T> data;
+    private final Iterator<T> data;
     private final Class<T> itemClass;
+    protected long cursor;
 
-    public IteratorBatcherStep( StageControl control, Configuration config, InputIterator<T> data, Class<T> itemClass )
+    public IteratorBatcherStep( StageControl control, Configuration config, Iterator<T> data, Class<T> itemClass )
     {
         super( control, config );
         this.data = data;
@@ -53,25 +53,8 @@ public class IteratorBatcherStep<T> extends IoProducerStep
         for ( ; i < batchSize && data.hasNext(); i++ )
         {
             batch[i] = data.next();
+            cursor++;
         }
         return i == batchSize ? batch : Arrays.copyOf( batch, i );
-    }
-
-    @Override
-    public void close() throws Exception
-    {
-        data.close();
-    }
-
-    @Override
-    protected long position()
-    {
-        return data.position();
-    }
-
-    @Override
-    public int processors( int delta )
-    {
-        return data.processors( delta );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -47,10 +47,13 @@ import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.storemigration.ExistingTargetStrategy;
+import org.neo4j.kernel.impl.storemigration.StoreFile;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.LogProvider;
@@ -67,10 +70,12 @@ import static java.lang.String.valueOf;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_threshold;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_page_size;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
+import static org.neo4j.helpers.collection.Iterables.iterable;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.ByteUnit.kibiBytes;
 import static org.neo4j.io.ByteUnit.mebiBytes;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_COMMIT_TIMESTAMP;
+import static org.neo4j.kernel.impl.storemigration.FileOperation.MOVE;
 
 /**
  * Creator and accessor of {@link NeoStores} with some logic to provide very batch friendly services to the
@@ -90,11 +95,16 @@ public class BatchingNeoStores implements AutoCloseable
     private final LifeSupport life = new LifeSupport();
     private final LabelScanStore labelScanStore;
     private final IoTracer ioTracer;
+    private final RecordFormats recordFormats;
+
+    private NeoStores replacementNeoStores;
+    private StoreType[] replacementStoreTypes;
 
     public BatchingNeoStores( FileSystemAbstraction fileSystem, File storeDir, RecordFormats recordFormats,
             Configuration config, LogService logService, AdditionalInitialIds initialIds, Config dbConfig )
     {
         this.fileSystem = fileSystem;
+        this.recordFormats = recordFormats;
         this.logProvider = logService.getInternalLogProvider();
         this.storeDir = storeDir;
         long mappedMemory = config.pageCacheMemory();
@@ -110,7 +120,7 @@ public class BatchingNeoStores implements AutoCloseable
         final PageCacheTracer tracer = new DefaultPageCacheTracer();
         this.pageCache = createPageCache( fileSystem, neo4jConfig, logProvider, tracer );
         this.ioTracer = tracer::bytesWritten;
-        this.neoStores = newNeoStores( pageCache, recordFormats );
+        this.neoStores = newNeoStores();
         if ( alreadyContainsData( neoStores ) )
         {
             neoStores.close();
@@ -208,12 +218,43 @@ public class BatchingNeoStores implements AutoCloseable
         }
     }
 
-    private NeoStores newNeoStores( PageCache pageCache, RecordFormats recordFormats )
+    private NeoStores newNeoStores()
     {
-        BatchingIdGeneratorFactory idGeneratorFactory = new BatchingIdGeneratorFactory( fileSystem );
-        StoreFactory storeFactory = new StoreFactory( storeDir, neo4jConfig, idGeneratorFactory, pageCache, fileSystem,
-                recordFormats, logProvider );
+        return newNeoStores( storeDir );
+    }
+
+    private NeoStores newNeoStores( File storeDir )
+    {
+        StoreFactory storeFactory = newStoreFactory( pageCache, recordFormats, storeDir );
         return storeFactory.openAllNeoStores( true );
+    }
+
+    private StoreFactory newStoreFactory( PageCache pageCache, RecordFormats recordFormats, File storeDir )
+    {
+        StoreFactory storeFactory = new StoreFactory( storeDir, neo4jConfig,
+                new BatchingIdGeneratorFactory( fileSystem ), pageCache, fileSystem, recordFormats, logProvider );
+        return storeFactory;
+    }
+
+    /**
+     * The idea with replacement stores is that at some point a store is decided to be restructured
+     * one way or another, so that store is opened in the replacement store. When the {@link BatchingNeoStores}
+     * is closed those replacement stores will be swapped in.
+     */
+    public NeoStores getReplacementNeoStores( StoreType... stores )
+    {
+        if ( replacementNeoStores == null )
+        {
+            StoreFactory storeFactory = newStoreFactory( pageCache, recordFormats, replacementStoreDir() );
+            replacementNeoStores = storeFactory.openNeoStores( true, stores );
+            replacementStoreTypes = stores;
+        }
+        return replacementNeoStores;
+    }
+
+    private File replacementStoreDir()
+    {
+        return new File( storeDir, "replacement" );
     }
 
     public IoTracer getIoTracer()
@@ -272,7 +313,27 @@ public class BatchingNeoStores implements AutoCloseable
         // Close the neo store
         life.shutdown();
         neoStores.close();
+        if ( replacementNeoStores != null )
+        {
+            replacementNeoStores.close();
+        }
         pageCache.close();
+
+        if ( replacementNeoStores != null )
+        {
+            StoreFile.fileOperation( MOVE, fileSystem, replacementStoreDir(), storeDir, replacementStoreFiles(),
+                    false, ExistingTargetStrategy.OVERWRITE );
+        }
+    }
+
+    private Iterable<StoreFile> replacementStoreFiles()
+    {
+        StoreFile[] files = new StoreFile[replacementStoreTypes.length];
+        for ( int i = 0; i < files.length; i++ )
+        {
+            files[i] = replacementStoreTypes[i].getStoreFile();
+        }
+        return iterable( files );
     }
 
     public long getLastCommittedTransactionId()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormat.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormat.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.impl.store.StoreHeader;
+import org.neo4j.kernel.impl.store.id.IdSequence;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+
+public class ForcedSecondaryUnitRecordFormat<RECORD extends AbstractBaseRecord> implements RecordFormat<RECORD>
+{
+    private final RecordFormat<RECORD> actual;
+
+    public ForcedSecondaryUnitRecordFormat( RecordFormat<RECORD> actual )
+    {
+        this.actual = actual;
+    }
+
+    @Override
+    public RECORD newRecord()
+    {
+        return actual.newRecord();
+    }
+
+    @Override
+    public int getRecordSize( StoreHeader storeHeader )
+    {
+        return actual.getRecordSize( storeHeader );
+    }
+
+    @Override
+    public int getRecordHeaderSize()
+    {
+        return actual.getRecordHeaderSize();
+    }
+
+    @Override
+    public boolean isInUse( PageCursor cursor )
+    {
+        return actual.isInUse( cursor );
+    }
+
+    @Override
+    public void read( RECORD record, PageCursor cursor, RecordLoad mode, int recordSize ) throws IOException
+    {
+        actual.read( record, cursor, mode, recordSize );
+    }
+
+    @Override
+    public void prepare( RECORD record, int recordSize, IdSequence idSequence )
+    {
+        actual.prepare( record, recordSize, idSequence );
+        if ( !record.hasSecondaryUnitId() )
+        {
+            record.setSecondaryUnitId( idSequence.nextId() );
+        }
+    }
+
+    @Override
+    public void write( RECORD record, PageCursor cursor, int recordSize ) throws IOException
+    {
+        actual.write( record, cursor, recordSize );
+    }
+
+    @Override
+    public long getNextRecordReference( RECORD record )
+    {
+        return actual.getNextRecordReference( record );
+    }
+
+    @Override
+    public boolean equals( Object otherFormat )
+    {
+        return actual.equals( otherFormat );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return actual.hashCode();
+    }
+
+    @Override
+    public long getMaxId()
+    {
+        return actual.getMaxId();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/format/ForcedSecondaryUnitRecordFormats.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format;
+
+import org.neo4j.kernel.impl.store.id.IdSequence;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
+import org.neo4j.kernel.impl.store.record.MetaDataRecord;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
+
+/**
+ * Wraps another {@link RecordFormats} and merely forces {@link AbstractBaseRecord#setSecondaryUnitId(long)}
+ * to be used, and in extension {@link IdSequence#nextId()} to be called in
+ * {@link RecordFormat#prepare(AbstractBaseRecord, int, IdSequence)}. All {@link RecordFormat} instances
+ * will also be wrapped. This is a utility to test behavior when there are secondary record units at play.
+ */
+public class ForcedSecondaryUnitRecordFormats implements RecordFormats
+{
+    private final RecordFormats actual;
+
+    public ForcedSecondaryUnitRecordFormats( RecordFormats actual )
+    {
+        this.actual = actual;
+    }
+
+    @Override
+    public String storeVersion()
+    {
+        return actual.storeVersion();
+    }
+
+    @Override
+    public int generation()
+    {
+        return actual.generation();
+    }
+
+    private static <R extends AbstractBaseRecord> RecordFormat<R> withForcedSecondaryUnit( RecordFormat<R> format )
+    {
+        return new ForcedSecondaryUnitRecordFormat<>( format );
+    }
+
+    @Override
+    public RecordFormat<NodeRecord> node()
+    {
+        return withForcedSecondaryUnit( actual.node() );
+    }
+
+    @Override
+    public RecordFormat<RelationshipGroupRecord> relationshipGroup()
+    {
+        return withForcedSecondaryUnit( actual.relationshipGroup() );
+    }
+
+    @Override
+    public RecordFormat<RelationshipRecord> relationship()
+    {
+        return withForcedSecondaryUnit( actual.relationship() );
+    }
+
+    @Override
+    public RecordFormat<PropertyRecord> property()
+    {
+        return withForcedSecondaryUnit( actual.property() );
+    }
+
+    @Override
+    public RecordFormat<LabelTokenRecord> labelToken()
+    {
+        return withForcedSecondaryUnit( actual.labelToken() );
+    }
+
+    @Override
+    public RecordFormat<PropertyKeyTokenRecord> propertyKeyToken()
+    {
+        return withForcedSecondaryUnit( actual.propertyKeyToken() );
+    }
+
+    @Override
+    public RecordFormat<RelationshipTypeTokenRecord> relationshipTypeToken()
+    {
+        return withForcedSecondaryUnit( actual.relationshipTypeToken() );
+    }
+
+    @Override
+    public RecordFormat<DynamicRecord> dynamic()
+    {
+        return withForcedSecondaryUnit( actual.dynamic() );
+    }
+
+    @Override
+    public RecordFormat<MetaDataRecord> metaData()
+    {
+        return withForcedSecondaryUnit( actual.metaData() );
+    }
+
+    @Override
+    public Capability[] capabilities()
+    {
+        return actual.capabilities();
+    }
+
+    @Override
+    public boolean hasCapability( Capability capability )
+    {
+        return actual.hasCapability( capability );
+    }
+
+    @Override
+    public boolean hasSameCapabilities( RecordFormats other, CapabilityType type )
+    {
+        return actual.hasSameCapabilities( other, type );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCacheTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.io.ByteUnit;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.test.RandomRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.HEAP;
+
+public class RelationshipGroupCacheTest
+{
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Test
+    public void shouldPutGroupsOnlyWithinPreparedRange() throws Exception
+    {
+        // GIVEN
+        int nodeCount = 1000;
+        RelationshipGroupCache cache = new RelationshipGroupCache( HEAP, ByteUnit.kibiBytes( 4 ), nodeCount );
+        int[] counts = new int[nodeCount];
+        for ( int nodeId = 0; nodeId < counts.length; nodeId++ )
+        {
+            counts[nodeId] = random.nextInt( 10 );
+            setCount( cache, nodeId, counts[nodeId] );
+        }
+
+        long toNodeId = cache.prepare( 0 );
+        assertTrue( toNodeId < nodeCount );
+
+        // WHEN
+        boolean thereAreMoreGroups = true;
+        int cachedCount = 0;
+        while ( thereAreMoreGroups )
+        {
+            thereAreMoreGroups = false;
+            for ( int nodeId = 0; nodeId < nodeCount; nodeId++ )
+            {
+                if ( counts[nodeId] > 0 )
+                {
+                    thereAreMoreGroups = true;
+                    int typeId = counts[nodeId]--;
+                    if ( cache.put( new RelationshipGroupRecord( nodeId )
+                            .initialize( true, typeId, -1, -1, -1, nodeId, -1 ) ) )
+                    {
+                        cachedCount++;
+                    }
+                }
+            }
+        }
+        assertTrue( cachedCount >= toNodeId );
+
+        // THEN the relationship groups we get back are only for those we prepared for
+        int readCount = 0;
+        for ( RelationshipGroupRecord cachedGroup : cache )
+        {
+            assertTrue( cachedGroup.getOwningNode() >= 0 && cachedGroup.getOwningNode() < toNodeId );
+            readCount++;
+        }
+        assertEquals( cachedCount, readCount );
+    }
+
+    @Test
+    public void shouldNotFindSpaceToPutMoreGroupsThanSpecifiedForANode() throws Exception
+    {
+        // GIVEN
+        int nodeCount = 10;
+        RelationshipGroupCache cache = new RelationshipGroupCache( HEAP, ByteUnit.kibiBytes( 4 ), nodeCount );
+        setCount( cache, 1, 7 );
+        assertEquals( nodeCount, cache.prepare( 0 ) );
+
+        // WHEN
+        for ( int i = 0; i < 7; i++ )
+        {
+            cache.put( new RelationshipGroupRecord( i+1 ).initialize( true, i, -1, -1, -1, 1, -1 ) );
+        }
+        try
+        {
+            cache.put( new RelationshipGroupRecord( 8 ).initialize( true, 8, -1, -1, -1, 1, -1 ) );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalStateException e )
+        {   // Good
+        }
+    }
+
+    @Test
+    public void shouldSortOutOfOrderTypes() throws Exception
+    {
+        // GIVEN
+        int nodeCount = 100;
+        RelationshipGroupCache cache = new RelationshipGroupCache( HEAP, ByteUnit.kibiBytes( 40 ), nodeCount );
+        int[] counts = new int[nodeCount];
+        int groupCount = 0;
+        for ( int nodeId = 0; nodeId < counts.length; nodeId++ )
+        {
+            counts[nodeId] = random.nextInt( 10 );
+            setCount( cache, nodeId, counts[nodeId] );
+            groupCount += counts[nodeId];
+        }
+        assertEquals( nodeCount, cache.prepare( 0 ) );
+        boolean thereAreMoreGroups = true;
+        int cachedCount = 0;
+        int[] types = scrambledTypes( 10 );
+        for ( int i = 0; thereAreMoreGroups; i++ )
+        {
+            int typeId = types[i];
+            thereAreMoreGroups = false;
+            for ( int nodeId = 0; nodeId < nodeCount; nodeId++ )
+            {
+                if ( counts[nodeId] > 0 )
+                {
+                    thereAreMoreGroups = true;
+                    if ( cache.put( new RelationshipGroupRecord( nodeId )
+                            .initialize( true, typeId, -1, -1, -1, nodeId, -1 ) ) )
+                    {
+                        cachedCount++;
+                        counts[nodeId]--;
+                    }
+                }
+            }
+        }
+        assertEquals( groupCount, cachedCount );
+
+        // WHEN/THEN
+        long currentNodeId = -1;
+        int currentTypeId = -1;
+        int readCount = 0;
+        for( RelationshipGroupRecord group : cache )
+        {
+            assertTrue( group.getOwningNode() >= currentNodeId );
+            if ( group.getOwningNode() > currentNodeId )
+            {
+                currentNodeId = group.getOwningNode();
+                currentTypeId = -1;
+            }
+            assertTrue( group.getType() > currentTypeId );
+            readCount++;
+        }
+        assertEquals( cachedCount, readCount );
+    }
+
+    private int[] scrambledTypes( int count )
+    {
+        int[] types = new int[count];
+        for ( int i = 0; i < count; i++ )
+        {
+            types[i] = i;
+        }
+
+        for ( int i = 0; i < 10; i++ )
+        {
+            swap( types, i, random.nextInt( count ) );
+        }
+        return types;
+    }
+
+    private void swap( int[] types, int a, int b )
+    {
+        int temp = types[a];
+        types[a] = types[b];
+        types[b] = temp;
+    }
+
+    private void setCount( RelationshipGroupCache cache, int nodeId, int count )
+    {
+        for ( int i = 0; i < count; i++ )
+        {
+            cache.incrementGroupCount( nodeId );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.IOException;
+import java.util.BitSet;
+import java.util.Collection;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.store.RecordCursor;
+import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.format.ForcedSecondaryUnitRecordFormats;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.Record;
+import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
+import org.neo4j.test.RandomRule;
+import org.neo4j.test.TargetDirectory;
+import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitors;
+import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import static java.util.Arrays.asList;
+
+import static org.neo4j.io.ByteUnit.mebiBytes;
+import static org.neo4j.kernel.impl.store.record.RecordLoad.CHECK;
+
+@RunWith( Parameterized.class )
+public class RelationshipGroupDefragmenterTest
+{
+    private static final Configuration CONFIG = Configuration.DEFAULT;
+
+    @Parameters
+    public static Collection<Object[]> formats()
+    {
+        return asList(
+                new Object[] {StandardV3_0.RECORD_FORMATS, 1},
+                new Object[] {new ForcedSecondaryUnitRecordFormats( StandardV3_0.RECORD_FORMATS ), 2} );
+    }
+
+    @Rule
+    public final TargetDirectory.TestDirectory directory = TargetDirectory.testDirForTest( getClass() );
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Parameter( 0 )
+    public RecordFormats format;
+    @Parameter( 1 )
+    public int units;
+
+    private BatchingNeoStores stores;
+
+    @Before
+    public void start()
+    {
+        stores = new BatchingNeoStores( new DefaultFileSystemAbstraction(),
+                directory.absolutePath(), format, CONFIG, NullLogService.getInstance(),
+                AdditionalInitialIds.EMPTY, Config.defaults() );
+    }
+
+    @After
+    public void stop() throws IOException
+    {
+        stores.close();
+    }
+
+    @Test
+    public void shouldDefragmentRelationshipGroupsWhenAllDense() throws Exception
+    {
+        // GIVEN some nodes which has their groups scattered
+        int nodeCount = 10_000;
+        int relationshipTypeCount = 50;
+        RecordStore<RelationshipGroupRecord> groupStore = stores.getRelationshipGroupStore();
+        RelationshipGroupRecord groupRecord = groupStore.newRecord();
+        RecordStore<NodeRecord> nodeStore = stores.getNodeStore();
+        NodeRecord nodeRecord = nodeStore.newRecord();
+        long cursor = 0;
+        for ( int typeId = relationshipTypeCount-1; typeId >= 0; typeId-- )
+        {
+            for ( long nodeId = 0; nodeId < nodeCount; nodeId++, cursor++ )
+            {
+                // next doesn't matter at all, as we're rewriting it anyway
+                // firstOut/In/Loop we could use in verification phase later
+                groupRecord.initialize( true, typeId, cursor, cursor+1, cursor+2, nodeId, 4 );
+                groupRecord.setId( groupStore.nextId() );
+                groupStore.updateRecord( groupRecord );
+
+                if ( typeId == 0 )
+                {
+                    // first round also create the nodes
+                    nodeRecord.initialize( true, -1, true, groupRecord.getId(), 0 );
+                    nodeRecord.setId( nodeId );
+                    nodeStore.updateRecord( nodeRecord );
+                }
+            }
+        }
+
+        // WHEN
+        defrag( nodeCount );
+
+        // THEN all groups should sit sequentially in the store
+        verifyGroupsAreSequentiallyOrderedByNode();
+    }
+
+    @Test
+    public void shouldDefragmentRelationshipGroupsWhenSomeDense() throws Exception
+    {
+        // GIVEN some nodes which has their groups scattered
+        int nodeCount = 10_000;
+        int relationshipTypeCount = 50;
+        RecordStore<RelationshipGroupRecord> groupStore = stores.getRelationshipGroupStore();
+        RelationshipGroupRecord groupRecord = groupStore.newRecord();
+        RecordStore<NodeRecord> nodeStore = stores.getNodeStore();
+        NodeRecord nodeRecord = nodeStore.newRecord();
+        long cursor = 0;
+        BitSet initializedNodes = new BitSet();
+        for ( int typeId = relationshipTypeCount-1; typeId >= 0; typeId-- )
+        {
+            for ( int nodeId = 0; nodeId < nodeCount; nodeId++, cursor++ )
+            {
+                // Reasoning behind this thing is that we want to have roughly 10% of the nodes dense
+                // right from the beginning and then some stray dense nodes coming into this in the
+                // middle of the type range somewhere
+                double comparison = typeId == 0 || initializedNodes.get( nodeId ) ? 0.1 : 0.001;
+
+                if ( random.nextDouble() < comparison )
+                {
+                    // next doesn't matter at all, as we're rewriting it anyway
+                    // firstOut/In/Loop we could use in verification phase later
+                    groupRecord.initialize( true, typeId, cursor, cursor+1, cursor+2, nodeId, 4 );
+                    groupRecord.setId( groupStore.nextId() );
+                    groupStore.updateRecord( groupRecord );
+
+                    if ( !initializedNodes.get( nodeId ) )
+                    {
+                        nodeRecord.initialize( true, -1, true, groupRecord.getId(), 0 );
+                        nodeRecord.setId( nodeId );
+                        nodeStore.updateRecord( nodeRecord );
+                        initializedNodes.set( nodeId );
+                    }
+                }
+            }
+        }
+
+        // WHEN
+        defrag( nodeCount );
+
+        // THEN all groups should sit sequentially in the store
+        verifyGroupsAreSequentiallyOrderedByNode();
+    }
+
+    private void defrag( long nodeCount )
+    {
+        RelationshipGroupDefragmenter defragmenter = new RelationshipGroupDefragmenter( CONFIG,
+                ExecutionMonitors.invisible() );
+        defragmenter.run( mebiBytes( 1 ), stores, nodeCount );
+    }
+
+    private void verifyGroupsAreSequentiallyOrderedByNode()
+    {
+        RecordStore<RelationshipGroupRecord> store = stores.getReplacementNeoStores().getRelationshipGroupStore();
+        long firstId = store.getNumberOfReservedLowIds();
+        long groupCount = store.getHighId() - firstId;
+        RelationshipGroupRecord groupRecord = store.newRecord();
+        RecordCursor<RelationshipGroupRecord> groupCursor =
+                store.newRecordCursor( groupRecord ).acquire( firstId, CHECK );
+        long highGroupId = store.getHighId();
+        long currentNodeId = -1;
+        int currentTypeId = -1;
+        int newGroupCount = 0;
+        int currentGroupLength = 0;
+        for ( long id = firstId; id < highGroupId; id++, newGroupCount++ )
+        {
+            if ( !groupCursor.next( id ) )
+            {
+                // This will be the case if we have double record units, just assert that fact
+                assertTrue( units > 1 );
+                assertTrue( currentGroupLength > 0 );
+                currentGroupLength--;
+                continue;
+            }
+
+            long nodeId = groupRecord.getOwningNode();
+            assertTrue(
+                    "Expected a group for node >= " + currentNodeId + ", but was " + nodeId + " in " + groupRecord,
+                    nodeId >= currentNodeId );
+            if ( nodeId != currentNodeId )
+            {
+                currentNodeId = nodeId;
+                currentTypeId = -1;
+                if ( units > 1 )
+                {
+                    assertEquals( 0, currentGroupLength );
+                }
+                currentGroupLength = 0;
+            }
+            currentGroupLength++;
+
+            assertTrue( "Expected this group to have a next of current + " + units + " OR NULL, " +
+                    "but was " + groupRecord.toString(),
+                    groupRecord.getNext() == groupRecord.getId() + 1 ||
+                    groupRecord.getNext() == Record.NO_NEXT_RELATIONSHIP.intValue() );
+            assertTrue( "Expected " + groupRecord + " to have type > " + currentTypeId,
+                    groupRecord.getType() > currentTypeId );
+            currentTypeId = groupRecord.getType();
+        }
+        assertEquals( groupCount, newGroupCount );
+    }
+}


### PR DESCRIPTION
now that the importer has been changed to import relationships per type
it means that relationship groups will be more scattered, which will
have read queries take a hit compared to previously.

This commit introduces a relationship group defragmenter which is
written using normal batch importer stages and steps and runs as part
of import, after the relationships have been imported.

CHANGELOG [tools]
Relationship groups chains are defragmented so that dense nodes are read more efficiently. This was recently changed as part of importing relationships per type due to high memory usage. With this change the memory requirements are unchanged, but adds the benefit of relationship groups being co-located on disk per node.
