### PR TITLE
Authorization through LDAP group to role mapping

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthManagerFactory.java
@@ -71,7 +71,7 @@ public class EnterpriseAuthManagerFactory extends AuthManager.Factory
         if ( config.get( SecuritySettings.ldap_authentication_enabled ) ||
              config.get( SecuritySettings.ldap_authorization_enabled ) )
         {
-            realms.add( new LdapRealm( config ) );
+            realms.add( new LdapRealm( config, logProvider ) );
         }
 
         if ( config.get( SecuritySettings.plugin_authentication_enabled ) ||

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthSubject.java
@@ -111,7 +111,15 @@ public class EnterpriseAuthSubject implements AuthSubject
     @Override
     public String name()
     {
-        return shiroSubject.getPrincipal().toString();
+        Object principal = shiroSubject.getPrincipal();
+        if ( principal != null )
+        {
+            return principal.toString();
+        }
+        else
+        {
+            return "<missing_principal>";
+        }
     }
 
     ShiroSubject getShiroSubject()

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecuritySettings.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.server.security.enterprise.auth;
 
+import java.util.List;
+
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.Description;
 import org.neo4j.helpers.HostnamePort;
@@ -27,6 +29,7 @@ import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.HOSTNAME_PORT;
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
 import static org.neo4j.kernel.configuration.Settings.STRING;
+import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
@@ -115,10 +118,10 @@ public class SecuritySettings
     public static Setting<String> ldap_authorization_user_search_filter =
             setting( "dbms.security.realms.ldap.authorization.user_search_filter", STRING, "(&(objectClass=*)(uid={0})" );
 
-    @Description( "The name of an attribute on a user object that contains groups to be used for mapping to roles " +
+    @Description( "A list of attribute names on a user object that contains groups to be used for mapping to roles " +
                   "when LDAP authorization is enabled." )
-    public static Setting<String> ldap_authorization_group_membership_attribute_name =
-            setting( "dbms.security.realms.ldap.authorization.group_membership_attribute", STRING, "memberOf" );
+    public static Setting<List<String>> ldap_authorization_group_membership_attribute_names =
+            setting( "dbms.security.realms.ldap.authorization.group_membership_attributes", STRING_LIST, "memberOf" );
 
     @Description( "An authorization mapping from LDAP group names to internal role names. " +
                   "The map should be formatted as semicolon separated list of key-value pairs, where the " +

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/SecuritySettings.java
@@ -65,23 +65,65 @@ public class SecuritySettings
     public static final Setting<HostnamePort> ldap_server =
             setting( "dbms.security.realms.ldap.host", HOSTNAME_PORT, "0.0.0.0:389" );
 
-    @Description( "Authentication mechanism." )
+    @Description( "LDAP authentication mechanism. This is one of `simple` or `sasl`, where `simple` is basic username" +
+                  " and password authentication and `sasl` is used for more advanced mechanisms. See RFC 2251 LDAPv3 " +
+                  "documentation for more details." )
     public static final Setting<String> ldap_auth_mechanism =
             setting( "dbms.security.realms.ldap.auth_mechanism", STRING, "simple" );
 
-    @Description( "Referral" )
+    @Description(
+            "The LDAP referral behavior when creating a connection. This is one of `follow`, `ignore` or `throw`.\n" +
+            "* `follow` automatically follows any referrals\n" +
+            "* `ignore` ignores any referrals\n" +
+            "* `throw` throws a `javax.naming.ReferralException` exception\n" )
     public static final Setting<String> ldap_referral =
             setting( "dbms.security.realms.ldap.referral", STRING, "follow" );
 
-    @Description( "User DN template." )
+    @Description(
+            "LDAP user DN template. An LDAP object is referenced by its distinguished name (DN), and a user DN is " +
+            "an LDAP fully-qualified unique user identifier. This setting is used to generate an LDAP DN that " +
+            "conforms with the LDAP directory's schema from the user principal that is submitted with the " +
+            "authentication token when logging in. The special token {0} is a " +
+            "placeholder where the user principal will be substituted into the DN string." )
     public static final Setting<String> ldap_user_dn_template =
             setting( "dbms.security.realms.ldap.user_dn_template", STRING, "uid={0},ou=users,dc=example,dc=com" );
 
-    @Description( "System username" )
+    @Description( "Perform LDAP search for authorization info using a system account." )
+    public static final Setting<Boolean> ldap_authorization_use_system_account =
+            setting( "dbms.security.realms.ldap.authorization.use_system_account", BOOLEAN, "false" );
+
+    @Description(
+            "An LDAP system account username to use for authorization searches when " +
+            "`dbms.security.realms.ldap.authorization.use_system_account` is `true`." )
     public static final Setting<String> ldap_system_username =
             setting( "dbms.security.realms.ldap.system_username", STRING, NO_DEFAULT );
 
-    @Description( "System password" )
+    @Description(
+            "An LDAP system account password to use for authorization searches when " +
+            "`dbms.security.realms.ldap.authorization.use_system_account` is `true`." )
     public static final Setting<String> ldap_system_password =
             setting( "dbms.security.realms.ldap.system_password", STRING, NO_DEFAULT );
+
+    @Description( "The name of the base object or named context to search for user objects when LDAP authorization is " +
+                  "enabled." )
+    public static Setting<String> ldap_authorization_user_search_base =
+            setting( "dbms.security.realms.ldap.authorization.user_search_base", STRING, NO_DEFAULT );
+
+    @Description( "The LDAP search filter to search for a user principal when LDAP authorization is " +
+                  "enabled. The filter should contain the placeholder token {0} which will be substituted for the " +
+                  "user principal." )
+    public static Setting<String> ldap_authorization_user_search_filter =
+            setting( "dbms.security.realms.ldap.authorization.user_search_filter", STRING, "(&(objectClass=*)(uid={0})" );
+
+    @Description( "The name of an attribute on a user object that contains groups to be used for mapping to roles " +
+                  "when LDAP authorization is enabled." )
+    public static Setting<String> ldap_authorization_group_membership_attribute_name =
+            setting( "dbms.security.realms.ldap.authorization.group_membership_attribute", STRING, "memberOf" );
+
+    @Description( "An authorization mapping from LDAP group names to internal role names. " +
+                  "The map should be formatted as semicolon separated list of key-value pairs, where the " +
+                  "key is the LDAP group name and the value is a comma separated list of corresponding role names. " +
+                  "E.g. group1=role1;group2=role2;group3=role3,role4,role5" )
+    public static Setting<String> ldap_authorization_group_to_role_mapping =
+            setting( "dbms.security.realms.ldap.authorization.group_to_role_mapping", STRING, NO_DEFAULT );
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth;
+
+import org.apache.shiro.realm.ldap.LdapContextFactory;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.LdapContext;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LdapRealmTest
+{
+    Config config = mock( Config.class );
+    LogProvider logProvider = NullLogProvider.getInstance();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void groupToRoleMappingShouldBeAbleToBeNull()
+    {
+        when( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) ).thenReturn( null );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+    }
+
+    @Test
+    public void groupToRoleMappingShouldBeAbleToBeEmpty()
+    {
+        when( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) ).thenReturn( "" );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+    }
+
+    @Test
+    public void groupToRoleMappingShouldBeAbleToHaveMultipleRoles()
+    {
+        when( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) )
+                .thenReturn( "group=role1,role2,role3" );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+
+        assertThat( realm.getGroupToRoleMapping().get( "group" ),
+                equalTo( Arrays.asList( "role1", "role2", "role3" ) ) );
+        assertThat( realm.getGroupToRoleMapping().size(), equalTo( 1 ) );
+    }
+
+    @Test
+    public void groupToRoleMappingShouldBeAbleToHaveMultipleGroups()
+    {
+        when( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) )
+                .thenReturn( "group1=role1;group2=role2,role3;group3=role4" );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+
+        assertThat( realm.getGroupToRoleMapping().keySet(),
+                equalTo( new TreeSet<>( Arrays.asList( "group1", "group2", "group3" ) ) ) );
+        assertThat( realm.getGroupToRoleMapping().get( "group1" ), equalTo( Arrays.asList( "role1" ) ) );
+        assertThat( realm.getGroupToRoleMapping().get( "group2" ), equalTo( Arrays.asList( "role2", "role3" ) ) );
+        assertThat( realm.getGroupToRoleMapping().get( "group3" ), equalTo( Arrays.asList( "role4" ) ) );
+        assertThat( realm.getGroupToRoleMapping().size(), equalTo( 3 ) );
+    }
+
+    @Test
+    public void groupToRoleMappingShouldBeAbleToHaveTrailingSemicolons()
+    {
+        when( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) ).thenReturn( "group=role;;" );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+
+        assertThat( realm.getGroupToRoleMapping().get( "group" ), equalTo( Collections.singletonList( "role" ) ) );
+        assertThat( realm.getGroupToRoleMapping().size(), equalTo( 1 ) );
+    }
+
+    @Test
+    public void groupToRoleMappingShouldBeAbleToHaveTrailingCommas()
+    {
+        when( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) )
+                .thenReturn( "group=role1,role2,role3,,," );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+
+        assertThat( realm.getGroupToRoleMapping().keySet(),
+                equalTo( Stream.of( "group" ).collect( Collectors.toSet() ) ) );
+        assertThat( realm.getGroupToRoleMapping().get( "group" ),
+                equalTo( Arrays.asList( "role1", "role2", "role3" ) ) );
+        assertThat( realm.getGroupToRoleMapping().size(), equalTo( 1 ) );
+    }
+
+    @Test
+    public void groupToRoleMappingShouldBeAbleToHaveNoRoles()
+    {
+        when( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) ).thenReturn( "group=," );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+
+        assertThat( realm.getGroupToRoleMapping().get( "group" ).size(), equalTo( 0 ) );
+        assertThat( realm.getGroupToRoleMapping().size(), equalTo( 1 ) );
+    }
+
+    @Test
+    public void groupToRoleMappingShouldNotBeAbleToHaveInvalidFormat()
+    {
+        when( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) ).thenReturn( "group" );
+
+        expectedException.expect( IllegalArgumentException.class );
+        expectedException.expectMessage( "wrong number of fields" );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+    }
+
+    @Test
+    public void groupToRoleMappingShouldNotBeAbleToHaveEmptyGroupName()
+    {
+        when( config.get( SecuritySettings.ldap_authorization_group_to_role_mapping ) ).thenReturn( "=role" );
+
+        expectedException.expect( IllegalArgumentException.class );
+        expectedException.expectMessage( "empty group name" );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+    }
+
+    @Test
+    public void shouldWarnAboutUserSearchFilterWithoutArgument() throws NamingException
+    {
+        when( config.get( SecuritySettings.ldap_authorization_user_search_filter ) ).thenReturn( "" );
+
+        LogProvider logProvider = mock( LogProvider.class );
+        Log log = mock( Log.class );
+        LdapContext ldapContext = mock( LdapContext.class );
+        NamingEnumeration result = mock( NamingEnumeration.class );
+        when( logProvider.getLog( LdapRealm.class ) ).thenReturn( log );
+        when( ldapContext.search( anyString(), anyString(), anyObject(), anyObject() ) ).thenReturn( result );
+        when( result.hasMoreElements() ).thenReturn( false );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+        realm.findRoleNamesForUser( "username", ldapContext );
+
+        verify( log ).warn( contains( "LDAP user search filter does not contain the argument placeholder {0}" ) );
+    }
+
+    @Test
+    public void shouldWarnAboutAmbiguousUserSearch() throws NamingException
+    {
+        when( config.get( SecuritySettings.ldap_authorization_user_search_filter ) ).thenReturn( "{0}" );
+
+        LogProvider logProvider = mock( LogProvider.class );
+        Log log = mock( Log.class );
+        LdapContext ldapContext = mock( LdapContext.class );
+        NamingEnumeration result = mock( NamingEnumeration.class );
+        SearchResult searchResult = mock( SearchResult.class );
+        when( logProvider.getLog( LdapRealm.class ) ).thenReturn( log );
+        when( ldapContext.search( anyString(), anyString(), anyObject(), anyObject() ) ).thenReturn( result );
+        when( result.hasMoreElements() ).thenReturn( true );
+        when( result.next() ).thenReturn( searchResult );
+        when( searchResult.toString() ).thenReturn( "<ldap search result>" );
+
+        LdapRealm realm = new LdapRealm( config, logProvider );
+        realm.findRoleNamesForUser( "username", ldapContext );
+
+        verify( log ).warn( contains( "LDAP user search for user principal 'username' is ambiguous" ) );
+    }
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/EnterpriseAuthenticationIT.java
@@ -25,7 +25,6 @@ import java.util.function.Consumer;
 import org.neo4j.bolt.v1.transport.integration.AuthenticationIT;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.server.security.enterprise.auth.SecuritySettings;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthenticationIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthenticationIT.java
