### PR TITLE
Panic in case of any unexpected problems during queued transaction apply on slave.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppender.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppender.java
@@ -28,7 +28,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.neo4j.helpers.ThisShouldNotHappenError;
 import org.neo4j.kernel.KernelHealth;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
@@ -169,9 +168,11 @@ public class BatchingTransactionAppender extends LifecycleAdapter implements Tra
             long transactionId = transactionIdStore.nextCommittingTransactionId();
             if ( transactionId != expectedTransactionId )
             {
-                throw new ThisShouldNotHappenError( "Zhen Li and Mattias Persson",
+                IllegalStateException illegalStateException = new IllegalStateException(
                         "Received " + transaction + " with txId:" + expectedTransactionId +
                         " to be applied, but appending it ended up generating an unexpected txId:" + transactionId );
+                kernelHealth.panic( illegalStateException );
+                throw illegalStateException;
             }
             return appendToLog( transaction, transactionId );
         }

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpackerTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/TransactionCommittingResponseUnpackerTest.java
@@ -75,6 +75,7 @@ import org.neo4j.test.CleanupRule;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -90,18 +91,73 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.com.storecopy.ResponseUnpacker.NO_OP_TX_HANDLER;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 
 public class TransactionCommittingResponseUnpackerTest
 {
-    public final @Rule CleanupRule cleanup = new CleanupRule();
-    public final @Rule LifeRule life = new LifeRule();
+    @Rule
+    public final CleanupRule cleanup = new CleanupRule();
+    @Rule
+    public final LifeRule life = new LifeRule();
 
     private final LogAppendEvent logAppendEvent = LogAppendEvent.NULL;
     private final LogService logging = new SimpleLogService(
             new AssertableLogProvider(), new AssertableLogProvider() );
+
+
+    @Test
+    public void panicAndSkipBatchOnApplyingFailure() throws Throwable
+    {
+        long committingTransactionId = BASE_TX_ID + 1;
+        TransactionIdStore txIdStore = mock( TransactionIdStore.class );
+        BatchingTransactionRepresentationStoreApplier applier = mock( BatchingTransactionRepresentationStoreApplier.class );
+        TransactionAppender appender = mock( TransactionAppender.class );
+        FakeCommitment fakeCommitment = new FakeCommitment( committingTransactionId, txIdStore );
+        when( appender.append( any( TransactionRepresentation.class ), anyLong() ) )
+                .thenReturn( fakeCommitment );
+
+        LogFile logFile = mock( LogFile.class );
+        LogRotation logRotation = mock( LogRotation.class );
+        KernelHealth kernelHealth = newKernelHealth();
+
+        IndexUpdatesValidator indexUpdatesValidator = mock( IndexUpdatesValidator.class );
+        String errorMessage = "Too many open files";
+
+        doReturn(null).
+        doThrow( new IOException( errorMessage ) )
+                .when( indexUpdatesValidator )
+                .validate( any( TransactionRepresentation.class ) );
+
+        TransactionCommittingResponseUnpacker.Dependencies dependencies = buildDependencies( logFile,
+                logRotation, indexUpdatesValidator, applier, appender,
+                mock( TransactionObligationFulfiller.class ), kernelHealth );
+
+        int maxBatchSize = 10;
+        DummyTransactionResponse response = new DummyTransactionResponse( committingTransactionId, 10, appender,
+                maxBatchSize );
+
+        TransactionCommittingResponseUnpacker unpacker = new TransactionCommittingResponseUnpacker( dependencies, maxBatchSize );
+        unpacker.start();
+
+        try
+        {
+            unpacker.unpackResponse( response, NO_OP_TX_HANDLER );
+            fail("Should fail during batch processing");
+        }
+        catch ( IOException ignore )
+        {
+            // ignored
+        }
+
+        assertFalse("Kernel should be unhealthy because of failure during index updates validation.", kernelHealth.isHealthy() );
+        assertEquals( "Root cause should have expected exception",
+                errorMessage, kernelHealth.getCauseOfPanic().getMessage() );
+
+        // 2 transactions where committed by none was closed.
+        verify( txIdStore, times( 2 ) ).transactionCommitted( anyLong(), anyLong() );
+        verify( txIdStore, times( 0 ) ).transactionClosed( anyLong(), anyLong(), anyLong() );
+    }
 
     /*
      * Tests that shutting down the response unpacker while in the middle of committing a transaction will
@@ -167,19 +223,6 @@ public class TransactionCommittingResponseUnpackerTest
         }
         verifyNoMoreInteractions( txIdStore );
         verifyNoMoreInteractions( appender );
-    }
-
-    private Function<DependencyResolver,BatchingTransactionRepresentationStoreApplier> customApplier(
-            final BatchingTransactionRepresentationStoreApplier storeApplier )
-    {
-        return new Function<DependencyResolver,BatchingTransactionRepresentationStoreApplier>()
-        {
-            @Override
-            public BatchingTransactionRepresentationStoreApplier apply( DependencyResolver from )
-            {
-                return storeApplier;
-            }
-        };
     }
 
     @Test
@@ -266,12 +309,6 @@ public class TransactionCommittingResponseUnpackerTest
         {
             assertThat( e.getMessage(), containsString( failure.getMessage() ) );
         }
-    }
-
-    private KernelHealth newKernelHealth()
-    {
-        Log log = logging.getInternalLog( getClass() );
-        return new KernelHealth( new KernelPanicEventGenerator( new KernelEventHandlers( log ) ), log );
     }
 
     @Test
@@ -396,18 +433,6 @@ public class TransactionCommittingResponseUnpackerTest
         verifyZeroInteractions( storeApplier );
     }
 
-    private Function<DependencyResolver,IndexUpdatesValidator> customValidator( final IndexUpdatesValidator validator )
-    {
-        return new Function<DependencyResolver,IndexUpdatesValidator>()
-        {
-            @Override
-            public IndexUpdatesValidator apply( DependencyResolver from ) throws RuntimeException
-            {
-                return validator;
-            }
-        };
-    }
-
     @Test
     public void shouldNotMarkTransactionsAsCommittedIfAppenderClosed() throws Throwable
     {
@@ -456,6 +481,12 @@ public class TransactionCommittingResponseUnpackerTest
             verify( transactionIdStore, times( 0 ) ).transactionCommitted( anyLong(), anyLong() );
             verify( transactionIdStore, times( 0 ) ).transactionClosed( anyLong(), anyLong(), anyLong() );
         }
+    }
+
+    private KernelHealth newKernelHealth()
+    {
+        Log log = logging.getInternalLog( getClass() );
+        return new KernelHealth( new KernelPanicEventGenerator( new KernelEventHandlers( log ) ), log );
     }
 
     private TransactionCommittingResponseUnpacker.Dependencies buildDependencies(


### PR DESCRIPTION
Update handling of exceptions to always propagate unexpected exception to kernelPanic.
Avoid cases of when transaction queue will be partially applied (fail in the middle of transaction batch).
Use IllegalStateException instead of ThisShouldNotHappenError.
