### PR TITLE
More defensive configuration of custom page swappers

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
@@ -46,13 +46,13 @@ public class ConfiguringPageCacheFactory
     public ConfiguringPageCacheFactory(
             FileSystemAbstraction fs, Config config, PageCacheTracer tracer, Log log )
     {
-        this.swapperFactory = createAndConfigureSwapperFactory( fs, config );
+        this.swapperFactory = createAndConfigureSwapperFactory( fs, config, log );
         this.config = config;
         this.tracer = tracer;
         this.log = log;
     }
 
-    private PageSwapperFactory createAndConfigureSwapperFactory( FileSystemAbstraction fs, Config config )
+    private PageSwapperFactory createAndConfigureSwapperFactory( FileSystemAbstraction fs, Config config, Log log )
     {
         String desiredImplementation = config.get( pagecache_swapper );
 
@@ -68,9 +68,11 @@ public class ConfiguringPageCacheFactory
                         ConfigurablePageSwapperFactory configurableFactory = (ConfigurablePageSwapperFactory) factory;
                         configurableFactory.configure( config );
                     }
+                    log.info( "Configured " + pagecache_swapper.name() + ": " + desiredImplementation );
                     return factory;
                 }
             }
+            throw new IllegalArgumentException( "Cannot find PageSwapperFactory: " + desiredImplementation );
         }
 
         SingleFilePageSwapperFactory factory = new SingleFilePageSwapperFactory();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactoryTest.java
@@ -27,11 +27,11 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.logging.BufferingLog;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 import org.neo4j.test.EphemeralFileSystemRule;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -84,7 +84,8 @@ public class ConfiguringPageCacheFactoryTest
         Config config = new Config( stringMap(
                 pagecache_memory.name(), "8m",
                 pagecache_swapper.name(), TEST_PAGESWAPPER_NAME ) );
-        BufferingLog log = new BufferingLog();
+        AssertableLogProvider logProvider = new AssertableLogProvider();
+        Log log = logProvider.getLog( PageCache.class );
 
         // When
         new ConfiguringPageCacheFactory( fsRule.get(), config, PageCacheTracer.NULL, log );
@@ -92,7 +93,7 @@ public class ConfiguringPageCacheFactoryTest
         // Then
         assertThat( PageSwapperFactoryForTesting.countCreatedPageSwapperFactories(), is( 1 ) );
         assertThat( PageSwapperFactoryForTesting.countConfiguredPageSwapperFactories(), is( 1 ) );
-        assertThat( log.toString(), containsString( TEST_PAGESWAPPER_NAME ) );
+        logProvider.assertContainsMessageContaining( TEST_PAGESWAPPER_NAME );
     }
 
     @Test( expected = IllegalArgumentException.class )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/PageSwapperFactoryForTesting.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/PageSwapperFactoryForTesting.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.pagecache;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
+import org.neo4j.kernel.configuration.Config;
+
+public class PageSwapperFactoryForTesting
+        extends SingleFilePageSwapperFactory
+        implements ConfigurablePageSwapperFactory
+{
+    public static final String TEST_PAGESWAPPER_NAME = "pageSwapperForTesting";
+
+    public static final AtomicInteger createdCounter = new AtomicInteger();
+    public static final AtomicInteger configuredCounter = new AtomicInteger();
+    public static final AtomicInteger cachePageSizeHint = new AtomicInteger( 8192 );
+    public static final AtomicBoolean cachePageSizeHintIsStrict = new AtomicBoolean();
+
+    public static int countCreatedPageSwapperFactories()
+    {
+        return createdCounter.get();
+    }
+
+    public static int countConfiguredPageSwapperFactories()
+    {
+        return configuredCounter.get();
+    }
+
+    public PageSwapperFactoryForTesting()
+    {
+        createdCounter.getAndIncrement();
+    }
+
+    @Override
+    public String implementationName()
+    {
+        return TEST_PAGESWAPPER_NAME;
+    }
+
+    @Override
+    public int getCachePageSizeHint()
+    {
+        return cachePageSizeHint.get();
+    }
+
+    @Override
+    public boolean isCachePageSizeHintStrict()
+    {
+        return cachePageSizeHintIsStrict.get();
+    }
+
+    @Override
+    public void configure( Config config )
+    {
+        configuredCounter.getAndIncrement();
+    }
+}

