### PR TITLE
Mixing old and new procedure annotation is not supported

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -123,10 +123,10 @@ public class ReflectiveProcedureCompiler
         }
         if ( method.isAnnotationPresent( PerformsWrites.class ) )
         {
-            if ( mode == ProcedureSignature.Mode.DBMS || mode == ProcedureSignature.Mode.SCHEMA_WRITE )
+            if ( !procedure.mode().equals( Procedure.Mode.DEFAULT ) )
             {
                 throw new ProcedureException( Status.Procedure.ProcedureRegistrationFailed,
-                        "Conflicting procedure annotation, PerformsWrites and mode = %s.", procedure.mode() );
+                        "Conflicting procedure annotation, cannot use PerformsWrites and mode" );
             }
             else
             {

--- a/community/kernel/src/main/java/org/neo4j/procedure/Procedure.java
+++ b/community/kernel/src/main/java/org/neo4j/procedure/Procedure.java
@@ -128,10 +128,10 @@ public @interface Procedure
      *      SCHEMA  allows reading the graphs and performing schema operations
      *      DBMS    allows managing the database (i.e. change password)
      */
-    Mode mode() default Mode.READ;
+    Mode mode() default Mode.DEFAULT;
 
     enum Mode
     {
-        READ, WRITE, SCHEMA, DBMS
+        READ, WRITE, SCHEMA, DBMS, DEFAULT
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProceduresTest.java
@@ -187,39 +187,48 @@ public class ProceduresTest
     }
 
     @Test
-    public void shouldCompileProcedureWithPerformsWrites() throws Throwable
+    public void shouldFailCompileProcedureWithReadConflict() throws Throwable
     {
-        procs.register( ProcedureWithPerformsWritesAndRead.class );
-        assertNotNull( procs.get( new ProcedureSignature.ProcedureName( "org.neo4j.kernel.impl.proc".split( "\\." ),
-                "shouldCompile" ) ) );
-        assertNotNull( procs.get( new ProcedureSignature.ProcedureName( "org.neo4j.kernel.impl.proc".split( "\\." ),
-                "shouldCompileToo" ) ) );
+        exception.expect( ProcedureException.class );
+        exception.expectMessage( "Conflicting procedure annotation, cannot use PerformsWrites and mode" );
+        procs.register( ProcedureWithReadConflictAnnotation.class );
     }
 
     @Test
-    public void shouldFailCompileProcedureWithDBMSConflict() throws Throwable
+    public void shouldFailCompileProcedureWithWriteConflict() throws Throwable
     {
         exception.expect( ProcedureException.class );
-        exception.expectMessage( "Conflicting procedure annotation, PerformsWrites and mode = DBMS." );
-        procs.register( ProcedureWithDBMSConflictAnnotation.class );
+        exception.expectMessage( "Conflicting procedure annotation, cannot use PerformsWrites and mode" );
+        procs.register( ProcedureWithWriteConflictAnnotation.class );
     }
 
     @Test
     public void shouldFailCompileProcedureWithSchemaConflict() throws Throwable
     {
         exception.expect( ProcedureException.class );
-        exception.expectMessage( "Conflicting procedure annotation, PerformsWrites and mode = SCHEMA." );
+        exception.expectMessage( "Conflicting procedure annotation, cannot use PerformsWrites and mode" );
         procs.register( ProcedureWithSchemaConflictAnnotation.class );
     }
 
-    public static class ProcedureWithPerformsWritesAndRead
+    @Test
+    public void shouldFailCompileProcedureWithDBMSConflict() throws Throwable
+    {
+        exception.expect( ProcedureException.class );
+        exception.expectMessage( "Conflicting procedure annotation, cannot use PerformsWrites and mode" );
+        procs.register( ProcedureWithDBMSConflictAnnotation.class );
+    }
+
+    public static class ProcedureWithReadConflictAnnotation
     {
         @PerformsWrites
         @Procedure( mode = Procedure.Mode.READ )
         public void shouldCompile()
         {
         }
+    }
 
+    public static class ProcedureWithWriteConflictAnnotation
+    {
         @PerformsWrites
         @Procedure( mode = Procedure.Mode.WRITE )
         public void shouldCompileToo()


### PR DESCRIPTION
Using `@PerformsWrites` with `@Procedure( mode = ... )` will not be supported.
