### PR TITLE
Better error handling for unpackable values

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -66,6 +66,7 @@ public class Neo4jPack
             super( output );
         }
 
+        @SuppressWarnings( "unchecked" )
         public void pack( Object obj ) throws IOException
         {
             // Note: below uses instanceof for quick implementation, this should be swapped over
@@ -96,8 +97,7 @@ public class Neo4jPack
             }
             else if (obj instanceof Character )
             {
-                Character character = (Character) obj;
-                pack( character.toString() );
+                pack( (Character) obj );
             }
             else if ( obj instanceof Map )
             {
@@ -127,8 +127,12 @@ public class Neo4jPack
             }
             else if ( obj instanceof char[] )
             {
-                // Treat it as a String
-                pack( new String( (char[]) obj ) );
+                char[] array = (char[]) obj;
+                packListHeader( array.length );
+                for ( char item : array )
+                {
+                    pack( item );
+                }
             }
             else if ( obj instanceof short[] )
             {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 
 import org.neo4j.bolt.v1.messaging.infrastructure.ValueNode;
 import org.neo4j.bolt.v1.messaging.infrastructure.ValueRelationship;
@@ -97,7 +96,7 @@ public class Neo4jPack
             }
             else if (obj instanceof Character )
             {
-                pack( (Character) obj );
+                pack( (char) obj );
             }
             else if ( obj instanceof Map )
             {
@@ -122,7 +121,7 @@ public class Neo4jPack
             else if ( obj instanceof byte[] )
             {
                 error = Optional.of(new Error( Status.Request.Invalid,
-                        "Binary values is not yet supported in Bolt"));
+                        "Byte array is not yet supported in Bolt"));
                 packNull();
             }
             else if ( obj instanceof char[] )

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -90,6 +90,11 @@ public class Neo4jPack
             {
                 pack( (String) obj );
             }
+            else if (obj instanceof Character )
+            {
+                Character character = (Character) obj;
+                pack( character.toString() );
+            }
             else if ( obj instanceof Map )
             {
                 Map<Object, Object> map = (Map<Object, Object>) obj;
@@ -114,6 +119,11 @@ public class Neo4jPack
             {
                 // Pending decision
                 throw new UnsupportedOperationException( "Binary values cannot be packed." );
+            }
+            else if ( obj instanceof char[] )
+            {
+                // Treat it as a String
+                pack( new String( (char[]) obj ) );
             }
             else if ( obj instanceof short[] )
             {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/PackStreamMessageFormatV1.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/PackStreamMessageFormatV1.java
@@ -136,6 +136,11 @@ public class PackStreamMessageFormatV1 implements MessageFormat
                 packer.pack( field );
             }
             onMessageComplete.onMessageComplete();
+
+            //The record might contain unpackable values,
+            //hence we must consume any errors that might
+            //have occurred.
+            packer.consumeError();
         }
 
         @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
@@ -167,6 +167,20 @@ public class PackStream
         private PackOutput out;
         private UTF8Encoder utf8 = UTF8Encoder.fastestAvailableEncoder();
 
+        private static final String[] PACKED_CHARS = prePackChars();
+        private static final char PACKED_CHAR_START_CHAR = (char) 32;
+        private static final char PACKED_CHAR_END_CHAR = (char) 126;
+        private static String[] prePackChars()
+        {
+            int size = PACKED_CHAR_END_CHAR + 1 - PACKED_CHAR_START_CHAR;
+            String[] packedChars = new String[size];
+            for ( int i = 0; i < size; i++ )
+            {
+                packedChars[i] = ( String.valueOf( (char)(i + PACKED_CHAR_START_CHAR) ) );
+            }
+            return packedChars;
+        }
+
         public Packer( PackOutput out )
         {
             this.out = out;
@@ -218,12 +232,14 @@ public class PackStream
 
         public void pack( char character ) throws IOException
         {
-            pack( new String( new char[]{character} ) );
-        }
-
-        public void pack( Character character ) throws IOException
-        {
-            pack( new String( new char[]{character} ) );
+            if( character >= PACKED_CHAR_START_CHAR && character <= PACKED_CHAR_END_CHAR )
+            {
+                pack( PACKED_CHARS[character - PACKED_CHAR_START_CHAR] );
+            }
+            else
+            {
+                pack( String.valueOf( character ) );
+            }
         }
 
         public void pack( String value ) throws IOException

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
@@ -221,6 +221,11 @@ public class PackStream
             pack( new String( new char[]{character} ) );
         }
 
+        public void pack( Character character ) throws IOException
+        {
+            pack( new String( new char[]{character} ) );
+        }
+
         public void pack( String value ) throws IOException
         {
             if ( value == null ) { packNull(); }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
@@ -216,6 +216,11 @@ public class PackStream
             out.writeByte( FLOAT_64 ).writeDouble( value );
         }
 
