### PR TITLE
core-edge: stop raft log-shipper earlier

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
@@ -263,11 +263,11 @@ public class RaftInstance implements LeaderLocator,
         LeaderContext leaderContext = new LeaderContext( outcome.getTerm(), outcome.getLeaderCommit() );
         if ( outcome.isElectedLeader() )
         {
-            logShipping.start( leaderContext );
+            logShipping.resume( leaderContext );
         }
         else if ( outcome.isSteppingDown() )
         {
-            logShipping.stop();
+            logShipping.pause();
         }
 
         if ( outcome.getRole() == LEADER )

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipper.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/replication/shipping/RaftLogShipper.java
@@ -169,7 +169,7 @@ public class RaftLogShipper
         }
         catch ( Throwable e )
         {
-            log.error( "Failed to start log shipper " + statusAsString(), e );
+            log.error( "Failed to stop log shipper " + statusAsString(), e );
         }
         abortTimeout();
     }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -575,6 +575,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
                         myself, raftMembershipManager, electionTimeout,
                         config.get( CoreEdgeClusterSettings.catchup_batch_size ),
                         config.get( CoreEdgeClusterSettings.log_shipping_max_lag ), inFlightMap );
+        life.add( logShipping );
 
         RaftInstance raftInstance =
                 new RaftInstance( myself, termState, voteState, raftLog, raftStateMachine, electionTimeout,
@@ -592,15 +593,6 @@ public class EnterpriseCoreEditionModule extends EditionModule
         loggingRaftInbound.registerHandler( batchingMessageHandler );
 
         life.add( new RaftDiscoveryServiceConnector( discoveryService, raftInstance ) );
-
-        life.add( new LifecycleAdapter()
-        {
-            @Override
-            public void shutdown() throws Throwable
-            {
-                logShipping.destroy();
-            }
-        } );
 
         return raftInstance;
     }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/elections/Fixture.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/elections/Fixture.java
@@ -109,7 +109,7 @@ public class Fixture
         }
         for ( RaftInstance raft : rafts )
         {
-            raft.logShippingManager().destroy();
+            raft.logShippingManager().stop();
         }
     }
 }


### PR DESCRIPTION
Was previously destroyed in shutdown phase for unknown reason.

Also renames start/stop to pause/resume in log shipper to not
confuse it with the lifecycle methods.
