### PR TITLE
Improve core edge logging

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/RaftInstance.java
@@ -130,7 +130,7 @@ public class RaftInstance implements LeaderLocator,
 
         this.membershipManager = membershipManager;
 
-        this.state = new RaftState( myself, termStorage, membershipManager, entryLog, voteStorage, inFlightMap );
+        this.state = new RaftState( myself, termStorage, membershipManager, entryLog, voteStorage, inFlightMap, logProvider );
 
         leaderNotFoundMonitor = monitors.newMonitor( LeaderNotFoundMonitor.class );
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/RaftChannelInitializer.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/net/RaftChannelInitializer.java
@@ -28,14 +28,18 @@ import org.neo4j.coreedge.raft.net.codecs.RaftMessageEncoder;
 import org.neo4j.coreedge.raft.replication.ReplicatedContent;
 import org.neo4j.coreedge.raft.state.ChannelMarshal;
 import org.neo4j.coreedge.server.logging.ExceptionLoggingHandler;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
 
 public class RaftChannelInitializer extends ChannelInitializer<SocketChannel>
 {
     private final ChannelMarshal<ReplicatedContent> marshal;
+    private final Log log;
 
-    public RaftChannelInitializer( ChannelMarshal<ReplicatedContent> marshal )
+    public RaftChannelInitializer( ChannelMarshal<ReplicatedContent> marshal, LogProvider logProvider )
     {
         this.marshal = marshal;
+        log = logProvider.getLog( getClass() );
     }
 
     @Override
@@ -44,6 +48,6 @@ public class RaftChannelInitializer extends ChannelInitializer<SocketChannel>
         ChannelPipeline pipeline = ch.pipeline();
         pipeline.addLast( "frameEncoder", new LengthFieldPrepender( 4 ) );
         pipeline.addLast( "raftMessageEncoder", new RaftMessageEncoder( marshal ) );
-        pipeline.addLast( new ExceptionLoggingHandler( null ) );
+        pipeline.addLast( new ExceptionLoggingHandler( log ) );
     }
 }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/core/EnterpriseCoreEditionModule.java
@@ -260,7 +260,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
         int maxQueueSize = config.get( CoreEdgeClusterSettings.outgoing_queue_size );
         long logThresholdMillis = config.get( CoreEdgeClusterSettings.unknown_address_logging_throttle );
         final SenderService senderService =
-                new SenderService( new RaftChannelInitializer( marshal ), logProvider, platformModule.monitors,
+                new SenderService( new RaftChannelInitializer( marshal, logProvider ), logProvider, platformModule.monitors,
                         maxQueueSize, new NonBlockingChannels() );
         life.add( senderService );
 

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/ExceptionLoggingHandler.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/server/logging/ExceptionLoggingHandler.java
@@ -38,6 +38,13 @@ public class ExceptionLoggingHandler extends ChannelHandlerAdapter
     @Override
     public void exceptionCaught( ChannelHandlerContext ctx, Throwable cause ) throws Exception
     {
-        log.error( format( "Failed to process message on channel %s.", ctx.channel() ), cause );
+        if ( ctx != null )
+        {
+            log.error( format( "Failed to process message on channel %s.", ctx.channel() ), cause );
+        }
+        else
+        {
+            log.error( format( "Failed to process message on a null channel." ), cause );
+        }
     }
 }

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateBuilder.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateBuilder.java
@@ -36,6 +36,7 @@ import org.neo4j.coreedge.raft.state.follower.FollowerStates;
 import org.neo4j.coreedge.raft.state.term.TermState;
 import org.neo4j.coreedge.raft.state.vote.VoteState;
 import org.neo4j.coreedge.server.CoreMember;
+import org.neo4j.logging.NullLogProvider;
 
 import static java.util.Collections.emptySet;
 import static org.neo4j.helpers.collection.Iterators.asSet;
@@ -126,7 +127,7 @@ public class RaftStateBuilder
         StubMembership membership = new StubMembership();
 
         RaftState state =
-                new RaftState( myself, termStore, membership, entryLog, voteStore, new InFlightMap<>() );
+                new RaftState( myself, termStore, membership, entryLog, voteStore, new InFlightMap<>(), NullLogProvider.getInstance() );
 
         Collection<RaftMessages.Directed> noMessages = Collections.emptyList();
         List<LogCommand> noLogCommands = Collections.emptyList();

--- a/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateTest.java
+++ b/enterprise/core-edge/src/test/java/org/neo4j/coreedge/raft/state/RaftStateTest.java
@@ -42,6 +42,7 @@ import org.neo4j.coreedge.raft.state.follower.FollowerState;
 import org.neo4j.coreedge.raft.state.follower.FollowerStates;
 import org.neo4j.coreedge.raft.state.term.TermState;
 import org.neo4j.coreedge.raft.state.vote.VoteState;
+import org.neo4j.logging.NullLogProvider;
 
 import static java.util.Collections.emptySet;
 import static org.junit.Assert.assertEquals;
@@ -63,7 +64,7 @@ public class RaftStateTest
         InFlightMap<Long,RaftLogEntry> cache = new InFlightMap<>();
         RaftState raftState = new RaftState( member( 0 ),
                 new InMemoryStateStorage<>( new TermState() ), new FakeMembership(), new InMemoryRaftLog(),
-                new InMemoryStateStorage<>( new VoteState() ), cache );
+                new InMemoryStateStorage<>( new VoteState() ), cache, NullLogProvider.getInstance() );
 
         List<LogCommand> logCommands = new LinkedList<LogCommand>()
         {{
@@ -98,7 +99,7 @@ public class RaftStateTest
                 new InMemoryStateStorage<>( new TermState() ),
                 new FakeMembership(), new InMemoryRaftLog(),
                 new InMemoryStateStorage<>( new VoteState( ) ),
-                new InFlightMap<>());
+                new InFlightMap<>(), NullLogProvider.getInstance() );
 
         raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, new HashSet<>(), -1, initialFollowerStates(), true, emptyLogCommands(),
                 emptyOutgoingMessages(), Collections.emptySet(), -1) );


### PR DESCRIPTION
We were passing in a null logger to RaftChannelInitializer so any
Netty based problems weren't being correctly logged.

We also don't log leader changes on the follower which makes it tricky
to figure out what's going on when monitoring a cluster.