@@ -107,7 +107,7 @@ public class LdapAuthenticationIT extends AbstractLdapTestUnit
             settings.put( SecuritySettings.ldap_authorization_use_system_account, "true" );
             settings.put( SecuritySettings.ldap_authorization_user_search_base, "dc=example,dc=com" );
             settings.put( SecuritySettings.ldap_authorization_user_search_filter, "(&(objectClass=*)(uid={0}))" );
-            settings.put( SecuritySettings.ldap_authorization_group_membership_attribute_name, "gidnumber" );
+            settings.put( SecuritySettings.ldap_authorization_group_membership_attribute_names, "gidnumber" );
             settings.put( SecuritySettings.ldap_authorization_group_to_role_mapping, "500=reader;501=publisher;502=architect;503=admin" );
         };
     }
@@ -138,12 +138,7 @@ public class LdapAuthenticationIT extends AbstractLdapTestUnit
     @ApplyLdifFiles( "ldap_test_data.ldif" )
     public void shouldBeAbleToLoginAndAuthorizeReaderWithLdapOnly() throws Throwable
     {
-        restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.internal_authentication_enabled, "false" );
-            settings.put( SecuritySettings.internal_authorization_enabled, "false" );
-            settings.put( SecuritySettings.ldap_authentication_enabled, "true" );
-            settings.put( SecuritySettings.ldap_authorization_enabled, "true" );
-        } );
+        restartNeo4jServerWithOverriddenSettings( ldapOnlyAuthSettings );
 
         testAuthWithReaderUser();
     }
