### PR TITLE
Test that injectable alternative API for procedures works

### DIFF
--- a/community/neo4j-harness/src/test/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
+++ b/community/neo4j-harness/src/test/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
@@ -1,1 +1,2 @@
 org.neo4j.harness.JavaProceduresTest$MyExtensionThatAddsInjectable
+org.neo4j.harness.JavaProceduresTest$MyExtensionThatAddsAlternativeCoreAPI


### PR DESCRIPTION
There has been some thinking about the idea of getting people to prototype new alternative Core API's for possible consideration in the future. The idea being that we would benefit from several alternative suggestions, actually implemented as prototypes, before knowing enough to make a real decision.

It turns out that the framework for this already exists, including tests that demonstrate it.

This PR just adds a more extensive test that proves the point a little more. It does not change the procedures framework in any way.
