### PR TITLE
Got rid of compiler warning

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/predicates/Equivalent.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/predicates/Equivalent.scala
@@ -123,7 +123,7 @@ object Equivalent {
     if (it.isEmpty) return (e1, e2, e3)
 
     it.foldLeft(ArrayBuffer(e1, e2, e3)) {
-      case (acc, element: T) => acc += eager(element)
+      case (acc, element) => acc += eager(element)
     }
   }
 }


### PR DESCRIPTION
Matching on an erased type serves no purpose and generates compiler warnings.
