### PR TITLE
Include new cypher-shell in all distributions, if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ out
 Thumbs.db
 .cache-main
 .cache-tests
+
+packaging/standalone/src/main/distribution/cypher-shell

--- a/packaging/installer-linux/installer-debian/build.xml
+++ b/packaging/installer-linux/installer-debian/build.xml
@@ -40,6 +40,8 @@
                   toFile="${project.build.outputDirectory}/@{name}/server/scripts/neo4j-import"/>
             <copy file="${project.build.sourceDirectory}/../resources/common/neo4j-script"
                   toFile="${project.build.outputDirectory}/@{name}/server/scripts/neo4j-shell"/>
+            <copy file="${project.build.sourceDirectory}/../resources/common/neo4j-script"
+                  toFile="${project.build.outputDirectory}/@{name}/server/scripts/cypher-shell"/>
 
             <!-- Set the directories to match the FHS. -->
             <replace file="${project.build.outputDirectory}/@{name}/server/conf/neo4j.conf"
@@ -71,12 +73,14 @@ dbms.directories.certificates=/var/lib/neo4j/certificates
                     <include name="**/server/bin/neo4j-import"/>
                     <include name="**/server/bin/neo4j-backup"/>
                     <include name="**/server/bin/neo4j-admin"/>
+                    <include name="**/server/bin/cypher-shell"/>
 
                     <include name="**/server/scripts/neo4j"/>
                     <include name="**/server/scripts/neo4j-shell"/>
                     <include name="**/server/scripts/neo4j-import"/>
                     <include name="**/server/scripts/neo4j-backup"/>
                     <include name="**/server/scripts/neo4j-admin"/>
+                    <include name="**/server/scripts/cypher-shell"/>
                 </fileset>
             </chmod>
 

--- a/packaging/neo4j-desktop/README.asciidoc
+++ b/packaging/neo4j-desktop/README.asciidoc
@@ -7,6 +7,8 @@ This project can build two artifacts:
 * `mvn package` builds an über jar containing all dependencies and neo4j desktop
 * `mvn package -Dinstall4j.home=<path-to-install4j>` additionally builds a windows installer in `target/install4j` that packages the über jar and includes a bundled JRE.
 