+        public void pack( char character ) throws IOException
+        {
+            pack( new String( new char[]{character} ) );
+        }
+
         public void pack( String value ) throws IOException
         {
             if ( value == null ) { packNull(); }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/CypherAdapterStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/internal/CypherAdapterStream.java
@@ -33,8 +33,6 @@ import org.neo4j.graphdb.Notification;
 import org.neo4j.graphdb.QueryExecutionType;
 import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.spatial.Point;
-import org.neo4j.kernel.api.exceptions.Status;
 
 public class CypherAdapterStream implements RecordStream
 {
@@ -160,23 +158,8 @@ public class CypherAdapterStream implements RecordStream
             for ( int i = 0; i < fields.length; i++ )
             {
                 fields[i] = cypherRecord.get( fieldNames[i] );
-                assertPackable( fields[i] );
             }
             return this;
-        }
-
-        private void assertPackable( Object field ) throws BoltIOException
-        {
-            //TODO this is a temporary measure, currently the packing of points
-            //fails in Neo4jPack#pack but it fails there when already begun writing
-            //headers to the result, so failing there and writing an error while in the process
-            //of writing a record results in a malformed error message.
-            //What needs to be done is inverting this so that the field has a visitable method
-            //that calls the proper pack method.
-            if (field instanceof Point)
-            {
-                throw new BoltIOException( Status.Request.Invalid, "Point is not yet supported as a return type in Bolt" );
-            }
         }
     }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
@@ -180,4 +180,32 @@ public class Neo4jPackTest
             unpacked( packed( path ) );
         }
     }
+
+    @Test
+    public void shouldTreatSingleCharAsSingleCharacterString() throws IOException
+    {
+        // Given
+        PackedOutputArray output = new PackedOutputArray();
+        Neo4jPack.Packer packer = new Neo4jPack.Packer( output );
+        packer.pack( 'C' );
+        Object unpacked = unpacked( output.bytes() );
+
+        // Then
+        assertThat( unpacked, instanceOf( String.class ) );
+        assertThat( unpacked, equalTo( "C" ) );
+    }
+
+    @Test
+    public void shouldTreatCharArrayAsString() throws IOException
+    {
+        // Given
+        PackedOutputArray output = new PackedOutputArray();
+        Neo4jPack.Packer packer = new Neo4jPack.Packer( output );
+        packer.pack( new char[]{'W', 'H', 'Y'} );
+        Object unpacked = unpacked( output.bytes() );
+
+        // Then
+        assertThat( unpacked, instanceOf( String.class ) );
+        assertThat( unpacked, equalTo( "WHY" ) );
+    }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
@@ -36,6 +36,7 @@ import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Path;
 import org.neo4j.kernel.impl.util.HexPrinter;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -68,6 +69,7 @@ public class Neo4jPackTest
         return unpacker.unpack();
     }
 
+    @SuppressWarnings( "unchecked" )
     @Test
     public void shouldBeAbleToPackAndUnpackListStream() throws IOException
     {
@@ -91,6 +93,7 @@ public class Neo4jPackTest
         assertThat( unpackedList, equalTo( expected ) );
     }
 
+    @SuppressWarnings( "unchecked" )
     @Test
     public void shouldBeAbleToPackAndUnpackMapStream() throws IOException
     {
@@ -98,7 +101,7 @@ public class Neo4jPackTest
         PackedOutputArray output = new PackedOutputArray();
         Neo4jPack.Packer packer = new Neo4jPack.Packer( output );
         packer.packMapStreamHeader();
-        for ( Map.Entry<String, Object> entry : ALICE.getAllProperties().entrySet() )
+        for ( Map.Entry<String,Object> entry : ALICE.getAllProperties().entrySet() )
         {
             packer.pack( entry.getKey() );
             packer.pack( entry.getValue() );
@@ -108,17 +111,18 @@ public class Neo4jPackTest
 
         // Then
         assertThat( unpacked, instanceOf( Map.class ) );
-        Map<String, Object> unpackedMap = (Map<String, Object>) unpacked;
+        Map<String,Object> unpackedMap = (Map<String,Object>) unpacked;
         assertThat( unpackedMap, equalTo( ALICE.getAllProperties() ) );
     }
 
+    @SuppressWarnings( "unchecked" )
     @Test
     public void shouldFailNicelyWhenPackingAMapWithUnpackableValues() throws IOException
     {
         // Given
         PackedOutputArray output = new PackedOutputArray();
         Neo4jPack.Packer packer = new Neo4jPack.Packer( output );
-        packer.packRawMap( map("unpackable", new Unpackable() ) );
+        packer.packRawMap( map( "unpackable", new Unpackable() ) );
         Object unpacked = unpacked( output.bytes() );
 
         // Then
@@ -151,10 +155,10 @@ public class Neo4jPackTest
     public void shouldHandleDeletedNodesGracefully() throws IOException
     {
         // Given
-        Node node = mock(Node.class);
-        when(node.getId()).thenReturn( 42L );
-        doThrow( NotFoundException.class ).when(node).getAllProperties(  );
-        doThrow( NotFoundException.class ).when(node).getLabels(  );
+        Node node = mock( Node.class );
+        when( node.getId() ).thenReturn( 42L );
+        doThrow( NotFoundException.class ).when( node ).getAllProperties();
+        doThrow( NotFoundException.class ).when( node ).getLabels();
 
         // When
         byte[] packed = packed( node );
@@ -166,7 +170,7 @@ public class Neo4jPackTest
         //    labels: [] (90)
         //    props: {} (A0)
         //}
-        assertThat(HexPrinter.hex( packed ), equalTo("B3 4E 2A 90 A0"));
+        assertThat( HexPrinter.hex( packed ), equalTo( "B3 4E 2A 90 A0" ) );
     }
 
     @Test
@@ -214,7 +218,7 @@ public class Neo4jPackTest
     }
 
     @Test
-    public void shouldTreatCharArrayAsString() throws IOException
+    public void shouldTreatCharArrayAsListOfStrings() throws IOException
     {
         // Given
         PackedOutputArray output = new PackedOutputArray();
@@ -223,8 +227,8 @@ public class Neo4jPackTest
         Object unpacked = unpacked( output.bytes() );
 
         // Then
-        assertThat( unpacked, instanceOf( String.class ) );
-        assertThat( unpacked, equalTo( "WHY" ) );
+        assertThat( unpacked, instanceOf( List.class ) );
+        assertThat( unpacked, equalTo( asList( "W", "H", "Y" ) ) );
     }
 
     private static class Unpackable

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackStreamTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/packstream/PackStreamTest.java
@@ -284,6 +284,49 @@ public class PackStreamTest
     }
 
     @Test
