### PR TITLE
Backport "Lower the limit when aborting CNF normalisation of queries"

### DIFF
--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/CNFNormalizer.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/ast/rewriters/CNFNormalizer.scala
@@ -58,7 +58,7 @@ case class deMorganRewriter()(implicit monitor: AstRewritingMonitor) extends Rew
 object distributeLawsRewriter {
   // converting from DNF to CNF is exponentially expensive, so we only do it for a small amount of clauses
   // see https://en.wikipedia.org/wiki/Conjunctive_normal_form#Conversion_into_CNF
-  val DNF_CONVERSION_LIMIT = 16
+  val DNF_CONVERSION_LIMIT = 8
 }
 
 case class distributeLawsRewriter()(implicit monitor: AstRewritingMonitor) extends Rewriter {


### PR DESCRIPTION
This is a backport of 22d544ba143121645905f1f4816f02910f517009, forward merges
should be done as null merges.
