### PR TITLE
Make the PageCacheTest.concurrentFlushing* tests use the long test timeout

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -3403,7 +3403,7 @@ public abstract class PageCacheTest<T extends PageCache>
         pagedFileB.close();
     }
 
-    @Test( timeout = SEMI_LONG_TIMEOUT_MILLIS )
+    @Test( timeout = LONG_TIMEOUT_MILLIS )
     public void concurrentPageFaultingMustNotPutInterleavedDataIntoPages() throws Exception
     {
         final int filePageCount = 11;
@@ -3440,7 +3440,7 @@ public abstract class PageCacheTest<T extends PageCache>
             }
         } );
 
-        harness.run( SEMI_LONG_TIMEOUT_MILLIS, MILLISECONDS );
+        harness.run( LONG_TIMEOUT_MILLIS, MILLISECONDS );
     }
 
     @Test( timeout = SEMI_LONG_TIMEOUT_MILLIS )
@@ -3461,10 +3461,10 @@ public abstract class PageCacheTest<T extends PageCache>
         harness.disableCommands( Command.MapFile, Command.UnmapFile, Command.ReadRecord );
         harness.setVerification( filesAreCorrectlyWrittenVerification( recordFormat, filePageCount ) );
 
-        harness.run( SEMI_LONG_TIMEOUT_MILLIS, MILLISECONDS );
+        harness.run( LONG_TIMEOUT_MILLIS, MILLISECONDS );
     }
 
-    @Test( timeout = SEMI_LONG_TIMEOUT_MILLIS )
+    @Test( timeout = LONG_TIMEOUT_MILLIS )
     public void concurrentFlushingWithMischiefMustNotPutInterleavedDataIntoFile() throws Exception
     {
         final RecordFormat recordFormat = new StandardRecordFormat();
@@ -3485,10 +3485,10 @@ public abstract class PageCacheTest<T extends PageCache>
         harness.disableCommands( Command.MapFile, Command.UnmapFile, Command.ReadRecord );
         harness.setVerification( filesAreCorrectlyWrittenVerification( recordFormat, filePageCount ) );
 
-        harness.run( SEMI_LONG_TIMEOUT_MILLIS, MILLISECONDS );
+        harness.run( LONG_TIMEOUT_MILLIS, MILLISECONDS );
     }
 
-    @Test( timeout = SEMI_LONG_TIMEOUT_MILLIS )
+    @Test( timeout = LONG_TIMEOUT_MILLIS )
     public void concurrentFlushingWithFailuresMustNotPutInterleavedDataIntoFile() throws Exception
     {
         final RecordFormat recordFormat = new StandardRecordFormat();
@@ -3509,7 +3509,7 @@ public abstract class PageCacheTest<T extends PageCache>
         harness.disableCommands( Command.MapFile, Command.UnmapFile, Command.ReadRecord );
         harness.setVerification( filesAreCorrectlyWrittenVerification( recordFormat, filePageCount ) );
 
-        harness.run( SEMI_LONG_TIMEOUT_MILLIS, MILLISECONDS );
+        harness.run( LONG_TIMEOUT_MILLIS, MILLISECONDS );
     }
 
     private Phase filesAreCorrectlyWrittenVerification( final RecordFormat recordFormat, final int filePageCount )


### PR DESCRIPTION
Because the tests in some of our builds run on spinning hard disk drives, which means they have a very large variance in their execution times.

**Note** that in 3.0 these tests have moved to the `org.neo4j.io.pagecache.harness.PageCacheHarnessTest` class, which will complicate the forward merge a bit.
