### PR TITLE
Limit restrict on transaction access mode

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -150,7 +150,8 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService, logProvider: 
         val tc = externalTransactionalContext.provideContext()
 
         // Temporarily change access mode during query planning
-        val revertable = tc.restrictCurrentTransaction(AccessMode.Static.READ)
+        // NOTE: The OVERRIDE_READ mode will force read access even if the current transaction did not have it
+        val revertable = tc.restrictCurrentTransaction(AccessMode.Static.OVERRIDE_READ)
 
         val ((plan: ExecutionPlan, extractedParameters), touched) = try {
           // fetch plan cache

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AccessMode.java
@@ -44,6 +44,12 @@ public interface AccessMode
                     {
                         return false;
                     }
+
+                    @Override
+                    public boolean overrideOriginalMode()
+                    {
+                        return false;
+                    }
                 },
 
         /** Allows reading data and schema, but not writing. */
@@ -63,6 +69,12 @@ public interface AccessMode
 
                     @Override
                     public boolean allowsSchemaWrites()
+                    {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean overrideOriginalMode()
                     {
                         return false;
                     }
@@ -88,6 +100,12 @@ public interface AccessMode
                     {
                         return false;
                     }
+
+                    @Override
+                    public boolean overrideOriginalMode()
+                    {
+                        return false;
+                    }
                 },
 
         /** Allows reading and writing data, but not schema. */
@@ -107,6 +125,12 @@ public interface AccessMode
 
                     @Override
                     public boolean allowsSchemaWrites()
+                    {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean overrideOriginalMode()
                     {
                         return false;
                     }
@@ -132,11 +156,51 @@ public interface AccessMode
                     {
                         return true;
                     }
-                }
-    }
+
+                    @Override
+                    public boolean overrideOriginalMode()
+                    {
+                        return false;
+                    }
+                },
+
+        /** Allows reading data and schema, but not writing.
+         * NOTE: This is a special mode that will override the original access mode when put as a temporary restriction
+         * on a transaction, potentially elevating the access mode to give read access to a transaction that did not
+         * have read access before.
+         */
+        OVERRIDE_READ
+        {
+            @Override
+            public boolean allowsReads()
+            {
+                return true;
+            }
+
+            @Override
+            public boolean allowsWrites()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean allowsSchemaWrites()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean overrideOriginalMode()
+            {
+                return true;
+            }
+        },
+
+        }
 
     boolean allowsReads();
     boolean allowsWrites();
     boolean allowsSchemaWrites();
+    boolean overrideOriginalMode();
     String name();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthSubject.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthSubject.java
@@ -79,6 +79,12 @@ public interface AuthSubject extends AccessMode
         }
 
         @Override
+        public boolean overrideOriginalMode()
+        {
+            return false;
+        }
+
+        @Override
         public String name()
         {
             return "<anonymous>";
@@ -109,6 +115,12 @@ public interface AuthSubject extends AccessMode
         }
 
         @Override
+        public boolean overrideOriginalMode()
+        {
+            return false;
+        }
+
+        @Override
         public String name()
         {
             return "<auth disabled>";
@@ -130,5 +142,4 @@ public interface AuthSubject extends AccessMode
         {
         }
     };
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
+import org.neo4j.kernel.impl.api.security.RestrictedAccessMode;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.TxState;
 import org.neo4j.kernel.impl.locking.Locks;
@@ -688,7 +689,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     public Revertable restrict( AccessMode mode )
     {
         AccessMode oldMode = this.accessMode;
-        this.accessMode = mode;
+        this.accessMode = new RestrictedAccessMode( oldMode, mode );
         return () -> this.accessMode = oldMode;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/RestrictedAccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/RestrictedAccessMode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.security;
+
+import org.neo4j.kernel.api.security.AccessMode;
+
+public class RestrictedAccessMode implements AccessMode
+{
+    private final AccessMode originalMode;
+    private final AccessMode restrictedMode;
+
+    public RestrictedAccessMode( AccessMode originalMode, AccessMode restrictedMode )
+    {
+        this.originalMode = originalMode;
+        this.restrictedMode = restrictedMode;
+    }
+
+    @Override
+    public boolean allowsReads()
+    {
+        return restrictedMode.allowsReads() &&
+               (restrictedMode.overrideOriginalMode() || originalMode.allowsReads());
+    }
+
+    @Override
+    public boolean allowsWrites()
+    {
+        return restrictedMode.allowsWrites() &&
+               (restrictedMode.overrideOriginalMode() || originalMode.allowsWrites());
+    }
+
+    @Override
+    public boolean allowsSchemaWrites()
+    {
+        return restrictedMode.allowsSchemaWrites() &&
+               (restrictedMode.overrideOriginalMode() || originalMode.allowsSchemaWrites());
+    }
+
+    @Override
+    public boolean overrideOriginalMode()
+    {
+        return false;
+    }
+
+    @Override
+    public String name()
+    {
+        if ( restrictedMode.overrideOriginalMode() )
+        {
+            return originalMode.name() + " overridden by " + restrictedMode.name();
+        }
+        else
+        {
+            return originalMode.name() + " restricted to " + restrictedMode.name();
+        }
+    }
+}

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthSubject.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthSubject.java
@@ -115,6 +115,12 @@ public class BasicAuthSubject implements AuthSubject
     }
 
     @Override
+    public boolean overrideOriginalMode()
+    {
+        return false;
+    }
+
+    @Override
     public String name()
     {
         return accessMode.name();

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthSubject.java
@@ -109,6 +109,12 @@ public class EnterpriseAuthSubject implements AuthSubject
     }
 
     @Override
+    public boolean overrideOriginalMode()
+    {
+        return false;
+    }
+
+    @Override
     public String name()
     {
         Object principal = shiroSubject.getPrincipal();


### PR DESCRIPTION
A tempory restriction on the transaction access mode should not be able to
elevate the access rights above the current level - only limit it.

There is one exception where the query planner needs read access that now
uses a separate special access mode.
