### PR TITLE
Make locks tx termination aware by default

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -795,7 +795,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         KernelTransactions kernelTransactions = life.add( new KernelTransactions( locks, constraintIndexCreator,
                 statementOperations, schemaWriteGuard, transactionHeaderInformationFactory, transactionCommitProcess,
                 indexConfigStore, legacyIndexProviderLookup, hooks, transactionMonitor, life, tracers, storageEngine,
-                procedures, transactionIdStore, config, Clock.SYSTEM_CLOCK ) );
+                procedures, transactionIdStore, Clock.SYSTEM_CLOCK ) );
 
         final Kernel kernel = new Kernel( kernelTransactions, hooks, databaseHealth, transactionMonitor, procedures );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -127,7 +127,6 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     private final TransactionTracer tracer;
     private final Pool<KernelTransactionImplementation> pool;
     private final Supplier<LegacyIndexTransactionState> legacyIndexTxStateSupplier;
-    private final boolean txTerminationAwareLocks;
 
     // For committing
     private final TransactionHeaderInformationFactory headerInformationFactory;
@@ -179,8 +178,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                                             Pool<KernelTransactionImplementation> pool,
                                             Clock clock,
                                             TransactionTracer tracer,
-                                            StorageEngine storageEngine,
-                                            boolean txTerminationAwareLocks )
+                                            StorageEngine storageEngine )
     {
         this.operations = operations;
         this.schemaWriteGuard = schemaWriteGuard;
@@ -197,7 +195,6 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.tracer = tracer;
         this.storageStatement = storeLayer.newStatement();
         this.currentStatement = new KernelStatement( this, this, operations, storageStatement, procedures );
-        this.txTerminationAwareLocks = txTerminationAwareLocks;
     }
 
     /**
@@ -270,7 +267,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
             {
                 failure = true;
                 terminationReason = reason;
-                if ( txTerminationAwareLocks && locks != null )
+                if ( locks != null )
                 {
                     locks.stop();
                 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -29,14 +29,11 @@ import org.neo4j.collection.pool.LinkedQueuePool;
 import org.neo4j.collection.pool.MarshlandPool;
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.DatabaseShutdownException;
-import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.Clock;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.txstate.LegacyIndexTransactionState;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.impl.api.state.LegacyIndexTransactionStateImpl;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
@@ -52,7 +49,6 @@ import org.neo4j.kernel.monitoring.tracing.Tracers;
 import org.neo4j.storageengine.api.StorageEngine;
 
 import static java.util.Collections.newSetFromMap;
-import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
  * Central source of transactions in the database.
@@ -65,13 +61,9 @@ import static org.neo4j.kernel.configuration.Settings.setting;
 public class KernelTransactions extends LifecycleAdapter
         implements Supplier<KernelTransactionsSnapshot>   // For providing KernelTransactionSnapshots
 {
-    public static final Setting<Boolean> tx_termination_aware_locks = setting(
-            "unsupported.dbms.tx_termination_aware_locks", Settings.BOOLEAN, Settings.FALSE );
-
     // Transaction dependencies
 
     private final Locks locks;
-    private final boolean txTerminationAwareLocks;
     private final ConstraintIndexCreator constraintIndexCreator;
     private final StatementOperationParts statementOperations;
     private final SchemaWriteGuard schemaWriteGuard;
@@ -118,11 +110,9 @@ public class KernelTransactions extends LifecycleAdapter
                                StorageEngine storageEngine,
                                Procedures procedures,
                                TransactionIdStore transactionIdStore,
-                               Config config,
                                Clock clock )
     {
         this.locks = locks;
-        this.txTerminationAwareLocks = config.get( tx_termination_aware_locks );
         this.constraintIndexCreator = constraintIndexCreator;
         this.statementOperations = statementOperations;
         this.schemaWriteGuard = schemaWriteGuard;
@@ -152,7 +142,7 @@ public class KernelTransactions extends LifecycleAdapter
                     statementOperations, schemaWriteGuard, hooks, constraintIndexCreator, procedures,
                     transactionHeaderInformationFactory, transactionCommitProcess, transactionMonitor,
                     legacyIndexTxStateSupplier, localTxPool, clock, tracers.transactionTracer,
-                    storageEngine, txTerminationAwareLocks );
+                    storageEngine );
 
             allTransactions.add( tx );
             return tx;

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -84,7 +84,7 @@ public class KernelTransactionFactory
                 mock( Pool.class ),
                 Clock.SYSTEM_CLOCK,
                 TransactionTracer.NULL,
-                storageEngine, false );
+                storageEngine );
 
         transaction.initialize( 0, 0, new NoOpClient(), KernelTransaction.Type.implicit, accessMode );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
@@ -442,7 +442,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void markForTerminationNotInitializedTransaction()
     {
-        KernelTransactionImplementation tx = newNotInitializedTransaction( true );
+        KernelTransactionImplementation tx = newNotInitializedTransaction();
 
         tx.markForTermination( Status.General.UnknownError );
 
@@ -453,7 +453,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void markForTerminationInitializedTransaction()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient, true );
+        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient );
 
         tx.markForTermination( Status.General.UnknownError );
 
@@ -465,7 +465,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void markForTerminationTerminatedTransaction()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient, true );
+        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient );
         transactionInitializer.accept( tx );
 
         tx.markForTermination( Status.Transaction.Terminated );
@@ -481,7 +481,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void terminatedTxMarkedNeitherSuccessNorFailureClosesWithoutThrowing() throws TransactionFailureException
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient, true );
+        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient );
         transactionInitializer.accept( tx );
         tx.markForTermination( Status.General.UnknownError );
 
@@ -495,7 +495,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void terminatedTxMarkedForSuccessThrowsOnClose()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient, true );
+        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient );
         transactionInitializer.accept( tx );
         tx.success();
         tx.markForTermination( Status.General.UnknownError );
@@ -515,7 +515,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void terminatedTxMarkedForFailureClosesWithoutThrowing() throws TransactionFailureException
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient, true );
+        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient );
         transactionInitializer.accept( tx );
         tx.failure();
         tx.markForTermination( Status.General.UnknownError );
@@ -530,7 +530,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void terminatedTxMarkedForBothSuccessAndFailureThrowsOnClose()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient, true );
+        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient );
         transactionInitializer.accept( tx );
         tx.success();
         tx.failure();
@@ -550,7 +550,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void txMarkedForBothSuccessAndFailureThrowsOnClose()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient, true );
+        KernelTransactionImplementation tx = newTransaction( accessMode(), locksClient );
         tx.success();
         tx.failure();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
@@ -360,7 +360,7 @@ public class KernelTransactionTerminationTest
                     mock( ConstraintIndexCreator.class ), new Procedures(), TransactionHeaderInformationFactory.DEFAULT,
                     mock( TransactionCommitProcess.class ), monitor, () -> mock( LegacyIndexTransactionState.class ),
                     mock( Pool.class ), new FakeClock(), TransactionTracer.NULL,
-                    mock( StorageEngine.class, RETURNS_MOCKS ), true );
+                    mock( StorageEngine.class, RETURNS_MOCKS ) );
 
             this.monitor = monitor;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -97,30 +97,29 @@ public class KernelTransactionTestBase
         return newTransaction( 0, accessMode );
     }
 
-    public KernelTransactionImplementation newTransaction( AccessMode accessMode, Locks.Client locks,
-            boolean txTerminationAwareLocks )
+    public KernelTransactionImplementation newTransaction( AccessMode accessMode, Locks.Client locks )
     {
-        return newTransaction( 0, accessMode, locks, txTerminationAwareLocks );
+        return newTransaction( 0, accessMode, locks );
     }
 
     public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted, AccessMode accessMode )
     {
-        return newTransaction( lastTransactionIdWhenStarted, accessMode, new NoOpClient(), false );
+        return newTransaction( lastTransactionIdWhenStarted, accessMode, new NoOpClient() );
     }
 
     public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted, AccessMode accessMode,
-            Locks.Client locks, boolean txTerminationAwareLocks )
+            Locks.Client locks )
     {
-        KernelTransactionImplementation tx = newNotInitializedTransaction( txTerminationAwareLocks );
+        KernelTransactionImplementation tx = newNotInitializedTransaction();
         tx.initialize( lastTransactionIdWhenStarted, BASE_TX_COMMIT_TIMESTAMP,locks, Type.implicit, accessMode );
         return tx;
     }
 
-    public KernelTransactionImplementation newNotInitializedTransaction( boolean txTerminationAwareLocks )
+    public KernelTransactionImplementation newNotInitializedTransaction()
     {
         return new KernelTransactionImplementation( null, schemaWriteGuard, hooks, null, null, headerInformationFactory,
                 commitProcess, transactionMonitor, legacyIndexStateSupplier, txPool, clock, TransactionTracer.NULL,
-                storageEngine, txTerminationAwareLocks );
+                storageEngine );
     }
 
     public class CapturingCommitProcess implements TransactionCommitProcess

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -39,13 +39,9 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AccessMode;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.proc.Procedures;
-import org.neo4j.kernel.impl.store.MetaDataStore;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.TransactionId;
-import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
@@ -436,8 +432,7 @@ public class KernelTransactionsTest
                 null, null, null, TransactionHeaderInformationFactory.DEFAULT,
                 commitProcess, null,
                 null, new TransactionHooks(), mock( TransactionMonitor.class ), life,
-                tracers, storageEngine, new Procedures(), transactionIdStore, Config.empty(),
-                Clock.SYSTEM_CLOCK );
+                tracers, storageEngine, new Procedures(), transactionIdStore, Clock.SYSTEM_CLOCK );
     }
 
     private static TransactionCommitProcess newRememberingCommitProcess( final TransactionRepresentation[] slot )

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLockManager.java
@@ -23,7 +23,6 @@ import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.com.RequestContextFactory;
 import org.neo4j.kernel.ha.com.master.Master;
-import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.logging.LogProvider;
 
@@ -34,7 +33,6 @@ public class SlaveLockManager implements Locks
     private final Master master;
     private final AvailabilityGuard availabilityGuard;
     private final LogProvider logProvider;
-    private final boolean txTerminationAwareLocks;
 
     public SlaveLockManager( Locks localLocks, RequestContextFactory requestContextFactory, Master master,
             AvailabilityGuard availabilityGuard, LogProvider logProvider, Config config )
@@ -44,15 +42,13 @@ public class SlaveLockManager implements Locks
         this.local = localLocks;
         this.master = master;
         this.logProvider = logProvider;
-        this.txTerminationAwareLocks = config.get( KernelTransactions.tx_termination_aware_locks );
     }
 
     @Override
     public Client newClient()
     {
         Client client = local.newClient();
-        return new SlaveLocksClient( master, client, local, requestContextFactory, availabilityGuard, logProvider,
-                txTerminationAwareLocks );
+        return new SlaveLocksClient( master, client, local, requestContextFactory, availabilityGuard, logProvider );
     }
 
     @Override

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TestPullUpdates.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TestPullUpdates.java
@@ -45,10 +45,8 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransientTransactionFailureException;
 import org.neo4j.graphdb.factory.TestHighlyAvailableGraphDatabaseFactory;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
-import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
@@ -133,15 +131,14 @@ public class TestPullUpdates
     }
 
     @Test
-    public void terminatedTransactionDoesNotForceUpdatePullingWithTxTerminationAwareLocks() throws Throwable
+    public void terminatedTransactionDoesNotForceUpdatePulling() throws Throwable
     {
         int testTxsOnMaster = 42;
         File root = testDirectory.directory( testName.getMethodName() );
         ClusterManager clusterManager = new ClusterManager.Builder( root )
                 .withSharedConfig( MapUtil.stringMap(
                         HaSettings.pull_interval.name(), "0s",
-                        HaSettings.tx_push_factor.name(), "0",
-                        KernelTransactions.tx_termination_aware_locks.name(), Settings.TRUE ) ).build();
+                        HaSettings.tx_push_factor.name(), "0" ) ).build();
         clusterManager.start();
         cluster = clusterManager.getCluster();
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesTest.java
@@ -54,7 +54,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.runners.Parameterized.Parameters;
 import static org.neo4j.graphdb.DynamicRelationshipType.withName;
-import static org.neo4j.kernel.impl.api.KernelTransactions.tx_termination_aware_locks;
 
 @RunWith( Parameterized.class )
 public class TerminationOfSlavesDuringPullUpdatesTest
@@ -71,8 +70,6 @@ public class TerminationOfSlavesDuringPullUpdatesTest
     @Parameter
     public ReadContestantActions action;
     @Parameter( 1 )
-    public boolean txTerminationAwareLocks;
-    @Parameter( 2 )
     public String name;
 
     @Parameters( name = "{1}" )
@@ -81,34 +78,34 @@ public class TerminationOfSlavesDuringPullUpdatesTest
         return Arrays.<Object>asList( new Object[][]
                 {
                         {new PropertyValueActions( longString( 'a' ), longString( 'b' ), true ),
-                                true, "NodeStringProperty[txTerminationAwareLocks=yes]"},
+                                "NodeStringProperty[txTerminationAwareLocks=yes]"},
                         {new PropertyValueActions( longString( 'a' ), longString( 'b' ), true ),
-                                false, "NodeStringProperty[txTerminationAwareLocks=no]"},
+                                "NodeStringProperty[txTerminationAwareLocks=no]"},
 
                         {new PropertyValueActions( longString( 'a' ), longString( 'b' ), false ),
-                                true, "RelationshipStringProperty[txTerminationAwareLocks=yes]"},
+                                "RelationshipStringProperty[txTerminationAwareLocks=yes]"},
                         {new PropertyValueActions( longString( 'a' ), longString( 'b' ), false ),
-                                false, "RelationshipStringProperty[txTerminationAwareLocks=no]"},
+                                "RelationshipStringProperty[txTerminationAwareLocks=no]"},
 
                         {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), true ),
-                                true, "NodeArrayProperty[txTerminationAwareLocks=yes]"},
+                                "NodeArrayProperty[txTerminationAwareLocks=yes]"},
                         {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), true ),
-                                false, "NodeArrayProperty[txTerminationAwareLocks=no]"},
+                                "NodeArrayProperty[txTerminationAwareLocks=no]"},
 
                         {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), false ),
-                                true, "RelationshipArrayProperty[txTerminationAwareLocks=yes]"},
+                                "RelationshipArrayProperty[txTerminationAwareLocks=yes]"},
                         {new PropertyValueActions( longArray( 'a' ), longArray( 'b' ), false ),
-                                false, "RelationshipArrayProperty[txTerminationAwareLocks=no]"},
+                                "RelationshipArrayProperty[txTerminationAwareLocks=no]"},
 
                         {new PropertyKeyActions( 'a', 'b', true ),
-                                true, "NodePropertyKeys[txTerminationAwareLocks=yes]"},
+                                "NodePropertyKeys[txTerminationAwareLocks=yes]"},
                         {new PropertyKeyActions( 'a', 'b', true ),
-                                false, "NodePropertyKeys[txTerminationAwareLocks=no]"},
+                                "NodePropertyKeys[txTerminationAwareLocks=no]"},
 
                         {new PropertyKeyActions( 'a', 'b', false ),
-                                true, "RelationshipPropertyKeys[txTerminationAwareLocks=yes]"},
+                                "RelationshipPropertyKeys[txTerminationAwareLocks=yes]"},
                         {new PropertyKeyActions( 'a', 'b', false ),
-                                false, "RelationshipPropertyKeys[txTerminationAwareLocks=no]"}
+                                "RelationshipPropertyKeys[txTerminationAwareLocks=no]"}
                 }
         );
     }
@@ -119,7 +116,7 @@ public class TerminationOfSlavesDuringPullUpdatesTest
         long safeZone = TimeUnit.MILLISECONDS.toMillis( 0 );
         clusterRule.withSharedSetting( HaSettings.id_reuse_safe_zone_time, String.valueOf( safeZone ) );
         // given
-        final ClusterManager.ManagedCluster cluster = startCluster();
+        final ClusterManager.ManagedCluster cluster = clusterRule.startCluster();
         HighlyAvailableGraphDatabase master = cluster.getMaster();
 
         // when
@@ -153,7 +150,7 @@ public class TerminationOfSlavesDuringPullUpdatesTest
         long safeZone = TimeUnit.MINUTES.toMillis( 1 );
         clusterRule.withSharedSetting( HaSettings.id_reuse_safe_zone_time, String.valueOf( safeZone ) );
         // given
-        final ClusterManager.ManagedCluster cluster = startCluster();
+        final ClusterManager.ManagedCluster cluster = clusterRule.startCluster();
         HighlyAvailableGraphDatabase master = cluster.getMaster();
 
         // when
@@ -416,12 +413,6 @@ public class TerminationOfSlavesDuringPullUpdatesTest
         {
             return node ? db.getNodeById( id ) : db.getRelationshipById( id );
         }
-    }
-
-    private ClusterManager.ManagedCluster startCluster() throws Exception
-    {
-        return clusterRule.withSharedSetting( tx_termination_aware_locks, String.valueOf( txTerminationAwareLocks ) )
-                .startCluster();
     }
 
     private static Object longArray( char b )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientConcurrentTest.java
@@ -42,8 +42,8 @@ import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.impl.enterprise.lock.forseti.ForsetiLockManager;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.logging.Log;
-import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.storageengine.api.lock.ResourceType;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -111,7 +111,7 @@ public class SlaveLocksClientConcurrentTest
     private SlaveLocksClient createClient()
     {
         return new SlaveLocksClient( master, lockManager.newClient(), lockManager,
-                requestContextFactory, availabilityGuard, NullLogProvider.getInstance(), false );
+                requestContextFactory, availabilityGuard, NullLogProvider.getInstance() );
     }
 
     private static class LockedOnMasterAnswer implements Answer

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveLocksClientTest.java
@@ -57,7 +57,6 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -93,7 +92,8 @@ public class SlaveLocksClientTest
 
         whenMasterAcquireExclusive().thenReturn( responseOk );
 
-        client = newSlaveLocksClient( lockManager, true );
+        client = new SlaveLocksClient( master, local, lockManager, mock( RequestContextFactory.class ),
+                availabilityGuard, logProvider );
     }
 
     private OngoingStubbing<Response<LockResult>> whenMasterAcquireShared()
@@ -530,23 +530,6 @@ public class SlaveLocksClientTest
         logProvider.assertExactly( inLog( SlaveLocksClient.class )
                 .warn( equalTo( "Unable to stop lock session on master" ),
                         CoreMatchers.<Throwable>equalTo( error ) ) );
-    }
-
-    @Test
-    public void stopDoesNothingWhenLocksAreNotTxTerminationAware()
-    {
-        SlaveLocksClient client = newSlaveLocksClient( lockManager, false );
-
-        client.stop();
-
-        verify( local, never() ).stop();
-        verify( master, never() ).endLockSession( any( RequestContext.class ), anyBoolean() );
-    }
-
-    private SlaveLocksClient newSlaveLocksClient( Locks lockManager, boolean txTerminationAwareLocks )
-    {
-        return new SlaveLocksClient( master, local, lockManager, mock( RequestContextFactory.class ),
-                availabilityGuard, logProvider, txTerminationAwareLocks );
     }
 
     private SlaveLocksClient stoppedClient()

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
@@ -21,12 +21,7 @@ package org.neo4j.kernel.ha.transaction;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -51,7 +46,6 @@ import static org.neo4j.helpers.TimeUtil.parseTimeMillis;
 import static org.neo4j.kernel.ha.cluster.modeswitch.HighAvailabilityModeSwitcher.MASTER;
 import static org.neo4j.kernel.ha.cluster.modeswitch.HighAvailabilityModeSwitcher.UNKNOWN;
 import static org.neo4j.kernel.impl.MyRelTypes.TEST;
-import static org.neo4j.kernel.impl.api.KernelTransactions.tx_termination_aware_locks;
 import static org.neo4j.kernel.impl.ha.ClusterManager.memberThinksItIsRole;
 
 /**
@@ -79,25 +73,12 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.memberThinksItIsRole;
  * This test is a stress test and duration of execution can be controlled via system property
  * -D{@link org.neo4j.kernel.ha.transaction.TransactionThroughMasterSwitchStressIT}.duration
  */
