### PR TITLE
Prune the Term and Index in-memory storage.

### DIFF
--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentedRaftLog.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/SegmentedRaftLog.java
@@ -38,15 +38,15 @@ import org.neo4j.logging.LogProvider;
 /**
  * The segmented RAFT log is an append only log supporting the operations required to support
  * the RAFT consensus algorithm.
- * <p>
+ *
  * A RAFT log must be able to append new entries, but also truncate not yet committed entries,
  * prune out old compacted entries and skip to a later starting point.
- * <p>
+ *
  * The RAFT log consists of a sequence of individual log files, called segments, with
  * the following format:
- * <p>
+ *
  * [HEADER] [ENTRY]*
- * <p>
+ *
  * So a header with zero or more entries following it. Each segment file contains a consecutive
  * sequence of appended entries. The operations of truncating and skipping in the log is implemented
  * by switching to the next segment file, called the next version. A new segment file is also started
@@ -227,7 +227,7 @@ public class SegmentedRaftLog extends LifecycleAdapter implements RaftLog
     @Override
     public long readEntryTerm( long logIndex ) throws IOException
     {
-        long term = state.terms.get( logIndex );
+        long term = state.terms.getTermFor( logIndex );
         if ( term == -1 && logIndex >= state.prevIndex )
         {
             RaftLogEntry entry = readLogEntry( logIndex );

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/Terms.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/Terms.java
@@ -26,10 +26,10 @@ import static java.lang.Math.max;
 /**
  * Keeps track of all the terms in memory for efficient lookup.
  * The implementation favours lookup of recent entries.
- *
+ * <p>
  * Exposed methods shadow the regular RAFT log manipulation
  * functions and must be invoked from respective places.
- *
+ * <p>
  * During recovery truncate should be called between every segment
  * switch to "simulate" eventual truncations as a reason for switching
  * segments. It is ok to call truncate even if the reason was not a
@@ -66,8 +66,8 @@ public class Terms
         if ( term != terms[size - 1] )
         {
             setSize( size + 1 );
-            indexes[size - 1 ] = index;
-            terms[size - 1 ] = term;
+            indexes[size - 1] = index;
+            terms[size - 1] = term;
         }
     }
 
@@ -115,16 +115,16 @@ public class Terms
             return;
         }
 
-        size = 1;
+        size = indexes.length - offset;
         indexes = Arrays.copyOfRange( indexes, offset, indexes.length );
-        terms = Arrays.copyOfRange( terms, offset, terms.length);
+        terms = Arrays.copyOfRange( terms, offset, terms.length );
     }
 
     private int find( long min )
     {
         for ( int i = 0; i < indexes.length; i++ )
         {
-            if ( indexes[i] == min )
+            if ( indexes[i] >= min )
             {
                 return i;
             }

--- a/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/Terms.java
+++ b/enterprise/core-edge/src/main/java/org/neo4j/coreedge/raft/log/segmented/Terms.java
@@ -66,8 +66,8 @@ public class Terms
         if ( term != terms[size - 1] )
         {
             setSize( size + 1 );
-            indexes[size - 1] = index;
-            terms[size - 1] = term;
+            indexes[size - 1 ] = index;
+            terms[size - 1 ] = term;
         }
     }
 
@@ -107,7 +107,30 @@ public class Terms
     synchronized void prune( long upToIndex )
     {
         min = max( upToIndex, min );
-        // could also prune out array
+
+        int offset = find( min );
+
+        if ( offset == -1 )
+        {
+            return;
+        }
+
+        size = 1;
+        indexes = Arrays.copyOfRange( indexes, offset, indexes.length );
+        terms = Arrays.copyOfRange( terms, offset, terms.length);
+    }
+
+    private int find( long min )
+    {
+        for ( int i = 0; i < indexes.length; i++ )
+        {
+            if ( indexes[i] == min )
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     synchronized void skip( long prevIndex, long prevTerm )
@@ -120,7 +143,7 @@ public class Terms
         terms[0] = prevTerm;
     }
 
-    synchronized long get( long logIndex )
+    synchronized long getTermFor( long logIndex )
     {
         if ( logIndex == -1 || logIndex < min || logIndex > max )
         {


### PR DESCRIPTION
Previously kept all terms and indexes forever. Now we prune them when
the log is pruned.
