### PR TITLE
Make transaction id accessible after KTI commit

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.bolt.security.auth.AuthenticationException;
 import org.neo4j.bolt.security.auth.AuthenticationResult;
-import org.neo4j.bolt.security.auth.BasicAuthenticationResult;
 import org.neo4j.bolt.v1.messaging.MessageHandler;
 import org.neo4j.bolt.v1.messaging.message.DiscardAllMessage;
 import org.neo4j.bolt.v1.messaging.message.Message;
@@ -43,11 +42,11 @@ import org.neo4j.bolt.v1.runtime.integration.RecordingCallback;
 import org.neo4j.bolt.v1.runtime.internal.concurrent.ThreadedSessions;
 import org.neo4j.bolt.v1.runtime.spi.RecordStream;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.lifecycle.LifeSupport;
@@ -247,9 +246,10 @@ public class ResetFuzzTest
         }
 
         @Override
-        public void close() throws TransactionFailureException
+        public long closeTransaction() throws TransactionFailureException
         {
             liveTransactions.decrementAndGet();
+            return NOT_COMMITTED;
         }
 
         @Override

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/internal/ResetFuzzTest.java
@@ -249,7 +249,7 @@ public class ResetFuzzTest
         public long closeTransaction() throws TransactionFailureException
         {
             liveTransactions.decrementAndGet();
-            return NOT_COMMITTED;
+            return ROLLBACK;
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -84,6 +84,8 @@ public interface KernelTransaction extends AutoCloseable
         void notify( boolean success );
     }
 
+    long NOT_COMMITTED = -1;
+
     /**
      * Acquires a new {@link Statement} for this transaction which allows for reading and writing data from and
      * to the underlying database. After the group of reads and writes have been performed the statement
@@ -108,9 +110,20 @@ public interface KernelTransaction extends AutoCloseable
     /**
      * Closes this transaction, committing its changes iff {@link #success()} has been called and
      * {@link #failure()} has NOT been called. Otherwise its changes will be rolled back.
+     *
+     * @return id of the committed transaction or {@link #NOT_COMMITTED} if transaction was rolled back or read-only.
+     */
+    long closeTransaction() throws TransactionFailureException;
+
+    /**
+     * Closes this transaction, committing its changes iff {@link #success()} has been called and
+     * {@link #failure()} has NOT been called. Otherwise its changes will be rolled back.
      */
     @Override
-    void close() throws TransactionFailureException;
+    default void close() throws TransactionFailureException
+    {
+        closeTransaction();
+    }
 
     /**
      * @return {@code true} if the transaction is still open, i.e. if {@link #close()} hasn't been called yet.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -84,7 +84,8 @@ public interface KernelTransaction extends AutoCloseable
         void notify( boolean success );
     }
 
-    long NOT_COMMITTED = -1;
+    long ROLLBACK = -1;
+    long READ_ONLY = 0;
 
     /**
      * Acquires a new {@link Statement} for this transaction which allows for reading and writing data from and
@@ -108,16 +109,19 @@ public interface KernelTransaction extends AutoCloseable
     void failure();
 
     /**
-     * Closes this transaction, committing its changes iff {@link #success()} has been called and
-     * {@link #failure()} has NOT been called. Otherwise its changes will be rolled back.
+     * Closes this transaction, committing its changes if {@link #success()} has been called and neither
+     * {@link #failure()} nor {@link #markForTermination()} has been called.
+     * Otherwise its changes will be rolled back.
      *
-     * @return id of the committed transaction or {@link #NOT_COMMITTED} if transaction was rolled back or read-only.
+     * @return id of the committed transaction or {@link #ROLLBACK} if transaction was rolled back or
+     * {@link #READ_ONLY} if transaction was read-only.
      */
     long closeTransaction() throws TransactionFailureException;
 
     /**
-     * Closes this transaction, committing its changes iff {@link #success()} has been called and
-     * {@link #failure()} has NOT been called. Otherwise its changes will be rolled back.
+     * Closes this transaction, committing its changes if {@link #success()} has been called and neither
+     * {@link #failure()} nor {@link #markForTermination()} has been called.
+     * Otherwise its changes will be rolled back.
      */
     @Override
     default void close() throws TransactionFailureException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -413,7 +413,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
             {
                 rollback();
                 failOnNonExplicitRollbackIfNeeded();
-                return NOT_COMMITTED;
+                return ROLLBACK;
             }
             else
             {
@@ -538,7 +538,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                 }
             }
             success = true;
