### PR TITLE
Only session worker thread is allowed to write to outbound channel

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/TransportBridge.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/msgprocess/TransportBridge.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.neo4j.bolt.v1.messaging.MessageHandler;
 import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.runtime.StatementMetadata;
+import org.neo4j.bolt.v1.runtime.internal.Neo4jError;
 import org.neo4j.bolt.v1.runtime.spi.RecordStream;
 import org.neo4j.logging.Log;
 
@@ -89,5 +90,10 @@ public class TransportBridge extends MessageHandler.Adapter<RuntimeException>
     public void handleAckFailureMessage() throws RuntimeException
     {
         session.ackFailure( null, simpleCallback );
+    }
+
+    public void handleFatalError( Neo4jError from )
+    {
+        session.externalError( from, null, simpleCallback );
     }
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredSessions.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredSessions.java
@@ -118,6 +118,13 @@ public class MonitoredSessions implements Sessions
         }
 
         @Override
+        public <A> void externalError( Neo4jError error, A attachment, Callback<Void,A> callback )
+        {
+            monitor.messageReceived();
+            delegate.externalError( error, attachment, withMonitor( callback ) );
+        }
+
+        @Override
         public <A> void ackFailure( A attachment, Callback<Void,A> callback )
         {
             monitor.messageReceived();

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Session.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/Session.java
@@ -183,6 +183,18 @@ public interface Session extends AutoCloseable
     <A> void reset( A attachment, Callback<Void,A> callback );
 
     /**
+     * Signals that the infrastructure around the session has failed in some non-recoverable way; it will
+     * not be able to deliver more messages to the session. This is meant to allow the session to signal
+     * back out any final message it wants delivered.
+     *
+     * Note that this does not close the session; close can be expected to be called immediately after
+     * this call.
+     *
+     * @param error cause of the fatal error
+     */
+    <A> void externalError( Neo4jError error, A attachment, Callback<Void,A> callback  );
+
+    /**
      * This is a special mechanism, it is the only method on this interface
      * that is thread safe. When this is invoked, the machine will make attempts
      * at interrupting any currently running action,

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReportingSession.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/ErrorReportingSession.java
@@ -97,6 +97,12 @@ public class ErrorReportingSession implements Session
     }
 
     @Override
+    public <A> void externalError( Neo4jError error, A attachment, Callback<Void,A> callback )
+    {
+        reportError( attachment, callback );
+    }
+
+    @Override
     public void interrupt()
     {
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/SessionStateMachine.java
@@ -761,6 +761,18 @@ public class SessionStateMachine implements Session, SessionState
     }
 
     @Override
+    public <A> void externalError( Neo4jError error, A attachment, Callback<Void,A> callback )
+    {
+        before( attachment, callback );
+        try
+        {
+            state = state.error( this, error );
+        }
+        finally { after(); }
+
+    }
+
+    @Override
     public <A> void reset( A attachment, Callback<Void,A> callback )
     {
         before( attachment, callback );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/concurrent/SessionWorkerFacade.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/concurrent/SessionWorkerFacade.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 
 import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.runtime.StatementMetadata;
+import org.neo4j.bolt.v1.runtime.internal.Neo4jError;
 import org.neo4j.bolt.v1.runtime.spi.RecordStream;
 
 /**
@@ -91,6 +92,13 @@ public class SessionWorkerFacade implements Session
     public <A> void ackFailure( A attachment, Callback<Void,A> callback )
     {
         queue( session -> session.ackFailure( attachment, callback ) );
+    }
+
+
+    @Override
+    public <A> void externalError( Neo4jError error, A attachment, Callback<Void,A> callback )
+    {
+        queue( session -> session.externalError( error, attachment, callback ) );
     }
 
     @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/BoltProtocolV1.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/BoltProtocolV1.java
@@ -20,7 +20,6 @@
 package org.neo4j.bolt.v1.transport;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.io.IOException;
@@ -28,19 +27,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.bolt.transport.BoltProtocol;
 import org.neo4j.bolt.v1.messaging.MessageFormat;
-import org.neo4j.bolt.v1.messaging.Neo4jPack;
 import org.neo4j.bolt.v1.messaging.PackStreamMessageFormatV1;
 import org.neo4j.bolt.v1.messaging.msgprocess.TransportBridge;
 import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.runtime.internal.Neo4jError;
 import org.neo4j.kernel.impl.logging.LogService;
-import org.neo4j.logging.Log;
-
-import static java.lang.String.format;
-import static org.neo4j.bolt.v1.messaging.msgprocess.MessageProcessingCallback.publishError;
 
 /**
- * Implements version one of the Neo4j protocol when transported over a socket. This means this class will handle a
+ * Implements version one of the Bolt Protocol when transported over a socket. This means this class will handle a
  * simple message framing protocol and forward messages to the messaging protocol implementation, version 1.
  * <p/>
  * Versions of the framing protocol are lock-step with the messaging protocol versioning.
@@ -48,27 +42,24 @@ import static org.neo4j.bolt.v1.messaging.msgprocess.MessageProcessingCallback.p
 public class BoltProtocolV1 implements BoltProtocol
 {
     public static final int VERSION = 1;
-    public static final int DEFAULT_BUFFER_SIZE = 8192;
-
-    private final ChunkedOutput output;
     private final MessageFormat.Writer packer;
     private final BoltV1Dechunker dechunker;
 
     private final Session session;
 
-    private final Log log;
     private final AtomicInteger inFlight = new AtomicInteger( 0 );
+    private final TransportBridge bridge;
 
-    public BoltProtocolV1( final LogService logging, Session session, Channel channel)
+    public BoltProtocolV1( final LogService logging, Session session, PackStreamMessageFormatV1.Writer output )
     {
-        this.log = logging.getInternalLog( getClass() );
+        // TODO; this part of the Bolt server side is rather messy - notably, the MessageHandler, Session and Session.Callback interfaces all
+        //       should reasonably be able to be refactored into something much less complicated.
+        //       Likewise the tracking of when to flush the outbound channel - if we moved that logic to ThreadedSessions, a lot of the complexity
+        //       below could likely be undone.
         this.session = session;
-        this.output = new ChunkedOutput( channel, DEFAULT_BUFFER_SIZE );
-        this.packer = new PackStreamMessageFormatV1.Writer( new Neo4jPack.Packer( output ), output );
-        this.dechunker = new BoltV1Dechunker(
-            new TransportBridge( log, session, packer, this::onMessageDone) ,
-            this::onMessageStarted
-        );
+        this.packer = output;
+        this.bridge = new TransportBridge( logging.getInternalLog( getClass() ), session, packer, this::onMessageDone );
+        this.dechunker = new BoltV1Dechunker( bridge, this::onMessageStarted );
     }
 
     /**
@@ -86,7 +77,8 @@ public class BoltProtocolV1 implements BoltProtocol
         }
         catch ( Throwable e )
         {
-            handleUnexpectedError( channelContext, e );
+            bridge.handleFatalError( Neo4jError.from( e ) );
+            close();
         }
         finally
         {
@@ -105,34 +97,6 @@ public class BoltProtocolV1 implements BoltProtocol
     {
         dechunker.close();
         session.close();
-        output.close();
-    }
-
-    private void handleUnexpectedError( ChannelHandlerContext channelContext, Throwable e )
-    {
-        try
-        {
-            try
-            {
-                // TODO: This is dangerousish, since the worker thread may be writing to the packer at the same time. Better have an approach where we can
-                // signal to the worker that we are shutting it down because of this error, and it can signal to the client.
-                publishError( packer, Neo4jError.from( e ) );
-                packer.flush();
-            }
-            catch ( Throwable e1 )
-            {
-                log.error( format( "Session %s: Secondary error while notifying client of problem: %s",
-                        session.key(), e.getMessage() ), e );
-            }
-            finally
-            {
-                channelContext.close();
-            }
-        }
-        finally
-        {
-            close();
-        }
     }
 
     /*
@@ -145,6 +109,9 @@ public class BoltProtocolV1 implements BoltProtocol
         inFlight.incrementAndGet();
     }
 
+    // Note: This will get called from another thread; specifically, while most of the code in this class runs in an IO Thread, this method gets
+    //       called from a the session worker thread. This smells bad, and can likely be resolved by moving this whole "when to flush" logic to something
+    //       that hooks into ThreadedSessions somehow, since that class has a lot of knowledge about when there are no pending requests.
     private void onMessageDone()
     {
         // If this is the last in-flight message, and we're not in the middle of reading another message over the wire

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredSessionsTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredSessionsTest.java
@@ -27,6 +27,7 @@ import java.time.ZoneId;
 import java.util.Map;
 
 import org.neo4j.bolt.v1.runtime.MonitoredSessions.MonitoredSession;
+import org.neo4j.bolt.v1.runtime.internal.Neo4jError;
 import org.neo4j.bolt.v1.runtime.spi.RecordStream;
 import org.neo4j.kernel.monitoring.Monitors;
 
@@ -168,6 +169,12 @@ public class MonitoredSessionsTest
         public <A> void reset( A attachment, Callback<Void,A> callback )
         {
             this.callback = callback;
+        }
+
+        @Override
+        public <A> void externalError( Neo4jError error, A attachment, Callback<Void,A> callback )
+        {
+
         }
 
         @Override

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/BoltProtocolV1Test.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/BoltProtocolV1Test.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.transport;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.bolt.v1.messaging.PackStreamMessageFormatV1;
+import org.neo4j.bolt.v1.runtime.Session;
+import org.neo4j.kernel.impl.logging.NullLogService;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class BoltProtocolV1Test
+{
+    @Test
+    public void shouldNotTalkToChannelDirectlyOnFatalError() throws Throwable
+    {
+        // Given
+        PackStreamMessageFormatV1.Writer output = mock( PackStreamMessageFormatV1.Writer.class );
+        Session session = mock( Session.class );
+        BoltProtocolV1 protocol = new BoltProtocolV1( NullLogService.getInstance(), session, output );
+
+        // And given inbound data that'll explode when the protocol tries to interpret it
+        ByteBuf bomb = mock(ByteBuf.class);
+        doThrow( IOException.class ).when( bomb ).readableBytes();
+
+        // When
+        protocol.handle( mock(ChannelHandlerContext.class), bomb );
+
+        // Then the protocol should not mess with the channel (because it runs on the IO thread, and only the worker thread should produce writes)
+        verifyNoMoreInteractions( output );
+
+        // But instead signal to the session that shit hit the fan.
+        verify( session ).externalError( any(), any(), any() );
+        verify( session ).close();
+    }
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
@@ -36,6 +36,7 @@ import org.neo4j.bolt.v1.messaging.message.Message;
 import org.neo4j.bolt.v1.packstream.BufferedChannelOutput;
 import org.neo4j.bolt.v1.runtime.Session;
 import org.neo4j.bolt.v1.transport.BoltProtocolV1;
+import org.neo4j.bolt.v1.transport.ChunkedOutput;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.util.HexPrinter;
 
@@ -115,7 +116,9 @@ public class FragmentedMessageDeliveryTest
         ChannelHandlerContext ctx = mock( ChannelHandlerContext.class );
         when(ctx.channel()).thenReturn( ch );
 
-        BoltProtocolV1 protocol = new BoltProtocolV1( NullLogService.getInstance(), sess, ch );
+        ChunkedOutput output = new ChunkedOutput( ch, 8192 );
+        BoltProtocolV1 protocol = new BoltProtocolV1( NullLogService.getInstance(), sess,
+                new PackStreamMessageFormatV1.Writer( new Neo4jPack.Packer( output ), output ) );
 
         // When data arrives split up according to the current permutation
         for ( ByteBuf fragment : fragments )


### PR DESCRIPTION
Bolt can be seen as implemented in two layers - one syntactic layer dealing
with protocol format, chunking, message fragmentation and all that, and one
semantic layer dealing with what the abstract messages in Bolt mean.

This is implemented as two separate layers of threads as well - one set
of threads deal with IO, IO Threads, and another set of threads
deal with executing the semantic work, Session Worker Threads.

The model is that all traffic moves through the same pipeline:

```
(IO Thread) -[queue]-> (Worker Thread) -[queue]-> (IO Thread)
```

Meaning; there's no way for the IO Thread that receives inbound data
to immediately respond back on its own; it can _only_ forward messages to
the Worker Thread, which then acts on them and produces outbound messages
for the IO layer again.

The problem this commit solves was a violation of this, where an IO Thread
would write directly back to the client in the case of a fatal error
while processing a request. This caused illegal states to occur, because the
worker thread could very likely be telling the IO Layer to write something
else at the same time.

This resolves the violation by introducing a special "externalError" signal
that the IO layer can send, which basically is just a roundabout way of
sending an error back to the client.

Overall, the area of code that this touches - MessageHandler, Session,
Callback and TransportBridge - are a set of interfaces that are very hard
to find how they interact. The design is the result of an original approach
that did not quite fit and under-refactoring as we learned that.

Hence; I'd love to refactor this further, but for now, this resolves the
immediate issue and removes the only violation we had of this message flow
approach.