+    public void testCanPackCommonlyUsedCharAndUnpackAsString() throws Throwable
+    {
+        // Given
+        Machine machine = new Machine();
+
+        for ( int i = 32; i < 127; i++ )
+        {
+            char c = (char) i;
+
+            // When
+            machine.reset();
+            machine.packer().pack( c );
+            machine.packer().flush();
+
+            // Then
+            String value = newUnpacker( machine.output() ).unpackString();
+            assertThat( value, equalTo( String.valueOf( c ) ) );
+        }
+    }
+
+    @Test
+    public void testCanPackRandomCharAndUnpackAsString() throws Throwable
+    {
+        // Given
+        Machine machine = new Machine();
+        char[] chars = {'ø', 'å', '´', '†', 'œ', '≈'};
+
+        for ( int i = 0; i < chars.length; i++ )
+        {
+            char c = chars[i];
+
+            // When
+            machine.reset();
+            machine.packer().pack( c );
+            machine.packer().flush();
+
+            // Then
+            String value = newUnpacker( machine.output() ).unpackString();
+            assertThat( value, equalTo( String.valueOf( c ) ) );
+        }
+    }
+
+    @Test
     public void testCanPackAndUnpackStrings() throws Throwable
     {
         // Given

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionIT.java
@@ -50,6 +50,7 @@ import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.recorded;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.streamContaining;
 import static org.neo4j.bolt.v1.runtime.integration.SessionMatchers.success;
 
+@SuppressWarnings( "unchecked" )
 public class SessionIT
 {
     private static final Map<String,Object> EMPTY_PARAMS = emptyMap();

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
@@ -44,6 +44,7 @@ public class Neo4jWithSocket implements TestRule
 {
     private final Consumer<Map<Setting<?>,String>> configure;
     private StoreId storeId;
+    private  GraphDatabaseService gdb;
 
     public Neo4jWithSocket()
     {
@@ -69,7 +70,7 @@ public class Neo4jWithSocket implements TestRule
                 settings.put( BoltKernelExtension.Settings.tls_key_file, tempPath( "key", ".key" ) );
                 settings.put( BoltKernelExtension.Settings.tls_certificate_file, tempPath( "cert", ".cert" ) );
                 configure.accept( settings );
-                final GraphDatabaseService gdb = new TestGraphDatabaseFactory().newImpermanentDatabase( settings );
+                gdb = new TestGraphDatabaseFactory().newImpermanentDatabase( settings );
                 storeId = ((GraphDatabaseFacade) gdb).storeId();
                 try
                 {
@@ -81,6 +82,11 @@ public class Neo4jWithSocket implements TestRule
                 }
             }
         };
+    }
+
+    public GraphDatabaseService graphDatabaseService()
+    {
+        return gdb;
     }
 
     private String tempPath(String prefix, String suffix ) throws IOException

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/TransportSessionIT.java
@@ -318,7 +318,7 @@ public class TransportSessionIT
                 msgSuccess(),
                 msgSuccess( map( "fields", singletonList( "n.binary") ) ),
                 msgRecord(eqRecord( nullValue() )),
-                msgFailure( Status.Request.Invalid, "Binary values is not yet supported in Bolt")) );
+                msgFailure( Status.Request.Invalid, "Byte array is not yet supported in Bolt")) );
     }
 
     @Before


### PR DESCRIPTION
Instead of throw an error midstream when data has already been written to the
channel. We right nulls back for all unpackable values, and follows up with a
FAILURE

Also add pack-support for char and char[] by treating them as String
Based on #7479 
