### PR TITLE
Fixed VarLengthExpand Optimization Performance Issue

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/VarLengthExpandPipe.scala
@@ -28,20 +28,21 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 import scala.collection.mutable
 
-trait VarlenghtPredicate {
-  def filterNode(row: ExecutionContext, state:QueryState)(node: Node): Boolean
-  def filterRelationship(row: ExecutionContext, state:QueryState)(rel: Relationship): Boolean
+trait VarLengthPredicate {
+  def filterNode(row: ExecutionContext, state: QueryState)(node: Node): Boolean
+
+  def filterRelationship(row: ExecutionContext, state: QueryState)(rel: Relationship): Boolean
 }
 
-object VarlenghtPredicate {
+object VarLengthPredicate {
 
-  val NONE = new VarlenghtPredicate {
+  val NONE = new VarLengthPredicate {
+    override def filterNode(row: ExecutionContext, state: QueryState)(node: Node): Boolean = true
 
-    override def filterNode(row: ExecutionContext, state:QueryState)(node: Node): Boolean = true
-
-    override def filterRelationship(row: ExecutionContext, state:QueryState)(rel: Relationship): Boolean = true
+    override def filterRelationship(row: ExecutionContext, state: QueryState)(rel: Relationship): Boolean = true
   }
 }
+
 case class VarLengthExpandPipe(source: Pipe,
                                fromName: String,
                                relName: String,
@@ -52,38 +53,63 @@ case class VarLengthExpandPipe(source: Pipe,
                                min: Int,
                                max: Option[Int],
                                nodeInScope: Boolean,
-                               filteringStep: VarlenghtPredicate = VarlenghtPredicate.NONE)
+                               filteringStep: VarLengthPredicate = VarLengthPredicate.NONE)
                               (val estimatedCardinality: Option[Double] = None)
                               (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with RonjaPipe {
 
+  private val needsFlipping = if (dir == SemanticDirection.BOTH)
+    projectedDir == SemanticDirection.INCOMING
+  else
+    dir != projectedDir
+
+  val stack = new mutable.ArrayBuffer[(Node, Int, List[Relationship])]()
+  val relSet = mutable.HashSet[Relationship]()
+
   private def varLengthExpand(node: Node, state: QueryState, maxDepth: Option[Int],
                               row: ExecutionContext): Iterator[(Node, Seq[Relationship])] = {
-    val stack = new mutable.Stack[(Node, Seq[Relationship])]
-    stack.push((node, Seq.empty))
+
+    val nodeFilter: (Node) => Boolean = filteringStep.filterNode(row, state)
+
+    if (!nodeFilter(node)) return Iterator((node, List.empty))
+
+    val relationshipFilter: (Relationship) => Boolean = filteringStep.filterRelationship(row, state)
+
+    val maxDepthValue = maxDepth.getOrElse(Int.MaxValue)
+    val relTypes = types.types(state.query)
+
+    if (stack.nonEmpty) stack.clear()
+
+    stack.append((node, 0, List.empty))
 
     new Iterator[(Node, Seq[Relationship])] {
-      def next(): (Node, Seq[Relationship]) = {
-        val (node, rels) = stack.pop()
-        if (rels.length < maxDepth.getOrElse(Int.MaxValue) && filteringStep.filterNode(row,state)(node)) {
-          val relationships: Iterator[Relationship] = state.query.getRelationshipsForIds(node, dir, types.types(state.query))
+      override def next(): (Node, Seq[Relationship]) = {
+        val (node, count, relsFromStack) = stack.remove(stack.length - 1)
+        if (count < maxDepthValue) {
+          val relationships: Iterator[Relationship] = state.query
+            .getRelationshipsForIds(node, dir, relTypes)
+            .filter(relationshipFilter)
 
-          relationships.filter(filteringStep.filterRelationship(row, state)).foreach { rel =>
-            val otherNode = rel.getOtherNode(node)
-            if (!rels.contains(rel) && filteringStep.filterNode(row,state)(otherNode)) {
-              stack.push((otherNode, rels :+ rel))
+          if (relationships.nonEmpty) {
+            relSet.clear()
+            relsFromStack.foreach(relSet.add)
+
+            relationships.foreach { rel =>
+              val otherNode = rel.getOtherNode(node)
+              if (!relSet.contains(rel) && nodeFilter(otherNode)) {
+                stack.append((otherNode, count+1, (rel :: relsFromStack)))
+              }
             }
           }
         }
-        val needsFlipping = if (dir == SemanticDirection.BOTH) projectedDir == SemanticDirection.INCOMING else dir != projectedDir
         val projectedRels = if (needsFlipping) {
-          rels.reverse
+          relsFromStack
         } else {
-          rels
+          relsFromStack.reverse
         }
         (node, projectedRels)
       }
 
-      def hasNext: Boolean = stack.nonEmpty
+      override def hasNext: Boolean = stack.nonEmpty
     }
   }
 

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/execution/PipeExecutionPlanBuilder.scala
@@ -416,7 +416,7 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
     val nodeCommand = asCommand(nodePreds)
     val relCommand = asCommand(relPreds)
 
-    new VarlenghtPredicate {
+    new VarLengthPredicate {
 
       override def filterNode(row: ExecutionContext, state: QueryState)(node: Node) = nodeCommand(row, state, node)
 

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/VarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/pipes/VarLengthExpandPipeTest.scala
@@ -689,7 +689,7 @@ class VarLengthExpandPipeTest extends CypherFunSuite {
     val left = newMockedPipe(SymbolTable(Map("a" -> CTNode)))
     when(left.createResults(queryState)).thenReturn(Iterator(row("a" -> firstNode)))
 
-    val filteringStep = new VarlenghtPredicate {
+    val filteringStep = new VarLengthPredicate {
 
       override def filterNode(row: ExecutionContext,
                               state: QueryState)


### PR DESCRIPTION
- a large array-buffer of 1MB was create for each call of VarLengthPipe.next()
- fix: default array size, move arraybuffer and relationship-set into instance variables
- replace vector with list as vector append showed up in profiling
- removed one duplicate node-filter call
- fixed spelling of VarLengthPredicate
