### PR TITLE
Added procedures to manage transactions

### DIFF
--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -146,6 +146,15 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
         return users.getUserByName( username );
     }
 
+    @Override
+    public User assertAndGetUser( String username ) throws IllegalArgumentException
+    {
+        User user = getUser( username );
+        if ( user == null )
+            throw new IllegalArgumentException( "User " + username + " does not exist!" );
+        return user;
+    }
+
     public void setPassword( AuthSubject authSubject, String username, String password ) throws IOException,
             IllegalCredentialsException
     {

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -151,7 +151,9 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
     {
         User user = getUser( username );
         if ( user == null )
+        {
             throw new IllegalArgumentException( "User " + username + " does not exist!" );
+        }
         return user;
     }
 

--- a/community/security/src/main/java/org/neo4j/server/security/auth/UserManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/UserManager.java
@@ -32,5 +32,7 @@ public interface UserManager
 
     User getUser( String username );
 
+    User assertAndGetUser( String username ) throws IllegalArgumentException;
+
     void setUserPassword( String username, String password ) throws IOException, IllegalCredentialsException;
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProcedures.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProcedures.java
@@ -200,15 +200,16 @@ public class AuthProcedures
         DependencyResolver resolver = graph.getDependencyResolver();
         KernelTransactions kernelTransactions = resolver.resolveDependency( KernelTransactions.class );
         ArrayList<TransactionResult> killedTransactions = new ArrayList<>();
-        for ( KernelTransaction tx : kernelTransactions.activeTransactions() )
-        {
-            if (( (EnterpriseAuthSubject) tx.mode()).doesUsernameMatch( username ))
-            {
-                TransactionResult r = new TransactionResult( tx );
-                tx.markForTermination();
-                killedTransactions.add( r );
-            }
-        }
+        kernelTransactions.activeTransactions().forEach(
+                tx ->
+                {
+                    if ( tx.mode().name().equals( username ) )
+                    {
+                        TransactionResult r = new TransactionResult( tx );
+                        tx.markForTermination();
+                        killedTransactions.add( r );
+                    }
+                } );
         return killedTransactions.stream();
     }
 
@@ -267,15 +268,7 @@ public class AuthProcedures
 
         public TransactionResult( KernelTransaction tx )
         {
-            if ( tx.mode() instanceof AuthSubject )
-            {
-                AuthSubject authSubject = (AuthSubject) tx.mode();
-                username = authSubject.name();
-            }
-            else
-            {
-                username = "-";
-            }
+            username = tx.mode().name();
             transaction = tx.toString();
         }
     }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseUserManager.java
@@ -39,6 +39,8 @@ public interface EnterpriseUserManager extends UserManager
 
     RoleRecord newRole( String roleName, String... usernames ) throws IOException;
 
