### PR TITLE
Fix flaky PageCacheTest.backgroundThreadsMustGracefullyShutDown

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.file.NoSuchFileException;
@@ -3588,23 +3589,11 @@ public abstract class PageCacheTest<T extends PageCache>
         // hasn't, then something must be keeping it alive, even though it has been closed.
         int maxChecks = 200;
         //noinspection unused -- we use old-gen heap pollution, as well as System.gc(), to cause old-gen GCs
-        byte[] randomHeapPollution;
+        LinkedList<SoftReference<byte[]>> heapPollution = new LinkedList<>();
         boolean passed;
         do
         {
-            System.gc();
-            Thread.sleep( 100 );
-            passed = true;
-            //noinspection UnusedAssignment -- dumping unused crap into the old-gen heap to provoke GCs
-            randomHeapPollution = new byte[(int) ByteUnit.mebiBytes( 2 )];
-
-            for ( WeakReference<PageCache> ref : refs )
-            {
-                if ( ref.get() != null )
-                {
-                    passed = false;
-                }
-            }
+            passed = causeGcAndCheckReferences( refs, heapPollution );
         }
         while ( !passed && maxChecks-- > 0 );
 
@@ -3625,6 +3614,27 @@ public abstract class PageCacheTest<T extends PageCache>
                 fail( "PageCaches should not be held live after close: " + nonNullPageCaches );
             }
         }
+    }
+
+    private boolean causeGcAndCheckReferences(
+            List<WeakReference<PageCache>> refs,
+            LinkedList<SoftReference<byte[]>> heapPollution )
+            throws InterruptedException
+    {
+        System.gc();
+        Thread.sleep( 50 );
+        boolean passed = true;
+        //noinspection UnusedAssignment -- dumping unused crap into the old-gen heap to provoke GCs
+        heapPollution.add( new SoftReference<>( new byte[(int) ByteUnit.mebiBytes( 32 )] ) );
+
+        for ( WeakReference<PageCache> ref : refs )
+        {
+            if ( ref.get() != null )
+            {
+                passed = false;
+            }
+        }
+        return passed;
     }
 
     private void createAndDirtyAndShutDownPageCache( List<WeakReference<PageCache>> refs, int filePagesInTotal )


### PR DESCRIPTION
This test is relying on the GC to finalise and collect PageCache instances that are no longer referenced.
The GC did not always do this, because finalising objects is hard, and why try if it's been promoted to the old-gen heap and you can get away with a young-gen collection.

The test has been fixed by making it pollute the old-gen heap much more aggressively.
Apparently the previous old-gen pollution would often never leave the eden, and thus had little effect.
The effectiveness of the new heap pollution has been verified through GC log inspection across hundreds of test executions, across the 3 major garbage collectors: parallel, G1 and CMS.

The flakiness of the test has now been dropped from about one false positive in 20 runs, to less than (I have not observed a failure since these changes) one in 600 for all garbage collectors.
