### PR TITLE
Fixing bug in restore for core-edge cluster

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
@@ -46,13 +46,7 @@ public class RestoreDatabaseCommand
         this.fromPath = fromPath;
         this.databaseName = databaseName;
         this.forceOverwrite = forceOverwrite;
-        this.databaseDir = configWith( config, databaseName ).get( database_path ).getAbsoluteFile();
-
-    }
-
-    public static Config configWith( Config config, String databaseName )
-    {
-        return config.with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) );
+        this.databaseDir = config.get( database_path ).getAbsoluteFile();
     }
 
     public void execute() throws IOException

--- a/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandTest.java
@@ -38,6 +38,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
 public class RestoreDatabaseCommandTest
 {
     @Rule
@@ -49,7 +51,7 @@ public class RestoreDatabaseCommandTest
         // given
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         String databaseName = "to";
-        Config config = RestoreDatabaseCommand.configWith(  Config.empty(), databaseName);
+        Config config = configWith(  Config.empty(), databaseName);
 
         File fromPath = new File( directory.absolutePath(), "from" );
         File toPath = config.get( DatabaseManagementSystemSettings.database_path );
@@ -78,7 +80,7 @@ public class RestoreDatabaseCommandTest
         // given
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         String databaseName = "to";
-        Config config = RestoreDatabaseCommand.configWith(  Config.empty(), databaseName);
+        Config config = configWith(  Config.empty(), databaseName);
 
         File fromPath = new File( directory.absolutePath(), "from" );
         File toPath = config.get( DatabaseManagementSystemSettings.database_path );
@@ -106,7 +108,7 @@ public class RestoreDatabaseCommandTest
         // given
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         String databaseName = "to";
-        Config config = RestoreDatabaseCommand.configWith(  Config.empty(), databaseName);
+        Config config = configWith(  Config.empty(), databaseName);
 
         File fromPath = new File( directory.absolutePath(), "from" );
         File toPath = config.get( DatabaseManagementSystemSettings.database_path );
@@ -128,6 +130,11 @@ public class RestoreDatabaseCommandTest
         }
 
         copiedDb.shutdown();
+    }
+
+    public static Config configWith( Config config, String databaseName )
+    {
+        return config.with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) );
     }
 
     private void createDbAt( File fromPath, int nodesToCreate )

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertClassicStoreToCoreCommand.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertClassicStoreToCoreCommand.java
@@ -86,11 +86,11 @@ import static org.neo4j.kernel.impl.store.id.IdType.RELATIONSHIP_TYPE_TOKEN_NAME
 import static org.neo4j.kernel.impl.store.id.IdType.SCHEMA;
 import static org.neo4j.kernel.impl.store.id.IdType.STRING_BLOCK;
 
-public class ConvertClassicStoreCommand
+public class ConvertClassicStoreToCoreCommand
 {
     private final ConversionVerifier conversionVerifier;
 
-    public ConvertClassicStoreCommand( ConversionVerifier conversionVerifier )
+    public ConvertClassicStoreToCoreCommand( ConversionVerifier conversionVerifier )
     {
         this.conversionVerifier = conversionVerifier;
     }
@@ -123,7 +123,7 @@ public class ConvertClassicStoreCommand
         }
     }
 
-    private ClusterSeed changeStoreId( File storeDir, ClusterSeed conversionId ) throws IOException
+    public static ClusterSeed changeStoreId( File storeDir, ClusterSeed conversionId ) throws IOException
     {
         FileSystemAbstraction fs = new DefaultFileSystemAbstraction();
         File metadataStore = new File( storeDir, MetaDataStore.DEFAULT_NAME );
@@ -141,7 +141,7 @@ public class ConvertClassicStoreCommand
         }
     }
 
-    private StoreId readStoreId( File metadataStore, PageCache pageCache ) throws IOException
+    public static StoreId readStoreId( File metadataStore, PageCache pageCache ) throws IOException
     {
         long creationTime = MetaDataStore.getRecord( pageCache, metadataStore, TIME );
         long randomNumber = MetaDataStore.getRecord( pageCache, metadataStore, RANDOM_NUMBER );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertNonCoreEdgeStoreCli.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/convert/ConvertNonCoreEdgeStoreCli.java
@@ -54,7 +54,7 @@ public class ConvertNonCoreEdgeStoreCli
 
         Config config = createConfig( homeDir, databaseName, configPath );
 
-        new ConvertClassicStoreCommand( new ConversionVerifier() ).convert(
+        new ConvertClassicStoreToCoreCommand( new ConversionVerifier() ).convert(
                 config.get( DatabaseManagementSystemSettings.database_path ),
                 config.get( GraphDatabaseSettings.record_format ),
                 clusterSeed );

--- a/enterprise/core-edge/src/main/java/org/neo4j/restore/RestoreExistingClusterCli.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/restore/RestoreExistingClusterCli.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.neo4j.coreedge.convert.ConversionVerifier;
-import org.neo4j.coreedge.convert.ConvertClassicStoreCommand;
+import org.neo4j.coreedge.convert.ConvertClassicStoreToCoreCommand;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
@@ -42,6 +42,7 @@ import org.neo4j.server.configuration.ConfigLoader;
 
 import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.record_format;
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
 public class RestoreExistingClusterCli
 {
@@ -63,7 +64,7 @@ public class RestoreExistingClusterCli
 
         try
         {
-            Config config = loadNeo4jConfig( homeDir, configPath );
+            Config config = loadNeo4jConfig( homeDir, configPath, databaseName );
             restoreDatabase( databaseName, fromPath, forceOverwrite, config );
             convertStore( config, clusterSeed );
         }
@@ -73,15 +74,20 @@ public class RestoreExistingClusterCli
         }
     }
 
-    private static Config loadNeo4jConfig( File homeDir, String configPath )
+    private static Config loadNeo4jConfig( File homeDir, String configPath, String databaseName )
     {
-        return new ConfigLoader( settings() ).loadConfig( Optional.of( homeDir ),
-                Optional.of( new File( configPath, "neo4j.conf" ) ), NullLog.getInstance() );
+        ConfigLoader configLoader = new ConfigLoader( settings() );
+        Config config = configLoader.loadConfig(
+                Optional.of( homeDir ),
+                Optional.of( new File( configPath, "neo4j.conf" ) ),
+                NullLog.getInstance() );
+
+        return config.with( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName ) );
     }
 
     private static void convertStore( Config config, String seed ) throws IOException, TransactionFailureException
     {
-        ConvertClassicStoreCommand convert = new ConvertClassicStoreCommand( new ConversionVerifier() );
+        ConvertClassicStoreToCoreCommand convert = new ConvertClassicStoreToCoreCommand( new ConversionVerifier() );
         convert.convert( config.get( database_path ), config.get( record_format ), seed );
     }
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/Cluster.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/discovery/Cluster.java
@@ -53,7 +53,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
-import org.neo4j.kernel.impl.store.format.RecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.logging.Level;
@@ -120,12 +119,17 @@ public class Cluster
 
     public File coreServerStoreDirectory( int serverId )
     {
-        return coreServerStoreDirectory( parentDir, serverId );
+        return coreServerStoreDirectory( homeDir( serverId ) );
     }
 