+Note that you must have built the standalone zip with an included [cypher-shell](https://github.com/neo4j/cypher-shell). Do this by placing `cypher-shell.zip` in the `neo4j/in` directory before building the standalone zip.
+
 We brand the Windows installer and the Windows application "Neo4j Community".
 
 To build the windows installer, you first need to install install4j and obtain a license. Additionally, copy a JRE for bundling to `<path-to-install4j/jres>`.

--- a/packaging/neo4j-desktop/README.asciidoc
+++ b/packaging/neo4j-desktop/README.asciidoc
@@ -7,7 +7,7 @@ This project can build two artifacts:
 * `mvn package` builds an über jar containing all dependencies and neo4j desktop
 * `mvn package -Dinstall4j.home=<path-to-install4j>` additionally builds a windows installer in `target/install4j` that packages the über jar and includes a bundled JRE.
 
-Note that you must have built the standalone zip with an included [cypher-shell](https://github.com/neo4j/cypher-shell). Do this by placing `cypher-shell.zip` in the `neo4j/in` directory before building the standalone zip.
+Note that you must have built the standalone zip with an included [cypher-shell](https://github.com/neo4j/cypher-shell). Do this by placing `cypher-shell.zip` in the root of the neo4j directory before building the standalone zip.
 
 We brand the Windows installer and the Windows application "Neo4j Community".
 

--- a/packaging/neo4j-desktop/neo4j-desktop.install4j
+++ b/packaging/neo4j-desktop/neo4j-desktop.install4j
@@ -32,6 +32,7 @@
       <fileEntry mountPoint="262" file="./src/main/install4j/neo4j-community.vmoptions" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="262" file="./src/main/install4j/install.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="262" file="./target/shell-scripts/Neo4j-Management.psd1" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-shared.sh" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-import" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-import.bat" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-shell" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
@@ -75,6 +76,7 @@
         <include all="false">
           <entry location="bin/Neo4j-Management" fileType="regular" />
           <entry location="bin/Neo4j-Management.psd1" fileType="regular" />
+          <entry location="bin/neo4j-shared.sh" fileType="regular" />
           <entry location="bin/neo4j-import" fileType="regular" />
           <entry location="bin/neo4j-import.bat" fileType="regular" />
           <entry location="bin/neo4j-shell" fileType="regular" />
@@ -713,6 +715,7 @@ return "${APPDATA}" + context.getVariable("sys.fileSeparator") + context.getComp
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
+        <entry location="bin/neo4j-shared.sh" fileType="regular" />
         <entry location="bin/neo4j-import" fileType="regular" />
         <entry location="bin/neo4j-shell" fileType="regular" />
         <entry location="bin/neo4j-admin" fileType="regular" />
@@ -734,6 +737,7 @@ return "${APPDATA}" + context.getVariable("sys.fileSeparator") + context.getComp
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
+        <entry location="bin/neo4j-shared.sh" fileType="regular" />
         <entry location="bin/neo4j-import" fileType="regular" />
         <entry location="bin/neo4j-shell" fileType="regular" />
         <entry location="bin/neo4j-admin" fileType="regular" />

--- a/packaging/neo4j-desktop/neo4j-desktop.install4j
+++ b/packaging/neo4j-desktop/neo4j-desktop.install4j
@@ -31,9 +31,17 @@
       <fileEntry mountPoint="262" file="./target/neo4j-desktop-@NEO4J_VERSION@.jar" overwriteMode="4" shared="true" fileMode="644" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="true" overrideUninstallMode="true" />
       <fileEntry mountPoint="262" file="./src/main/install4j/neo4j-community.vmoptions" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="262" file="./src/main/install4j/install.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
-      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-import" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
-      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-shell" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="262" file="./target/shell-scripts/Neo4j-Management.psd1" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-import" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-import.bat" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-shell" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-shell.bat" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-admin" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-admin.bat" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-backup" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/shell-scripts/neo4j-backup.bat" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/cypher-shell/cypher-shell" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="262" file="./target/cypher-shell/cypher-shell.bat" overwriteMode="4" shared="false" fileMode="755" uninstallMode="0" overrideFileMode="true" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="386" file="./target/plugins/README.txt" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="210" file="./target/licenses/LICENSES.txt" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="210" file="./target/licenses/NOTICE.txt" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
@@ -66,9 +74,23 @@
         <description />
         <include all="false">
           <entry location="bin/Neo4j-Management" fileType="regular" />
-          <entry location="bin/neo4j-import" fileType="regular" />
-          <entry location="bin/neo4j-shell" fileType="regular" />
           <entry location="bin/Neo4j-Management.psd1" fileType="regular" />
+          <entry location="bin/neo4j-import" fileType="regular" />
+          <entry location="bin/neo4j-import.bat" fileType="regular" />
+          <entry location="bin/neo4j-shell" fileType="regular" />
+          <entry location="bin/neo4j-shell.bat" fileType="regular" />
+          <entry location="bin/neo4j-admin" fileType="regular" />
+          <entry location="bin/neo4j-admin.bat" fileType="regular" />
+          <entry location="bin/neo4j-backup" fileType="regular" />
+          <entry location="bin/neo4j-backup.bat" fileType="regular" />
+        </include>
+        <dependencies />
+      </component>
+      <component name="cypher-shell" id="630" customizedId="" displayDescription="false" hideHelpButton="false" selected="true" changeable="true" downloadable="false" hidden="false">
+        <description />
+        <include all="false">
+          <entry location="bin/cypher-shell" fileType="regular" />
+          <entry location="bin/cypher-shell.bat" fileType="regular" />
         </include>
         <dependencies />
       </component>
@@ -690,7 +712,13 @@ return "${APPDATA}" + context.getVariable("sys.fileSeparator") + context.getComp
       <excludedLaunchers />
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
-      <exclude />
+      <exclude>
+        <entry location="bin/neo4j-import" fileType="regular" />
+        <entry location="bin/neo4j-shell" fileType="regular" />
+        <entry location="bin/neo4j-admin" fileType="regular" />
+        <entry location="bin/neo4j-backup" fileType="regular" />
+        <entry location="bin/cypher-shell" fileType="regular" />
+      </exclude>
       <variables />
       <autoUpdate useMinUpdatableVersion="false" minUpdatableVersion="" useMaxUpdatableVersion="false" maxUpdatableVersion="">
         <commentFiles />
@@ -705,7 +733,13 @@ return "${APPDATA}" + context.getVariable("sys.fileSeparator") + context.getComp
       <excludedLaunchers />
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
-      <exclude />
+      <exclude>
+        <entry location="bin/neo4j-import" fileType="regular" />
+        <entry location="bin/neo4j-shell" fileType="regular" />
+        <entry location="bin/neo4j-admin" fileType="regular" />
+        <entry location="bin/neo4j-backup" fileType="regular" />
+        <entry location="bin/cypher-shell" fileType="regular" />
+      </exclude>
       <variables />
       <autoUpdate useMinUpdatableVersion="false" minUpdatableVersion="" useMaxUpdatableVersion="false" maxUpdatableVersion="">
         <commentFiles />
@@ -717,7 +751,15 @@ return "${APPDATA}" + context.getVariable("sys.fileSeparator") + context.getComp
       <includedDownloadableComponents />
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
-      <exclude />
+      <exclude>
+        <entry location="bin/Neo4j-Management" fileType="regular" />
+        <entry location="bin/Neo4j-Management.psd1" fileType="regular" />
+        <entry location="bin/neo4j-import.bat" fileType="regular" />
+        <entry location="bin/neo4j-shell.bat" fileType="regular" />
+        <entry location="bin/neo4j-admin.bat" fileType="regular" />
+        <entry location="bin/neo4j-backup.bat" fileType="regular" />
+        <entry location="bin/cypher-shell.bat" fileType="regular" />
+      </exclude>
       <variables />
       <autoUpdate useMinUpdatableVersion="false" minUpdatableVersion="" useMaxUpdatableVersion="false" maxUpdatableVersion="">
         <commentFiles />

--- a/packaging/neo4j-desktop/pom.xml
+++ b/packaging/neo4j-desktop/pom.xml
@@ -149,6 +149,7 @@
                 <fixcrlf file="src/main/distribution/text/community/LICENSES.txt" destDir="${project.build.directory}/licenses" eol="dos" />
                 <fixcrlf file="src/main/distribution/text/community/NOTICE.txt" destDir="${project.build.directory}/licenses" eol="dos" />
                 <fixcrlf file="src/main/distribution/text/plugins/README.txt" destDir="${project.build.directory}/plugins" eol="dos" />
+                <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.sh" todir="${project.build.directory}/shell-scripts" />
                 <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-import" todir="${project.build.directory}/shell-scripts" />
                 <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-shell" todir="${project.build.directory}/shell-scripts" />
                 <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-admin" todir="${project.build.directory}/shell-scripts" />

--- a/packaging/neo4j-desktop/pom.xml
+++ b/packaging/neo4j-desktop/pom.xml
@@ -143,6 +143,7 @@
                 <mkdir dir="${project.build.directory}/licenses" />
                 <mkdir dir="${project.build.directory}/plugins" />
                 <mkdir dir="${project.build.directory}/shell-scripts" />
+                <mkdir dir="${project.build.directory}/cypher-shell" />
                 <mkdir dir="${project.build.directory}/shell-scripts/Neo4j-Management" />
                 <fixcrlf file="${project.basedir}/../../community/LICENSE.txt" destDir="${project.build.directory}/licenses" eol="dos" />
                 <fixcrlf file="src/main/distribution/text/community/LICENSES.txt" destDir="${project.build.directory}/licenses" eol="dos" />
@@ -150,6 +151,9 @@
                 <fixcrlf file="src/main/distribution/text/plugins/README.txt" destDir="${project.build.directory}/plugins" eol="dos" />
                 <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-import" todir="${project.build.directory}/shell-scripts" />
                 <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-shell" todir="${project.build.directory}/shell-scripts" />
+                <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-admin" todir="${project.build.directory}/shell-scripts" />
+                <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-backup" todir="${project.build.directory}/shell-scripts" />
+                <copy file="${project.basedir}/../standalone/src/main/distribution/cypher-shell/bin/cypher-shell" todir="${project.build.directory}/cypher-shell" />
 
                 <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management.psd1" todir="${project.build.directory}/shell-scripts" />
                 <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Java.ps1" todir="${project.build.directory}/shell-scripts/Neo4j-Management" />
@@ -172,8 +176,10 @@
                 <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Stop-Neo4jServer.ps1" todir="${project.build.directory}/shell-scripts/Neo4j-Management" />
                 <copy file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Uninstall-Neo4jServer.ps1" todir="${project.build.directory}/shell-scripts/Neo4j-Management" />
 
-                <fixcrlf file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-import.bat" destDir="${project.build.directory}/shell-scripts" eol="dos" />
-                <fixcrlf file="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin/neo4j-shell.bat" destDir="${project.build.directory}/shell-scripts" eol="dos" />
+                <fixcrlf srcdir="${project.basedir}/../standalone/src/main/distribution/shell-scripts/bin" includes="**/*.bat"
+                         destDir="${project.build.directory}/shell-scripts" eol="dos" />
+                <fixcrlf srcdir="${project.basedir}/../standalone/src/main/distribution/cypher-shell/bin" includes="**/*.bat"
+                         destDir="${project.build.directory}/cypher-shell" eol="dos" />
               </target>
             </configuration>
           </execution>

--- a/packaging/standalone/build.xml
+++ b/packaging/standalone/build.xml
@@ -1,30 +1,34 @@
-<project default="copy-shell">
-  <property name="shell.dist" location="../../in/cypher-shell"/>
+<project default="extract-shell-zip">
+  <property name="shell.dist" location="../../cypher-shell"/>
   <property name="shell.zip" location="${shell.dist}.zip"/>
   <!-- Extract zip file -->
 
   <target name="find-shell-zip" description="See if shell zip file exists">
-    <echo>Checking if ${shell.zip} exists</echo>
     <available file="${shell.zip}" property="zip.present"/>
+    <echo>Checking if ${shell.zip} exists: ${zip.present}</echo>
   </target>
   <target name="extract-shell-zip" depends="find-shell-zip"
           if="zip.present">
-    <unzip src="${shell.zip}" dest="../../in"/>
+    <echo>Unzipping...</echo>
+    <unzip src="${shell.zip}" dest="src/main/distribution"/>
   </target>
 
   <!-- Copy to source directory -->
+  <!--
   <target name="find-shell" description="Check that cypher-shell is available"
           depends="extract-shell-zip">
-    <echo>Checking if ${shell.dist} exists</echo>
     <available file="${shell.dist}" type="dir"
                property="shell.present"/>
+    <echo>Checking if ${shell.dist} exists: ${shell.present}</echo>
   </target>
 
   <target name="copy-shell" description="Copy cypher-shell files"
           depends="find-shell" if="shell.present">
+    <echo>Copying...</echo>
     <copy todir="src/main/distribution/cypher-shell">
       <fileset dir="${shell.dist}"/>
     </copy>
   </target>
+  -->
 
 </project>

--- a/packaging/standalone/build.xml
+++ b/packaging/standalone/build.xml
@@ -1,0 +1,30 @@
+<project default="copy-shell">
+  <property name="shell.dist" location="../../in/cypher-shell"/>
+  <property name="shell.zip" location="${shell.dist}.zip"/>
+  <!-- Extract zip file -->
+
+  <target name="find-shell-zip" description="See if shell zip file exists">
+    <echo>Checking if ${shell.zip} exists</echo>
+    <available file="${shell.zip}" property="zip.present"/>
+  </target>
+  <target name="extract-shell-zip" depends="find-shell-zip"
+          if="zip.present">
+    <unzip src="${shell.zip}" dest="../../in"/>
+  </target>
+
+  <!-- Copy to source directory -->
+  <target name="find-shell" description="Check that cypher-shell is available"
+          depends="extract-shell-zip">
+    <echo>Checking if ${shell.dist} exists</echo>
+    <available file="${shell.dist}" type="dir"
+               property="shell.present"/>
+  </target>
+
+  <target name="copy-shell" description="Copy cypher-shell files"
+          depends="find-shell" if="shell.present">
+    <copy todir="src/main/distribution/cypher-shell">
+      <fileset dir="${shell.dist}"/>
+    </copy>
+  </target>
+
+</project>

--- a/packaging/standalone/pom.xml
+++ b/packaging/standalone/pom.xml
@@ -80,6 +80,25 @@
   <build>
     <plugins>
       <plugin>
+        <inherited>false</inherited>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-shell</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <ant antfile="${project.basedir}/build.xml" inheritRefs="true"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <executions>
           <execution>

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-unix-dist.xml
@@ -74,6 +74,23 @@
         <include>**/config-migrator.jar</include>
       </includes>
     </fileSet>
+    <!-- filter and chmod 755 cypher-shell -->
+    <fileSet>
+      <directory>${project.parent.basedir}/src/main/distribution/cypher-shell/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <lineEnding>unix</lineEnding>
+      <fileMode>0755</fileMode>
+      <excludes>
+        <exclude>*.bat</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.parent.basedir}/src/main/distribution/cypher-shell/lib</directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
   </fileSets>
 
   <dependencySets>
@@ -124,4 +141,3 @@
  </dependencySets>
 
 </assembly>
-

--- a/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
+++ b/packaging/standalone/standalone-community/src/main/assemblies/community-windows-dist.xml
@@ -70,6 +70,23 @@
       </excludes>
       <filtered>true</filtered>
     </fileSet>
+    <!-- cypher-shell -->
+    <fileSet>
+      <directory>${project.parent.basedir}/src/main/distribution/cypher-shell/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <lineEnding>dos</lineEnding>
+      <includes>
+        <include>*.exe</include>
+        <include>*.bat</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.parent.basedir}/src/main/distribution/cypher-shell/lib</directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
   </fileSets>
 
   <dependencySets>
@@ -116,4 +133,3 @@
   </dependencySets>
 
 </assembly>
-

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-unix-dist.xml
@@ -85,6 +85,23 @@
         <include>**/config-migrator.jar</include>
       </includes>
     </fileSet>
+    <!-- filter and chmod 755 cypher-shell -->
+    <fileSet>
+      <directory>${project.parent.basedir}/src/main/distribution/cypher-shell/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <lineEnding>unix</lineEnding>
+      <fileMode>0755</fileMode>
+      <excludes>
+        <exclude>*.bat</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.parent.basedir}/src/main/distribution/cypher-shell/lib</directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
   </fileSets>
 
   <dependencySets>

