### PR TITLE
Change so that TransientErrors are reported to user

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/MessageProcessingCallback.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/MessageProcessingCallback.java
@@ -23,10 +23,10 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-import org.neo4j.logging.Log;
 import org.neo4j.bolt.v1.messaging.MessageHandler;
 import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.runtime.internal.Neo4jError;
+import org.neo4j.logging.Log;
 
 public class MessageProcessingCallback<T> extends Session.Callback.Adapter<T,Void>
 {
@@ -34,7 +34,7 @@ public class MessageProcessingCallback<T> extends Session.Callback.Adapter<T,Voi
     public static void publishError( MessageHandler<IOException> out, Neo4jError error )
             throws IOException
     {
-        if ( error.status().code().classification().refersToLog() )
+        if ( !error.status().code().classification().shouldRespondToClient() )
         {
             // If not intended for client, we only return an error reference. This must
             // be cross-referenced with the log files for full error detail.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReporter.java
@@ -46,7 +46,7 @@ class ErrorReporter
 
     public void report( Neo4jError error )
     {
-        if ( error.status().code().classification().refersToLog() )
+        if ( error.status().code().classification().shouldLog() )
         {
             userLog.error( "Client triggered an unexpected error [%s]: %s. " +
                             "See debug.log for more details, reference %s.",

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/Neo4jErrorTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/Neo4jErrorTest.java
@@ -60,6 +60,6 @@ public class Neo4jErrorTest
         Neo4jError error = Neo4jError.from( new LoadExternalResourceException( "foo", null ) );
 
         // Then
-        assertThat( error.status().code().classification().refersToLog(), is( false ) );
+        assertThat( error.status().code().classification().shouldLog(), is( false ) );
     }
 }

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -557,7 +557,7 @@ public interface Status
                 "There are notifications about the request sent by the client." ),
 
         /** The database cannot service the request right now, retrying later might yield a successful outcome. */
-        TransientError( TransactionEffect.ROLLBACK, PublishingPolicy.REFERS_TO_LOG,
+        TransientError( TransactionEffect.ROLLBACK, PublishingPolicy.REPORTS_TO_CLIENT_AND_LOG,
                 "The database cannot service the request right now, retrying later might yield a successful outcome. "),
 
         // Implementation note: These are a sharp tool, database error signals
@@ -576,17 +576,32 @@ public interface Status
 
         private enum PublishingPolicy
         {
-            REPORTS_TO_CLIENT, REFERS_TO_LOG
+            REPORTS_TO_CLIENT( false ), REPORTS_TO_CLIENT_AND_LOG( true ), REFERS_TO_LOG( true );
+
+            private final boolean shouldLog;
+
+            PublishingPolicy( boolean shouldLog )
+            {
+                this.shouldLog = shouldLog;
+            }
+
+            boolean shouldLog()
+            {
+                return shouldLog;
+            }
+
         }
 
         private final boolean rollbackTransaction;
-        private final boolean refersToLog;
+        private final boolean shouldLog;
+        private final boolean respondToClient;
         private final String description;
 
         Classification( TransactionEffect transactionEffect, PublishingPolicy publishingPolicy, String description )
         {
             this.description = description;
-            this.refersToLog = publishingPolicy == PublishingPolicy.REFERS_TO_LOG;
+            this.shouldLog = publishingPolicy.shouldLog();
+            this.respondToClient = publishingPolicy != PublishingPolicy.REFERS_TO_LOG;
             this.rollbackTransaction = transactionEffect == TransactionEffect.ROLLBACK;
         }
 
@@ -595,9 +610,14 @@ public interface Status
             return rollbackTransaction;
         }
 
-        public boolean refersToLog()
+        public boolean shouldLog()
         {
-            return refersToLog;
+            return shouldLog;
+        }
+
+        public boolean shouldRespondToClient()
+        {
+            return respondToClient;
         }
 
         public String description()


### PR DESCRIPTION
Changing the classification means that the error will be returned to
the user and allow them to have retry the call.
