### PR TITLE
Moving StoreId checking down a layer so that we can do message

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/MismatchedStoreIdService.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/MismatchedStoreIdService.java
@@ -17,17 +17,25 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.coreedge.raft.net;
+package org.neo4j.coreedge.raft;
 
-import org.neo4j.coreedge.network.Message;
-import org.neo4j.coreedge.raft.BatchingMessageHandler;
+import org.neo4j.coreedge.server.StoreId;
+import org.neo4j.kernel.impl.store.StoreFailureException;
 
-public interface Inbound<M extends Message>
+public interface MismatchedStoreIdService
 {
-    void registerHandler( MessageHandler<M> handler );
+    void addMismatchedStoreListener( BatchingMessageHandler.MismatchedStoreListener listener );
 
-    interface MessageHandler<M extends Message>
+    interface MismatchedStoreListener
     {
-        void handle( M message );
+        void onMismatchedStore( BatchingMessageHandler.MismatchedStoreIdException ex );
+    }
+
+    class MismatchedStoreIdException extends StoreFailureException
+    {
+        public MismatchedStoreIdException( StoreId expected, StoreId encountered )
+        {
+            super( "Expected:" + expected + ", encountered:" + encountered );
+        }
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/ClusterIdentityIT.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/ClusterIdentityIT.java
@@ -53,6 +53,7 @@ import static org.junit.Assert.fail;
 
 import static org.neo4j.coreedge.TestStoreId.assertAllStoresHaveTheSameStoreId;
 import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.kernel.impl.store.MetaDataStore.Position.RANDOM_NUMBER;
 import static org.neo4j.kernel.impl.store.MetaDataStore.Position.TIME;
 import static org.neo4j.test.rule.SuppressOutput.suppress;
 
@@ -268,7 +269,7 @@ public class ClusterIdentityIT
         File neoStoreFile = new File( storeDir, MetaDataStore.DEFAULT_NAME );
         try ( PageCache pageCache = StandalonePageCacheFactory.createPageCache( fs ) )
         {
-            MetaDataStore.setRecord( pageCache, neoStoreFile, TIME, System.currentTimeMillis() );
+            MetaDataStore.setRecord( pageCache, neoStoreFile, RANDOM_NUMBER, System.currentTimeMillis() );
         }
     }
 

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/MembershipWaiterTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/membership/MembershipWaiterTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
+import org.neo4j.coreedge.raft.BatchingMessageHandler;
 import org.neo4j.coreedge.raft.RaftServer;
 import org.neo4j.coreedge.raft.log.InMemoryRaftLog;
 import org.neo4j.coreedge.raft.log.RaftLogEntry;
@@ -47,7 +48,7 @@ public class MembershipWaiterTest
     {
         OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
         MembershipWaiter waiter = new MembershipWaiter( member( 0 ), jobScheduler, 500,
-                mock(RaftServer.class), NullLogProvider.getInstance() );
+                mock(BatchingMessageHandler.class), NullLogProvider.getInstance() );
 
         InMemoryRaftLog raftLog = new InMemoryRaftLog();
         raftLog.append( new RaftLogEntry( 0, valueOf( 0 ) ) );
@@ -69,7 +70,7 @@ public class MembershipWaiterTest
     {
         OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
         MembershipWaiter waiter = new MembershipWaiter( member( 0 ), jobScheduler, 1,
-                mock(RaftServer.class), NullLogProvider.getInstance());
+                mock(BatchingMessageHandler.class), NullLogProvider.getInstance());
 
         RaftState raftState = RaftStateBuilder.raftState()
                 .votingMembers( member( 1 ) )
@@ -96,7 +97,7 @@ public class MembershipWaiterTest
     {
         OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
         MembershipWaiter waiter = new MembershipWaiter( member( 0 ), jobScheduler, 1,
-                mock(RaftServer.class), NullLogProvider.getInstance() );
+                mock(BatchingMessageHandler.class), NullLogProvider.getInstance() );
 
         RaftState raftState = RaftStateBuilder.raftState()
                 .votingMembers( member( 0 ), member( 1 ) )


### PR DESCRIPTION
verification of messages sequentially.

We previously had a race condition where we'd start downloading
a store and if we processed another message before we'd finished
downloading we could end up thinking we had a mismatching StoreId
on a non empty store because our StoreId hadn't updated yet

make the batch handle raft messages