--- a/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
+++ b/packaging/standalone/standalone-enterprise/src/main/assemblies/enterprise-windows-dist.xml
@@ -67,6 +67,23 @@
       </includes>
 	  <filtered>true</filtered>
     </fileSet>
+    <!-- cypher-shell -->
+    <fileSet>
+      <directory>${project.parent.basedir}/src/main/distribution/cypher-shell/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <lineEnding>dos</lineEnding>
+      <includes>
+        <include>*.exe</include>
+        <include>*.bat</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.parent.basedir}/src/main/distribution/cypher-shell/lib</directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>*.jar</include>
+      </includes>
+    </fileSet>
   </fileSets>
 
   <dependencySets>


### PR DESCRIPTION
Tree of mac installer:

```
Neo4j Community Edition 3.1.0-SNAPSHOT.app
└── Contents
    ├── firstrun
    ├── Info.plist
    ├── MacOS
    │   └── JavaApplicationStub
    ├── PkgInfo
    └── Resources
        ├── app
        │   ├── bin
        │   │   ├── cypher-shell
        │   │   ├── install.properties
        │   │   ├── neo4j-admin
        │   │   ├── neo4j-backup
        │   │   ├── neo4j-community.vmoptions
        │   │   ├── neo4j-desktop-3.1.0-SNAPSHOT.jar
        │   │   ├── neo4j-import
        │   │   ├── neo4j-shared.sh
        │   │   └── neo4j-shell
        │   ├── LICENSES.txt
        │   ├── LICENSE.txt
        │   ├── NOTICE.txt
        │   └── plugins
        │       └── README.txt
        ├── app.icns
        ├── i4jlauncher.config
        └── jre.bundle
```

Tree of windows installation result:

```
/home/jonas/.wine/drive_c/Program Files (x86)/Neo4j CE 3.1.0-SNAPSHOT
├── bin
│   ├── cypher-shell.bat
│   ├── install.properties
│   ├── neo4j-ce.exe
│   ├── neo4j-community.vmoptions
│   └── neo4j-desktop-3.1.0-SNAPSHOT.jar
├── jre
├── LICENSES.txt
├── LICENSE.txt
├── NOTICE.txt
├── plugins
│   └── README.txt
└── uninstall.exe
```

changelog: Included a new `cypher-shell`