@@ -152,12 +147,7 @@ public class LdapAuthenticationIT extends AbstractLdapTestUnit
     @ApplyLdifFiles( "ldap_test_data.ldif" )
     public void shouldBeAbleToLoginAndAuthorizePublisherWithLdapOnly() throws Throwable
     {
-        restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.internal_authentication_enabled, "false" );
-            settings.put( SecuritySettings.internal_authorization_enabled, "false" );
-            settings.put( SecuritySettings.ldap_authentication_enabled, "true" );
-            settings.put( SecuritySettings.ldap_authorization_enabled, "true" );
-        } );
+        restartNeo4jServerWithOverriddenSettings( ldapOnlyAuthSettings );
 
         testAuthWithPublisherUser();
     }
@@ -166,12 +156,7 @@ public class LdapAuthenticationIT extends AbstractLdapTestUnit
     @ApplyLdifFiles( "ldap_test_data.ldif" )
     public void shouldBeAbleToLoginAndAuthorizeNoPermissionUserWithLdapOnly() throws Throwable
     {
-        restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.internal_authentication_enabled, "false" );
-            settings.put( SecuritySettings.internal_authorization_enabled, "false" );
-            settings.put( SecuritySettings.ldap_authentication_enabled, "true" );
-            settings.put( SecuritySettings.ldap_authorization_enabled, "true" );
-        } );
+        restartNeo4jServerWithOverriddenSettings( ldapOnlyAuthSettings );
 
         testAuthWithNoPermissionUser( "smith" );
     }
