### PR TITLE
Update cost model

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
@@ -89,8 +89,8 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     val b = createNode("x")
     val r = relate(a, b)
 
-    val result = executeWithAllPlannersAndCompatibilityMode(s"match (a)-[r]-(b) where id(r) = ${r.getId} return a,r,b")
-    result.toList should equal(List(
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode(s"match (a)-[r]-(b) where id(r) = ${r.getId} return a,r,b")
+    result.toSet should equal(Set(
       Map("r" -> r, "a" -> a, "b" -> b),
       Map("r" -> r, "a" -> b, "b" -> a)))
   }

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModel.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModel.scala
@@ -38,16 +38,20 @@ object CardinalityCostModel extends CostModel {
 
   private def costPerRow(plan: LogicalPlan): CostPerRow = plan match {
 
-    case  _: AllNodesScan |
-         _: DirectedRelationshipByIdSeek |
-         _: UndirectedRelationshipByIdSeek |
+    case  _: NodeByLabelScan |
          _: ProjectEndpoints
     => FAST_STORE
 
-    case _: NodeByLabelScan => 1.6
+    case _: AllNodesScan => 1.2
 
     case _: Expand |
-         _: VarExpand  => 2.5
+         _: VarExpand  => 2.0
+
+    case _: NodeUniqueIndexSeek |
+         _: NodeIndexSeek |
+         _: NodeIndexContainsScan |
+         _: NodeIndexEndsWithScan |
+         _: NodeIndexScan => 3.0
 
     // Filtering on labels and properties
     case Selection(predicates, _) if predicates.exists {
@@ -55,6 +59,8 @@ object CardinalityCostModel extends CostModel {
       case _ => false
     }
     => FAST_STORE
+
+    case _: NodeByIdSeek  => 8.0
 
     case _: NodeHashJoin |
          _: Aggregation |
@@ -76,12 +82,8 @@ object CardinalityCostModel extends CostModel {
 
     case _: FindShortestPaths |
          _: LegacyIndexSeek |
-         _: NodeByIdSeek |
-         _: NodeUniqueIndexSeek |
-         _: NodeIndexSeek |
-         _: NodeIndexContainsScan |
-         _: NodeIndexEndsWithScan |
-         _: NodeIndexScan
+         _: DirectedRelationshipByIdSeek |
+         _: UndirectedRelationshipByIdSeek
     => SLOW_STORE
 
     case _

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModelTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/CardinalityCostModelTest.scala
@@ -39,7 +39,7 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
           )(solvedWithEstimation(10.0)), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r1")(solvedWithEstimation(100.0))
       )(solvedWithEstimation(10.0))
 
-    CardinalityCostModel(plan, QueryGraphSolverInput.empty) should equal(Cost(251))
+    CardinalityCostModel(plan, QueryGraphSolverInput.empty) should equal(Cost(241))
   }
 
   test("should introduce increase cost when estimating an eager operator and lazyness is preferred") {

--- a/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/LeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.1/src/test/scala/org/neo4j/cypher/internal/compiler/v3_1/planner/logical/LeafPlanningIntegrationTest.scala
@@ -398,11 +398,11 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     // Index selectivity is 0.02, and label selectivity is 0.2.
     // The OR query will use the formula A ∪ B = ¬ ( ¬ A ∩ ¬ B ) to calculate the selectivities,
     // which gives us the formula:
-    // 1 - (1 - 0.02)^15 = 1 - .98^10 = 1 - .713702596 = 0.286297404 which is less selective than .2, so the index
+    // 1 - (1 - 0.02)^25 = 1 - .98^25 = 1 - .713702596 = 0.4 which is less selective than .2, so the index
     // should not win
     (new given {
       indexOn("Awesome", "prop")
-    } planFor "MATCH (n:Awesome) WHERE n.prop IN [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] RETURN n").plan should beLike {
+    } planFor "MATCH (n:Awesome) WHERE n.prop IN [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25] RETURN n").plan should beLike {
       case _: Selection => ()
     }
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ExecutionEngineTest.scala
@@ -286,7 +286,7 @@ with QueryStatisticsTestSupport with CreateTempFileTestSupport with NewPlannerTe
   }
 
   test("parameterTypeErrorShouldBeNicelyExplained") {
-    for (i <- 1 to 10) createNode()
+    createNode()
     val query = "match (pA) where id(pA) = {a} return pA"
 
     executeWithAllPlannersAndRuntimesAndCompatibilityMode(query, "a" -> "Andres") should be (empty)


### PR DESCRIPTION
The relative costs of operators have changed quite some bit since 2.3 and the
cost model should be updated to accommodate this.
![2_3](https://cloud.githubusercontent.com/assets/88000/16569212/f19db4a4-4233-11e6-8318-b5d51aa7d4bf.png)
![3_1](https://cloud.githubusercontent.com/assets/88000/16569215/fb1c364a-4233-11e6-8992-a3628a6a9724.png)