-    public static File coreServerStoreDirectory( File parentDir, int serverId )
+    public File homeDir( int serverId )
     {
         return new File( parentDir, "server-core-" + serverId );
+    }
+
+    public static File coreServerStoreDirectory( File neo4jHome )
+    {
+        return new File( new File( new File( neo4jHome, "data" ), "databases" ), "graph.db" );
     }
 
     public static File edgeServerStoreDirectory( File parentDir, int serverId )
@@ -238,8 +242,9 @@ public class Cluster
             params.put( entry.getKey(), entry.getValue().apply( serverId ) );
         }
 
-        final File storeDir = coreServerStoreDirectory( parentDir, serverId );
-        params.put( GraphDatabaseSettings.logs_directory.name(), storeDir.getAbsolutePath() );
+        File neo4jHome = new File( parentDir, "server-core-" + serverId );
+        final File storeDir = coreServerStoreDirectory( neo4jHome );
+        params.put( GraphDatabaseSettings.logs_directory.name(), new File(neo4jHome, "logs").getAbsolutePath() );
         return new CoreGraphDatabase( storeDir, params, GraphDatabaseDependencies.newDependencies(),
                 discoveryServiceFactory );
     }

--- a/enterprise/core-edge/src/test/java/org/neo4j/restore/ArgsBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/restore/ArgsBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.restore;
+
+import java.io.File;
+import java.util.LinkedList;
+
+public class ArgsBuilder
+{
+    private LinkedList<String> args = new LinkedList<>(  );
+
+    public static ArgsBuilder args()
+    {
+        return new ArgsBuilder();
+    }
+
+    public ArgsBuilder homeDir( File homeDir)
+    {
+        args.add( String.format( "--home-dir=%s", homeDir.getPath() ) );
+        return this;
+    }
+
+    public ArgsBuilder database( String databaseName)
+    {
+        args.add( String.format( "--database=%s", databaseName ) );
+        return this;
+    }
+
+    public ArgsBuilder seed( String seed)
+    {
+        args.add( String.format( "--cluster-seed=%s", seed ) );
+        return this;
+    }
+
+    public ArgsBuilder config( File config)
+    {
+        args.add( String.format( "--config=%s", config.getPath() ) );
+        return this;
+    }
+
+    public ArgsBuilder from( File from)
+    {
+        args.add( String.format( "--from=%s", from.getPath() ) );
+        return this;
+    }
+
+    public ArgsBuilder force()
+    {
+        args.add( "--force=true" );
+        return this;
+    }
+
+    public LinkedList<String> build()
+    {
+        return args;
+    }
+
+    public static String[] toArray( LinkedList<String> restoreOtherArgs )
+    {
+        return restoreOtherArgs.toArray( new String[restoreOtherArgs.size()] );
+    }
+}

--- a/enterprise/core-edge/src/test/java/org/neo4j/restore/RestoreClusterUtils.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/restore/RestoreClusterUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.restore;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class RestoreClusterUtils
+{
+    public static StringBuilder execute( Runnable function )
+    {
+        StringBuilder builder = new StringBuilder();
+        PrintStream theRealOut = System.out;
+        System.setOut( new PrintStream( new MyOutputStream( builder ) ) );
+        function.run();
+        System.setOut( theRealOut );
+        return builder;
+    }
+
+    private static class MyOutputStream extends OutputStream
+    {
+        private final StringBuilder stringBuilder;
+
+        public MyOutputStream( StringBuilder stringBuilder )
+        {
+            this.stringBuilder = stringBuilder;
+        }
+
+        @Override
+        public void write( int b ) throws IOException
+        {
+            stringBuilder.append( (char) b );
+        }
+    }
+
+}


### PR DESCRIPTION
It would previously only allow you to restore a database called
graph.db due to a config change not being passed through.

Also updated backup/restore tests to use the CLI command instead
of manually composing individual commands