--- a/community/kernel/src/test/resources/META-INF/services/org.neo4j.io.pagecache.PageSwapperFactory
+++ b/community/kernel/src/test/resources/META-INF/services/org.neo4j.io.pagecache.PageSwapperFactory
@@ -1,2 +1,2 @@
 org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory
-org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactoryTest$PageSwapperFactoryForTesting
+org.neo4j.kernel.impl.pagecache.PageSwapperFactoryForTesting

--- a/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
+++ b/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
@@ -37,6 +37,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.neo4j.kernel.impl.pagecache.PageSwapperFactoryForTesting.TEST_PAGESWAPPER_NAME;
 import static org.neo4j.kernel.impl.storemigration.MigrationTestUtils.prepareSampleLegacyDatabase;
 
 public class PlatformConstraintStoreUpgradeTest
@@ -75,6 +76,6 @@ public class PlatformConstraintStoreUpgradeTest
     {
         return new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( workingDir )
                 .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" )
-                .setConfig( GraphDatabaseSettings.pagecache_swapper, "custom" ).newGraphDatabase();
+                .setConfig( GraphDatabaseSettings.pagecache_swapper, TEST_PAGESWAPPER_NAME ).newGraphDatabase();
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/PlatformConstraintBackupTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/PlatformConstraintBackupTest.java
@@ -34,6 +34,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.neo4j.kernel.impl.pagecache.PageSwapperFactoryForTesting.TEST_PAGESWAPPER_NAME;
 
 public class PlatformConstraintBackupTest
 {
@@ -55,7 +56,7 @@ public class PlatformConstraintBackupTest
         {
             GraphDatabaseBuilder builder = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( workingDir );
             builder.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE );
-            builder.setConfig( GraphDatabaseSettings.pagecache_swapper, "custom" );
+            builder.setConfig( GraphDatabaseSettings.pagecache_swapper, TEST_PAGESWAPPER_NAME );
             builder.newGraphDatabase();
             fail( "Should not have created database with custom IO configuration and online backup." );
         }
@@ -71,7 +72,7 @@ public class PlatformConstraintBackupTest
     {
         GraphDatabaseBuilder builder = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( workingDir );
         builder.setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE );
-        builder.setConfig( GraphDatabaseSettings.pagecache_swapper, "custom" );
+        builder.setConfig( GraphDatabaseSettings.pagecache_swapper, TEST_PAGESWAPPER_NAME );
         builder.newGraphDatabase().shutdown();
     }
 
@@ -79,6 +80,6 @@ public class PlatformConstraintBackupTest
     {
         return new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( workingDir )
                 .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.TRUE )
-                .setConfig( GraphDatabaseSettings.pagecache_swapper, "custom" ).newGraphDatabase();
+                .setConfig( GraphDatabaseSettings.pagecache_swapper, TEST_PAGESWAPPER_NAME ).newGraphDatabase();
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/graphdb/factory/PlatformConstraintGraphDatabaseFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/graphdb/factory/PlatformConstraintGraphDatabaseFactoryTest.java
@@ -32,6 +32,7 @@ import org.neo4j.test.TargetDirectory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.neo4j.kernel.impl.pagecache.PageSwapperFactoryForTesting.TEST_PAGESWAPPER_NAME;
 
 public class PlatformConstraintGraphDatabaseFactoryTest
 {
@@ -63,7 +64,7 @@ public class PlatformConstraintGraphDatabaseFactoryTest
     private GraphDatabaseService createGraphDatabaseService()
     {
         return new TestHighlyAvailableGraphDatabaseFactory().newEmbeddedDatabaseBuilder( workingDir )
-                .setConfig( GraphDatabaseSettings.pagecache_swapper, "custom" )
+                .setConfig( GraphDatabaseSettings.pagecache_swapper, TEST_PAGESWAPPER_NAME )
                 .setConfig( ClusterSettings.initial_hosts, "127.0.0.1:5001" )
                 .setConfig( ClusterSettings.server_id, "1" ).newGraphDatabase();
     }


### PR DESCRIPTION
- We now log when a custom page swapper is being configured.
- If we cannot configure the desired custom page swapper, we now throw an exception to avoid falling back to the default page swapper implementation.