-            return NOT_COMMITTED;
+            return READ_ONLY;
         }
         catch ( ConstraintValidationKernelException | CreateConstraintFailureException e )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -35,6 +34,7 @@ import org.neo4j.kernel.api.exceptions.schema.ConstraintVerificationFailedKernel
 import org.neo4j.kernel.api.index.IndexDescriptor;
 import org.neo4j.kernel.api.index.PreexistingIndexEntryConflictException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.api.StatementOperationParts;
@@ -175,8 +175,9 @@ public class ConstraintIndexCreatorTest
                 }
 
                 @Override
-                public void close() throws TransactionFailureException
+                public long closeTransaction() throws TransactionFailureException
                 {
+                    return NOT_COMMITTED;
                 }
 
                 @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -177,7 +177,7 @@ public class ConstraintIndexCreatorTest
                 @Override
                 public long closeTransaction() throws TransactionFailureException
                 {
-                    return NOT_COMMITTED;
+                    return ROLLBACK;
                 }
 
                 @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -553,7 +553,40 @@ public class KernelIT extends KernelIntegrationTest
         }
         tx.failure();
 
-        assertEquals( KernelTransaction.NOT_COMMITTED, tx.closeTransaction() );
+        assertEquals( KernelTransaction.ROLLBACK, tx.closeTransaction() );
+        assertFalse( tx.isOpen() );
+    }
+
+    @Test
+    public void txReturnsCorrectIdWhenMarkedForTermination() throws Exception
+    {
+        executeDummyTxs( db, 42 );
+
+        KernelTransaction tx = kernel.newTransaction( KernelTransaction.Type.implicit, AccessMode.Static.FULL );
+        try ( Statement statement = tx.acquireStatement() )
+        {
+            statement.dataWriteOperations().nodeCreate();
+        }
+        tx.markForTermination();
+
+        assertEquals( KernelTransaction.ROLLBACK, tx.closeTransaction() );
+        assertFalse( tx.isOpen() );
+    }
+
+    @Test
+    public void txReturnsCorrectIdWhenFailedlAndMarkedForTermination() throws Exception
+    {
+        executeDummyTxs( db, 42 );
+
+        KernelTransaction tx = kernel.newTransaction( KernelTransaction.Type.implicit, AccessMode.Static.FULL );
+        try ( Statement statement = tx.acquireStatement() )
+        {
+            statement.dataWriteOperations().nodeCreate();
+        }
+        tx.failure();
+        tx.markForTermination();
+
+        assertEquals( KernelTransaction.ROLLBACK, tx.closeTransaction() );
         assertFalse( tx.isOpen() );
     }
 
@@ -571,7 +604,7 @@ public class KernelIT extends KernelIntegrationTest
         }
         tx.success();
 
-        assertEquals( KernelTransaction.NOT_COMMITTED, tx.closeTransaction() );
+        assertEquals( KernelTransaction.READ_ONLY, tx.closeTransaction() );
         assertFalse( tx.isOpen() );
     }
 


### PR DESCRIPTION
Transaction id is only assigned during commit of `KernelTransactionImplementation`. It is not assigned if transaction was rolled back or read-only. Currently it is not possible to obtain committed transaction id because KTI just implements `AutoCloseable` and commit happens in `#close()`.

However, it might be sometimes valuable to know committed transaction id and track it.

This commit makes KTI expose it's id (if committed) via `#closeTransaction()` method while still keeping KTI an `AutoCloseable`.