@@ -180,13 +165,9 @@ public class LdapAuthenticationIT extends AbstractLdapTestUnit
     @ApplyLdifFiles( "ldap_test_data.ldif" )
     public void shouldBeAbleToLoginAndAuthorizeNoPermissionUserWithLdapOnlyAndNoGroupToRoleMapping() throws Throwable
     {
-        restartNeo4jServerWithOverriddenSettings( settings -> {
-            settings.put( SecuritySettings.internal_authentication_enabled, "false" );
-            settings.put( SecuritySettings.internal_authorization_enabled, "false" );
-            settings.put( SecuritySettings.ldap_authentication_enabled, "true" );
-            settings.put( SecuritySettings.ldap_authorization_enabled, "true" );
+        restartNeo4jServerWithOverriddenSettings( ldapOnlyAuthSettings.andThen( settings -> {
             settings.put( SecuritySettings.ldap_authorization_group_to_role_mapping, null );
-        } );
+        } ) );
 
         // User 'neo' has reader role by default, but since we are not passing a group-to-role mapping
         // he should get no permissions

--- a/enterprise/security/src/test/resources/ldap_test_data.ldif
+++ b/enterprise/security/src/test/resources/ldap_test_data.ldif
@@ -72,16 +72,16 @@ objectclass: organizationalUnit
 objectclass: top
 ou: users
 
-# Entry 10: cn=morpheus,ou=users,dc=example,dc=com
-dn: cn=morpheus,ou=users,dc=example,dc=com
-cn:  morpheus
+# Entry 10: cn=neo4j,ou=users,dc=example,dc=com
+dn: cn=neo4j,ou=users,dc=example,dc=com
+cn:  neo4j
 gidnumber: 503
-homedirectory: /home/users/morpheus
+homedirectory: /home/users/neo4j
 objectclass: inetOrgPerson
 objectclass: posixAccount
 objectclass: top
-sn: morpheus
-uid: morpheus
+sn: neo4j
+uid: neo4j
 uidnumber: 1003
 userpassword: {MD5}6ZoYxCjLONXyYIU2eJIuAw==
 


### PR DESCRIPTION
Adds settings for configuring an LDAP search for a user's group memberships.
The result will be mapped to internal roles with a static configuration
setting map.
- Add some more documentation of SecuritySettings
- Make it possible to restart the Neo4jWithSocket test database with
  overridden settings from individual tests

Currently only supports LDAP search using configured system account.