-@RunWith( Parameterized.class )
 public class TransactionThroughMasterSwitchStressIT
 {
     @Rule
-    public final ClusterRule clusterRule;
-
-    public TransactionThroughMasterSwitchStressIT( boolean txTerminationAwareLocks )
-    {
-        clusterRule = new ClusterRule( getClass() )
-                .withInstanceSetting( HaSettings.slave_only,
-                        value -> value == 1 || value == 2 ? Settings.TRUE : Settings.FALSE )
-                .withSharedSetting( tx_termination_aware_locks, String.valueOf( txTerminationAwareLocks ) );
-    }
-
-    @Parameters(name = "txTerminationAwareLocks={0}")
-    public static List<Object> txTerminationAwareLocks()
-    {
-        return Arrays.asList( false, true );
-    }
+    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+            .withInstanceSetting( HaSettings.slave_only,
+                    value -> value == 1 || value == 2 ? Settings.TRUE : Settings.FALSE );
 
     @Test
     public void shouldNotHaveTransactionsRunningThroughRoleSwitchProduceInconsistencies() throws Throwable

--- a/integrationtests/src/test/java/org/neo4j/TransactionTerminationIT.java
+++ b/integrationtests/src/test/java/org/neo4j/TransactionTerminationIT.java
@@ -94,8 +94,7 @@ public class TransactionTerminationIT
             .withCluster( clusterOfSize( 3 ) )
             .withSharedSetting( HaSettings.ha_server, ":6001-6005" )
             .withSharedSetting( HaSettings.tx_push_factor, "2" )
-            .withSharedSetting( HaSettings.lock_read_timeout, "1m" )
-            .withSharedSetting( KernelTransactions.tx_termination_aware_locks, Settings.TRUE );
+            .withSharedSetting( HaSettings.lock_read_timeout, "1m" );
 
     @Rule
     public final RuleChain ruleChain = RuleChain.outerRule( SuppressOutput.suppressAll() )
@@ -114,7 +113,6 @@ public class TransactionTerminationIT
         ServerControls server = cleanupRule.add( TestServerBuilders.newInProcessBuilder()
                 .withConfig( GraphDatabaseSettings.auth_enabled, Settings.FALSE )
                 .withConfig( GraphDatabaseFacadeFactory.Configuration.lock_manager, lockManagerName )
-                .withConfig( KernelTransactions.tx_termination_aware_locks, Settings.TRUE )
                 .newServer() );
 
         GraphDatabaseService db = server.graph();


### PR DESCRIPTION
PR removes `unsupported.dbms.tx_termination_aware_locks` setting and makes locks abort waiting if the owning transaction was terminated. This behaviour is now default and not configurable.
