### PR TITLE
Introduce new commands for restoring new/existing cluster

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ClusterSeed.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ClusterSeed.java
@@ -25,20 +25,20 @@ import java.util.Objects;
 
 import org.neo4j.kernel.impl.store.StoreId;
 
-public class SourceMetadata
+public class ClusterSeed
 {
     private final StoreId before;
     private final StoreId after;
     private final long lastTxId;
 
-    public SourceMetadata( StoreId before, StoreId after, long lastTxId )
+    public ClusterSeed( StoreId before, StoreId after, long lastTxId )
     {
         this.before = before;
         this.after = after;
         this.lastTxId = lastTxId;
     }
 
-    public static SourceMetadata create( String rawConversionId )
+    public static ClusterSeed create( String rawConversionId )
     {
         byte[] bytes = Base64.getDecoder().decode( rawConversionId );
         ByteBuffer buffer = ByteBuffer.wrap( bytes );
@@ -47,7 +47,7 @@ public class SourceMetadata
         StoreId before = readStoreId( buffer );
         StoreId after = readStoreId( buffer );
 
-        return new SourceMetadata( before, after, txId );
+        return new ClusterSeed( before, after, txId );
     }
 
     private static StoreId readStoreId( ByteBuffer buffer )
@@ -104,7 +104,7 @@ public class SourceMetadata
         {
             return false;
         }
-        SourceMetadata that = (SourceMetadata) o;
+        ClusterSeed that = (ClusterSeed) o;
         return lastTxId == that.lastTxId &&
                 storeIdEquals( before, that.before ) &&
                 storeIdEquals( after, that.after );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConversionVerifier.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConversionVerifier.java
@@ -23,11 +23,11 @@ import org.neo4j.kernel.impl.store.StoreId;
 
 public class ConversionVerifier
 {
-    public void conversionGuard( SourceMetadata source,
-                                 TargetMetadata target )
+    public void conversionGuard( ClusterSeed source,
+                                 StoreMetadata target )
     {
         StoreId sourceBefore = source.before();
-        StoreId targetBefore = target.before();
+        StoreId targetBefore = target.storeId();
 
         long sourceLastTxId = source.lastTxId();
         long targetLastTxId = target.lastTxId();

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/GenerateClusterSeedCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/GenerateClusterSeedCommand.java
@@ -39,12 +39,12 @@ import static org.neo4j.kernel.impl.store.MetaDataStore.getRecord;
 
 public class GenerateClusterSeedCommand
 {
-    public SourceMetadata generate( File databaseDir ) throws Throwable
+    public ClusterSeed generate( File databaseDir ) throws IOException
     {
         return metadata( databaseDir );
     }
 
-    private SourceMetadata metadata( File storeDir ) throws IOException
+    private ClusterSeed metadata( File storeDir ) throws IOException
     {
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         File metadataStore = new File( storeDir, MetaDataStore.DEFAULT_NAME );
@@ -54,11 +54,11 @@ public class GenerateClusterSeedCommand
             StoreId after = storeId( metadataStore, pageCache, System.currentTimeMillis() );
             long lastTxId = getRecord( pageCache, metadataStore, LAST_TRANSACTION_ID );
 
-            return new SourceMetadata( before, after, lastTxId );
+            return new ClusterSeed( before, after, lastTxId );
         }
     }
 
-    private StoreId storeId( File metadataStore, PageCache pageCache, long upgradeTime ) throws IOException
+    public static StoreId storeId( File metadataStore, PageCache pageCache, long upgradeTime ) throws IOException
     {
         long creationTime = getRecord( pageCache, metadataStore, TIME );
         long randomNumber = getRecord( pageCache, metadataStore, RANDOM_NUMBER );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/StoreMetadata.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/StoreMetadata.java
@@ -23,21 +23,21 @@ import java.util.Objects;
 
 import org.neo4j.kernel.impl.store.StoreId;
 
-public class TargetMetadata
+public class StoreMetadata
 {
-    private final StoreId before;
+    private final StoreId storeId;
     private final long lastTxId;
 
-    public TargetMetadata( StoreId before, long lastTxId )
+    public StoreMetadata( StoreId storeId, long lastTxId )
     {
-        this.before = before;
+        this.storeId = storeId;
         this.lastTxId = lastTxId;
     }
 
     @Override
     public String toString()
     {
-        return String.format( "TargetMetadata{before=%s, lastTxId=%d}", before, lastTxId );
+        return String.format( "TargetMetadata{before=%s, lastTxId=%d}", storeId, lastTxId );
     }
 
     @Override
@@ -51,14 +51,14 @@ public class TargetMetadata
         {
             return false;
         }
-        TargetMetadata that = (TargetMetadata) o;
-        return lastTxId == that.lastTxId && storeIdEquals( before, that.before );
+        StoreMetadata that = (StoreMetadata) o;
+        return lastTxId == that.lastTxId && storeIdEquals( storeId, that.storeId );
     }
 
     @Override
     public int hashCode()
     {
-        int result = 31 + (this.before == null ? 0 : before.theRealHashCode());
+        int result = 31 + (this.storeId == null ? 0 : storeId.theRealHashCode());
         return 31 * result + Objects.hash( lastTxId );
     }
 
@@ -67,9 +67,9 @@ public class TargetMetadata
         return (one == two || (one != null && one.theRealEquals( two )));
     }
 
-    public StoreId before()
+    public StoreId storeId()
     {
-        return before;
+        return storeId;
     }
 
     public long lastTxId()

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/DurableStateStorage.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/state/DurableStateStorage.java
@@ -80,7 +80,7 @@ public class DurableStateStorage<STATE> extends LifecycleAdapter implements Stat
     }
 
     @Override
-    public synchronized void shutdown() throws Throwable
+    public synchronized void shutdown() throws IOException
     {
         currentStoreChannel.close();
         currentStoreChannel = null;

--- a/enterprise/core-edge/src/main/java/org/neo4j/restore/RestoreExistingClusterCli.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/restore/RestoreExistingClusterCli.java
@@ -1,0 +1,119 @@
+
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.restore;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.neo4j.coreedge.convert.ConversionVerifier;
+import org.neo4j.coreedge.convert.ConvertClassicStoreCommand;
+import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Args;
+import org.neo4j.helpers.ArrayUtil;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.Converters;
+import org.neo4j.logging.NullLog;
+import org.neo4j.server.configuration.ConfigLoader;
+
+import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.record_format;
+
+public class RestoreExistingClusterCli
+{
+    public static void main( String[] incomingArguments )
+    {
+        Args args = Args.parse( incomingArguments );
+        if ( ArrayUtil.isEmpty( incomingArguments ) )
+        {
+            printUsage( System.out );
+            System.exit( 1 );
+        }
+
+        File homeDir = args.interpretOption( "home-dir", Converters.<File>mandatory(), File::new );
+        String databaseName = args.interpretOption( "database", Converters.<String>mandatory(), s -> s );
+        String configPath = args.interpretOption( "config", Converters.<String>mandatory(), s -> s );
+        String fromPath = args.interpretOption( "from", Converters.<String>mandatory(), s -> s );
+        String clusterSeed = args.interpretOption( "cluster-seed", Converters.<String>mandatory(), s -> s );
+        boolean forceOverwrite = args.getBoolean( "force", Boolean.FALSE, true );
+
+        try
+        {
+            Config config = loadNeo4jConfig( homeDir, configPath );
+            restoreDatabase( databaseName, fromPath, forceOverwrite, config );
+            convertStore( config, clusterSeed );
+        }
+        catch ( IOException | TransactionFailureException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    private static Config loadNeo4jConfig( File homeDir, String configPath )
+    {
+        return new ConfigLoader( settings() ).loadConfig( Optional.of( homeDir ),
+                Optional.of( new File( configPath, "neo4j.conf" ) ), NullLog.getInstance() );
+    }
+
+    private static void convertStore( Config config, String seed ) throws IOException, TransactionFailureException
+    {
+        ConvertClassicStoreCommand convert = new ConvertClassicStoreCommand( new ConversionVerifier() );
+        convert.convert( config.get( database_path ), config.get( record_format ), seed );
+    }
+
+    private static void restoreDatabase( String databaseName, String fromPath, boolean forceOverwrite, Config config )
+            throws IOException
+    {
+        new RestoreDatabaseCommand( new DefaultFileSystemAbstraction(),
+                new File( fromPath ), config, databaseName, forceOverwrite ).execute();
+    }
+
+    public static List<Class<?>> settings()
+    {
+        List<Class<?>> settings = new ArrayList<>();
+        settings.add( GraphDatabaseSettings.class );
+        settings.add( DatabaseManagementSystemSettings.class );
+        return settings;
+    }
+
+    private static void printUsage( PrintStream out )
+    {
+        out.println( "Neo4j Restore Existing Cluster Tool" );
+        for ( String line : Args.splitLongLine( "The restore tool is used to restore a backed up core database", 80 ) )
+        {
+            out.println( "\t" + line );
+        }
+
+        out.println( "Usage:" );
+        out.println("--home-dir <path-to-neo4j>");
+        out.println("--from <path-to-backup-directory>");
+        out.println("--database <database-name>");
+        out.println("--config <path-to-config-directory>");
+        out.println("--seed <generated seed>");
+        out.println("--force");
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/convert/ConversionMetaDataTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/convert/ConversionMetaDataTest.java
@@ -35,12 +35,12 @@ public class ConversionMetaDataTest
         StoreId after = new StoreId( 6, 7, 8, 9, 10 );
         long transactionId = 44L;
 
-        SourceMetadata initialMetadata = new SourceMetadata( before, after, transactionId );
+        ClusterSeed initialMetadata = new ClusterSeed( before, after, transactionId );
 
         // when
         String conversionId = initialMetadata.getConversionId();
 
-        SourceMetadata expectedMetadata = SourceMetadata.create( conversionId );
+        ClusterSeed expectedMetadata = ClusterSeed.create( conversionId );
 
         // then
         assertEquals( expectedMetadata, initialMetadata );

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/convert/ConversionVerifierTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/convert/ConversionVerifierTest.java
@@ -38,11 +38,11 @@ public class ConversionVerifierTest
         StoreId after = new StoreId( 6, 7, 8, 9, 10 );
         long transactionId = 44L;
 
-        SourceMetadata metadata = new SourceMetadata( before, after, transactionId );
-        TargetMetadata targetMetadata = new TargetMetadata( before, transactionId );
+        ClusterSeed metadata = new ClusterSeed( before, after, transactionId );
+        StoreMetadata storeMetadata = new StoreMetadata( before, transactionId );
 
         // when
-        verifier.conversionGuard( metadata, targetMetadata );
+        verifier.conversionGuard( metadata, storeMetadata );
 
         // then happily convert
     }
@@ -57,13 +57,13 @@ public class ConversionVerifierTest
         StoreId after = new StoreId( 6, 7, 8, 9, 10 );
         long transactionId = 44L;
 
-        SourceMetadata metadata = new SourceMetadata( before, after, transactionId );
-        TargetMetadata targetMetadata = new TargetMetadata( new StoreId( 9, 9, 9, 9, 9 ), transactionId );
+        ClusterSeed metadata = new ClusterSeed( before, after, transactionId );
+        StoreMetadata storeMetadata = new StoreMetadata( new StoreId( 9, 9, 9, 9, 9 ), transactionId );
 
         // when
         try
         {
-            verifier.conversionGuard( metadata, targetMetadata );
+            verifier.conversionGuard( metadata, storeMetadata );
             fail("Should not have been able to convert");
         }
         catch ( Exception e )
@@ -86,13 +86,13 @@ public class ConversionVerifierTest
         StoreId after = new StoreId( 6, 7, 8, 9, 10 );
         long transactionId = 44L;
 
-        SourceMetadata metadata = new SourceMetadata( before, after, transactionId );
-        TargetMetadata targetMetadata = new TargetMetadata( before, 999L );
+        ClusterSeed metadata = new ClusterSeed( before, after, transactionId );
+        StoreMetadata storeMetadata = new StoreMetadata( before, 999L );
 
         // when
         try
         {
-            verifier.conversionGuard( metadata, targetMetadata );
+            verifier.conversionGuard( metadata, storeMetadata );
             fail( "Should not have been able to convert" );
         }
         catch ( Exception e )

--- a/enterprise/core-edge/src/test/java/org/neo4j/restore/RestoreClusterCliTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/restore/RestoreClusterCliTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.restore;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.LinkedList;
+import java.util.Optional;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.coreedge.convert.ClusterSeed;
+import org.neo4j.coreedge.convert.StoreMetadata;
+import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.pagecache.StandalonePageCacheFactory;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.StoreId;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.logging.NullLog;
+import org.neo4j.server.configuration.ConfigLoader;
+import org.neo4j.test.rule.TargetDirectory;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.coreedge.convert.GenerateClusterSeedCommand.storeId;
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.LAST_TRANSACTION_ID;
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.UPGRADE_TIME;
+import static org.neo4j.kernel.impl.store.MetaDataStore.getRecord;
+import static org.neo4j.restore.RestoreExistingClusterCli.settings;
+
+public class RestoreClusterCliTest
+{
+    @Rule
+    public TargetDirectory.TestDirectory testDirectory = TargetDirectory.testDirForTest( getClass() );
+
+    @Test
+    public void shouldRestoreDatabase() throws Throwable
+    {
+        File classicDatabaseDir = testDirectory.cleanDirectory( "classic-db" );
+        File classicNeo4jStore = createClassicNeo4jStore( classicDatabaseDir, 10, StandardV3_0.NAME );
+        StoreMetadata storeMetadata = metadataFor( classicNeo4jStore );
+
+        // when
+        LinkedList<String> args = args( classicNeo4jStore, testDirectory.cleanDirectory( "new-db-1" ) );
+        StringBuilder out = execute( () -> RestoreNewClusterCli.main( args.toArray( new String[args.size()] ) ) );
+
+        // then
+        String seed = extractSeed( out );
+        ClusterSeed clusterSeed = ClusterSeed.create( seed );
+
+        assertTrue( storeMetadata.storeId().theRealEquals( clusterSeed.before() ) );
+        assertEquals( storeMetadata.lastTxId(), clusterSeed.lastTxId() );
+        assertFalse( storeMetadata.storeId().theRealEquals( clusterSeed.after() ) );
+
+        // when restore to another place
+        File rootNewDatabaseDir = testDirectory.cleanDirectory( "new-db-2" );
+        LinkedList<String> newArgs = args( classicNeo4jStore, rootNewDatabaseDir );
+        newArgs.add( "--cluster-seed=" + seed );
+        execute( () -> RestoreExistingClusterCli.main( newArgs.toArray( new String[newArgs.size()] ) ) );
+
+        // then
+        StoreMetadata newMetadata = metadataFor( extractDatabaseDir( rootNewDatabaseDir ) );
+        assertTrue( clusterSeed.after().theRealEquals( newMetadata.storeId() ) );
+    }
+
+    private File extractDatabaseDir( File rootNewDatabaseDir )
+    {
+        Config config = new ConfigLoader( settings() ).loadConfig( Optional.of( rootNewDatabaseDir ),
+                Optional.of( new File( rootNewDatabaseDir, "neo4j.conf" ) ), NullLog.getInstance() );
+        return config.get( DatabaseManagementSystemSettings.database_path );
+    }
+
+    private LinkedList<String> args( File classicNeo4jStore, File newDatabaseDir ) throws IOException
+    {
+        String homeDir = newDatabaseDir.getPath();
+        String configPath = newDatabaseDir.getPath();
+        String databaseName = "graph.db";
+
+        // given
+        LinkedList<String> args = new LinkedList<>();
+        args.add( "--home-dir=" + homeDir );
+        args.add( "--database=" + databaseName );
+        args.add( "--config=" + configPath );
+        args.add( "--from=" + classicNeo4jStore );
+        return args;
+    }
+
+    private StringBuilder execute( Runnable function )
+    {
+        StringBuilder builder = new StringBuilder();
+
+        PrintStream theRealOut = System.out;
+        System.setOut( new PrintStream( new MyOutputStream( builder ) ) );
+        function.run();
+        System.setOut( theRealOut );
+        return builder;
+    }
+
+    private StoreMetadata metadataFor( File classicNeo4jStore ) throws IOException
+    {
+        FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
+        File metadataStore = new File( classicNeo4jStore, MetaDataStore.DEFAULT_NAME );
+
+        try ( PageCache pageCache = StandalonePageCacheFactory.createPageCache( fs ) )
+        {
+            StoreId classicStoreId = storeId( metadataStore, pageCache, getRecord( pageCache, metadataStore,
+                    UPGRADE_TIME ) );
+            long lastTransactionId = getRecord( pageCache, metadataStore, LAST_TRANSACTION_ID );
+            return new StoreMetadata( classicStoreId, lastTransactionId );
+        }
+    }
+
+    private String extractSeed( StringBuilder builder )
+    {
+        return builder.toString().replace( "Cluster Seed: ", "" ).replace( "\n", "" );
+    }
+
+    private File createClassicNeo4jStore( File base, int nodesToCreate, String recordFormat )
+    {
+        File existingDbDir = new File( base, "existing" );
+        GraphDatabaseService db = new GraphDatabaseFactory()
+                .newEmbeddedDatabaseBuilder( existingDbDir )
+                .setConfig( GraphDatabaseSettings.record_format, recordFormat )
+                .newGraphDatabase();
+
+        for ( int i = 0; i < (nodesToCreate / 2); i++ )
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                Node node1 = db.createNode( Label.label( "Label-" + i ) );
+                Node node2 = db.createNode( Label.label( "Label-" + i ) );
+                node1.createRelationshipTo( node2, RelationshipType.withName( "REL-" + i ) );
+                tx.success();
+            }
+        }
+
+        db.shutdown();
+
+        return existingDbDir;
+    }
+
+    private class MyOutputStream extends OutputStream
+    {
+        private final StringBuilder stringBuilder;
+
+        public MyOutputStream( StringBuilder stringBuilder )
+        {
+
+            this.stringBuilder = stringBuilder;
+        }
+
+        @Override
+        public void write( int b ) throws IOException
+        {
+            stringBuilder.append( (char) b );
+        }
+    }
+}

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
@@ -112,6 +112,20 @@ cmd_restore() {
   exec "${JAVA_CMD}" -cp "${CLASSPATH}" -Dfile.encoding=UTF-8 "org.neo4j.restore.RestoreDatabaseCli" --home-dir=${NEO4J_HOME} --config=${NEO4J_CONF} "$@"
 }
 
+cmd_restore_new_cluster() {
+  setup_environment
+  check_java
+  build_classpath
+  exec "${JAVA_CMD}" -cp "${CLASSPATH}" -Dfile.encoding=UTF-8 "org.neo4j.restore.RestoreNewClusterCli" --home-dir=${NEO4J_HOME} --config=${NEO4J_CONF} "$@"
+}
+
+cmd_restore_existing_cluster() {
+  setup_environment
+  check_java
+  build_classpath
+  exec "${JAVA_CMD}" -cp "${CLASSPATH}" -Dfile.encoding=UTF-8 "org.neo4j.restore.RestoreExistingClusterCli" --home-dir=${NEO4J_HOME} --config=${NEO4J_CONF} "$@"
+}
+
 cmd_generate_cluster_seed() {
   setup_environment
   check_java
@@ -150,6 +164,14 @@ usage() {
 
     Restores a database backed up using the neo4j-backup tool.
 
+  ${PROGRAM} restore-new-cluster ---from <backup-directory> --database=<database-name> [--force]
+
+    Restores a database backed up using the neo4j-backup tool to be used as the first instance of a new cluster.
+
+  ${PROGRAM} restore-existing-cluster ---from <backup-directory> --database=<database-name> --cluster-seed=<generated id> [--force]
+
+    Restores a database backed up using the neo4j-backup tool to be used as an additional instance of an existing cluster.
+
   ${PROGRAM} help
 
     Display this help text.
@@ -162,12 +184,14 @@ main() {
   declare -r command="$1"
   shift
   case "${command}" in
-    import)                 cmd_import "$@" ;;
-    core-convert)           cmd_core_convert "$@" ;;
-    generate-cluster-seed)  cmd_generate_cluster_seed "$@" ;;
-    restore)                cmd_restore "$@" ;;
-    help|--help|-h)         usage ;;
-    *)                      bad_usage "unrecognised command '${command}'" ;;
+    import)                         cmd_import "$@" ;;
+    core-convert)                   cmd_core_convert "$@" ;;
+    generate-cluster-seed)          cmd_generate_cluster_seed "$@" ;;
+    restore)                        cmd_restore "$@" ;;
+    restore-new-cluster)            cmd_restore_new_cluster "$@" ;;
+    restore-existing-cluster)       cmd_restore_existing_cluster "$@" ;;
+    help|--help|-h)                 usage ;;
+    *)                              bad_usage "unrecognised command '${command}'" ;;
   esac
 }
 


### PR DESCRIPTION
These commands are wrappers around restore, generate-cluster-seed and
core-convert and make the interface simpler and more task-oriented for
the operator.
