### PR TITLE
Fixed tests failing on windows due to newline

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SyntaxExceptionAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SyntaxExceptionAcceptanceTest.scala
@@ -176,7 +176,8 @@ class SyntaxExceptionAcceptanceTest extends ExecutionEngineFunSuite {
   }
 
   test("should handle newline") {
-    test(System.lineSeparator(), "Unexpected end of input: expected whitespace, comment, CYPHER options, EXPLAIN, PROFILE or Query (line 2, column 1 (offset: 1))")
+    val sep = System.lineSeparator()
+    test(sep, s"Unexpected end of input: expected whitespace, comment, CYPHER options, EXPLAIN, PROFILE or Query (line 2, column 1 (offset: ${sep.length}))")
   }
 
   def test(query: String, message: String) {

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/FixturesTest.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/FixturesTest.java
@@ -34,6 +34,7 @@ import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TargetDirectory;
 import org.neo4j.test.server.HTTP;
 
+import static java.lang.System.lineSeparator;
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -186,8 +187,9 @@ public class FixturesTest
         }
         catch(RuntimeException e)
         {
-            assertThat(e.getMessage(), equalTo("Invalid input 't': expected <init> " +
-                    "(line 1, column 1 (offset: 0))\n\"this is not a valid cypher statement\"\n ^"));
+            assertThat( e.getMessage(), equalTo(
+                    "Invalid input 't': expected <init> (line 1, column 1 (offset: 0))" + lineSeparator() +
+                    "\"this is not a valid cypher statement\"" + lineSeparator() + " ^" ) );
         }
     }
 


### PR DESCRIPTION
Recent work to improve the use of platform specific newlines in generating error messages has also resulted in some tests failing in windows. Tests that previously expected unix newlines. This PR fixes two of those.
