### PR TITLE
Added handling of cornercases in auth procedures

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthSubject.java
@@ -75,7 +75,7 @@ public class EnterpriseAuthSubject implements AuthSubject
 
     public boolean isAdmin()
     {
-        return shiroSubject.isPermitted( "*" );
+        return shiroSubject.isAuthenticated() && shiroSubject.isPermitted( "*" );
     }
 
     public boolean doesUsernameMatch( String username )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthScenariosLogic.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthScenariosLogic.java
@@ -379,7 +379,7 @@ public abstract class AuthScenariosLogic<S> extends AuthTestBase<S>
         assertCallEmpty( adminSubject, "CALL dbms.suspendUser('Henrik')" );
 
         // TODO: uncomment and fix
-        // testUnAuthenticated( subject );
+        testUnAuthenticated( subject );
 
         subject = neo.login( "Henrik", "bar" );
         assertEquals( AuthenticationResult.FAILURE, neo.authenticationResult( subject ) );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthScenariosLogic.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthScenariosLogic.java
@@ -458,7 +458,8 @@ public abstract class AuthScenariosLogic<S> extends AuthTestBase<S>
     Henrik lists all roles for user Craig → permission denied
     Admin lists all roles for user Craig → ok
     Admin adds user Henrik to role Publisher
-    Henrik lists all roles for user Henrik → ok
+    Craig logs in with correct password → ok
+    Craig lists all roles for user Craig → ok
     */
     @Test
     public void listingUserRoles() throws Throwable
@@ -473,10 +474,9 @@ public abstract class AuthScenariosLogic<S> extends AuthTestBase<S>
         executeQuery( adminSubject, "CALL dbms.listRolesForUser('Craig') YIELD value as roles RETURN roles",
                 r -> assertKeyIs( r, "roles", PUBLISHER ) );
 
-        assertCallEmpty( adminSubject, "CALL dbms.addUserToRole('Henrik', '" + PUBLISHER + "')" );
-        //TODO: uncomment the next line and make the test pass
-        //testResult( subject, "CALL dbms.listRolesForUser('Henrik') YIELD value as roles RETURN roles",
-        //        r -> assertKeyIs( r, "roles", PUBLISHER ) );
+        S craigSubject = neo.login( "Craig", "foo" );
+        executeQuery( craigSubject, "CALL dbms.listRolesForUser('Craig') YIELD value as roles RETURN roles",
+                r -> assertKeyIs( r, "roles", PUBLISHER ) );
     }
 
     /*

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/AuthTestBase.java
@@ -35,6 +35,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -220,11 +221,28 @@ abstract class AuthTestBase<S>
         assertThat( err, containsString( partOfErrorMsg ) );
     }
 
+    void assertCallSuccess( S subject, String call )
+    {
+        String err = assertCallEmpty( subject, call );
+        assertThat( err, equalTo( "" ) );
+    }
+
+    void assertCallSuccess( S subject, String call, Consumer<ResourceIterator<Map<String, Object>>> resultConsumer )
+    {
+        String err = neo.executeQuery( subject, call, null, resultConsumer );
+        assertThat( err, equalTo( "" ) );
+    }
+
     String assertCallEmpty( S subject, String call )
     {
         return neo.executeQuery( subject, call, null,
                 ( res ) -> assertFalse( "Expected no results", res.hasNext()
             ) );
+    }
+
+    void testAuthenticated( S subject )
+    {
+        assertTrue( neo.isAuthenticated( subject ) );
     }
 
     void testUnAuthenticated( S subject )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/NeoShallowEmbeddedInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/NeoShallowEmbeddedInteraction.java
@@ -91,10 +91,12 @@ class NeoShallowEmbeddedInteraction implements NeoInteractionLevel<EnterpriseAut
         subject.logout();
     }
 
+    // To overcome that the Shiro subject caches it's authentication status.
+    // This assumes that zero authorization equals not being authenticated.
     @Override
     public boolean isAuthenticated( EnterpriseAuthSubject subject )
     {
-        return subject.getShiroSubject().isAuthenticated();
+        return subject.getShiroSubject().isAuthenticated() && subject.allowsReads();
     }
 
     @Override

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/NeoFullRESTInteraction.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/NeoFullRESTInteraction.java
@@ -122,7 +122,8 @@ public class NeoFullRESTInteraction extends CommunityServerTestBase implements N
     {
         subject.response = authenticate( subject.principalCredentials );
         return subject.response.status() == 200 || // OK
-                subject.response.status() == 403; // PASSWORD CHANGE REQUIRED
+                ( subject.response.status() == 403 &&
+                  subject.response.rawContent().contains( "password_change" ) );
     }
 
     @Override

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/NeoFullRESTProceduresIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/NeoFullRESTProceduresIT.java
@@ -19,11 +19,19 @@
  */
 package org.neo4j.server.rest.security;
 
+import org.junit.Rule;
+
 import org.neo4j.server.security.enterprise.auth.AuthProceduresTestLogic;
 import org.neo4j.server.security.enterprise.auth.NeoInteractionLevel;
+import org.neo4j.test.rule.SuppressOutput;
+
+import static org.neo4j.test.rule.SuppressOutput.suppressAll;
 
 public class NeoFullRESTProceduresIT extends AuthProceduresTestLogic<RESTSubject>
 {
+    @Rule
+    public SuppressOutput suppressOutput = suppressAll();
+
     public NeoFullRESTProceduresIT()
     {
         super();

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/NeoFullRESTScenariosIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/NeoFullRESTScenariosIT.java
@@ -19,11 +19,19 @@
  */
 package org.neo4j.server.rest.security;
 
+import org.junit.Rule;
+
 import org.neo4j.server.security.enterprise.auth.AuthScenariosLogic;
 import org.neo4j.server.security.enterprise.auth.NeoInteractionLevel;
+import org.neo4j.test.rule.SuppressOutput;
+
+import static org.neo4j.test.rule.SuppressOutput.suppressAll;
 
 public class NeoFullRESTScenariosIT extends AuthScenariosLogic<RESTSubject>
 {
+    @Rule
+    public SuppressOutput suppressOutput = suppressAll();
+
     public NeoFullRESTScenariosIT()
     {
         super();


### PR DESCRIPTION
Allows users to list their own roles even if they are not admin.
Checks that subject in authenticated when checking admin status.
changelog: Protects admins from deleting themselves, suspending themselves, or removing themselves from the admin role.
