### PR TITLE
Introduce new parameter syntax

### DIFF
--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/Literals.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/Literals.scala
@@ -23,6 +23,8 @@ import org.neo4j.cypher.internal.frontend.v3_1.ast
 import org.neo4j.cypher.internal.frontend.v3_1.symbols._
 import org.parboiled.scala._
 
+import scala.language.postfixOps
+
 trait Literals extends Parser
   with Base with Strings {
 
@@ -78,6 +80,14 @@ trait Literals extends Parser
   }
 
   def Parameter: Rule1[ast.Parameter] = rule("a parameter") {
+    NewParameter | OldParameter
+  }
+
+  def NewParameter: Rule1[ast.Parameter] = rule("a parameter (new syntax") {
+    ((ch('$') ~~ (UnescapedSymbolicNameString | EscapedSymbolicNameString | UnsignedDecimalInteger ~> (_.toString))) memoMismatches) ~~>> (ast.Parameter(_, CTAny))
+  }
+
+  def OldParameter: Rule1[ast.Parameter] = rule("a parameter (old syntax)") {
     ((ch('{') ~~ (UnescapedSymbolicNameString | EscapedSymbolicNameString | UnsignedDecimalInteger ~> (_.toString)) ~~ ch('}')) memoMismatches) ~~>> (ast.Parameter(_, CTAny))
   }
 

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/matchers/IdentifierStartMatcher.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/matchers/IdentifierStartMatcher.scala
@@ -20,5 +20,5 @@
 package org.neo4j.cypher.internal.frontend.v3_1.parser.matchers
 
 class IdentifierStartMatcher extends ScalaCharMatcher("an identifier") {
-  protected def matchChar(c: Char): Boolean = Character.isJavaIdentifierStart(c)
+  protected def matchChar(c: Char): Boolean = Character.isJavaIdentifierStart(c) && Character.getType(c) != Character.CURRENCY_SYMBOL
 }

--- a/community/cypher/frontend-3.1/src/test/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/LiteralsTest.scala
+++ b/community/cypher/frontend-3.1/src/test/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/LiteralsTest.scala
@@ -96,5 +96,13 @@ class LiteralsTest extends ParserTest[Any, Any] with Literals {
     parsing("$0") shouldGive ast.Parameter("0", CTAny)(t)
   }
 
+  test("variables are not allowed to start with currency symbols") {
+    implicit val parserToTest = Variable
+
+    Seq("$", "¢", "£", "₲", "₶", "\u20BD", "＄", "﹩").foreach { curr =>
+      assertFails(s"${curr}var")
+    }
+  }
+
   def convert(result: Any): Any = result
 }

--- a/community/cypher/frontend-3.1/src/test/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/LiteralsTest.scala
+++ b/community/cypher/frontend-3.1/src/test/scala/org/neo4j/cypher/internal/frontend/v3_1/parser/LiteralsTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.frontend.v3_1.parser
 
 import org.neo4j.cypher.internal.frontend.v3_1.{DummyPosition, ast}