+    RoleRecord assertAndGetRole( String roleName ) throws IllegalArgumentException;
+
     /**
      * Add a user to a role. The role has to exist.
      *

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -430,10 +430,20 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
         return u;
     }
 
+    public User assertCredentialsAndGetUser( String username ) throws IllegalCredentialsException
+    {
+        User u = getUser( username );
+        if ( u == null )
+        {
+            throw new IllegalCredentialsException( "User " + username + " does not exist." );
+        }
+        return u;
+    }
+
     @Override
     public void setUserPassword( String username, String password ) throws IOException, IllegalCredentialsException
     {
-        User existingUser = assertAndGetUser( username );
+        User existingUser = assertCredentialsAndGetUser( username );
 
         passwordPolicy.validatePassword( password );
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -424,7 +424,9 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
     {
         User u = getUser( username );
         if ( u == null )
+        {
             throw new IllegalArgumentException( "User " + username + " does not exist." );
+        }
         return u;
     }
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/NeoInteractionLevel.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/NeoInteractionLevel.java
@@ -24,10 +24,16 @@ import java.util.function.Consumer;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.kernel.api.security.AuthenticationResult;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 
 public interface NeoInteractionLevel<S>
 {
     EnterpriseUserManager getManager();
+
+    GraphDatabaseFacade getGraph();
+
+    InternalTransaction startTransactionAsUser( S subject ) throws Throwable;
 
     /*
      * The returned String is empty if the query executed as expected, and contains an error msg otherwise
@@ -44,6 +50,8 @@ public interface NeoInteractionLevel<S>
     AuthenticationResult authenticationResult( S subject );
 
     void updateAuthToken( S subject, String username, String password );
+
+    String nameOf( S subject );
 
     void tearDown() throws Throwable;
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ThreadedTransactionCreate.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ThreadedTransactionCreate.java
@@ -1,0 +1,55 @@
+package org.neo4j.server.security.enterprise.auth;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
+import org.neo4j.test.Barrier;
+import org.neo4j.test.NamedFunction;
+import org.neo4j.test.rule.concurrent.ThreadingRule;
+
+public class ThreadedTransactionCreate<S>
+{
+    final Barrier.Control barrier = new Barrier.Control();
+    Future<Long> done;
+
+    NeoInteractionLevel<S> neo;
+
+    ThreadedTransactionCreate( NeoInteractionLevel<S> neo )
+    {
+        this.neo = neo;
+    }
+
+    NamedFunction<S, Long> startTransaction =
+            new NamedFunction<S, Long>( "start-transaction" )
+            {
+                @Override
+                public Long apply( S subject )
+                {
+                    try
+                    {
+                        InternalTransaction tx = neo.startTransactionAsUser( subject );
+                        barrier.reached();
+                        neo.getGraph().execute( "CREATE (:Test { name: '" + neo.nameOf( subject ) + "-node'})" );
+                        tx.success();
+                        tx.close();
+                        return 0L;
+                    }
+                    catch (Throwable t)
+                    {
+                        return 1L;
+                    }
+                }
+            };
+
+    void execute( ThreadingRule threading, S subject )
+    {
+        done = threading.execute( startTransaction, subject );
+    }
+
+    Long close() throws ExecutionException, InterruptedException
+    {
+        barrier.release();
+        return done.get();
+    }
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ThreadedTransactionCreate.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ThreadedTransactionCreate.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.server.security.enterprise.auth;
 
 import java.util.concurrent.ExecutionException;
@@ -11,7 +30,7 @@ import org.neo4j.test.rule.concurrent.ThreadingRule;
 public class ThreadedTransactionCreate<S>
 {
     final Barrier.Control barrier = new Barrier.Control();
-    Future<Long> done;
+    private Future<Long> done;
 
     NeoInteractionLevel<S> neo;
 
@@ -20,30 +39,30 @@ public class ThreadedTransactionCreate<S>
         this.neo = neo;
     }
 
-    NamedFunction<S, Long> startTransaction =
-            new NamedFunction<S, Long>( "start-transaction" )
-            {
-                @Override
-                public Long apply( S subject )
-                {
-                    try
-                    {
-                        InternalTransaction tx = neo.startTransactionAsUser( subject );
-                        barrier.reached();
-                        neo.getGraph().execute( "CREATE (:Test { name: '" + neo.nameOf( subject ) + "-node'})" );
-                        tx.success();
-                        tx.close();
-                        return 0L;
-                    }
-                    catch (Throwable t)
-                    {
-                        return 1L;
-                    }
-                }
-            };
-
     void execute( ThreadingRule threading, S subject )
     {
+        NamedFunction<S, Long> startTransaction =
+                new NamedFunction<S, Long>( "start-transaction" )
+                {
+                    @Override
+                    public Long apply( S subject )
+                    {
+                        try
+                        {
+                            InternalTransaction tx = neo.startTransactionAsUser( subject );
+                            barrier.reached();
+                            neo.getGraph().execute( "CREATE (:Test { name: '" + neo.nameOf( subject ) + "-node'})" );
+                            tx.success();
+                            tx.close();
+                            return 0L;
+                        }
+                        catch (Throwable t)
+                        {
+                            return 1L;
+                        }
+                    }
+                };
+
         done = threading.execute( startTransaction, subject );
     }
 

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/NeoFullRESTInteraction.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/NeoFullRESTInteraction.java
@@ -21,6 +21,7 @@ package org.neo4j.server.rest.security;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.IntNode;
 import org.codehaus.jackson.node.ObjectNode;
 import org.codehaus.jackson.node.TextNode;
 
@@ -236,10 +237,14 @@ public class NeoFullRESTInteraction extends CommunityServerTestBase implements N
                 {
                     map.put( key, value );
                 }
+                else if ( value instanceof IntNode )
+                {
+                    map.put( key, value.getIntValue() );
+                }
                 else
                 {
                     throw new RuntimeException( "Unhandled REST value type '" + value.getClass() +
-                            "'. Need String (TextNode) or List (ArrayNode)." );
+                            "'. Need String (TextNode), List (ArrayNode), Object (ObjectNode) or int (IntNode)." );
                 }
             }
 

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTSubject.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/RESTSubject.java
@@ -25,10 +25,14 @@ public class RESTSubject
 {
     HTTP.Response response;
     String principalCredentials;
+    String username;
+    String password;
 
-    public RESTSubject( HTTP.Response response, String principalCredentials )
+    public RESTSubject( HTTP.Response response, String username, String password, String principalCredentials )
     {
         this.response = response;
+        this.username = username;
+        this.password = password;
         this.principalCredentials = principalCredentials;
     }
 }


### PR DESCRIPTION
New procedures:
`listTransactions` to list currently running transactions
`terminateTransactionsForUser( username )` to terminate all currently running transactions for user

Also minor collateral improvements in `UserManager` implementers.

changelog: [3.1, security] Added listTransactions and terminateTransactionsForUser procedures for managing transactions