+import org.neo4j.cypher.internal.frontend.v3_1.symbols._
 import org.parboiled.scala._
 
 class LiteralsTest extends ParserTest[Any, Any] with Literals {
@@ -52,7 +53,7 @@ class LiteralsTest extends ParserTest[Any, Any] with Literals {
     assertFails("1bcd")
   }
 
-  test("can parse numbersz") {
+  test("can parse numbers") {
     implicit val parserToTest = NumberLiteral
 
     parsing("123") shouldGive ast.SignedDecimalIntegerLiteral("123")(t)
@@ -77,6 +78,22 @@ class LiteralsTest extends ParserTest[Any, Any] with Literals {
     parsing("1E23") shouldGive ast.DecimalDoubleLiteral("1E23")(t)
     parsing("1.34E99") shouldGive ast.DecimalDoubleLiteral("1.34E99")(t)
     parsing("9E-443") shouldGive ast.DecimalDoubleLiteral("9E-443")(t)
+  }
+
+  test("can parse legacy parameter syntax") {
+    implicit val parserToTest = Parameter
+
+    parsing("{p}") shouldGive ast.Parameter("p", CTAny)(t)
+    parsing("{`the funny horse`}") shouldGive ast.Parameter("the funny horse", CTAny)(t)
+    parsing("{0}") shouldGive ast.Parameter("0", CTAny)(t)
+  }
+
+  test("can parse new parameter syntax") {
+    implicit val parserToTest = Parameter
+
+    parsing("$p") shouldGive ast.Parameter("p", CTAny)(t)
+    parsing("$`the funny horse`") shouldGive ast.Parameter("the funny horse", CTAny)(t)
+    parsing("$0") shouldGive ast.Parameter("0", CTAny)(t)
   }
 
   def convert(result: Any): Any = result

--- a/manual/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
+++ b/manual/cypher/cypher-docs/src/docs/dev/syntax/expressions.asciidoc
@@ -14,8 +14,8 @@ An expression in Cypher can be:
 * A variable: `n`, `x`, `rel`, `myFancyVariable`, +\`A name with weird stuff in it[]!`+.
 * A property: `n.prop`, `x.prop`, `rel.thisProperty`, +myFancyVariable.\`(weird property name)`+.
 * A dynamic property: `n["prop"]`, `rel[n.city + n.zip]`, `map[coll[0]]`.
-* A parameter: `{param}`, `{0}`
-* A list of expressions: `["a", "b"]`, `[1,2,3]`, `["a", 2, n.property, {param}]`, `[ ]`.
+* A parameter: `$param`, `$0`
+* A list of expressions: `["a", "b"]`, `[1,2,3]`, `["a", 2, n.property, $param]`, `[ ]`.
 * A function call: `length(p)`, `nodes(p)`.
 * An aggregate function: `avg(x.prop)`, `count(*)`.
 * A path-pattern: `(a)-->()<--(b)`.

--- a/manual/cypher/cypher-docs/src/docs/graphgists/intro/getting-the-results-you-want.adoc
+++ b/manual/cypher/cypher-docs/src/docs/graphgists/intro/getting-the-results-you-want.adoc
@@ -177,7 +177,7 @@ So for instance if you return `person.name` you can still `ORDER BY person.age` 
 You cannot order by things that you can't infer from the information you return.
 This is especially important with aggregation and `DISTINCT` return values as both remove the visibility of data that is aggregated.
 
-Pagination is a straightforward use of `SKIP {offset} LIMIT {count}`.
+Pagination is a straightforward use of `SKIP $offset LIMIT $count`.
 
 A common pattern is to aggregate for a count (score or frequency), order by it and only return the top-n entries.
 

--- a/manual/cypher/cypher-docs/src/docs/graphgists/intro/loading-data.adoc
+++ b/manual/cypher/cypher-docs/src/docs/graphgists/intro/loading-data.adoc
@@ -35,7 +35,7 @@ For instance to create a movie graph from JSON data structures pulled from an AP
 
 [source,cypher,hideexec=true]
 ----
-UNWIND {movies} as movie
+UNWIND $movies as movie
 MERGE (m:Movie {title:movie.title}) ON CREATE SET m.released = movie.released
 FOREACH (role IN movie.cast |
    MERGE (a:Person {name:role.actor.name}) ON CREATE SET a.born = role.actor.born

--- a/manual/cypher/cypher-docs/src/docs/intro/use-in-application.adoc
+++ b/manual/cypher/cypher-docs/src/docs/intro/use-in-application.adoc
@@ -8,7 +8,7 @@ For immediate execution you can use the `/db/data/transaction/commit` endpoint w
 [source,bash]
 ----
 curl -i -H accept:application/json -H content-type:application/json -XPOST http://localhost:7474/db/data/transaction/commit \
-  -d '{"statements":[{"statement":"CREATE (p:Person {name:{name},born:{born}}) RETURN p","parameters":{"name":"Keanu Reeves","born":1964}}]}'
+  -d '{"statements":[{"statement":"CREATE (p:Person {name: $name, born: $born}) RETURN p","parameters":{"name":"Keanu Reeves","born":1964}}]}'
 ----
 
 The above command results in:
@@ -27,7 +27,7 @@ At the end you either commit the whole transaction by POSTing to the (also retur
 [source,bash]
 ----
 curl -i -H accept:application/json -H content-type:application/json -XPOST http://localhost:7474/db/data/transaction \
-  -d '{"statements":[{"statement":"CREATE (p:Person {name:{name},born:{born}}) RETURN p","parameters":{"name":"Clint Eastwood","born":1930}}]}'
+  -d '{"statements":[{"statement":"CREATE (p:Person {name:$name,born:$born}) RETURN p","parameters":{"name":"Clint Eastwood","born":1930}}]}'
 ----
 
 The above command results in:

--- a/manual/cypher/cypher-docs/src/test/java/org/neo4j/cypher/example/JavaExecutionEngineDocTest.java
+++ b/manual/cypher/cypher-docs/src/test/java/org/neo4j/cypher/example/JavaExecutionEngineDocTest.java
@@ -197,7 +197,7 @@ public class JavaExecutionEngineDocTest
         // START SNIPPET: exampleWithParameterForNodeId
         Map<String, Object> params = new HashMap<>();
         params.put( "id", 0 );
-        String query = "MATCH (n) WHERE id(n) = {id} RETURN n.name";
+        String query = "MATCH (n) WHERE id(n) = $id RETURN n.name";
         Result result = db.execute( query, params );
         // END SNIPPET: exampleWithParameterForNodeId
 
@@ -213,7 +213,7 @@ public class JavaExecutionEngineDocTest
         // START SNIPPET: exampleWithParameterForMultipleNodeIds
         Map<String, Object> params = new HashMap<>();
         params.put( "ids", Arrays.asList( 0, 1, 2 ) );
-        String query = "MATCH (n) WHERE id(n) in {ids} RETURN n.name";
+        String query = "MATCH (n) WHERE id(n) in $ids RETURN n.name";
         Result result = db.execute( query, params );
         // END SNIPPET: exampleWithParameterForMultipleNodeIds
 
@@ -234,7 +234,7 @@ public class JavaExecutionEngineDocTest
         // START SNIPPET: exampleWithStringLiteralAsParameter
         Map<String, Object> params = new HashMap<>();
         params.put( "name", "Johan" );
-        String query = "MATCH (n) WHERE n.name = {name} RETURN n";
+        String query = "MATCH (n) WHERE n.name = $name RETURN n";
         Result result = db.execute( query, params );
         // END SNIPPET: exampleWithStringLiteralAsParameter
 
@@ -248,7 +248,7 @@ public class JavaExecutionEngineDocTest
         // START SNIPPET: exampleWithShortSyntaxStringLiteralAsParameter
         Map<String, Object> params = new HashMap<>();
         params.put( "name", "Johan" );
-        String query = "MATCH (n {name: {name}}) RETURN n";
+        String query = "MATCH (n {name: $name}) RETURN n";
         Result result = db.execute( query, params );
         // END SNIPPET: exampleWithShortSyntaxStringLiteralAsParameter
 
@@ -264,7 +264,7 @@ public class JavaExecutionEngineDocTest
             // START SNIPPET: exampleWithParameterForIndexValue
             Map<String, Object> params = new HashMap<>();
             params.put( "value", "Michaela" );
-            String query = "START n=node:people(name = {value}) RETURN n";
+            String query = "START n=node:people(name = $value) RETURN n";
             Result result = db.execute( query, params );
             // END SNIPPET: exampleWithParameterForIndexValue
             assertEquals( asList( michaelaNode ), this.<Node>toList( result, "n" ) );
@@ -280,7 +280,7 @@ public class JavaExecutionEngineDocTest
             // START SNIPPET: exampleWithParametersForQuery
             Map<String, Object> params = new HashMap<>();
             params.put( "query", "name:Andreas" );
-            String query = "START n=node:people({query}) RETURN n";
+            String query = "START n=node:people($query) RETURN n";
             Result result = db.execute( query, params );
             // END SNIPPET: exampleWithParametersForQuery
             assertEquals( asList( andreasNode ), this.<Node>toList( result, "n" ) );
@@ -294,7 +294,7 @@ public class JavaExecutionEngineDocTest
         // START SNIPPET: exampleWithParameterForNodeObject
         Map<String, Object> params = new HashMap<>();
         params.put( "node", andreasNode );
-        String query = "MATCH (n) WHERE n = {node} RETURN n.name";
+        String query = "MATCH (n) WHERE n = $node RETURN n.name";
         Result result = db.execute( query, params );
         // END SNIPPET: exampleWithParameterForNodeObject
 
@@ -310,7 +310,7 @@ public class JavaExecutionEngineDocTest
         Map<String, Object> params = new HashMap<>();
         params.put( "s", 1 );
         params.put( "l", 1 );
-        String query = "MATCH (n) RETURN n.name SKIP {s} LIMIT {l}";
+        String query = "MATCH (n) RETURN n.name SKIP $s LIMIT $l";
         Result result = db.execute( query, params );
         // END SNIPPET: exampleWithParameterForSkipLimit
 
@@ -326,7 +326,7 @@ public class JavaExecutionEngineDocTest
         // START SNIPPET: exampleWithParameterRegularExpression
         Map<String, Object> params = new HashMap<>();
         params.put( "regex", ".*h.*" );
-        String query = "MATCH (n) WHERE n.name =~ {regex} RETURN n.name";
+        String query = "MATCH (n) WHERE n.name =~ $regex RETURN n.name";
         Result result = db.execute( query, params );
         // END SNIPPET: exampleWithParameterRegularExpression
         dumpToFile( "exampleWithParameterRegularExpression", query, params );
@@ -343,7 +343,7 @@ public class JavaExecutionEngineDocTest
         // START SNIPPET: exampleWithParameterCSCIStringPatternMatching
         Map<String, Object> params = new HashMap<>();
         params.put( "name", "Michael" );
-        String query = "MATCH (n) WHERE n.name STARTS WITH {name} RETURN n.name";
+        String query = "MATCH (n) WHERE n.name STARTS WITH $name RETURN n.name";
         Result result = db.execute( query, params );
         // END SNIPPET: exampleWithParameterCSCIStringPatternMatching
         dumpToFile( "exampleWithParameterCSCIStringPatternMatching", query, params );
@@ -363,7 +363,7 @@ public class JavaExecutionEngineDocTest
 
         Map<String, Object> params = new HashMap<>();
         params.put( "props", props );
-        String query = "CREATE ({props})";
+        String query = "CREATE ($props)";
         db.execute( query, params );
         // END SNIPPET: create_node_from_map
         dumpToFile( "create_node_from_map", query, params );
@@ -389,7 +389,7 @@ public class JavaExecutionEngineDocTest
         Map<String, Object> params = new HashMap<>();
         List<Map<String, Object>> maps = Arrays.asList( n1, n2 );
         params.put( "props", maps );
-        String query = "UNWIND {props} AS properties CREATE (n:Person) SET n = properties RETURN n";
+        String query = "UNWIND $props AS properties CREATE (n:Person) SET n = properties RETURN n";
         db.execute( query, params );
         // END SNIPPET: create_multiple_nodes_from_map
         dumpToFile( "create_multiple_nodes_from_map", query, params );
@@ -417,7 +417,7 @@ public class JavaExecutionEngineDocTest
             Map<String, Object> params = new HashMap<>();
             params.put( "props", n1 );
 
-            String query = "MATCH (n) WHERE n.name='Michaela' SET n = {props}";
+            String query = "MATCH (n) WHERE n.name='Michaela' SET n = $props";
             db.execute( query, params );
             // END SNIPPET: set_properties_on_a_node_from_a_map
             dumpToFile( "set_properties_on_a_node_from_a_map", query, params );
@@ -437,7 +437,7 @@ public class JavaExecutionEngineDocTest
         Map<String, Object> params = new HashMap<>();
         params.put( "props", props );
 
-        String query = "MATCH (n) WHERE id(n) = 0 CREATE UNIQUE p = (n)-[:REL]->({props}) RETURN last(nodes(p)) AS X";
+        String query = "MATCH (n) WHERE id(n) = 0 CREATE UNIQUE p = (n)-[:REL]->($props) RETURN last(nodes(p)) AS X";
         Result result = db.execute( query, params );
         assertThat( count( result ), is( 1L ) );
     }
@@ -457,7 +457,7 @@ public class JavaExecutionEngineDocTest
         params.put( "props1", props1 );
         params.put( "props2", props2 );
 
-        String query = "MATCH (n) WHERE id(n) = 0 CREATE UNIQUE p = (n)-[:REL]->({props1})-[:LER]->({props2}) RETURN p";
+        String query = "MATCH (n) WHERE id(n) = 0 CREATE UNIQUE p = (n)-[:REL]->($props1)-[:LER]->($props2) RETURN p";
         Result result = db.execute( query, params );
         assertThat( count( result ), is( 1L ) );
     }
@@ -476,7 +476,7 @@ public class JavaExecutionEngineDocTest
     public void explain_returns_plan() throws Exception
     {
         // START SNIPPET: explain_returns_plan
-        Result result = db.execute( "EXPLAIN CREATE (user:User{name:{name}}) RETURN user" );
+        Result result = db.execute( "EXPLAIN CREATE (user:User{name:$name}) RETURN user" );
 
         assert result.getQueryExecutionType().isExplained();
         assert result.getQueryExecutionType().requestedExecutionPlanDescription();

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CallTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CallTest.scala
@@ -99,7 +99,7 @@ class CallTest extends DocumentingTestBase with QueryStatisticsTestSupport with 
     testQuery(
       title = "Call a procedure with mixed literal and parameter arguments",
       text = "This invokes the example procedure `org.neo4j.procedure.example.addNodeToIndex` using both literal and parameterized arguments.",
-      queryText = "CALL org.neo4j.procedure.example.addNodeToIndex('users', {node}, 'name')",
+      queryText = "CALL org.neo4j.procedure.example.addNodeToIndex('users', $node, 'name')",
       parameters = Map("node"->nodeId),
       optionalResultExplanation = "Since our example procedure does not return any result, the result is empty.",
       assertions = (p) => assert(p.isEmpty) )

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/CreateTest.scala
@@ -157,7 +157,7 @@ All the key/value pairs in the map will be set as properties on the created rela
 In this case we add a +Person+ label to the node as well.
 """,
       parameters = Map("props" -> Map("name" -> "Andres", "position" -> "Developer")),
-      queryText = "create (n:Person {props}) return n",
+      queryText = "create (n:Person $props) return n",
       optionalResultExplanation = "",
       assertions = (p) => assertStats(p, nodesCreated = 1, propertiesWritten = 2, labelsAdded = 1))
   }
@@ -169,7 +169,7 @@ In this case we add a +Person+ label to the node as well.
       parameters = Map("props" -> List(
         Map("name" -> "Andres", "position" -> "Developer"),
         Map("name" -> "Michael", "position" -> "Developer"))),
-      queryText = "UNWIND {props} as map CREATE (n) SET n = map",
+      queryText = "UNWIND $props as map CREATE (n) SET n = map",
       optionalResultExplanation = "",
       assertions = (p) => assertStats(p, nodesCreated = 2, propertiesWritten = 4))
   }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentationTestBaseTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/DocumentationTestBaseTest.scala
@@ -79,7 +79,7 @@ Use `UNWIND` to create multiple nodes from a parameter.
           Map("name" -> "Andres", "position" -> "Developer"),
           Map("name" -> "Michael", "position" -> "Developer")))
       ,
-      queryText = "unwind {props} as properties create (n) set n = properties return n",
+      queryText = "unwind $props as properties create (n) set n = properties return n",
       optionalResultExplanation = "",
       assertions = (p) => assertStats(p, nodesCreated = 2, propertiesWritten = 4))
 

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MergeTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/MergeTest.scala
@@ -201,7 +201,7 @@ return keanu.name, keanu.created, keanu.lastSeen""",
 To use map parameters with +MERGE+, it is necessary to explicitly use the expected properties, like in the following example.
 For more information on parameters, see <<cypher-parameters>>.""",
       parameters = Map("param" -> Map("name" -> "Keanu Reeves", "role" -> "Neo")),
-      queryText = "merge (person:Person {name:{param}.name, role:{param}.role}) return person.name, person.role",
+      queryText = "merge (person:Person {name:$param.name, role:$param.role}) return person.name, person.role",
       optionalResultExplanation = "",
       assertions = p => assertStats(p, nodesCreated = 1, propertiesWritten = 2, labelsAdded = 1)
     )

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/PatternTest.scala
@@ -144,7 +144,7 @@ In the case of a `CREATE` clause, the properties will be set in the newly create
 In the case of a `MERGE` clause, the properties will be used as additional constraints on the shape any existing data must have (the specified properties must exactly match any existing data in the graph).
 If no matching data is found, then `MERGE` behaves like `CREATE` and the properties will be set in the newly created nodes and relationships.
 
-Note that patterns supplied to `CREATE` may use a single parameter to specify properties, e.g: `CREATE (node {paramName})`.
+Note that patterns supplied to `CREATE` may use a single parameter to specify properties, e.g: `CREATE (node $paramName)`.
 This is not possible with patterns used in other clauses, as Cypher needs to know the property names at the time the query is compiled, so that matching can be done effectively.
 
 == Describing relationships ==

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SetTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/SetTest.scala
@@ -96,7 +96,7 @@ will remove all other properties on the receiving graph element.""".stripMargin,
 Use a parameter to give the value of a property.
 """,
       parameters = Map("surname" -> "Taylor"),
-      queryText = "match (n {name: 'Andres'}) set n.surname = {surname} return n",
+      queryText = "match (n {name: 'Andres'}) set n.surname = $surname return n",
       optionalResultExplanation = "The Andres node has got an surname added.",
       assertions = (p) => assertStats(p, nodesCreated = 0, propertiesWritten = 1))
   }
@@ -108,7 +108,7 @@ Use a parameter to give the value of a property.
 This will replace all existing properties on the node with the new set provided by the parameter.
 """,
       parameters = Map("props" -> Map("name" -> "Andres", "position" -> "Developer")),
-      queryText = "match (n {name: 'Andres'}) set n = {props} return n",
+      queryText = "match (n {name: 'Andres'}) set n = $props return n",
       optionalResultExplanation = "The Andres node has had all it's properties replaced by the properties in the +props+ parameter.",
       assertions = (p) => assertStats(p, nodesCreated = 0, propertiesWritten = 4))
   }

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UnwindTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/UnwindTest.scala
@@ -51,7 +51,7 @@ class UnwindTest extends DocumentingTestBase {
       text = "Create a number of nodes and relationships from a parameter-list without using +FOREACH+.",
       parameters = Map("events" -> List(Map("year" -> 2014, "id" -> 1), Map("year" -> 2014, "id" -> 2))),
       queryText =
-        """UNWIND {events} as event
+        """UNWIND $events as event
            MERGE (y:Year {year:event.year})
            MERGE (y)<-[:IN]-(e:Event {id:event.id})
            RETURN e.id as x order by x""",

--- a/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
+++ b/manual/cypher/cypher-docs/src/test/scala/org/neo4j/cypher/docgen/WhereTest.scala
@@ -76,7 +76,7 @@ class WhereTest extends DocumentingTestBase {
     testQuery(
       title = "Filter on dynamic node property",
       text = "To filter on a property using a dynamically computed name, use square bracket syntax.",
-      queryText = """match (n) where n[toLower({prop})] < 30 return n""",
+      queryText = """match (n) where n[toLower($prop)] < 30 return n""",
       optionalResultExplanation = """"+Tobias+" is returned because he is younger than 30.""",
       parameters = Map("prop" -> "AGE"),
       assertions = (p) => assertEquals(List(node("Tobias")), p.columnAs[Node]("n").toList))

--- a/manual/cypher/graphgist/src/test/java/org/neo4j/doc/cypherdoc/BlockTypeTest.java
+++ b/manual/cypher/graphgist/src/test/java/org/neo4j/doc/cypherdoc/BlockTypeTest.java
@@ -80,7 +80,7 @@ public class BlockTypeTest
     private static final List<String> PARAMS = Arrays.asList( "[source, json, role=parameters]", "----",
             "{\"name\": \"Adam\"}", "----" );
     private static final List<String> ADAM_PARAMS_QUERY = Arrays.asList( "[source, cypher]", "----",
-            "RETURN {name} = 'Adam';", "----" );
+            "RETURN $name = 'Adam';", "----" );
     private static final List<String> RETURN_ONE_QUERY = Arrays.asList( "[source, cypher]", "----",
             "CREATE (n:Person {name:'Alice'}), (m:Person {name:'Bob'}) ", "RETURN m;", "----" );
     private static final List<String> TWO_NODES_ONE_REL = Arrays.asList( "[source, cypher]", "----",

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AggregationTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/AggregationTest.scala
@@ -111,9 +111,9 @@ Sum numerical values. Similar functions are +avg+, +min+, +max+.
 MATCH (n) WHERE id(n) IN [%A%, %B%, %C%]
 RETURN
 
-percentileDisc(n.property, {percentile})
+percentileDisc(n.property, $percentile)
 
-,percentileCont(n.property, {percentile})
+,percentileCont(n.property, $percentile)
 ###
 
 Discrete percentile. Continuous percentile is +percentileCont+.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateTest.scala
@@ -72,7 +72,7 @@ class CreateTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=create-node parameters=aname
 //
 
-CREATE (n {name: {value}})
+CREATE (n {name: $value})
 
 RETURN n###
 
@@ -81,7 +81,7 @@ Create a node with the given properties.
 ###assertion=create-node-from-map parameters=map
 //
 
-CREATE (n {map})
+CREATE (n $map)
 
 RETURN n###
 
@@ -90,7 +90,7 @@ Create a node with the given properties.
 ###assertion=create-nodes-from-maps parameters=maps
 //
 
-UNWIND {listOfMaps} AS properties CREATE (n) SET n = properties
+UNWIND $listOfMaps AS properties CREATE (n) SET n = properties
 
 RETURN n###
 
@@ -110,7 +110,7 @@ Create a relationship with the given type and direction; bind a variable to it.
 MATCH (n), (m)
 WHERE id(n) = %A% AND id(m) = %B%
 
-CREATE (n)-[:LOVES {since: {value}}]->(m)
+CREATE (n)-[:LOVES {since: $value}]->(m)
 
 RETURN n###
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateUniqueTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/CreateUniqueTest.scala
@@ -56,7 +56,7 @@ class CreateUniqueTest extends RefcardTest with QueryStatisticsTestSupport {
 MATCH (n)  WHERE id(n) = %A%
 
 CREATE UNIQUE
-    (n)-[:KNOWS]->(m {property: {value}})
+    (n)-[:KNOWS]->(m {property: $value})
 
 RETURN m###
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ExampleTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ExampleTest.scala
@@ -58,12 +58,12 @@ class ExamplesTest extends RefcardTest with QueryStatisticsTestSupport {
 //
 
 MATCH (user:Person)-[:FRIEND]-(friend)
-WHERE user.city = {city}
+WHERE user.city = $city
 WITH user, count(friend) AS friendCount
 WHERE friendCount > 10
 RETURN user.name
 ORDER BY friendCount DESC
-SKIP {skipNumber}
+SKIP $skipNumber
 LIMIT 10
 
 ###
@@ -74,8 +74,8 @@ See the `WITH` section for additional options on its usage.
 ###assertion=create parameters=name
 //
 
-CREATE (user:Person {name: {name}})
-SET user.city = {city}
+CREATE (user:Person {name: $name})
+SET user.city = $city
 FOREACH (n IN [user] : SET n.marked = true)
 DELETE user
 ###

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/FunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/FunctionsTest.scala
@@ -38,9 +38,9 @@ class FunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
         assertStats(result, nodesCreated = 0)
         assert(result.toList.size === 0)
       case "toInt" =>
-        assert(result.toList === List(Map("toInt({expr})" -> 10)))
+        assert(result.toList === List(Map("toInt($expr)" -> 10)))
       case "toFloat" =>
-        assert(result.toList === List(Map("toFloat({expr})" -> 10.1)))
+        assert(result.toList === List(Map("toFloat($expr)" -> 10.1)))
     }
   }
 
@@ -68,7 +68,7 @@ class FunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
 MATCH (n)  WHERE id(n) = %A%
 RETURN
 
-coalesce(n.property, {defaultValue})###
+coalesce(n.property, $defaultValue)###
 
 The first non-++NULL++ expression.
 
@@ -91,21 +91,21 @@ The internal id of the relationship or node.
 ###assertion=toInt parameters=toInt
 RETURN
 
-toInt({expr})###
+toInt($expr)###
 
 Converts the given input into an integer if possible; otherwise it returns +NULL+.
 
 ###assertion=toFloat parameters=toFloat
 RETURN
 
-toFloat({expr})###
+toFloat($expr)###
 
 Converts the given input into a floating point number if possible; otherwise it returns +NULL+.
 
 ###assertion=returns-one parameters=map
 RETURN
 
-keys({expr})###
+keys($expr)###
 
 Returns a list of string representations for the property names of a node, relationship, or map."""
 }

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/IndexTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/IndexTest.scala
@@ -69,18 +69,18 @@ Create an index on the label `Person` and property `name`.
 ###assertion=match parameters=aname
 //
 
-MATCH (n:Person) WHERE n.name = {value}
+MATCH (n:Person) WHERE n.name = $value
 
 RETURN n
 ###
 
 An index can be automatically used for the equality comparison.
-Note that for example `lower(n.name) = {value}` will not use an index.
+Note that for example `lower(n.name) = $value` will not use an index.
 
 ###assertion=match parameters=aname
 //
 
-MATCH (n:Person) WHERE n.name IN [{value}]
+MATCH (n:Person) WHERE n.name IN [$value]
 
 RETURN n
 ###
@@ -92,7 +92,7 @@ An index can be automatically used for the `IN` list checks.
 
 MATCH (n:Person)
 USING INDEX n:Person(name)
-WHERE n.name = {value}
+WHERE n.name = $value
 
 RETURN n
 ###

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/LabelsTest.scala
@@ -66,7 +66,7 @@ class LabelsTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=create parameters=bname
 //
 
-CREATE (n:Person {name: {value}})
+CREATE (n:Person {name: $value})
 
 DELETE n
 RETURN n###
@@ -76,7 +76,7 @@ Create a node with label and property.
 ###assertion=create parameters=bname
 //
 
-MERGE (n:Person {name: {value}})
+MERGE (n:Person {name: $value})
 
 DELETE n
 RETURN n###
@@ -105,7 +105,7 @@ Matches nodes labeled `Person`.
 //
 
 MATCH (n:Person)
-WHERE n.name = {value}
+WHERE n.name = $value
 
 RETURN n###
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListExpressionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListExpressionsTest.scala
@@ -65,7 +65,7 @@ class ListExpressionsTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=returns-one parameters=list
 RETURN
 
-size({list})
+size($list)
 ###
 
 Number of elements in the list.
@@ -73,7 +73,7 @@ Number of elements in the list.
 ###assertion=returns-one parameters=list
 RETURN
 
-head({list}), last({list}), tail({list})
+head($list), last($list), tail($list)
 ###
 
 +head+ returns the first, +last+ the last element
@@ -86,7 +86,7 @@ WHERE id(n) = %A% AND id(m) = %B%
 WITH nodes(path) AS list
 RETURN
 
-[x IN list WHERE x.prop <> {value} | x.prop]
+[x IN list WHERE x.prop <> $value | x.prop]
 ###
 
 Combination of filter and extract in a concise notation.
@@ -106,7 +106,7 @@ MATCH (n) WHERE id(n) = %A%
 WITH [n] AS list
 RETURN
 
-filter(x IN list WHERE x.prop <> {value})
+filter(x IN list WHERE x.prop <> $value)
 ###
 
 A filtered list of the elements where the predicate is `TRUE`.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ListsTest.scala
@@ -76,7 +76,7 @@ Literal lists are declared in square brackets.
 ###assertion=returns-one parameters=list
 RETURN
 
-size({list}) AS len, {list}[0] AS value
+size($list) AS len, $list[0] AS value
 
 ###
 
@@ -85,7 +85,7 @@ Lists can be passed in as parameters.
 ###assertion=returns-one parameters=range
 RETURN
 
-range({firstNum}, {lastNum}, {step}) AS list
+range($firstNum, $lastNum, $step) AS list
 
 ###
 
@@ -116,8 +116,8 @@ Properties can be lists of strings, numbers or booleans.
 WITH [1, 2, 3] AS list
 RETURN
 
-list[{idx}] AS value,
-list[{startIdx}..{endIdx}] AS slice
+list[$idx] AS value,
+list[$startIdx..$endIdx] AS slice
 
 ###
 
@@ -129,7 +129,7 @@ Out of range elements are ignored.
 ###assertion=returns-one parameters=names
 //
 
-UNWIND {names} AS name
+UNWIND $names AS name
 MATCH (n {name: name})
 RETURN avg(n.age)
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MapsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MapsTest.scala
@@ -75,8 +75,8 @@ Nested maps and list are supported.
 ###assertion=returns-one-merge parameters=map
 //
 
-MERGE (p:Person {name: {map}.name})
-ON CREATE SET p = {map}
+MERGE (p:Person {name: $map.name})
+ON CREATE SET p = $map
 
 RETURN p
 ###

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MathematicalFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MathematicalFunctionsTest.scala
@@ -54,7 +54,7 @@ class MathematicalFunctionsTest extends RefcardTest with QueryStatisticsTestSupp
 ###assertion=returns-one parameters=expression
 RETURN
 
-abs({expr})
+abs($expr)
 ###
 
 The absolute value.
@@ -72,9 +72,9 @@ Also useful for selecting subset or random ordering.
 ###assertion=returns-one parameters=expression
 RETURN
 
-round({expr})
+round($expr)
 
-, floor({expr}), ceil({expr})
+, floor($expr), ceil($expr)
 ###
 
 Round to the nearest integer, +ceil+ and +floor+ find the next integer up or down.
@@ -82,7 +82,7 @@ Round to the nearest integer, +ceil+ and +floor+ find the next integer up or dow
 ###assertion=returns-one parameters=expression
 RETURN
 
-sqrt({expr})
+sqrt($expr)
 ###
 
 The square root.
@@ -90,7 +90,7 @@ The square root.
 ###assertion=returns-one parameters=expression
 RETURN
 
-sign({expr})
+sign($expr)
 ###
 
 `0` if zero, `-1` if negative, `1` if positive.
@@ -98,9 +98,9 @@ sign({expr})
 ###assertion=returns-one parameters=expression
 RETURN
 
-sin({expr})
+sin($expr)
 
-,cos({expr}), tan({expr}), cot({expr}), asin({expr}), acos({expr}), atan({expr}), atan2({expr}, {expr}), haversin({expr})
+,cos($expr), tan($expr), cot($expr), asin($expr), acos($expr), atan($expr), atan2($expr, $expr), haversin($expr)
 ###
 
 Trigonometric functions, also `cos`, `tan`, `cot`, `asin`, `acos`, `atan`, `atan2`, `haversin`.
@@ -109,7 +109,7 @@ All arguments for the trigonometric functions should be in radians, if not other
 ###assertion=returns-one parameters=expression
 RETURN
 
-degrees({expr}), radians({expr}), pi()
+degrees($expr), radians($expr), pi()
 ###
 
 Converts radians into degrees, use `radians` for the reverse. `pi` for π.
@@ -117,7 +117,7 @@ Converts radians into degrees, use `radians` for the reverse. `pi` for π.
 ###assertion=returns-one parameters=expression
 RETURN
 
-log10({expr}), log({expr}), exp({expr}), e()
+log10($expr), log($expr), exp($expr), e()
 ###
 
 Logarithm base 10, natural logarithm, `e` to the power of the parameter. Value of `e`.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MergeTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/MergeTest.scala
@@ -61,7 +61,7 @@ class MergeTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=merge parameters=aname
 //
 
-MERGE (n:Person {name: {value}})
+MERGE (n:Person {name: $value})
 ON CREATE SET n.created = timestamp()
 ON MATCH SET
     n.counter = coalesce(n.counter, 0) + 1,
@@ -75,8 +75,8 @@ Use +ON CREATE+ and +ON MATCH+ for conditional updates.
 ###assertion=merge-rel parameters=names
 //
 
-MATCH (a:Person {name: {value1}}),
-      (b:Person {name: {value2}})
+MATCH (a:Person {name: $value1}),
+      (b:Person {name: $value2})
 MERGE (a)-[r:LOVES]->(b)
 
 RETURN r###
@@ -86,9 +86,9 @@ RETURN r###
 ###assertion=merge-sub parameters=names
 //
 
-MATCH (a:Person {name: {value1}})
+MATCH (a:Person {name: $value1})
 MERGE
-  (a)-[r:KNOWS]->(b:Person {name: {value3}})
+  (a)-[r:KNOWS]->(b:Person {name: $value3})
 
 RETURN r, b###
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PatternsTest.scala
@@ -82,11 +82,20 @@ Node with both `Person` and `Swedish` labels.
 ###assertion=related parameters=alice
 MATCH
 
-(n:Person {name: {value}})
+(n:Person {name: $value})
 
 RETURN n###
 
 Node with the declared properties.
+
+###assertion=empty parameters=alice
+MATCH
+
+()-[r {name: $value}]-()
+
+RETURN r###
+
+Matches relationships with the declared properties.
 
 ###assertion=related
 MATCH
@@ -179,7 +188,7 @@ Variable length path of any number of relationships from `n` to `m`.
 MATCH (n) WHERE id(n) = %A%
 CREATE UNIQUE
 
-(n)-[:KNOWS]->(m {property: {value}})
+(n)-[:KNOWS]->(m {property: $value})
 
 RETURN m###
 
@@ -206,7 +215,7 @@ RETURN p###
 Find all shortest paths.
 
 ###assertion=returns-one parameters=alice
-MATCH (n:Person {name: {value}})
+MATCH (n:Person {name: $value})
 RETURN
 
 size((n)-->()-->())
@@ -216,14 +225,4 @@ AS fof###
 Count the paths matching the pattern.
 """
 }
-/* confirm this, then add.
-###assertion=empty parameters=alice
-MATCH
 
-()-[r {name: {value}}]-()
-
-RETURN r###
-
-Matches relationships with the declared properties.
-
-*/

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/PredicatesTest.scala
@@ -74,7 +74,7 @@ MATCH (n)-->(m)
 WHERE id(n) = %A% AND id(m) = %B%
 AND
 
-n.property <> {value}
+n.property <> $value
 
 RETURN n, m###
 
@@ -136,7 +136,7 @@ Check if something is `NULL`.
 MATCH (n)
 WHERE
 
-NOT exists(n.property) OR n.property = {value}
+NOT exists(n.property) OR n.property = $value
 
 RETURN n###
 
@@ -146,7 +146,7 @@ Either property does not exist or predicate is +TRUE+.
 MATCH (n)
 WHERE
 
-n.property = {value}
+n.property = $value
 
 RETURN n###
 
@@ -156,7 +156,7 @@ Non-existing property returns `NULL`, which is not equal to anything.
 MATCH (n)
 WHERE
 
-n["property"] = {value}
+n["property"] = $value
 
 RETURN n###
 
@@ -208,7 +208,7 @@ Exclude matches to `(n)-[:KNOWS]->(m)` from the result.
 MATCH (n)
 WHERE exists(n.property) AND
 
-n.property IN [{value1}, {value2}]
+n.property IN [$value1, $value2]
 
 RETURN n###
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ReturnTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/ReturnTest.scala
@@ -116,7 +116,7 @@ Sort the result in descending order.
 MATCH (n)
 RETURN *
 
-SKIP {skipNumber}
+SKIP $skipNumber
 ###
 
 Skip a number of results.
@@ -126,7 +126,7 @@ Skip a number of results.
 MATCH (n)
 RETURN *
 
-LIMIT {limitNumber}
+LIMIT $limitNumber
 ###
 
 Limit the number of results.
@@ -136,7 +136,7 @@ Limit the number of results.
 MATCH (n)
 RETURN *
 
-SKIP {skipNumber} LIMIT {limitNumber}
+SKIP $skipNumber LIMIT $limitNumber
 ###
 
 Skip results at the top and limit the number of results.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SetTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/SetTest.scala
@@ -57,8 +57,8 @@ class SetTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=set parameters=set
 MATCH (n) WHERE id(n) = %A%
 
-SET n.property1 = {value1},
-    n.property2 = {value2}
+SET n.property1 = $value1,
+    n.property2 = $value2
 
 RETURN n.property1###
 
@@ -67,7 +67,7 @@ Update or create a property.
 ###assertion=map parameters=map
 CREATE (n)
 
-SET n = {map}
+SET n = $map
 
 RETURN n.property###
 
@@ -77,7 +77,7 @@ This will remove any existing properties.
 ###assertion=map parameters=map
 CREATE (n)
 
-SET n += {map}
+SET n += $map
 
 RETURN n.property###
 

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StartTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StartTest.scala
@@ -79,7 +79,7 @@ class StartTest extends RefcardTest with QueryStatisticsTestSupport {
 ### assertion=index-match parameters=index-match
 //
 
-START n = node:nodeIndexName(key = {value})
+START n = node:nodeIndexName(key = $value)
 
 RETURN n###
 
@@ -88,17 +88,3 @@ Use `node_auto_index` for the automatic index.
 Note that other uses of `START` have been removed as of Cypher 2.2.
 """
 }
-
-/*
-
-### assertion=index-match parameters=index-query
-//
-
-START n=node:nodeIndexName({query})
-
-RETURN n###
-
-Query the index using a full Lucene query.
-A query can look like this: "name:Bob"
-
-*/

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StringFunctionsTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/StringFunctionsTest.scala
@@ -66,7 +66,7 @@ class StringFunctionsTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=returns-one parameters=expression
 RETURN
 
-toString({expression})
+toString($expression)
 ###
 
 String representation of the expression.
@@ -74,7 +74,7 @@ String representation of the expression.
 ###assertion=returns-one parameters=replace
 RETURN
 
-replace({original}, {search}, {replacement})
+replace($original, $search, $replacement)
 ###
 
 Replace all occurrences of `search` with `replacement`.
@@ -83,7 +83,7 @@ All arguments are be expressions.
 ###assertion=returns-one parameters=sub
 RETURN
 
-substring({original}, {begin}, {subLength})
+substring($original, $begin, $subLength)
 ###
 
 Get part of a string.
@@ -92,8 +92,8 @@ The `subLength` argument is optional.
 ###assertion=returns-one parameters=sub
 RETURN
 
-left({original}, {subLength}),
-  right({original}, {subLength})
+left($original, $subLength),
+  right($original, $subLength)
 ###
 
 The first part of a string. The last part of the string.
@@ -101,8 +101,8 @@ The first part of a string. The last part of the string.
 ###assertion=returns-one parameters=sub
 RETURN
 
-trim({original}), ltrim({original}),
-  rtrim({original})
+trim($original), ltrim($original),
+  rtrim($original)
 ###
 
 Trim all whitespace, or on left or right side.
@@ -110,7 +110,7 @@ Trim all whitespace, or on left or right side.
 ###assertion=returns-one parameters=sub
 RETURN
 
-upper({original}), lower({original})
+upper($original), lower($original)
 ###
 
 UPPERCASE and lowercase.
@@ -118,7 +118,7 @@ UPPERCASE and lowercase.
 ###assertion=returns-one parameters=split
 RETURN
 
-split({original}, {delimiter})
+split($original, $delimiter)
 ###
 
 Split a string into a list of strings.
@@ -126,7 +126,7 @@ Split a string into a list of strings.
 ###assertion=returns-one parameters=sub
 RETURN
 
-reverse({original})
+reverse($original)
 ###
 
 Reverse a string.
@@ -134,7 +134,7 @@ Reverse a string.
 ###assertion=returns-one parameters=string
 RETURN
 
-length({string})
+length($string)
 ###
 
 Calculate the number of characters in the string.

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/WhereTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/WhereTest.scala
@@ -52,7 +52,7 @@ class WhereTest extends RefcardTest with QueryStatisticsTestSupport {
 ###assertion=returns-one parameters=aname
 MATCH (n)-->(m)
 
-WHERE n.property <> {value}
+WHERE n.property <> $value
 
 AND id(n) = %A% AND id(m) = %B%
 RETURN n, m###

--- a/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/WithTest.scala
+++ b/manual/cypher/refcard-tests/src/test/scala/org/neo4j/cypher/docgen/refcard/WithTest.scala
@@ -57,7 +57,7 @@ class WithTest extends RefcardTest with QueryStatisticsTestSupport {
 //
 
 MATCH (user)-[:FRIEND]-(friend)
-WHERE user.name = {name}
+WHERE user.name = $name
 WITH user, count(friend) AS friends
 WHERE friends > 10
 RETURN user

--- a/manual/embedded-examples/src/test/java/org/neo4j/examples/GetOrCreateDocIT.java
+++ b/manual/embedded-examples/src/test/java/org/neo4j/examples/GetOrCreateDocIT.java
@@ -340,7 +340,7 @@ public class GetOrCreateDocIT extends AbstractJavaDocTestBase
         ResourceIterator<Node> resultIterator = null;
         try ( Transaction tx = graphDb.beginTx() )
         {
-            String queryString = "MERGE (n:User {name: {name}}) RETURN n";
+            String queryString = "MERGE (n:User {name: $name}) RETURN n";
             Map<String, Object> parameters = new HashMap<>();
             parameters.put( "name", username );
             resultIterator = graphDb.execute( queryString, parameters ).columnAs( "n" );

--- a/manual/refcard/src/cypher-refcard.asciidoc
+++ b/manual/refcard/src/cypher-refcard.asciidoc
@@ -22,7 +22,7 @@ For live graph models using Cypher check out <a href="http://gist.neo4j.org" tar
 
 The Cypher Refcard is also link:{docs-home}/pdf/neo4j-cypher-refcard-{neo4j-version}.pdf[available in PDF format].
 
-Note: `{value}` denotes either literals, for ad hoc Cypher queries; or parameters, which is the best practice for applications.
+Note: `$value` denotes either literals, for ad hoc Cypher queries; or parameters, which is the best practice for applications.
 Neo4j properties can be strings, numbers, booleans or arrays thereof.
 Cypher also supports maps and lists.
 

--- a/manual/refcard/src/cypher-refcard.asciidoc
+++ b/manual/refcard/src/cypher-refcard.asciidoc
@@ -117,14 +117,14 @@ include::{sources}/import.asciidoc[]
 |===
 | link:../cypher-working-with-null.html[NULL]
 |
-* +NULL+ is used to represent missing/undefined values.
-* +NULL+ is not equal to +NULL+.
+* `null` is used to represent missing/undefined values.
+* `null` is not equal to `null`.
   Not knowing two values does not imply that they are the same value.
-  So the expression `NULL = NULL` yields +NULL+ and not +TRUE+.
-  To check if an expression is +NULL+, use +IS NULL+.
-* Arithmetic expressions, comparisons and function calls (except +coalesce+) will return +NULL+ if any argument is +NULL+.
-* An attempt to access a missing element in a list or a property that doesn't exist yields +NULL+.
-* In +OPTIONAL MATCH+ clauses, ++NULL++s will be used for missing parts of the pattern.
+  So the expression `null = null` yields `null` and not `true`.
+  To check if an expression is `null`, use `IS NULL`.
+* Arithmetic expressions, comparisons and function calls (except `coalesce()`) will return `null` if any argument is `null`.
+* An attempt to access a missing element in a list or a property that doesn't exist yields `null`.
+* In `OPTIONAL MATCH` clauses, `null`s will be used for missing parts of the pattern.
 |===
 
 ++++

--- a/manual/server-examples/src/main/java/org/neo4j/examples/server/unmanaged/ColleaguesCypherExecutionResource.java
+++ b/manual/server-examples/src/main/java/org/neo4j/examples/server/unmanaged/ColleaguesCypherExecutionResource.java
@@ -93,7 +93,7 @@ public class ColleaguesCypherExecutionResource
 
     private String colleaguesQuery()
     {
-        return "MATCH (p:Person {name: {personName} })-[:ACTED_IN]->()<-[:ACTED_IN]-(colleague) RETURN colleague";
+        return "MATCH (p:Person {name: $personName })-[:ACTED_IN]->()<-[:ACTED_IN]-(colleague) RETURN colleague";
     }
 }
 // END SNIPPET: ColleaguesCypherExecutionResource


### PR DESCRIPTION
Note: The old syntax is not going away for a long time

The link to the CIP for this change is [here](https://github.com/opencypher/openCypher/blob/master/cip/CIP2016-07-07-Parameter-syntax.adoc)

changelog: Introduce new syntax for parameters in Cypher ($param and $`param`)
